### PR TITLE
Fix recurring actions shown in Task Schedules UI

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/tasko/ScheduleDetailAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/tasko/ScheduleDetailAction.java
@@ -211,6 +211,9 @@ public class ScheduleDetailAction extends RhnAction {
         List dropDown = new ArrayList();
         try {
             List<Map> bunches = new TaskomaticApi().listSatBunchSchedules(loggedInUser);
+            // Since recurring states have their own place in the webUI we don't
+            // want them to show up in the Task Schedules UI
+            bunches.removeIf(bunch -> bunch.get("name").equals("recurring-state-apply-bunch"));
 
             for (Map b : bunches) {
                 addOption(dropDown, (String)b.get("name"), (String)b.get("name"));

--- a/java/code/src/com/redhat/rhn/taskomatic/TaskoFactory.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/TaskoFactory.java
@@ -251,15 +251,22 @@ public class TaskoFactory extends HibernateFactory {
      * @return list of active schedules
      */
     public static List<TaskoSchedule> listActiveSchedulesByOrg(Integer orgId) {
+        List<TaskoSchedule> schedules;
+        List<String> filter = List.of("recurring-state-apply-bunch");    // List of bunch names to be excluded
         Map<String, Object> params = new HashMap<String, Object>();
+
         params.put("timestamp", new Date());    // use server time, not DB time
         if (orgId == null) {
-            return singleton.listObjectsByNamedQuery(
-                    "TaskoSchedule.listActiveInSat", params);
+            schedules = singleton.listObjectsByNamedQuery("TaskoSchedule.listActiveInSat", params);
         }
-        params.put("org_id", orgId);
-        return singleton.listObjectsByNamedQuery(
-               "TaskoSchedule.listActiveByOrg", params);
+        else {
+            params.put("org_id", orgId);
+            schedules = singleton.listObjectsByNamedQuery("TaskoSchedule.listActiveByOrg", params);
+        }
+
+        // Remove schedules with bunch names in 'filter'
+        schedules.removeIf(schedule -> filter.contains(schedule.getBunch().getName()));
+        return  schedules;
     }
 
     /**

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix recurring actions being displayed in Task Schedules list
 - Fix: handle corner case of deb pkg compare version (bsc#1173201)
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Since recurring actions have their own place in the webUI they where not
supposed to show up in the `Admin` -> `Task Schedules` list.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: Does not affect behavior described in the docs

- [x] **DONE**

## Test coverage

- No tests: Just restores intended recurring action functionality

- [x] **DONE**

## Links

Fixes: https://github.com/SUSE/spacewalk/issues/11581

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle" 
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
