### PR TITLE
Cluster UI: return to overview page after scheduling actions

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/clusters/ClustersController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/clusters/ClustersController.java
@@ -49,6 +49,7 @@ import com.suse.manager.webui.controllers.clusters.mappers.ResponseMappers;
 import com.suse.manager.webui.controllers.clusters.response.ClusterNodeResponse;
 import com.suse.manager.webui.controllers.clusters.response.ClusterProviderResponse;
 import com.suse.manager.webui.controllers.clusters.response.ClusterResponse;
+import com.suse.manager.webui.controllers.clusters.response.MessageResponse;
 import com.suse.manager.webui.controllers.clusters.response.ServerResponse;
 import com.suse.manager.webui.utils.FlashScopeHelper;
 import com.suse.manager.webui.utils.MinionActionUtils;
@@ -394,8 +395,9 @@ public class ClustersController {
             LOG.error("Adding cluster failed", e);
             return json(response, HttpStatus.SC_INTERNAL_SERVER_ERROR, ResultJson.error(e.getMessage()));
         }
-        FlashScopeHelper.flash(request, String.format("Cluster '%s' has been added successfully",
-                clusterRequest.getName()));
+        FlashScopeHelper.flash(request,
+                GSON.toJson(MessageResponse.success("cluster_added",
+                        cluster.getName())));
         return json(response, ResultJson.success(cluster.getId()));
     }
 
@@ -416,8 +418,9 @@ public class ClustersController {
             LOG.error("Deleting cluster failed", e);
             return json(response, HttpStatus.SC_INTERNAL_SERVER_ERROR, ResultJson.error(e.getMessage()));
         }
-        FlashScopeHelper.flash(request, String.format("Cluster '%s' has been deleted successfully",
-                cluster.getName()));
+        FlashScopeHelper.flash(request,
+                GSON.toJson(MessageResponse.success("cluster_deleted",
+                        cluster.getName())));
         return json(response, ResultJson.success());
     }
 
@@ -472,6 +475,8 @@ public class ClustersController {
             return json(response, HttpStatus.SC_INTERNAL_SERVER_ERROR,
                     ResultJson.error("Internal error " + e.getClass()));
         }
+        FlashScopeHelper.flash(request,
+                GSON.toJson(MessageResponse.success("action_scheduled", Long.toString(actionId))));
         return json(response, ResultJson.success(actionId));
     }
 
@@ -498,6 +503,8 @@ public class ClustersController {
             return json(response, HttpStatus.SC_INTERNAL_SERVER_ERROR,
                     ResultJson.error("Internal error " + e.getClass()));
         }
+        FlashScopeHelper.flash(request,
+                GSON.toJson(MessageResponse.success("action_scheduled", Long.toString(actionId))));
         return json(response, ResultJson.success(actionId));
     }
 

--- a/java/code/src/com/suse/manager/webui/controllers/clusters/response/MessageResponse.java
+++ b/java/code/src/com/suse/manager/webui/controllers/clusters/response/MessageResponse.java
@@ -15,6 +15,9 @@
 
 package com.suse.manager.webui.controllers.clusters.response;
 
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * Message view bean.
  */
@@ -22,6 +25,7 @@ public class MessageResponse {
 
     private String severity;
     private String text;
+    private List<String> args;
 
     /**
      * @param severityIn message severity
@@ -30,6 +34,57 @@ public class MessageResponse {
     public MessageResponse(String severityIn, String textIn) {
         this.severity = severityIn;
         this.text = textIn;
+    }
+
+    /**
+     * @param severityIn message severity
+     * @param textIn message text
+     * @param argsIn message parameters
+     */
+    public MessageResponse(String severityIn, String textIn, List<String> argsIn) {
+        this.severity = severityIn;
+        this.text = textIn;
+        this.args = argsIn;
+    }
+
+    /**
+     * Creates a success message.
+     * @param textIn the text
+     * @param args optional arguments
+     * @return a success message
+     */
+    public static MessageResponse success(String textIn, String... args) {
+        return new MessageResponse("success", textIn, Arrays.asList(args));
+    }
+
+    /**
+     * Creates an info message.
+     * @param textIn the text
+     * @param args optional arguments
+     * @return an info message
+     */
+    public static MessageResponse info(String textIn, String... args) {
+        return new MessageResponse("info", textIn, Arrays.asList(args));
+    }
+
+    /**
+     * Creates a warning message.
+     * @param textIn the text
+     * @param args optional arguments
+     * @return a warning message
+     */
+    public static MessageResponse warning(String textIn, String... args) {
+        return new MessageResponse("warning", textIn, Arrays.asList(args));
+    }
+
+    /**
+     * Creates an error message.
+     * @param textIn the text
+     * @param args optional arguments
+     * @return a warning message
+     */
+    public static MessageResponse error(String textIn, String... args) {
+        return new MessageResponse("error", textIn, Arrays.asList(args));
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/controllers/clusters/templates/cluster.jade
+++ b/java/code/src/com/suse/manager/webui/controllers/clusters/templates/cluster.jade
@@ -18,6 +18,6 @@ script(type='text/javascript').
             'cluster',
                 {
                     cluster: document.getElementById('init_data_cluster').textContent,
-                    flashMessage: "#{flashMessage}"
+                    flashMessage: !{flashMessage ? flashMessage : "null"}
                 }
             ); });

--- a/java/code/src/com/suse/manager/webui/controllers/clusters/templates/list.jade
+++ b/java/code/src/com/suse/manager/webui/controllers/clusters/templates/list.jade
@@ -18,6 +18,6 @@ script(type='text/javascript').
             'clusters',
                 {
                     clusters: document.getElementById('init_data_clusters').textContent,
-                    flashMessage: "#{flashMessage}"
+                    flashMessage: !{flashMessage ? flashMessage : "null"}
                 }
             ); });

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Cluster UI: return to overview page after scheduling actions
 - fix NPE on auto installation when no kernel options are given (bsc#1173932)
 - fix issue with disabling self_update for autoyast autoupgrade (bsc#1170654)
 - Adapt expectations for jobs return events after switching Salt

--- a/web/html/src/components/messages.js
+++ b/web/html/src/components/messages.js
@@ -4,6 +4,12 @@ import * as React from "react";
 
 type Severity = "info" | "success" | "warning" | "error";
 
+export type ServerMessageType = {
+  severity: Severity,
+  text: string,
+  args: Array<string>
+}
+
 export type MessageType = {
   severity: Severity,
   text: string |
@@ -89,6 +95,32 @@ export class Messages extends React.Component<Props> {
         return (<div key={"messages-pop-up"}>{msgs}</div>);
     }
 
+}
+
+export const fromServerMessage = (message: ServerMessageType, messageMap?: {[string]: string | ((any) => string | React.Node)}): ?MessageType => {
+  let messageText = message.text;
+  if (messageMap && (messageText in messageMap)) {
+    messageText = messageMap[message.text];
+    if (typeof messageText === "function") {
+      messageText = messageText(message.args);
+    }
+  }
+  let msg: ?MessageType;
+  switch (message.severity) {
+    case "info":
+      msg = Messages.info(messageText);
+      break;
+    case "success":
+      msg = Messages.success(messageText);
+      break;
+    case "warning":
+      msg = Messages.warning(messageText);
+      break;
+    case "error":
+      msg = Messages.error(messageText);
+      break;
+  }
+  return msg;
 }
 
 function msg(severityIn: Severity, ...textIn: Array<React.Node>) {

--- a/web/html/src/manager/clusters/cluster/cluster.js
+++ b/web/html/src/manager/clusters/cluster/cluster.js
@@ -14,14 +14,21 @@ import {isClusterAdmin} from "core/auth/auth.utils";
 import {LinkButton} from 'components/buttons';
 import {DeleteDialog} from 'components/dialog/DeleteDialog';
 import {showDialog} from 'components/dialog/util';
-import {Messages} from 'components/messages';
+import {fromServerMessage} from 'components/messages';
+import {ActionLink, ActionChainLink} from 'components/links';
 
 import type {ClusterType, ErrorMessagesType} from '../shared/api/use-clusters-api'
-import type {MessageType} from 'components/messages';
+import type {ServerMessageType, MessageType} from 'components/messages';
+
+const msgMap = {
+  "action_scheduled": (actionId) => <>{t("Action has been ")}<ActionLink id={actionId}>{t("scheduled")}</ActionLink>{t(" successfully.")}</>,
+  "action_chain_scheduled": (actionChainId, actionChain) => <>{t("Action has been successfully added to the Action Chain ")}<ActionChainLink id={actionChainId}>{actionChain}</ActionChainLink>.</>,
+  "cluster_added": (name) => <>{t("Cluster ")}<strong>{name}</strong>{t(" has been added successfully.")}</>
+}
 
 type Props = {
   cluster: ClusterType,
-  flashMessage: String,
+  flashMessage: ?ServerMessageType,
   setMessages: (Array<MessageType>) => void
 };
 
@@ -50,7 +57,10 @@ const Cluster = (props: Props) => {
 
     useEffect(() => {
       if(props.flashMessage) {
-        props.setMessages([Messages.info(props.flashMessage)])
+        const message = fromServerMessage(props.flashMessage, msgMap);
+        if (message) {
+          props.setMessages([message]);
+        }
       }
     }, []);
 

--- a/web/html/src/manager/clusters/join-cluster/join-cluster.js
+++ b/web/html/src/manager/clusters/join-cluster/join-cluster.js
@@ -26,7 +26,10 @@ const JoinCluster = (props: Props) => {
 
     const scheduleJoin = (earliest: Date, actionChain: ?string): Promise<any> => {
         if (nodesToJoin && joinConfig) {
-            return scheduleJoinNode(props.cluster.id, nodesToJoin.map(node => node.id), joinConfig, earliest, actionChain);
+            return scheduleJoinNode(props.cluster.id, nodesToJoin.map(node => node.id), joinConfig, earliest, actionChain)
+                .then(() => {
+                    window.location = `/rhn/manager/cluster/${props.cluster.id}`;
+                });
         }
         return Promise.reject(new Error('invalid data'));
     }
@@ -64,6 +67,7 @@ const JoinCluster = (props: Props) => {
                             {({goTo, back}) => {
                                 return nodesToJoin?
                                     <ScheduleClusterAction
+                                        cluster={props.cluster}
                                         title={t("Schedule join node")}
                                         panel={
                                                 <div className="form-horizontal">

--- a/web/html/src/manager/clusters/list-clusters/list-clusters.js
+++ b/web/html/src/manager/clusters/list-clusters/list-clusters.js
@@ -11,13 +11,21 @@ import {Column} from 'components/table/Column';
 import {SearchField} from 'components/table/SearchField';
 import Functions from 'utils/functions';
 import {SystemLink} from 'components/links';
-import {showInfoToastr} from 'components/toastr/toastr';
+import {fromServerMessage} from 'components/messages';
+import {withErrorMessages} from '../shared/api/use-clusters-api';
 
 import type {ClusterType} from '../shared/api/use-clusters-api';
+import type {MessageType} from 'components/messages';
+
+const msgMap = {
+  "cluster_deleted": (name) => <>{t("Cluster ")}<strong>{name}</strong>{t(" has been deleted successfully.")}</>
+}
+
 
 type Props = {
   clusters: Array<ClusterType>,
   flashMessage: String,
+  setMessages: (Array<MessageType>) => void
 };
 
 const ListClusters = (props) => {
@@ -49,7 +57,10 @@ const ListClusters = (props) => {
 
     useEffect(()=> {
         if(props.flashMessage) {
-            showInfoToastr(props.flashMessage);
+            const message = fromServerMessage(props.flashMessage, msgMap);
+            if (message) {
+                props.setMessages([message]);
+            }
         }
     }, []);
 
@@ -99,4 +110,4 @@ const ListClusters = (props) => {
 
 }
 
-export default hot(module)(withPageWrapper<Props>(ListClusters));
+export default hot(module)(withPageWrapper<Props>(withErrorMessages(ListClusters)));

--- a/web/html/src/manager/clusters/remove-node/remove-node.js
+++ b/web/html/src/manager/clusters/remove-node/remove-node.js
@@ -28,7 +28,10 @@ const RemoveNode = (props: Props) => {
                  props.nodes
                     .filter(node => node.server ? true : false)
                     .map(node => node.server ? node.server.id : 0),
-                removeConfig, earliest, actionChain);
+                removeConfig, earliest, actionChain)
+                .then(() => {
+                    window.location = `/rhn/manager/cluster/${props.cluster.id}`;
+                });
         }
         return Promise.reject(new Error('invalid data'));
     }

--- a/web/html/src/manager/clusters/shared/ui/schedule-cluster-action.js
+++ b/web/html/src/manager/clusters/shared/ui/schedule-cluster-action.js
@@ -3,12 +3,10 @@ import * as React from 'react';
 import {useState} from 'react';
 import {Panel} from 'components/panels/Panel';
 import {AsyncButton, Button} from 'components/buttons';
-import {ActionLink, ActionChainLink} from 'components/links';
 import {ActionSchedule} from 'components/action-schedule';
 import Functions from 'utils/functions';
 import {withErrorMessages}  from '../api/use-clusters-api';
 import useUserLocalization from 'core/user-localization/use-user-localization';
-import {Messages} from 'components/messages';
 
 import type {ActionChain} from "components/action-schedule";
 import type {ErrorMessagesType} from '../api/use-clusters-api';
@@ -36,11 +34,6 @@ const ScheduleClusterAction = (props: Props) => {
         return props.schedule(earliest, actionChain ? actionChain.text: null).then(
             (actionId) => {
                 setDisableSchedule(true);
-                const actionChainMsg = Messages.success(<span>{t("Action has been successfully added to the Action Chain ")}
-                        <ActionChainLink id={actionId}>{actionChain ? actionChain.text : ""}</ActionChainLink>.</span>);
-                const actionMsg = Messages.success(<span>{t("Action has been ")}
-                          <ActionLink id={actionId}>{t("scheduled")}</ActionLink>{t(" successfully.")}</span>);
-                props.setMessages([actionChain ? actionChainMsg : actionMsg]);
             },
             (error: ErrorMessagesType) => {
                 props.setMessages(error.messages);

--- a/web/html/src/manager/clusters/upgrade-cluster/upgrade-cluster.js
+++ b/web/html/src/manager/clusters/upgrade-cluster/upgrade-cluster.js
@@ -22,7 +22,10 @@ const UpgradeCluster = (props: Props) => {
     const { scheduleUpgradeCluster } = useClustersApi();
 
     const scheduleUpgrade = (earliest: Date, actionChain: ?string): Promise<any> => {
-        return scheduleUpgradeCluster(props.cluster.id, earliest, actionChain);
+        return scheduleUpgradeCluster(props.cluster.id, earliest, actionChain)
+                .then(() => {
+                    window.location = `/rhn/manager/cluster/${props.cluster.id}`;
+                });
     }
 
     return (<TopPanel title={t('Upgrade ') + props.cluster.name}

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,5 @@
+- Cluster UI: return to overview page after scheduling actions
+
 -------------------------------------------------------------------
 Mon Jun 29 10:09:39 CEST 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

In the cluster UI, return to the cluster overview page after scheduling a join/remove/upgrade action.

## GUI diff

Before:

![image](https://user-images.githubusercontent.com/11468018/85708538-9366ad80-b6e4-11ea-95a7-9f9c7b696853.png)


After:

![image](https://user-images.githubusercontent.com/11468018/85707481-82696c80-b6e3-11ea-9e01-fb7a2396c7f5.png)

![image](https://user-images.githubusercontent.com/11468018/85714668-f0fdf880-b6ea-11ea-8b95-2d0e1c9ee242.png)
 
![image](https://user-images.githubusercontent.com/11468018/85714720-fce9ba80-b6ea-11ea-8f4b-c63cbccc54c9.png)


- [x] **DONE**

## Documentation
- No documentation needed: simple UI change

- [x] **DONE**

## Test coverage
- No tests: simple UI change, will be tested using Cucumber

- [x] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/11642

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
