### PR TITLE
Flatten array of array messages passed to toastr to make them visible

### DIFF
--- a/web/html/src/components/toastr/toastr.js
+++ b/web/html/src/components/toastr/toastr.js
@@ -19,6 +19,7 @@ const FadeTransition = cssTransition({
 
 function show(message: string | React.Node | Array<string | React.Node>, notify: (string | React.Node) => void) {
   if (Array.isArray(message)) {
+    message = message.reduce((acc, val) => acc.concat(val), []);
     for (const msg of message) {
       notify(msg);
     }

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,5 @@
+- Flatten messages passed as array of array to toastr in order to make
+  them visible
 - Update help link URLs in the UI
 - Use volumes for VMs disks and allow attaching cdrom images
 - Compute the websockify URL on browser side (bsc#1149644)


### PR DESCRIPTION
## What does this PR change?

Toastr will silently ignore arrays of messages. Arrays of arrays must be flattened to make toastr behave correctly.

Arrays of array messages can be produced by the `info|success|warning|error` functions `components/messages.js`. This should be fixed. However this requires extensive testing and it should be better addressed after GM.


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: simple bugfix

- [x] **DONE**

## Test coverage
- No tests:  javascript bugfix. Will be tested indirectly by cucumber.

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
