### PR TITLE
Better exception when product channel is not found

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/product/SUSEProductFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/product/SUSEProductFactory.java
@@ -277,7 +277,8 @@ public class SUSEProductFactory extends HibernateFactory {
             Channel channel = ChannelFactory.lookupByLabel(channelLabel);
             Channel baseChannel = Optional.ofNullable(channel.getParentChannel()).orElse(channel);
 
-            SUSEProductChannel baseProductChannel = findSyncProductChannelByLabel(baseChannel.getLabel()).get();
+            SUSEProductChannel baseProductChannel = findSyncProductChannelByLabel(baseChannel.getLabel())
+                    .orElseThrow(() -> new IllegalStateException("No product channel found for " + baseChannel));
             Stream<SUSEProductChannel> suseProductChannelStream = findSyncedMandatoryChannels(
                         suseProductChannel.getProduct(),
                         baseProductChannel.getProduct(),


### PR DESCRIPTION
## What does this PR change?

We use `Optional.get()` for getting product channel when looking for synced
mandatory channels. In case the product channel is not found (which shouldn't
happen under normal circumstances), we get a cryptic exception. I added a better exception in case this
happens, so we have more information about the problem.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: internal
- [x] **DONE**

## Test coverage
- No tests: just logging

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"