### PR TITLE
Cucumber: fix salt-minion start/stop/restart for KVM and Xen

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1168,15 +1168,6 @@ When(/I refresh the "([^"]*)" storage pool of this "([^"]*)"/) do |pool, host|
   node.run("virsh pool-refresh #{pool}")
 end
 
-When(/^I reduce virtpoller run interval on "([^"]*)"$/) do |host|
-  node = get_target(host)
-  source = File.dirname(__FILE__) + '/../upload_files/susemanager-virtpoller.conf'
-  dest = "/etc/salt/minion.d/susemanager-virtpoller.conf"
-  return_code = file_inject(node, source, dest)
-  raise 'File injection failed' unless return_code.zero?
-  node.run("systemctl restart salt-minion")
-end
-
 # WORKAROUND
 # Work around issue https://github.com/SUSE/spacewalk/issues/10360
 # Remove as soon as the issue is fixed

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -29,19 +29,19 @@ end
 When(/^I stop salt-minion on "(.*?)"$/) do |minion|
   node = get_target(minion)
   node.run('rcsalt-minion stop', false) if minion == 'sle_minion'
-  node.run('systemctl stop salt-minion', false) if %w[ceos_minion ceos_ssh_minion ubuntu_minion ubuntu_ssh_minion].include?(minion)
+  node.run('systemctl stop salt-minion', false) if %w[ceos_minion ceos_ssh_minion ubuntu_minion ubuntu_ssh_minion kvm_server xen_server].include?(minion)
 end
 
 When(/^I start salt-minion on "(.*?)"$/) do |minion|
   node = get_target(minion)
   node.run('rcsalt-minion restart', false) if minion == 'sle_minion'
-  node.run('systemctl restart salt-minion', false) if %w[ceos_minion ceos_ssh_minion ubuntu_minion ubuntu_ssh_minion].include?(minion)
+  node.run('systemctl restart salt-minion', false) if %w[ceos_minion ceos_ssh_minion ubuntu_minion ubuntu_ssh_minion kvm_server xen_server].include?(minion)
 end
 
 When(/^I restart salt-minion on "(.*?)"$/) do |minion|
   node = get_target(minion)
   node.run('rcsalt-minion restart', false) if minion == 'sle_minion'
-  node.run('systemctl restart salt-minion', false) if %w[ceos_minion ceos_ssh_minion ubuntu_minion ubuntu_ssh_minion].include?(minion)
+  node.run('systemctl restart salt-minion', false) if %w[ceos_minion ceos_ssh_minion ubuntu_minion ubuntu_ssh_minion kvm_server xen_server].include?(minion)
 end
 
 When(/^I wait at most (\d+) seconds until Salt master sees "([^"]*)" as "([^"]*)"$/) do |key_timeout, minion, key_type|


### PR DESCRIPTION
## What does this PR change?

The salt-minion start, stop and restart steps are doing nothing for the
xen_server and kvm_server machines.

This fixes the current KVM cucumber test failures

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: testsuite fix

- [X] **DONE**

## Test coverage
- No tests: fixing tests

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
