### PR TITLE
Prevent deadlock on suseusernotification (bsc#1173073)

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/notification/UserNotificationFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/UserNotificationFactory.java
@@ -27,6 +27,7 @@ import com.suse.manager.webui.websocket.Notification;
 
 import org.apache.log4j.Logger;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -89,15 +90,6 @@ public class UserNotificationFactory extends HibernateFactory {
         if (!isNotificationTypeDisabled(userNotificationIn)) {
             singleton.saveObject(userNotificationIn);
         }
-    }
-
-    /**
-     * Remove {@link UserNotification} from the database.
-     *
-     * @param userNotificationIn userNotification
-     */
-    public static void remove(UserNotification userNotificationIn) {
-        singleton.removeObject(userNotificationIn);
     }
 
     /**
@@ -273,6 +265,16 @@ public class UserNotificationFactory extends HibernateFactory {
         Root<NotificationMessage> root = delete.from(NotificationMessage.class);
         delete.where(builder.lessThan(root.<Date>get("created"), before));
         return getSession().createQuery(delete).executeUpdate();
+    }
+
+    /**
+     * Deletes multiple notifications
+     *
+     * @param notifications the notifications to delete
+     * @return int number of deleted notifications
+     */
+    public static int delete(Collection<UserNotification> notifications) {
+        return delete(notifications, UserNotification.class);
     }
 
     @Override

--- a/java/code/src/com/redhat/rhn/domain/notification/test/NotificationFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/test/NotificationFactoryTest.java
@@ -15,6 +15,9 @@
 
 package com.redhat.rhn.domain.notification.test;
 
+import static java.util.Optional.empty;
+
+import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.notification.NotificationMessage;
 import com.redhat.rhn.domain.notification.UserNotification;
 import com.redhat.rhn.domain.notification.UserNotificationFactory;
@@ -26,8 +29,6 @@ import java.time.Instant;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
-
-import static java.util.Optional.empty;
 
 
 public class NotificationFactoryTest extends BaseTestCaseWithUser {
@@ -97,5 +98,37 @@ public class NotificationFactoryTest extends BaseTestCaseWithUser {
         result = UserNotificationFactory.deleteNotificationMessagesBefore(Date.from(Instant.now()));
         assertEquals(1, result);
         assertEquals(0, UserNotificationFactory.listAllNotificationMessages().size());
+    }
+
+    public final void testDeleteNotificationMessages() {
+        // Clean up all notifications that might be present
+        if (UserNotificationFactory.listAllNotificationMessages().size() > 0) {
+            UserNotificationFactory.deleteNotificationMessagesBefore(Date.from(Instant.now()));
+        }
+        assertEquals(0, UserNotificationFactory.listAllNotificationMessages().size());
+
+        // Create notifications
+        NotificationMessage msg = UserNotificationFactory.createNotificationMessage(new OnboardingFailed("minion1"));
+        UserNotificationFactory.storeNotificationMessageFor(msg, Collections.emptySet(), empty());
+
+        // There should be one present
+        assertEquals(1, UserNotificationFactory.listAllNotificationMessages().size());
+        List<UserNotification> unread = UserNotificationFactory.listUnreadByUser(user);
+        assertEquals(1, unread.size());
+
+        // Try deleting
+        int result = UserNotificationFactory.delete(unread);
+        assertEquals(1, result);
+
+        HibernateFactory.getSession().flush();
+
+        // Should be deleted
+        assertEquals(0, UserNotificationFactory.listUnreadByUser(user).size());
+
+        // Try deleting again
+        int resultAfter = UserNotificationFactory.delete(unread);
+
+        // Should not be deleted
+        assertEquals(0, resultAfter);
     }
 }

--- a/java/code/src/com/suse/manager/webui/controllers/NotificationMessageController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/NotificationMessageController.java
@@ -146,12 +146,12 @@ public class NotificationMessageController {
     public String delete(Request request, Response response, User user) {
         List<Long> messageIds = Json.GSON.fromJson(request.body(), new TypeToken<List<Long>>() { }.getType());
 
-        messageIds.forEach(messageId -> {
-                    Optional<UserNotification> un = UserNotificationFactory.lookupByUserAndMessageId(messageId, user);
-                    if (un.isPresent()) {
-                        UserNotificationFactory.remove(un.get());
-                    }
-                });
+        List<UserNotification> notifications = messageIds.stream()
+                .map(id -> UserNotificationFactory.lookupByUserAndMessageId(id, user))
+                .flatMap(Optional::stream)
+                .collect(Collectors.toList());
+
+        UserNotificationFactory.delete(notifications);
 
         Notification.spreadUpdate();
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- prevent deadlock on suseusernotification (bsc#1173073)
+
 -------------------------------------------------------------------
 Tue Jun 23 17:21:48 CEST 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

It changes the way multiple notifications are deleted from the UI (with one DELETE statement instead of several). That prevents a deadlock.

The order of locking of `suseusernotification` rows might have been different from the ordering taken by Taskomatic leading to deadlocks when users discarded notifications from the UI while Taskomatic cleanup is in progress.

Specifically, the following error would appear in logs:

```
ERROR:  deadlock detected
DETAIL:  Process 7024 waits for ShareLock on transaction 417908323; blocked by process 25919.
	Process 25919 waits for ShareLock on transaction 327822245; blocked by process 7024.
	Process 7024: delete from susenotificationmessage where created<$1
	Process 25919: delete from suseusernotification where id=$1
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**

- [c] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Fixes partially https://bugzilla.suse.com/show_bug.cgi?id=1173073
Tracks https://github.com/SUSE/spacewalk/pull/11790 (3.2) https://github.com/SUSE/spacewalk/pull/11791 (4.0)

- [x] **DONE**

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"  
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
