### PR TITLE
GPG Signature Verification of Release files (in Debian-like repos)

### DIFF
--- a/backend/satellite_tools/repo_plugins/deb_src.py
+++ b/backend/satellite_tools/repo_plugins/deb_src.py
@@ -81,7 +81,16 @@ class DebPackage:
 
 class DebRepo:
     # url example - http://ftp.debian.org/debian/dists/jessie/main/binary-amd64/
-    def __init__(self, url, cache_dir, pkg_dir, proxy_addr="", proxy_user="", proxy_pass=""):
+    def __init__(
+        self,
+        url,
+        cache_dir,
+        pkg_dir,
+        proxy_addr="",
+        proxy_user="",
+        proxy_pass="",
+        gpg_verify=True,
+    ):
         self.url = url
         parts = url.rsplit('/dists/', 1)
         self.base_url = [parts[0]]
@@ -93,6 +102,7 @@ class DebRepo:
         self.proxy = proxy_addr
         self.proxy_username = proxy_user
         self.proxy_password = proxy_pass
+        self.gpg_verify = gpg_verify
 
         self.basecachedir = cache_dir
         if not os.path.isdir(self.basecachedir):
@@ -108,8 +118,7 @@ class DebRepo:
 
         :return:
         """
-        # TODO: Signature verification is not yet implemented here.
-        if not repo.DpkgRepo(self.url, self._get_proxies()).verify_packages_index():
+        if not repo.DpkgRepo(self.url, self._get_proxies(), self.gpg_verify).verify_packages_index():
             raise repo.GeneralRepoException("Package index checksum failure")
 
     def _get_proxies(self):
@@ -257,7 +266,7 @@ class ContentSource:
 
         self.repo = DebRepo(url, os.path.join(CACHE_DIR, self.org, name),
                             os.path.join(CFG.MOUNT_POINT, CFG.PREPENDED_DIR, self.org, 'stage'),
-                            self.proxy_addr, self.proxy_user, self.proxy_pass)
+                            self.proxy_addr, self.proxy_user, self.proxy_pass, gpg_verify=not(insecure))
         self.repo.verify()
 
         self.num_packages = 0

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,4 +1,5 @@
 - Only check strongest available Ubuntu/Debian repository index checksum
+- Verify GPG signature of Ubuntu/Debian repository metadata (Release file)
 
 -------------------------------------------------------------------
 Wed Jun 10 12:14:57 CEST 2020 - jgonzalez@suse.com


### PR DESCRIPTION
## What does this PR change?

Add basic GPG signature verification of Release files. These files are used in repositories for Debian-like Linux distributions like Ubuntu or Debian.

## GUI diff

No difference.

## Documentation
- No documentation needed: The workflow for the user does not change, only internals.

## Test coverage
- Unit tests were added

## Links

Partially fixes SUSE/spacewalk#9882
Tracks # **add downstream PR, if any**


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
