### PR TITLE
Include number of package updates in system group update status counting (bsc#1170468)

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/SystemGroup_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/SystemGroup_queries.xml
@@ -13,18 +13,20 @@
                               WHERE SFV.server_id = SGM.server_id
                                     AND SFV.label = 'ftr_system_grouping')) AS  SERVER_COUNT,
         (SELECT CASE MAX(CASE E.advisory_type
-            WHEN 'Security Advisory' THEN 3
-            WHEN 'Bug Fix Advisory' THEN 2
-            WHEN 'Product Enhancement Advisory' THEN 1 END)
-          WHEN 3 THEN 'Security Advisory'
-          WHEN 2 THEN 'Bug Fix Advisory'
-          WHEN 1 THEN 'Product Enhancement Advisory' END type_value
-                       from rhnErrata E inner join
-                            rhnServerNeededCache SNPC on E.id = SNPC.errata_id inner join
-                            rhnServerGroupMembers SGM on SGM.server_id = SNPC.server_id inner join
-                            rhnServerFeaturesView SFV on SGM.server_id = SFV.server_id
-                       where sgm.server_group_id = G.id
-                         AND SFV.label = 'ftr_system_grouping') as MOST_SEVERE_ERRATA
+                WHEN 'Security Advisory' THEN 3
+                WHEN 'Bug Fix Advisory' THEN 2
+                WHEN 'Product Enhancement Advisory' THEN 1
+                ELSE 0 END)
+            WHEN 3 THEN 'Security Advisory'
+            WHEN 2 THEN 'Bug Fix Advisory'
+            WHEN 1 THEN 'Product Enhancement Advisory'
+            WHEN 0 THEN 'Outdated Packages' END type_value
+        FROM rhnServerNeededCache SNPC
+            INNER JOIN rhnServerGroupMembers SGM on SGM.server_id = SNPC.server_id
+            INNER JOIN rhnServerFeaturesView SFV on SGM.server_id = SFV.server_id
+            LEFT JOIN rhnErrata E on E.id = SNPC.errata_id
+        WHERE SGM.server_group_id = G.id
+          AND SFV.label = 'ftr_system_grouping') as MOST_SEVERE_ERRATA
  FROM   rhnServerGroup G, rhnUserManagedServerGroups UMSG
  WHERE   G.ORG_ID = :org_id
    AND   UMSG.user_id = :user_id
@@ -67,15 +69,17 @@ ORDER BY UPPER(NAME)
         CASE MAX(CASE e.advisory_type
             WHEN 'Security Advisory' THEN 3
             WHEN 'Bug Fix Advisory' THEN 2
-            WHEN 'Product Enhancement Advisory' THEN 1 END)
+            WHEN 'Product Enhancement Advisory' THEN 1
+            ELSE 0 END)
             WHEN 3 THEN 'Security Advisory'
             WHEN 2 THEN 'Bug Fix Advisory'
             WHEN 1 THEN 'Product Enhancement Advisory'
+            WHEN 0 THEN 'Outdated Packages'
         END AS most_severe_errata
-    FROM rhnErrata e
-        INNER JOIN rhnServerNeededCache snpc ON e.id = snpc.errata_id
+    FROM rhnServerNeededCache snpc
         INNER JOIN rhnServerGroupMembers sgm ON sgm.server_id = snpc.server_id
         INNER JOIN rhnServerFeaturesView sfv ON sgm.server_id = sfv.server_id
+        LEFT JOIN rhnErrata e ON e.id = snpc.errata_id
     WHERE sgm.server_group_id IN (%s) AND sfv.label = 'ftr_system_grouping'
     GROUP BY server_group_id
 </query>
@@ -141,16 +145,19 @@ ORDER BY UPPER(SG.name), SG.id
 
 <mode name="group_errata_counts">
   <query params="sgid">
-     SELECT count(DISTINCT e.id),
+     SELECT count(DISTINCT CASE
+                WHEN snc.errata_id IS NULL THEN snc.package_id
+                ELSE snc.errata_id END), --Count multiple packages in an erratum as one
             CASE e.advisory_type
                 WHEN 'Security Advisory' THEN 'se'
                 WHEN 'Bug Fix Advisory' THEN 'be'
                 WHEN 'Product Enhancement Advisory' THEN 'ee'
+                ELSE 'op' --Outdated packages
             END AS advisory_type
-      FROM rhnErrata e
-        INNER JOIN rhnServerNeededCache snc ON e.id = snc.errata_id
+      FROM rhnServerNeededCache snc
         INNER JOIN rhnServerGroupMembers sgm ON sgm.server_id = snc.server_id
         INNER JOIN rhnServerFeaturesView sfv ON sgm.server_id = sfv.server_id
+        LEFT JOIN rhnErrata e ON e.id = snc.errata_id
       WHERE sgm.server_group_id = :sgid AND sfv.label = 'ftr_system_grouping'
       GROUP BY e.advisory_type
   </query>

--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/SystemGroup_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/SystemGroup_queries.xml
@@ -32,25 +32,6 @@
    AND   G.id = UMSG.server_group_id
   </query>
 
-  <query name="errata_count">
-           SELECT
-                 sgm.server_group_id AS ID,
-                 ( select count(distinct E.id) from rhnErrata E where E.id = SNEC.errata_id AND E.advisory_type = 'Security Advisory') AS SECURITY_ERRATA,
-                 ( select count(distinct E.id) from rhnErrata E where E.id = SNEC.errata_id AND E.advisory_type = 'Bug Fix Advisory') AS BUG_ERRATA,
-                 ( select count(distinct E.id) from rhnErrata E where E.id = SNEC.errata_id AND E.advisory_type = 'Product Enhancement Advisory') AS ENHANCEMENT_ERRATA
-            FROM
-                 rhnServerNeededErrataCache SNEC,
-                 rhnServerGroupMembers SGM,
-
-
-           WHERE
-
-                  snpc.server_id = sgm.server_id
-                 AND sgm.server_group_id IN (%s)
-
-
-  </query>
-
 <query name="visible_to_user_ids" params="user_id">
 select * from (
 SELECT DISTINCT SG.id AS ID, SG.name AS NAME

--- a/java/code/src/com/redhat/rhn/frontend/action/groups/GroupDetailAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/groups/GroupDetailAction.java
@@ -15,7 +15,7 @@
 
 package com.redhat.rhn.frontend.action.groups;
 
-import java.util.HashMap;
+import java.util.Map;
 
 import com.redhat.rhn.domain.server.ManagedServerGroup;
 import com.redhat.rhn.domain.user.User;
@@ -47,8 +47,11 @@ public class GroupDetailAction extends RhnAction {
 
         User user = rctx.getCurrentUser();
         ManagedServerGroup sg = rctx.lookupAndBindServerGroup();
-        HashMap errataCounts =
-                (HashMap) ServerGroupManager.getInstance().errataCounts(user, sg);
+        Map<String, String> errataCounts = ServerGroupManager.getInstance().errataCounts(user, sg);
+        errataCounts.putIfAbsent("se", "0");
+        errataCounts.putIfAbsent("be", "0");
+        errataCounts.putIfAbsent("ee", "0");
+        errataCounts.putIfAbsent("op", "0");
         long minionCount = MinionServerUtils.filterSaltMinions(sg.getServers()).count();
 
         request.setAttribute("id", sg.getId());

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_bn_IN.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_bn_IN.xml
@@ -5779,21 +5779,21 @@ organization. You may grant or remove the organization administrator role in the
         </context-group>
       </trans-unit>
       <trans-unit id="grouplist.jsp.security">
-        <source>Security Updates Needed</source>
+        <source>Security updates needed</source>
         <target>নিরাপত্তাজনীত আপডেট প্রয়োজন</target>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/SystemGroupList</context>
         </context-group>
       </trans-unit>
       <trans-unit id="grouplist.jsp.updates">
-        <source>Patch Updates Available</source>
+        <source>Updates available</source>
         <target>ত্রুটি-বিচ্যুতির আপডেট উপলব্ধ রয়েছে</target>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/SystemGroupList</context>
         </context-group>
       </trans-unit>
       <trans-unit id="grouplist.jsp.noerrata">
-        <source>No Applicable Patches</source>
+        <source>No applicable updates</source>
         <target>কোনো প্রযোজ্য ত্রুটি-বিচ্যুতির তথ্য উপস্থিত নেই</target>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/frontend/dto/SystemGroupOverview</context>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ca.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ca.xml
@@ -5376,19 +5376,19 @@ organization. You may grant or remove the organization administrator role in the
         </context-group>
       </trans-unit>
       <trans-unit id="grouplist.jsp.security">
-        <source>Security Updates Needed</source>
+        <source>Security updates needed</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/SystemGroupList</context>
         </context-group>
       </trans-unit>
       <trans-unit id="grouplist.jsp.updates">
-        <source>Patch Updates Available</source>
+        <source>Updates available</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/SystemGroupList</context>
         </context-group>
       </trans-unit>
       <trans-unit id="grouplist.jsp.noerrata">
-        <source>No Applicable Patches</source>
+        <source>No applicable updates</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/SystemGroupList</context>
           <context context-type="sourcefile">/rhn/frontend/dto/SystemGroupOverview</context>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_de.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_de.xml
@@ -6161,21 +6161,21 @@ die Organisations-Administrator Rolle im Abschnitt &quot;Rollen&quot; des Tab &q
         <target>Im SSM verwenden</target>
       </trans-unit>
       <trans-unit id="grouplist.jsp.security">
-        <source>Security Updates Needed</source>
+        <source>Security updates needed</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/SystemGroupList</context>
         </context-group>
         <target>Sicherheitsupdates notwendig</target>
       </trans-unit>
       <trans-unit id="grouplist.jsp.updates">
-        <source>Patch Updates Available</source>
+        <source>Updates available</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/SystemGroupList</context>
         </context-group>
         <target>Errata-Updates verfügbar</target>
       </trans-unit>
       <trans-unit id="grouplist.jsp.noerrata">
-        <source>No Applicable Patches</source>
+        <source>No applicable updates</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/SystemGroupList</context>
           <context context-type="sourcefile">/rhn/frontend/dto/SystemGroupOverview</context>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -5291,19 +5291,19 @@ organization. You may grant or remove the organization administrator role in the
         </context-group>
       </trans-unit>
       <trans-unit id="grouplist.jsp.security">
-        <source>Security Updates Needed</source>
+        <source>Security updates needed</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/SystemGroupList</context>
         </context-group>
       </trans-unit>
       <trans-unit id="grouplist.jsp.updates">
-        <source>Patch Updates Available</source>
+        <source>Updates available</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/SystemGroupList</context>
         </context-group>
       </trans-unit>
       <trans-unit id="grouplist.jsp.noerrata">
-        <source>No Applicable Patches</source>
+        <source>No applicable updates</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/SystemGroupList</context>
           <context context-type="sourcefile">/rhn/frontend/dto/SystemGroupOverview</context>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_es.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_es.xml
@@ -6162,21 +6162,21 @@ administrador de la organización en la sección &quot;Roles&quot; de la pestañ
         <target>Utilizar en SSM</target>
       </trans-unit>
       <trans-unit id="grouplist.jsp.security">
-        <source>Security Updates Needed</source>
+        <source>Security updates needed</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/SystemGroupList</context>
         </context-group>
         <target>Actualizaciones de seguridad necesarias</target>
       </trans-unit>
       <trans-unit id="grouplist.jsp.updates">
-        <source>Patch Updates Available</source>
+        <source>Updates available</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/SystemGroupList</context>
         </context-group>
         <target>Erratas de actualización disponibles</target>
       </trans-unit>
       <trans-unit id="grouplist.jsp.noerrata">
-        <source>No Applicable Patches</source>
+        <source>No applicable updates</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/SystemGroupList</context>
           <context context-type="sourcefile">/rhn/frontend/dto/SystemGroupOverview</context>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_fr.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_fr.xml
@@ -6162,21 +6162,21 @@ organisation. Vous pouvez accorder ou retirer le rôle d'administrateur d'organi
         <target>Utiliser dans le SSM</target>
       </trans-unit>
       <trans-unit id="grouplist.jsp.security">
-        <source>Security Updates Needed</source>
+        <source>Security updates needed</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/SystemGroupList</context>
         </context-group>
         <target>Mises à jour de sécurité nécessaires</target>
       </trans-unit>
       <trans-unit id="grouplist.jsp.updates">
-        <source>Patch Updates Available</source>
+        <source>Updates available</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/SystemGroupList</context>
         </context-group>
         <target>Mises à jour d'errata disponibles</target>
       </trans-unit>
       <trans-unit id="grouplist.jsp.noerrata">
-        <source>No Applicable Patches</source>
+        <source>No applicable updates</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/SystemGroupList</context>
           <context context-type="sourcefile">/rhn/frontend/dto/SystemGroupOverview</context>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_gu.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_gu.xml
@@ -5909,14 +5909,14 @@ organization. You may grant or remove the organization administrator role in the
         <target>SSM માં વાપરો</target>
       </trans-unit>
       <trans-unit id="grouplist.jsp.security">
-        <source>Security Updates Needed</source>
+        <source>Security updates needed</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/SystemGroupList</context>
         </context-group>
         <target>સુરક્ષા સુધારાઓ જરૂરી છે</target>
       </trans-unit>
       <trans-unit id="grouplist.jsp.updates">
-        <source>Patch Updates Available</source>
+        <source>Updates available</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/SystemGroupList</context>
         </context-group>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_hi.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_hi.xml
@@ -5909,21 +5909,21 @@ organization. You may grant or remove the organization administrator role in the
         <target>SSM में प्रयोग करें</target>
       </trans-unit>
       <trans-unit id="grouplist.jsp.security">
-        <source>Security Updates Needed</source>
+        <source>Security updates needed</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/SystemGroupList</context>
         </context-group>
         <target>सुरक्षा अद्यतन जरूरी</target>
       </trans-unit>
       <trans-unit id="grouplist.jsp.updates">
-        <source>Patch Updates Available</source>
+        <source>Updates available</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/SystemGroupList</context>
         </context-group>
         <target>इरेटा अद्यतन उपलब्ध</target>
       </trans-unit>
       <trans-unit id="grouplist.jsp.noerrata">
-        <source>No Applicable Patches</source>
+        <source>No applicable updates</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/SystemGroupList</context>
           <context context-type="sourcefile">/rhn/frontend/dto/SystemGroupOverview</context>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_it.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_it.xml
@@ -6161,21 +6161,21 @@ amministratore dell'organizzazione all'interno della sezione &quot;Ruoli&quot; d
         <target>Utilizza in SSM</target>
       </trans-unit>
       <trans-unit id="grouplist.jsp.security">
-        <source>Security Updates Needed</source>
+        <source>Security updates needed</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/SystemGroupList</context>
         </context-group>
         <target>Aggiornamenti sulla Sicurezza necessari</target>
       </trans-unit>
       <trans-unit id="grouplist.jsp.updates">
-        <source>Patch Updates Available</source>
+        <source>Updates available</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/SystemGroupList</context>
         </context-group>
         <target>Aggiornamenti Errata disponibili</target>
       </trans-unit>
       <trans-unit id="grouplist.jsp.noerrata">
-        <source>No Applicable Patches</source>
+        <source>No applicable updates</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/SystemGroupList</context>
           <context context-type="sourcefile">/rhn/frontend/dto/SystemGroupOverview</context>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ja.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ja.xml
@@ -6162,21 +6162,21 @@ organization. You may grant or remove the organization administrator role in the
         <target>SSM で 使用</target>
       </trans-unit>
       <trans-unit id="grouplist.jsp.security">
-        <source>Security Updates Needed</source>
+        <source>Security updates needed</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/SystemGroupList</context>
         </context-group>
         <target>セキュリティ更新が必要です</target>
       </trans-unit>
       <trans-unit id="grouplist.jsp.updates">
-        <source>Patch Updates Available</source>
+        <source>Updates available</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/SystemGroupList</context>
         </context-group>
         <target>エラータ更新があります</target>
       </trans-unit>
       <trans-unit id="grouplist.jsp.noerrata">
-        <source>No Applicable Patches</source>
+        <source>No applicable updates</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/SystemGroupList</context>
           <context context-type="sourcefile">/rhn/frontend/dto/SystemGroupOverview</context>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ko.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ko.xml
@@ -6044,14 +6044,14 @@ organization. You may grant or remove the organization administrator role in the
         <target>SSM에서 사용</target>
       </trans-unit>
       <trans-unit id="grouplist.jsp.security">
-        <source>Security Updates Needed</source>
+        <source>Security updates needed</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/SystemGroupList</context>
         </context-group>
         <target>보안 업데이트 필요</target>
       </trans-unit>
       <trans-unit id="grouplist.jsp.updates">
-        <source>Patch Updates Available</source>
+        <source>Updates available</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/SystemGroupList</context>
         </context-group>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_pa.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_pa.xml
@@ -5909,21 +5909,21 @@ organization. You may grant or remove the organization administrator role in the
         <target>SSM ਵਿੱਚ ਵਰਤੋਂ</target>
       </trans-unit>
       <trans-unit id="grouplist.jsp.security">
-        <source>Security Updates Needed</source>
+        <source>Security updates needed</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/SystemGroupList</context>
         </context-group>
         <target>ਸੁਰੱਖਿਆ ਅੱਪਡੇਟ ਲੋੜੀਦੇ ਹਨ</target>
       </trans-unit>
       <trans-unit id="grouplist.jsp.updates">
-        <source>Patch Updates Available</source>
+        <source>Updates available</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/SystemGroupList</context>
         </context-group>
         <target>ਇਰੱਟਾ ਅੱਪਡੇਟ ਉਪਲੱਬਧ ਹੈ</target>
       </trans-unit>
       <trans-unit id="grouplist.jsp.noerrata">
-        <source>No Applicable Patches</source>
+        <source>No applicable updates</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/SystemGroupList</context>
           <context context-type="sourcefile">/rhn/frontend/dto/SystemGroupOverview</context>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_pt_BR.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_pt_BR.xml
@@ -6163,21 +6163,21 @@ permanecer sem modificações nesta página. Caso queira modificá-los, visite
         <target>Usar no SSM</target>
       </trans-unit>
       <trans-unit id="grouplist.jsp.security">
-        <source>Security Updates Needed</source>
+        <source>Security updates needed</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/SystemGroupList</context>
         </context-group>
         <target>Atualizações de Segurança Necessárias</target>
       </trans-unit>
       <trans-unit id="grouplist.jsp.updates">
-        <source>Patch Updates Available</source>
+        <source>Updates available</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/SystemGroupList</context>
         </context-group>
         <target>Atualizações de Errata Disponíveis</target>
       </trans-unit>
       <trans-unit id="grouplist.jsp.noerrata">
-        <source>No Applicable Patches</source>
+        <source>No applicable updates</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/SystemGroupList</context>
           <context context-type="sourcefile">/rhn/frontend/dto/SystemGroupOverview</context>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ru.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ru.xml
@@ -6160,14 +6160,14 @@ organization. You may grant or remove the organization administrator role in the
         <target>В менеджер комплектов</target>
       </trans-unit>
       <trans-unit id="grouplist.jsp.security">
-        <source>Security Updates Needed</source>
+        <source>Security updates needed</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/SystemGroupList</context>
         </context-group>
         <target>Необходимы обновления безопасности</target>
       </trans-unit>
       <trans-unit id="grouplist.jsp.updates">
-        <source>Patch Updates Available</source>
+        <source>Updates available</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/SystemGroupList</context>
         </context-group>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ta.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ta.xml
@@ -5909,21 +5909,21 @@ organization. You may grant or remove the organization administrator role in the
         <target>SSM ல் பயன்படுத்தவும்</target>
       </trans-unit>
       <trans-unit id="grouplist.jsp.security">
-        <source>Security Updates Needed</source>
+        <source>Security updates needed</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/SystemGroupList</context>
         </context-group>
         <target>பாதுகாப்பு மேம்படுத்தல் தேவைப்படுகிறது</target>
       </trans-unit>
       <trans-unit id="grouplist.jsp.updates">
-        <source>Patch Updates Available</source>
+        <source>Updates available</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/SystemGroupList</context>
         </context-group>
         <target>பிழைத்திருத்தங்கள் மேம்படுத்தல் உள்ளன</target>
       </trans-unit>
       <trans-unit id="grouplist.jsp.noerrata">
-        <source>No Applicable Patches</source>
+        <source>No applicable updates</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/SystemGroupList</context>
           <context context-type="sourcefile">/rhn/frontend/dto/SystemGroupOverview</context>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_uk.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_uk.xml
@@ -5679,19 +5679,19 @@ organization. You may grant or remove the organization administrator role in the
         </context-group>
       </trans-unit>
       <trans-unit id="grouplist.jsp.security">
-        <source>Security Updates Needed</source>
+        <source>Security updates needed</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/SystemGroupList</context>
         </context-group>
       </trans-unit>
       <trans-unit id="grouplist.jsp.updates">
-        <source>Patch Updates Available</source>
+        <source>Updates available</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/SystemGroupList</context>
         </context-group>
       </trans-unit>
       <trans-unit id="grouplist.jsp.noerrata">
-        <source>No Applicable Patches</source>
+        <source>No applicable updates</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/SystemGroupList</context>
           <context context-type="sourcefile">/rhn/frontend/dto/SystemGroupOverview</context>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_zh_CN.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_zh_CN.xml
@@ -6168,14 +6168,14 @@ organization. You may grant or remove the organization administrator role in the
         <target>在 SSM 中使用</target>
       </trans-unit>
       <trans-unit id="grouplist.jsp.security">
-        <source>Security Updates Needed</source>
+        <source>Security updates needed</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/SystemGroupList</context>
         </context-group>
         <target>需要的安全性更新</target>
       </trans-unit>
       <trans-unit id="grouplist.jsp.updates">
-        <source>Patch Updates Available</source>
+        <source>Updates available</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/SystemGroupList</context>
         </context-group>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_zh_TW.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_zh_TW.xml
@@ -6157,21 +6157,21 @@ organization. You may grant or remove the organization administrator role in the
         <target>用於 SSM</target>
       </trans-unit>
       <trans-unit id="grouplist.jsp.security">
-        <source>Security Updates Needed</source>
+        <source>Security updates needed</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/SystemGroupList</context>
         </context-group>
         <target>需要安全升級</target>
       </trans-unit>
       <trans-unit id="grouplist.jsp.updates">
-        <source>Patch Updates Available</source>
+        <source>Updates available</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/SystemGroupList</context>
         </context-group>
         <target>可用的勘誤升級</target>
       </trans-unit>
       <trans-unit id="grouplist.jsp.noerrata">
-        <source>No Applicable Patches</source>
+        <source>No applicable updates</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/SystemGroupList</context>
           <context context-type="sourcefile">/rhn/frontend/dto/SystemGroupOverview</context>

--- a/java/code/webapp/WEB-INF/pages/common/fragments/systems/group_listdisplay.jspf
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/systems/group_listdisplay.jspf
@@ -36,7 +36,7 @@
       <c:when test="${current.mostSevereErrata == 'Security Advisory'}">
         <rhn:icon type="system-crit" title="grouplist.jsp.security" />
       </c:when>
-      <c:when test="${current.mostSevereErrata == 'Bug Fix Advisory' or current.mostSevereErrata == 'Product Enhancement Advisory'}">
+      <c:when test="${current.mostSevereErrata == 'Bug Fix Advisory' or current.mostSevereErrata == 'Product Enhancement Advisory' or current.mostSevereErrata == 'Outdated Packages'}">
         <rhn:icon type="system-warn" title="grouplist.jsp.updates" />
       </c:when>
       <c:otherwise>

--- a/java/code/webapp/WEB-INF/pages/common/fragments/yourrhn/systemGroups.jsp
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/yourrhn/systemGroups.jsp
@@ -20,7 +20,7 @@
                                         <c:when test="${current.mostSevereErrata == 'Security Advisory'}">
                                         <rhn:icon type="system-crit" title="grouplist.jsp.security" />
                                         </c:when>
-                                        <c:when test="${current.mostSevereErrata == 'Bug Fix Advisory' or current.mostSevereErrata == 'Product Enhancement Advisory'}">
+                                        <c:when test="${current.mostSevereErrata == 'Bug Fix Advisory' or current.mostSevereErrata == 'Product Enhancement Advisory' or current.mostSevereErrata == 'Outdated Packages'}">
                                         <rhn:icon type="system-warn" title="grouplist.jsp.updates" />
                                 </c:when>
                                         <c:otherwise>

--- a/java/code/webapp/WEB-INF/pages/groups/detail.jsp
+++ b/java/code/webapp/WEB-INF/pages/groups/detail.jsp
@@ -28,7 +28,7 @@
             <c:when test="${errata_counts['se'] > 0}">
                 <rhn:icon type="system-crit" />
             </c:when>
-            <c:when test="${(errata_counts['se'] == 0) && (errata_counts['be'] > 0 || errata_counts['ee'] > 0)}">
+            <c:when test="${(errata_counts['se'] == 0) && (errata_counts['be'] > 0 || errata_counts['ee'] > 0 || errata_counts['op'] > 0)}">
                 <rhn:icon type="system-warn" />
             </c:when>
             <c:otherwise>
@@ -36,7 +36,7 @@
             </c:otherwise>
         </c:choose>
         <c:choose>
-            <c:when test="${errata_counts['se'] == 0 && errata_counts['be'] == 0 && errata_counts['ee'] == 0}">
+            <c:when test="${errata_counts['se'] == 0 && errata_counts['be'] == 0 && errata_counts['ee'] == 0 && errata_counts['op'] == 0}">
                 <bean:message key="systemgroup.details.noupdates"/>
             </c:when>
             <c:otherwise>
@@ -44,8 +44,8 @@
                 <c:if test="${errata_counts['se'] > 0}">
                     <bean:message key="systemgroup.details.updates.critical" arg0="/rhn/groups/ListErrata.do?sgid=${id}" arg1="${errata_counts['se']}"/>&nbsp;&nbsp;&nbsp;
                 </c:if>
-                <c:if test="${errata_counts['be'] > 0 || errata_counts['ee'] > 0}">
-                    <bean:message key="systemgroup.details.updates.noncritical" arg0="/rhn/groups/ListErrata.do?sgid=${id}" arg1="${errata_counts['be'] + errata_counts['ee']}"/>
+                <c:if test="${errata_counts['be'] > 0 || errata_counts['ee'] > 0 || errata_counts['op'] > 0}">
+                    <bean:message key="systemgroup.details.updates.noncritical" arg0="/rhn/groups/ListErrata.do?sgid=${id}" arg1="${errata_counts['be'] + errata_counts['ee'] + errata_counts['op']}"/>
                 </c:if>
             </c:otherwise>
         </c:choose>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Include number of non-patch package updates to non-critical update counts
+  in system group pages (bsc#1170468)
 - bump XMLRPC API version number to distinguish from Spacewalk 2.10
 - Cluster UI: return to overview page after scheduling actions
 - fix NPE on auto installation when no kernel options are given (bsc#1173932)


### PR DESCRIPTION
Unlike system info pages, system group pages show update status by counting only the number of patches available. This PR changes this behavior to take into account the number of package updates as well.

**Additional fixes:**
 - Fixed the message text where it displays "Software updates available" even when there isn't any
 - Removed a deprecated SQL query

https://bugzilla.suse.com/1170468

Port of: https://github.com/SUSE/spacewalk/pull/11743

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
