### PR TITLE
Install same version of rubocop as for SUSE Manager

### DIFF
--- a/.github/workflows/ruby-checkstyle.yml
+++ b/.github/workflows/ruby-checkstyle.yml
@@ -19,7 +19,7 @@ jobs:
         ruby-version: '2.5'
 
     - name: Install RuboCop
-      run: gem install rubocop
+      run: gem install rubocop -v 0.84.0
       
     - name: Run RuboCop
       run: |

--- a/testsuite/.rubocop_todo.yml
+++ b/testsuite/.rubocop_todo.yml
@@ -539,9 +539,6 @@ Style/RedundantInterpolation:
     - 'features/step_definitions/command_steps.rb'
     - 'features/step_definitions/common_steps.rb'
 
-Style/RedundantRegexpEscape:
-  Enabled: false
-  
 # Offense count: 2
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, AllowInnerSlashes.


### PR DESCRIPTION
## What does this PR change?

This PR specifies version of `rubocop` gem to install for github actions to `0.84`.

That way, we have same version as for pipelines in SUSE Manager.

What triggers this change is that latest version `0.86` of `rubocop` introduces a new cop named `Lint/ConstantResolution` that creates 377 failures.


## Links

No ports, uyuni only.


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
