### PR TITLE
Optimize Salt and DB calls in virtualization guests and pools pages

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/action/Action.java
+++ b/java/code/src/com/redhat/rhn/domain/action/Action.java
@@ -21,6 +21,8 @@ import com.redhat.rhn.domain.org.Org;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.user.User;
 
+import com.suse.manager.webui.websocket.WebSocketActionIdProvider;
+
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
@@ -34,7 +36,7 @@ import java.util.Set;
  * Action - Class representation of the table rhnAction.
  * @version $Rev$
  */
-public class Action extends BaseDomainHelper implements Serializable {
+public class Action extends BaseDomainHelper implements Serializable, WebSocketActionIdProvider {
 
     public static final Integer NAME_LENGTH_LIMIT = 128;
 
@@ -431,5 +433,10 @@ public class Action extends BaseDomainHelper implements Serializable {
      */
     public String getHistoryDetails(Server server, User currentUser) {
         return "";
+    }
+
+    @Override
+    public String getWebSocketActionId() {
+        return null;
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
@@ -50,22 +50,22 @@ import com.redhat.rhn.domain.action.scap.ScapAction;
 import com.redhat.rhn.domain.action.script.ScriptActionDetails;
 import com.redhat.rhn.domain.action.script.ScriptRunAction;
 import com.redhat.rhn.domain.action.server.ServerAction;
-import com.redhat.rhn.domain.action.virtualization.VirtualizationCreateAction;
-import com.redhat.rhn.domain.action.virtualization.VirtualizationDeleteAction;
-import com.redhat.rhn.domain.action.virtualization.VirtualizationDestroyAction;
+import com.redhat.rhn.domain.action.virtualization.VirtualizationCreateGuestAction;
+import com.redhat.rhn.domain.action.virtualization.VirtualizationDeleteGuestAction;
+import com.redhat.rhn.domain.action.virtualization.VirtualizationDestroyGuestAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationPoolCreateAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationPoolDeleteAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationPoolRefreshAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationPoolStartAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationPoolStopAction;
-import com.redhat.rhn.domain.action.virtualization.VirtualizationRebootAction;
-import com.redhat.rhn.domain.action.virtualization.VirtualizationResumeAction;
+import com.redhat.rhn.domain.action.virtualization.VirtualizationRebootGuestAction;
+import com.redhat.rhn.domain.action.virtualization.VirtualizationResumeGuestAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationSchedulePollerAction;
-import com.redhat.rhn.domain.action.virtualization.VirtualizationSetMemoryAction;
-import com.redhat.rhn.domain.action.virtualization.VirtualizationSetVcpusAction;
-import com.redhat.rhn.domain.action.virtualization.VirtualizationShutdownAction;
-import com.redhat.rhn.domain.action.virtualization.VirtualizationStartAction;
-import com.redhat.rhn.domain.action.virtualization.VirtualizationSuspendAction;
+import com.redhat.rhn.domain.action.virtualization.VirtualizationSetMemoryGuestAction;
+import com.redhat.rhn.domain.action.virtualization.VirtualizationSetVcpusGuestAction;
+import com.redhat.rhn.domain.action.virtualization.VirtualizationShutdownGuestAction;
+import com.redhat.rhn.domain.action.virtualization.VirtualizationStartGuestAction;
+import com.redhat.rhn.domain.action.virtualization.VirtualizationSuspendGuestAction;
 import com.redhat.rhn.domain.action.virtualization.BaseVirtualizationVolumeAction;
 import com.redhat.rhn.domain.config.ConfigRevision;
 import com.redhat.rhn.domain.org.Org;
@@ -406,31 +406,31 @@ public class ActionFactory extends HibernateFactory {
             retval = new DaemonConfigAction();
         }
         else if (typeIn.equals(TYPE_VIRTUALIZATION_SHUTDOWN)) {
-            retval = new VirtualizationShutdownAction();
+            retval = new VirtualizationShutdownGuestAction();
         }
         else if (typeIn.equals(TYPE_VIRTUALIZATION_START)) {
-            retval = new VirtualizationStartAction();
+            retval = new VirtualizationStartGuestAction();
         }
         else if (typeIn.equals(TYPE_VIRTUALIZATION_SUSPEND)) {
-            retval = new VirtualizationSuspendAction();
+            retval = new VirtualizationSuspendGuestAction();
         }
         else if (typeIn.equals(TYPE_VIRTUALIZATION_RESUME)) {
-            retval = new VirtualizationResumeAction();
+            retval = new VirtualizationResumeGuestAction();
         }
         else if (typeIn.equals(TYPE_VIRTUALIZATION_REBOOT)) {
-            retval = new VirtualizationRebootAction();
+            retval = new VirtualizationRebootGuestAction();
         }
         else if (typeIn.equals(TYPE_VIRTUALIZATION_DESTROY)) {
-            retval = new VirtualizationDestroyAction();
+            retval = new VirtualizationDestroyGuestAction();
         }
         else if (typeIn.equals(TYPE_VIRTUALIZATION_DELETE)) {
-            retval = new VirtualizationDeleteAction();
+            retval = new VirtualizationDeleteGuestAction();
         }
         else if (typeIn.equals(TYPE_VIRTUALIZATION_SET_MEMORY)) {
-            retval = new VirtualizationSetMemoryAction();
+            retval = new VirtualizationSetMemoryGuestAction();
         }
         else if (typeIn.equals(TYPE_VIRTUALIZATION_SET_VCPUS)) {
-            retval = new VirtualizationSetVcpusAction();
+            retval = new VirtualizationSetVcpusGuestAction();
         }
         else if (typeIn.equals(TYPE_VIRTUALIZATION_SCHEDULE_POLLER)) {
             retval = new VirtualizationSchedulePollerAction();
@@ -442,7 +442,7 @@ public class ActionFactory extends HibernateFactory {
             retval = new KickstartGuestToolsChannelSubscriptionAction();
         }
         else if (typeIn.equals(TYPE_VIRTUALIZATION_CREATE)) {
-            retval = new VirtualizationCreateAction();
+            retval = new VirtualizationCreateGuestAction();
         }
         else if (typeIn.equals(TYPE_VIRTUALIZATION_POOL_REFRESH)) {
             retval = new VirtualizationPoolRefreshAction();

--- a/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
@@ -245,7 +245,7 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
           </subclass>
         </subclass>
 
-        <subclass name="com.redhat.rhn.domain.action.virtualization.VirtualizationShutdownAction"
+        <subclass name="com.redhat.rhn.domain.action.virtualization.VirtualizationShutdownGuestAction"
                 discriminator-value="36" lazy="true">
           <join table="rhnActionVirtShutdown">
             <key column="action_id"/>
@@ -254,7 +254,7 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
           </join>
         </subclass>
 
-        <subclass name="com.redhat.rhn.domain.action.virtualization.VirtualizationStartAction"
+        <subclass name="com.redhat.rhn.domain.action.virtualization.VirtualizationStartGuestAction"
                 discriminator-value="37" lazy="true">
           <join table="rhnActionVirtStart">
             <key column="action_id"/>
@@ -262,7 +262,7 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
           </join>
         </subclass>
 
-        <subclass name="com.redhat.rhn.domain.action.virtualization.VirtualizationSuspendAction"
+        <subclass name="com.redhat.rhn.domain.action.virtualization.VirtualizationSuspendGuestAction"
                 discriminator-value="38" lazy="true">
           <join table="rhnActionVirtSuspend">
             <key column="action_id"/>
@@ -270,7 +270,7 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
           </join>
         </subclass>
 
-        <subclass name="com.redhat.rhn.domain.action.virtualization.VirtualizationResumeAction"
+        <subclass name="com.redhat.rhn.domain.action.virtualization.VirtualizationResumeGuestAction"
                 discriminator-value="39" lazy="true">
           <join table="rhnActionVirtResume">
             <key column="action_id"/>
@@ -278,7 +278,7 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
           </join>
         </subclass>
 
-        <subclass name="com.redhat.rhn.domain.action.virtualization.VirtualizationRebootAction"
+        <subclass name="com.redhat.rhn.domain.action.virtualization.VirtualizationRebootGuestAction"
                 discriminator-value="40" lazy="true">
           <join table="rhnActionVirtReboot">
             <key column="action_id"/>
@@ -287,7 +287,7 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
           </join>
         </subclass>
 
-        <subclass name="com.redhat.rhn.domain.action.virtualization.VirtualizationDestroyAction"
+        <subclass name="com.redhat.rhn.domain.action.virtualization.VirtualizationDestroyGuestAction"
                 discriminator-value="41" lazy="true">
           <join table="rhnActionVirtDestroy">
             <key column="action_id"/>
@@ -295,7 +295,7 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
           </join>
         </subclass>
 
-        <subclass name="com.redhat.rhn.domain.action.virtualization.VirtualizationSetMemoryAction"
+        <subclass name="com.redhat.rhn.domain.action.virtualization.VirtualizationSetMemoryGuestAction"
                 discriminator-value="42" lazy="true">
           <join table="rhnActionVirtSetMemory">
             <key column="action_id"/>
@@ -304,7 +304,7 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
           </join>
         </subclass>
 
-        <subclass name="com.redhat.rhn.domain.action.virtualization.VirtualizationSetVcpusAction"
+        <subclass name="com.redhat.rhn.domain.action.virtualization.VirtualizationSetVcpusGuestAction"
                 discriminator-value="48" lazy="true">
           <join table="rhnActionVirtVcpu">
             <key column="action_id"/>
@@ -340,7 +340,7 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
                   discriminator-value="51" lazy="true">
         </subclass>
 
-        <subclass name="com.redhat.rhn.domain.action.virtualization.VirtualizationDeleteAction"
+        <subclass name="com.redhat.rhn.domain.action.virtualization.VirtualizationDeleteGuestAction"
                 discriminator-value="507" lazy="true">
           <join table="rhnActionVirtDelete">
             <key column="action_id"/>
@@ -348,7 +348,7 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
           </join>
         </subclass>
 
-        <subclass name="com.redhat.rhn.domain.action.virtualization.VirtualizationCreateAction"
+        <subclass name="com.redhat.rhn.domain.action.virtualization.VirtualizationCreateGuestAction"
                 discriminator-value="508" lazy="true">
           <list name="disks" lazy="true" cascade="save-update">
               <key column="action_id"/>

--- a/java/code/src/com/redhat/rhn/domain/action/test/ActionFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/action/test/ActionFactoryTest.java
@@ -37,9 +37,9 @@ import com.redhat.rhn.domain.action.script.ScriptActionDetails;
 import com.redhat.rhn.domain.action.script.ScriptRunAction;
 import com.redhat.rhn.domain.action.server.ServerAction;
 import com.redhat.rhn.domain.action.server.test.ServerActionTest;
-import com.redhat.rhn.domain.action.virtualization.BaseVirtualizationAction;
-import com.redhat.rhn.domain.action.virtualization.VirtualizationSetMemoryAction;
-import com.redhat.rhn.domain.action.virtualization.VirtualizationSetVcpusAction;
+import com.redhat.rhn.domain.action.virtualization.BaseVirtualizationGuestAction;
+import com.redhat.rhn.domain.action.virtualization.VirtualizationSetMemoryGuestAction;
+import com.redhat.rhn.domain.action.virtualization.VirtualizationSetVcpusGuestAction;
 import com.redhat.rhn.domain.config.ConfigFileName;
 import com.redhat.rhn.domain.config.ConfigRevision;
 import com.redhat.rhn.domain.config.ConfigurationFactory;
@@ -516,16 +516,16 @@ public class ActionFactoryTest extends RhnBaseTestCase {
                  type.equals(ActionFactory.TYPE_VIRTUALIZATION_SHUTDOWN) ||
                  type.equals(ActionFactory.TYPE_VIRTUALIZATION_START) ||
                  type.equals(ActionFactory.TYPE_VIRTUALIZATION_SUSPEND)) {
-            BaseVirtualizationAction va = (BaseVirtualizationAction)newA;
+            BaseVirtualizationGuestAction va = (BaseVirtualizationGuestAction)newA;
             va.setUuid("testuuid");
         }
         else if (type.equals(ActionFactory.TYPE_VIRTUALIZATION_SET_MEMORY)) {
-           VirtualizationSetMemoryAction va = (VirtualizationSetMemoryAction)newA;
+           VirtualizationSetMemoryGuestAction va = (VirtualizationSetMemoryGuestAction)newA;
            va.setUuid("testuuid");
            va.setMemory(1234);
         }
         else if (type.equals(ActionFactory.TYPE_VIRTUALIZATION_SET_VCPUS)) {
-            VirtualizationSetVcpusAction va = (VirtualizationSetVcpusAction)newA;
+            VirtualizationSetVcpusGuestAction va = (VirtualizationSetVcpusGuestAction)newA;
             va.setUuid("testuuid");
             va.setVcpu(12);
         }

--- a/java/code/src/com/redhat/rhn/domain/action/virtualization/BaseVirtualizationGuestAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/virtualization/BaseVirtualizationGuestAction.java
@@ -14,6 +14,7 @@
  */
 package com.redhat.rhn.domain.action.virtualization;
 
+
 import com.redhat.rhn.domain.action.Action;
 
 import java.util.Map;
@@ -54,4 +55,12 @@ public abstract class BaseVirtualizationGuestAction extends Action {
         // therefore does nothing.
     }
 
+    @Override
+    public String getWebSocketActionId() {
+        String id = "new-" + getId();
+        if (uuid != null) {
+            id = uuid;
+        }
+        return id;
+    }
 }

--- a/java/code/src/com/redhat/rhn/domain/action/virtualization/BaseVirtualizationGuestAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/virtualization/BaseVirtualizationGuestAction.java
@@ -14,43 +14,44 @@
  */
 package com.redhat.rhn.domain.action.virtualization;
 
+import com.redhat.rhn.domain.action.Action;
+
 import java.util.Map;
 
 /**
- * VirtualizationSetVcpusAction - Class representing TYPE_VIRTUALIZATION_SET_VCPUS
- * @version $Rev$
+ * Base class representing virtualization actions
  */
-public class VirtualizationSetVcpusAction extends BaseVirtualizationAction {
+public abstract class BaseVirtualizationGuestAction extends Action {
 
-    public static final String SET_CPU_STRING = "setVcpu";
+    public static final String FORCE_STRING = "force";
 
-    private Integer vcpu;
+    private String uuid;
 
     /**
-     * Set the vcpus to be appied to the guest.
-     * @param vcpuIn New setting for guest vcpus.
+     * Getter for uuid
+     * @return String to get
      */
-    public void setVcpu(Integer vcpuIn) {
-        vcpu = vcpuIn;
+    public String getUuid() {
+        return this.uuid;
     }
 
     /**
-     * Guest the guest vcpus.
-     * @return The guest vcpu setting.
+     * Setter for uuid
+     * @param stringIn String to set uuid to
      */
-    public Integer getVcpu() {
-        return vcpu;
+    public void setUuid(String stringIn) {
+        this.uuid = stringIn;
     }
 
     /**
-     * {@inheritDoc}
+     * Extract any required parameters from the provided context and call the
+     * appropriate setters.
+     *
+     * @param context Map of strings
      */
     public void extractParameters(Map context) {
-        if (context.containsKey(VirtualizationSetVcpusAction.SET_CPU_STRING)) {
-            setVcpu(Integer.valueOf((String)context.get(
-                    VirtualizationSetVcpusAction.SET_CPU_STRING)));
-        }
+        // Most virtualization actions require no parameters, default implementation
+        // therefore does nothing.
     }
 
 }
-

--- a/java/code/src/com/redhat/rhn/domain/action/virtualization/BaseVirtualizationPoolAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/virtualization/BaseVirtualizationPoolAction.java
@@ -36,4 +36,9 @@ public class BaseVirtualizationPoolAction extends Action {
     public void setPoolName(String poolNameIn) {
         poolName = poolNameIn;
     }
+
+    @Override
+    public String getWebSocketActionId() {
+        return String.format("pool-%s", getPoolName());
+    }
 }

--- a/java/code/src/com/redhat/rhn/domain/action/virtualization/VirtualizationCreateActionDiskDetails.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/virtualization/VirtualizationCreateActionDiskDetails.hbm.xml
@@ -22,7 +22,7 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         <property name="format" type="string" column="format"/>
 
         <many-to-one name="action" column="action_id"
-                class="com.redhat.rhn.domain.action.virtualization.VirtualizationCreateAction"
+                class="com.redhat.rhn.domain.action.virtualization.VirtualizationCreateGuestAction"
                 not-null="true" insert="true" update="false" />
 
     </class>

--- a/java/code/src/com/redhat/rhn/domain/action/virtualization/VirtualizationCreateActionDiskDetails.java
+++ b/java/code/src/com/redhat/rhn/domain/action/virtualization/VirtualizationCreateActionDiskDetails.java
@@ -22,7 +22,7 @@ import java.util.Objects;
 public class VirtualizationCreateActionDiskDetails {
 
     private Long id;
-    private VirtualizationCreateAction action;
+    private VirtualizationCreateGuestAction action;
     private String device;
     private String template;
     private long size = 0;
@@ -62,14 +62,14 @@ public class VirtualizationCreateActionDiskDetails {
     /**
      * @return the associated virtualization create action details
      */
-    public VirtualizationCreateAction getAction() {
+    public VirtualizationCreateGuestAction getAction() {
         return action;
     }
 
     /**
      * @param actionIn the associated virtualization create action details
      */
-    public void setAction(VirtualizationCreateAction actionIn) {
+    public void setAction(VirtualizationCreateGuestAction actionIn) {
         action = actionIn;
     }
 

--- a/java/code/src/com/redhat/rhn/domain/action/virtualization/VirtualizationCreateActionInterfaceDetails.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/virtualization/VirtualizationCreateActionInterfaceDetails.hbm.xml
@@ -18,7 +18,7 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         <property name="mac" type="string" column="mac"/>
 
         <many-to-one name="action" column="action_id"
-                class="com.redhat.rhn.domain.action.virtualization.VirtualizationCreateAction"
+                class="com.redhat.rhn.domain.action.virtualization.VirtualizationCreateGuestAction"
                 not-null="true" insert="true" update="false" />
 
     </class>

--- a/java/code/src/com/redhat/rhn/domain/action/virtualization/VirtualizationCreateActionInterfaceDetails.java
+++ b/java/code/src/com/redhat/rhn/domain/action/virtualization/VirtualizationCreateActionInterfaceDetails.java
@@ -22,7 +22,7 @@ import java.util.Objects;
 public class VirtualizationCreateActionInterfaceDetails {
 
     private Long id;
-    private VirtualizationCreateAction action;
+    private VirtualizationCreateGuestAction action;
     private String type;
     private String source;
     private String mac;
@@ -44,14 +44,14 @@ public class VirtualizationCreateActionInterfaceDetails {
     /**
      * @return the associated virtualization create action details
      */
-    public VirtualizationCreateAction getAction() {
+    public VirtualizationCreateGuestAction getAction() {
         return action;
     }
 
     /**
      * @param actionIn the associated virtualization create action details
      */
-    public void setAction(VirtualizationCreateAction actionIn) {
+    public void setAction(VirtualizationCreateGuestAction actionIn) {
         action = actionIn;
     }
 

--- a/java/code/src/com/redhat/rhn/domain/action/virtualization/VirtualizationCreateGuestAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/virtualization/VirtualizationCreateGuestAction.java
@@ -19,10 +19,9 @@ import java.util.Map;
 import java.util.Objects;
 
 /**
- *
- * VirtualizationCreateAction - Class representing TYPE_VIRTUALIZATION_CREATE
+ * CreateAction - Class representing TYPE_VIRTUALIZATION_CREATE
  */
-public class VirtualizationCreateAction extends BaseVirtualizationAction {
+public class VirtualizationCreateGuestAction extends BaseVirtualizationGuestAction {
 
     private static final long serialVersionUID = 5911199267745279497L;
     public static final String TYPE = "type";
@@ -261,8 +260,8 @@ public class VirtualizationCreateAction extends BaseVirtualizationAction {
     @Override
     public boolean equals(Object other) {
         boolean result = false;
-        if (other instanceof VirtualizationCreateAction) {
-            VirtualizationCreateAction otherAction = (VirtualizationCreateAction)other;
+        if (other instanceof VirtualizationCreateGuestAction) {
+            VirtualizationCreateGuestAction otherAction = (VirtualizationCreateGuestAction)other;
             result = Objects.equals(getType(), otherAction.getType()) &&
                     Objects.equals(getGuestName(), otherAction.getGuestName()) &&
                     Objects.equals(getOsType(), otherAction.getOsType()) &&

--- a/java/code/src/com/redhat/rhn/domain/action/virtualization/VirtualizationDeleteGuestAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/virtualization/VirtualizationDeleteGuestAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2009--2010 Red Hat, Inc.
+ * Copyright (c) 2018 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -15,9 +15,8 @@
 package com.redhat.rhn.domain.action.virtualization;
 
 /**
- * VirtualizationDestroyAction - Class representing TYPE_VIRTUALIZATION_DESTROY
- * @version $Rev$
+ * Class representing TYPE_VIRTUALIZATION_DELETE
  */
-public class VirtualizationDestroyAction extends BaseVirtualizationAction {
+public class VirtualizationDeleteGuestAction extends BaseVirtualizationGuestAction {
 
 }

--- a/java/code/src/com/redhat/rhn/domain/action/virtualization/VirtualizationDestroyGuestAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/virtualization/VirtualizationDestroyGuestAction.java
@@ -15,9 +15,8 @@
 package com.redhat.rhn.domain.action.virtualization;
 
 /**
- * VirtualizationResumeAction - Class representing TYPE_VIRTUALIZATION_RESUME
- * @version $Rev$
+ * Class representing TYPE_VIRTUALIZATION_DESTROY
  */
-public class VirtualizationResumeAction extends BaseVirtualizationAction {
+public class VirtualizationDestroyGuestAction extends BaseVirtualizationGuestAction {
 
 }

--- a/java/code/src/com/redhat/rhn/domain/action/virtualization/VirtualizationPoolCreateAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/virtualization/VirtualizationPoolCreateAction.java
@@ -189,4 +189,13 @@ public class VirtualizationPoolCreateAction extends BaseVirtualizationPoolAction
             source = null;
         }
     }
+
+    @Override
+    public String getWebSocketActionId() {
+        String id = super.getWebSocketActionId();
+        if (getUuid() == null) {
+            id = String.format("new-%s", getId());
+        }
+        return id;
+    }
 }

--- a/java/code/src/com/redhat/rhn/domain/action/virtualization/VirtualizationRebootGuestAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/virtualization/VirtualizationRebootGuestAction.java
@@ -17,10 +17,9 @@ package com.redhat.rhn.domain.action.virtualization;
 import java.util.Map;
 
 /**
- * VirtualizationShutdownAction - Class representing TYPE_VIRTUALIZATION_SHUTDOWN
- * @version $Rev$
+ * Class representing TYPE_VIRTUALIZATION_REBOOT
  */
-public class VirtualizationShutdownAction extends BaseVirtualizationAction {
+public class VirtualizationRebootGuestAction extends BaseVirtualizationGuestAction {
 
     private boolean force = false;
 
@@ -42,9 +41,9 @@ public class VirtualizationShutdownAction extends BaseVirtualizationAction {
      * {@inheritDoc}
      */
     public void extractParameters(Map context) {
-        if (context.containsKey(BaseVirtualizationAction.FORCE_STRING)) {
+        if (context.containsKey(BaseVirtualizationGuestAction.FORCE_STRING)) {
             setForce(Boolean.valueOf((String)context.get(
-                    BaseVirtualizationAction.FORCE_STRING)));
+                    BaseVirtualizationGuestAction.FORCE_STRING)));
         }
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/action/virtualization/VirtualizationResumeGuestAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/virtualization/VirtualizationResumeGuestAction.java
@@ -15,9 +15,8 @@
 package com.redhat.rhn.domain.action.virtualization;
 
 /**
- * VirtualizationSuspendAction - Class representing TYPE_VIRTUALIZATION_SUSPEND
- * @version $Rev$
+ * Class representing TYPE_VIRTUALIZATION_RESUME
  */
-public class VirtualizationSuspendAction extends BaseVirtualizationAction {
+public class VirtualizationResumeGuestAction extends BaseVirtualizationGuestAction {
 
 }

--- a/java/code/src/com/redhat/rhn/domain/action/virtualization/VirtualizationSetMemoryGuestAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/virtualization/VirtualizationSetMemoryGuestAction.java
@@ -17,12 +17,10 @@ package com.redhat.rhn.domain.action.virtualization;
 import java.util.Map;
 
 /**
- * VirtualizationSetMemoryAction - Class representing TYPE_VIRTUALIZATION_SET_MEMORY.
+ * Class representing TYPE_VIRTUALIZATION_SET_MEMORY.
  * Make sure the 'memory' field is in kilobytes.
- *
- * @version $Rev$
  */
-public class VirtualizationSetMemoryAction extends BaseVirtualizationAction {
+public class VirtualizationSetMemoryGuestAction extends BaseVirtualizationGuestAction {
 
     public static final String SET_MEMORY_STRING = "setMemory";
 
@@ -48,9 +46,9 @@ public class VirtualizationSetMemoryAction extends BaseVirtualizationAction {
      * {@inheritDoc}
      */
     public void extractParameters(Map context) {
-        if (context.containsKey(VirtualizationSetMemoryAction.SET_MEMORY_STRING)) {
+        if (context.containsKey(VirtualizationSetMemoryGuestAction.SET_MEMORY_STRING)) {
             setMemory(Integer.valueOf((String)context.get(
-                    VirtualizationSetMemoryAction.SET_MEMORY_STRING)));
+                    VirtualizationSetMemoryGuestAction.SET_MEMORY_STRING)));
         }
     }
 

--- a/java/code/src/com/redhat/rhn/domain/action/virtualization/VirtualizationSetVcpusGuestAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/virtualization/VirtualizationSetVcpusGuestAction.java
@@ -14,45 +14,42 @@
  */
 package com.redhat.rhn.domain.action.virtualization;
 
-import com.redhat.rhn.domain.action.Action;
-
 import java.util.Map;
 
 /**
- * BaseVirtualizationAction - Base class representing virtualization actions
- * @version $Rev$
+ * Class representing TYPE_VIRTUALIZATION_SET_VCPUS
  */
-public abstract class BaseVirtualizationAction extends Action {
+public class VirtualizationSetVcpusGuestAction extends BaseVirtualizationGuestAction {
 
-    public static final String FORCE_STRING = "force";
+    public static final String SET_CPU_STRING = "setVcpu";
 
-    private String uuid;
+    private Integer vcpu;
 
     /**
-     * Getter for uuid
-     * @return String to get
+     * Set the vcpus to be appied to the guest.
+     * @param vcpuIn New setting for guest vcpus.
      */
-    public String getUuid() {
-        return this.uuid;
+    public void setVcpu(Integer vcpuIn) {
+        vcpu = vcpuIn;
     }
 
     /**
-     * Setter for uuid
-     * @param stringIn String to set uuid to
+     * Guest the guest vcpus.
+     * @return The guest vcpu setting.
      */
-    public void setUuid(String stringIn) {
-        this.uuid = stringIn;
+    public Integer getVcpu() {
+        return vcpu;
     }
 
     /**
-     * Extract any required parameters from the provided context and call the
-     * appropriate setters.
-     *
-     * @param context Map of strings
+     * {@inheritDoc}
      */
     public void extractParameters(Map context) {
-        // Most virtualization actions require no parameters, default implementation
-        // therefore does nothing.
+        if (context.containsKey(VirtualizationSetVcpusGuestAction.SET_CPU_STRING)) {
+            setVcpu(Integer.valueOf((String)context.get(
+                    VirtualizationSetVcpusGuestAction.SET_CPU_STRING)));
+        }
     }
 
 }
+

--- a/java/code/src/com/redhat/rhn/domain/action/virtualization/VirtualizationShutdownGuestAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/virtualization/VirtualizationShutdownGuestAction.java
@@ -17,10 +17,9 @@ package com.redhat.rhn.domain.action.virtualization;
 import java.util.Map;
 
 /**
- * VirtualizationRebootAction - Class representing TYPE_VIRTUALIZATION_REBOOT
- * @version $Rev$
+ * Class representing TYPE_VIRTUALIZATION_SHUTDOWN
  */
-public class VirtualizationRebootAction extends BaseVirtualizationAction {
+public class VirtualizationShutdownGuestAction extends BaseVirtualizationGuestAction {
 
     private boolean force = false;
 
@@ -42,9 +41,9 @@ public class VirtualizationRebootAction extends BaseVirtualizationAction {
      * {@inheritDoc}
      */
     public void extractParameters(Map context) {
-        if (context.containsKey(BaseVirtualizationAction.FORCE_STRING)) {
+        if (context.containsKey(BaseVirtualizationGuestAction.FORCE_STRING)) {
             setForce(Boolean.valueOf((String)context.get(
-                    BaseVirtualizationAction.FORCE_STRING)));
+                    BaseVirtualizationGuestAction.FORCE_STRING)));
         }
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/action/virtualization/VirtualizationStartGuestAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/virtualization/VirtualizationStartGuestAction.java
@@ -15,9 +15,8 @@
 package com.redhat.rhn.domain.action.virtualization;
 
 /**
- * VirtualizationStartAction - Class representing TYPE_VIRTUALIZATION_SHUTDOWN
- * @version $Rev$
+ * Class representing TYPE_VIRTUALIZATION_SHUTDOWN
  */
-public class VirtualizationStartAction extends BaseVirtualizationAction {
+public class VirtualizationStartGuestAction extends BaseVirtualizationGuestAction {
 
 }

--- a/java/code/src/com/redhat/rhn/domain/action/virtualization/VirtualizationSuspendGuestAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/virtualization/VirtualizationSuspendGuestAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2018 SUSE LLC
+ * Copyright (c) 2009--2010 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -15,8 +15,8 @@
 package com.redhat.rhn.domain.action.virtualization;
 
 /**
- * VirtualizationDeleteAction - Class representing TYPE_VIRTUALIZATION_DELETE
+ * Class representing TYPE_VIRTUALIZATION_SUSPEND
  */
-public class VirtualizationDeleteAction extends BaseVirtualizationAction {
+public class VirtualizationSuspendGuestAction extends BaseVirtualizationGuestAction {
 
 }

--- a/java/code/src/com/redhat/rhn/domain/action/virtualization/test/VirtualizationActionsTest.java
+++ b/java/code/src/com/redhat/rhn/domain/action/virtualization/test/VirtualizationActionsTest.java
@@ -18,22 +18,22 @@ import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionFactory;
 import com.redhat.rhn.domain.action.ActionType;
 import com.redhat.rhn.domain.action.test.ActionFactoryTest;
-import com.redhat.rhn.domain.action.virtualization.BaseVirtualizationAction;
-import com.redhat.rhn.domain.action.virtualization.VirtualizationCreateAction;
+import com.redhat.rhn.domain.action.virtualization.BaseVirtualizationGuestAction;
+import com.redhat.rhn.domain.action.virtualization.VirtualizationCreateGuestAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationCreateActionDiskDetails;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationCreateActionInterfaceDetails;
-import com.redhat.rhn.domain.action.virtualization.VirtualizationDeleteAction;
+import com.redhat.rhn.domain.action.virtualization.VirtualizationDeleteGuestAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationGuestPackageInstall;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationHostPackageInstall;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationPoolCreateAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationPoolCreateActionSource;
-import com.redhat.rhn.domain.action.virtualization.VirtualizationRebootAction;
-import com.redhat.rhn.domain.action.virtualization.VirtualizationResumeAction;
-import com.redhat.rhn.domain.action.virtualization.VirtualizationSetMemoryAction;
-import com.redhat.rhn.domain.action.virtualization.VirtualizationSetVcpusAction;
-import com.redhat.rhn.domain.action.virtualization.VirtualizationShutdownAction;
-import com.redhat.rhn.domain.action.virtualization.VirtualizationStartAction;
-import com.redhat.rhn.domain.action.virtualization.VirtualizationSuspendAction;
+import com.redhat.rhn.domain.action.virtualization.VirtualizationRebootGuestAction;
+import com.redhat.rhn.domain.action.virtualization.VirtualizationResumeGuestAction;
+import com.redhat.rhn.domain.action.virtualization.VirtualizationSetMemoryGuestAction;
+import com.redhat.rhn.domain.action.virtualization.VirtualizationSetVcpusGuestAction;
+import com.redhat.rhn.domain.action.virtualization.VirtualizationShutdownGuestAction;
+import com.redhat.rhn.domain.action.virtualization.VirtualizationStartGuestAction;
+import com.redhat.rhn.domain.action.virtualization.VirtualizationSuspendGuestAction;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
 
 import com.suse.manager.virtualization.PoolSourceAuthentication;
@@ -71,15 +71,15 @@ public class VirtualizationActionsTest extends BaseTestCaseWithUser {
     }
 
     public void testDomainLifecycleActions() throws Exception {
-        HashMap<ActionType, Class<? extends BaseVirtualizationAction>> types = new HashMap<>();
-        types.put(ActionFactory.TYPE_VIRTUALIZATION_DELETE, VirtualizationDeleteAction.class);
-        types.put(ActionFactory.TYPE_VIRTUALIZATION_REBOOT, VirtualizationRebootAction.class);
-        types.put(ActionFactory.TYPE_VIRTUALIZATION_RESUME, VirtualizationResumeAction.class);
-        types.put(ActionFactory.TYPE_VIRTUALIZATION_SHUTDOWN, VirtualizationShutdownAction.class);
-        types.put(ActionFactory.TYPE_VIRTUALIZATION_START, VirtualizationStartAction.class);
-        types.put(ActionFactory.TYPE_VIRTUALIZATION_SUSPEND, VirtualizationSuspendAction.class);
+        HashMap<ActionType, Class<? extends BaseVirtualizationGuestAction>> types = new HashMap<>();
+        types.put(ActionFactory.TYPE_VIRTUALIZATION_DELETE, VirtualizationDeleteGuestAction.class);
+        types.put(ActionFactory.TYPE_VIRTUALIZATION_REBOOT, VirtualizationRebootGuestAction.class);
+        types.put(ActionFactory.TYPE_VIRTUALIZATION_RESUME, VirtualizationResumeGuestAction.class);
+        types.put(ActionFactory.TYPE_VIRTUALIZATION_SHUTDOWN, VirtualizationShutdownGuestAction.class);
+        types.put(ActionFactory.TYPE_VIRTUALIZATION_START, VirtualizationStartGuestAction.class);
+        types.put(ActionFactory.TYPE_VIRTUALIZATION_SUSPEND, VirtualizationSuspendGuestAction.class);
 
-        for (Entry<ActionType, Class<? extends BaseVirtualizationAction>> entry : types.entrySet()) {
+        for (Entry<ActionType, Class<? extends BaseVirtualizationGuestAction>> entry : types.entrySet()) {
             Action a = ActionFactoryTest.createAction(user, entry.getKey());
             flushAndEvict(a);
 
@@ -92,29 +92,29 @@ public class VirtualizationActionsTest extends BaseTestCaseWithUser {
 
     public void testDomainForceoff() throws Exception {
         Action a = ActionFactoryTest.createAction(user, ActionFactory.TYPE_VIRTUALIZATION_SHUTDOWN);
-        VirtualizationShutdownAction va = (VirtualizationShutdownAction)a;
+        VirtualizationShutdownGuestAction va = (VirtualizationShutdownGuestAction)a;
         va.setForce(true);
         flushAndEvict(va);
 
         Action a1 = ActionFactory.lookupById(a.getId());
         assertNotNull(a1);
 
-        assertTrue(a1 instanceof VirtualizationShutdownAction);
-        VirtualizationShutdownAction rebootAction = (VirtualizationShutdownAction)a1;
+        assertTrue(a1 instanceof VirtualizationShutdownGuestAction);
+        VirtualizationShutdownGuestAction rebootAction = (VirtualizationShutdownGuestAction)a1;
         assertTrue(rebootAction.isForce());
     }
 
     public void testDomainReset() throws Exception {
         Action a = ActionFactoryTest.createAction(user, ActionFactory.TYPE_VIRTUALIZATION_REBOOT);
-        VirtualizationRebootAction va = (VirtualizationRebootAction)a;
+        VirtualizationRebootGuestAction va = (VirtualizationRebootGuestAction)a;
         va.setForce(true);
         flushAndEvict(va);
 
         Action a1 = ActionFactory.lookupById(a.getId());
         assertNotNull(a1);
 
-        assertTrue(a1 instanceof VirtualizationRebootAction);
-        VirtualizationRebootAction rebootAction = (VirtualizationRebootAction)a1;
+        assertTrue(a1 instanceof VirtualizationRebootGuestAction);
+        VirtualizationRebootGuestAction rebootAction = (VirtualizationRebootGuestAction)a1;
         assertTrue(rebootAction.isForce());
     }
 
@@ -125,7 +125,7 @@ public class VirtualizationActionsTest extends BaseTestCaseWithUser {
         Action a1 = ActionFactory.lookupById(a.getId());
         assertNotNull(a1);
 
-        VirtualizationSetMemoryAction va = (VirtualizationSetMemoryAction)a1;
+        VirtualizationSetMemoryGuestAction va = (VirtualizationSetMemoryGuestAction)a1;
         assertEquals(Integer.valueOf(1234), va.getMemory());
     }
 
@@ -136,7 +136,7 @@ public class VirtualizationActionsTest extends BaseTestCaseWithUser {
         Action a1 = ActionFactory.lookupById(a.getId());
         assertNotNull(a1);
 
-        VirtualizationSetVcpusAction va = (VirtualizationSetVcpusAction)a1;
+        VirtualizationSetVcpusGuestAction va = (VirtualizationSetVcpusGuestAction)a1;
         assertEquals(Integer.valueOf(12), va.getVcpu());
     }
 
@@ -146,7 +146,7 @@ public class VirtualizationActionsTest extends BaseTestCaseWithUser {
      * @throws Exception something bad happened
      */
     public void testCreateLookup() throws Exception {
-        VirtualizationCreateAction a1 = (VirtualizationCreateAction)ActionFactoryTest
+        VirtualizationCreateGuestAction a1 = (VirtualizationCreateGuestAction)ActionFactoryTest
                 .createAction(user, ActionFactory.TYPE_VIRTUALIZATION_CREATE);
         a1.setType("kvm");
         a1.setName("guest0");
@@ -178,8 +178,8 @@ public class VirtualizationActionsTest extends BaseTestCaseWithUser {
         Action a = ActionFactory.lookupById(a1.getId());
 
         assertNotNull(a);
-        assertTrue(a instanceof VirtualizationCreateAction);
-        VirtualizationCreateAction actual = (VirtualizationCreateAction)a;
+        assertTrue(a instanceof VirtualizationCreateGuestAction);
+        VirtualizationCreateGuestAction actual = (VirtualizationCreateGuestAction)a;
         assertEquals("kvm", actual.getType());
         assertEquals("guest0", actual.getName());
         assertEquals("x86_64", actual.getArch());

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -38,8 +38,8 @@ import com.redhat.rhn.domain.action.script.ScriptActionDetails;
 import com.redhat.rhn.domain.action.script.ScriptResult;
 import com.redhat.rhn.domain.action.script.ScriptRunAction;
 import com.redhat.rhn.domain.action.server.ServerAction;
-import com.redhat.rhn.domain.action.virtualization.VirtualizationSetMemoryAction;
-import com.redhat.rhn.domain.action.virtualization.VirtualizationSetVcpusAction;
+import com.redhat.rhn.domain.action.virtualization.VirtualizationSetMemoryGuestAction;
+import com.redhat.rhn.domain.action.virtualization.VirtualizationSetVcpusGuestAction;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.channel.ChannelArch;
 import com.redhat.rhn.domain.channel.ChannelFactory;
@@ -5618,7 +5618,7 @@ public class SystemHandler extends BaseHandler {
 
         Map<String, String> context = new HashMap<String, String>();
         //convert from mega to kilo bytes
-        context.put(VirtualizationSetMemoryAction.SET_MEMORY_STRING,
+        context.put(VirtualizationSetMemoryGuestAction.SET_MEMORY_STRING,
                 Integer.valueOf(memory * 1024).toString());
 
 
@@ -5662,7 +5662,7 @@ public class SystemHandler extends BaseHandler {
                 loggedInUser.getOrg(), sid.longValue());
 
         Map<String, String> context = new HashMap<String, String>();
-        context.put(VirtualizationSetVcpusAction.SET_CPU_STRING, numOfCpus.toString());
+        context.put(VirtualizationSetVcpusGuestAction.SET_CPU_STRING, numOfCpus.toString());
 
         VirtualizationActionCommand cmd = new VirtualizationActionCommand(loggedInUser,
                 new Date(),

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
@@ -29,8 +29,8 @@ import com.redhat.rhn.domain.action.salt.ApplyStatesActionDetails;
 import com.redhat.rhn.domain.action.script.ScriptActionDetails;
 import com.redhat.rhn.domain.action.script.ScriptResult;
 import com.redhat.rhn.domain.action.script.ScriptRunAction;
-import com.redhat.rhn.domain.action.virtualization.VirtualizationSetMemoryAction;
-import com.redhat.rhn.domain.action.virtualization.VirtualizationSetVcpusAction;
+import com.redhat.rhn.domain.action.virtualization.VirtualizationSetMemoryGuestAction;
+import com.redhat.rhn.domain.action.virtualization.VirtualizationSetVcpusGuestAction;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.channel.ChannelFactory;
 import com.redhat.rhn.domain.channel.test.ChannelFactoryTest;
@@ -2301,8 +2301,8 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
                 contains = true;
                 assertEquals(act.getActionType(),
                         ActionFactory.TYPE_VIRTUALIZATION_SET_MEMORY);
-                VirtualizationSetMemoryAction action = HibernateFactory.getSession().load(
-                        VirtualizationSetMemoryAction.class,  (long) id);
+                VirtualizationSetMemoryGuestAction action = HibernateFactory.getSession().load(
+                        VirtualizationSetMemoryGuestAction.class,  (long) id);
                 assertEquals(action.getMemory(), Integer.valueOf(512 * 1024));
             }
         }
@@ -2329,8 +2329,8 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
                 contains = true;
                 assertEquals(act.getActionType(),
                         ActionFactory.TYPE_VIRTUALIZATION_SET_VCPUS);
-                VirtualizationSetVcpusAction action = HibernateFactory.getSession().load(
-                        VirtualizationSetVcpusAction.class,  (long) id);
+                VirtualizationSetVcpusGuestAction action = HibernateFactory.getSession().load(
+                        VirtualizationSetVcpusGuestAction.class,  (long) id);
                 assertEquals(action.getVcpu(), Integer.valueOf(3));
             }
         }

--- a/java/code/src/com/redhat/rhn/manager/system/VirtualInstanceManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/VirtualInstanceManager.java
@@ -24,13 +24,14 @@ import com.redhat.rhn.manager.BaseManager;
 
 import com.suse.manager.utils.SaltUtils;
 import com.suse.manager.webui.utils.salt.custom.VmInfo;
+import com.suse.manager.webui.websocket.VirtNotifications;
+
+import org.apache.log4j.Logger;
 
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-
-import org.apache.log4j.Logger;
 
 /**
  * VirtualInstanceManager
@@ -133,6 +134,10 @@ public class VirtualInstanceManager extends BaseManager {
             virtualInstances.stream().forEach(virtualInstance -> {
                 deleteGuestVirtualInstance(virtualInstance);
             });
+        }
+
+        if (!plan.isEmpty()) {
+            VirtNotifications.spreadRefresh("guest");
         }
     }
 

--- a/java/code/src/com/redhat/rhn/manager/system/VirtualizationActionCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/system/VirtualizationActionCommand.java
@@ -21,7 +21,7 @@ import com.redhat.rhn.domain.action.ActionChain;
 import com.redhat.rhn.domain.action.ActionChainFactory;
 import com.redhat.rhn.domain.action.ActionFactory;
 import com.redhat.rhn.domain.action.ActionType;
-import com.redhat.rhn.domain.action.virtualization.BaseVirtualizationAction;
+import com.redhat.rhn.domain.action.virtualization.BaseVirtualizationGuestAction;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.action.ActionManager;
@@ -97,8 +97,8 @@ public class VirtualizationActionCommand {
         LOG.debug("store() called.");
 
         LOG.debug("creating virtAction");
-        BaseVirtualizationAction virtAction =
-            (BaseVirtualizationAction) ActionFactory.createAction(this.getActionType());
+        BaseVirtualizationGuestAction virtAction =
+            (BaseVirtualizationGuestAction) ActionFactory.createAction(this.getActionType());
         String actionName = this.getActionType().getName().replaceAll("\\.$", "");
 
         // Handle VM Update name change.

--- a/java/code/src/com/suse/manager/reactor/SaltReactor.java
+++ b/java/code/src/com/suse/manager/reactor/SaltReactor.java
@@ -34,13 +34,12 @@ import com.suse.manager.reactor.messaging.JobReturnEventMessage;
 import com.suse.manager.reactor.messaging.JobReturnEventMessageAction;
 import com.suse.manager.reactor.messaging.LibvirtEngineDomainLifecycleMessage;
 import com.suse.manager.reactor.messaging.LibvirtEngineDomainLifecycleMessageAction;
+import com.suse.manager.reactor.messaging.LibvirtEnginePoolLifecycleMessage;
+import com.suse.manager.reactor.messaging.LibvirtEnginePoolMessageAction;
+import com.suse.manager.reactor.messaging.LibvirtEnginePoolRefreshMessage;
 import com.suse.manager.reactor.messaging.MinionStartEventDatabaseMessage;
 import com.suse.manager.reactor.messaging.MinionStartEventMessage;
 import com.suse.manager.reactor.messaging.MinionStartEventMessageAction;
-import com.suse.manager.virtualization.VirtManagerSalt;
-import com.suse.manager.webui.services.iface.SaltApi;
-import com.suse.manager.webui.services.iface.VirtManager;
-import com.suse.manager.webui.utils.salt.MinionStartupGrains;
 import com.suse.manager.reactor.messaging.RefreshGeneratedSaltFilesEventMessage;
 import com.suse.manager.reactor.messaging.RefreshGeneratedSaltFilesEventMessageAction;
 import com.suse.manager.reactor.messaging.RegisterMinionEventMessage;
@@ -51,9 +50,13 @@ import com.suse.manager.reactor.messaging.SystemIdGenerateEventMessage;
 import com.suse.manager.reactor.messaging.SystemIdGenerateEventMessageAction;
 import com.suse.manager.reactor.messaging.VirtpollerBeaconEventMessage;
 import com.suse.manager.reactor.messaging.VirtpollerBeaconEventMessageAction;
+import com.suse.manager.virtualization.VirtManagerSalt;
+import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.SystemQuery;
+import com.suse.manager.webui.services.iface.VirtManager;
 import com.suse.manager.webui.utils.salt.ImageDeployedEvent;
 import com.suse.manager.webui.utils.salt.MinionStartEvent;
+import com.suse.manager.webui.utils.salt.MinionStartupGrains;
 import com.suse.manager.webui.utils.salt.SystemIdGenerateEvent;
 import com.suse.manager.webui.utils.salt.custom.VirtpollerData;
 import com.suse.salt.netapi.datatypes.Event;
@@ -62,6 +65,7 @@ import com.suse.salt.netapi.event.BeaconEvent;
 import com.suse.salt.netapi.event.EngineEvent;
 import com.suse.salt.netapi.event.EventStream;
 import com.suse.salt.netapi.event.JobReturnEvent;
+
 import org.apache.log4j.Logger;
 
 import java.util.Optional;
@@ -126,6 +130,10 @@ public class SaltReactor {
                 ImageDeployedEventMessage.class);
         MessageQueue.registerAction(new LibvirtEngineDomainLifecycleMessageAction(virtManager),
                 LibvirtEngineDomainLifecycleMessage.class);
+        MessageQueue.registerAction(new LibvirtEnginePoolMessageAction(),
+                LibvirtEnginePoolLifecycleMessage.class);
+        MessageQueue.registerAction(new LibvirtEnginePoolMessageAction(),
+                LibvirtEnginePoolRefreshMessage.class);
         MessageQueue.registerAction(new BatchStartedEventMessageAction(),
                 BatchStartedEventMessage.class);
 

--- a/java/code/src/com/suse/manager/reactor/messaging/AbstractLibvirtEngineMessage.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/AbstractLibvirtEngineMessage.java
@@ -14,10 +14,14 @@
  */
 package com.suse.manager.reactor.messaging;
 
+import com.redhat.rhn.common.hibernate.HibernateFactory;
+import com.redhat.rhn.common.messaging.EventDatabaseMessage;
 import com.redhat.rhn.common.messaging.EventMessage;
 
 import com.google.gson.JsonElement;
 import com.suse.salt.netapi.event.EngineEvent;
+
+import org.hibernate.Transaction;
 
 import java.util.Arrays;
 import java.util.List;
@@ -26,13 +30,14 @@ import java.util.Optional;
 /**
  * Libvirt_events engine message to handle
  */
-public abstract class AbstractLibvirtEngineMessage implements EventMessage {
+public abstract class AbstractLibvirtEngineMessage implements EventMessage, EventDatabaseMessage {
 
     private static final int LIBVIRT_EVENTS_ADDITIONAL_PARTS_COUNT = 3;
 
     private String connection;
     private Optional<String> minionId;
     private String timestamp;
+    private Transaction txn;
 
     /**
      * Parse the engine event if it is a libvirt_events one.
@@ -86,6 +91,15 @@ public abstract class AbstractLibvirtEngineMessage implements EventMessage {
         return null;
     }
 
+    /**
+     *
+     * {@inheritDoc}
+     */
+    @Override
+    public Transaction getTransaction() {
+        return txn;
+    }
+
     @Override
     public String toText() {
         return toString();
@@ -102,5 +116,7 @@ public abstract class AbstractLibvirtEngineMessage implements EventMessage {
         this.connection = connectIn;
         this.minionId = minionIdIn;
         this.timestamp = timestampIn;
+
+        this.txn = HibernateFactory.getSession().getTransaction();
     }
 }

--- a/java/code/src/com/suse/manager/reactor/messaging/AbstractLibvirtEngineMessage.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/AbstractLibvirtEngineMessage.java
@@ -18,8 +18,9 @@ import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.common.messaging.EventDatabaseMessage;
 import com.redhat.rhn.common.messaging.EventMessage;
 
-import com.google.gson.JsonElement;
 import com.suse.salt.netapi.event.EngineEvent;
+
+import com.google.gson.JsonElement;
 
 import org.hibernate.Transaction;
 
@@ -58,6 +59,11 @@ public abstract class AbstractLibvirtEngineMessage implements EventMessage, Even
 
         if ("domain".equals(objectType)) {
             return LibvirtEngineDomainMessage.createDomainMessage(connection,
+                    eventType, engineEvent.getMinionId(), engineEvent.getTimestamp(),
+                    engineEvent.getData(JsonElement.class));
+        }
+        else if ("pool".equals(objectType)) {
+            return LibvirtEnginePoolMessage.createPoolMessage(connection,
                     eventType, engineEvent.getMinionId(), engineEvent.getTimestamp(),
                     engineEvent.getData(JsonElement.class));
         }

--- a/java/code/src/com/suse/manager/reactor/messaging/LibvirtEngineDomainLifecycleMessage.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/LibvirtEngineDomainLifecycleMessage.java
@@ -14,12 +14,7 @@
  */
 package com.suse.manager.reactor.messaging;
 
-import com.redhat.rhn.common.hibernate.HibernateFactory;
-import com.redhat.rhn.common.messaging.EventDatabaseMessage;
-
 import com.google.gson.JsonElement;
-
-import org.hibernate.Transaction;
 
 import java.util.Optional;
 
@@ -27,11 +22,10 @@ import java.util.Optional;
  *
  * LibvirtEngineDomainLifecycleMessage
  */
-public class LibvirtEngineDomainLifecycleMessage extends LibvirtEngineDomainMessage implements EventDatabaseMessage {
+public class LibvirtEngineDomainLifecycleMessage extends LibvirtEngineDomainMessage {
 
     private String event;
     private String detail;
-    private Transaction txn;
 
     /**
      * @return the domain lifecycle event type (start, destroy, etc)
@@ -53,22 +47,11 @@ public class LibvirtEngineDomainLifecycleMessage extends LibvirtEngineDomainMess
         return super.toString() + "[" + event + "]";
     }
 
-    /**
-    *
-    * {@inheritDoc}
-    */
-   @Override
-   public Transaction getTransaction() {
-       return txn;
-   }
-
     protected LibvirtEngineDomainLifecycleMessage(String connection,
             Optional<String> minionId, String timestamp, JsonElement data) {
         super(connection, minionId, timestamp, data);
 
         this.event = data.getAsJsonObject().get("event").getAsString();
         this.detail = data.getAsJsonObject().get("detail").getAsString();
-
-        txn = HibernateFactory.getSession().getTransaction();
     }
 }

--- a/java/code/src/com/suse/manager/reactor/messaging/LibvirtEngineDomainLifecycleMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/LibvirtEngineDomainLifecycleMessageAction.java
@@ -24,6 +24,7 @@ import com.redhat.rhn.manager.system.VirtualInstanceManager;
 
 import com.suse.manager.virtualization.GuestDefinition;
 import com.suse.manager.webui.services.iface.VirtManager;
+import com.suse.manager.webui.websocket.VirtNotifications;
 
 import org.apache.log4j.Logger;
 
@@ -130,5 +131,6 @@ public class LibvirtEngineDomainLifecycleMessageAction implements MessageAction 
                 }
             });
         }
+        VirtNotifications.spreadRefresh("guest");
     }
 }

--- a/java/code/src/com/suse/manager/reactor/messaging/LibvirtEnginePoolLifecycleMessage.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/LibvirtEnginePoolLifecycleMessage.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.reactor.messaging;
+
+import com.google.gson.JsonElement;
+
+import java.util.Optional;
+
+/**
+ * Class representing a Salt Pool Lifecycle event
+ */
+public class LibvirtEnginePoolLifecycleMessage extends LibvirtEnginePoolMessage {
+
+    private String event;
+    private String detail;
+
+    /**
+     * @return the lifecycle event type (start, destroy, etc)
+     */
+    public String getEvent() {
+        return event;
+    }
+
+    /**
+     * @return the lifecycle event detail, mostly indicating the
+     *         reason of the event
+     */
+    public String getDetail() {
+        return detail;
+    }
+
+    @Override
+    public String toString() {
+        return super.toString() + "[" + event + "]";
+    }
+
+    protected LibvirtEnginePoolLifecycleMessage(String connection, Optional<String> minionId,
+                                                String timestamp, JsonElement data) {
+        super(connection, minionId, timestamp, data);
+
+        event = data.getAsJsonObject().get("event").getAsString();
+        detail = data.getAsJsonObject().get("detail").getAsString();
+    }
+}

--- a/java/code/src/com/suse/manager/reactor/messaging/LibvirtEnginePoolMessage.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/LibvirtEnginePoolMessage.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.reactor.messaging;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import java.util.Optional;
+
+/**
+ * Libvirt_events engine pool message to handle
+ */
+public class LibvirtEnginePoolMessage extends AbstractLibvirtEngineMessage {
+    private String poolName;
+    private String poolUUID;
+
+    /**
+     * Create a pool message corresponding to the event type
+     *
+     * @param connection libvirt connection
+     * @param eventType libvirt event type (lifecycle, refresh)
+     * @param minionId the minion ID or empty if the message comes from the master
+     * @param timestamp the event time stamp
+     * @param data the JSon data of the event
+     *
+     * @return a specialized object matching the event
+     */
+    public static AbstractLibvirtEngineMessage createPoolMessage(String connection, String eventType,
+                                                                 Optional<String> minionId, String timestamp,
+                                                                 JsonElement data) {
+        if (eventType.equals("lifecycle")) {
+            return new LibvirtEnginePoolLifecycleMessage(connection, minionId,
+                    timestamp, data);
+        }
+        else if (eventType.equals("refresh")) {
+            return new LibvirtEnginePoolRefreshMessage(connection, minionId,
+                    timestamp, data);
+        }
+        return null;
+    }
+
+    /**
+     * @return name of the pool related to the event
+     */
+    public String getPoolName() {
+        return poolName;
+    }
+
+    /**
+     * @return uuid of the pool related to the event
+     */
+    public String getPoolUUID() {
+        return poolUUID;
+    }
+
+    @Override
+    public String toString() {
+        return super.toString() + "[" + poolName + "]";
+    }
+
+    protected LibvirtEnginePoolMessage(String connection, Optional<String> minionId,
+                                       String timestamp, JsonElement data) {
+        super(connection, minionId, timestamp);
+
+        JsonObject pool = data.getAsJsonObject().get("pool").getAsJsonObject();
+        this.poolName = pool.get("name").getAsString();
+        this.poolUUID = pool.get("uuid").getAsString();
+    }
+}

--- a/java/code/src/com/suse/manager/reactor/messaging/LibvirtEnginePoolMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/LibvirtEnginePoolMessageAction.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.reactor.messaging;
+
+import com.redhat.rhn.common.messaging.EventMessage;
+import com.redhat.rhn.common.messaging.MessageAction;
+
+import com.suse.manager.webui.websocket.VirtNotifications;
+
+/**
+ * Virt Engine Storage Pool Lifecycle Event Action Handler
+ */
+public class LibvirtEnginePoolMessageAction implements MessageAction {
+    @Override
+    public void execute(EventMessage msg) {
+        // Notify that there was a pool change
+        VirtNotifications.spreadRefresh("pool");
+    }
+}

--- a/java/code/src/com/suse/manager/reactor/messaging/LibvirtEnginePoolRefreshMessage.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/LibvirtEnginePoolRefreshMessage.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.reactor.messaging;
+
+import com.google.gson.JsonElement;
+
+import java.util.Optional;
+
+/**
+ * Class representing a Salt Pool refresh event
+ */
+public class LibvirtEnginePoolRefreshMessage extends LibvirtEnginePoolMessage {
+    private String event;
+
+    /**
+     * @return the domain lifecycle event type (start, destroy, etc)
+     */
+    public String getEvent() {
+        return event;
+    }
+
+    @Override
+    public String toString() {
+        return super.toString() + "[" + event + "]";
+    }
+
+    protected LibvirtEnginePoolRefreshMessage(String connection, Optional<String> minionId,
+                                                String timestamp, JsonElement data) {
+        super(connection, minionId, timestamp, data);
+
+        event = data.getAsJsonObject().get("event").getAsString();
+    }
+}

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -49,7 +49,7 @@ import com.redhat.rhn.domain.action.scap.ScapAction;
 import com.redhat.rhn.domain.action.script.ScriptResult;
 import com.redhat.rhn.domain.action.script.ScriptRunAction;
 import com.redhat.rhn.domain.action.server.ServerAction;
-import com.redhat.rhn.domain.action.virtualization.BaseVirtualizationAction;
+import com.redhat.rhn.domain.action.virtualization.BaseVirtualizationGuestAction;
 import com.redhat.rhn.domain.action.virtualization.BaseVirtualizationPoolAction;
 import com.redhat.rhn.domain.channel.AccessToken;
 import com.redhat.rhn.domain.channel.Channel;
@@ -691,7 +691,7 @@ public class SaltUtils {
         else if (action.getActionType().equals(ActionFactory.TYPE_SUBSCRIBE_CHANNELS)) {
             handleSubscribeChannels(serverAction, jsonResult, action);
         }
-        else if (action instanceof BaseVirtualizationAction) {
+        else if (action instanceof BaseVirtualizationGuestAction) {
             // Tell VirtNotifications that we got a change, passing actionId
             VirtNotifications.spreadActionUpdate(action);
             JsonObject result = jsonResult.getAsJsonObject();

--- a/java/code/src/com/suse/manager/webui/controllers/virtualization/VirtualGuestsController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/virtualization/VirtualGuestsController.java
@@ -27,8 +27,8 @@ import com.redhat.rhn.domain.action.ActionChain;
 import com.redhat.rhn.domain.action.ActionChainFactory;
 import com.redhat.rhn.domain.action.ActionFactory;
 import com.redhat.rhn.domain.action.ActionType;
-import com.redhat.rhn.domain.action.virtualization.BaseVirtualizationAction;
-import com.redhat.rhn.domain.action.virtualization.VirtualizationCreateAction;
+import com.redhat.rhn.domain.action.virtualization.BaseVirtualizationGuestAction;
+import com.redhat.rhn.domain.action.virtualization.VirtualizationCreateGuestAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationCreateActionDiskDetails;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationCreateActionInterfaceDetails;
 import com.redhat.rhn.domain.role.RoleFactory;
@@ -340,7 +340,8 @@ public class VirtualGuestsController {
                         else {
                             Map<String, String> context = new HashMap<>();
                             if (data.getForce() != null) {
-                                context.put(BaseVirtualizationAction.FORCE_STRING, Boolean.toString(data.getForce()));
+                                context.put(BaseVirtualizationGuestAction.FORCE_STRING,
+                                        Boolean.toString(data.getForce()));
                             }
                             result = triggerGuestAction(host, guest, type, user, context);
                         }
@@ -529,16 +530,16 @@ public class VirtualGuestsController {
         // and that is only possible for the KVM driver.
         data.setName(guest != null ? guest.getName() : data.getName());
 
-        context.put(VirtualizationCreateAction.TYPE, data.getType());
-        context.put(VirtualizationCreateAction.NAME, data.getName());
-        context.put(VirtualizationCreateAction.OS_TYPE, data.getOsType());
-        context.put(VirtualizationCreateAction.MEMORY, data.getMemory());
-        context.put(VirtualizationCreateAction.VCPUS, data.getVcpu());
-        context.put(VirtualizationCreateAction.ARCH, data.getArch());
-        context.put(VirtualizationCreateAction.GRAPHICS, data.getGraphicsType());
+        context.put(VirtualizationCreateGuestAction.TYPE, data.getType());
+        context.put(VirtualizationCreateGuestAction.NAME, data.getName());
+        context.put(VirtualizationCreateGuestAction.OS_TYPE, data.getOsType());
+        context.put(VirtualizationCreateGuestAction.MEMORY, data.getMemory());
+        context.put(VirtualizationCreateGuestAction.VCPUS, data.getVcpu());
+        context.put(VirtualizationCreateGuestAction.ARCH, data.getArch());
+        context.put(VirtualizationCreateGuestAction.GRAPHICS, data.getGraphicsType());
 
         if (data.getDisks() != null) {
-            context.put(VirtualizationCreateAction.DISKS, data.getDisks().stream().map(disk -> {
+            context.put(VirtualizationCreateGuestAction.DISKS, data.getDisks().stream().map(disk -> {
                 VirtualizationCreateActionDiskDetails details = new VirtualizationCreateActionDiskDetails();
                 details.setDevice(disk.getDevice());
                 details.setTemplate(disk.getTemplate());
@@ -552,7 +553,7 @@ public class VirtualGuestsController {
         }
 
         if (data.getInterfaces() != null) {
-            context.put(VirtualizationCreateAction.INTERFACES, data.getInterfaces().stream().map(nic -> {
+            context.put(VirtualizationCreateGuestAction.INTERFACES, data.getInterfaces().stream().map(nic -> {
                 VirtualizationCreateActionInterfaceDetails details = new VirtualizationCreateActionInterfaceDetails();
                 details.setType(nic.getType());
                 details.setSource(nic.getSource());

--- a/java/code/src/com/suse/manager/webui/controllers/virtualization/test/VirtualGuestsControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/virtualization/test/VirtualGuestsControllerTest.java
@@ -18,9 +18,9 @@ package com.suse.manager.webui.controllers.virtualization.test;
 import com.redhat.rhn.common.db.datasource.DataResult;
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionFactory;
-import com.redhat.rhn.domain.action.virtualization.VirtualizationSetMemoryAction;
-import com.redhat.rhn.domain.action.virtualization.VirtualizationSetVcpusAction;
-import com.redhat.rhn.domain.action.virtualization.VirtualizationShutdownAction;
+import com.redhat.rhn.domain.action.virtualization.VirtualizationSetMemoryGuestAction;
+import com.redhat.rhn.domain.action.virtualization.VirtualizationSetVcpusGuestAction;
+import com.redhat.rhn.domain.action.virtualization.VirtualizationShutdownGuestAction;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.VirtualInstance;
@@ -187,7 +187,7 @@ public class VirtualGuestsControllerTest extends BaseControllerTestCase {
                      actions.get(0).getTypeName());
 
         Action action = ActionManager.lookupAction(user, actions.get(0).getId());
-        VirtualizationShutdownAction virtAction = (VirtualizationShutdownAction)action;
+        VirtualizationShutdownGuestAction virtAction = (VirtualizationShutdownGuestAction)action;
         assertEquals(guest.getUuid(), virtAction.getUuid());
 
         // Check the response
@@ -218,7 +218,7 @@ public class VirtualGuestsControllerTest extends BaseControllerTestCase {
                      actions.get(0).getTypeName());
 
         Action action = ActionManager.lookupAction(user, actions.get(0).getId());
-        VirtualizationSetVcpusAction virtAction = (VirtualizationSetVcpusAction)action;
+        VirtualizationSetVcpusGuestAction virtAction = (VirtualizationSetVcpusGuestAction)action;
         assertEquals(vcpus, virtAction.getVcpu());
 
         // Check the response
@@ -271,10 +271,10 @@ public class VirtualGuestsControllerTest extends BaseControllerTestCase {
 
         // Make sure the setVpu action was queued
         DataResult<ScheduledAction> scheduledActions = ActionManager.pendingActions(user, null);
-        ArrayList<VirtualizationSetMemoryAction> virtActions = new ArrayList<VirtualizationSetMemoryAction>();
+        ArrayList<VirtualizationSetMemoryGuestAction> virtActions = new ArrayList<VirtualizationSetMemoryGuestAction>();
         scheduledActions.stream().forEach(action -> virtActions.add(
-                (VirtualizationSetMemoryAction)ActionManager.lookupAction(user, action.getId())));
-        virtActions.sort((VirtualizationSetMemoryAction a1, VirtualizationSetMemoryAction a2) ->
+                (VirtualizationSetMemoryGuestAction)ActionManager.lookupAction(user, action.getId())));
+        virtActions.sort((VirtualizationSetMemoryGuestAction a1, VirtualizationSetMemoryGuestAction a2) ->
                 a1.getUuid().compareTo(a2.getUuid()));
 
         assertEquals(ActionFactory.TYPE_VIRTUALIZATION_SET_MEMORY.getName(),

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -61,24 +61,24 @@ import com.redhat.rhn.domain.action.scap.ScapAction;
 import com.redhat.rhn.domain.action.scap.ScapActionDetails;
 import com.redhat.rhn.domain.action.script.ScriptAction;
 import com.redhat.rhn.domain.action.server.ServerAction;
-import com.redhat.rhn.domain.action.virtualization.BaseVirtualizationAction;
+import com.redhat.rhn.domain.action.virtualization.BaseVirtualizationGuestAction;
 import com.redhat.rhn.domain.action.virtualization.BaseVirtualizationVolumeAction;
-import com.redhat.rhn.domain.action.virtualization.VirtualizationCreateAction;
+import com.redhat.rhn.domain.action.virtualization.VirtualizationCreateGuestAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationCreateActionDiskDetails;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationCreateActionInterfaceDetails;
-import com.redhat.rhn.domain.action.virtualization.VirtualizationDeleteAction;
+import com.redhat.rhn.domain.action.virtualization.VirtualizationDeleteGuestAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationPoolCreateAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationPoolDeleteAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationPoolRefreshAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationPoolStartAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationPoolStopAction;
-import com.redhat.rhn.domain.action.virtualization.VirtualizationRebootAction;
-import com.redhat.rhn.domain.action.virtualization.VirtualizationResumeAction;
-import com.redhat.rhn.domain.action.virtualization.VirtualizationSetMemoryAction;
-import com.redhat.rhn.domain.action.virtualization.VirtualizationSetVcpusAction;
-import com.redhat.rhn.domain.action.virtualization.VirtualizationShutdownAction;
-import com.redhat.rhn.domain.action.virtualization.VirtualizationStartAction;
-import com.redhat.rhn.domain.action.virtualization.VirtualizationSuspendAction;
+import com.redhat.rhn.domain.action.virtualization.VirtualizationRebootGuestAction;
+import com.redhat.rhn.domain.action.virtualization.VirtualizationResumeGuestAction;
+import com.redhat.rhn.domain.action.virtualization.VirtualizationSetMemoryGuestAction;
+import com.redhat.rhn.domain.action.virtualization.VirtualizationSetVcpusGuestAction;
+import com.redhat.rhn.domain.action.virtualization.VirtualizationShutdownGuestAction;
+import com.redhat.rhn.domain.action.virtualization.VirtualizationStartGuestAction;
+import com.redhat.rhn.domain.action.virtualization.VirtualizationSuspendGuestAction;
 import com.redhat.rhn.domain.channel.AccessToken;
 import com.redhat.rhn.domain.channel.AccessTokenFactory;
 import com.redhat.rhn.domain.channel.Channel;
@@ -331,49 +331,49 @@ public class SaltServerActionService {
             return subscribeChanelsAction(minions, subscribeAction.getDetails());
         }
         else if (ActionFactory.TYPE_VIRTUALIZATION_SHUTDOWN.equals(actionType)) {
-            VirtualizationShutdownAction virtAction =
-                    (VirtualizationShutdownAction)actionIn;
+            VirtualizationShutdownGuestAction virtAction =
+                    (VirtualizationShutdownGuestAction)actionIn;
             return virtStateChangeAction(minions, virtAction.getUuid(), "stopped", virtAction);
         }
         else if (ActionFactory.TYPE_VIRTUALIZATION_START.equals(actionType)) {
-            VirtualizationStartAction virtAction = (VirtualizationStartAction)actionIn;
+            VirtualizationStartGuestAction virtAction = (VirtualizationStartGuestAction)actionIn;
             return virtStateChangeAction(minions, virtAction.getUuid(), "running", virtAction);
         }
         else if (ActionFactory.TYPE_VIRTUALIZATION_SUSPEND.equals(actionType)) {
-            VirtualizationSuspendAction virtAction =
-                    (VirtualizationSuspendAction)actionIn;
+            VirtualizationSuspendGuestAction virtAction =
+                    (VirtualizationSuspendGuestAction)actionIn;
             return virtStateChangeAction(minions, virtAction.getUuid(), "suspended", virtAction);
         }
         else if (ActionFactory.TYPE_VIRTUALIZATION_RESUME.equals(actionType)) {
-            VirtualizationResumeAction virtAction =
-                    (VirtualizationResumeAction)actionIn;
+            VirtualizationResumeGuestAction virtAction =
+                    (VirtualizationResumeGuestAction)actionIn;
             return virtStateChangeAction(minions, virtAction.getUuid(), "resumed", virtAction);
         }
         else if (ActionFactory.TYPE_VIRTUALIZATION_REBOOT.equals(actionType)) {
-            VirtualizationRebootAction virtAction =
-                    (VirtualizationRebootAction)actionIn;
+            VirtualizationRebootGuestAction virtAction =
+                    (VirtualizationRebootGuestAction)actionIn;
             return virtStateChangeAction(minions, virtAction.getUuid(), "rebooted", virtAction);
         }
         else if (ActionFactory.TYPE_VIRTUALIZATION_DELETE.equals(actionType)) {
-            VirtualizationDeleteAction virtAction =
-                    (VirtualizationDeleteAction)actionIn;
+            VirtualizationDeleteGuestAction virtAction =
+                    (VirtualizationDeleteGuestAction)actionIn;
             return virtStateChangeAction(minions, virtAction.getUuid(), "deleted", virtAction);
         }
         else if (ActionFactory.TYPE_VIRTUALIZATION_SET_VCPUS.equals(actionType)) {
-            VirtualizationSetVcpusAction virtAction =
-                    (VirtualizationSetVcpusAction)actionIn;
+            VirtualizationSetVcpusGuestAction virtAction =
+                    (VirtualizationSetVcpusGuestAction)actionIn;
             return virtSetterAction(minions, virtAction.getUuid(),
                                     "vcpus", virtAction.getVcpu());
         }
         else if (ActionFactory.TYPE_VIRTUALIZATION_SET_MEMORY.equals(actionType)) {
-            VirtualizationSetMemoryAction virtAction =
-                    (VirtualizationSetMemoryAction)actionIn;
+            VirtualizationSetMemoryGuestAction virtAction =
+                    (VirtualizationSetMemoryGuestAction)actionIn;
             return virtSetterAction(minions, virtAction.getUuid(),
                                     "mem", virtAction.getMemory());
         }
         else if (ActionFactory.TYPE_VIRTUALIZATION_CREATE.equals(actionType)) {
-            VirtualizationCreateAction createAction =
-                    (VirtualizationCreateAction)actionIn;
+            VirtualizationCreateGuestAction createAction =
+                    (VirtualizationCreateGuestAction)actionIn;
             return virtCreateAction(minions, createAction);
         }
         else if (ActionFactory.TYPE_KICKSTART_INITIATE.equals(actionType)) {
@@ -1529,7 +1529,7 @@ public class SaltServerActionService {
     }
 
     private Map<LocalCall<?>, List<MinionSummary>> virtStateChangeAction(
-            List<MinionSummary> minionSummaries, String uuid, String state, BaseVirtualizationAction action) {
+            List<MinionSummary> minionSummaries, String uuid, String state, BaseVirtualizationGuestAction action) {
         Map<LocalCall<?>, List<MinionSummary>> ret = minionSummaries.stream().collect(
                 Collectors.toMap(minion -> {
 
@@ -1544,13 +1544,13 @@ public class SaltServerActionService {
                                     Collections.singletonList("virt." + state),
                                     Optional.of(pillar));
                         }
-                        else if (state.equals("rebooted") && ((VirtualizationRebootAction)action).isForce()) {
+                        else if (state.equals("rebooted") && ((VirtualizationRebootGuestAction)action).isForce()) {
                             return State.apply(
                                     Collections.singletonList("virt.reset"),
                                     Optional.of(pillar));
                         }
                         else {
-                            if (state.equals("stopped") && ((VirtualizationShutdownAction)action).isForce()) {
+                            if (state.equals("stopped") && ((VirtualizationShutdownGuestAction)action).isForce()) {
                                 pillar.put("domain_state", "powered_off");
                             }
                             else {
@@ -1606,7 +1606,7 @@ public class SaltServerActionService {
     }
 
     private Map<LocalCall<?>, List<MinionSummary>> virtCreateAction(List<MinionSummary> minions,
-            VirtualizationCreateAction action) {
+            VirtualizationCreateGuestAction action) {
         String state = action.getUuid() != null ? "virt.update-vm" : "virt.create-vm";
 
         Map<LocalCall<?>, List<MinionSummary>> ret = minions.stream().collect(

--- a/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
+++ b/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
@@ -32,9 +32,9 @@ import com.redhat.rhn.domain.action.config.ConfigAction;
 import com.redhat.rhn.domain.action.script.ScriptActionDetails;
 import com.redhat.rhn.domain.action.server.ServerAction;
 import com.redhat.rhn.domain.action.test.ActionFactoryTest;
-import com.redhat.rhn.domain.action.virtualization.BaseVirtualizationAction;
-import com.redhat.rhn.domain.action.virtualization.VirtualizationRebootAction;
-import com.redhat.rhn.domain.action.virtualization.VirtualizationShutdownAction;
+import com.redhat.rhn.domain.action.virtualization.BaseVirtualizationGuestAction;
+import com.redhat.rhn.domain.action.virtualization.VirtualizationRebootGuestAction;
+import com.redhat.rhn.domain.action.virtualization.VirtualizationShutdownGuestAction;
 import com.redhat.rhn.domain.channel.AccessToken;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.channel.test.ChannelFactoryTest;
@@ -336,7 +336,7 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
 
         for (ActionType type : actionTypes) {
             Action action = ActionFactoryTest.createAction(user, type);
-            BaseVirtualizationAction va = (BaseVirtualizationAction)action;
+            BaseVirtualizationGuestAction va = (BaseVirtualizationGuestAction)action;
             va.setUuid(minionHost.getGuests().iterator().next().getUuid());
             ActionFactory.addServerToAction(minionHost, action);
 
@@ -350,7 +350,7 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
         List<MinionSummary> minions = Arrays.asList(new MinionSummary(minionHost));
 
         Action action = ActionFactoryTest.createAction(user, ActionFactory.TYPE_VIRTUALIZATION_SHUTDOWN);
-        VirtualizationShutdownAction va = (VirtualizationShutdownAction)action;
+        VirtualizationShutdownGuestAction va = (VirtualizationShutdownGuestAction)action;
         va.setUuid(minionHost.getGuests().iterator().next().getUuid());
         va.setForce(true);
         ActionFactory.addServerToAction(minionHost, action);
@@ -365,7 +365,7 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
         List<MinionSummary> minions = Arrays.asList(new MinionSummary(minionHost));
 
         Action action = ActionFactoryTest.createAction(user, ActionFactory.TYPE_VIRTUALIZATION_REBOOT);
-        VirtualizationRebootAction va = (VirtualizationRebootAction)action;
+        VirtualizationRebootGuestAction va = (VirtualizationRebootGuestAction)action;
         va.setUuid(minionHost.getGuests().iterator().next().getUuid());
         va.setForce(true);
         ActionFactory.addServerToAction(minionHost, action);

--- a/java/code/src/com/suse/manager/webui/websocket/VirtNotifications.java
+++ b/java/code/src/com/suse/manager/webui/websocket/VirtNotifications.java
@@ -241,6 +241,24 @@ public class VirtNotifications {
     }
 
     /**
+     * A static method to notify all {@link Session}s attached to WebSocket that a refresh is needed.
+     * Must be synchronized. Sending messages concurrently from separate threads
+     * will result in IllegalStateException.
+     *
+     * @param kind the kind of object list that needs refresh. One of "guest", "pool"
+     */
+    public static void spreadRefresh(String kind) {
+        synchronized (LOCK) {
+            // Notify sessions waiting for this action
+            wsSessions.forEach((session, servers) -> {
+                Map<String, Object> data = new HashMap<>();
+                data.put("refresh", kind);
+                sendMessage(session, GSON.toJson(data));
+            });
+        }
+    }
+
+    /**
      * A static method to clean up all invalid sessions
      */
     public static void clearBrokenSessions() {

--- a/java/code/src/com/suse/manager/webui/websocket/VirtNotifications.java
+++ b/java/code/src/com/suse/manager/webui/websocket/VirtNotifications.java
@@ -18,7 +18,7 @@ import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionFactory;
 import com.redhat.rhn.domain.action.server.ServerAction;
-import com.redhat.rhn.domain.action.virtualization.BaseVirtualizationAction;
+import com.redhat.rhn.domain.action.virtualization.BaseVirtualizationGuestAction;
 import com.redhat.rhn.domain.action.virtualization.BaseVirtualizationPoolAction;
 import com.redhat.rhn.domain.action.virtualization.BaseVirtualizationVolumeAction;
 import com.redhat.rhn.domain.action.virtualization.VirtualizationPoolCreateAction;
@@ -81,10 +81,10 @@ public class VirtNotifications {
     // Map each virtualization action types to an id supplier. The id is indeed
     // different for guests, pools, volumes and networks
     private static final Map<Class<? extends Action>, Function<Action, String>> IDS_MAPPER = Map.of(
-            BaseVirtualizationAction.class,
+            BaseVirtualizationGuestAction.class,
             (action) -> {
                 String id = "new-" + action.getId();
-                BaseVirtualizationAction virtAction = (BaseVirtualizationAction)action;
+                BaseVirtualizationGuestAction virtAction = (BaseVirtualizationGuestAction)action;
                 String uuid = virtAction.getUuid();
                 if (uuid != null) {
                     id = uuid;

--- a/java/code/src/com/suse/manager/webui/websocket/WebSocketActionIdProvider.java
+++ b/java/code/src/com/suse/manager/webui/websocket/WebSocketActionIdProvider.java
@@ -12,31 +12,15 @@
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
  */
-package com.redhat.rhn.domain.action.virtualization;
+package com.suse.manager.webui.websocket;
 
-
-public class BaseVirtualizationVolumeAction extends BaseVirtualizationPoolAction {
-
-    private String volumeName;
-
-
-    /**
-     * @return Returns the volumeName.
-     */
-    public String getVolumeName() {
-        return volumeName;
-    }
-
+/**
+ * Interface to be implemented to provide proper action ID for VirtNotification Web socket
+ */
+public interface WebSocketActionIdProvider {
 
     /**
-     * @param volumeNameIn The volumeName to set.
+     * @return the ID of the action
      */
-    public void setVolumeName(String volumeNameIn) {
-        volumeName = volumeNameIn;
-    }
-
-    @Override
-    public String getWebSocketActionId() {
-        return String.format("volume-%s/%s", getPoolName(), getVolumeName());
-    }
+    String getWebSocketActionId();
 }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Refresh virtualization pages only on events
 - fix up2date detection on RH8 when salt-minion is used for registration
 - improve performance of the System Groups page with many clients (bsc#1172839)
 - Include number of non-patch package updates to non-critical update counts

--- a/susemanager-utils/susemanager-sls/salt/virt/volume-deleted.sls
+++ b/susemanager-utils/susemanager-sls/salt/virt/volume-deleted.sls
@@ -1,6 +1,10 @@
+include:
+  - virt.pool-refreshed
+
 mgr_volume_deleted:
   mgrcompat.module_run:
     - name: virt.volume_delete
     - pool: {{ pillar['pool_name'] }}
     - volume: {{ pillar['volume_name'] }}
-
+    - require_in:
+        - sls: virt.pool-refreshed

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Force a refresh after deleting a virtual storage volume
 - Prevent stuck Hardware Refresh actions on Salt 2016.11.10 based SSH minions (bsc#1173169)
 - Require PyYAML version >= 5.1
 - Log out of Docker registries after image build (bsc#1165572)

--- a/web/html/src/manager/virtualization/guests/GuestProperties.js
+++ b/web/html/src/manager/virtualization/guests/GuestProperties.js
@@ -67,7 +67,7 @@ export function GuestProperties(props: Props) : React.Node {
           networks,
           error: netListError,
         }) => (
-          <VirtualizationPoolsListRefreshApi serverId={props.host.id}>
+          <VirtualizationPoolsListRefreshApi serverId={props.host.id} lastRefresh={Date.now()}>
             {
               ({
                 pools,

--- a/web/html/src/manager/virtualization/guests/list/guests-list.js
+++ b/web/html/src/manager/virtualization/guests/list/guests-list.js
@@ -34,8 +34,14 @@ export function GuestsList(props: Props) {
   const [errors, setErrors] = React.useState<Array<string>>([]);
   const [lastRefresh, setLastRefresh] = React.useState(Date.now());
 
+  const refresh = (type: string) => {
+    if (type === "guest") {
+      setLastRefresh(Date.now());
+    }
+  }
+
   const [actionsResults, setActionsResults] = useVirtNotification(errors, setErrors,
-                                                                  props.serverId, props.saltEntitled);
+                                                                  props.serverId, refresh, props.saltEntitled);
 
   const searchData = (datum: Object, criteria?: string): boolean => {
     if (criteria) {

--- a/web/html/src/manager/virtualization/guests/list/guests-list.js
+++ b/web/html/src/manager/virtualization/guests/list/guests-list.js
@@ -23,7 +23,6 @@ declare var userPrefPageSize: number;
 
 type Props = {
   serverId: string,
-  refreshInterval: number,
   saltEntitled: boolean,
   foreignEntitled: boolean,
   isAdmin: boolean,
@@ -33,6 +32,7 @@ export function GuestsList(props: Props) {
   const [selectedItems, setSelectedItems] = React.useState([]);
   const [selected, setSelected] = React.useState(undefined);
   const [errors, setErrors] = React.useState<Array<string>>([]);
+  const [lastRefresh, setLastRefresh] = React.useState(Date.now());
 
   const [actionsResults, setActionsResults] = useVirtNotification(errors, setErrors,
                                                                   props.serverId, props.saltEntitled);
@@ -50,6 +50,7 @@ export function GuestsList(props: Props) {
       return Object.assign(actions, newAction);
     }, {});
     setActionsResults(Object.assign({}, actionsResults, newActions));
+    setLastRefresh(Date.now());
   }
 
   const createModalButton = (actionType: string, actionData: Array<Object>, row: Object): React.Node => {
@@ -181,7 +182,7 @@ export function GuestsList(props: Props) {
           return (
             <VirtualizationGuestsListRefreshApi
               serverId={props.serverId}
-              refreshInterval={props.refreshInterval}
+              lastRefresh={lastRefresh}
             >
               {
                 ({

--- a/web/html/src/manager/virtualization/guests/list/guests-list.renderer.js
+++ b/web/html/src/manager/virtualization/guests/list/guests-list.renderer.js
@@ -5,7 +5,6 @@ const { GuestsList } = require('./guests-list');
 export const renderer = (id, { serverId, saltEntitled, foreignEntitled, isAdmin }) => {
   SpaRenderer.renderNavigationReact(
     <GuestsList
-      refreshInterval={5 * 1000}
       serverId={serverId}
       saltEntitled={saltEntitled}
       foreignEntitled={foreignEntitled}

--- a/web/html/src/manager/virtualization/pools/list/pools-list.js
+++ b/web/html/src/manager/virtualization/pools/list/pools-list.js
@@ -21,7 +21,6 @@ import type {MessageType} from 'components/messages';
 
 type Props = {
   serverId: string,
-  refreshInterval: number,
   pageSize: number,
 };
 
@@ -147,6 +146,7 @@ const DeleteActionConfirm = (props) => {
 export function PoolsList(props: Props) {
   const [selected, setSelected] = React.useState({});
   const [errors, setErrors] = React.useState([]);
+  const [lastRefresh, setLastRefresh] = React.useState(Date.now());
 
   const [actionsResults, setActionsResults] = useVirtNotification(errors, setErrors,
                                                                   props.serverId);
@@ -191,7 +191,7 @@ export function PoolsList(props: Props) {
         return (
           <VirtualizationPoolsListRefreshApi
             serverId={props.serverId}
-            refreshInterval={props.refreshInterval}
+            lastRefresh={lastRefresh}
           >
           {
             ({

--- a/web/html/src/manager/virtualization/pools/list/pools-list.js
+++ b/web/html/src/manager/virtualization/pools/list/pools-list.js
@@ -148,8 +148,14 @@ export function PoolsList(props: Props) {
   const [errors, setErrors] = React.useState([]);
   const [lastRefresh, setLastRefresh] = React.useState(Date.now());
 
+  const refresh = (type: string) => {
+    if (type === "pool") {
+      setLastRefresh(Date.now());
+    }
+  };
+
   const [actionsResults, setActionsResults] = useVirtNotification(errors, setErrors,
-                                                                  props.serverId);
+                                                                  props.serverId, refresh);
 
   const actionCallback = (results: Object) => {
     const newActions = Object.keys(results).reduce((actions, poolName) => {

--- a/web/html/src/manager/virtualization/pools/list/pools-list.renderer.js
+++ b/web/html/src/manager/virtualization/pools/list/pools-list.renderer.js
@@ -5,7 +5,6 @@ import SpaRenderer from "core/spa/spa-renderer";
 export const renderer = (id, { serverId, pageSize }) => {
   SpaRenderer.renderNavigationReact(
     <PoolsList
-      refreshInterval={5 * 1000}
       pageSize={pageSize}
       serverId={serverId}
     />,

--- a/web/html/src/manager/virtualization/useVirtNotification.js
+++ b/web/html/src/manager/virtualization/useVirtNotification.js
@@ -5,6 +5,7 @@ export function useVirtNotification(
     errors: Array<string>,
     setErrors: Function,
     serverId: string,
+    refresh: (type: string) => void,
     listen: boolean = true): [Object, Function] {
   const [actionsResults, setActionsResults] = React.useState({});
   const [webSocketErr, setWebSocketErr] = React.useState(false);
@@ -57,6 +58,12 @@ export function useVirtNotification(
       ws.onmessage = (e) => {
         if (typeof e.data === 'string') {
           const newActions = JSON.parse(e.data);
+          const refreshKind = newActions['refresh'];
+          if (refreshKind != null) {
+            refresh(refreshKind);
+            return;
+          }
+
           /*
            * The received items are split in two maps:
            *   - one with the actions that we don't already know about

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Refresh virtualization pages only on events
 - Product list in the Wizard doesn't show SLE products first (bsc#1173522)
 - Cluster UI: return to overview page after scheduling actions
 


### PR DESCRIPTION
## What does this PR change?

As of today the Guests and Pools virtualization pages are refreshing every 5s and thus issuing calls to the DB and Salt minion to get the data they need.
This PR removes the periodic refresh and only refreshes when a virtualization event is triggered.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: no difference

- [X] **DONE**

## Test coverage
- No tests: hard to test features involving websockets

- [X] **DONE**

## Links

Requires openSUSE/salt#248 in the KVM Salt minion

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
