### PR TITLE
for the base channel use generated metadata

### DIFF
--- a/backend/satellite_tools/repo_plugins/deb_src.py
+++ b/backend/satellite_tools/repo_plugins/deb_src.py
@@ -280,6 +280,10 @@ class ContentSource:
         # No susedata
         return []
 
+    def get_mediaproducts(self):
+        # No mediaproducts data
+        return None
+
     def list_packages(self, filters, latest):
         """ list packages"""
 

--- a/backend/satellite_tools/repo_plugins/yum_src.py
+++ b/backend/satellite_tools/repo_plugins/yum_src.py
@@ -964,6 +964,30 @@ type=rpm-md
             modules = self._retrieve_md_path('modules')
         return modules
 
+    def get_mediaproducts(self):
+        """
+        Return path to media.1/products file if available
+
+        :returns: str
+        """
+        media_products_path = os.path.join(self._get_repodata_path(), 'media.1/products')
+        try:
+            (s,b,p,q,f,o) = urlparse(self.url)
+            if p[-1] != '/':
+                p = p + '/'
+            p = p + 'media.1/products'
+        except (ValueError, IndexError, KeyError) as e:
+            return None
+        url = urlunparse((s,b,p,q,f,o))
+        try:
+            urlgrabber_opts = {}
+            self.set_download_parameters(urlgrabber_opts, url, media_products_path)
+            urlgrabber.urlgrab(url, media_products_path, **urlgrabber_opts)
+        except Exception as exc:
+            # no mirror list found continue without
+            return None
+        return media_products_path
+
     def raw_list_packages(self, filters=None):
         """
         Return a raw list of available packages.
@@ -1099,7 +1123,8 @@ type=rpm-md
             return False
 
     # Get download parameters for threaded downloader
-    def set_download_parameters(self, params, relative_path, target_file, checksum_type=None, checksum_value=None, bytes_range=None):
+    def set_download_parameters(self, params, relative_path, target_file, checksum_type=None,
+                                checksum_value=None, bytes_range=None):
         # Create directories if needed
         target_dir = os.path.dirname(target_file)
         if not os.path.exists(target_dir):

--- a/backend/satellite_tools/repo_plugins/yum_src.py
+++ b/backend/satellite_tools/repo_plugins/yum_src.py
@@ -984,7 +984,7 @@ type=rpm-md
             self.set_download_parameters(urlgrabber_opts, url, media_products_path)
             urlgrabber.urlgrab(url, media_products_path, **urlgrabber_opts)
         except Exception as exc:
-            # no mirror list found continue without
+            # no 'media.1/products' file found
             return None
         return media_products_path
 

--- a/backend/satellite_tools/reposync.py
+++ b/backend/satellite_tools/reposync.py
@@ -70,6 +70,7 @@ if '.' not in hostname:
 default_log_location = '/var/log/rhn/'
 relative_comps_dir = 'rhn/comps'
 relative_modules_dir = 'rhn/modules'
+relative_mediaproducts_dir = 'suse/media.1'
 checksum_cache_filename = 'reposync/checksum_cache'
 default_import_batch_size = 20
 
@@ -593,6 +594,8 @@ class RepoSync(object):
                         if not self.no_errata:
                             self.import_updates(plugin)
 
+                        self.import_mediaproducts(plugin)
+
                         # only for repos obtained from the DB
                         if self.sync_kickstart and data['repo_label']:
                             try:
@@ -767,7 +770,7 @@ class RepoSync(object):
         src.close()
         if old_checksum and old_checksum != getFileChecksum('sha256', abspath):
             self.regen = True
-        log(0, "*** NOTE: Importing comps file for the channel '%s'. Previous comps will be discarded." % (self.channel['label']))        
+        log(0, "*** NOTE: Importing {1} file for the channel '{0}'. Previous {1} will be discarded.".format(self.channel['label'], comps_type))
 
         repoDataKey = 'group' if comps_type == 'comps' else comps_type
         file_timestamp = os.path.getmtime(filename)
@@ -813,6 +816,11 @@ class RepoSync(object):
         modulesfile = plug.get_modules()
         if modulesfile:
             self.copy_metadata_file(plug, modulesfile, 'modules', relative_modules_dir)
+    def import_mediaproducts(self, plug):
+        mediaproducts = plug.get_mediaproducts()
+        if mediaproducts:
+            self.copy_metadata_file(plug, mediaproducts, 'mediaproducts', relative_mediaproducts_dir)
+
     def _populate_erratum(self, notice):
         patch_name = self._patch_naming(notice)
         existing_errata = self.get_errata(patch_name)

--- a/backend/satellite_tools/reposync.py
+++ b/backend/satellite_tools/reposync.py
@@ -816,6 +816,7 @@ class RepoSync(object):
         modulesfile = plug.get_modules()
         if modulesfile:
             self.copy_metadata_file(plug, modulesfile, 'modules', relative_modules_dir)
+
     def import_mediaproducts(self, plug):
         mediaproducts = plug.get_mediaproducts()
         if mediaproducts:

--- a/backend/satellite_tools/test/unit/test_reposync.py
+++ b/backend/satellite_tools/test/unit/test_reposync.py
@@ -689,6 +689,7 @@ class RepoSyncTest(unittest.TestCase):
         rs.import_products = Mock()
         rs.import_susedata = Mock()
         rs.import_groups = Mock()
+        rs.import_mediaproducts = Mock()
         rs.import_modules = Mock()
         self.reposync.taskomatic.add_to_repodata_queue_for_channel_package_subscription = Mock()
         self.reposync.taskomatic.add_to_erratacache_queue = Mock()
@@ -727,6 +728,7 @@ class SyncTest(unittest.TestCase):
             load_plugin=Mock(),
             import_packages=Mock(return_value=0),
             import_groups=Mock(),
+            import_mediaproducts=Mock(),
             import_modules=Mock(),
             import_updates=Mock(),
             import_products=Mock(),

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,6 @@
+- make media.1/products available for every channel. Needed for
+  autoinstallation of SLE15 SP2 (bsc#1173204)
+
 -------------------------------------------------------------------
 Tue Jun 23 17:20:14 CEST 2020 - jgonzalez@suse.com
 

--- a/java/code/src/com/redhat/rhn/domain/channel/Channel.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/channel/Channel.hbm.xml
@@ -76,6 +76,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         <one-to-one name="modules" property-ref="channel"
             class="com.redhat.rhn.domain.channel.Modules" cascade="all" lazy="proxy"/>
 
+        <one-to-one name="mediaProducts" property-ref="channel"
+            class="com.redhat.rhn.domain.channel.MediaProducts" cascade="all" lazy="proxy"/>
+
         <set name="trustedOrgs" lazy="true" table="rhnChannelTrust"
          cascade="save-update">
             <key column="channel_id"/>

--- a/java/code/src/com/redhat/rhn/domain/channel/Channel.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/Channel.java
@@ -77,6 +77,7 @@ public class Channel extends BaseDomainHelper implements Comparable<Channel> {
     private ProductName productName;
     private Comps comps;
     private Modules modules;
+    private MediaProducts mediaProducts;
     private String summary;
     private Set<Errata> erratas = new HashSet<Errata>();
     private Set<Package> packages = new HashSet<Package>();
@@ -230,6 +231,20 @@ public class Channel extends BaseDomainHelper implements Comparable<Channel> {
 
     public boolean isModular() {
         return modules != null;
+    }
+
+    /**
+     * @param mediaProductsIn The Media Products to set.
+     */
+    public void setMediaProducts(MediaProducts mediaProductsIn) {
+        this.mediaProducts = mediaProductsIn;
+    }
+
+    /**
+     * @return Returns the Modules.
+     */
+    public MediaProducts getMediaProducts() {
+        return mediaProducts;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/channel/MediaProducts.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/MediaProducts.java
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.domain.channel;
+
+/**
+ * MediaProducts
+ */
+public class MediaProducts extends RepoMetadata {
+
+}

--- a/java/code/src/com/redhat/rhn/domain/channel/RepoMetadata.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/channel/RepoMetadata.hbm.xml
@@ -36,6 +36,10 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
                      discriminator-value="2" lazy="true">
         </subclass>
 
+        <subclass
+                     name="com.redhat.rhn.domain.channel.MediaProducts"
+                     discriminator-value="3" lazy="true">
+        </subclass>
 
     </class>
 </hibernate-mapping>

--- a/java/code/src/com/redhat/rhn/frontend/action/common/DownloadFile.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/common/DownloadFile.java
@@ -628,6 +628,10 @@ public class DownloadFile extends DownloadAction {
                         Config.get().getString("repomd_path_prefix", "rhn/repodata/") + "/" +
                         StringUtils.join(split, '/');
                 }
+                else if (path.endsWith("/media.1/products") && tree.getChannel().getMediaProducts() != null) {
+                    diskPath = Config.get().getString(ConfigDefaults.MOUNT_POINT) +
+                        "/" + tree.getChannel().getMediaProducts().getRelativeFilename();
+                }
                 else {
                     diskPath = kickstartMount + "/" + tree.getBasePath() + path;
                 }

--- a/java/code/src/com/redhat/rhn/frontend/action/common/DownloadFile.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/common/DownloadFile.java
@@ -624,9 +624,9 @@ public class DownloadFile extends DownloadAction {
                     if (split[0].equals("repodata")) {
                         split[0] = tree.getChannel().getLabel();
                     }
-                    diskPath = "/var/cache/" +
-                        Config.get().getString("repomd_path_prefix", "rhn/repodata/") + "/" +
-                        StringUtils.join(split, '/');
+                    diskPath = Config.get().getString(ConfigDefaults.REPOMD_CACHE_MOUNT_POINT, "/pub") +
+                            File.separator + Config.get().getString("repomd_path_prefix", "rhn/repodata/") +
+                            File.separator + StringUtils.join(split, '/');
                 }
                 else if (path.endsWith("/media.1/products") && tree.getChannel().getMediaProducts() != null) {
                     diskPath = Config.get().getString(ConfigDefaults.MOUNT_POINT) +
@@ -649,9 +649,9 @@ public class DownloadFile extends DownloadAction {
                 if (split[0].equals("repodata")) {
                     split[0] = child.getLabel();
                 }
-                diskPath = "/var/cache/" +
-                    Config.get().getString("repomd_path_prefix", "rhn/repodata/") + "/" +
-                    StringUtils.join(split, '/');
+                diskPath = Config.get().getString(ConfigDefaults.REPOMD_CACHE_MOUNT_POINT, "/pub") +
+                        File.separator + Config.get().getString("repomd_path_prefix", "rhn/repodata/") +
+                        File.separator + StringUtils.join(split, File.separator);
             }
 
             if (log.isDebugEnabled()) {

--- a/java/code/src/com/redhat/rhn/frontend/action/common/DownloadFile.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/common/DownloadFile.java
@@ -619,7 +619,18 @@ public class DownloadFile extends DownloadAction {
             // my $dp = File::Spec->catfile($kickstart_mount, $tree->base_path, $path);
 
             if (child == null) {
-                diskPath = kickstartMount + "/" + tree.getBasePath() + path;
+                if (path.contains("repodata/") && tree.getKernelOptions().contains("useonlinerepo")) {
+                    String[] split = StringUtils.split(path, '/');
+                    if (split[0].equals("repodata")) {
+                        split[0] = tree.getChannel().getLabel();
+                    }
+                    diskPath = "/var/cache/" +
+                        Config.get().getString("repomd_path_prefix", "rhn/repodata/") + "/" +
+                        StringUtils.join(split, '/');
+                }
+                else {
+                    diskPath = kickstartMount + "/" + tree.getBasePath() + path;
+                }
             }
             else if (path.endsWith("/comps.xml")) {
                 diskPath = Config.get().getString(ConfigDefaults.MOUNT_POINT) +

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,6 @@
+- serve media.1/products when available (bsc#1173204)
+- use repo metadata of the synced base channel when kernel
+  option "useonlinerepo" is provided (bsc#1173204)
 - Fix recurring actions being displayed in Task Schedules list
 - Fix: handle corner case of deb pkg compare version (bsc#1173201)
 

--- a/schema/spacewalk/common/data/rhnCompsType.sql
+++ b/schema/spacewalk/common/data/rhnCompsType.sql
@@ -15,3 +15,4 @@
 
 INSERT INTO rhnCompsType (id, label) VALUES (1, 'comps');
 INSERT INTO rhnCompsType (id, label) VALUES (2, 'modules');
+INSERT INTO rhnCompsType (id, label) VALUES (3, 'mediaproducts');

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,4 +1,6 @@
+- add new comps type mediaproducts (bsc#1173204)
 - Fix: handle corner case of deb pkg compare version (bsc#1173201)
+
 -------------------------------------------------------------------
 Tue Jun 23 17:24:11 CEST 2020 - jgonzalez@suse.com
 

--- a/schema/spacewalk/upgrade/susemanager-schema-4.1.9-to-susemanager-schema-4.1.10/001-new-comps-type.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.1.9-to-susemanager-schema-4.1.10/001-new-comps-type.sql
@@ -1,0 +1,4 @@
+INSERT INTO rhnCompsType
+  SELECT 3, 'mediaproducts'
+   WHERE NOT EXISTS ( SELECT 1 FROM rhnCompsType WHERE label = 'mediaproducts');
+


### PR DESCRIPTION
## What does this PR change?

SLE 15 Online media has empty metadata. In this case the installer ask for an SCC registration.
Check for a kernel option `useonlinerepo` and switch to use the metadata from the mirrored repo for the ks/dist URL.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- https://github.com/SUSE/spacewalk/issues/11810

- [x] **DONE**

## Test coverage
- No tests: **autoinstallation can only be tested manual**

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
