### PR TITLE
Fix Combobox dropdown list being cutoff

### DIFF
--- a/branding/css/susemanager-theme.less
+++ b/branding/css/susemanager-theme.less
@@ -180,7 +180,6 @@ section {
     padding-right: 4em;
     padding-top: 0;
     padding-bottom: 4em;
-    overflow-y: auto!important;
     float: right;
   }
 }

--- a/branding/css/uyuni/uyuni-theme.less
+++ b/branding/css/uyuni/uyuni-theme.less
@@ -173,7 +173,6 @@ section {
     padding-right: 2em;
     padding-top: 0;
     padding-bottom: 2em;
-    overflow-y: auto!important;
     float: right;
   }
 }

--- a/branding/spacewalk-branding.changes
+++ b/branding/spacewalk-branding.changes
@@ -1,6 +1,7 @@
 -------------------------------------------------------------------
 Wed Jun 10 12:15:27 CEST 2020 - jgonzalez@suse.com
 
+- Fix combobox dropdown list being cut off if exceeding the section
 - version 4.1.5-1
 - Add cluster icon
 - Split branding style themes for Uyuni and SUSE Manager


### PR DESCRIPTION
## What does this PR change?

If a `Combobox` is close to the end of the page the dropdown list is cutoff if the length of the list exceeds the section. Removing `overflow-y: auto!important` from the sections css causes the section to adapt to the change of the pages length when opening the dropdown list.

## GUI diff

Before:
![section_fix_before](https://user-images.githubusercontent.com/31698054/85399281-da269d00-b556-11ea-8f5c-cabe5a3b79ae.png)

After:
![section_fix_after](https://user-images.githubusercontent.com/31698054/85399292-df83e780-b556-11ea-9700-ef798f9b928d.png)

- [x] **DONE**

## Documentation

- No documentation needed: Just a fix of unintended behavior

- [x] **DONE**

## Test coverage

- No tests: Just a fix of unintended behavior

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
