### PR TITLE
WIP: Refactoring

### DIFF
--- a/java/code/src/com/redhat/rhn/GlobalInstanceHolder.java
+++ b/java/code/src/com/redhat/rhn/GlobalInstanceHolder.java
@@ -24,14 +24,14 @@ public class GlobalInstanceHolder {
     public static final SystemQuery SYSTEM_QUERY = SALT_SERVICE;
     public static final SaltApi SALT_API = SALT_SERVICE;
     private static final ServerGroupManager SERVER_GROUP_MANAGER = ServerGroupManager.getInstance();
-    public static final FormulaManager FORMULA_MANAGER = FormulaManager.getInstance();
+    public static final FormulaManager FORMULA_MANAGER = new FormulaManager(SALT_API);
     public static final ClusterManager CLUSTER_MANAGER = new ClusterManager(
             SALT_API, SYSTEM_QUERY, SERVER_GROUP_MANAGER, FORMULA_MANAGER
     );
     public static final SaltUtils SALT_UTILS = new SaltUtils(SYSTEM_QUERY, SALT_API,
             CLUSTER_MANAGER, FORMULA_MANAGER);
     public static final SaltServerActionService SALT_SERVER_ACTION_SERVICE = new SaltServerActionService(
-            SYSTEM_QUERY, SALT_UTILS, CLUSTER_MANAGER);
+            SYSTEM_QUERY, SALT_UTILS, CLUSTER_MANAGER, FORMULA_MANAGER);
     public static final Access ACCESS = new Access(CLUSTER_MANAGER);
     public static final AclFactory ACL_FACTORY = new AclFactory(ACCESS);
     public static final MenuTree MENU_TREE = new MenuTree(ACL_FACTORY);

--- a/java/code/src/com/redhat/rhn/GlobalInstanceHolder.java
+++ b/java/code/src/com/redhat/rhn/GlobalInstanceHolder.java
@@ -53,13 +53,13 @@ public class GlobalInstanceHolder {
     private static final SaltService SALT_SERVICE = new SaltService();
     public static final SystemQuery SYSTEM_QUERY = SALT_SERVICE;
     public static final SaltApi SALT_API = SALT_SERVICE;
-    private static final ServerGroupManager SERVER_GROUP_MANAGER = ServerGroupManager.getInstance();
+    public static final ServerGroupManager SERVER_GROUP_MANAGER = new ServerGroupManager();
     public static final FormulaManager FORMULA_MANAGER = new FormulaManager(SALT_API);
     public static final ClusterManager CLUSTER_MANAGER = new ClusterManager(
             SALT_API, SYSTEM_QUERY, SERVER_GROUP_MANAGER, FORMULA_MANAGER
     );
     public static final SaltUtils SALT_UTILS = new SaltUtils(SYSTEM_QUERY, SALT_API,
-            CLUSTER_MANAGER, FORMULA_MANAGER);
+            CLUSTER_MANAGER, FORMULA_MANAGER, SERVER_GROUP_MANAGER);
     public static final SaltKeyUtils SALT_KEY_UTILS = new SaltKeyUtils(SYSTEM_QUERY);
     public static final SaltServerActionService SALT_SERVER_ACTION_SERVICE = new SaltServerActionService(
             SYSTEM_QUERY, SALT_UTILS, CLUSTER_MANAGER, FORMULA_MANAGER, SALT_KEY_UTILS);
@@ -76,7 +76,8 @@ public class GlobalInstanceHolder {
     public static final SSHMinionBootstrapper SSH_MINION_BOOTSTRAPPER = new SSHMinionBootstrapper(SYSTEM_QUERY);
     public static final MonitoringManager MONITORING_MANAGER = new FormulaMonitoringManager();
     public static final SystemEntitlementManager SYSTEM_ENTITLEMENT_MANAGER = new SystemEntitlementManager(
-            new SystemUnentitler(VIRT_MANAGER, MONITORING_MANAGER),
-            new SystemEntitler(GlobalInstanceHolder.SYSTEM_QUERY, VIRT_MANAGER, MONITORING_MANAGER)
+            new SystemUnentitler(VIRT_MANAGER, MONITORING_MANAGER, SERVER_GROUP_MANAGER),
+            new SystemEntitler(GlobalInstanceHolder.SYSTEM_QUERY, VIRT_MANAGER, MONITORING_MANAGER,
+                    SERVER_GROUP_MANAGER)
     );
 }

--- a/java/code/src/com/redhat/rhn/GlobalInstanceHolder.java
+++ b/java/code/src/com/redhat/rhn/GlobalInstanceHolder.java
@@ -1,0 +1,41 @@
+package com.redhat.rhn;
+
+import com.redhat.rhn.common.security.acl.Access;
+import com.redhat.rhn.common.security.acl.AclFactory;
+import com.redhat.rhn.frontend.taglibs.helpers.RenderUtils;
+import com.redhat.rhn.manager.formula.FormulaManager;
+import com.redhat.rhn.manager.system.ServerGroupManager;
+import com.suse.manager.clusters.ClusterManager;
+import com.suse.manager.utils.SaltUtils;
+import com.suse.manager.webui.menu.MenuTree;
+import com.suse.manager.webui.services.SaltServerActionService;
+import com.suse.manager.webui.services.iface.SaltApi;
+import com.suse.manager.webui.services.iface.SystemQuery;
+import com.suse.manager.webui.services.impl.SaltService;
+import com.suse.manager.webui.utils.MinionActionUtils;
+
+/**
+ * This is a "hack" and should only be used by the main entry points of
+ * tomcat and taskomatic and those places that don't have a good way yet to
+ * get dependencies passed via constructor.
+ */
+public class GlobalInstanceHolder {
+    private static final SaltService SALT_SERVICE = new SaltService();
+    public static final SystemQuery SYSTEM_QUERY = SALT_SERVICE;
+    public static final SaltApi SALT_API = SALT_SERVICE;
+    private static final ServerGroupManager SERVER_GROUP_MANAGER = ServerGroupManager.getInstance();
+    public static final FormulaManager FORMULA_MANAGER = FormulaManager.getInstance();
+    public static final ClusterManager CLUSTER_MANAGER = new ClusterManager(
+            SALT_API, SYSTEM_QUERY, SERVER_GROUP_MANAGER, FORMULA_MANAGER
+    );
+    public static final SaltUtils SALT_UTILS = new SaltUtils(SYSTEM_QUERY, SALT_API,
+            CLUSTER_MANAGER, FORMULA_MANAGER);
+    public static final SaltServerActionService SALT_SERVER_ACTION_SERVICE = new SaltServerActionService(
+            SYSTEM_QUERY, SALT_UTILS, CLUSTER_MANAGER);
+    public static final Access ACCESS = new Access(CLUSTER_MANAGER);
+    public static final AclFactory ACL_FACTORY = new AclFactory(ACCESS);
+    public static final MenuTree MENU_TREE = new MenuTree(ACL_FACTORY);
+    public static final RenderUtils RENDER_UTILS = new RenderUtils(ACL_FACTORY);
+    public static final MinionActionUtils MINION_ACTION_UTILS = new MinionActionUtils(
+            SALT_SERVER_ACTION_SERVICE, SYSTEM_QUERY, SALT_UTILS);
+}

--- a/java/code/src/com/redhat/rhn/GlobalInstanceHolder.java
+++ b/java/code/src/com/redhat/rhn/GlobalInstanceHolder.java
@@ -6,11 +6,16 @@ import com.redhat.rhn.frontend.taglibs.helpers.RenderUtils;
 import com.redhat.rhn.manager.formula.FormulaManager;
 import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.suse.manager.clusters.ClusterManager;
+import com.suse.manager.kubernetes.KubernetesManager;
 import com.suse.manager.utils.SaltUtils;
+import com.suse.manager.virtualization.VirtManagerSalt;
+import com.suse.manager.webui.controllers.utils.RegularMinionBootstrapper;
+import com.suse.manager.webui.controllers.utils.SSHMinionBootstrapper;
 import com.suse.manager.webui.menu.MenuTree;
 import com.suse.manager.webui.services.SaltServerActionService;
 import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.SystemQuery;
+import com.suse.manager.webui.services.iface.VirtManager;
 import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.manager.webui.utils.MinionActionUtils;
 
@@ -38,4 +43,8 @@ public class GlobalInstanceHolder {
     public static final RenderUtils RENDER_UTILS = new RenderUtils(ACL_FACTORY);
     public static final MinionActionUtils MINION_ACTION_UTILS = new MinionActionUtils(
             SALT_SERVER_ACTION_SERVICE, SYSTEM_QUERY, SALT_UTILS);
+    public static final KubernetesManager KUBERNETES_MANAGER = new KubernetesManager(SYSTEM_QUERY);
+    public static final VirtManager VIRT_MANAGER = new VirtManagerSalt(SALT_API);
+    public static final RegularMinionBootstrapper REGULAR_MINION_BOOTSTRAPPER = RegularMinionBootstrapper.getInstance(SYSTEM_QUERY);
+    public static final SSHMinionBootstrapper SSH_MINION_BOOTSTRAPPER = SSHMinionBootstrapper.getInstance(SYSTEM_QUERY);
 }

--- a/java/code/src/com/redhat/rhn/GlobalInstanceHolder.java
+++ b/java/code/src/com/redhat/rhn/GlobalInstanceHolder.java
@@ -1,3 +1,17 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
 package com.redhat.rhn;
 
 import com.redhat.rhn.common.security.acl.Access;

--- a/java/code/src/com/redhat/rhn/GlobalInstanceHolder.java
+++ b/java/code/src/com/redhat/rhn/GlobalInstanceHolder.java
@@ -77,7 +77,7 @@ public class GlobalInstanceHolder {
     public static final MonitoringManager MONITORING_MANAGER = new FormulaMonitoringManager();
     public static final SystemEntitlementManager SYSTEM_ENTITLEMENT_MANAGER = new SystemEntitlementManager(
             new SystemUnentitler(VIRT_MANAGER, MONITORING_MANAGER, SERVER_GROUP_MANAGER),
-            new SystemEntitler(GlobalInstanceHolder.SYSTEM_QUERY, VIRT_MANAGER, MONITORING_MANAGER,
+            new SystemEntitler(SYSTEM_QUERY, VIRT_MANAGER, MONITORING_MANAGER,
                     SERVER_GROUP_MANAGER)
     );
 }

--- a/java/code/src/com/redhat/rhn/GlobalInstanceHolder.java
+++ b/java/code/src/com/redhat/rhn/GlobalInstanceHolder.java
@@ -4,7 +4,11 @@ import com.redhat.rhn.common.security.acl.Access;
 import com.redhat.rhn.common.security.acl.AclFactory;
 import com.redhat.rhn.frontend.taglibs.helpers.RenderUtils;
 import com.redhat.rhn.manager.formula.FormulaManager;
+import com.redhat.rhn.manager.formula.FormulaMonitoringManager;
 import com.redhat.rhn.manager.system.ServerGroupManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitler;
+import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
 import com.suse.manager.clusters.ClusterManager;
 import com.suse.manager.kubernetes.KubernetesManager;
 import com.suse.manager.utils.SaltUtils;
@@ -13,6 +17,7 @@ import com.suse.manager.webui.controllers.utils.RegularMinionBootstrapper;
 import com.suse.manager.webui.controllers.utils.SSHMinionBootstrapper;
 import com.suse.manager.webui.menu.MenuTree;
 import com.suse.manager.webui.services.SaltServerActionService;
+import com.suse.manager.webui.services.iface.MonitoringManager;
 import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.manager.webui.services.iface.VirtManager;
@@ -48,4 +53,9 @@ public class GlobalInstanceHolder {
     public static final RegularMinionBootstrapper REGULAR_MINION_BOOTSTRAPPER =
             new RegularMinionBootstrapper(SYSTEM_QUERY);
     public static final SSHMinionBootstrapper SSH_MINION_BOOTSTRAPPER = new SSHMinionBootstrapper(SYSTEM_QUERY);
+    public static final MonitoringManager MONITORING_MANAGER = new FormulaMonitoringManager();
+    public static final SystemEntitlementManager SYSTEM_ENTITLEMENT_MANAGER = new SystemEntitlementManager(
+            new SystemUnentitler(VIRT_MANAGER, MONITORING_MANAGER),
+            new SystemEntitler(GlobalInstanceHolder.SYSTEM_QUERY, VIRT_MANAGER, MONITORING_MANAGER)
+    );
 }

--- a/java/code/src/com/redhat/rhn/GlobalInstanceHolder.java
+++ b/java/code/src/com/redhat/rhn/GlobalInstanceHolder.java
@@ -65,6 +65,7 @@ public class GlobalInstanceHolder {
             SYSTEM_QUERY, SALT_UTILS, CLUSTER_MANAGER, FORMULA_MANAGER, SALT_KEY_UTILS);
     public static final Access ACCESS = new Access(CLUSTER_MANAGER);
     public static final AclFactory ACL_FACTORY = new AclFactory(ACCESS);
+    // Referenced from JSP
     public static final MenuTree MENU_TREE = new MenuTree(ACL_FACTORY);
     public static final RenderUtils RENDER_UTILS = new RenderUtils(ACL_FACTORY);
     public static final MinionActionUtils MINION_ACTION_UTILS = new MinionActionUtils(

--- a/java/code/src/com/redhat/rhn/GlobalInstanceHolder.java
+++ b/java/code/src/com/redhat/rhn/GlobalInstanceHolder.java
@@ -25,11 +25,16 @@ import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.manager.webui.utils.MinionActionUtils;
 
 /**
- * This is a "hack" and should only be used by the main entry points of
- * tomcat and taskomatic and those places that don't have a good way yet to
- * get dependencies passed via constructor.
+ * This class only exists to have a single place for initializing objects
+ * and share a single consistent instance in multiple parts of tomcat/taskomatic.
+ * These instances should only be referenced from entry points of the program and
+ * places that cant receive them otherwise though the constructor (i.e because of reflection)
  */
 public class GlobalInstanceHolder {
+
+    private GlobalInstanceHolder() {
+    }
+
     private static final SaltService SALT_SERVICE = new SaltService();
     public static final SystemQuery SYSTEM_QUERY = SALT_SERVICE;
     public static final SaltApi SALT_API = SALT_SERVICE;

--- a/java/code/src/com/redhat/rhn/GlobalInstanceHolder.java
+++ b/java/code/src/com/redhat/rhn/GlobalInstanceHolder.java
@@ -25,6 +25,7 @@ import com.redhat.rhn.manager.system.entitling.SystemEntitler;
 import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
 import com.suse.manager.clusters.ClusterManager;
 import com.suse.manager.kubernetes.KubernetesManager;
+import com.suse.manager.utils.SaltKeyUtils;
 import com.suse.manager.utils.SaltUtils;
 import com.suse.manager.virtualization.VirtManagerSalt;
 import com.suse.manager.webui.controllers.utils.RegularMinionBootstrapper;
@@ -59,8 +60,9 @@ public class GlobalInstanceHolder {
     );
     public static final SaltUtils SALT_UTILS = new SaltUtils(SYSTEM_QUERY, SALT_API,
             CLUSTER_MANAGER, FORMULA_MANAGER);
+    public static final SaltKeyUtils SALT_KEY_UTILS = new SaltKeyUtils(SYSTEM_QUERY);
     public static final SaltServerActionService SALT_SERVER_ACTION_SERVICE = new SaltServerActionService(
-            SYSTEM_QUERY, SALT_UTILS, CLUSTER_MANAGER, FORMULA_MANAGER);
+            SYSTEM_QUERY, SALT_UTILS, CLUSTER_MANAGER, FORMULA_MANAGER, SALT_KEY_UTILS);
     public static final Access ACCESS = new Access(CLUSTER_MANAGER);
     public static final AclFactory ACL_FACTORY = new AclFactory(ACCESS);
     public static final MenuTree MENU_TREE = new MenuTree(ACL_FACTORY);

--- a/java/code/src/com/redhat/rhn/GlobalInstanceHolder.java
+++ b/java/code/src/com/redhat/rhn/GlobalInstanceHolder.java
@@ -45,6 +45,7 @@ public class GlobalInstanceHolder {
             SALT_SERVER_ACTION_SERVICE, SYSTEM_QUERY, SALT_UTILS);
     public static final KubernetesManager KUBERNETES_MANAGER = new KubernetesManager(SYSTEM_QUERY);
     public static final VirtManager VIRT_MANAGER = new VirtManagerSalt(SALT_API);
-    public static final RegularMinionBootstrapper REGULAR_MINION_BOOTSTRAPPER = RegularMinionBootstrapper.getInstance(SYSTEM_QUERY);
-    public static final SSHMinionBootstrapper SSH_MINION_BOOTSTRAPPER = SSHMinionBootstrapper.getInstance(SYSTEM_QUERY);
+    public static final RegularMinionBootstrapper REGULAR_MINION_BOOTSTRAPPER =
+            new RegularMinionBootstrapper(SYSTEM_QUERY);
+    public static final SSHMinionBootstrapper SSH_MINION_BOOTSTRAPPER = new SSHMinionBootstrapper(SYSTEM_QUERY);
 }

--- a/java/code/src/com/redhat/rhn/common/security/acl/Access.java
+++ b/java/code/src/com/redhat/rhn/common/security/acl/Access.java
@@ -51,12 +51,14 @@ import java.util.Map;
 public class Access extends BaseHandler {
 
     protected static final Logger LOG = Logger.getLogger(Access.class);
+    private final ClusterManager clusterManager;
 
     /**
      * Constructor for Access object
+     * @param clusterManagerIn
      */
-    public Access() {
-        super();
+    public Access(ClusterManager clusterManagerIn) {
+        this.clusterManager = clusterManagerIn;
     }
 
     /**
@@ -546,7 +548,7 @@ public class Access extends BaseHandler {
         Map map = (Map) ctx;
         Long sgid = getAsLong(map.get("sgid"));
         User user = (User) map.get("user");
-        return ClusterManager.instance().isClusterGroup(sgid);
+        return clusterManager.isClusterGroup(sgid);
     }
 
 }

--- a/java/code/src/com/redhat/rhn/common/security/acl/AclFactory.java
+++ b/java/code/src/com/redhat/rhn/common/security/acl/AclFactory.java
@@ -29,22 +29,14 @@ import org.apache.commons.lang3.StringUtils;
  */
 public class AclFactory {
 
-    // private instance of the service.
-    private static AclFactory instance = new AclFactory();
+    private final Access access;
 
     /**
      * hidden constructor
+     * @param accessIn
      */
-    private AclFactory() {
-        // hidden constructor
-    }
-
-    /** Get the running instance of the AclFactory
-     *
-     * @return The AclFactory singleton
-     */
-    public static AclFactory getInstance() {
-        return instance;
+    public AclFactory(Access accessIn) {
+        this.access = accessIn;
     }
 
     /**
@@ -54,7 +46,6 @@ public class AclFactory {
      */
     public Acl getAcl(String mixinsIn) {
         Acl aclObj = new Acl();
-        Access access = new Access();
         aclObj.registerHandler(access);
 
         // Add the mixin handlers as well.

--- a/java/code/src/com/redhat/rhn/common/security/acl/AclFactory.java
+++ b/java/code/src/com/redhat/rhn/common/security/acl/AclFactory.java
@@ -52,7 +52,9 @@ public class AclFactory {
         if (mixinsIn != null) {
             String[] mixin = StringUtils.split(mixinsIn, ",");
             for (int i = 0; i < mixin.length; i++) {
-                aclObj.registerHandler(StringUtils.trim(mixin[i]));
+                if (!mixin[i].equals(Access.class.getName())) {
+                    aclObj.registerHandler(StringUtils.trim(mixin[i]));
+                }
             }
         }
         return aclObj;

--- a/java/code/src/com/redhat/rhn/common/security/acl/test/AccessTest.java
+++ b/java/code/src/com/redhat/rhn/common/security/acl/test/AccessTest.java
@@ -60,7 +60,7 @@ public class AccessTest extends BaseTestCaseWithUser {
     private final SaltService saltService = new SaltService();
     private final SystemQuery systemQuery = saltService;
     private final SaltApi saltApi = saltService;
-    private final ServerGroupManager serverGroupManager =  ServerGroupManager.getInstance();
+    private final ServerGroupManager serverGroupManager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
     private final FormulaManager formulaManager = new FormulaManager(saltApi);
     private final ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);
 
@@ -336,8 +336,10 @@ public class AccessTest extends BaseTestCaseWithUser {
 
     public void testIsVirtual() throws Exception {
         SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(new VirtManagerSalt(saltService), new FormulaMonitoringManager()),
-                new SystemEntitler(saltService, new VirtManagerSalt(saltService), new FormulaMonitoringManager())
+                new SystemUnentitler(new VirtManagerSalt(saltService), new FormulaMonitoringManager(),
+                        serverGroupManager),
+                new SystemEntitler(saltService, new VirtManagerSalt(saltService), new FormulaMonitoringManager(),
+                        serverGroupManager)
         );
         Server host = ServerTestUtils.createVirtHostWithGuests(user, 1, systemEntitlementManager);
         Server guest = host.getGuests().iterator().next().getGuestSystem();

--- a/java/code/src/com/redhat/rhn/common/security/acl/test/AccessTest.java
+++ b/java/code/src/com/redhat/rhn/common/security/acl/test/AccessTest.java
@@ -60,7 +60,7 @@ public class AccessTest extends BaseTestCaseWithUser {
     private final SaltService saltService = new SaltService();
     private final SystemQuery systemQuery = saltService;
     private final SaltApi saltApi = saltService;
-    private final ServerGroupManager serverGroupManager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
+    private final ServerGroupManager serverGroupManager = new ServerGroupManager();
     private final FormulaManager formulaManager = new FormulaManager(saltApi);
     private final ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);
 

--- a/java/code/src/com/redhat/rhn/common/security/acl/test/AccessTest.java
+++ b/java/code/src/com/redhat/rhn/common/security/acl/test/AccessTest.java
@@ -43,8 +43,9 @@ import com.suse.manager.virtualization.VirtManagerSalt;
 import com.suse.manager.webui.services.iface.MonitoringManager;
 import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.SystemQuery;
+import com.suse.manager.webui.services.test.TestSaltApi;
+import com.suse.manager.webui.services.test.TestSystemQuery;
 import com.suse.manager.webui.services.iface.VirtManager;
-import com.suse.manager.webui.services.impl.SaltService;
 
 import java.util.Date;
 import java.util.HashMap;
@@ -58,9 +59,8 @@ import java.util.Set;
 public class AccessTest extends BaseTestCaseWithUser {
 
     private Acl acl;
-    private final SaltService saltService = new SaltService();
-    private final SystemQuery systemQuery = saltService;
-    private final SaltApi saltApi = saltService;
+    private final SystemQuery systemQuery = new TestSystemQuery();
+    private final SaltApi saltApi = new TestSaltApi();
     private final ServerGroupManager serverGroupManager = new ServerGroupManager();
     private final FormulaManager formulaManager = new FormulaManager(saltApi);
     private final ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);
@@ -342,12 +342,6 @@ public class AccessTest extends BaseTestCaseWithUser {
     }
 
     public void testIsVirtual() throws Exception {
-        SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(new VirtManagerSalt(saltService), new FormulaMonitoringManager(),
-                        serverGroupManager),
-                new SystemEntitler(saltService, new VirtManagerSalt(saltService), new FormulaMonitoringManager(),
-                        serverGroupManager)
-        );
         Server host = ServerTestUtils.createVirtHostWithGuests(user, 1, systemEntitlementManager);
         Server guest = host.getGuests().iterator().next().getGuestSystem();
 

--- a/java/code/src/com/redhat/rhn/common/security/acl/test/AccessTest.java
+++ b/java/code/src/com/redhat/rhn/common/security/acl/test/AccessTest.java
@@ -14,6 +14,7 @@
  */
 package com.redhat.rhn.common.security.acl.test;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.security.acl.Access;
 import com.redhat.rhn.common.security.acl.Acl;
@@ -237,7 +238,7 @@ public class AccessTest extends BaseTestCaseWithUser {
         assertTrue(acl.evalAcl(context, "system_has_salt_entitlement()"));
 
         // Change the base entitlement to MANAGEMENT
-        SystemEntitlementManager.INSTANCE.setBaseEntitlement(s, EntitlementManager.MANAGEMENT);
+        GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER.setBaseEntitlement(s, EntitlementManager.MANAGEMENT);
         context.put("sid", new String[] {s.getId().toString()});
         context.put("user", user);
         assertFalse(acl.evalAcl(context, "system_has_salt_entitlement()"));

--- a/java/code/src/com/redhat/rhn/common/security/acl/test/AclFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/common/security/acl/test/AclFactoryTest.java
@@ -14,9 +14,16 @@
  */
 package com.redhat.rhn.common.security.acl.test;
 
+import com.redhat.rhn.common.security.acl.Access;
 import com.redhat.rhn.common.security.acl.Acl;
 import com.redhat.rhn.common.security.acl.AclFactory;
+import com.redhat.rhn.manager.formula.FormulaManager;
+import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.testing.RhnBaseTestCase;
+import com.suse.manager.clusters.ClusterManager;
+import com.suse.manager.webui.services.iface.SaltApi;
+import com.suse.manager.webui.services.iface.SystemQuery;
+import com.suse.manager.webui.services.impl.SaltService;
 
 /**
  * AccessTest
@@ -25,8 +32,14 @@ import com.redhat.rhn.testing.RhnBaseTestCase;
 public class AclFactoryTest extends RhnBaseTestCase {
 
     public void testGetAcl() {
-        Acl test = AclFactory.getInstance().
-            getAcl("  com.redhat.rhn.common.security.acl.test.MixinTestHandler  ");
+        SaltService saltService = new SaltService();
+        SystemQuery systemQuery = saltService;
+        SaltApi saltApi = saltService;
+        ServerGroupManager serverGroupManager =  ServerGroupManager.getInstance();
+        FormulaManager formulaManager = new FormulaManager(saltApi);
+        ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);
+        AclFactory aclFactory = new AclFactory(new Access(clusterManager));
+        Acl test = aclFactory.getAcl("  com.redhat.rhn.common.security.acl.test.MixinTestHandler  ");
         assertNotNull(test);
     }
 }

--- a/java/code/src/com/redhat/rhn/common/security/acl/test/AclFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/common/security/acl/test/AclFactoryTest.java
@@ -36,7 +36,7 @@ public class AclFactoryTest extends RhnBaseTestCase {
         SaltService saltService = new SaltService();
         SystemQuery systemQuery = saltService;
         SaltApi saltApi = saltService;
-        ServerGroupManager serverGroupManager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
+        ServerGroupManager serverGroupManager = new ServerGroupManager();
         FormulaManager formulaManager = new FormulaManager(saltApi);
         ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);
         AclFactory aclFactory = new AclFactory(new Access(clusterManager));

--- a/java/code/src/com/redhat/rhn/common/security/acl/test/AclFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/common/security/acl/test/AclFactoryTest.java
@@ -14,6 +14,7 @@
  */
 package com.redhat.rhn.common.security.acl.test;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.security.acl.Access;
 import com.redhat.rhn.common.security.acl.Acl;
 import com.redhat.rhn.common.security.acl.AclFactory;
@@ -35,7 +36,7 @@ public class AclFactoryTest extends RhnBaseTestCase {
         SaltService saltService = new SaltService();
         SystemQuery systemQuery = saltService;
         SaltApi saltApi = saltService;
-        ServerGroupManager serverGroupManager =  ServerGroupManager.getInstance();
+        ServerGroupManager serverGroupManager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
         FormulaManager formulaManager = new FormulaManager(saltApi);
         ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);
         AclFactory aclFactory = new AclFactory(new Access(clusterManager));

--- a/java/code/src/com/redhat/rhn/common/security/acl/test/AclFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/common/security/acl/test/AclFactoryTest.java
@@ -14,7 +14,6 @@
  */
 package com.redhat.rhn.common.security.acl.test;
 
-import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.security.acl.Access;
 import com.redhat.rhn.common.security.acl.Acl;
 import com.redhat.rhn.common.security.acl.AclFactory;
@@ -24,7 +23,8 @@ import com.redhat.rhn.testing.RhnBaseTestCase;
 import com.suse.manager.clusters.ClusterManager;
 import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.SystemQuery;
-import com.suse.manager.webui.services.impl.SaltService;
+import com.suse.manager.webui.services.test.TestSaltApi;
+import com.suse.manager.webui.services.test.TestSystemQuery;
 
 /**
  * AccessTest
@@ -33,9 +33,8 @@ import com.suse.manager.webui.services.impl.SaltService;
 public class AclFactoryTest extends RhnBaseTestCase {
 
     public void testGetAcl() {
-        SaltService saltService = new SaltService();
-        SystemQuery systemQuery = saltService;
-        SaltApi saltApi = saltService;
+        SystemQuery systemQuery = new TestSystemQuery();
+        SaltApi saltApi = new TestSaltApi();
         ServerGroupManager serverGroupManager = new ServerGroupManager();
         FormulaManager formulaManager = new FormulaManager(saltApi);
         ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);

--- a/java/code/src/com/redhat/rhn/domain/action/script/ScriptRunAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/script/ScriptRunAction.java
@@ -19,6 +19,7 @@ import com.redhat.rhn.common.util.FileUtils;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.download.DownloadManager;
+import com.redhat.rhn.taskomatic.core.SchedulerKernel;
 import com.suse.manager.utils.SaltUtils;
 
 import org.apache.commons.lang3.StringEscapeUtils;
@@ -29,6 +30,8 @@ import org.apache.commons.lang3.StringEscapeUtils;
  * @version $Rev$
  */
 public class ScriptRunAction extends ScriptAction {
+
+    private final SaltUtils saltUtils = SchedulerKernel.SALT_UTILS;
 
     /**
      * {@inheritDoc}
@@ -81,7 +84,7 @@ public class ScriptRunAction extends ScriptAction {
     @Override
     public void onCancelAction() {
         if (allServersFinished()) {
-            FileUtils.deleteFile(SaltUtils.INSTANCE.getScriptPath(getId()));
+            FileUtils.deleteFile(saltUtils.getScriptPath(getId()));
         }
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/action/script/ScriptRunAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/script/ScriptRunAction.java
@@ -14,12 +14,12 @@
  */
 package com.redhat.rhn.domain.action.script;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.common.util.FileUtils;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.download.DownloadManager;
-import com.redhat.rhn.taskomatic.core.SchedulerKernel;
 import com.suse.manager.utils.SaltUtils;
 
 import org.apache.commons.lang3.StringEscapeUtils;
@@ -31,7 +31,7 @@ import org.apache.commons.lang3.StringEscapeUtils;
  */
 public class ScriptRunAction extends ScriptAction {
 
-    private final SaltUtils saltUtils = SchedulerKernel.SALT_UTILS;
+    private final SaltUtils saltUtils = GlobalInstanceHolder.SALT_UTILS;
 
     /**
      * {@inheritDoc}

--- a/java/code/src/com/redhat/rhn/domain/entitlement/test/BaseEntitlementTestCase.java
+++ b/java/code/src/com/redhat/rhn/domain/entitlement/test/BaseEntitlementTestCase.java
@@ -18,8 +18,21 @@ import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.entitlement.Entitlement;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
+import com.redhat.rhn.manager.formula.FormulaManager;
+import com.redhat.rhn.manager.formula.FormulaMonitoringManager;
+import com.redhat.rhn.manager.system.ServerGroupManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitler;
+import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
 import com.redhat.rhn.testing.ServerTestUtils;
+import com.suse.manager.clusters.ClusterManager;
+import com.suse.manager.virtualization.VirtManagerSalt;
+import com.suse.manager.webui.services.iface.MonitoringManager;
+import com.suse.manager.webui.services.iface.SaltApi;
+import com.suse.manager.webui.services.iface.SystemQuery;
+import com.suse.manager.webui.services.iface.VirtManager;
+import com.suse.manager.webui.services.impl.SaltService;
 
 /**
  * BaseEntitlementTestCase
@@ -28,6 +41,17 @@ import com.redhat.rhn.testing.ServerTestUtils;
 public abstract class BaseEntitlementTestCase extends BaseTestCaseWithUser {
 
     protected Entitlement ent;
+
+    private final SaltService saltService = new SaltService();
+    private final SystemQuery systemQuery = saltService;
+    private final SaltApi saltApi = saltService;
+    private final ServerGroupManager serverGroupManager = new ServerGroupManager();
+    private final VirtManager virtManager = new VirtManagerSalt(saltApi);
+    private final MonitoringManager monitoringManager = new FormulaMonitoringManager();
+    private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
+            new SystemUnentitler(virtManager, monitoringManager, serverGroupManager),
+            new SystemEntitler(systemQuery, virtManager, monitoringManager, serverGroupManager)
+    );
 
     @Override
     public void setUp() throws Exception {
@@ -44,8 +68,8 @@ public abstract class BaseEntitlementTestCase extends BaseTestCaseWithUser {
         Server traditional = ServerTestUtils.createTestSystem(user);
         Server foreign = ServerTestUtils.createForeignSystem(user, "9999");
 
-        GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER.setBaseEntitlement(traditional, EntitlementManager.MANAGEMENT);
-        GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER.setBaseEntitlement(foreign, EntitlementManager.FOREIGN);
+        systemEntitlementManager.setBaseEntitlement(traditional, EntitlementManager.MANAGEMENT);
+        systemEntitlementManager.setBaseEntitlement(foreign, EntitlementManager.FOREIGN);
 
         assertTrue(traditional.getValidAddonEntitlementsForServer().size() > 0);
         assertTrue(foreign.getValidAddonEntitlementsForServer().size() == 0);
@@ -55,8 +79,8 @@ public abstract class BaseEntitlementTestCase extends BaseTestCaseWithUser {
         Server traditional = ServerTestUtils.createTestSystem(user);
         Server foreign = ServerTestUtils.createForeignSystem(user, "9999");
 
-        GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER.setBaseEntitlement(traditional, EntitlementManager.MANAGEMENT);
-        GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER.setBaseEntitlement(foreign, EntitlementManager.FOREIGN);
+        systemEntitlementManager.setBaseEntitlement(traditional, EntitlementManager.MANAGEMENT);
+        systemEntitlementManager.setBaseEntitlement(foreign, EntitlementManager.FOREIGN);
 
         assertTrue(ent.isAllowedOnServer(traditional, null));
         assertFalse(ent.isAllowedOnServer(foreign, null));

--- a/java/code/src/com/redhat/rhn/domain/entitlement/test/BaseEntitlementTestCase.java
+++ b/java/code/src/com/redhat/rhn/domain/entitlement/test/BaseEntitlementTestCase.java
@@ -14,11 +14,9 @@
  */
 package com.redhat.rhn.domain.entitlement.test;
 
-import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.entitlement.Entitlement;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
-import com.redhat.rhn.manager.formula.FormulaManager;
 import com.redhat.rhn.manager.formula.FormulaMonitoringManager;
 import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
@@ -26,13 +24,10 @@ import com.redhat.rhn.manager.system.entitling.SystemEntitler;
 import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
 import com.redhat.rhn.testing.ServerTestUtils;
-import com.suse.manager.clusters.ClusterManager;
 import com.suse.manager.virtualization.VirtManagerSalt;
-import com.suse.manager.webui.services.iface.MonitoringManager;
-import com.suse.manager.webui.services.iface.SaltApi;
-import com.suse.manager.webui.services.iface.SystemQuery;
-import com.suse.manager.webui.services.iface.VirtManager;
-import com.suse.manager.webui.services.impl.SaltService;
+import com.suse.manager.webui.services.iface.*;
+import com.suse.manager.webui.services.test.TestSaltApi;
+import com.suse.manager.webui.services.test.TestSystemQuery;
 
 /**
  * BaseEntitlementTestCase
@@ -42,9 +37,8 @@ public abstract class BaseEntitlementTestCase extends BaseTestCaseWithUser {
 
     protected Entitlement ent;
 
-    private final SaltService saltService = new SaltService();
-    private final SystemQuery systemQuery = saltService;
-    private final SaltApi saltApi = saltService;
+    private final SystemQuery systemQuery = new TestSystemQuery();
+    private final SaltApi saltApi = new TestSaltApi();
     private final ServerGroupManager serverGroupManager = new ServerGroupManager();
     private final VirtManager virtManager = new VirtManagerSalt(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager();

--- a/java/code/src/com/redhat/rhn/domain/entitlement/test/BaseEntitlementTestCase.java
+++ b/java/code/src/com/redhat/rhn/domain/entitlement/test/BaseEntitlementTestCase.java
@@ -14,11 +14,10 @@
  */
 package com.redhat.rhn.domain.entitlement.test;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.entitlement.Entitlement;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
-import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
-import com.redhat.rhn.manager.system.entitling.SystemEntitler;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
 import com.redhat.rhn.testing.ServerTestUtils;
 
@@ -45,8 +44,8 @@ public abstract class BaseEntitlementTestCase extends BaseTestCaseWithUser {
         Server traditional = ServerTestUtils.createTestSystem(user);
         Server foreign = ServerTestUtils.createForeignSystem(user, "9999");
 
-        SystemEntitlementManager.INSTANCE.setBaseEntitlement(traditional, EntitlementManager.MANAGEMENT);
-        SystemEntitlementManager.INSTANCE.setBaseEntitlement(foreign, EntitlementManager.FOREIGN);
+        GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER.setBaseEntitlement(traditional, EntitlementManager.MANAGEMENT);
+        GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER.setBaseEntitlement(foreign, EntitlementManager.FOREIGN);
 
         assertTrue(traditional.getValidAddonEntitlementsForServer().size() > 0);
         assertTrue(foreign.getValidAddonEntitlementsForServer().size() == 0);
@@ -56,8 +55,8 @@ public abstract class BaseEntitlementTestCase extends BaseTestCaseWithUser {
         Server traditional = ServerTestUtils.createTestSystem(user);
         Server foreign = ServerTestUtils.createForeignSystem(user, "9999");
 
-        SystemEntitlementManager.INSTANCE.setBaseEntitlement(traditional, EntitlementManager.MANAGEMENT);
-        SystemEntitlementManager.INSTANCE.setBaseEntitlement(foreign, EntitlementManager.FOREIGN);
+        GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER.setBaseEntitlement(traditional, EntitlementManager.MANAGEMENT);
+        GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER.setBaseEntitlement(foreign, EntitlementManager.FOREIGN);
 
         assertTrue(ent.isAllowedOnServer(traditional, null));
         assertFalse(ent.isAllowedOnServer(foreign, null));

--- a/java/code/src/com/redhat/rhn/domain/entitlement/test/ContainerBuildHostEntitlementTest.java
+++ b/java/code/src/com/redhat/rhn/domain/entitlement/test/ContainerBuildHostEntitlementTest.java
@@ -28,20 +28,17 @@ import com.redhat.rhn.testing.ServerTestUtils;
 
 import com.suse.manager.reactor.utils.ValueMap;
 import com.suse.manager.virtualization.VirtManagerSalt;
-import com.suse.manager.webui.services.iface.MonitoringManager;
-import com.suse.manager.webui.services.iface.SaltApi;
-import com.suse.manager.webui.services.iface.SystemQuery;
-import com.suse.manager.webui.services.iface.VirtManager;
-import com.suse.manager.webui.services.impl.SaltService;
+import com.suse.manager.webui.services.iface.*;
+import com.suse.manager.webui.services.test.TestSaltApi;
+import com.suse.manager.webui.services.test.TestSystemQuery;
 
 import java.util.HashMap;
 import java.util.Map;
 
 public class ContainerBuildHostEntitlementTest extends BaseEntitlementTestCase {
 
-    private final SaltService saltService = new SaltService();
-    private final SystemQuery systemQuery = saltService;
-    private final SaltApi saltApi = saltService;
+    private final SystemQuery systemQuery = new TestSystemQuery();
+    private final SaltApi saltApi = new TestSaltApi();
     private final ServerGroupManager serverGroupManager = new ServerGroupManager();
     private final VirtManager virtManager = new VirtManagerSalt(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager();

--- a/java/code/src/com/redhat/rhn/domain/entitlement/test/ContainerBuildHostEntitlementTest.java
+++ b/java/code/src/com/redhat/rhn/domain/entitlement/test/ContainerBuildHostEntitlementTest.java
@@ -15,19 +15,40 @@
 
 package com.redhat.rhn.domain.entitlement.test;
 
-import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.entitlement.ContainerBuildHostEntitlement;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
+import com.redhat.rhn.manager.formula.FormulaMonitoringManager;
+import com.redhat.rhn.manager.system.ServerGroupManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitler;
+import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
 import com.redhat.rhn.testing.ServerTestUtils;
 
 import com.suse.manager.reactor.utils.ValueMap;
+import com.suse.manager.virtualization.VirtManagerSalt;
+import com.suse.manager.webui.services.iface.MonitoringManager;
+import com.suse.manager.webui.services.iface.SaltApi;
+import com.suse.manager.webui.services.iface.SystemQuery;
+import com.suse.manager.webui.services.iface.VirtManager;
+import com.suse.manager.webui.services.impl.SaltService;
 
 import java.util.HashMap;
 import java.util.Map;
 
 public class ContainerBuildHostEntitlementTest extends BaseEntitlementTestCase {
+
+    private final SaltService saltService = new SaltService();
+    private final SystemQuery systemQuery = saltService;
+    private final SaltApi saltApi = saltService;
+    private final ServerGroupManager serverGroupManager = new ServerGroupManager();
+    private final VirtManager virtManager = new VirtManagerSalt(saltApi);
+    private final MonitoringManager monitoringManager = new FormulaMonitoringManager();
+    private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
+            new SystemUnentitler(virtManager, monitoringManager, serverGroupManager),
+            new SystemEntitler(systemQuery, virtManager, monitoringManager, serverGroupManager)
+    );
 
     @Override
     protected void createEntitlement() {
@@ -46,8 +67,8 @@ public class ContainerBuildHostEntitlementTest extends BaseEntitlementTestCase {
         minion.setOs("SLES");
         minion.setRelease("12.2");
 
-        GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER.setBaseEntitlement(traditional, EntitlementManager.MANAGEMENT);
-        GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER.setBaseEntitlement(minion, EntitlementManager.SALT);
+        systemEntitlementManager.setBaseEntitlement(traditional, EntitlementManager.MANAGEMENT);
+        systemEntitlementManager.setBaseEntitlement(minion, EntitlementManager.SALT);
 
         assertTrue(ent.isAllowedOnServer(minion));
         assertFalse(ent.isAllowedOnServer(traditional));
@@ -70,7 +91,7 @@ public class ContainerBuildHostEntitlementTest extends BaseEntitlementTestCase {
         grains.put("osmajorrelease", "7");
         assertTrue(ent.isAllowedOnServer(minion, new ValueMap(grains)));
 
-        GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER.setBaseEntitlement(minion, EntitlementManager.MANAGEMENT);
+        systemEntitlementManager.setBaseEntitlement(minion, EntitlementManager.MANAGEMENT);
         assertFalse(ent.isAllowedOnServer(minion, new ValueMap(grains)));
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/entitlement/test/ContainerBuildHostEntitlementTest.java
+++ b/java/code/src/com/redhat/rhn/domain/entitlement/test/ContainerBuildHostEntitlementTest.java
@@ -15,12 +15,11 @@
 
 package com.redhat.rhn.domain.entitlement.test;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.entitlement.ContainerBuildHostEntitlement;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
-import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
-import com.redhat.rhn.manager.system.entitling.SystemEntitler;
 import com.redhat.rhn.testing.ServerTestUtils;
 
 import com.suse.manager.reactor.utils.ValueMap;
@@ -47,8 +46,8 @@ public class ContainerBuildHostEntitlementTest extends BaseEntitlementTestCase {
         minion.setOs("SLES");
         minion.setRelease("12.2");
 
-        SystemEntitlementManager.INSTANCE.setBaseEntitlement(traditional, EntitlementManager.MANAGEMENT);
-        SystemEntitlementManager.INSTANCE.setBaseEntitlement(minion, EntitlementManager.SALT);
+        GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER.setBaseEntitlement(traditional, EntitlementManager.MANAGEMENT);
+        GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER.setBaseEntitlement(minion, EntitlementManager.SALT);
 
         assertTrue(ent.isAllowedOnServer(minion));
         assertFalse(ent.isAllowedOnServer(traditional));
@@ -71,7 +70,7 @@ public class ContainerBuildHostEntitlementTest extends BaseEntitlementTestCase {
         grains.put("osmajorrelease", "7");
         assertTrue(ent.isAllowedOnServer(minion, new ValueMap(grains)));
 
-        SystemEntitlementManager.INSTANCE.setBaseEntitlement(minion, EntitlementManager.MANAGEMENT);
+        GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER.setBaseEntitlement(minion, EntitlementManager.MANAGEMENT);
         assertFalse(ent.isAllowedOnServer(minion, new ValueMap(grains)));
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/entitlement/test/OSImageBuildHostEntitlementTest.java
+++ b/java/code/src/com/redhat/rhn/domain/entitlement/test/OSImageBuildHostEntitlementTest.java
@@ -1,15 +1,36 @@
 package com.redhat.rhn.domain.entitlement.test;
 
-import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.domain.entitlement.OSImageBuildHostEntitlement;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
+import com.redhat.rhn.manager.formula.FormulaMonitoringManager;
+import com.redhat.rhn.manager.system.ServerGroupManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitler;
+import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
 import com.redhat.rhn.testing.ServerTestUtils;
+import com.suse.manager.virtualization.VirtManagerSalt;
+import com.suse.manager.webui.services.iface.MonitoringManager;
+import com.suse.manager.webui.services.iface.SaltApi;
+import com.suse.manager.webui.services.iface.SystemQuery;
+import com.suse.manager.webui.services.iface.VirtManager;
+import com.suse.manager.webui.services.impl.SaltService;
 
 public class OSImageBuildHostEntitlementTest extends BaseEntitlementTestCase {
+
+    private final SaltService saltService = new SaltService();
+    private final SystemQuery systemQuery = saltService;
+    private final SaltApi saltApi = saltService;
+    private final ServerGroupManager serverGroupManager = new ServerGroupManager();
+    private final VirtManager virtManager = new VirtManagerSalt(saltApi);
+    private final MonitoringManager monitoringManager = new FormulaMonitoringManager();
+    private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
+            new SystemUnentitler(virtManager, monitoringManager, serverGroupManager),
+            new SystemEntitler(systemQuery, virtManager, monitoringManager, serverGroupManager)
+    );
 
     @Override public void setUp() throws Exception {
         super.setUp();
@@ -35,8 +56,8 @@ public class OSImageBuildHostEntitlementTest extends BaseEntitlementTestCase {
         minion.setOs("SLES");
         minion.setRelease("12.2");
 
-        GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER.setBaseEntitlement(traditional, EntitlementManager.MANAGEMENT);
-        GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER.setBaseEntitlement(minion, EntitlementManager.SALT);
+        systemEntitlementManager.setBaseEntitlement(traditional, EntitlementManager.MANAGEMENT);
+        systemEntitlementManager.setBaseEntitlement(minion, EntitlementManager.SALT);
 
         assertTrue(ent.isAllowedOnServer(minion));
         assertFalse(ent.isAllowedOnServer(traditional));

--- a/java/code/src/com/redhat/rhn/domain/entitlement/test/OSImageBuildHostEntitlementTest.java
+++ b/java/code/src/com/redhat/rhn/domain/entitlement/test/OSImageBuildHostEntitlementTest.java
@@ -13,17 +13,14 @@ import com.redhat.rhn.manager.system.entitling.SystemEntitler;
 import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
 import com.redhat.rhn.testing.ServerTestUtils;
 import com.suse.manager.virtualization.VirtManagerSalt;
-import com.suse.manager.webui.services.iface.MonitoringManager;
-import com.suse.manager.webui.services.iface.SaltApi;
-import com.suse.manager.webui.services.iface.SystemQuery;
-import com.suse.manager.webui.services.iface.VirtManager;
-import com.suse.manager.webui.services.impl.SaltService;
+import com.suse.manager.webui.services.iface.*;
+import com.suse.manager.webui.services.test.TestSaltApi;
+import com.suse.manager.webui.services.test.TestSystemQuery;
 
 public class OSImageBuildHostEntitlementTest extends BaseEntitlementTestCase {
 
-    private final SaltService saltService = new SaltService();
-    private final SystemQuery systemQuery = saltService;
-    private final SaltApi saltApi = saltService;
+    private final SystemQuery systemQuery = new TestSystemQuery();
+    private final SaltApi saltApi = new TestSaltApi();
     private final ServerGroupManager serverGroupManager = new ServerGroupManager();
     private final VirtManager virtManager = new VirtManagerSalt(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager();

--- a/java/code/src/com/redhat/rhn/domain/entitlement/test/OSImageBuildHostEntitlementTest.java
+++ b/java/code/src/com/redhat/rhn/domain/entitlement/test/OSImageBuildHostEntitlementTest.java
@@ -1,12 +1,12 @@
 package com.redhat.rhn.domain.entitlement.test;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.domain.entitlement.OSImageBuildHostEntitlement;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
-import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 import com.redhat.rhn.testing.ServerTestUtils;
 
 public class OSImageBuildHostEntitlementTest extends BaseEntitlementTestCase {
@@ -35,8 +35,8 @@ public class OSImageBuildHostEntitlementTest extends BaseEntitlementTestCase {
         minion.setOs("SLES");
         minion.setRelease("12.2");
 
-        SystemEntitlementManager.INSTANCE.setBaseEntitlement(traditional, EntitlementManager.MANAGEMENT);
-        SystemEntitlementManager.INSTANCE.setBaseEntitlement(minion, EntitlementManager.SALT);
+        GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER.setBaseEntitlement(traditional, EntitlementManager.MANAGEMENT);
+        GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER.setBaseEntitlement(minion, EntitlementManager.SALT);
 
         assertTrue(ent.isAllowedOnServer(minion));
         assertFalse(ent.isAllowedOnServer(traditional));

--- a/java/code/src/com/redhat/rhn/domain/entitlement/test/VirtualizationEntitlementTest.java
+++ b/java/code/src/com/redhat/rhn/domain/entitlement/test/VirtualizationEntitlementTest.java
@@ -15,6 +15,7 @@
 
 package com.redhat.rhn.domain.entitlement.test;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.entitlement.VirtualizationEntitlement;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
@@ -53,7 +54,7 @@ public class VirtualizationEntitlementTest extends BaseEntitlementTestCase {
         );
         Server host = ServerTestUtils.createVirtHostWithGuests(1, systemEntitlementManager);
         Server guest = host.getGuests().iterator().next().getGuestSystem();
-        SystemEntitlementManager.INSTANCE.setBaseEntitlement(guest, EntitlementManager.MANAGEMENT);
+        GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER.setBaseEntitlement(guest, EntitlementManager.MANAGEMENT);
 
         assertTrue(ent.isAllowedOnServer(host));
         assertFalse(ent.isAllowedOnServer(guest));
@@ -62,7 +63,7 @@ public class VirtualizationEntitlementTest extends BaseEntitlementTestCase {
     @Override
     public void testIsAllowedOnServerWithGrains() throws Exception {
         Server minion = MinionServerFactoryTest.createTestMinionServer(user);
-        SystemEntitlementManager.INSTANCE.setBaseEntitlement(minion, EntitlementManager.SALT);
+        GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER.setBaseEntitlement(minion, EntitlementManager.SALT);
 
         Map<String, Object> grains = new HashMap<>();
         grains.put("virtual", "physical");

--- a/java/code/src/com/redhat/rhn/domain/entitlement/test/VirtualizationEntitlementTest.java
+++ b/java/code/src/com/redhat/rhn/domain/entitlement/test/VirtualizationEntitlementTest.java
@@ -28,20 +28,17 @@ import com.redhat.rhn.testing.ServerTestUtils;
 
 import com.suse.manager.reactor.utils.ValueMap;
 import com.suse.manager.virtualization.VirtManagerSalt;
-import com.suse.manager.webui.services.iface.MonitoringManager;
-import com.suse.manager.webui.services.iface.SaltApi;
-import com.suse.manager.webui.services.iface.SystemQuery;
-import com.suse.manager.webui.services.iface.VirtManager;
-import com.suse.manager.webui.services.impl.SaltService;
+import com.suse.manager.webui.services.iface.*;
+import com.suse.manager.webui.services.test.TestSaltApi;
+import com.suse.manager.webui.services.test.TestSystemQuery;
 
 import java.util.HashMap;
 import java.util.Map;
 
 public class VirtualizationEntitlementTest extends BaseEntitlementTestCase {
 
-    private final SaltService saltService = new SaltService();
-    private final SystemQuery systemQuery = saltService;
-    private final SaltApi saltApi = saltService;
+    private final SystemQuery systemQuery = new TestSystemQuery();
+    private final SaltApi saltApi = new TestSaltApi();
     private final ServerGroupManager serverGroupManager = new ServerGroupManager();
     private final VirtManager virtManager = new VirtManagerSalt(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager();

--- a/java/code/src/com/redhat/rhn/domain/entitlement/test/VirtualizationEntitlementTest.java
+++ b/java/code/src/com/redhat/rhn/domain/entitlement/test/VirtualizationEntitlementTest.java
@@ -21,6 +21,7 @@ import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.manager.formula.FormulaMonitoringManager;
+import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitler;
 import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
@@ -48,9 +49,12 @@ public class VirtualizationEntitlementTest extends BaseEntitlementTestCase {
     @Override
     public void testIsAllowedOnServer() throws Exception {
         SaltService saltService = new SaltService();
+        ServerGroupManager serverGroupManager = new ServerGroupManager();
         SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(new VirtManagerSalt(saltService), new FormulaMonitoringManager()),
-                new SystemEntitler(saltService, new VirtManagerSalt(saltService), new FormulaMonitoringManager())
+                new SystemUnentitler(new VirtManagerSalt(saltService), new FormulaMonitoringManager(),
+                        serverGroupManager),
+                new SystemEntitler(saltService, new VirtManagerSalt(saltService), new FormulaMonitoringManager(),
+                        serverGroupManager)
         );
         Server host = ServerTestUtils.createVirtHostWithGuests(1, systemEntitlementManager);
         Server guest = host.getGuests().iterator().next().getGuestSystem();

--- a/java/code/src/com/redhat/rhn/domain/formula/FormulaFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/formula/FormulaFactory.java
@@ -14,6 +14,7 @@
  */
 package com.redhat.rhn.domain.formula;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.validator.ValidatorError;
 import com.redhat.rhn.common.validator.ValidatorException;
 import com.redhat.rhn.domain.org.Org;
@@ -114,7 +115,7 @@ public class FormulaFactory {
             .create();
     private static final Yaml YAML = new Yaml(new SafeConstructor());
 
-    private static SystemEntitlementManager systemEntitlementManager = SystemEntitlementManager.INSTANCE;
+    private static SystemEntitlementManager systemEntitlementManager = GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER;
 
     private FormulaFactory() { }
 

--- a/java/code/src/com/redhat/rhn/domain/image/test/ImageInfoFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/image/test/ImageInfoFactoryTest.java
@@ -57,11 +57,9 @@ import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
 
 import com.suse.manager.virtualization.VirtManagerSalt;
-import com.suse.manager.webui.services.iface.MonitoringManager;
-import com.suse.manager.webui.services.iface.SaltApi;
-import com.suse.manager.webui.services.iface.SystemQuery;
-import com.suse.manager.webui.services.iface.VirtManager;
-import com.suse.manager.webui.services.impl.SaltService;
+import com.suse.manager.webui.services.iface.*;
+import com.suse.manager.webui.services.test.TestSaltApi;
+import com.suse.manager.webui.services.test.TestSystemQuery;
 import com.suse.manager.webui.utils.salt.custom.ImageChecksum;
 
 import org.apache.commons.codec.digest.DigestUtils;
@@ -86,9 +84,8 @@ public class ImageInfoFactoryTest extends BaseTestCaseWithUser {
     }};
 
     private static TaskomaticApi taskomaticApi;
-    private final SaltService saltService = new SaltService();
-    private final SystemQuery systemQuery = saltService;
-    private final SaltApi saltApi = saltService;
+    private final SystemQuery systemQuery = new TestSystemQuery();
+    private final SaltApi saltApi = new TestSaltApi();
     private final ServerGroupManager serverGroupManager = new ServerGroupManager();
     private final VirtManager virtManager = new VirtManagerSalt(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager();

--- a/java/code/src/com/redhat/rhn/domain/image/test/ImageInfoFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/image/test/ImageInfoFactoryTest.java
@@ -21,6 +21,7 @@ import static com.redhat.rhn.testing.ImageTestUtils.createImageProfile;
 import static com.redhat.rhn.testing.ImageTestUtils.createImageStore;
 import static com.redhat.rhn.testing.ImageTestUtils.createProfileCustomDataValue;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.salt.inspect.ImageInspectActionDetails;
 import com.redhat.rhn.domain.channel.Channel;
@@ -44,9 +45,7 @@ import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
 import com.redhat.rhn.domain.token.ActivationKey;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
-import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
-import com.redhat.rhn.manager.system.entitling.SystemEntitler;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
@@ -78,7 +77,7 @@ public class ImageInfoFactoryTest extends BaseTestCaseWithUser {
     }};
 
     private static TaskomaticApi taskomaticApi;
-    private SystemEntitlementManager systemEntitlementManager = SystemEntitlementManager.INSTANCE;
+    private SystemEntitlementManager systemEntitlementManager = GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER;
 
     @Override
     public void setUp() throws Exception {

--- a/java/code/src/com/redhat/rhn/domain/recurringactions/GroupRecurringAction.java
+++ b/java/code/src/com/redhat/rhn/domain/recurringactions/GroupRecurringAction.java
@@ -15,6 +15,7 @@
 
 package com.redhat.rhn.domain.recurringactions;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.hibernate.LookupException;
 import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.domain.server.MinionServer;
@@ -46,6 +47,7 @@ import javax.persistence.Transient;
 public class GroupRecurringAction extends RecurringAction {
 
     private ServerGroup group;
+    private final ServerGroupManager serverGroupManager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
 
     /**
      * Standard constructor
@@ -82,13 +84,12 @@ public class GroupRecurringAction extends RecurringAction {
      */
     @Override
     public boolean canAccess(User user) {
-        ServerGroupManager groupManager = ServerGroupManager.getInstance();
         if (!user.hasRole(RoleFactory.SYSTEM_GROUP_ADMIN)) {
             return false;
         }
         try {
             /* Check if user has permission to access the group */
-            groupManager.lookup(group.getId(), user);
+            serverGroupManager.lookup(group.getId(), user);
         }
         catch (LookupException e) {
             return false;

--- a/java/code/src/com/redhat/rhn/domain/server/ManagedServerGroup.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ManagedServerGroup.java
@@ -14,6 +14,7 @@
  */
 package com.redhat.rhn.domain.server;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.system.ServerGroupManager;
 
@@ -27,7 +28,10 @@ import java.util.Set;
  * @version $Rev$
  */
 public class ManagedServerGroup extends ServerGroup {
+
     private Set associatedAdmins = new HashSet();
+    private final ServerGroupManager serverGroupManager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
+
     /**
      * returns the set of 'non-org-admin' users that have been
      * subscribed to this ServerGroup
@@ -48,7 +52,7 @@ public class ManagedServerGroup extends ServerGroup {
      * @return a set of users
      */
     public Set getAssociatedAdminsFor(User user) {
-        ServerGroupManager.getInstance().
+        serverGroupManager.
                 validateAdminCredentials(user);
         return getAssociatedAdmins();
     }

--- a/java/code/src/com/redhat/rhn/domain/server/ServerGroup.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerGroup.java
@@ -14,6 +14,7 @@
  */
 package com.redhat.rhn.domain.server;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.BaseDomainHelper;
 import com.redhat.rhn.domain.Identifiable;
 import com.redhat.rhn.domain.config.ConfigChannel;
@@ -21,7 +22,6 @@ import com.redhat.rhn.domain.org.Org;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.configuration.SaltConfigSubscriptionService;
 import com.redhat.rhn.manager.configuration.SaltConfigurable;
-import com.redhat.rhn.manager.system.ServerGroupManager;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
@@ -129,7 +129,7 @@ public class ServerGroup extends BaseDomainHelper implements Identifiable, SaltC
      * @return a list of Servers which are members of the group.
      */
     public List<Server> getServers() {
-        return ServerGroupManager.getInstance().
+        return GlobalInstanceHolder.SERVER_GROUP_MANAGER.
                                 listServers(this);
     }
 

--- a/java/code/src/com/redhat/rhn/domain/server/test/HostBuilder.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/HostBuilder.java
@@ -14,6 +14,7 @@
  */
 package com.redhat.rhn.domain.server.test;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.VirtualInstance;
@@ -25,7 +26,6 @@ import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
 import com.redhat.rhn.testing.ServerTestUtils;
 
 import com.suse.manager.virtualization.VirtManagerSalt;
-import com.suse.manager.webui.services.impl.SaltService;
 import org.hibernate.Session;
 
 import java.util.Iterator;
@@ -92,9 +92,9 @@ public class HostBuilder {
      */
     public HostBuilder createVirtHost() throws Exception {
         SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(new VirtManagerSalt(SaltService.INSTANCE_SALT_API),
+                new SystemUnentitler(new VirtManagerSalt(GlobalInstanceHolder.SALT_API),
                         new FormulaMonitoringManager()),
-                new SystemEntitler(SaltService.INSTANCE, new VirtManagerSalt(SaltService.INSTANCE_SALT_API),
+                new SystemEntitler(GlobalInstanceHolder.SYSTEM_QUERY, new VirtManagerSalt(GlobalInstanceHolder.SALT_API),
                         new FormulaMonitoringManager())
         );
         host = ServerTestUtils.createVirtHostWithGuests(owner, 0, systemEntitlementManager);

--- a/java/code/src/com/redhat/rhn/domain/server/test/HostBuilder.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/HostBuilder.java
@@ -19,13 +19,8 @@ import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.VirtualInstance;
 import com.redhat.rhn.domain.user.User;
-import com.redhat.rhn.manager.formula.FormulaMonitoringManager;
-import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
-import com.redhat.rhn.manager.system.entitling.SystemEntitler;
-import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
 import com.redhat.rhn.testing.ServerTestUtils;
 
-import com.suse.manager.virtualization.VirtManagerSalt;
 import org.hibernate.Session;
 
 import java.util.Iterator;
@@ -91,13 +86,8 @@ public class HostBuilder {
      * @throws Exception if an error occurs
      */
     public HostBuilder createVirtHost() throws Exception {
-        SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(new VirtManagerSalt(GlobalInstanceHolder.SALT_API),
-                        new FormulaMonitoringManager()),
-                new SystemEntitler(GlobalInstanceHolder.SYSTEM_QUERY, new VirtManagerSalt(GlobalInstanceHolder.SALT_API),
-                        new FormulaMonitoringManager())
-        );
-        host = ServerTestUtils.createVirtHostWithGuests(owner, 0, systemEntitlementManager);
+        host = ServerTestUtils.createVirtHostWithGuests(owner, 0,
+                GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER);
         return this;
     }
 

--- a/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
@@ -90,11 +90,9 @@ import com.suse.manager.utils.SaltKeyUtils;
 import com.suse.manager.utils.SaltUtils;
 import com.suse.manager.virtualization.VirtManagerSalt;
 import com.suse.manager.webui.services.SaltServerActionService;
-import com.suse.manager.webui.services.iface.MonitoringManager;
-import com.suse.manager.webui.services.iface.SaltApi;
-import com.suse.manager.webui.services.iface.SystemQuery;
-import com.suse.manager.webui.services.iface.VirtManager;
-import com.suse.manager.webui.services.impl.SaltService;
+import com.suse.manager.webui.services.iface.*;
+import com.suse.manager.webui.services.test.TestSaltApi;
+import com.suse.manager.webui.services.test.TestSystemQuery;
 import com.suse.salt.netapi.calls.LocalCall;
 
 import java.util.ArrayList;
@@ -123,9 +121,8 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
     public static final String RUNNING_KERNEL = "2.6.9-55.EL";
     public static final String HOSTNAME = "foo.bar.com";
 
-    private static final SaltService saltService = new SaltService();
-    private static final SystemQuery systemQuery = saltService;
-    private static final SaltApi saltApi = saltService;
+    private static final SystemQuery systemQuery = new TestSystemQuery();
+    private static final SaltApi saltApi = new TestSaltApi();
     private static final ServerGroupManager serverGroupManager = new ServerGroupManager();
     private static final FormulaManager formulaManager = new FormulaManager(saltApi);
     private static final ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);

--- a/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
@@ -83,6 +83,7 @@ import com.redhat.rhn.testing.ServerGroupTestUtils;
 import com.redhat.rhn.testing.ServerTestUtils;
 import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
+import com.suse.manager.utils.SaltUtils;
 import com.suse.manager.webui.services.SaltServerActionService;
 import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.salt.netapi.calls.LocalCall;
@@ -114,7 +115,10 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
     public static final String HOSTNAME = "foo.bar.com";
 
     private static SystemEntitlementManager systemEntitlementManager = SystemEntitlementManager.INSTANCE;
-    private SaltServerActionService saltServerActionService = new SaltServerActionService(new SaltService());
+    private SaltServerActionService saltServerActionService = new SaltServerActionService(
+            new SaltService(),
+            SaltUtils.INSTANCE
+    );
 
     @Override
     public void setUp() throws Exception {

--- a/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
@@ -68,6 +68,7 @@ import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.domain.user.UserFactory;
 import com.redhat.rhn.frontend.xmlrpc.ServerNotInGroupException;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
+import com.redhat.rhn.manager.formula.FormulaManager;
 import com.redhat.rhn.manager.rhnset.RhnSetDecl;
 import com.redhat.rhn.manager.rhnset.RhnSetManager;
 import com.redhat.rhn.manager.system.ServerGroupManager;
@@ -120,10 +121,14 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
     private SaltService saltService = new SaltService();
     private SystemQuery systemQuery = saltService;
     private SaltApi saltApi = saltService;
-    private SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, ClusterManager.instance());
+    private ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+    private FormulaManager formulaManager = new FormulaManager(saltApi);
+    private ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);
+    private SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, clusterManager);
     private SaltServerActionService saltServerActionService = new SaltServerActionService(
             systemQuery,
-            saltUtils
+            saltUtils,
+            clusterManager
     );
 
     @Override

--- a/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
@@ -122,10 +122,10 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
     private SaltService saltService = new SaltService();
     private SystemQuery systemQuery = saltService;
     private SaltApi saltApi = saltService;
-    private ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+    private ServerGroupManager serverGroupManager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
     private FormulaManager formulaManager = new FormulaManager(saltApi);
     private ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);
-    private SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, clusterManager, formulaManager);
+    private SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, clusterManager, formulaManager, serverGroupManager);
     private SaltKeyUtils saltKeyUtils = new SaltKeyUtils(systemQuery);
     private SaltServerActionService saltServerActionService = new SaltServerActionService(
             systemQuery,
@@ -273,7 +273,7 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
 
         Collection servers = new ArrayList();
         servers.add(server);
-        ServerGroupManager manager = ServerGroupManager.getInstance();
+        ServerGroupManager manager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
         user.addPermanentRole(RoleFactory.SYSTEM_GROUP_ADMIN);
         ManagedServerGroup sg1 = manager.create(user, "FooFooFOO", "Foo Description");
         manager.addServers(sg1, servers, user);
@@ -851,7 +851,7 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
         Server serverToSearch = ServerFactoryTest.createTestServer(admin, true);
         Set servers = new HashSet();
         servers.add(serverToSearch);
-        ServerGroupManager manager = ServerGroupManager.getInstance();
+        ServerGroupManager manager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
         manager.addServers(group, servers, admin);
         assertTrue(group.getServers().size() > 0);
         //create admins set and add it to the grup

--- a/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
@@ -14,6 +14,7 @@
  */
 package com.redhat.rhn.domain.server.test;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.channel.ChannelFactory;
@@ -74,7 +75,6 @@ import com.redhat.rhn.manager.rhnset.RhnSetManager;
 import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
-import com.redhat.rhn.manager.system.entitling.SystemEntitler;
 import com.redhat.rhn.manager.user.UserManager;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
 import com.redhat.rhn.testing.ChannelTestUtils;
@@ -117,7 +117,7 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
     public static final String RUNNING_KERNEL = "2.6.9-55.EL";
     public static final String HOSTNAME = "foo.bar.com";
 
-    private static SystemEntitlementManager systemEntitlementManager = SystemEntitlementManager.INSTANCE;
+    private static SystemEntitlementManager systemEntitlementManager = GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER;
     private SaltService saltService = new SaltService();
     private SystemQuery systemQuery = saltService;
     private SaltApi saltApi = saltService;

--- a/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
@@ -124,7 +124,7 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
     private ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
     private FormulaManager formulaManager = new FormulaManager(saltApi);
     private ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);
-    private SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, clusterManager);
+    private SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, clusterManager, formulaManager);
     private SaltServerActionService saltServerActionService = new SaltServerActionService(
             systemQuery,
             saltUtils,

--- a/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
@@ -15,7 +15,6 @@
 package com.redhat.rhn.domain.server.test;
 
 import com.redhat.rhn.common.hibernate.HibernateFactory;
-import com.redhat.rhn.common.hibernate.LookupException;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.channel.ChannelFactory;
 import com.redhat.rhn.domain.channel.ChannelFamily;
@@ -83,8 +82,11 @@ import com.redhat.rhn.testing.ServerGroupTestUtils;
 import com.redhat.rhn.testing.ServerTestUtils;
 import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
+import com.suse.manager.clusters.ClusterManager;
 import com.suse.manager.utils.SaltUtils;
 import com.suse.manager.webui.services.SaltServerActionService;
+import com.suse.manager.webui.services.iface.SaltApi;
+import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.salt.netapi.calls.LocalCall;
 
@@ -115,9 +117,13 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
     public static final String HOSTNAME = "foo.bar.com";
 
     private static SystemEntitlementManager systemEntitlementManager = SystemEntitlementManager.INSTANCE;
+    private SaltService saltService = new SaltService();
+    private SystemQuery systemQuery = saltService;
+    private SaltApi saltApi = saltService;
+    private SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, ClusterManager.instance());
     private SaltServerActionService saltServerActionService = new SaltServerActionService(
-            new SaltService(),
-            SaltUtils.INSTANCE
+            systemQuery,
+            saltUtils
     );
 
     @Override

--- a/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
@@ -128,7 +128,8 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
     private SaltServerActionService saltServerActionService = new SaltServerActionService(
             systemQuery,
             saltUtils,
-            clusterManager
+            clusterManager,
+            formulaManager
     );
 
     @Override

--- a/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
@@ -122,7 +122,7 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
     private SaltService saltService = new SaltService();
     private SystemQuery systemQuery = saltService;
     private SaltApi saltApi = saltService;
-    private ServerGroupManager serverGroupManager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
+    private ServerGroupManager serverGroupManager = new ServerGroupManager();
     private FormulaManager formulaManager = new FormulaManager(saltApi);
     private ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);
     private SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, clusterManager, formulaManager, serverGroupManager);
@@ -273,10 +273,9 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
 
         Collection servers = new ArrayList();
         servers.add(server);
-        ServerGroupManager manager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
         user.addPermanentRole(RoleFactory.SYSTEM_GROUP_ADMIN);
-        ManagedServerGroup sg1 = manager.create(user, "FooFooFOO", "Foo Description");
-        manager.addServers(sg1, servers, user);
+        ManagedServerGroup sg1 = serverGroupManager.create(user, "FooFooFOO", "Foo Description");
+        serverGroupManager.addServers(sg1, servers, user);
 
         server = reload(server);
         assertTrue(server.getEntitledGroupTypes().size() == 1);
@@ -851,14 +850,13 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
         Server serverToSearch = ServerFactoryTest.createTestServer(admin, true);
         Set servers = new HashSet();
         servers.add(serverToSearch);
-        ServerGroupManager manager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
-        manager.addServers(group, servers, admin);
+        serverGroupManager.addServers(group, servers, admin);
         assertTrue(group.getServers().size() > 0);
         //create admins set and add it to the grup
         Set admins = new HashSet();
         admins.add(regular);
-        manager.associateAdmins(group, admins, admin);
-        assertTrue(manager.canAccess(regular, group));
+        serverGroupManager.associateAdmins(group, admins, admin);
+        assertTrue(serverGroupManager.canAccess(regular, group));
         ServerGroupFactory.save(group);
         group = reload(group);
         UserFactory.save(admin);

--- a/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
@@ -84,6 +84,7 @@ import com.redhat.rhn.testing.ServerTestUtils;
 import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
 import com.suse.manager.clusters.ClusterManager;
+import com.suse.manager.utils.SaltKeyUtils;
 import com.suse.manager.utils.SaltUtils;
 import com.suse.manager.webui.services.SaltServerActionService;
 import com.suse.manager.webui.services.iface.SaltApi;
@@ -125,11 +126,13 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
     private FormulaManager formulaManager = new FormulaManager(saltApi);
     private ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);
     private SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, clusterManager, formulaManager);
+    private SaltKeyUtils saltKeyUtils = new SaltKeyUtils(systemQuery);
     private SaltServerActionService saltServerActionService = new SaltServerActionService(
             systemQuery,
             saltUtils,
             clusterManager,
-            formulaManager
+            formulaManager,
+            saltKeyUtils
     );
 
     @Override

--- a/java/code/src/com/redhat/rhn/domain/server/test/ServerTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/ServerTest.java
@@ -14,6 +14,7 @@
  */
 package com.redhat.rhn.domain.server.test;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.domain.server.ClientCapability;
@@ -30,7 +31,6 @@ import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.manager.formula.FormulaMonitoringManager;
 import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.manager.system.SystemManager;
-import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
 import com.redhat.rhn.manager.system.test.SystemManagerTest;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
@@ -74,7 +74,7 @@ public class ServerTest extends BaseTestCaseWithUser {
         UserTestUtils.addManagement(s.getCreator().getOrg());
         HibernateFactory.getSession().clear();
         s = ServerFactory.lookupById(s.getId());
-        SystemEntitlementManager.INSTANCE.setBaseEntitlement(s, EntitlementManager.MANAGEMENT);
+        GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER.setBaseEntitlement(s, EntitlementManager.MANAGEMENT);
         TestUtils.saveAndFlush(s);
         s = reload(s);
         assertTrue(s.getBaseEntitlement().equals(EntitlementManager.MANAGEMENT));

--- a/java/code/src/com/redhat/rhn/domain/server/test/ServerTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/ServerTest.java
@@ -56,7 +56,8 @@ public class ServerTest extends BaseTestCaseWithUser {
     private final SaltService saltService = new SaltService();
     private final SystemUnentitler systemUnentitler = new SystemUnentitler(
             new VirtManagerSalt(saltService),
-            new FormulaMonitoringManager());
+            new FormulaMonitoringManager(),
+            new ServerGroupManager());
 
     public void testIsInactive() throws Exception {
         Server s = ServerFactory.createServer();
@@ -316,7 +317,7 @@ public class ServerTest extends BaseTestCaseWithUser {
     private class VirtEntitledServer extends Server {
         VirtEntitledServer(User user) {
             setOrg(user.getOrg());
-            ServerGroupManager manager = ServerGroupManager.getInstance();
+            ServerGroupManager manager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
             EntitlementServerGroup group = manager.
                         lookupEntitled(EntitlementManager.VIRTUALIZATION, user);
             List servers = new ArrayList();

--- a/java/code/src/com/redhat/rhn/domain/server/test/ServerTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/ServerTest.java
@@ -40,11 +40,9 @@ import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
 
 import com.suse.manager.virtualization.VirtManagerSalt;
-import com.suse.manager.webui.services.iface.MonitoringManager;
-import com.suse.manager.webui.services.iface.SaltApi;
-import com.suse.manager.webui.services.iface.SystemQuery;
-import com.suse.manager.webui.services.iface.VirtManager;
-import com.suse.manager.webui.services.impl.SaltService;
+import com.suse.manager.webui.services.iface.*;
+import com.suse.manager.webui.services.test.TestSaltApi;
+import com.suse.manager.webui.services.test.TestSystemQuery;
 
 import java.sql.Timestamp;
 import java.util.ArrayList;
@@ -58,9 +56,8 @@ import java.util.Optional;
  */
 public class ServerTest extends BaseTestCaseWithUser {
 
-    private final SaltService saltService = new SaltService();
-    private final SystemQuery systemQuery = saltService;
-    private final SaltApi saltApi = saltService;
+    private final SystemQuery systemQuery = new TestSystemQuery();
+    private final SaltApi saltApi = new TestSaltApi();
     private final ServerGroupManager serverGroupManager = new ServerGroupManager();
     private final VirtManager virtManager = new VirtManagerSalt(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager();

--- a/java/code/src/com/redhat/rhn/domain/server/test/ServerTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/ServerTest.java
@@ -317,7 +317,7 @@ public class ServerTest extends BaseTestCaseWithUser {
     private class VirtEntitledServer extends Server {
         VirtEntitledServer(User user) {
             setOrg(user.getOrg());
-            ServerGroupManager manager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
+            ServerGroupManager manager = new ServerGroupManager();
             EntitlementServerGroup group = manager.
                         lookupEntitled(EntitlementManager.VIRTUALIZATION, user);
             List servers = new ArrayList();

--- a/java/code/src/com/redhat/rhn/domain/server/test/VirtualInstanceFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/VirtualInstanceFactoryTest.java
@@ -21,6 +21,7 @@ import com.redhat.rhn.domain.server.VirtualInstance;
 import com.redhat.rhn.domain.server.VirtualInstanceFactory;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.formula.FormulaMonitoringManager;
+import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitler;
 import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
@@ -56,9 +57,11 @@ public class VirtualInstanceFactoryTest extends RhnBaseTestCase {
         user = UserTestUtils.findNewUser("testUser",
                 "testOrg" + this.getClass().getSimpleName());
         builder = new GuestBuilder(user);
+        ServerGroupManager serverGroupManager = new ServerGroupManager();
         systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(new TestVirtManager(), new FormulaMonitoringManager()),
-                new SystemEntitler(new SaltService(), new TestVirtManager(), new FormulaMonitoringManager())
+                new SystemUnentitler(new TestVirtManager(), new FormulaMonitoringManager(), serverGroupManager),
+                new SystemEntitler(new SaltService(), new TestVirtManager(), new FormulaMonitoringManager(),
+                        serverGroupManager)
         );
     }
 

--- a/java/code/src/com/redhat/rhn/domain/server/test/VirtualInstanceFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/VirtualInstanceFactoryTest.java
@@ -30,7 +30,7 @@ import com.redhat.rhn.testing.ServerTestUtils;
 import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
 import com.suse.manager.virtualization.test.TestVirtManager;
-import com.suse.manager.webui.services.impl.SaltService;
+import com.suse.manager.webui.services.test.TestSystemQuery;
 import org.apache.commons.collections.CollectionUtils;
 import org.hibernate.Session;
 import org.hibernate.criterion.Restrictions;
@@ -60,7 +60,7 @@ public class VirtualInstanceFactoryTest extends RhnBaseTestCase {
         ServerGroupManager serverGroupManager = new ServerGroupManager();
         systemEntitlementManager = new SystemEntitlementManager(
                 new SystemUnentitler(new TestVirtManager(), new FormulaMonitoringManager(), serverGroupManager),
-                new SystemEntitler(new SaltService(), new TestVirtManager(), new FormulaMonitoringManager(),
+                new SystemEntitler(new TestSystemQuery(), new TestVirtManager(), new FormulaMonitoringManager(),
                         serverGroupManager)
         );
     }

--- a/java/code/src/com/redhat/rhn/frontend/action/errata/test/ChannelActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/errata/test/ChannelActionTest.java
@@ -14,7 +14,6 @@
  */
 package com.redhat.rhn.frontend.action.errata.test;
 
-import com.redhat.rhn.common.messaging.MessageQueue;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.channel.test.ChannelFactoryTest;
 import com.redhat.rhn.domain.errata.Errata;
@@ -36,7 +35,6 @@ import com.redhat.rhn.testing.RhnMockHttpServletResponse;
 import com.redhat.rhn.testing.RhnMockHttpSession;
 import com.redhat.rhn.testing.TestUtils;
 
-import com.suse.manager.webui.services.impl.SaltService;
 import org.apache.struts.action.ActionForward;
 import org.apache.struts.action.ActionMapping;
 
@@ -47,9 +45,6 @@ import org.apache.struts.action.ActionMapping;
 public class ChannelActionTest extends RhnBaseTestCase {
 
     public void testPublish() throws Exception {
-        SaltService saltService = new SaltService();
-        MessageQueue.configureDefaultActions(saltService, saltService);
-
         ChannelAction action = new ChannelAction();
 
         ActionMapping mapping = new ActionMapping();

--- a/java/code/src/com/redhat/rhn/frontend/action/groups/AddSystemsAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/groups/AddSystemsAction.java
@@ -15,6 +15,7 @@
 
 package com.redhat.rhn.frontend.action.groups;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.server.ManagedServerGroup;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.user.User;
@@ -44,6 +45,8 @@ import javax.servlet.http.HttpServletResponse;
  */
 public class AddSystemsAction extends BaseListAction {
 
+    private final ServerGroupManager serverGroupManager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
+
     /** {@inheritDoc} */
     @Override
     public ActionForward handleDispatch(ListSessionSetHelper helper,
@@ -60,8 +63,7 @@ public class AddSystemsAction extends BaseListAction {
             servers.add(SystemManager.lookupByIdAndUser(sid, user));
         }
 
-        ServerGroupManager manager = ServerGroupManager.getInstance();
-        manager.addServers(sg, servers, user);
+        serverGroupManager.addServers(sg, servers, user);
         getStrutsDelegate().saveMessage(
                     "systemgroup.target-systems.added",
                         new String [] {String.valueOf(set.size()),

--- a/java/code/src/com/redhat/rhn/frontend/action/groups/DeleteGroupAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/groups/DeleteGroupAction.java
@@ -18,6 +18,7 @@ package com.redhat.rhn.frontend.action.groups;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionForward;
@@ -45,7 +46,7 @@ public class DeleteGroupAction extends RhnAction {
         RequestContext context = new RequestContext(request);
         ManagedServerGroup serverGroup = context.lookupAndBindServerGroup();
         if (context.isSubmitted()) {
-            ServerGroupManager manager = ServerGroupManager.getInstance();
+            ServerGroupManager manager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
             manager.remove(context.getCurrentUser(), serverGroup);
             String [] params = {StringEscapeUtils.escapeHtml4(serverGroup.getName())};
             getStrutsDelegate().saveMessage(DELETED_MESSAGE_KEY, params, request);

--- a/java/code/src/com/redhat/rhn/frontend/action/groups/EditGroupAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/groups/EditGroupAction.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.server.ManagedServerGroup;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.ServerFactory;
@@ -49,6 +50,8 @@ import javax.servlet.http.HttpServletResponse;
  * @version $Rev$
  */
 public class EditGroupAction extends RhnAction {
+
+    private final ServerGroupManager serverGroupManager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
 
     /** {@inheritDoc} */
     public ActionForward execute(ActionMapping mapping,
@@ -122,8 +125,7 @@ public class EditGroupAction extends RhnAction {
         validate(form, errors, ctx);
 
         if (errors.isEmpty()) {
-            ServerGroupManager manager = ServerGroupManager.getInstance();
-            ManagedServerGroup sg = manager.create(ctx.getCurrentUser(),
+            ManagedServerGroup sg = serverGroupManager.create(ctx.getCurrentUser(),
                     form.getString("name"), form.getString("description"));
 
             if (form.get("is_ssm") != null && (Boolean)form.get("is_ssm")) {
@@ -133,7 +135,7 @@ public class EditGroupAction extends RhnAction {
                 for (SystemOverview system : systems) {
                     hibernateServers.add(ServerFactory.lookupById(system.getId()));
                 }
-                manager.addServers(sg, hibernateServers, ctx.getCurrentUser());
+                serverGroupManager.addServers(sg, hibernateServers, ctx.getCurrentUser());
             }
 
             return sg.getId();

--- a/java/code/src/com/redhat/rhn/frontend/action/groups/GroupDetailAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/groups/GroupDetailAction.java
@@ -17,13 +17,14 @@ package com.redhat.rhn.frontend.action.groups;
 
 import java.util.Map;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.server.ManagedServerGroup;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.struts.RequestContext;
 import com.redhat.rhn.frontend.struts.RhnAction;
 import com.redhat.rhn.frontend.struts.RhnHelper;
-import com.redhat.rhn.manager.system.ServerGroupManager;
 
+import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.suse.manager.utils.MinionServerUtils;
 import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionForward;
@@ -39,6 +40,8 @@ import javax.servlet.http.HttpServletResponse;
  */
 public class GroupDetailAction extends RhnAction {
 
+    private final ServerGroupManager serverGroupManager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
+
     /** {@inheritDoc} */
     @Override
     public ActionForward execute(ActionMapping mapping, ActionForm form,
@@ -47,7 +50,7 @@ public class GroupDetailAction extends RhnAction {
 
         User user = rctx.getCurrentUser();
         ManagedServerGroup sg = rctx.lookupAndBindServerGroup();
-        Map<String, String> errataCounts = ServerGroupManager.getInstance().errataCounts(user, sg);
+        Map<String, String> errataCounts = serverGroupManager.errataCounts(user, sg);
         errataCounts.putIfAbsent("se", "0");
         errataCounts.putIfAbsent("be", "0");
         errataCounts.putIfAbsent("ee", "0");

--- a/java/code/src/com/redhat/rhn/frontend/action/groups/ListRemoveSystemsAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/groups/ListRemoveSystemsAction.java
@@ -15,6 +15,7 @@
 
 package com.redhat.rhn.frontend.action.groups;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.server.ManagedServerGroup;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.user.User;
@@ -44,6 +45,8 @@ import javax.servlet.http.HttpServletResponse;
  */
 public class ListRemoveSystemsAction extends BaseListAction {
 
+    private final ServerGroupManager serverGroupManager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
+
     /** {@inheritDoc} */
     @Override
     public ActionForward handleDispatch(ListSessionSetHelper helper,
@@ -59,8 +62,7 @@ public class ListRemoveSystemsAction extends BaseListAction {
             Long sid = Long.valueOf(id);
             servers.add(SystemManager.lookupByIdAndUser(sid, user));
         }
-        ServerGroupManager manager = ServerGroupManager.getInstance();
-        manager.removeServers(sg, servers, user);
+        serverGroupManager.removeServers(sg, servers, user);
         getStrutsDelegate().saveMessage(
                     "systemgroup.systems.removed",
                         new String [] {String.valueOf(set.size()),

--- a/java/code/src/com/redhat/rhn/frontend/action/groups/SSMGroupConfirmAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/groups/SSMGroupConfirmAction.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionForward;
 import org.apache.struts.action.ActionMapping;
@@ -59,6 +60,8 @@ public class SSMGroupConfirmAction extends RhnAction
     private String ADD_LIST = "addList";
     private String RMV_DATA = "removeSet";
     private String RMV_LIST = "removeList";
+
+    private final ServerGroupManager serverGroupManager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
 
     /**
      * {@inheritDoc}
@@ -120,18 +123,17 @@ public class SSMGroupConfirmAction extends RhnAction
             for (SystemOverview system : systems) {
                 servers.add(ServerFactory.lookupById(system.getId()));
             }
-            ServerGroupManager manager = ServerGroupManager.getInstance();
             for (SystemGroupOverview group : addList) {
-                ManagedServerGroup msg = manager.lookup(group.getId(), user);
+                ManagedServerGroup msg = serverGroupManager.lookup(group.getId(), user);
                 Set<Server> difference = new HashSet<Server>(servers);
                 difference.removeAll(msg.getServers());
-                manager.addServers(msg, difference, user);
+                serverGroupManager.addServers(msg, difference, user);
             }
             for (SystemGroupOverview group : removeList) {
-                ManagedServerGroup msg = manager.lookup(group.getId(), user);
+                ManagedServerGroup msg = serverGroupManager.lookup(group.getId(), user);
                 Set<Server> intersection = new HashSet<Server>(msg.getServers());
                 intersection.retainAll(servers);
-                manager.removeServers(msg, intersection, user);
+                serverGroupManager.removeServers(msg, intersection, user);
             }
             createSuccessMessage(request, "ssm.groups.changed", null);
             groupSet.clear();

--- a/java/code/src/com/redhat/rhn/frontend/action/renderers/TasksRenderer.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/renderers/TasksRenderer.java
@@ -15,12 +15,11 @@
 
 package com.redhat.rhn.frontend.action.renderers;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.listview.PageControl;
 import com.redhat.rhn.manager.system.SystemManager;
-
-import com.suse.manager.webui.services.impl.SaltService;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -40,7 +39,7 @@ public class TasksRenderer extends BaseFragmentRenderer {
         request.setAttribute(TASKS, Boolean.TRUE);
         request.setAttribute("documentation", ConfigDefaults.get().isDocAvailable());
         request.setAttribute("amountOfMinions",
-                SaltService.INSTANCE.getKeys().getUnacceptedMinions().size());
+                GlobalInstanceHolder.SYSTEM_QUERY.getKeys().getUnacceptedMinions().size());
         request.setAttribute("requiringReboot", SystemManager.requiringRebootList(user).size());
         RendererHelper.setTableStyle(request, null);
     }

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/entitlements/SystemEntitlementsSubmitAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/entitlements/SystemEntitlementsSubmitAction.java
@@ -14,6 +14,7 @@
  */
 package com.redhat.rhn.frontend.action.systems.entitlements;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.db.datasource.DataResult;
 import com.redhat.rhn.common.validator.ValidatorResult;
 import com.redhat.rhn.domain.entitlement.Entitlement;
@@ -58,7 +59,7 @@ public class SystemEntitlementsSubmitAction extends
     public static final String KEY_REMOVE_ENTITLED =
         "systementitlements.jsp.remove_entitlement";
 
-    private static SystemEntitlementManager systemEntitlementManager = SystemEntitlementManager.INSTANCE;
+    private static SystemEntitlementManager systemEntitlementManager = GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER;
 
     /**
      * {@inheritDoc}

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/entitlements/test/SystemEntitlementsSetupActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/entitlements/test/SystemEntitlementsSetupActionTest.java
@@ -30,6 +30,7 @@ import com.redhat.rhn.frontend.action.systems.entitlements.SystemEntitlementsSet
 import com.redhat.rhn.frontend.struts.RequestContext;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.manager.formula.FormulaMonitoringManager;
+import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitler;
@@ -68,11 +69,12 @@ public class SystemEntitlementsSetupActionTest extends RhnMockStrutsTestCase {
         Config.get().setBoolean(ConfigDefaults.KIWI_OS_IMAGE_BUILDING_ENABLED, "true");
         context.setImposteriser(ClassImposteriser.INSTANCE);
         saltServiceMock = context.mock(SaltService.class);
+        ServerGroupManager serverGroupManager = new ServerGroupManager();
         systemEntitlementManager = new SystemEntitlementManager(
                 new SystemUnentitler(new VirtManagerSalt(saltServiceMock),
-                        new FormulaMonitoringManager()),
+                        new FormulaMonitoringManager(), serverGroupManager),
                 new SystemEntitler(saltServiceMock, new VirtManagerSalt(saltServiceMock),
-                        new FormulaMonitoringManager())
+                        new FormulaMonitoringManager(), serverGroupManager)
         );
         setRequestPathInfo("/systems/SystemEntitlements");
         UserTestUtils.addManagement(user.getOrg());

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/entitlements/test/SystemEntitlementsSubmitActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/entitlements/test/SystemEntitlementsSubmitActionTest.java
@@ -36,11 +36,9 @@ import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
 import com.redhat.rhn.testing.RhnPostMockStrutsTestCase;
 import com.redhat.rhn.testing.ServerTestUtils;
 import com.suse.manager.virtualization.VirtManagerSalt;
-import com.suse.manager.webui.services.iface.MonitoringManager;
-import com.suse.manager.webui.services.iface.SaltApi;
-import com.suse.manager.webui.services.iface.SystemQuery;
-import com.suse.manager.webui.services.iface.VirtManager;
-import com.suse.manager.webui.services.impl.SaltService;
+import com.suse.manager.webui.services.iface.*;
+import com.suse.manager.webui.services.test.TestSaltApi;
+import com.suse.manager.webui.services.test.TestSystemQuery;
 
 import java.util.Iterator;
 
@@ -54,9 +52,8 @@ public class SystemEntitlementsSubmitActionTest extends RhnPostMockStrutsTestCas
     private static final String UNENTITLED =
                                     "system_entitlements.unentitle";
 
-    private final SaltService saltService = new SaltService();
-    private final SystemQuery systemQuery = saltService;
-    private final SaltApi saltApi = saltService;
+    private final SystemQuery systemQuery = new TestSystemQuery();
+    private final SaltApi saltApi = new TestSaltApi();
     private final ServerGroupManager serverGroupManager = new ServerGroupManager();
     private final VirtManager virtManager = new VirtManagerSalt(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager();
@@ -172,14 +169,6 @@ public class SystemEntitlementsSubmitActionTest extends RhnPostMockStrutsTestCas
                                             Entitlement ent,
                                             ServerGroupType groupType
                                             )  throws Exception {
-        SaltService saltService = new SaltService();
-        ServerGroupManager serverGroupManager = new ServerGroupManager();
-        SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(new VirtManagerSalt(saltService), new FormulaMonitoringManager(),
-                        serverGroupManager),
-                new SystemEntitler(saltService, new VirtManagerSalt(saltService), new FormulaMonitoringManager(),
-                        serverGroupManager)
-        );
         Server server = ServerTestUtils.createVirtHostWithGuests(user, 1, systemEntitlementManager);
 
         systemEntitlementManager.removeServerEntitlement(server, EntitlementManager.VIRTUALIZATION);

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/entitlements/test/SystemEntitlementsSubmitActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/entitlements/test/SystemEntitlementsSubmitActionTest.java
@@ -14,7 +14,6 @@
  */
 package com.redhat.rhn.frontend.action.systems.entitlements.test;
 
-import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.entitlement.Entitlement;
 import com.redhat.rhn.domain.org.OrgFactory;
 import com.redhat.rhn.domain.server.EntitlementServerGroup;
@@ -37,6 +36,10 @@ import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
 import com.redhat.rhn.testing.RhnPostMockStrutsTestCase;
 import com.redhat.rhn.testing.ServerTestUtils;
 import com.suse.manager.virtualization.VirtManagerSalt;
+import com.suse.manager.webui.services.iface.MonitoringManager;
+import com.suse.manager.webui.services.iface.SaltApi;
+import com.suse.manager.webui.services.iface.SystemQuery;
+import com.suse.manager.webui.services.iface.VirtManager;
 import com.suse.manager.webui.services.impl.SaltService;
 
 import java.util.Iterator;
@@ -51,7 +54,16 @@ public class SystemEntitlementsSubmitActionTest extends RhnPostMockStrutsTestCas
     private static final String UNENTITLED =
                                     "system_entitlements.unentitle";
 
-    private SystemEntitlementManager systemEntitlementManager = GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER;
+    private final SaltService saltService = new SaltService();
+    private final SystemQuery systemQuery = saltService;
+    private final SaltApi saltApi = saltService;
+    private final ServerGroupManager serverGroupManager = new ServerGroupManager();
+    private final VirtManager virtManager = new VirtManagerSalt(saltApi);
+    private final MonitoringManager monitoringManager = new FormulaMonitoringManager();
+    private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
+            new SystemUnentitler(virtManager, monitoringManager, serverGroupManager),
+            new SystemEntitler(systemQuery, virtManager, monitoringManager, serverGroupManager)
+    );
 
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/entitlements/test/SystemEntitlementsSubmitActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/entitlements/test/SystemEntitlementsSubmitActionTest.java
@@ -14,6 +14,7 @@
  */
 package com.redhat.rhn.frontend.action.systems.entitlements.test;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.entitlement.Entitlement;
 import com.redhat.rhn.domain.org.OrgFactory;
 import com.redhat.rhn.domain.server.EntitlementServerGroup;
@@ -49,7 +50,7 @@ public class SystemEntitlementsSubmitActionTest extends RhnPostMockStrutsTestCas
     private static final String UNENTITLED =
                                     "system_entitlements.unentitle";
 
-    private SystemEntitlementManager systemEntitlementManager = SystemEntitlementManager.INSTANCE;
+    private SystemEntitlementManager systemEntitlementManager = GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER;
 
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/entitlements/test/SystemEntitlementsSubmitActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/entitlements/test/SystemEntitlementsSubmitActionTest.java
@@ -29,6 +29,7 @@ import com.redhat.rhn.frontend.action.systems.entitlements.SystemEntitlementsSub
 import com.redhat.rhn.frontend.struts.RhnAction;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.manager.formula.FormulaMonitoringManager;
+import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitler;
@@ -160,9 +161,12 @@ public class SystemEntitlementsSubmitActionTest extends RhnPostMockStrutsTestCas
                                             ServerGroupType groupType
                                             )  throws Exception {
         SaltService saltService = new SaltService();
+        ServerGroupManager serverGroupManager = new ServerGroupManager();
         SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(new VirtManagerSalt(saltService), new FormulaMonitoringManager()),
-                new SystemEntitler(saltService, new VirtManagerSalt(saltService), new FormulaMonitoringManager())
+                new SystemUnentitler(new VirtManagerSalt(saltService), new FormulaMonitoringManager(),
+                        serverGroupManager),
+                new SystemEntitler(saltService, new VirtManagerSalt(saltService), new FormulaMonitoringManager(),
+                        serverGroupManager)
         );
         Server server = ServerTestUtils.createVirtHostWithGuests(user, 1, systemEntitlementManager);
 

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/groups/AddGroupsAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/groups/AddGroupsAction.java
@@ -15,6 +15,7 @@
 
 package com.redhat.rhn.frontend.action.systems.groups;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.db.datasource.DataResult;
 import com.redhat.rhn.domain.server.ManagedServerGroup;
 import com.redhat.rhn.domain.server.Server;
@@ -48,6 +49,8 @@ import javax.servlet.http.HttpServletResponse;
  */
 public class AddGroupsAction extends RhnAction implements Listable {
 
+    private final ServerGroupManager serverGroupManager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
+
     /** {@inheritDoc} */
     @Override
     public ActionForward execute(ActionMapping mapping, ActionForm formIn,
@@ -60,13 +63,12 @@ public class AddGroupsAction extends RhnAction implements Listable {
         helper.execute();
 
         if (helper.isDispatched()) {
-            ServerGroupManager manager = ServerGroupManager.getInstance();
             List<Server> servers = new LinkedList<Server>();
             servers.add(server);
 
             for (String id : helper.getSet()) {
-                ServerGroup group = manager.lookup(Long.valueOf(id), user);
-                manager.addServers(group, servers, user);
+                ServerGroup group = serverGroupManager.lookup(Long.valueOf(id), user);
+                serverGroupManager.addServers(group, servers, user);
             }
             helper.destroy();
             getStrutsDelegate().saveMessage(
@@ -87,13 +89,12 @@ public class AddGroupsAction extends RhnAction implements Listable {
     public DataResult<ManagedServerGroup> getResult(RequestContext context) {
 
         Server server = context.lookupAndBindServer();
-        ServerGroupManager manager = ServerGroupManager.getInstance();
         List<ManagedServerGroup> serverGroups = server.getManagedGroups();
         List<ManagedServerGroup> all = context.getCurrentUser().getOrg().
             getManagedServerGroups();
         List<ManagedServerGroup> ret = new LinkedList<ManagedServerGroup>();
         for (ManagedServerGroup group : all) {
-            if (!serverGroups.contains(group) && manager.canAccess(
+            if (!serverGroups.contains(group) && serverGroupManager.canAccess(
                         context.getCurrentUser(), group)) {
                 ret.add(group);
             }

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/groups/ListRemoveGroupsAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/groups/ListRemoveGroupsAction.java
@@ -15,6 +15,7 @@
 
 package com.redhat.rhn.frontend.action.systems.groups;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.ServerGroup;
 import com.redhat.rhn.domain.user.User;
@@ -46,6 +47,8 @@ import javax.servlet.http.HttpServletResponse;
  */
 public class ListRemoveGroupsAction extends BaseListAction implements Listable {
 
+    private final ServerGroupManager serverGroupManager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
+
     /** {@inheritDoc} */
     public ActionForward execute(ActionMapping mapping,
                                  ActionForm formIn,
@@ -73,15 +76,14 @@ public class ListRemoveGroupsAction extends BaseListAction implements Listable {
         RequestContext context = new RequestContext(request);
         User user = context.getCurrentUser();
         Server server = context.lookupAndBindServer();
-        ServerGroupManager manager = ServerGroupManager.getInstance();
         List<Server> servers = new LinkedList<Server>();
         servers.add(server);
         Set<String> set = helper.getSet();
 
         for (String id : set) {
             Long sgid = Long.valueOf(id);
-            ServerGroup group = manager.lookup(sgid, user);
-            manager.removeServers(group, servers, user);
+            ServerGroup group = serverGroupManager.lookup(sgid, user);
+            serverGroupManager.removeServers(group, servers, user);
         }
         helper.destroy();
         getStrutsDelegate().saveMessage(

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemDetailsEditAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemDetailsEditAction.java
@@ -146,7 +146,7 @@ public class SystemDetailsEditAction extends RhnAction {
         Entitlement base = EntitlementManager.getByName(selectedEnt);
         log.debug("base: " + base);
         if (base != null) {
-            GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER.setBaseEntitlement(s, base);
+            systemEntitlementManager.setBaseEntitlement(s, base);
         }
         else if (selectedEnt.equals(UNENTITLE)) {
             systemEntitlementManager.removeAllServerEntitlements(s);

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemDetailsEditAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemDetailsEditAction.java
@@ -14,6 +14,7 @@
  */
 package com.redhat.rhn.frontend.action.systems.sdc;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.common.validator.ValidatorError;
@@ -81,7 +82,7 @@ public class SystemDetailsEditAction extends RhnAction {
     public static final String RACK = "rack";
     public static final String UNENTITLE = "unentitle";
 
-    private SystemEntitlementManager systemEntitlementManager = SystemEntitlementManager.INSTANCE;
+    private SystemEntitlementManager systemEntitlementManager = GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER;
 
     /** {@inheritDoc} */
     @Override
@@ -145,7 +146,7 @@ public class SystemDetailsEditAction extends RhnAction {
         Entitlement base = EntitlementManager.getByName(selectedEnt);
         log.debug("base: " + base);
         if (base != null) {
-            SystemEntitlementManager.INSTANCE.setBaseEntitlement(s, base);
+            GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER.setBaseEntitlement(s, base);
         }
         else if (selectedEnt.equals(UNENTITLE)) {
             systemEntitlementManager.removeAllServerEntitlements(s);

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/test/SystemDetailsEditActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/test/SystemDetailsEditActionTest.java
@@ -14,7 +14,7 @@
  */
 package com.redhat.rhn.frontend.action.systems.sdc.test;
 
-import com.redhat.rhn.common.hibernate.HibernateFactory;
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.entitlement.Entitlement;
 import com.redhat.rhn.domain.entitlement.VirtualizationEntitlement;
 import com.redhat.rhn.domain.server.Server;
@@ -23,10 +23,7 @@ import com.redhat.rhn.frontend.action.systems.sdc.SystemDetailsEditAction;
 import com.redhat.rhn.frontend.struts.RhnAction;
 import com.redhat.rhn.frontend.struts.RhnHelper;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
-import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
-import com.redhat.rhn.manager.system.entitling.SystemEntitler;
-import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
 import com.redhat.rhn.testing.ChannelTestUtils;
 import com.redhat.rhn.testing.RhnPostMockStrutsTestCase;
 import com.redhat.rhn.testing.ServerTestUtils;
@@ -45,7 +42,7 @@ import java.util.Set;
 public class SystemDetailsEditActionTest extends RhnPostMockStrutsTestCase {
 
     protected Server s;
-    private SystemEntitlementManager systemEntitlementManager = SystemEntitlementManager.INSTANCE;
+    private SystemEntitlementManager systemEntitlementManager = GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER;
 
     /**
      * {@inheritDoc}

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/test/SystemDetailsEditActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/test/SystemDetailsEditActionTest.java
@@ -14,7 +14,6 @@
  */
 package com.redhat.rhn.frontend.action.systems.sdc.test;
 
-import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.entitlement.Entitlement;
 import com.redhat.rhn.domain.entitlement.VirtualizationEntitlement;
 import com.redhat.rhn.domain.server.Server;
@@ -23,13 +22,23 @@ import com.redhat.rhn.frontend.action.systems.sdc.SystemDetailsEditAction;
 import com.redhat.rhn.frontend.struts.RhnAction;
 import com.redhat.rhn.frontend.struts.RhnHelper;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
+import com.redhat.rhn.manager.formula.FormulaMonitoringManager;
+import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitler;
+import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
 import com.redhat.rhn.testing.ChannelTestUtils;
 import com.redhat.rhn.testing.RhnPostMockStrutsTestCase;
 import com.redhat.rhn.testing.ServerTestUtils;
 import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
 
+import com.suse.manager.virtualization.VirtManagerSalt;
+import com.suse.manager.webui.services.iface.MonitoringManager;
+import com.suse.manager.webui.services.iface.SaltApi;
+import com.suse.manager.webui.services.iface.SystemQuery;
+import com.suse.manager.webui.services.iface.VirtManager;
+import com.suse.manager.webui.services.impl.SaltService;
 import org.apache.struts.util.LabelValueBean;
 
 import java.util.Iterator;
@@ -42,7 +51,16 @@ import java.util.Set;
 public class SystemDetailsEditActionTest extends RhnPostMockStrutsTestCase {
 
     protected Server s;
-    private SystemEntitlementManager systemEntitlementManager = GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER;
+    private final SaltService saltService = new SaltService();
+    private final SystemQuery systemQuery = saltService;
+    private final SaltApi saltApi = saltService;
+    private final ServerGroupManager serverGroupManager = new ServerGroupManager();
+    private final VirtManager virtManager = new VirtManagerSalt(saltApi);
+    private final MonitoringManager monitoringManager = new FormulaMonitoringManager();
+    private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
+            new SystemUnentitler(virtManager, monitoringManager, serverGroupManager),
+            new SystemEntitler(systemQuery, virtManager, monitoringManager, serverGroupManager)
+    );
 
     /**
      * {@inheritDoc}

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/test/SystemDetailsEditActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/test/SystemDetailsEditActionTest.java
@@ -34,11 +34,9 @@ import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
 
 import com.suse.manager.virtualization.VirtManagerSalt;
-import com.suse.manager.webui.services.iface.MonitoringManager;
-import com.suse.manager.webui.services.iface.SaltApi;
-import com.suse.manager.webui.services.iface.SystemQuery;
-import com.suse.manager.webui.services.iface.VirtManager;
-import com.suse.manager.webui.services.impl.SaltService;
+import com.suse.manager.webui.services.iface.*;
+import com.suse.manager.webui.services.test.TestSaltApi;
+import com.suse.manager.webui.services.test.TestSystemQuery;
 import org.apache.struts.util.LabelValueBean;
 
 import java.util.Iterator;
@@ -51,9 +49,8 @@ import java.util.Set;
 public class SystemDetailsEditActionTest extends RhnPostMockStrutsTestCase {
 
     protected Server s;
-    private final SaltService saltService = new SaltService();
-    private final SystemQuery systemQuery = saltService;
-    private final SaltApi saltApi = saltService;
+    private final SystemQuery systemQuery = new TestSystemQuery();
+    private final SaltApi saltApi = new TestSaltApi();
     private final ServerGroupManager serverGroupManager = new ServerGroupManager();
     private final VirtManager virtManager = new VirtManagerSalt(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager();

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/test/SystemOverviewActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/test/SystemOverviewActionTest.java
@@ -15,7 +15,6 @@
 package com.redhat.rhn.frontend.action.systems.sdc.test;
 
 import com.redhat.rhn.domain.channel.Channel;
-import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.errata.Errata;
 import com.redhat.rhn.domain.errata.ErrataFactory;
 import com.redhat.rhn.domain.errata.test.ErrataFactoryTest;
@@ -31,10 +30,20 @@ import com.redhat.rhn.domain.server.test.ServerFactoryTest;
 import com.redhat.rhn.domain.user.UserFactory;
 import com.redhat.rhn.manager.contentmgmt.test.MockModulemdApi;
 import com.redhat.rhn.manager.errata.cache.ErrataCacheManager;
+import com.redhat.rhn.manager.formula.FormulaMonitoringManager;
+import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitler;
+import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
 import com.redhat.rhn.testing.RhnMockStrutsTestCase;
 import com.redhat.rhn.testing.TestUtils;
+import com.suse.manager.virtualization.VirtManagerSalt;
+import com.suse.manager.webui.services.iface.MonitoringManager;
+import com.suse.manager.webui.services.iface.SaltApi;
+import com.suse.manager.webui.services.iface.SystemQuery;
+import com.suse.manager.webui.services.iface.VirtManager;
+import com.suse.manager.webui.services.impl.SaltService;
 
 import java.sql.Timestamp;
 import java.util.Calendar;
@@ -48,7 +57,16 @@ import java.util.Date;
 public class SystemOverviewActionTest extends RhnMockStrutsTestCase {
 
     protected Server s;
-    private SystemEntitlementManager systemEntitlementManager = GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER;
+    private final SaltService saltService = new SaltService();
+    private final SystemQuery systemQuery = saltService;
+    private final SaltApi saltApi = saltService;
+    private final ServerGroupManager serverGroupManager = new ServerGroupManager();
+    private final VirtManager virtManager = new VirtManagerSalt(saltApi);
+    private final MonitoringManager monitoringManager = new FormulaMonitoringManager();
+    private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
+            new SystemUnentitler(virtManager, monitoringManager, serverGroupManager),
+            new SystemEntitler(systemQuery, virtManager, monitoringManager, serverGroupManager)
+    );
 
     /**
      * {@inheritDoc}

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/test/SystemOverviewActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/test/SystemOverviewActionTest.java
@@ -15,6 +15,7 @@
 package com.redhat.rhn.frontend.action.systems.sdc.test;
 
 import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.errata.Errata;
 import com.redhat.rhn.domain.errata.ErrataFactory;
 import com.redhat.rhn.domain.errata.test.ErrataFactoryTest;
@@ -32,8 +33,6 @@ import com.redhat.rhn.manager.contentmgmt.test.MockModulemdApi;
 import com.redhat.rhn.manager.errata.cache.ErrataCacheManager;
 import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
-import com.redhat.rhn.manager.system.entitling.SystemEntitler;
-import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
 import com.redhat.rhn.testing.RhnMockStrutsTestCase;
 import com.redhat.rhn.testing.TestUtils;
 
@@ -49,7 +48,7 @@ import java.util.Date;
 public class SystemOverviewActionTest extends RhnMockStrutsTestCase {
 
     protected Server s;
-    private SystemEntitlementManager systemEntitlementManager = SystemEntitlementManager.INSTANCE;
+    private SystemEntitlementManager systemEntitlementManager = GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER;
 
     /**
      * {@inheritDoc}

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/test/SystemOverviewActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/test/SystemOverviewActionTest.java
@@ -39,11 +39,9 @@ import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
 import com.redhat.rhn.testing.RhnMockStrutsTestCase;
 import com.redhat.rhn.testing.TestUtils;
 import com.suse.manager.virtualization.VirtManagerSalt;
-import com.suse.manager.webui.services.iface.MonitoringManager;
-import com.suse.manager.webui.services.iface.SaltApi;
-import com.suse.manager.webui.services.iface.SystemQuery;
-import com.suse.manager.webui.services.iface.VirtManager;
-import com.suse.manager.webui.services.impl.SaltService;
+import com.suse.manager.webui.services.iface.*;
+import com.suse.manager.webui.services.test.TestSaltApi;
+import com.suse.manager.webui.services.test.TestSystemQuery;
 
 import java.sql.Timestamp;
 import java.util.Calendar;
@@ -57,9 +55,8 @@ import java.util.Date;
 public class SystemOverviewActionTest extends RhnMockStrutsTestCase {
 
     protected Server s;
-    private final SaltService saltService = new SaltService();
-    private final SystemQuery systemQuery = saltService;
-    private final SaltApi saltApi = saltService;
+    private final SystemQuery systemQuery = new TestSystemQuery();
+    private final SaltApi saltApi = new TestSaltApi();
     private final ServerGroupManager serverGroupManager = new ServerGroupManager();
     private final VirtManager virtManager = new VirtManagerSalt(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager();

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/virtualization/test/ProvisionVirtualizationWizardActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/virtualization/test/ProvisionVirtualizationWizardActionTest.java
@@ -14,6 +14,7 @@
  */
 package com.redhat.rhn.frontend.action.systems.virtualization.test;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.channel.test.ChannelFactoryTest;
@@ -39,9 +40,7 @@ import com.redhat.rhn.frontend.struts.RequestContext;
 import com.redhat.rhn.manager.kickstart.KickstartScheduleCommand;
 import com.redhat.rhn.manager.profile.test.ProfileManagerTest;
 import com.redhat.rhn.manager.rhnpackage.test.PackageManagerTest;
-import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
-import com.redhat.rhn.manager.system.entitling.SystemEntitler;
 import com.redhat.rhn.testing.RhnMockStrutsTestCase;
 import com.redhat.rhn.testing.ServerGroupTestUtils;
 import com.redhat.rhn.testing.TestUtils;
@@ -59,7 +58,7 @@ import junit.framework.AssertionFailedError;
 public class ProvisionVirtualizationWizardActionTest extends RhnMockStrutsTestCase {
 
     private Server s;
-    private SystemEntitlementManager systemEntitlementManager = SystemEntitlementManager.INSTANCE;
+    private SystemEntitlementManager systemEntitlementManager = GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER;
 
     /**
      * {@inheritDoc}

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/virtualization/test/ProvisionVirtualizationWizardActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/virtualization/test/ProvisionVirtualizationWizardActionTest.java
@@ -14,7 +14,6 @@
  */
 package com.redhat.rhn.frontend.action.systems.virtualization.test;
 
-import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.channel.test.ChannelFactoryTest;
@@ -37,10 +36,14 @@ import com.redhat.rhn.frontend.action.kickstart.test.ScheduleKickstartWizardTest
 import com.redhat.rhn.frontend.action.systems.virtualization.ProvisionVirtualizationWizardAction;
 import com.redhat.rhn.frontend.dto.ProfileDto;
 import com.redhat.rhn.frontend.struts.RequestContext;
+import com.redhat.rhn.manager.formula.FormulaMonitoringManager;
 import com.redhat.rhn.manager.kickstart.KickstartScheduleCommand;
 import com.redhat.rhn.manager.profile.test.ProfileManagerTest;
 import com.redhat.rhn.manager.rhnpackage.test.PackageManagerTest;
+import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitler;
+import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
 import com.redhat.rhn.testing.RhnMockStrutsTestCase;
 import com.redhat.rhn.testing.ServerGroupTestUtils;
 import com.redhat.rhn.testing.TestUtils;
@@ -49,6 +52,12 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
 
+import com.suse.manager.virtualization.VirtManagerSalt;
+import com.suse.manager.webui.services.iface.MonitoringManager;
+import com.suse.manager.webui.services.iface.SaltApi;
+import com.suse.manager.webui.services.iface.SystemQuery;
+import com.suse.manager.webui.services.iface.VirtManager;
+import com.suse.manager.webui.services.impl.SaltService;
 import junit.framework.AssertionFailedError;
 
 /**
@@ -58,7 +67,16 @@ import junit.framework.AssertionFailedError;
 public class ProvisionVirtualizationWizardActionTest extends RhnMockStrutsTestCase {
 
     private Server s;
-    private SystemEntitlementManager systemEntitlementManager = GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER;
+    private final SaltService saltService = new SaltService();
+    private final SystemQuery systemQuery = saltService;
+    private final SaltApi saltApi = saltService;
+    private final ServerGroupManager serverGroupManager = new ServerGroupManager();
+    private final VirtManager virtManager = new VirtManagerSalt(saltApi);
+    private final MonitoringManager monitoringManager = new FormulaMonitoringManager();
+    private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
+            new SystemUnentitler(virtManager, monitoringManager, serverGroupManager),
+            new SystemEntitler(systemQuery, virtManager, monitoringManager, serverGroupManager)
+    );
 
     /**
      * {@inheritDoc}

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/virtualization/test/ProvisionVirtualizationWizardActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/virtualization/test/ProvisionVirtualizationWizardActionTest.java
@@ -53,11 +53,9 @@ import java.util.HashSet;
 import java.util.Set;
 
 import com.suse.manager.virtualization.VirtManagerSalt;
-import com.suse.manager.webui.services.iface.MonitoringManager;
-import com.suse.manager.webui.services.iface.SaltApi;
-import com.suse.manager.webui.services.iface.SystemQuery;
-import com.suse.manager.webui.services.iface.VirtManager;
-import com.suse.manager.webui.services.impl.SaltService;
+import com.suse.manager.webui.services.iface.*;
+import com.suse.manager.webui.services.test.TestSaltApi;
+import com.suse.manager.webui.services.test.TestSystemQuery;
 import junit.framework.AssertionFailedError;
 
 /**
@@ -67,9 +65,8 @@ import junit.framework.AssertionFailedError;
 public class ProvisionVirtualizationWizardActionTest extends RhnMockStrutsTestCase {
 
     private Server s;
-    private final SaltService saltService = new SaltService();
-    private final SystemQuery systemQuery = saltService;
-    private final SaltApi saltApi = saltService;
+    private final SystemQuery systemQuery = new TestSystemQuery();
+    private final SaltApi saltApi = new TestSaltApi();
     private final ServerGroupManager serverGroupManager = new ServerGroupManager();
     private final VirtManager virtManager = new VirtManagerSalt(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager();

--- a/java/code/src/com/redhat/rhn/frontend/action/token/groups/AddGroupsAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/token/groups/AddGroupsAction.java
@@ -15,6 +15,7 @@
 
 package com.redhat.rhn.frontend.action.token.groups;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.server.ManagedServerGroup;
 import com.redhat.rhn.domain.server.ServerGroup;
 import com.redhat.rhn.domain.server.ServerGroupFactory;
@@ -47,6 +48,8 @@ import javax.servlet.http.HttpServletResponse;
 public class AddGroupsAction extends BaseListAction {
     private static final String ACCESS_MAP = "accessMap";
 
+    private final ServerGroupManager sgm = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
+
     /** {@inheritDoc} */
     public ActionForward handleDispatch(ListSessionSetHelper helper,
                                     ActionMapping mapping,
@@ -55,7 +58,6 @@ public class AddGroupsAction extends BaseListAction {
         RequestContext context = new RequestContext(request);
         ActivationKey key = context.lookupAndBindActivationKey();
         User user = context.getCurrentUser();
-        ServerGroupManager sgm = ServerGroupManager.getInstance();
         for (String id : helper.getSet()) {
             Long sgid = Long.valueOf(id);
             key.addServerGroup(sgm.lookup(sgid, user));
@@ -95,7 +97,7 @@ public class AddGroupsAction extends BaseListAction {
      * @param groups list of server groups
      */
     static void setupAccessMap(RequestContext context, List<ManagedServerGroup> groups) {
-        ServerGroupManager sgm = ServerGroupManager.getInstance();
+        ServerGroupManager sgm = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
         Map<Long, Long> accessMap = new HashMap<Long, Long>();
         for (ServerGroup sg : groups) {
             if (sgm.canAccess(context.getCurrentUser(), sg)) {

--- a/java/code/src/com/redhat/rhn/frontend/action/token/groups/ListRemoveGroupsAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/token/groups/ListRemoveGroupsAction.java
@@ -15,6 +15,7 @@
 
 package com.redhat.rhn.frontend.action.token.groups;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.server.ManagedServerGroup;
 import com.redhat.rhn.domain.token.ActivationKey;
 import com.redhat.rhn.domain.user.User;
@@ -45,6 +46,8 @@ import javax.servlet.http.HttpServletResponse;
  */
 public class ListRemoveGroupsAction extends BaseListAction {
 
+    private final ServerGroupManager serverGroupManager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
+
     /** {@inheritDoc} */
     @Override
     public ActionForward handleDispatch(ListSessionSetHelper helper,
@@ -54,11 +57,10 @@ public class ListRemoveGroupsAction extends BaseListAction {
         RequestContext context = new RequestContext(request);
         ActivationKey key = context.lookupAndBindActivationKey();
         User user = context.getCurrentUser();
-        ServerGroupManager sgm = ServerGroupManager.getInstance();
         Set<String> set = helper.getSet();
         for (String id : set) {
             Long sgid = Long.valueOf(id);
-            key.removeServerGroup(sgm.lookup(sgid, user));
+            key.removeServerGroup(serverGroupManager.lookup(sgid, user));
         }
 
         getStrutsDelegate().saveMessage(

--- a/java/code/src/com/redhat/rhn/frontend/action/user/AdminUserEditAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/user/AdminUserEditAction.java
@@ -14,6 +14,7 @@
  */
 package com.redhat.rhn.frontend.action.user;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.security.PermissionException;
 import com.redhat.rhn.domain.org.Org;
 import com.redhat.rhn.domain.role.Role;
@@ -54,6 +55,8 @@ public class AdminUserEditAction extends UserEditActionHelper {
 
     private static Logger log = Logger.getLogger(AdminUserEditAction.class);
     private static final String ROLE_SETTING_PREFIX = "role_";
+
+    private final ServerGroupManager serverGroupManager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
 
     /** {@inheritDoc} */
     public ActionForward execute(ActionMapping mapping,
@@ -185,14 +188,13 @@ public class AdminUserEditAction extends UserEditActionHelper {
             // will be empty..
             if (targetUser.hasRole(RoleFactory.ORG_ADMIN) &&
                     !targetUser.getAssociatedServerGroups().isEmpty()) {
-                ServerGroupManager manager = ServerGroupManager.getInstance();
                 Set admins = new HashSet();
                 admins.add(targetUser);
                 for (Iterator itr = targetUser.getAssociatedServerGroups().iterator();
                         itr.hasNext();) {
 
                     ManagedServerGroup sg = (ManagedServerGroup) itr.next();
-                    manager.dissociateAdmins(sg, admins, loggedInUser);
+                    serverGroupManager.dissociateAdmins(sg, admins, loggedInUser);
                     itr.remove();
                 }
             }

--- a/java/code/src/com/redhat/rhn/frontend/nav/AclGuard.java
+++ b/java/code/src/com/redhat/rhn/frontend/nav/AclGuard.java
@@ -26,25 +26,29 @@ import java.util.Map;
 public class AclGuard implements RenderGuard {
     private Map context;
     private String mixins;
+    private final AclFactory aclFactory;
 
 
     /**
      * Constructor
      * @param ctx Acl Context
      * @param mixinsIn The string of classnames used to add extra Acl Handlers
+     * @param aclFactoryIn
      */
-    public AclGuard(Map ctx, String mixinsIn) {
+    public AclGuard(Map ctx, String mixinsIn, AclFactory aclFactoryIn) {
         super();
         context = ctx;
         this.mixins = mixinsIn;
+        this.aclFactory = aclFactoryIn;
     }
 
     /**
      * Constructor
      * @param ctx Acl Context
+     * @param aclFactoryIn
      */
-    public AclGuard(Map ctx) {
-        this(ctx, null);
+    public AclGuard(Map ctx, AclFactory aclFactoryIn) {
+        this(ctx, null, aclFactoryIn);
     }
 
     /**
@@ -65,7 +69,7 @@ public class AclGuard implements RenderGuard {
             return true;
         }
 
-        Acl acl = AclFactory.getInstance().getAcl(mixins);
+        Acl acl = aclFactory.getAcl(mixins);
         return acl.evalAcl(context, aclStr);
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/nav/test/AclGuardTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/nav/test/AclGuardTest.java
@@ -19,7 +19,11 @@ import com.redhat.rhn.common.security.acl.AclFactory;
 import com.redhat.rhn.common.security.acl.AclHandler;
 import com.redhat.rhn.frontend.nav.AclGuard;
 import com.redhat.rhn.frontend.nav.NavNode;
+import com.redhat.rhn.manager.formula.FormulaManager;
+import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.testing.RhnBaseTestCase;
+import com.suse.manager.clusters.ClusterManager;
+import com.suse.manager.webui.services.impl.SaltService;
 
 import java.util.HashMap;
 
@@ -29,16 +33,22 @@ import java.util.HashMap;
  */
 public class AclGuardTest extends RhnBaseTestCase {
 
+    private final SaltService saltService = new SaltService();
+    private final ServerGroupManager serverGroupManager = new ServerGroupManager();
+    private final FormulaManager formulaManager = new FormulaManager(saltService);
+    private final ClusterManager clusterManager = new ClusterManager(
+            saltService, saltService, serverGroupManager, formulaManager);
+
     public void testNoAclDefined() {
         NavNode node = new NavNode();
-        AclFactory aclFactory = new AclFactory(new Access(null));
+        AclFactory aclFactory = new AclFactory(new Access(clusterManager));
         AclGuard aclGuard = new AclGuard(new HashMap(), aclFactory);
         boolean rc = aclGuard.canRender(node, 0);
         assertTrue(rc);
     }
 
     public void testNullNodeDefined() {
-        AclGuard aclGuard = new AclGuard(new HashMap(), new AclFactory(new Access(null)));
+        AclGuard aclGuard = new AclGuard(new HashMap(), new AclFactory(new Access(clusterManager)));
         boolean rc = aclGuard.canRender(null, 0);
         assertTrue(rc);
     }
@@ -47,7 +57,7 @@ public class AclGuardTest extends RhnBaseTestCase {
         NavNode node = new NavNode();
         node.setAcl("false_test()");
         AclGuard aclGuard = new AclGuard(new HashMap(),
-                MockAclHandler.class.getName(), new AclFactory(new Access(null)));
+                MockAclHandler.class.getName(), new AclFactory(new Access(clusterManager)));
         boolean rc = aclGuard.canRender(node, 0);
         assertFalse(rc);
     }
@@ -56,7 +66,7 @@ public class AclGuardTest extends RhnBaseTestCase {
         NavNode node = new NavNode();
         node.setAcl("true_test()");
         AclGuard aclGuard = new AclGuard(new HashMap(),
-                MockAclHandler.class.getName(), new AclFactory(new Access(null)));
+                MockAclHandler.class.getName(), new AclFactory(new Access(clusterManager)));
         boolean rc = aclGuard.canRender(node, 0);
         assertTrue(rc);
     }

--- a/java/code/src/com/redhat/rhn/frontend/nav/test/AclGuardTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/nav/test/AclGuardTest.java
@@ -23,7 +23,10 @@ import com.redhat.rhn.manager.formula.FormulaManager;
 import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.testing.RhnBaseTestCase;
 import com.suse.manager.clusters.ClusterManager;
-import com.suse.manager.webui.services.impl.SaltService;
+import com.suse.manager.webui.services.iface.SaltApi;
+import com.suse.manager.webui.services.iface.SystemQuery;
+import com.suse.manager.webui.services.test.TestSaltApi;
+import com.suse.manager.webui.services.test.TestSystemQuery;
 
 import java.util.HashMap;
 
@@ -33,11 +36,12 @@ import java.util.HashMap;
  */
 public class AclGuardTest extends RhnBaseTestCase {
 
-    private final SaltService saltService = new SaltService();
+    private final SystemQuery systemQuery = new TestSystemQuery();
+    private final SaltApi saltApi = new TestSaltApi();
     private final ServerGroupManager serverGroupManager = new ServerGroupManager();
-    private final FormulaManager formulaManager = new FormulaManager(saltService);
+    private final FormulaManager formulaManager = new FormulaManager(saltApi);
     private final ClusterManager clusterManager = new ClusterManager(
-            saltService, saltService, serverGroupManager, formulaManager);
+            saltApi, systemQuery, serverGroupManager, formulaManager);
 
     public void testNoAclDefined() {
         NavNode node = new NavNode();

--- a/java/code/src/com/redhat/rhn/frontend/nav/test/AclGuardTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/nav/test/AclGuardTest.java
@@ -14,6 +14,8 @@
  */
 package com.redhat.rhn.frontend.nav.test;
 
+import com.redhat.rhn.common.security.acl.Access;
+import com.redhat.rhn.common.security.acl.AclFactory;
 import com.redhat.rhn.common.security.acl.AclHandler;
 import com.redhat.rhn.frontend.nav.AclGuard;
 import com.redhat.rhn.frontend.nav.NavNode;
@@ -29,13 +31,14 @@ public class AclGuardTest extends RhnBaseTestCase {
 
     public void testNoAclDefined() {
         NavNode node = new NavNode();
-        AclGuard aclGuard = new AclGuard(new HashMap());
+        AclFactory aclFactory = new AclFactory(new Access(null));
+        AclGuard aclGuard = new AclGuard(new HashMap(), aclFactory);
         boolean rc = aclGuard.canRender(node, 0);
         assertTrue(rc);
     }
 
     public void testNullNodeDefined() {
-        AclGuard aclGuard = new AclGuard(new HashMap());
+        AclGuard aclGuard = new AclGuard(new HashMap(), new AclFactory(new Access(null)));
         boolean rc = aclGuard.canRender(null, 0);
         assertTrue(rc);
     }
@@ -44,7 +47,7 @@ public class AclGuardTest extends RhnBaseTestCase {
         NavNode node = new NavNode();
         node.setAcl("false_test()");
         AclGuard aclGuard = new AclGuard(new HashMap(),
-                MockAclHandler.class.getName());
+                MockAclHandler.class.getName(), new AclFactory(new Access(null)));
         boolean rc = aclGuard.canRender(node, 0);
         assertFalse(rc);
     }
@@ -53,7 +56,7 @@ public class AclGuardTest extends RhnBaseTestCase {
         NavNode node = new NavNode();
         node.setAcl("true_test()");
         AclGuard aclGuard = new AclGuard(new HashMap(),
-                MockAclHandler.class.getName());
+                MockAclHandler.class.getName(), new AclFactory(new Access(null)));
         boolean rc = aclGuard.canRender(node, 0);
         assertTrue(rc);
     }

--- a/java/code/src/com/redhat/rhn/frontend/struts/RequestContext.java
+++ b/java/code/src/com/redhat/rhn/frontend/struts/RequestContext.java
@@ -14,6 +14,7 @@
  */
 package com.redhat.rhn.frontend.struts;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.common.security.PermissionException;
 import com.redhat.rhn.domain.errata.Errata;
@@ -102,6 +103,8 @@ public class RequestContext {
     public static final String NO_SCRIPT = "noscript";
     public static final String MODE = "mode";
     public static final String POST = "POST";
+
+    private final ServerGroupManager serverGroupManager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
 
     /**
      * Names of pagination elements (and their corresponding attributes).
@@ -349,9 +352,8 @@ public class RequestContext {
     public ManagedServerGroup lookupAndBindServerGroup() {
         if (request.getAttribute(SERVER_GROUP) == null) {
             Long id = getRequiredParam(SERVER_GROUP_ID);
-            ServerGroupManager manager = ServerGroupManager.getInstance();
             User user = getCurrentUser();
-            ManagedServerGroup sg = manager.lookup(id, user);
+            ManagedServerGroup sg = serverGroupManager.lookup(id, user);
             if (sg == null) {
                 String msg = "No server group with id = [%s] found.";
                 throw new IllegalArgumentException(String.format(msg, id));

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/NavDialogMenuTag.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/NavDialogMenuTag.java
@@ -18,6 +18,7 @@ import com.redhat.rhn.frontend.nav.NavTreeIndex;
 import com.redhat.rhn.frontend.nav.RenderGuard;
 import com.redhat.rhn.frontend.nav.Renderable;
 import com.redhat.rhn.frontend.taglibs.helpers.RenderUtils;
+import com.redhat.rhn.webapp.RhnServletListener;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -49,12 +50,14 @@ public class NavDialogMenuTag extends TagSupport {
     /** rendering classname which implements the Renderable interface */
     private String renderer;
 
+    private final RenderUtils renderUtils = RhnServletListener.RENDER_UTILS;
+
     /** {@inheritDoc}
      * @throws JspException*/
     @Override
     public int doStartTag() throws JspException {
         try {
-            pageContext.getOut().print(RenderUtils.getInstance().renderNavigationMenu(
+            pageContext.getOut().print(renderUtils.renderNavigationMenu(
                     pageContext, definition, renderer, mindepth, maxdepth, new HashMap<String, String>()));
         }
         catch (Exception e) {
@@ -143,7 +146,7 @@ public class NavDialogMenuTag extends TagSupport {
     /** {@inheritDoc} */
     protected String renderNav(NavTreeIndex navTreeIndex, Renderable renderable,
             RenderGuard guard, Map<String, String[]> params) {
-        String body = RenderUtils.getInstance().render(
+        String body = renderUtils.render(
                 navTreeIndex, renderable, guard, params);
         return body;
     }

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/NavDialogMenuTag.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/NavDialogMenuTag.java
@@ -14,11 +14,11 @@
  */
 package com.redhat.rhn.frontend.taglibs;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.frontend.nav.NavTreeIndex;
 import com.redhat.rhn.frontend.nav.RenderGuard;
 import com.redhat.rhn.frontend.nav.Renderable;
 import com.redhat.rhn.frontend.taglibs.helpers.RenderUtils;
-import com.redhat.rhn.webapp.RhnServletListener;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -50,7 +50,7 @@ public class NavDialogMenuTag extends TagSupport {
     /** rendering classname which implements the Renderable interface */
     private String renderer;
 
-    private final RenderUtils renderUtils = RhnServletListener.RENDER_UTILS;
+    private final RenderUtils renderUtils = GlobalInstanceHolder.RENDER_UTILS;
 
     /** {@inheritDoc}
      * @throws JspException*/

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/helpers/RenderUtils.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/helpers/RenderUtils.java
@@ -14,6 +14,7 @@
  */
 package com.redhat.rhn.frontend.taglibs.helpers;
 
+import com.redhat.rhn.common.security.acl.AclFactory;
 import com.redhat.rhn.common.util.ServletUtils;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.nav.AclGuard;
@@ -38,20 +39,15 @@ import javax.servlet.jsp.PageContext;
 /**
  * Utility methods for rendering navigation menus that are defined in XML files.
  */
-public enum RenderUtils {
-    /**
-     * Singleton instance
-     */
-    INSTANCE;
+public class RenderUtils {
 
-    RenderUtils() { }
+    private final AclFactory aclFactory;
 
     /**
-     * Singleton implementation
-     * @return an instance of this class
+     * @param aclFactoryIn
      */
-    public static RenderUtils getInstance() {
-        return INSTANCE;
+    public RenderUtils(AclFactory aclFactoryIn) {
+        this.aclFactory = aclFactoryIn;
     }
 
     /**
@@ -116,7 +112,7 @@ public enum RenderUtils {
                 aclContext.put(token, value);
             }
         }
-        AclGuard guard = new AclGuard(aclContext, navTree.getAclMixins());
+        AclGuard guard = new AclGuard(aclContext, navTree.getAclMixins(), aclFactory);
         navTree.setGuard(guard);
 
         // We try to fetch the previously successful navigation match from the Session.

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/HandlerFactory.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/HandlerFactory.java
@@ -15,6 +15,7 @@
 
 package com.redhat.rhn.frontend.xmlrpc;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.server.ServerGroupFactory;
 import com.redhat.rhn.frontend.xmlrpc.activationkey.ActivationKeyHandler;
@@ -83,7 +84,6 @@ import com.suse.manager.webui.controllers.utils.RegularMinionBootstrapper;
 import com.suse.manager.webui.controllers.utils.SSHMinionBootstrapper;
 import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.SystemQuery;
-import com.suse.manager.webui.services.impl.SaltService;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -124,8 +124,8 @@ public class HandlerFactory {
         TaskomaticApi taskomaticApi = new TaskomaticApi();
         SystemEntitlementManager systemEntitlementManager = SystemEntitlementManager.INSTANCE;
         SystemManager systemManager = new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON);
-        SystemQuery systemQuery = SaltService.INSTANCE;
-        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
+        SystemQuery systemQuery = GlobalInstanceHolder.SYSTEM_QUERY;
+        SaltApi saltApi = GlobalInstanceHolder.SALT_API;
 
         FormulaManager formulaManager = new FormulaManager(saltApi);
         ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/HandlerFactory.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/HandlerFactory.java
@@ -74,7 +74,6 @@ import com.redhat.rhn.frontend.xmlrpc.taskomatic.TaskomaticOrgHandler;
 import com.redhat.rhn.frontend.xmlrpc.user.UserHandler;
 import com.redhat.rhn.frontend.xmlrpc.user.external.UserExternalHandler;
 import com.redhat.rhn.frontend.xmlrpc.virtualhostmanager.VirtualHostManagerHandler;
-import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.manager.formula.FormulaManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
@@ -82,8 +81,6 @@ import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.suse.manager.clusters.ClusterManager;
 import com.suse.manager.webui.controllers.utils.RegularMinionBootstrapper;
 import com.suse.manager.webui.controllers.utils.SSHMinionBootstrapper;
-import com.suse.manager.webui.services.iface.SaltApi;
-import com.suse.manager.webui.services.iface.SystemQuery;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -122,7 +119,7 @@ public class HandlerFactory {
     public static HandlerFactory getDefaultHandlerFactory() {
         HandlerFactory factory = new HandlerFactory();
         TaskomaticApi taskomaticApi = new TaskomaticApi();
-        SystemEntitlementManager systemEntitlementManager = SystemEntitlementManager.INSTANCE;
+        SystemEntitlementManager systemEntitlementManager = GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER;
         SystemManager systemManager = new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON);
         FormulaManager formulaManager = GlobalInstanceHolder.FORMULA_MANAGER;
         ClusterManager clusterManager = GlobalInstanceHolder.CLUSTER_MANAGER;

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/HandlerFactory.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/HandlerFactory.java
@@ -124,14 +124,11 @@ public class HandlerFactory {
         TaskomaticApi taskomaticApi = new TaskomaticApi();
         SystemEntitlementManager systemEntitlementManager = SystemEntitlementManager.INSTANCE;
         SystemManager systemManager = new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON);
-        SystemQuery systemQuery = GlobalInstanceHolder.SYSTEM_QUERY;
-        SaltApi saltApi = GlobalInstanceHolder.SALT_API;
+        FormulaManager formulaManager = GlobalInstanceHolder.FORMULA_MANAGER;
+        ClusterManager clusterManager = GlobalInstanceHolder.CLUSTER_MANAGER;
 
-        FormulaManager formulaManager = new FormulaManager(saltApi);
-        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
-        ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);
-        RegularMinionBootstrapper regularMinionBootstrapper = RegularMinionBootstrapper.getInstance(systemQuery);
-        SSHMinionBootstrapper sshMinionBootstrapper = SSHMinionBootstrapper.getInstance(systemQuery);
+        RegularMinionBootstrapper regularMinionBootstrapper = GlobalInstanceHolder.REGULAR_MINION_BOOTSTRAPPER;
+        SSHMinionBootstrapper sshMinionBootstrapper = GlobalInstanceHolder.SSH_MINION_BOOTSTRAPPER;
         XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
                 regularMinionBootstrapper,
                 sshMinionBootstrapper

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/HandlerFactory.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/HandlerFactory.java
@@ -75,6 +75,7 @@ import com.redhat.rhn.frontend.xmlrpc.taskomatic.TaskomaticOrgHandler;
 import com.redhat.rhn.frontend.xmlrpc.user.UserHandler;
 import com.redhat.rhn.frontend.xmlrpc.user.external.UserExternalHandler;
 import com.redhat.rhn.frontend.xmlrpc.virtualhostmanager.VirtualHostManagerHandler;
+import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.manager.formula.FormulaManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
@@ -126,6 +127,7 @@ public class HandlerFactory {
         FormulaManager formulaManager = GlobalInstanceHolder.FORMULA_MANAGER;
         ClusterManager clusterManager = GlobalInstanceHolder.CLUSTER_MANAGER;
         SaltKeyUtils saltKeyUtils = GlobalInstanceHolder.SALT_KEY_UTILS;
+        ServerGroupManager serverGroupManager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
 
         RegularMinionBootstrapper regularMinionBootstrapper = GlobalInstanceHolder.REGULAR_MINION_BOOTSTRAPPER;
         SSHMinionBootstrapper sshMinionBootstrapper = GlobalInstanceHolder.SSH_MINION_BOOTSTRAPPER;
@@ -134,9 +136,11 @@ public class HandlerFactory {
                 sshMinionBootstrapper
         );
         ProxyHandler proxyHandler = new ProxyHandler(xmlRpcSystemHelper);
+        SystemHandler systemHandler = new SystemHandler(taskomaticApi, xmlRpcSystemHelper, systemEntitlementManager,
+                systemManager, serverGroupManager);
 
         factory.addHandler("actionchain", new ActionChainHandler());
-        factory.addHandler("activationkey", new ActivationKeyHandler());
+        factory.addHandler("activationkey", new ActivationKeyHandler(serverGroupManager));
         factory.addHandler("admin.monitoring", new AdminMonitoringHandler());
         factory.addHandler("api", new ApiHandler(factory));
         factory.addHandler("audit", new CVEAuditHandler());
@@ -144,7 +148,8 @@ public class HandlerFactory {
         factory.addHandler("channel", new ChannelHandler());
         factory.addHandler("channel.access", new ChannelAccessHandler());
         factory.addHandler("channel.org", new ChannelOrgHandler());
-        factory.addHandler("channel.software", new ChannelSoftwareHandler(taskomaticApi, xmlRpcSystemHelper));
+        factory.addHandler("channel.software", new ChannelSoftwareHandler(taskomaticApi, xmlRpcSystemHelper,
+            systemHandler));
         factory.addHandler("cluster", new ClusterHandler(clusterManager));
         factory.addHandler("configchannel", new ConfigChannelHandler());
         factory.addHandler("contentmanagement", new ContentManagementHandler());
@@ -178,8 +183,7 @@ public class HandlerFactory {
         factory.addHandler("sync.master", new MasterHandler());
         factory.addHandler("sync.slave", new SlaveHandler());
         factory.addHandler("sync.content", new ContentSyncHandler());
-        factory.addHandler("system", new SystemHandler(taskomaticApi, xmlRpcSystemHelper, systemEntitlementManager,
-                systemManager));
+        factory.addHandler("system", systemHandler);
         factory.addHandler("system.config", new ServerConfigHandler(taskomaticApi, xmlRpcSystemHelper));
         factory.addHandler("system.crash", new CrashHandler(xmlRpcSystemHelper));
         factory.addHandler("system.custominfo", new CustomInfoHandler());
@@ -187,10 +191,10 @@ public class HandlerFactory {
         factory.addHandler("system.scap", new SystemScapHandler());
         factory.addHandler("system.search", new SystemSearchHandler());
         factory.addHandler("virtualhostmanager", new VirtualHostManagerHandler());
-        factory.addHandler("systemgroup", new ServerGroupHandler(xmlRpcSystemHelper));
+        factory.addHandler("systemgroup", new ServerGroupHandler(xmlRpcSystemHelper, serverGroupManager));
         factory.addHandler("taskomatic", new TaskomaticHandler());
         factory.addHandler("taskomatic.org", new TaskomaticOrgHandler());
-        factory.addHandler("user", new UserHandler());
+        factory.addHandler("user", new UserHandler(serverGroupManager));
         factory.addHandler("user.external", new UserExternalHandler());
         return factory;
     }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/HandlerFactory.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/HandlerFactory.java
@@ -73,10 +73,12 @@ import com.redhat.rhn.frontend.xmlrpc.taskomatic.TaskomaticOrgHandler;
 import com.redhat.rhn.frontend.xmlrpc.user.UserHandler;
 import com.redhat.rhn.frontend.xmlrpc.user.external.UserExternalHandler;
 import com.redhat.rhn.frontend.xmlrpc.virtualhostmanager.VirtualHostManagerHandler;
+import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.manager.formula.FormulaManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
+import com.suse.manager.clusters.ClusterManager;
 import com.suse.manager.webui.controllers.utils.RegularMinionBootstrapper;
 import com.suse.manager.webui.controllers.utils.SSHMinionBootstrapper;
 import com.suse.manager.webui.services.iface.SaltApi;
@@ -126,6 +128,8 @@ public class HandlerFactory {
         SaltApi saltApi = SaltService.INSTANCE_SALT_API;
 
         FormulaManager formulaManager = new FormulaManager(saltApi);
+        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);
         RegularMinionBootstrapper regularMinionBootstrapper = RegularMinionBootstrapper.getInstance(systemQuery);
         SSHMinionBootstrapper sshMinionBootstrapper = SSHMinionBootstrapper.getInstance(systemQuery);
         XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
@@ -144,7 +148,7 @@ public class HandlerFactory {
         factory.addHandler("channel.access", new ChannelAccessHandler());
         factory.addHandler("channel.org", new ChannelOrgHandler());
         factory.addHandler("channel.software", new ChannelSoftwareHandler(taskomaticApi, xmlRpcSystemHelper));
-        factory.addHandler("cluster", new ClusterHandler());
+        factory.addHandler("cluster", new ClusterHandler(clusterManager));
         factory.addHandler("configchannel", new ConfigChannelHandler());
         factory.addHandler("contentmanagement", new ContentManagementHandler());
         factory.addHandler("distchannel", new DistChannelHandler());

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/HandlerFactory.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/HandlerFactory.java
@@ -54,6 +54,7 @@ import com.redhat.rhn.frontend.xmlrpc.packages.search.PackagesSearchHandler;
 import com.redhat.rhn.frontend.xmlrpc.preferences.locale.PreferencesLocaleHandler;
 import com.redhat.rhn.frontend.xmlrpc.proxy.ProxyHandler;
 import com.redhat.rhn.frontend.xmlrpc.recurringaction.RecurringActionHandler;
+import com.redhat.rhn.frontend.xmlrpc.saltkey.SaltKeyHandler;
 import com.redhat.rhn.frontend.xmlrpc.satellite.SatelliteHandler;
 import com.redhat.rhn.frontend.xmlrpc.schedule.ScheduleHandler;
 import com.redhat.rhn.frontend.xmlrpc.subscriptionmatching.PinnedSubscriptionHandler;
@@ -79,6 +80,7 @@ import com.redhat.rhn.manager.formula.FormulaManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.suse.manager.clusters.ClusterManager;
+import com.suse.manager.utils.SaltKeyUtils;
 import com.suse.manager.webui.controllers.utils.RegularMinionBootstrapper;
 import com.suse.manager.webui.controllers.utils.SSHMinionBootstrapper;
 
@@ -123,6 +125,7 @@ public class HandlerFactory {
         SystemManager systemManager = new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON);
         FormulaManager formulaManager = GlobalInstanceHolder.FORMULA_MANAGER;
         ClusterManager clusterManager = GlobalInstanceHolder.CLUSTER_MANAGER;
+        SaltKeyUtils saltKeyUtils = GlobalInstanceHolder.SALT_KEY_UTILS;
 
         RegularMinionBootstrapper regularMinionBootstrapper = GlobalInstanceHolder.REGULAR_MINION_BOOTSTRAPPER;
         SSHMinionBootstrapper sshMinionBootstrapper = GlobalInstanceHolder.SSH_MINION_BOOTSTRAPPER;
@@ -168,6 +171,7 @@ public class HandlerFactory {
         factory.addHandler("preferences.locale", new PreferencesLocaleHandler());
         factory.addHandler("proxy", proxyHandler);
         factory.addHandler("recurringaction", new RecurringActionHandler());
+        factory.addHandler("saltkey", new SaltKeyHandler(saltKeyUtils));
         factory.addHandler("satellite", new SatelliteHandler(proxyHandler));
         factory.addHandler("schedule", new ScheduleHandler());
         factory.addHandler("subscriptionmatching.pinnedsubscription", new PinnedSubscriptionHandler());

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/HandlerFactory.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/HandlerFactory.java
@@ -79,6 +79,7 @@ import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.suse.manager.webui.controllers.utils.RegularMinionBootstrapper;
 import com.suse.manager.webui.controllers.utils.SSHMinionBootstrapper;
+import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.manager.webui.services.impl.SaltService;
 
@@ -122,6 +123,9 @@ public class HandlerFactory {
         SystemEntitlementManager systemEntitlementManager = SystemEntitlementManager.INSTANCE;
         SystemManager systemManager = new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON);
         SystemQuery systemQuery = SaltService.INSTANCE;
+        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
+
+        FormulaManager formulaManager = new FormulaManager(saltApi);
         RegularMinionBootstrapper regularMinionBootstrapper = RegularMinionBootstrapper.getInstance(systemQuery);
         SSHMinionBootstrapper sshMinionBootstrapper = SSHMinionBootstrapper.getInstance(systemQuery);
         XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
@@ -145,7 +149,7 @@ public class HandlerFactory {
         factory.addHandler("contentmanagement", new ContentManagementHandler());
         factory.addHandler("distchannel", new DistChannelHandler());
         factory.addHandler("errata", new ErrataHandler());
-        factory.addHandler("formula", new FormulaHandler(FormulaManager.getInstance()));
+        factory.addHandler("formula", new FormulaHandler(formulaManager));
         factory.addHandler("image.store", new ImageStoreHandler());
         factory.addHandler("image.profile", new ImageProfileHandler());
         factory.addHandler("image", new ImageInfoHandler());

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/activationkey/ActivationKeyHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/activationkey/ActivationKeyHandler.java
@@ -88,6 +88,15 @@ public class ActivationKeyHandler extends BaseHandler {
     private static final String VALIDATION_XSD =
         "/com/redhat/rhn/frontend/action/token/validation/activationKeyForm.xsd";
 
+    private final ServerGroupManager serverGroupManager;
+
+    /**
+     * @param serverGroupManagerIn
+     */
+    public ActivationKeyHandler(ServerGroupManager serverGroupManagerIn) {
+        this.serverGroupManager = serverGroupManagerIn;
+    }
+
     /**
      * Creates a new activation key.
      * @param loggedInUser The current user
@@ -679,7 +688,7 @@ public class ActivationKeyHandler extends BaseHandler {
 
             ManagedServerGroup group = null;
             try {
-                group = ServerGroupManager.getInstance().lookup(
+                group = serverGroupManager.lookup(
                         serverGroupId.longValue(), loggedInUser);
             }
             catch (LookupException e) {
@@ -716,7 +725,7 @@ public class ActivationKeyHandler extends BaseHandler {
 
             ServerGroup group = null;
             try {
-                group = ServerGroupManager.getInstance().lookup(
+                group = serverGroupManager.lookup(
                         serverGroupId.longValue(), loggedInUser);
             }
             catch (LookupException e) {

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/activationkey/test/ActivationKeyHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/activationkey/test/ActivationKeyHandlerTest.java
@@ -43,6 +43,7 @@ import com.redhat.rhn.frontend.xmlrpc.activationkey.NoSuchActivationKeyException
 import com.redhat.rhn.frontend.xmlrpc.serializer.ActivationKeySerializer;
 import com.redhat.rhn.frontend.xmlrpc.test.BaseHandlerTestCase;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
+import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.manager.token.ActivationKeyManager;
 import com.redhat.rhn.testing.ChannelTestUtils;
 import com.redhat.rhn.testing.ConfigTestUtils;
@@ -69,7 +70,7 @@ import redstone.xmlrpc.XmlRpcSerializer;
 
 public class ActivationKeyHandlerTest extends BaseHandlerTestCase {
 
-    private ActivationKeyHandler keyHandler = new ActivationKeyHandler();
+    private ActivationKeyHandler keyHandler = new ActivationKeyHandler(new ServerGroupManager());
     private static final String KEY = "myexplicitkey";
     private static final String KEY_DESCRIPTION = "Test Key";
     private static final Integer KEY_USAGE_LIMIT = 0;

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandler.java
@@ -15,7 +15,6 @@
 package com.redhat.rhn.frontend.xmlrpc.channel.software;
 
 import com.redhat.rhn.FaultException;
-import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.client.InvalidCertificateException;
 import com.redhat.rhn.common.db.datasource.DataResult;
 import com.redhat.rhn.common.db.datasource.ModeFactory;
@@ -45,7 +44,6 @@ import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.MinionServerFactory;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.ServerFactory;
-import com.redhat.rhn.domain.server.ServerGroupFactory;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.context.Context;
 import com.redhat.rhn.frontend.dto.ErrataOverview;
@@ -123,16 +121,20 @@ public class ChannelSoftwareHandler extends BaseHandler {
     private static Logger log = Logger.getLogger(ChannelSoftwareHandler.class);
     private final TaskomaticApi taskomaticApi;
     private final XmlRpcSystemHelper xmlRpcSystemHelper;
+    private final SystemHandler systemHandler;
 
     /**
      * Set the {@link TaskomaticApi} instance to use, only for unit tests.
      *
      * @param taskomaticApiIn the {@link TaskomaticApi}
      * @param xmlRpcSystemHelperIn XmlRpcSystemHelper
+     * @param systemHandlerIn
      */
-    public ChannelSoftwareHandler(TaskomaticApi taskomaticApiIn, XmlRpcSystemHelper xmlRpcSystemHelperIn) {
+    public ChannelSoftwareHandler(TaskomaticApi taskomaticApiIn, XmlRpcSystemHelper xmlRpcSystemHelperIn,
+                                  SystemHandler systemHandlerIn) {
         taskomaticApi = taskomaticApiIn;
         xmlRpcSystemHelper = xmlRpcSystemHelperIn;
+        systemHandler = systemHandlerIn;
     }
 
     /**
@@ -2062,15 +2064,12 @@ public class ChannelSoftwareHandler extends BaseHandler {
                 childChannelIds.add(channel.getId().intValue());
             }
         }
-        SystemHandler sysHandler =
-                new SystemHandler(taskomaticApi, xmlRpcSystemHelper, GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER,
-                        new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON));
         if (base != null) {
 
-            sysHandler.setBaseChannel(loggedInUser, sid,
+            systemHandler.setBaseChannel(loggedInUser, sid,
                     base.getId().intValue());
         }
-        sysHandler.setChildChannels(loggedInUser, sid, childChannelIds);
+        systemHandler.setChildChannels(loggedInUser, sid, childChannelIds);
 
         return 1;
     }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandler.java
@@ -15,6 +15,7 @@
 package com.redhat.rhn.frontend.xmlrpc.channel.software;
 
 import com.redhat.rhn.FaultException;
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.client.InvalidCertificateException;
 import com.redhat.rhn.common.db.datasource.DataResult;
 import com.redhat.rhn.common.db.datasource.ModeFactory;
@@ -82,7 +83,6 @@ import com.redhat.rhn.manager.errata.ErrataManager;
 import com.redhat.rhn.manager.errata.cache.ErrataCacheManager;
 import com.redhat.rhn.manager.kickstart.crypto.NoSuchCryptoKeyException;
 import com.redhat.rhn.manager.system.SystemManager;
-import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 import com.redhat.rhn.manager.user.UserManager;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.taskomatic.task.TaskConstants;
@@ -2063,7 +2063,7 @@ public class ChannelSoftwareHandler extends BaseHandler {
             }
         }
         SystemHandler sysHandler =
-                new SystemHandler(taskomaticApi, xmlRpcSystemHelper, SystemEntitlementManager.INSTANCE,
+                new SystemHandler(taskomaticApi, xmlRpcSystemHelper, GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER,
                         new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON));
         if (base != null) {
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/test/ChannelSoftwareHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/test/ChannelSoftwareHandlerTest.java
@@ -91,7 +91,7 @@ public class ChannelSoftwareHandlerTest extends BaseHandlerTestCase {
     private TaskomaticApi taskomaticApi = new TaskomaticApi();
     private SystemQuery systemQuery = new SaltService();
     private RegularMinionBootstrapper regularMinionBootstrapper = new RegularMinionBootstrapper(systemQuery);
-    private SSHMinionBootstrapper sshMinionBootstrapper = SSHMinionBootstrapper.getInstance(systemQuery);
+    private SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery);
     private XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
             regularMinionBootstrapper,
             sshMinionBootstrapper

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/test/ChannelSoftwareHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/test/ChannelSoftwareHandlerTest.java
@@ -15,7 +15,6 @@
 package com.redhat.rhn.frontend.xmlrpc.channel.software.test;
 
 import com.redhat.rhn.FaultException;
-import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.common.validator.ValidatorException;
 import com.redhat.rhn.domain.action.Action;
@@ -56,15 +55,22 @@ import com.redhat.rhn.frontend.xmlrpc.system.XmlRpcSystemHelper;
 import com.redhat.rhn.frontend.xmlrpc.test.BaseHandlerTestCase;
 import com.redhat.rhn.manager.action.ActionChainManager;
 import com.redhat.rhn.manager.channel.ChannelManager;
+import com.redhat.rhn.manager.formula.FormulaMonitoringManager;
 import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
+import com.redhat.rhn.manager.system.entitling.SystemEntitler;
+import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
+import com.suse.manager.virtualization.VirtManagerSalt;
 import com.suse.manager.webui.controllers.utils.RegularMinionBootstrapper;
 import com.suse.manager.webui.controllers.utils.SSHMinionBootstrapper;
+import com.suse.manager.webui.services.iface.MonitoringManager;
+import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.SystemQuery;
+import com.suse.manager.webui.services.iface.VirtManager;
 import com.suse.manager.webui.services.impl.SaltService;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
@@ -91,14 +97,22 @@ import java.util.TimeZone;
 public class ChannelSoftwareHandlerTest extends BaseHandlerTestCase {
 
     private TaskomaticApi taskomaticApi = new TaskomaticApi();
-    private SystemQuery systemQuery = new SaltService();
+    private final SaltService saltService = new SaltService();
+    private final SystemQuery systemQuery = saltService;
+    private final SaltApi saltApi = saltService;
+    private final ServerGroupManager serverGroupManager = new ServerGroupManager();
     private RegularMinionBootstrapper regularMinionBootstrapper = new RegularMinionBootstrapper(systemQuery);
     private SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery);
     private XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
             regularMinionBootstrapper,
             sshMinionBootstrapper
     );
-    private SystemEntitlementManager systemEntitlementManager = GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER;
+    private final VirtManager virtManager = new VirtManagerSalt(saltApi);
+    private final MonitoringManager monitoringManager = new FormulaMonitoringManager();
+    private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
+            new SystemUnentitler(virtManager, monitoringManager, serverGroupManager),
+            new SystemEntitler(systemQuery, virtManager, monitoringManager, serverGroupManager)
+    );
     private SystemManager systemManager = new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON);
     private SystemHandler systemHandler = new SystemHandler(taskomaticApi, xmlRpcSystemHelper, systemEntitlementManager, systemManager,
                     new ServerGroupManager());

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/test/ChannelSoftwareHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/test/ChannelSoftwareHandlerTest.java
@@ -90,7 +90,7 @@ public class ChannelSoftwareHandlerTest extends BaseHandlerTestCase {
 
     private TaskomaticApi taskomaticApi = new TaskomaticApi();
     private SystemQuery systemQuery = new SaltService();
-    private RegularMinionBootstrapper regularMinionBootstrapper = RegularMinionBootstrapper.getInstance(systemQuery);
+    private RegularMinionBootstrapper regularMinionBootstrapper = new RegularMinionBootstrapper(systemQuery);
     private SSHMinionBootstrapper sshMinionBootstrapper = SSHMinionBootstrapper.getInstance(systemQuery);
     private XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
             regularMinionBootstrapper,

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/test/ChannelSoftwareHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/test/ChannelSoftwareHandlerTest.java
@@ -15,6 +15,7 @@
 package com.redhat.rhn.frontend.xmlrpc.channel.software.test;
 
 import com.redhat.rhn.FaultException;
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.common.validator.ValidatorException;
 import com.redhat.rhn.domain.action.Action;
@@ -96,7 +97,7 @@ public class ChannelSoftwareHandlerTest extends BaseHandlerTestCase {
             regularMinionBootstrapper,
             sshMinionBootstrapper
     );
-    private SystemEntitlementManager systemEntitlementManager = SystemEntitlementManager.INSTANCE;
+    private SystemEntitlementManager systemEntitlementManager = GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER;
     private SystemManager systemManager = new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON);
     private ChannelSoftwareHandler handler = new ChannelSoftwareHandler(taskomaticApi, xmlRpcSystemHelper);
     private ErrataHandler errataHandler = new ErrataHandler();

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/test/ChannelSoftwareHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/test/ChannelSoftwareHandlerTest.java
@@ -67,11 +67,9 @@ import com.redhat.rhn.testing.UserTestUtils;
 import com.suse.manager.virtualization.VirtManagerSalt;
 import com.suse.manager.webui.controllers.utils.RegularMinionBootstrapper;
 import com.suse.manager.webui.controllers.utils.SSHMinionBootstrapper;
-import com.suse.manager.webui.services.iface.MonitoringManager;
-import com.suse.manager.webui.services.iface.SaltApi;
-import com.suse.manager.webui.services.iface.SystemQuery;
-import com.suse.manager.webui.services.iface.VirtManager;
-import com.suse.manager.webui.services.impl.SaltService;
+import com.suse.manager.webui.services.iface.*;
+import com.suse.manager.webui.services.test.TestSaltApi;
+import com.suse.manager.webui.services.test.TestSystemQuery;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
 import org.jmock.integration.junit3.JUnit3Mockery;
@@ -97,9 +95,8 @@ import java.util.TimeZone;
 public class ChannelSoftwareHandlerTest extends BaseHandlerTestCase {
 
     private TaskomaticApi taskomaticApi = new TaskomaticApi();
-    private final SaltService saltService = new SaltService();
-    private final SystemQuery systemQuery = saltService;
-    private final SaltApi saltApi = saltService;
+    private final SystemQuery systemQuery = new TestSystemQuery();
+    private final SaltApi saltApi = new TestSaltApi();
     private final ServerGroupManager serverGroupManager = new ServerGroupManager();
     private RegularMinionBootstrapper regularMinionBootstrapper = new RegularMinionBootstrapper(systemQuery);
     private SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery);

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/test/ChannelSoftwareHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/test/ChannelSoftwareHandlerTest.java
@@ -56,6 +56,7 @@ import com.redhat.rhn.frontend.xmlrpc.system.XmlRpcSystemHelper;
 import com.redhat.rhn.frontend.xmlrpc.test.BaseHandlerTestCase;
 import com.redhat.rhn.manager.action.ActionChainManager;
 import com.redhat.rhn.manager.channel.ChannelManager;
+import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
@@ -99,7 +100,10 @@ public class ChannelSoftwareHandlerTest extends BaseHandlerTestCase {
     );
     private SystemEntitlementManager systemEntitlementManager = GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER;
     private SystemManager systemManager = new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON);
-    private ChannelSoftwareHandler handler = new ChannelSoftwareHandler(taskomaticApi, xmlRpcSystemHelper);
+    private SystemHandler systemHandler = new SystemHandler(taskomaticApi, xmlRpcSystemHelper, systemEntitlementManager, systemManager,
+                    new ServerGroupManager());
+    private ChannelSoftwareHandler handler = new ChannelSoftwareHandler(taskomaticApi, xmlRpcSystemHelper,
+            systemHandler);
     private ErrataHandler errataHandler = new ErrataHandler();
     private final Mockery MOCK_CONTEXT = new JUnit3Mockery() {{
         setThreadingPolicy(new Synchroniser());
@@ -275,7 +279,7 @@ public class ChannelSoftwareHandlerTest extends BaseHandlerTestCase {
         ChannelFactory.save(child2);
         assertFalse(child2.isBaseChannel());
 
-        ChannelSoftwareHandler csh = new ChannelSoftwareHandler(taskomaticApi, xmlRpcSystemHelper);
+        ChannelSoftwareHandler csh = new ChannelSoftwareHandler(taskomaticApi, xmlRpcSystemHelper, systemHandler);
         List<String> labels = new ArrayList<String>();
         labels.add(child.getLabel());
         // adding base last to make sure the handler does the right
@@ -309,7 +313,7 @@ public class ChannelSoftwareHandlerTest extends BaseHandlerTestCase {
     }
 
     public void testSetSystemChannels() throws Exception {
-        ChannelSoftwareHandler csh = new ChannelSoftwareHandler(taskomaticApi, xmlRpcSystemHelper);
+        ChannelSoftwareHandler csh = new ChannelSoftwareHandler(taskomaticApi, xmlRpcSystemHelper, systemHandler);
 
         Channel c1 = ChannelFactoryTest.createTestChannel(admin);
         Server server = ServerFactoryTest.createTestServer(admin, true);
@@ -383,7 +387,7 @@ public class ChannelSoftwareHandlerTest extends BaseHandlerTestCase {
     }
 
     public void testListSystemChannels() throws Exception {
-        ChannelSoftwareHandler csh = new ChannelSoftwareHandler(taskomaticApi, xmlRpcSystemHelper);
+        ChannelSoftwareHandler csh = new ChannelSoftwareHandler(taskomaticApi, xmlRpcSystemHelper, systemHandler);
 
         Channel c = ChannelFactoryTest.createTestChannel(admin);
         Server s = ServerFactoryTest.createTestServer(admin, true);
@@ -412,7 +416,7 @@ public class ChannelSoftwareHandlerTest extends BaseHandlerTestCase {
     }
 
     public void testListSubscribedSystems() throws Exception {
-        ChannelSoftwareHandler csh = new ChannelSoftwareHandler(taskomaticApi, xmlRpcSystemHelper);
+        ChannelSoftwareHandler csh = new ChannelSoftwareHandler(taskomaticApi, xmlRpcSystemHelper, systemHandler);
 
         Channel c = ChannelFactoryTest.createTestChannel(admin);
         Server s = ServerFactoryTest.createTestServer(admin);
@@ -445,7 +449,7 @@ public class ChannelSoftwareHandlerTest extends BaseHandlerTestCase {
     }
 
     public void testListArches() throws Exception {
-        ChannelSoftwareHandler csh = new ChannelSoftwareHandler(taskomaticApi, xmlRpcSystemHelper);
+        ChannelSoftwareHandler csh = new ChannelSoftwareHandler(taskomaticApi, xmlRpcSystemHelper, systemHandler);
         addRole(admin, RoleFactory.CHANNEL_ADMIN);
         List<ChannelArch> arches = csh.listArches(admin);
         assertNotNull(arches);
@@ -454,7 +458,7 @@ public class ChannelSoftwareHandlerTest extends BaseHandlerTestCase {
 
     public void testListArchesPermissionError() {
         try {
-            ChannelSoftwareHandler csh = new ChannelSoftwareHandler(taskomaticApi, xmlRpcSystemHelper);
+            ChannelSoftwareHandler csh = new ChannelSoftwareHandler(taskomaticApi, xmlRpcSystemHelper, systemHandler);
             List<ChannelArch> arches = csh.listArches(admin);
             assertNotNull(arches);
             assertTrue(arches.size() > 0);
@@ -524,7 +528,7 @@ public class ChannelSoftwareHandlerTest extends BaseHandlerTestCase {
     }
 
     public void testIsGloballySubscribable() throws Exception {
-        ChannelSoftwareHandler csh = new ChannelSoftwareHandler(taskomaticApi, xmlRpcSystemHelper);
+        ChannelSoftwareHandler csh = new ChannelSoftwareHandler(taskomaticApi, xmlRpcSystemHelper, systemHandler);
         addRole(admin, RoleFactory.CHANNEL_ADMIN);
         Channel c = ChannelFactoryTest.createTestChannel(admin);
         assertEquals(1, csh.isGloballySubscribable(admin, c.getLabel()));
@@ -532,7 +536,7 @@ public class ChannelSoftwareHandlerTest extends BaseHandlerTestCase {
     }
 
     public void testIsGloballySubscribableNoSuchChannel() throws Exception {
-        ChannelSoftwareHandler csh = new ChannelSoftwareHandler(taskomaticApi, xmlRpcSystemHelper);
+        ChannelSoftwareHandler csh = new ChannelSoftwareHandler(taskomaticApi, xmlRpcSystemHelper, systemHandler);
         addRole(admin, RoleFactory.CHANNEL_ADMIN);
         try {
             csh.isGloballySubscribable(admin, "notareallabel");
@@ -544,7 +548,7 @@ public class ChannelSoftwareHandlerTest extends BaseHandlerTestCase {
     }
 
     public void testGetDetails() throws Exception {
-        ChannelSoftwareHandler csh = new ChannelSoftwareHandler(taskomaticApi, xmlRpcSystemHelper);
+        ChannelSoftwareHandler csh = new ChannelSoftwareHandler(taskomaticApi, xmlRpcSystemHelper, systemHandler);
         addRole(admin, RoleFactory.CHANNEL_ADMIN);
         Channel c = ChannelFactoryTest.createTestChannel(admin);
         assertNotNull(c);
@@ -558,7 +562,7 @@ public class ChannelSoftwareHandlerTest extends BaseHandlerTestCase {
     }
 
     public void testSetDetails() throws Exception {
-        ChannelSoftwareHandler csh = new ChannelSoftwareHandler(taskomaticApi, xmlRpcSystemHelper);
+        ChannelSoftwareHandler csh = new ChannelSoftwareHandler(taskomaticApi, xmlRpcSystemHelper, systemHandler);
         addRole(admin, RoleFactory.CHANNEL_ADMIN);
         Channel c = ChannelFactoryTest.createTestChannel(admin);
         assertNotNull(c);
@@ -587,7 +591,7 @@ public class ChannelSoftwareHandlerTest extends BaseHandlerTestCase {
     }
 
    public void testGetChannelLastBuildById() throws Exception {
-       ChannelSoftwareHandler csh = new ChannelSoftwareHandler(taskomaticApi, xmlRpcSystemHelper);
+       ChannelSoftwareHandler csh = new ChannelSoftwareHandler(taskomaticApi, xmlRpcSystemHelper, systemHandler);
        addRole(admin, RoleFactory.CHANNEL_ADMIN);
        Channel c = ChannelFactoryTest.createTestChannel(admin);
        assertNotNull(c);
@@ -626,7 +630,7 @@ public class ChannelSoftwareHandlerTest extends BaseHandlerTestCase {
     }
 
     public void testCreate() throws Exception {
-        ChannelSoftwareHandler csh = new ChannelSoftwareHandler(taskomaticApi, xmlRpcSystemHelper);
+        ChannelSoftwareHandler csh = new ChannelSoftwareHandler(taskomaticApi, xmlRpcSystemHelper, systemHandler);
         addRole(admin, RoleFactory.CHANNEL_ADMIN);
         int i = csh.create(admin, "api-test-chan-label",
                 "apiTestChanName", "apiTestSummary", "channel-x86_64", null);
@@ -644,7 +648,7 @@ public class ChannelSoftwareHandlerTest extends BaseHandlerTestCase {
     }
 
     public void testCreateWithGPGCheckDisabled() throws Exception {
-        ChannelSoftwareHandler csh = new ChannelSoftwareHandler(taskomaticApi, xmlRpcSystemHelper);
+        ChannelSoftwareHandler csh = new ChannelSoftwareHandler(taskomaticApi, xmlRpcSystemHelper, systemHandler);
         addRole(admin, RoleFactory.CHANNEL_ADMIN);
         int i = csh.create(admin, "api-test-chan-label",
                 "apiTestChanName", "apiTestSummary", "channel-x86_64", null, "sha1", new HashMap<String, String>(),false);
@@ -662,7 +666,7 @@ public class ChannelSoftwareHandlerTest extends BaseHandlerTestCase {
     }
 
     public void testCreateWithChecksum() throws Exception {
-        ChannelSoftwareHandler csh = new ChannelSoftwareHandler(taskomaticApi, xmlRpcSystemHelper);
+        ChannelSoftwareHandler csh = new ChannelSoftwareHandler(taskomaticApi, xmlRpcSystemHelper, systemHandler);
         addRole(admin, RoleFactory.CHANNEL_ADMIN);
         int i = csh.create(admin, "api-test-checksum-chan-label",
                 "apiTestCSChanName", "apiTestSummary", "channel-ia32", null, "sha256");
@@ -680,7 +684,7 @@ public class ChannelSoftwareHandlerTest extends BaseHandlerTestCase {
     }
 
     public void testCreateUnauthUser() {
-        ChannelSoftwareHandler csh = new ChannelSoftwareHandler(taskomaticApi, xmlRpcSystemHelper);
+        ChannelSoftwareHandler csh = new ChannelSoftwareHandler(taskomaticApi, xmlRpcSystemHelper, systemHandler);
         try {
             csh.create(regular, "api-test-chan-label",
                    "apiTestChanName", "apiTestSummary", "channel-x86_64", null);
@@ -702,7 +706,7 @@ public class ChannelSoftwareHandlerTest extends BaseHandlerTestCase {
     }
 
     public void testCreateNullRequiredParams() {
-        ChannelSoftwareHandler csh = new ChannelSoftwareHandler(taskomaticApi, xmlRpcSystemHelper);
+        ChannelSoftwareHandler csh = new ChannelSoftwareHandler(taskomaticApi, xmlRpcSystemHelper, systemHandler);
         addRole(admin, RoleFactory.CHANNEL_ADMIN);
         // null label
         try {
@@ -749,7 +753,7 @@ public class ChannelSoftwareHandlerTest extends BaseHandlerTestCase {
     }
 
     public void testInvalidChannelNameAndLabel() {
-        ChannelSoftwareHandler csh = new ChannelSoftwareHandler(taskomaticApi, xmlRpcSystemHelper);
+        ChannelSoftwareHandler csh = new ChannelSoftwareHandler(taskomaticApi, xmlRpcSystemHelper, systemHandler);
         addRole(admin, RoleFactory.CHANNEL_ADMIN);
         int i;
         try {
@@ -1177,7 +1181,7 @@ public class ChannelSoftwareHandlerTest extends BaseHandlerTestCase {
 
         Date earliest = new Date();
         SystemHandler systemHandler = new SystemHandler(taskomaticApi, xmlRpcSystemHelper, systemEntitlementManager,
-                systemManager);
+                systemManager, new ServerGroupManager());
         long actionId = systemHandler.scheduleChangeChannels(admin, sid, base.getLabel(),
                 Arrays.asList(child1.getLabel(), child2.getLabel()), earliest);
 
@@ -1217,7 +1221,7 @@ public class ChannelSoftwareHandlerTest extends BaseHandlerTestCase {
 
         Date earliest = new Date();
         SystemHandler systemHandler = new SystemHandler(taskomaticApi, xmlRpcSystemHelper, systemEntitlementManager,
-                systemManager);
+                systemManager, new ServerGroupManager());
         long actionId = systemHandler.scheduleChangeChannels(admin, sid, base.getLabel(),
                 Arrays.asList(child1.getLabel(), child2.getLabel()), earliest);
         Action action = ActionFactory.lookupById(actionId);
@@ -1240,7 +1244,7 @@ public class ChannelSoftwareHandlerTest extends BaseHandlerTestCase {
 
     private ChannelSoftwareHandler getMockedHandler() throws Exception {
         TaskomaticApi taskomaticMock = MOCK_CONTEXT.mock(TaskomaticApi.class);
-        ChannelSoftwareHandler systemHandler = new ChannelSoftwareHandler(taskomaticMock, xmlRpcSystemHelper);
+        ChannelSoftwareHandler csh = new ChannelSoftwareHandler(taskomaticMock, xmlRpcSystemHelper, systemHandler);
         ChannelManager.setTaskomaticApi(taskomaticMock);
 
 
@@ -1255,6 +1259,6 @@ public class ChannelSoftwareHandlerTest extends BaseHandlerTestCase {
         }});
 
 
-        return systemHandler;
+        return csh;
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/formula/FormulaHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/formula/FormulaHandler.java
@@ -210,9 +210,8 @@ public class FormulaHandler extends BaseHandler {
      * @xmlrpc.returntype struct with saved formula data
      */
     public Map<String, Object> getSystemFormulaData(User loggedInUser, Integer systemId, String formulaName) {
-        Map<String, Object> savedData = formulaManager
+        return formulaManager
                 .getSystemFormulaData(loggedInUser, formulaName, systemId.longValue());
-        return savedData;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/formula/FormulaHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/formula/FormulaHandler.java
@@ -45,7 +45,7 @@ import com.redhat.rhn.manager.formula.InvalidFormulaException;
  */
 public class FormulaHandler extends BaseHandler {
 
-    private FormulaManager formulaManager;
+    private final FormulaManager formulaManager;
 
     /**
      * Instantiates a new formula handler.
@@ -210,8 +210,8 @@ public class FormulaHandler extends BaseHandler {
      * @xmlrpc.returntype struct with saved formula data
      */
     public Map<String, Object> getSystemFormulaData(User loggedInUser, Integer systemId, String formulaName) {
-        FormulaManager manager = FormulaManager.getInstance();
-        Map<String, Object> savedData = manager.getSystemFormulaData(loggedInUser, formulaName, systemId.longValue());
+        Map<String, Object> savedData = formulaManager
+                .getSystemFormulaData(loggedInUser, formulaName, systemId.longValue());
         return savedData;
     }
 
@@ -254,8 +254,8 @@ public class FormulaHandler extends BaseHandler {
      * @xmlrpc.returntype struct with saved formula data
      */
     public Map<String, Object> getGroupFormulaData(User loggedInUser, Integer groupId, String formulaName) {
-        FormulaManager manager = FormulaManager.getInstance();
-        Map<String, Object> savedData = manager.getGroupFormulaData(loggedInUser, formulaName, groupId.longValue());
+        Map<String, Object> savedData = formulaManager
+                .getGroupFormulaData(loggedInUser, formulaName, groupId.longValue());
         return savedData;
     }
 
@@ -280,11 +280,10 @@ public class FormulaHandler extends BaseHandler {
     public int setSystemFormulaData(User loggedInUser, Integer systemId, String formulaName, Map<String,
                 Object> content) throws IOFaultException, InvalidParameterException {
         try {
-            FormulaManager manager = FormulaManager.getInstance();
-            boolean assigned = manager.hasSystemFormulaAssignedCombined(formulaName, systemId);
+            boolean assigned = formulaManager.hasSystemFormulaAssignedCombined(formulaName, systemId);
             if (assigned) {
-                manager.validateInput(formulaName, content);
-                manager.saveServerFormulaData(loggedInUser, systemId.longValue(), formulaName, content);
+                formulaManager.validateInput(formulaName, content);
+                formulaManager.saveServerFormulaData(loggedInUser, systemId.longValue(), formulaName, content);
             }
             else {
                 throw new InvalidParameterException("One of the system doesn't have formula assigned, please assign" +
@@ -321,11 +320,10 @@ public class FormulaHandler extends BaseHandler {
     public int setGroupFormulaData(User loggedInUser, Integer groupId, String formulaName, Map<String,
             Object> content) throws IOFaultException, InvalidParameterException {
         try {
-            FormulaManager manager = FormulaManager.getInstance();
-            boolean assigned = manager.hasGroupFormulaAssigned(formulaName, groupId.longValue());
+            boolean assigned = formulaManager.hasGroupFormulaAssigned(formulaName, groupId.longValue());
             if (assigned) {
-                manager.validateInput(formulaName, content);
-                manager.saveGroupFormulaData(loggedInUser, groupId.longValue(), formulaName, content);
+                formulaManager.validateInput(formulaName, content);
+                formulaManager.saveGroupFormulaData(loggedInUser, groupId.longValue(), formulaName, content);
             }
             else {
                 throw new InvalidParameterException("Group doesn't have formula assigned, please assign it" +

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/test/ImageInfoHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/test/ImageInfoHandlerTest.java
@@ -22,7 +22,6 @@ import static com.redhat.rhn.testing.ImageTestUtils.createImageProfile;
 import static com.redhat.rhn.testing.ImageTestUtils.createImageStore;
 import static com.redhat.rhn.testing.ImageTestUtils.createKiwiImageProfile;
 
-import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.db.datasource.DataResult;
@@ -64,6 +63,10 @@ import com.redhat.rhn.testing.ImageTestUtils;
 import com.redhat.rhn.testing.TestUtils;
 
 import com.suse.manager.virtualization.VirtManagerSalt;
+import com.suse.manager.webui.services.iface.MonitoringManager;
+import com.suse.manager.webui.services.iface.SaltApi;
+import com.suse.manager.webui.services.iface.SystemQuery;
+import com.suse.manager.webui.services.iface.VirtManager;
 import com.suse.manager.webui.services.impl.SaltSSHService;
 import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.manager.webui.services.impl.runner.MgrUtilRunner;
@@ -89,7 +92,16 @@ public class ImageInfoHandlerTest extends BaseHandlerTestCase {
     }};
 
     private static TaskomaticApi taskomaticApi;
-    private static SystemEntitlementManager systemEntitlementManager = GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER;
+    private final SaltService saltService = new SaltService();
+    private final SystemQuery systemQuery = saltService;
+    private final SaltApi saltApi = saltService;
+    private final ServerGroupManager serverGroupManager = new ServerGroupManager();
+    private final VirtManager virtManager = new VirtManagerSalt(saltApi);
+    private final MonitoringManager monitoringManager = new FormulaMonitoringManager();
+    private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
+            new SystemUnentitler(virtManager, monitoringManager, serverGroupManager),
+            new SystemEntitler(systemQuery, virtManager, monitoringManager, serverGroupManager)
+    );
 
     @Override
     public void setUp() throws Exception {

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/test/ImageInfoHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/test/ImageInfoHandlerTest.java
@@ -54,6 +54,7 @@ import com.redhat.rhn.manager.action.ActionManager;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.manager.errata.cache.ErrataCacheManager;
 import com.redhat.rhn.manager.formula.FormulaMonitoringManager;
+import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitler;
 import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
@@ -163,10 +164,13 @@ public class ImageInfoHandlerTest extends BaseHandlerTestCase {
                 allowing(saltServiceMock).generateSSHKey(with(equal(SaltSSHService.SSH_KEY_PATH)));
                 will(returnValue(Optional.of(mockResult)));
         }});
+
+        ServerGroupManager serverGroupManager = new ServerGroupManager();
         SystemEntitlementManager sem = new SystemEntitlementManager(
-                new SystemUnentitler(new VirtManagerSalt(saltServiceMock), new FormulaMonitoringManager()),
+                new SystemUnentitler(new VirtManagerSalt(saltServiceMock), new FormulaMonitoringManager(),
+                        serverGroupManager),
                 new SystemEntitler(saltServiceMock, new VirtManagerSalt(saltServiceMock),
-                        new FormulaMonitoringManager())
+                        new FormulaMonitoringManager(), serverGroupManager)
         );
 
         MinionServer server = MinionServerFactoryTest.createTestMinionServer(admin);

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/test/ImageInfoHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/test/ImageInfoHandlerTest.java
@@ -63,14 +63,13 @@ import com.redhat.rhn.testing.ImageTestUtils;
 import com.redhat.rhn.testing.TestUtils;
 
 import com.suse.manager.virtualization.VirtManagerSalt;
-import com.suse.manager.webui.services.iface.MonitoringManager;
-import com.suse.manager.webui.services.iface.SaltApi;
-import com.suse.manager.webui.services.iface.SystemQuery;
-import com.suse.manager.webui.services.iface.VirtManager;
+import com.suse.manager.webui.services.iface.*;
 import com.suse.manager.webui.services.impl.SaltSSHService;
 import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.manager.webui.services.impl.runner.MgrUtilRunner;
 
+import com.suse.manager.webui.services.test.TestSaltApi;
+import com.suse.manager.webui.services.test.TestSystemQuery;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
 import org.jmock.integration.junit3.JUnit3Mockery;
@@ -92,9 +91,8 @@ public class ImageInfoHandlerTest extends BaseHandlerTestCase {
     }};
 
     private static TaskomaticApi taskomaticApi;
-    private final SaltService saltService = new SaltService();
-    private final SystemQuery systemQuery = saltService;
-    private final SaltApi saltApi = saltService;
+    private final SystemQuery systemQuery = new TestSystemQuery();
+    private final SaltApi saltApi = new TestSaltApi();
     private final ServerGroupManager serverGroupManager = new ServerGroupManager();
     private final VirtManager virtManager = new VirtManagerSalt(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager();

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/test/ImageInfoHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/test/ImageInfoHandlerTest.java
@@ -22,6 +22,7 @@ import static com.redhat.rhn.testing.ImageTestUtils.createImageProfile;
 import static com.redhat.rhn.testing.ImageTestUtils.createImageStore;
 import static com.redhat.rhn.testing.ImageTestUtils.createKiwiImageProfile;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.db.datasource.DataResult;
@@ -87,7 +88,7 @@ public class ImageInfoHandlerTest extends BaseHandlerTestCase {
     }};
 
     private static TaskomaticApi taskomaticApi;
-    private static SystemEntitlementManager systemEntitlementManager = SystemEntitlementManager.INSTANCE;
+    private static SystemEntitlementManager systemEntitlementManager = GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER;
 
     @Override
     public void setUp() throws Exception {

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/proxy/test/ProxyHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/proxy/test/ProxyHandlerTest.java
@@ -34,14 +34,14 @@ import com.redhat.rhn.testing.UserTestUtils;
 import com.suse.manager.webui.controllers.utils.RegularMinionBootstrapper;
 import com.suse.manager.webui.controllers.utils.SSHMinionBootstrapper;
 import com.suse.manager.webui.services.iface.SystemQuery;
-import com.suse.manager.webui.services.impl.SaltService;
+import com.suse.manager.webui.services.test.TestSystemQuery;
 
 import java.util.List;
 import java.util.Set;
 
 public class ProxyHandlerTest extends RhnBaseTestCase {
 
-    private SystemQuery systemQuery = new SaltService();
+    private SystemQuery systemQuery = new TestSystemQuery();
     private RegularMinionBootstrapper regularMinionBootstrapper = new RegularMinionBootstrapper(systemQuery);
     private SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery);
     private XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/proxy/test/ProxyHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/proxy/test/ProxyHandlerTest.java
@@ -42,7 +42,7 @@ import java.util.Set;
 public class ProxyHandlerTest extends RhnBaseTestCase {
 
     private SystemQuery systemQuery = new SaltService();
-    private RegularMinionBootstrapper regularMinionBootstrapper = RegularMinionBootstrapper.getInstance(systemQuery);
+    private RegularMinionBootstrapper regularMinionBootstrapper = new RegularMinionBootstrapper(systemQuery);
     private SSHMinionBootstrapper sshMinionBootstrapper = SSHMinionBootstrapper.getInstance(systemQuery);
     private XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
             regularMinionBootstrapper,

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/proxy/test/ProxyHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/proxy/test/ProxyHandlerTest.java
@@ -43,7 +43,7 @@ public class ProxyHandlerTest extends RhnBaseTestCase {
 
     private SystemQuery systemQuery = new SaltService();
     private RegularMinionBootstrapper regularMinionBootstrapper = new RegularMinionBootstrapper(systemQuery);
-    private SSHMinionBootstrapper sshMinionBootstrapper = SSHMinionBootstrapper.getInstance(systemQuery);
+    private SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery);
     private XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
             regularMinionBootstrapper,
             sshMinionBootstrapper

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/saltkey/SaltKeyHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/saltkey/SaltKeyHandler.java
@@ -26,6 +26,15 @@ import com.suse.manager.utils.SaltKeyUtils;
  */
 public class SaltKeyHandler extends BaseHandler {
 
+    private final SaltKeyUtils saltKeyUtils;
+
+    /**
+     * @param saltKeyUtilsIn
+     */
+    public SaltKeyHandler(SaltKeyUtils saltKeyUtilsIn) {
+        this.saltKeyUtils = saltKeyUtilsIn;
+    }
+
     /**
      * API endpoint to delete minion keys
      * @param loggedInUser the user
@@ -39,7 +48,7 @@ public class SaltKeyHandler extends BaseHandler {
      */
     public int delete(User loggedInUser, String minionId) {
         ensureOrgAdmin(loggedInUser);
-        if (SaltKeyUtils.deleteSaltKey(loggedInUser, minionId)) {
+        if (saltKeyUtils.deleteSaltKey(loggedInUser, minionId)) {
             return 1;
         }
         return 0;

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/satellite/test/SatelliteHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/satellite/test/SatelliteHandlerTest.java
@@ -23,13 +23,13 @@ import com.redhat.rhn.frontend.xmlrpc.test.BaseHandlerTestCase;
 import com.suse.manager.webui.controllers.utils.RegularMinionBootstrapper;
 import com.suse.manager.webui.controllers.utils.SSHMinionBootstrapper;
 import com.suse.manager.webui.services.iface.SystemQuery;
-import com.suse.manager.webui.services.impl.SaltService;
+import com.suse.manager.webui.services.test.TestSystemQuery;
 
 import java.util.Map;
 
 public class SatelliteHandlerTest extends BaseHandlerTestCase {
 
-    private SystemQuery systemQuery = new SaltService();
+    private SystemQuery systemQuery = new TestSystemQuery();
     private RegularMinionBootstrapper regularMinionBootstrapper = new RegularMinionBootstrapper(systemQuery);
     private SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery);
     private XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/satellite/test/SatelliteHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/satellite/test/SatelliteHandlerTest.java
@@ -30,7 +30,7 @@ import java.util.Map;
 public class SatelliteHandlerTest extends BaseHandlerTestCase {
 
     private SystemQuery systemQuery = new SaltService();
-    private RegularMinionBootstrapper regularMinionBootstrapper = RegularMinionBootstrapper.getInstance(systemQuery);
+    private RegularMinionBootstrapper regularMinionBootstrapper = new RegularMinionBootstrapper(systemQuery);
     private SSHMinionBootstrapper sshMinionBootstrapper = SSHMinionBootstrapper.getInstance(systemQuery);
     private XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
             regularMinionBootstrapper,

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/satellite/test/SatelliteHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/satellite/test/SatelliteHandlerTest.java
@@ -31,7 +31,7 @@ public class SatelliteHandlerTest extends BaseHandlerTestCase {
 
     private SystemQuery systemQuery = new SaltService();
     private RegularMinionBootstrapper regularMinionBootstrapper = new RegularMinionBootstrapper(systemQuery);
-    private SSHMinionBootstrapper sshMinionBootstrapper = SSHMinionBootstrapper.getInstance(systemQuery);
+    private SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery);
     private XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
             regularMinionBootstrapper,
             sshMinionBootstrapper

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -211,6 +211,7 @@ public class SystemHandler extends BaseHandler {
 
     private SystemEntitlementManager systemEntitlementManager;
     private SystemManager systemManager;
+    private final ServerGroupManager serverGroupManager;
 
     /**
      * Instantiates a new system handler.
@@ -219,14 +220,16 @@ public class SystemHandler extends BaseHandler {
      * @param xmlRpcSystemHelperIn the xml rpc system helper
      * @param systemEntitlementManagerIn the system entitlement manager
      * @param systemManagerIn the system manager
+     * @param serverGroupManagerIn
      */
     public SystemHandler(TaskomaticApi taskomaticApiIn, XmlRpcSystemHelper xmlRpcSystemHelperIn,
             SystemEntitlementManager systemEntitlementManagerIn,
-            SystemManager systemManagerIn) {
+            SystemManager systemManagerIn, ServerGroupManager serverGroupManagerIn) {
         this.taskomaticApi = taskomaticApiIn;
         this.xmlRpcSystemHelper = xmlRpcSystemHelperIn;
         this.systemEntitlementManager = systemEntitlementManagerIn;
         this.systemManager = systemManagerIn;
+        this.serverGroupManager = serverGroupManagerIn;
     }
 
     /**
@@ -1859,9 +1862,8 @@ public class SystemHandler extends BaseHandler {
         // Get the logged in user and server
         ensureSystemGroupAdmin(loggedInUser);
         Server server = lookupServer(loggedInUser, sid);
-        ServerGroupManager manager = ServerGroupManager.getInstance();
         try {
-            ManagedServerGroup group = manager.lookup(sgid.longValue(),
+            ManagedServerGroup group = serverGroupManager.lookup(sgid.longValue(),
                     loggedInUser);
 
 
@@ -1870,11 +1872,11 @@ public class SystemHandler extends BaseHandler {
 
             if (member) {
                 //add to server group
-                manager.addServers(group, servers, loggedInUser);
+                serverGroupManager.addServers(group, servers, loggedInUser);
             }
             else {
                 //remove from server group
-                manager.removeServers(group, servers, loggedInUser);
+                serverGroupManager.removeServers(group, servers, loggedInUser);
             }
         }
         catch (LookupException le) {

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -21,6 +21,7 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 
 import com.redhat.rhn.FaultException;
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.client.ClientCertificate;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.db.datasource.DataResult;
@@ -4736,7 +4737,7 @@ public class SystemHandler extends BaseHandler {
             String selectedEnt = (String)details.get("base_entitlement");
             Entitlement base = EntitlementManager.getByName(selectedEnt);
             if (base != null) {
-                SystemEntitlementManager.INSTANCE.setBaseEntitlement(server, base);
+                GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER.setBaseEntitlement(server, base);
             }
             else if (selectedEnt.equals("unentitle")) {
                 systemEntitlementManager.removeAllServerEntitlements(server);
@@ -4914,7 +4915,7 @@ public class SystemHandler extends BaseHandler {
         for (Entitlement en : EntitlementManager.getBaseEntitlements()) {
             if (addOnEnts.contains(en.getLabel())) {
                 addOnEnts.remove(en.getLabel());
-                SystemEntitlementManager.INSTANCE.setBaseEntitlement(server, en);
+                GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER.setBaseEntitlement(server, en);
             }
         }
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -21,7 +21,6 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 
 import com.redhat.rhn.FaultException;
-import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.client.ClientCertificate;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.db.datasource.DataResult;
@@ -4739,7 +4738,7 @@ public class SystemHandler extends BaseHandler {
             String selectedEnt = (String)details.get("base_entitlement");
             Entitlement base = EntitlementManager.getByName(selectedEnt);
             if (base != null) {
-                GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER.setBaseEntitlement(server, base);
+                systemEntitlementManager.setBaseEntitlement(server, base);
             }
             else if (selectedEnt.equals("unentitle")) {
                 systemEntitlementManager.removeAllServerEntitlements(server);
@@ -4917,7 +4916,7 @@ public class SystemHandler extends BaseHandler {
         for (Entitlement en : EntitlementManager.getBaseEntitlements()) {
             if (addOnEnts.contains(en.getLabel())) {
                 addOnEnts.remove(en.getLabel());
-                GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER.setBaseEntitlement(server, en);
+                systemEntitlementManager.setBaseEntitlement(server, en);
             }
         }
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/config/test/ServerConfigHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/config/test/ServerConfigHandlerTest.java
@@ -73,7 +73,7 @@ public class ServerConfigHandlerTest extends BaseHandlerTestCase {
     private TaskomaticApi taskomaticApi = new TaskomaticApi();
     private SystemQuery systemQuery = new SaltService();
     private RegularMinionBootstrapper regularMinionBootstrapper = new RegularMinionBootstrapper(systemQuery);
-    private SSHMinionBootstrapper sshMinionBootstrapper = SSHMinionBootstrapper.getInstance(systemQuery);
+    private SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery);
     private XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
             regularMinionBootstrapper,
             sshMinionBootstrapper
@@ -467,7 +467,7 @@ public class ServerConfigHandlerTest extends BaseHandlerTestCase {
         TaskomaticApi taskomaticMock = MOCK_CONTEXT.mock(TaskomaticApi.class);
         SystemQuery systemQuery = new SaltService();
         RegularMinionBootstrapper regularMinionBootstrapper = new RegularMinionBootstrapper(systemQuery);
-        SSHMinionBootstrapper sshMinionBootstrapper = SSHMinionBootstrapper.getInstance(systemQuery);
+        SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery);
         XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
                 regularMinionBootstrapper,
                 sshMinionBootstrapper

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/config/test/ServerConfigHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/config/test/ServerConfigHandlerTest.java
@@ -49,7 +49,7 @@ import com.redhat.rhn.testing.TestUtils;
 import com.suse.manager.webui.controllers.utils.RegularMinionBootstrapper;
 import com.suse.manager.webui.controllers.utils.SSHMinionBootstrapper;
 import com.suse.manager.webui.services.iface.SystemQuery;
-import com.suse.manager.webui.services.impl.SaltService;
+import com.suse.manager.webui.services.test.TestSystemQuery;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
 import org.jmock.integration.junit3.JUnit3Mockery;
@@ -71,7 +71,7 @@ import java.util.Set;
  */
 public class ServerConfigHandlerTest extends BaseHandlerTestCase {
     private TaskomaticApi taskomaticApi = new TaskomaticApi();
-    private SystemQuery systemQuery = new SaltService();
+    private SystemQuery systemQuery = new TestSystemQuery();
     private RegularMinionBootstrapper regularMinionBootstrapper = new RegularMinionBootstrapper(systemQuery);
     private SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery);
     private XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
@@ -465,7 +465,7 @@ public class ServerConfigHandlerTest extends BaseHandlerTestCase {
 
     private ServerConfigHandler getMockedHandler() throws Exception {
         TaskomaticApi taskomaticMock = MOCK_CONTEXT.mock(TaskomaticApi.class);
-        SystemQuery systemQuery = new SaltService();
+        SystemQuery systemQuery = new TestSystemQuery();
         RegularMinionBootstrapper regularMinionBootstrapper = new RegularMinionBootstrapper(systemQuery);
         SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery);
         XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/config/test/ServerConfigHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/config/test/ServerConfigHandlerTest.java
@@ -72,7 +72,7 @@ import java.util.Set;
 public class ServerConfigHandlerTest extends BaseHandlerTestCase {
     private TaskomaticApi taskomaticApi = new TaskomaticApi();
     private SystemQuery systemQuery = new SaltService();
-    private RegularMinionBootstrapper regularMinionBootstrapper = RegularMinionBootstrapper.getInstance(systemQuery);
+    private RegularMinionBootstrapper regularMinionBootstrapper = new RegularMinionBootstrapper(systemQuery);
     private SSHMinionBootstrapper sshMinionBootstrapper = SSHMinionBootstrapper.getInstance(systemQuery);
     private XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
             regularMinionBootstrapper,
@@ -466,7 +466,7 @@ public class ServerConfigHandlerTest extends BaseHandlerTestCase {
     private ServerConfigHandler getMockedHandler() throws Exception {
         TaskomaticApi taskomaticMock = MOCK_CONTEXT.mock(TaskomaticApi.class);
         SystemQuery systemQuery = new SaltService();
-        RegularMinionBootstrapper regularMinionBootstrapper = RegularMinionBootstrapper.getInstance(systemQuery);
+        RegularMinionBootstrapper regularMinionBootstrapper = new RegularMinionBootstrapper(systemQuery);
         SSHMinionBootstrapper sshMinionBootstrapper = SSHMinionBootstrapper.getInstance(systemQuery);
         XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
                 regularMinionBootstrapper,

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/provisioning/snapshot/test/SnapshotHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/provisioning/snapshot/test/SnapshotHandlerTest.java
@@ -30,7 +30,7 @@ import com.redhat.rhn.testing.TestUtils;
 import com.suse.manager.webui.controllers.utils.RegularMinionBootstrapper;
 import com.suse.manager.webui.controllers.utils.SSHMinionBootstrapper;
 import com.suse.manager.webui.services.iface.SystemQuery;
-import com.suse.manager.webui.services.impl.SaltService;
+import com.suse.manager.webui.services.test.TestSystemQuery;
 
 import java.util.HashMap;
 import java.util.List;
@@ -42,7 +42,7 @@ import java.util.Set;
  */
 public class SnapshotHandlerTest extends BaseHandlerTestCase {
 
-    private SystemQuery systemQuery = new SaltService();
+    private SystemQuery systemQuery = new TestSystemQuery();
     private RegularMinionBootstrapper regularMinionBootstrapper = new RegularMinionBootstrapper(systemQuery);
     private SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery);
     private XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/provisioning/snapshot/test/SnapshotHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/provisioning/snapshot/test/SnapshotHandlerTest.java
@@ -44,7 +44,7 @@ public class SnapshotHandlerTest extends BaseHandlerTestCase {
 
     private SystemQuery systemQuery = new SaltService();
     private RegularMinionBootstrapper regularMinionBootstrapper = new RegularMinionBootstrapper(systemQuery);
-    private SSHMinionBootstrapper sshMinionBootstrapper = SSHMinionBootstrapper.getInstance(systemQuery);
+    private SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery);
     private XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
             regularMinionBootstrapper,
             sshMinionBootstrapper

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/provisioning/snapshot/test/SnapshotHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/provisioning/snapshot/test/SnapshotHandlerTest.java
@@ -25,7 +25,6 @@ import com.redhat.rhn.domain.server.test.ServerFactoryTest;
 import com.redhat.rhn.frontend.xmlrpc.system.XmlRpcSystemHelper;
 import com.redhat.rhn.frontend.xmlrpc.system.provisioning.snapshot.SnapshotHandler;
 import com.redhat.rhn.frontend.xmlrpc.test.BaseHandlerTestCase;
-import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.testing.ServerGroupTestUtils;
 import com.redhat.rhn.testing.TestUtils;
 import com.suse.manager.webui.controllers.utils.RegularMinionBootstrapper;
@@ -44,7 +43,7 @@ import java.util.Set;
 public class SnapshotHandlerTest extends BaseHandlerTestCase {
 
     private SystemQuery systemQuery = new SaltService();
-    private RegularMinionBootstrapper regularMinionBootstrapper = RegularMinionBootstrapper.getInstance(systemQuery);
+    private RegularMinionBootstrapper regularMinionBootstrapper = new RegularMinionBootstrapper(systemQuery);
     private SSHMinionBootstrapper sshMinionBootstrapper = SSHMinionBootstrapper.getInstance(systemQuery);
     private XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
             regularMinionBootstrapper,

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/ServerGroupHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/ServerGroupHandlerTest.java
@@ -15,7 +15,6 @@
 package com.redhat.rhn.frontend.xmlrpc.system.test;
 
 import com.redhat.rhn.FaultException;
-import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.domain.server.ManagedServerGroup;
 import com.redhat.rhn.domain.server.Server;
@@ -51,7 +50,7 @@ import java.util.List;
 public class ServerGroupHandlerTest extends BaseHandlerTestCase {
     private SystemQuery systemQuery = new SaltService();
     private RegularMinionBootstrapper regularMinionBootstrapper = new RegularMinionBootstrapper(systemQuery);
-    private SSHMinionBootstrapper sshMinionBootstrapper = SSHMinionBootstrapper.getInstance(systemQuery);
+    private SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery);
     private XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
             regularMinionBootstrapper,
             sshMinionBootstrapper

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/ServerGroupHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/ServerGroupHandlerTest.java
@@ -15,7 +15,6 @@
 package com.redhat.rhn.frontend.xmlrpc.system.test;
 
 import com.redhat.rhn.FaultException;
-import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.domain.server.ManagedServerGroup;
 import com.redhat.rhn.domain.server.Server;
@@ -36,7 +35,7 @@ import com.redhat.rhn.testing.UserTestUtils;
 import com.suse.manager.webui.controllers.utils.RegularMinionBootstrapper;
 import com.suse.manager.webui.controllers.utils.SSHMinionBootstrapper;
 import com.suse.manager.webui.services.iface.SystemQuery;
-import com.suse.manager.webui.services.impl.SaltService;
+import com.suse.manager.webui.services.test.TestSystemQuery;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -49,7 +48,7 @@ import java.util.List;
  * @version $Rev$
  */
 public class ServerGroupHandlerTest extends BaseHandlerTestCase {
-    private SystemQuery systemQuery = new SaltService();
+    private SystemQuery systemQuery = new TestSystemQuery();
     private RegularMinionBootstrapper regularMinionBootstrapper = new RegularMinionBootstrapper(systemQuery);
     private SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery);
     private XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/ServerGroupHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/ServerGroupHandlerTest.java
@@ -15,6 +15,7 @@
 package com.redhat.rhn.frontend.xmlrpc.system.test;
 
 import com.redhat.rhn.FaultException;
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.domain.server.ManagedServerGroup;
 import com.redhat.rhn.domain.server.Server;
@@ -49,7 +50,7 @@ import java.util.List;
  */
 public class ServerGroupHandlerTest extends BaseHandlerTestCase {
     private SystemQuery systemQuery = new SaltService();
-    private RegularMinionBootstrapper regularMinionBootstrapper = RegularMinionBootstrapper.getInstance(systemQuery);
+    private RegularMinionBootstrapper regularMinionBootstrapper = new RegularMinionBootstrapper(systemQuery);
     private SSHMinionBootstrapper sshMinionBootstrapper = SSHMinionBootstrapper.getInstance(systemQuery);
     private XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
             regularMinionBootstrapper,

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/ServerGroupHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/ServerGroupHandlerTest.java
@@ -56,7 +56,7 @@ public class ServerGroupHandlerTest extends BaseHandlerTestCase {
             regularMinionBootstrapper,
             sshMinionBootstrapper
     );
-    private ServerGroupManager manager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
+    private ServerGroupManager manager = new ServerGroupManager();
     private ServerGroupHandler handler = new ServerGroupHandler(xmlRpcSystemHelper, manager);
     private static final String NAME = "HAHAHA" + TestUtils.randomString();
     private static final String DESCRIPTION =  TestUtils.randomString();
@@ -326,7 +326,7 @@ public class ServerGroupHandlerTest extends BaseHandlerTestCase {
         List  test = new ArrayList();
         test.add(server);
         test.add(server2);
-        GlobalInstanceHolder.SERVER_GROUP_MANAGER.addServers(group, test, admin);
+        manager.addServers(group, test, admin);
 
 
         Calendar cal = Calendar.getInstance();
@@ -353,7 +353,7 @@ public class ServerGroupHandlerTest extends BaseHandlerTestCase {
         cal.add(Calendar.HOUR, -442);
         server2.getServerInfo().setCheckin(cal.getTime());
 
-        GlobalInstanceHolder.SERVER_GROUP_MANAGER.addServers(group, test, admin);
+        manager.addServers(group, test, admin);
 
         TestUtils.saveAndFlush(server);
         TestUtils.saveAndFlush(group);

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/ServerGroupHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/ServerGroupHandlerTest.java
@@ -15,6 +15,7 @@
 package com.redhat.rhn.frontend.xmlrpc.system.test;
 
 import com.redhat.rhn.FaultException;
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.domain.server.ManagedServerGroup;
 import com.redhat.rhn.domain.server.Server;
@@ -55,8 +56,8 @@ public class ServerGroupHandlerTest extends BaseHandlerTestCase {
             regularMinionBootstrapper,
             sshMinionBootstrapper
     );
-    private ServerGroupHandler handler = new ServerGroupHandler(xmlRpcSystemHelper);
-    private ServerGroupManager manager = ServerGroupManager.getInstance();
+    private ServerGroupManager manager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
+    private ServerGroupHandler handler = new ServerGroupHandler(xmlRpcSystemHelper, manager);
     private static final String NAME = "HAHAHA" + TestUtils.randomString();
     private static final String DESCRIPTION =  TestUtils.randomString();
 
@@ -325,7 +326,7 @@ public class ServerGroupHandlerTest extends BaseHandlerTestCase {
         List  test = new ArrayList();
         test.add(server);
         test.add(server2);
-        ServerGroupManager.getInstance().addServers(group, test, admin);
+        GlobalInstanceHolder.SERVER_GROUP_MANAGER.addServers(group, test, admin);
 
 
         Calendar cal = Calendar.getInstance();
@@ -352,7 +353,7 @@ public class ServerGroupHandlerTest extends BaseHandlerTestCase {
         cal.add(Calendar.HOUR, -442);
         server2.getServerInfo().setCheckin(cal.getTime());
 
-        ServerGroupManager.getInstance().addServers(group, test, admin);
+        GlobalInstanceHolder.SERVER_GROUP_MANAGER.addServers(group, test, admin);
 
         TestUtils.saveAndFlush(server);
         TestUtils.saveAndFlush(group);

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
@@ -141,12 +141,10 @@ import com.redhat.rhn.testing.UserTestUtils;
 import com.suse.manager.virtualization.VirtManagerSalt;
 import com.suse.manager.webui.controllers.utils.RegularMinionBootstrapper;
 import com.suse.manager.webui.controllers.utils.SSHMinionBootstrapper;
-import com.suse.manager.webui.services.iface.MonitoringManager;
-import com.suse.manager.webui.services.iface.SaltApi;
-import com.suse.manager.webui.services.iface.SystemQuery;
-import com.suse.manager.webui.services.iface.VirtManager;
-import com.suse.manager.webui.services.impl.SaltService;
+import com.suse.manager.webui.services.iface.*;
 
+import com.suse.manager.webui.services.test.TestSaltApi;
+import com.suse.manager.webui.services.test.TestSystemQuery;
 import org.apache.commons.lang3.StringUtils;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
@@ -175,9 +173,8 @@ import java.util.stream.Collectors;
 public class SystemHandlerTest extends BaseHandlerTestCase {
 
     private TaskomaticApi taskomaticApi = new TaskomaticApi();
-    private final SaltService saltService = new SaltService();
-    private final SystemQuery systemQuery = saltService;
-    private final SaltApi saltApi = saltService;
+    private final SystemQuery systemQuery = new TestSystemQuery();
+    private final SaltApi saltApi = new TestSaltApi();
     private RegularMinionBootstrapper regularMinionBootstrapper = new RegularMinionBootstrapper(systemQuery);
     private SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery);
     private XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
@@ -1897,14 +1894,6 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
     }
 
     public void testAddEntitlements() throws Exception {
-        SaltService saltService = new SaltService();
-        ServerGroupManager serverGroupManager = new ServerGroupManager();
-        SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(new VirtManagerSalt(saltService), new FormulaMonitoringManager(),
-                        serverGroupManager),
-                new SystemEntitler(saltService, new VirtManagerSalt(saltService), new FormulaMonitoringManager(),
-                        serverGroupManager)
-        );
         Server server = ServerTestUtils.createVirtHostWithGuests(admin, 0, systemEntitlementManager);
 
         Integer serverId = server.getId().intValue();
@@ -1930,14 +1919,6 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
     }
 
     public void testAddEntitlementSystemAlreadyHas() throws Exception {
-        SaltService saltService = new SaltService();
-        ServerGroupManager serverGroupManager = new ServerGroupManager();
-        SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(new VirtManagerSalt(saltService), new FormulaMonitoringManager(),
-                        serverGroupManager),
-                new SystemEntitler(saltService, new VirtManagerSalt(saltService), new FormulaMonitoringManager(),
-                        serverGroupManager)
-        );
         Server server = ServerTestUtils.createVirtHostWithGuests(admin, 0, systemEntitlementManager);
 
         Integer serverId = server.getId().intValue();

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
@@ -174,7 +174,7 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
     private TaskomaticApi taskomaticApi = new TaskomaticApi();
     private SystemQuery systemQuery = new SaltService();
     private RegularMinionBootstrapper regularMinionBootstrapper = new RegularMinionBootstrapper(systemQuery);
-    private SSHMinionBootstrapper sshMinionBootstrapper = SSHMinionBootstrapper.getInstance(systemQuery);
+    private SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery);
     private XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
             regularMinionBootstrapper,
             sshMinionBootstrapper

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
@@ -183,7 +183,8 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
     private SystemEntitlementManager systemEntitlementManager = GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER;
     private SystemManager systemManager = new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON);
     private SystemHandler handler =
-            new SystemHandler(taskomaticApi, xmlRpcSystemHelper, systemEntitlementManager, systemManager);
+            new SystemHandler(taskomaticApi, xmlRpcSystemHelper, systemEntitlementManager, systemManager,
+                    new ServerGroupManager());
 
     private final Mockery MOCK_CONTEXT = new JUnit3Mockery() {{
         setThreadingPolicy(new Synchroniser());
@@ -1291,7 +1292,7 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
         Server server = ServerFactoryTest.createTestServer(admin, true);
         Set servers = new HashSet();
         servers.add(server);
-        ServerGroupManager manager = ServerGroupManager.getInstance();
+        ServerGroupManager manager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
         manager.addServers(group, servers, admin);
 
         Set admins = new HashSet();
@@ -1887,10 +1888,12 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
 
     public void testAddEntitlements() throws Exception {
         SaltService saltService = new SaltService();
-
+        ServerGroupManager serverGroupManager = new ServerGroupManager();
         SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(new VirtManagerSalt(saltService), new FormulaMonitoringManager()),
-                new SystemEntitler(saltService, new VirtManagerSalt(saltService), new FormulaMonitoringManager())
+                new SystemUnentitler(new VirtManagerSalt(saltService), new FormulaMonitoringManager(),
+                        serverGroupManager),
+                new SystemEntitler(saltService, new VirtManagerSalt(saltService), new FormulaMonitoringManager(),
+                        serverGroupManager)
         );
         Server server = ServerTestUtils.createVirtHostWithGuests(admin, 0, systemEntitlementManager);
 
@@ -1918,9 +1921,12 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
 
     public void testAddEntitlementSystemAlreadyHas() throws Exception {
         SaltService saltService = new SaltService();
+        ServerGroupManager serverGroupManager = new ServerGroupManager();
         SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(new VirtManagerSalt(saltService), new FormulaMonitoringManager()),
-                new SystemEntitler(saltService, new VirtManagerSalt(saltService), new FormulaMonitoringManager())
+                new SystemUnentitler(new VirtManagerSalt(saltService), new FormulaMonitoringManager(),
+                        serverGroupManager),
+                new SystemEntitler(saltService, new VirtManagerSalt(saltService), new FormulaMonitoringManager(),
+                        serverGroupManager)
         );
         Server server = ServerTestUtils.createVirtHostWithGuests(admin, 0, systemEntitlementManager);
 
@@ -2947,7 +2953,7 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
     private SystemHandler getMockedHandler() throws Exception {
         TaskomaticApi taskomaticMock = MOCK_CONTEXT.mock(TaskomaticApi.class);
         SystemHandler systemHandler = new SystemHandler(taskomaticMock, xmlRpcSystemHelper, systemEntitlementManager,
-                systemManager);
+                systemManager, new ServerGroupManager());
 
         MOCK_CONTEXT.checking(new Expectations() {{
             allowing(taskomaticMock).scheduleActionExecution(with(any(Action.class)));

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
@@ -1292,7 +1292,7 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
         Server server = ServerFactoryTest.createTestServer(admin, true);
         Set servers = new HashSet();
         servers.add(server);
-        ServerGroupManager manager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
+        ServerGroupManager manager = new ServerGroupManager();
         manager.addServers(group, servers, admin);
 
         Set admins = new HashSet();

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
@@ -173,7 +173,7 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
 
     private TaskomaticApi taskomaticApi = new TaskomaticApi();
     private SystemQuery systemQuery = new SaltService();
-    private RegularMinionBootstrapper regularMinionBootstrapper = RegularMinionBootstrapper.getInstance(systemQuery);
+    private RegularMinionBootstrapper regularMinionBootstrapper = new RegularMinionBootstrapper(systemQuery);
     private SSHMinionBootstrapper sshMinionBootstrapper = SSHMinionBootstrapper.getInstance(systemQuery);
     private XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
             regularMinionBootstrapper,

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
@@ -15,6 +15,7 @@
 package com.redhat.rhn.frontend.xmlrpc.system.test;
 
 import com.redhat.rhn.FaultException;
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.client.ClientCertificate;
 import com.redhat.rhn.common.db.datasource.DataResult;
 import com.redhat.rhn.common.db.datasource.ModeFactory;
@@ -179,7 +180,7 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
             regularMinionBootstrapper,
             sshMinionBootstrapper
     );
-    private SystemEntitlementManager systemEntitlementManager = SystemEntitlementManager.INSTANCE;
+    private SystemEntitlementManager systemEntitlementManager = GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER;
     private SystemManager systemManager = new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON);
     private SystemHandler handler =
             new SystemHandler(taskomaticApi, xmlRpcSystemHelper, systemEntitlementManager, systemManager);
@@ -903,7 +904,7 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
 
     public void testScheduleVirtProvision() throws Exception {
         Server server = ServerTestUtils.createTestSystem(admin);
-        SystemEntitlementManager.INSTANCE.setBaseEntitlement(server, EntitlementManager.MANAGEMENT);
+        GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER.setBaseEntitlement(server, EntitlementManager.MANAGEMENT);
         TestUtils.saveAndFlush(server);
         server = reload(server);
         KickstartDataTest.setupTestConfiguration(admin);

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/user/UserHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/user/UserHandler.java
@@ -91,6 +91,15 @@ public class UserHandler extends BaseHandler {
         USER_EDITABLE_DETAILS.put("password", "password");
     }
 
+    private final ServerGroupManager serverGroupManager;
+
+    /**
+     * @param serverGroupManagerIn
+     */
+    public UserHandler(ServerGroupManager serverGroupManagerIn) {
+        serverGroupManager = serverGroupManagerIn;
+    }
+
     /**
      * Lists the users in the org.
      * @param loggedInUser The current user
@@ -953,7 +962,6 @@ public class UserHandler extends BaseHandler {
          }
 
         User user = UserManager.lookupUser(loggedInUser, login);
-        ServerGroupManager manager = ServerGroupManager.getInstance();
 
         // Iterate once to lookup the server groups and avoid removing some when
         // an exception will only be thrown later:
@@ -961,7 +969,7 @@ public class UserHandler extends BaseHandler {
         for (String name : systemGroupNames) {
             ManagedServerGroup sg = null;
             try {
-                sg = manager.lookup(name, user);
+                sg = serverGroupManager.lookup(name, user);
             }
             catch (LookupException e) {
                 throw new InvalidServerGroupException();
@@ -1062,10 +1070,9 @@ public class UserHandler extends BaseHandler {
             String serverGroupName =  (String)it.next();
 
             // Make sure the server group exists:
-            ServerGroupManager manager = ServerGroupManager.getInstance();
             ManagedServerGroup group;
             try {
-                group = manager.lookup(serverGroupName, loggedInUser);
+                group = serverGroupManager.lookup(serverGroupName, loggedInUser);
             }
             catch (LookupException e) {
                 throw new InvalidServerGroupException();

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/user/external/test/UserExternalHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/user/external/test/UserExternalHandlerTest.java
@@ -116,7 +116,7 @@ public class UserExternalHandlerTest extends BaseHandlerTestCase {
         String systemGroupName = "my-system-group-name" + TestUtils.randomString();
         String desc = TestUtils.randomString();
         SystemQuery systemQuery = new SaltService();
-        RegularMinionBootstrapper regularMinionBootstrapper = RegularMinionBootstrapper.getInstance(systemQuery);
+        RegularMinionBootstrapper regularMinionBootstrapper =  new RegularMinionBootstrapper(systemQuery);
         SSHMinionBootstrapper sshMinionBootstrapper = SSHMinionBootstrapper.getInstance(systemQuery);
         XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
                 regularMinionBootstrapper,

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/user/external/test/UserExternalHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/user/external/test/UserExternalHandlerTest.java
@@ -117,7 +117,7 @@ public class UserExternalHandlerTest extends BaseHandlerTestCase {
         String desc = TestUtils.randomString();
         SystemQuery systemQuery = new SaltService();
         RegularMinionBootstrapper regularMinionBootstrapper =  new RegularMinionBootstrapper(systemQuery);
-        SSHMinionBootstrapper sshMinionBootstrapper = SSHMinionBootstrapper.getInstance(systemQuery);
+        SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery);
         XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
                 regularMinionBootstrapper,
                 sshMinionBootstrapper

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/user/external/test/UserExternalHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/user/external/test/UserExternalHandlerTest.java
@@ -29,7 +29,7 @@ import com.redhat.rhn.testing.TestUtils;
 import com.suse.manager.webui.controllers.utils.RegularMinionBootstrapper;
 import com.suse.manager.webui.controllers.utils.SSHMinionBootstrapper;
 import com.suse.manager.webui.services.iface.SystemQuery;
-import com.suse.manager.webui.services.impl.SaltService;
+import com.suse.manager.webui.services.test.TestSystemQuery;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -116,7 +116,7 @@ public class UserExternalHandlerTest extends BaseHandlerTestCase {
         String name = "My External Group Name" + TestUtils.randomString();
         String systemGroupName = "my-system-group-name" + TestUtils.randomString();
         String desc = TestUtils.randomString();
-        SystemQuery systemQuery = new SaltService();
+        SystemQuery systemQuery = new TestSystemQuery();
         RegularMinionBootstrapper regularMinionBootstrapper =  new RegularMinionBootstrapper(systemQuery);
         SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery);
         XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/user/external/test/UserExternalHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/user/external/test/UserExternalHandlerTest.java
@@ -24,6 +24,7 @@ import com.redhat.rhn.frontend.xmlrpc.system.XmlRpcSystemHelper;
 import com.redhat.rhn.frontend.xmlrpc.systemgroup.ServerGroupHandler;
 import com.redhat.rhn.frontend.xmlrpc.test.BaseHandlerTestCase;
 import com.redhat.rhn.frontend.xmlrpc.user.external.UserExternalHandler;
+import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.testing.TestUtils;
 import com.suse.manager.webui.controllers.utils.RegularMinionBootstrapper;
 import com.suse.manager.webui.controllers.utils.SSHMinionBootstrapper;
@@ -122,7 +123,7 @@ public class UserExternalHandlerTest extends BaseHandlerTestCase {
                 regularMinionBootstrapper,
                 sshMinionBootstrapper
         );
-        ServerGroupHandler sghandler = new ServerGroupHandler(xmlRpcSystemHelper);
+        ServerGroupHandler sghandler = new ServerGroupHandler(xmlRpcSystemHelper, new ServerGroupManager());
         sghandler.create(admin, systemGroupName, desc);
 
         //admin should be able to call list users, regular should not

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/user/test/UserHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/user/test/UserHandlerTest.java
@@ -28,6 +28,7 @@ import com.redhat.rhn.frontend.xmlrpc.PermissionCheckFailureException;
 import com.redhat.rhn.frontend.xmlrpc.UserNeverLoggedInException;
 import com.redhat.rhn.frontend.xmlrpc.test.BaseHandlerTestCase;
 import com.redhat.rhn.frontend.xmlrpc.user.UserHandler;
+import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.manager.user.UserManager;
 import com.redhat.rhn.testing.ServerGroupTestUtils;
 import com.redhat.rhn.testing.TestUtils;
@@ -42,7 +43,7 @@ import java.util.Set;
 
 public class UserHandlerTest extends BaseHandlerTestCase {
 
-    private UserHandler handler = new UserHandler();
+    private UserHandler handler = new UserHandler(new ServerGroupManager());
 
     public void testListUsers() throws Exception {
         //admin should be able to call list users, regular should not

--- a/java/code/src/com/redhat/rhn/manager/acl/AclManager.java
+++ b/java/code/src/com/redhat/rhn/manager/acl/AclManager.java
@@ -18,6 +18,7 @@ import com.redhat.rhn.common.security.acl.Acl;
 import com.redhat.rhn.common.security.acl.AclFactory;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.struts.RequestContext;
+import com.redhat.rhn.webapp.RhnServletListener;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -29,6 +30,8 @@ import javax.servlet.http.HttpServletRequest;
  * @version $Rev$
  */
 public class AclManager {
+
+    private static AclFactory aclFactory = RhnServletListener.ACL_FACTORY;
 
     private AclManager() {
         // hidden constructor
@@ -69,7 +72,7 @@ public class AclManager {
         // Acl everytime we need to use it. We should register
         // the acl handlers at startup and simply call acl.evalAcl()
         // when needed.
-        Acl aclObj = AclFactory.getInstance().getAcl(mixins);
+        Acl aclObj = aclFactory.getAcl(mixins);
         if (context == null) {
            context = new HashMap();
         }

--- a/java/code/src/com/redhat/rhn/manager/acl/AclManager.java
+++ b/java/code/src/com/redhat/rhn/manager/acl/AclManager.java
@@ -31,7 +31,7 @@ import javax.servlet.http.HttpServletRequest;
  */
 public class AclManager {
 
-    private static AclFactory aclFactory = GlobalInstanceHolder.ACL_FACTORY;
+    private static final AclFactory ACL_FACTORY = GlobalInstanceHolder.ACL_FACTORY;
 
     private AclManager() {
         // hidden constructor
@@ -72,7 +72,7 @@ public class AclManager {
         // Acl everytime we need to use it. We should register
         // the acl handlers at startup and simply call acl.evalAcl()
         // when needed.
-        Acl aclObj = aclFactory.getAcl(mixins);
+        Acl aclObj = ACL_FACTORY.getAcl(mixins);
         if (context == null) {
            context = new HashMap();
         }

--- a/java/code/src/com/redhat/rhn/manager/acl/AclManager.java
+++ b/java/code/src/com/redhat/rhn/manager/acl/AclManager.java
@@ -14,11 +14,11 @@
  */
 package com.redhat.rhn.manager.acl;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.security.acl.Acl;
 import com.redhat.rhn.common.security.acl.AclFactory;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.struts.RequestContext;
-import com.redhat.rhn.webapp.RhnServletListener;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -31,7 +31,7 @@ import javax.servlet.http.HttpServletRequest;
  */
 public class AclManager {
 
-    private static AclFactory aclFactory = RhnServletListener.ACL_FACTORY;
+    private static AclFactory aclFactory = GlobalInstanceHolder.ACL_FACTORY;
 
     private AclManager() {
         // hidden constructor

--- a/java/code/src/com/redhat/rhn/manager/action/test/ActionManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/action/test/ActionManagerTest.java
@@ -19,6 +19,7 @@ import static com.redhat.rhn.testing.ImageTestUtils.createActivationKey;
 import static com.redhat.rhn.testing.ImageTestUtils.createImageProfile;
 import static com.redhat.rhn.testing.ImageTestUtils.createImageStore;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.db.datasource.DataResult;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
@@ -125,7 +126,7 @@ import java.util.stream.Collectors;
 public class ActionManagerTest extends JMockBaseTestCaseWithUser {
     private static Logger log = Logger.getLogger(ActionManagerTest.class);
     private static TaskomaticApi taskomaticApi;
-    private SystemEntitlementManager systemEntitlementManager = SystemEntitlementManager.INSTANCE;
+    private SystemEntitlementManager systemEntitlementManager = GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER;
 
     private final Mockery MOCK_CONTEXT = new JUnit3Mockery() {{
         setThreadingPolicy(new Synchroniser());

--- a/java/code/src/com/redhat/rhn/manager/action/test/ActionManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/action/test/ActionManagerTest.java
@@ -19,7 +19,6 @@ import static com.redhat.rhn.testing.ImageTestUtils.createActivationKey;
 import static com.redhat.rhn.testing.ImageTestUtils.createImageProfile;
 import static com.redhat.rhn.testing.ImageTestUtils.createImageStore;
 
-import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.db.datasource.DataResult;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
@@ -96,11 +95,9 @@ import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
 
 import com.suse.manager.virtualization.VirtManagerSalt;
-import com.suse.manager.webui.services.iface.MonitoringManager;
-import com.suse.manager.webui.services.iface.SaltApi;
-import com.suse.manager.webui.services.iface.SystemQuery;
-import com.suse.manager.webui.services.iface.VirtManager;
-import com.suse.manager.webui.services.impl.SaltService;
+import com.suse.manager.webui.services.iface.*;
+import com.suse.manager.webui.services.test.TestSaltApi;
+import com.suse.manager.webui.services.test.TestSystemQuery;
 import com.suse.salt.netapi.calls.modules.Schedule;
 import com.suse.salt.netapi.results.Result;
 import com.suse.salt.netapi.utils.Xor;
@@ -136,9 +133,8 @@ import java.util.stream.Collectors;
 public class ActionManagerTest extends JMockBaseTestCaseWithUser {
     private static Logger log = Logger.getLogger(ActionManagerTest.class);
     private static TaskomaticApi taskomaticApi;
-    private final SaltService saltService = new SaltService();
-    private final SystemQuery systemQuery = saltService;
-    private final SaltApi saltApi = saltService;
+    private final SystemQuery systemQuery = new TestSystemQuery();
+    private final SaltApi saltApi = new TestSaltApi();
     private final ServerGroupManager serverGroupManager = new ServerGroupManager();
     private final VirtManager virtManager = new VirtManagerSalt(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager();

--- a/java/code/src/com/redhat/rhn/manager/action/test/MinionActionManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/action/test/MinionActionManagerTest.java
@@ -57,11 +57,9 @@ import com.redhat.rhn.testing.ServerTestUtils;
 import com.suse.manager.virtualization.VirtManagerSalt;
 import com.suse.manager.webui.controllers.utils.RegularMinionBootstrapper;
 import com.suse.manager.webui.controllers.utils.SSHMinionBootstrapper;
-import com.suse.manager.webui.services.iface.MonitoringManager;
-import com.suse.manager.webui.services.iface.SaltApi;
-import com.suse.manager.webui.services.iface.SystemQuery;
-import com.suse.manager.webui.services.iface.VirtManager;
-import com.suse.manager.webui.services.impl.SaltService;
+import com.suse.manager.webui.services.iface.*;
+import com.suse.manager.webui.services.test.TestSaltApi;
+import com.suse.manager.webui.services.test.TestSystemQuery;
 import org.hamcrest.Matcher;
 import org.hamcrest.collection.IsMapContaining;
 import org.hamcrest.core.AllOf;
@@ -90,9 +88,8 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
     private final String SALT_CONTENT_STAGING_WINDOW = "salt_content_staging_window";
     private final String SALT_CONTENT_STAGING_ADVANCE = "salt_content_staging_advance";
 
-    private final SaltService saltService = new SaltService();
-    private final SystemQuery systemQuery = saltService;
-    private final SaltApi saltApi = saltService;
+    private final SystemQuery systemQuery = new TestSystemQuery();
+    private final SaltApi saltApi = new TestSaltApi();
     private final ServerGroupManager serverGroupManager = new ServerGroupManager();
     private final VirtManager virtManager = new VirtManagerSalt(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager();

--- a/java/code/src/com/redhat/rhn/manager/action/test/MinionActionManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/action/test/MinionActionManagerTest.java
@@ -84,7 +84,7 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
 
     private SystemQuery systemQuery = new SaltService();
     private RegularMinionBootstrapper regularMinionBootstrapper = new RegularMinionBootstrapper(systemQuery);
-    private SSHMinionBootstrapper sshMinionBootstrapper = SSHMinionBootstrapper.getInstance(systemQuery);
+    private SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery);
     private XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
             regularMinionBootstrapper,
             sshMinionBootstrapper

--- a/java/code/src/com/redhat/rhn/manager/action/test/MinionActionManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/action/test/MinionActionManagerTest.java
@@ -45,6 +45,7 @@ import com.redhat.rhn.manager.action.ActionManager;
 import com.redhat.rhn.manager.action.MinionActionManager;
 import com.redhat.rhn.manager.errata.ErrataManager;
 import com.redhat.rhn.manager.errata.cache.ErrataCacheManager;
+import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
@@ -126,7 +127,7 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
         MinionActionManager.setTaskomaticApi(taskomaticMock);
 
         SystemHandler handler = new SystemHandler(taskomaticMock, xmlRpcSystemHelper, systemEntitlementManager,
-                systemManager);
+                systemManager, new ServerGroupManager());
         context().checking(new Expectations() { {
             Matcher<Map<Long, ZonedDateTime>> minionMatcher =
                     AllOf.allOf(IsMapContaining.hasKey(minion1.getId()));
@@ -176,7 +177,7 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
 
 
         SystemHandler handler = new SystemHandler(taskomaticMock, xmlRpcSystemHelper, systemEntitlementManager,
-                systemManager);
+                systemManager, new ServerGroupManager());
 
         context().checking(new Expectations() { {
             Matcher<Map<Long, ZonedDateTime>> minionMatcher =
@@ -227,7 +228,7 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
         MinionActionManager.setTaskomaticApi(taskomaticMock);
 
         SystemHandler handler = new SystemHandler(taskomaticMock, xmlRpcSystemHelper, systemEntitlementManager,
-                systemManager);
+                systemManager, new ServerGroupManager());
 
         context().checking(new Expectations() { {
             exactly(1).of(taskomaticMock)
@@ -277,7 +278,7 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
         MinionActionManager.setTaskomaticApi(taskomaticMock);
 
         SystemHandler handler = new SystemHandler(taskomaticMock, xmlRpcSystemHelper, systemEntitlementManager,
-                systemManager);
+                systemManager, new ServerGroupManager());
         context().checking(new Expectations() {{
             Matcher<Map<Long, ZonedDateTime>> minionMatcher =
                     AllOf.allOf(IsMapContaining.hasKey(minion1.getId()));
@@ -327,7 +328,7 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
         MinionActionManager.setTaskomaticApi(taskomaticMock);
 
         SystemHandler handler = new SystemHandler(taskomaticMock, xmlRpcSystemHelper, systemEntitlementManager,
-                systemManager);
+                systemManager, new ServerGroupManager());
 
         context().checking(new Expectations() { {
             exactly(1).of(taskomaticMock)

--- a/java/code/src/com/redhat/rhn/manager/action/test/MinionActionManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/action/test/MinionActionManagerTest.java
@@ -17,6 +17,7 @@ package com.redhat.rhn.manager.action.test;
 import static com.redhat.rhn.testing.ErrataTestUtils.createTestInstalledPackage;
 import static com.redhat.rhn.testing.ErrataTestUtils.createTestPackage;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.db.datasource.DataResult;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
@@ -89,7 +90,7 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
             regularMinionBootstrapper,
             sshMinionBootstrapper
     );
-    private SystemEntitlementManager systemEntitlementManager = SystemEntitlementManager.INSTANCE;
+    private SystemEntitlementManager systemEntitlementManager = GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER;
     private SystemManager systemManager = new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON);
 
     @Override

--- a/java/code/src/com/redhat/rhn/manager/action/test/MinionActionManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/action/test/MinionActionManagerTest.java
@@ -83,7 +83,7 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
     private final String SALT_CONTENT_STAGING_ADVANCE = "salt_content_staging_advance";
 
     private SystemQuery systemQuery = new SaltService();
-    private RegularMinionBootstrapper regularMinionBootstrapper = RegularMinionBootstrapper.getInstance(systemQuery);
+    private RegularMinionBootstrapper regularMinionBootstrapper = new RegularMinionBootstrapper(systemQuery);
     private SSHMinionBootstrapper sshMinionBootstrapper = SSHMinionBootstrapper.getInstance(systemQuery);
     private XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
             regularMinionBootstrapper,

--- a/java/code/src/com/redhat/rhn/manager/formula/FormulaManager.java
+++ b/java/code/src/com/redhat/rhn/manager/formula/FormulaManager.java
@@ -28,7 +28,6 @@ import com.redhat.rhn.domain.user.User;
 
 import com.suse.manager.model.clusters.Cluster;
 import com.suse.manager.webui.services.iface.SaltApi;
-import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.salt.netapi.datatypes.target.MinionList;
 import com.suse.utils.Opt;
@@ -50,7 +49,6 @@ import java.util.stream.Collectors;
 public class FormulaManager {
 
     private static FormulaManager instance;
-    private SystemQuery systemQuery;
     private SaltApi saltApi;
     private ServerGroupFactory serverGroupFactory = ServerGroupFactory.SINGLETON;
     private static final String DEFAULT_KEY = "$default";
@@ -58,9 +56,11 @@ public class FormulaManager {
     private static final String EDIT_GROUP = "edit-group";
     private static final String PROTOTYPE = "$prototype";
 
-    private FormulaManager() {
-        systemQuery = SaltService.INSTANCE;
-        saltApi = SaltService.INSTANCE_SALT_API;
+    /**
+     * @param saltApiIn
+     */
+    public FormulaManager(SaltApi saltApiIn) {
+        saltApi = saltApiIn;
     }
 
     /**
@@ -70,25 +70,9 @@ public class FormulaManager {
      */
     public static synchronized FormulaManager getInstance() {
         if (instance == null) {
-            instance = new FormulaManager();
+            instance = new FormulaManager(SaltService.INSTANCE_SALT_API);
         }
         return instance;
-    }
-
-    /**
-     * This method is only for testing purpose.
-     * @param systemQueryIn to set
-     */
-    public void setSystemQuery(SaltService systemQueryIn) {
-        this.systemQuery = systemQueryIn;
-    }
-
-    /**
-     * This method is only for testing purpose.
-     * @param saltApiIn to set
-     */
-    public void setSaltApi(SaltApi saltApiIn) {
-        this.saltApi = saltApiIn;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/formula/FormulaManager.java
+++ b/java/code/src/com/redhat/rhn/manager/formula/FormulaManager.java
@@ -16,6 +16,7 @@ package com.redhat.rhn.manager.formula;
 
 import static com.redhat.rhn.domain.formula.FormulaFactory.getGroupFormulaValuesByNameAndGroupId;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.dto.FormulaData;
 import com.redhat.rhn.domain.dto.SystemGroupID;
 import com.redhat.rhn.domain.formula.FormulaFactory;
@@ -28,7 +29,6 @@ import com.redhat.rhn.domain.user.User;
 
 import com.suse.manager.model.clusters.Cluster;
 import com.suse.manager.webui.services.iface.SaltApi;
-import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.salt.netapi.datatypes.target.MinionList;
 import com.suse.utils.Opt;
 
@@ -70,7 +70,7 @@ public class FormulaManager {
      */
     public static synchronized FormulaManager getInstance() {
         if (instance == null) {
-            instance = new FormulaManager(SaltService.INSTANCE_SALT_API);
+            instance = new FormulaManager(GlobalInstanceHolder.SALT_API);
         }
         return instance;
     }

--- a/java/code/src/com/redhat/rhn/manager/formula/FormulaManager.java
+++ b/java/code/src/com/redhat/rhn/manager/formula/FormulaManager.java
@@ -16,7 +16,6 @@ package com.redhat.rhn.manager.formula;
 
 import static com.redhat.rhn.domain.formula.FormulaFactory.getGroupFormulaValuesByNameAndGroupId;
 
-import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.dto.FormulaData;
 import com.redhat.rhn.domain.dto.SystemGroupID;
 import com.redhat.rhn.domain.formula.FormulaFactory;

--- a/java/code/src/com/redhat/rhn/manager/formula/FormulaManager.java
+++ b/java/code/src/com/redhat/rhn/manager/formula/FormulaManager.java
@@ -48,8 +48,7 @@ import java.util.stream.Collectors;
  */
 public class FormulaManager {
 
-    private static FormulaManager instance;
-    private SaltApi saltApi;
+    private final SaltApi saltApi;
     private ServerGroupFactory serverGroupFactory = ServerGroupFactory.SINGLETON;
     private static final String DEFAULT_KEY = "$default";
     private static final String TYPE_KEY = "$type";
@@ -61,18 +60,6 @@ public class FormulaManager {
      */
     public FormulaManager(SaltApi saltApiIn) {
         saltApi = saltApiIn;
-    }
-
-    /**
-     * get the singleton instance.
-     *
-     * @return instance
-     */
-    public static synchronized FormulaManager getInstance() {
-        if (instance == null) {
-            instance = new FormulaManager(GlobalInstanceHolder.SALT_API);
-        }
-        return instance;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/formula/FormulaUtil.java
+++ b/java/code/src/com/redhat/rhn/manager/formula/FormulaUtil.java
@@ -14,6 +14,7 @@
  */
 package com.redhat.rhn.manager.formula;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.hibernate.LookupException;
 import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.common.security.PermissionException;
@@ -29,6 +30,8 @@ import com.redhat.rhn.manager.system.SystemManager;
  */
 public class FormulaUtil {
 
+    private static final ServerGroupManager SERVER_GROUP_MANAGER = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
+
     private FormulaUtil() { }
 
     /**
@@ -38,8 +41,8 @@ public class FormulaUtil {
      */
     public static void ensureUserHasPermissionsOnServerGroup(User user, ServerGroup group) {
         try {
-            ServerGroupManager.getInstance().validateAccessCredentials(user, group, group.getName());
-            ServerGroupManager.getInstance().validateAdminCredentials(user);
+            SERVER_GROUP_MANAGER.validateAccessCredentials(user, group, group.getName());
+            SERVER_GROUP_MANAGER.validateAdminCredentials(user);
         }
         catch (NullPointerException | LookupException e) {
             throw new LookupException("Unable to find user or group");

--- a/java/code/src/com/redhat/rhn/manager/formula/test/FormulaManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/formula/test/FormulaManagerTest.java
@@ -104,7 +104,7 @@ public class FormulaManagerTest extends JMockBaseTestCaseWithUser {
         Map<String, Object> contents = Json.GSON.fromJson(contentsData, Map.class);
 
         Map<String, Object> layout = Json.GSON.fromJson(layoutData, Map.class);
-        FormulaManager manager = FormulaManager.getInstance();
+        FormulaManager manager = new FormulaManager(saltServiceMock);
         manager.validateContents(contents,layout);
 
     }
@@ -122,7 +122,7 @@ public class FormulaManagerTest extends JMockBaseTestCaseWithUser {
 
         contents.put("test","dummy"); // add a random field
 
-        FormulaManager manager = FormulaManager.getInstance();
+        FormulaManager manager = new FormulaManager(saltServiceMock);
         try {
             manager.validateContents(contents,layout);
             fail( "Exception expected but didn't throw" );
@@ -202,7 +202,7 @@ public class FormulaManagerTest extends JMockBaseTestCaseWithUser {
         Map<String, Object> contents = Json.GSON.fromJson(contentsData, Map.class);
         MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
         FormulaFactory.setDataDir(tmpSaltRoot.resolve(TEMP_PATH).toString());
-        FormulaManager manager = FormulaManager.getInstance();
+        FormulaManager manager = new FormulaManager(saltServiceMock);
         User testUser = UserTestUtils.createUser("test-user", user.getOrg().getId());
         try {
             manager.saveServerFormulaData(testUser,minion.getId(), formulaName, contents);

--- a/java/code/src/com/redhat/rhn/manager/formula/test/FormulaManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/formula/test/FormulaManagerTest.java
@@ -67,7 +67,7 @@ public class FormulaManagerTest extends JMockBaseTestCaseWithUser {
     static final String TEMP_PATH = "formulas/";
     static final String formulaName = "dhcpd";
     private SaltService saltServiceMock;
-    private FormulaManager manager = FormulaManager.getInstance();
+    private FormulaManager manager;
     private Path metadataDir;
 
     public FormulaManagerTest() { }
@@ -78,9 +78,8 @@ public class FormulaManagerTest extends JMockBaseTestCaseWithUser {
         setImposteriser(ClassImposteriser.INSTANCE);
         MockConnection.clear();
         saltServiceMock = mock(SaltService.class);
-        manager.setSystemQuery(saltServiceMock);
-        manager.setSaltApi(saltServiceMock);
         metadataDir = Files.createTempDirectory("metadata");
+        manager = new FormulaManager(saltServiceMock);
         FormulaFactory.setDataDir(tmpSaltRoot.toString());
         FormulaFactory.setMetadataDirOfficial(metadataDir.toString());
         createMetadataFiles();

--- a/java/code/src/com/redhat/rhn/manager/org/MigrationManager.java
+++ b/java/code/src/com/redhat/rhn/manager/org/MigrationManager.java
@@ -14,6 +14,7 @@
  */
 package com.redhat.rhn.manager.org;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.security.PermissionException;
 import com.redhat.rhn.domain.org.Org;
 import com.redhat.rhn.domain.org.OrgFactory;
@@ -50,6 +51,8 @@ import java.util.List;
  * @version $Rev$
  */
 public class MigrationManager extends BaseManager {
+
+    private static final ServerGroupManager SERVER_GROUP_MANAGER = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
 
     /**
      * Migrate a set of servers to the organization specified
@@ -130,11 +133,10 @@ public class MigrationManager extends BaseManager {
         SystemManager.unsubscribeServerFromChannel(server, server.getBaseChannel());
 
         // Remove from all system groups:
-        ServerGroupManager manager = ServerGroupManager.getInstance();
         for (ManagedServerGroup group : server.getManagedGroups()) {
             List<Server> tempList = new LinkedList<Server>();
             tempList.add(server);
-            manager.removeServers(group, tempList);
+            SERVER_GROUP_MANAGER.removeServers(group, tempList);
         }
 
         // Remove custom data values (aka System->CustomInfo)

--- a/java/code/src/com/redhat/rhn/manager/org/test/MigrationManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/org/test/MigrationManagerTest.java
@@ -40,11 +40,9 @@ import com.redhat.rhn.testing.ConfigTestUtils;
 import com.redhat.rhn.testing.ServerTestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
 import com.suse.manager.virtualization.VirtManagerSalt;
-import com.suse.manager.webui.services.iface.MonitoringManager;
-import com.suse.manager.webui.services.iface.SaltApi;
-import com.suse.manager.webui.services.iface.SystemQuery;
-import com.suse.manager.webui.services.iface.VirtManager;
-import com.suse.manager.webui.services.impl.SaltService;
+import com.suse.manager.webui.services.iface.*;
+import com.suse.manager.webui.services.test.TestSaltApi;
+import com.suse.manager.webui.services.test.TestSystemQuery;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -64,9 +62,8 @@ public class MigrationManagerTest extends BaseTestCaseWithUser {
     private Server server;  // virt host w/guests
     private Server server2; // server w/provisioning ent
 
-    private final SaltService saltService = new SaltService();
-    private final SystemQuery systemQuery = saltService;
-    private final SaltApi saltApi = saltService;
+    private final SystemQuery systemQuery = new TestSystemQuery();
+    private final SaltApi saltApi = new TestSaltApi();
     private final ServerGroupManager serverGroupManager = new ServerGroupManager();
     private final VirtManager virtManager = new VirtManagerSalt(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager();

--- a/java/code/src/com/redhat/rhn/manager/org/test/MigrationManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/org/test/MigrationManagerTest.java
@@ -14,6 +14,7 @@
  */
 package com.redhat.rhn.manager.org.test;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.common.security.PermissionException;
 import com.redhat.rhn.domain.config.ConfigChannel;
@@ -30,10 +31,7 @@ import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.domain.user.UserFactory;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.manager.org.MigrationManager;
-import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
-import com.redhat.rhn.manager.system.entitling.SystemEntitler;
-import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
 import com.redhat.rhn.testing.ConfigTestUtils;
 import com.redhat.rhn.testing.ServerTestUtils;
@@ -56,7 +54,7 @@ public class MigrationManagerTest extends BaseTestCaseWithUser {
     private Org destOrg;
     private Server server;  // virt host w/guests
     private Server server2; // server w/provisioning ent
-    private SystemEntitlementManager systemEntitlementManager = SystemEntitlementManager.INSTANCE;
+    private SystemEntitlementManager systemEntitlementManager = GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER;
 
     @Override
     public void setUp() throws Exception {

--- a/java/code/src/com/redhat/rhn/manager/recurringactions/RecurringActionManager.java
+++ b/java/code/src/com/redhat/rhn/manager/recurringactions/RecurringActionManager.java
@@ -15,6 +15,7 @@
 
 package com.redhat.rhn.manager.recurringactions;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.hibernate.LookupException;
 import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.common.security.PermissionException;
@@ -51,6 +52,7 @@ import java.util.List;
 public class RecurringActionManager {
 
     private static TaskomaticApi taskomaticApi = new TaskomaticApi();
+    private static final ServerGroupManager SERVER_GROUP_MANAGER = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
 
     /**
      * Set the {@link TaskomaticApi} instance to use. Only needed for unit tests.
@@ -157,13 +159,12 @@ public class RecurringActionManager {
      * @return list of group recurring actions
      */
     public static List<GroupRecurringAction> listGroupRecurringActions(long groupId, User user) {
-        ServerGroupManager groupManager = ServerGroupManager.getInstance();
         if (!user.hasRole(RoleFactory.SYSTEM_GROUP_ADMIN)) {
             throw new PermissionException(String.format("User does not have access to group id %d", groupId));
         }
         try {
             /* Check if user has permission to access the group */
-            groupManager.lookup(groupId, user);
+            SERVER_GROUP_MANAGER.lookup(groupId, user);
             return RecurringActionFactory.listGroupRecurringActions(groupId);
         }
         catch (LookupException e) {

--- a/java/code/src/com/redhat/rhn/manager/recurringactions/test/RecurringActionManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/recurringactions/test/RecurringActionManagerTest.java
@@ -195,7 +195,7 @@ public class RecurringActionManagerTest extends BaseTestCaseWithUser {
     }
 
     public void testListGroupRecurringActions() {
-        ServerGroupManager manager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
+        ServerGroupManager manager = new ServerGroupManager();
         ManagedServerGroup group = ServerGroupTestUtils.createManaged(user);
 
         var action = new GroupRecurringAction();

--- a/java/code/src/com/redhat/rhn/manager/recurringactions/test/RecurringActionManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/recurringactions/test/RecurringActionManagerTest.java
@@ -4,6 +4,7 @@ import static com.redhat.rhn.domain.recurringactions.RecurringAction.Type.GROUP;
 import static com.redhat.rhn.domain.recurringactions.RecurringAction.Type.MINION;
 import static com.redhat.rhn.domain.recurringactions.RecurringAction.Type.ORG;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.security.PermissionException;
 import com.redhat.rhn.common.validator.ValidatorException;
 import com.redhat.rhn.domain.org.Org;
@@ -194,7 +195,7 @@ public class RecurringActionManagerTest extends BaseTestCaseWithUser {
     }
 
     public void testListGroupRecurringActions() {
-        ServerGroupManager manager = ServerGroupManager.getInstance();
+        ServerGroupManager manager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
         ManagedServerGroup group = ServerGroupTestUtils.createManaged(user);
 
         var action = new GroupRecurringAction();

--- a/java/code/src/com/redhat/rhn/manager/system/ServerGroupManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/ServerGroupManager.java
@@ -52,26 +52,11 @@ import java.util.stream.Collectors;
  */
 public class ServerGroupManager {
 
-    private static final ServerGroupManager MANAGER = new ServerGroupManager();
-
     /** Logger */
     private static final Logger LOG = Logger.getLogger(ServerGroupManager.class);
 
     private MinionPillarFileManager minionGroupMembershipPillarFileManager =
             new MinionPillarFileManager(new MinionGroupMembershipPillarGenerator());
-
-    /**
-     * Singleton Instance to get manager object
-     * @return an instance of the manager
-     */
-    public static ServerGroupManager getInstance() {
-        return MANAGER;
-    }
-    /**
-     * Private constructor.
-     */
-    private ServerGroupManager() {
-    }
 
     /**
      * Only used for unit tests.

--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -157,7 +157,7 @@ public class SystemManager extends BaseManager {
     public static final String CAP_SCRIPT_RUN = "script.run";
     public static final String CAP_SCAP = "scap.xccdf_eval";
 
-    private static SystemEntitlementManager systemEntitlementManager = SystemEntitlementManager.INSTANCE;
+    private static SystemEntitlementManager systemEntitlementManager = GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER;
     private ServerFactory serverFactory;
     private ServerGroupFactory serverGroupFactory;
 

--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -19,6 +19,7 @@ import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
 import static java.util.Optional.ofNullable;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.client.ClientCertificate;
 import com.redhat.rhn.common.client.InvalidCertificateException;
 import com.redhat.rhn.common.conf.Config;
@@ -143,7 +144,7 @@ import java.util.stream.Collectors;
 public class SystemManager extends BaseManager {
 
     private static Logger log = Logger.getLogger(SystemManager.class);
-    private static SystemQuery saltServiceInstance = SaltService.INSTANCE;
+    private static SystemQuery saltServiceInstance = GlobalInstanceHolder.SYSTEM_QUERY;
 
     public static final String CAP_CONFIGFILES_UPLOAD = "configfiles.upload";
     public static final String CAP_CONFIGFILES_DIFF = "configfiles.diff";

--- a/java/code/src/com/redhat/rhn/manager/system/entitling/SystemEntitlementManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/entitling/SystemEntitlementManager.java
@@ -14,13 +14,13 @@
  */
 package com.redhat.rhn.manager.system.entitling;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.validator.ValidatorResult;
 import com.redhat.rhn.domain.entitlement.Entitlement;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.manager.formula.FormulaMonitoringManager;
 
 import com.suse.manager.virtualization.VirtManagerSalt;
-import com.suse.manager.webui.services.impl.SaltService;
 
 /**
  * Manager class for adding/removing entitlements to/from servers
@@ -28,9 +28,9 @@ import com.suse.manager.webui.services.impl.SaltService;
 public class SystemEntitlementManager {
 
     public static final SystemEntitlementManager INSTANCE = new SystemEntitlementManager(
-            new SystemUnentitler(new VirtManagerSalt(SaltService.INSTANCE_SALT_API),
+            new SystemUnentitler(new VirtManagerSalt(GlobalInstanceHolder.SALT_API),
                     new FormulaMonitoringManager()),
-            new SystemEntitler(SaltService.INSTANCE, new VirtManagerSalt(SaltService.INSTANCE_SALT_API),
+            new SystemEntitler(GlobalInstanceHolder.SYSTEM_QUERY, new VirtManagerSalt(GlobalInstanceHolder.SALT_API),
                     new FormulaMonitoringManager())
     );
 

--- a/java/code/src/com/redhat/rhn/manager/system/entitling/SystemEntitlementManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/entitling/SystemEntitlementManager.java
@@ -14,25 +14,15 @@
  */
 package com.redhat.rhn.manager.system.entitling;
 
-import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.validator.ValidatorResult;
 import com.redhat.rhn.domain.entitlement.Entitlement;
 import com.redhat.rhn.domain.server.Server;
-import com.redhat.rhn.manager.formula.FormulaMonitoringManager;
 
-import com.suse.manager.virtualization.VirtManagerSalt;
 
 /**
  * Manager class for adding/removing entitlements to/from servers
  */
 public class SystemEntitlementManager {
-
-    public static final SystemEntitlementManager INSTANCE = new SystemEntitlementManager(
-            new SystemUnentitler(new VirtManagerSalt(GlobalInstanceHolder.SALT_API),
-                    new FormulaMonitoringManager()),
-            new SystemEntitler(GlobalInstanceHolder.SYSTEM_QUERY, new VirtManagerSalt(GlobalInstanceHolder.SALT_API),
-                    new FormulaMonitoringManager())
-    );
 
     private SystemUnentitler systemUnentitler;
     private SystemEntitler systemEntitler;

--- a/java/code/src/com/redhat/rhn/manager/system/entitling/SystemEntitler.java
+++ b/java/code/src/com/redhat/rhn/manager/system/entitling/SystemEntitler.java
@@ -63,17 +63,20 @@ public class SystemEntitler {
     private SystemQuery systemQuery;
     private VirtManager virtManager;
     private MonitoringManager monitoringManager;
+    private ServerGroupManager serverGroupManager;
 
     /**
      * @param systemQueryIn instance for gathering data from a system.
      * @param virtManagerIn instance for managing virtual machines.
      * @param monitoringManagerIn instance for handling monitoring configuration.
+     * @param serverGroupManagerIn
      */
     public SystemEntitler(SystemQuery systemQueryIn, VirtManager virtManagerIn,
-            MonitoringManager monitoringManagerIn) {
+            MonitoringManager monitoringManagerIn, ServerGroupManager serverGroupManagerIn) {
         this.systemQuery = systemQueryIn;
         this.virtManager = virtManagerIn;
         this.monitoringManager = monitoringManagerIn;
+        this.serverGroupManager = serverGroupManagerIn;
     }
 
     /**
@@ -126,7 +129,7 @@ public class SystemEntitler {
         entitleServer(server, ent);
 
         server.asMinionServer().ifPresent(minion -> {
-            ServerGroupManager.getInstance().updatePillarAfterGroupUpdateForServers(Arrays.asList(minion));
+            serverGroupManager.updatePillarAfterGroupUpdateForServers(Arrays.asList(minion));
 
             if (wasVirtEntitled && !EntitlementManager.VIRTUALIZATION.equals(ent) ||
                     !wasVirtEntitled && EntitlementManager.VIRTUALIZATION.equals(ent)) {

--- a/java/code/src/com/redhat/rhn/manager/system/entitling/SystemUnentitler.java
+++ b/java/code/src/com/redhat/rhn/manager/system/entitling/SystemUnentitler.java
@@ -21,8 +21,8 @@ import com.redhat.rhn.domain.server.EntitlementServerGroup;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
-import com.redhat.rhn.manager.system.ServerGroupManager;
 
+import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.suse.manager.webui.services.iface.MonitoringManager;
 import com.suse.manager.webui.services.iface.VirtManager;
 
@@ -40,16 +40,20 @@ public class SystemUnentitler {
 
     private static final Logger LOG = Logger.getLogger(SystemUnentitler.class);
 
-    private MonitoringManager monitoringManager;
-    private VirtManager virtManager;
+    private final MonitoringManager monitoringManager;
+    private final VirtManager virtManager;
+    private final ServerGroupManager serverGroupManager;
 
     /**
      * @param virtManagerIn instance for managing virtual machines.
      * @param monitoringManagerIn instance for handling monitoring configuration.
+     * @param serverGroupManagerIn
      */
-    public SystemUnentitler(VirtManager virtManagerIn, MonitoringManager monitoringManagerIn) {
+    public SystemUnentitler(VirtManager virtManagerIn, MonitoringManager monitoringManagerIn,
+                            ServerGroupManager serverGroupManagerIn) {
         this.virtManager = virtManagerIn;
         this.monitoringManager = monitoringManagerIn;
+        this.serverGroupManager = serverGroupManagerIn;
     }
 
     /**
@@ -83,7 +87,7 @@ public class SystemUnentitler {
         }
 
         server.asMinionServer().ifPresent(s -> {
-            ServerGroupManager.getInstance().updatePillarAfterGroupUpdateForServers(Arrays.asList(s));
+            serverGroupManager.updatePillarAfterGroupUpdateForServers(Arrays.asList(s));
             if (EntitlementManager.MONITORING.equals(ent)) {
                 try {
                     monitoringManager.disableMonitoring(s);

--- a/java/code/src/com/redhat/rhn/manager/system/entitling/test/SystemEntitlementManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/entitling/test/SystemEntitlementManagerTest.java
@@ -26,6 +26,7 @@ import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.manager.formula.FormulaMonitoringManager;
+import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitler;
 import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
@@ -53,10 +54,12 @@ public class SystemEntitlementManagerTest extends JMockBaseTestCaseWithUser {
         super.setUp();
         setImposteriser(ClassImposteriser.INSTANCE);
         saltServiceMock = mock(SaltService.class);
+        ServerGroupManager serverGroupManager = new ServerGroupManager();
         systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(new VirtManagerSalt(saltServiceMock), new FormulaMonitoringManager()),
+                new SystemUnentitler(new VirtManagerSalt(saltServiceMock), new FormulaMonitoringManager(),
+                        serverGroupManager),
                 new SystemEntitler(saltServiceMock, new VirtManagerSalt(saltServiceMock),
-                        new FormulaMonitoringManager())
+                        new FormulaMonitoringManager(), serverGroupManager)
         );
     }
 

--- a/java/code/src/com/redhat/rhn/manager/system/test/ServerGroupManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/test/ServerGroupManagerTest.java
@@ -14,6 +14,7 @@
  */
 package com.redhat.rhn.manager.system.test;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.domain.server.ManagedServerGroup;
 import com.redhat.rhn.domain.server.ServerGroup;
@@ -43,7 +44,7 @@ public class ServerGroupManagerTest extends BaseTestCaseWithUser {
 
     public void setUp() throws Exception {
         super.setUp();
-        manager = ServerGroupManager.getInstance();
+        manager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
     }
 
     public void testCreate() {

--- a/java/code/src/com/redhat/rhn/manager/system/test/ServerGroupManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/test/ServerGroupManagerTest.java
@@ -44,7 +44,7 @@ public class ServerGroupManagerTest extends BaseTestCaseWithUser {
 
     public void setUp() throws Exception {
         super.setUp();
-        manager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
+        manager = new ServerGroupManager();
     }
 
     public void testCreate() {

--- a/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
@@ -95,6 +95,7 @@ import com.redhat.rhn.manager.kickstart.cobbler.test.MockXMLRPCInvoker;
 import com.redhat.rhn.manager.rhnpackage.test.PackageManagerTest;
 import com.redhat.rhn.manager.rhnset.RhnSetDecl;
 import com.redhat.rhn.manager.rhnset.RhnSetManager;
+import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.manager.system.SystemsExistException;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
@@ -178,9 +179,12 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
             }
         });
         SaltService saltService = new SaltService();
+        ServerGroupManager serverGroupManager = new ServerGroupManager();
         systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(new VirtManagerSalt(saltService), new FormulaMonitoringManager()),
-                new SystemEntitler(saltService, new VirtManagerSalt(saltService), new FormulaMonitoringManager())
+                new SystemUnentitler(new VirtManagerSalt(saltService), new FormulaMonitoringManager(),
+                        serverGroupManager),
+                new SystemEntitler(saltService, new VirtManagerSalt(saltService), new FormulaMonitoringManager(),
+                        serverGroupManager)
         );
         this.systemManager = new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON);
         createMetadataFiles();

--- a/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
@@ -111,10 +111,12 @@ import com.redhat.rhn.testing.TestStatics;
 import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
 
-import com.suse.manager.virtualization.VirtManagerSalt;
+import com.suse.manager.virtualization.test.TestVirtManager;
 import com.suse.manager.webui.controllers.utils.ContactMethodUtil;
+import com.suse.manager.webui.services.iface.*;
 import com.suse.manager.webui.services.impl.SaltService;
 
+import com.suse.manager.webui.services.test.TestSystemQuery;
 import org.apache.commons.io.FileUtils;
 import org.cobbler.test.MockConnection;
 import org.hibernate.Session;
@@ -178,12 +180,13 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
                     .scheduleActionExecution(with(any(Action.class)));
             }
         });
-        SaltService saltService = new SaltService();
+        SystemQuery systemQuery = new TestSystemQuery();
+        VirtManager virtManager = new TestVirtManager();
         ServerGroupManager serverGroupManager = new ServerGroupManager();
         systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(new VirtManagerSalt(saltService), new FormulaMonitoringManager(),
+                new SystemUnentitler(virtManager, new FormulaMonitoringManager(),
                         serverGroupManager),
-                new SystemEntitler(saltService, new VirtManagerSalt(saltService), new FormulaMonitoringManager(),
+                new SystemEntitler(systemQuery, virtManager, new FormulaMonitoringManager(),
                         serverGroupManager)
         );
         this.systemManager = new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON);

--- a/java/code/src/com/redhat/rhn/manager/user/UserManager.java
+++ b/java/code/src/com/redhat/rhn/manager/user/UserManager.java
@@ -16,6 +16,7 @@ package com.redhat.rhn.manager.user;
 
 import static java.util.stream.Collectors.toList;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.db.datasource.CallableMode;
 import com.redhat.rhn.common.db.datasource.DataResult;
 import com.redhat.rhn.common.db.datasource.ModeFactory;
@@ -47,8 +48,8 @@ import com.redhat.rhn.frontend.taglibs.list.decorators.PageSizeDecorator;
 import com.redhat.rhn.manager.BaseManager;
 import com.redhat.rhn.manager.SatManager;
 import com.redhat.rhn.manager.channel.ChannelManager;
-import com.redhat.rhn.manager.system.ServerGroupManager;
 
+import com.redhat.rhn.manager.system.ServerGroupManager;
 import org.apache.log4j.Logger;
 
 import java.util.Arrays;
@@ -76,6 +77,8 @@ public class UserManager extends BaseManager {
 
     private static Logger log = Logger.getLogger(UserManager.class);
     private static final String ORG_ADMIN_LABEL = "org_admin";
+
+    private static final ServerGroupManager SERVER_GROUP_MANAGER = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
 
     private UserManager() {
     }
@@ -922,7 +925,7 @@ public class UserManager extends BaseManager {
     public static boolean canAdministerSystemGroup(User user, ManagedServerGroup group) {
         return (user != null &&
                 group != null &&
-                ServerGroupManager.getInstance().canAccess(user, group) &&
+                SERVER_GROUP_MANAGER.canAccess(user, group) &&
                 user.hasRole(RoleFactory.SYSTEM_GROUP_ADMIN));
     }
 

--- a/java/code/src/com/redhat/rhn/manager/visualization/test/VisualizationManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/visualization/test/VisualizationManagerTest.java
@@ -15,6 +15,7 @@
 
 package com.redhat.rhn.manager.visualization.test;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.errata.Errata;
@@ -225,7 +226,7 @@ public class VisualizationManagerTest extends BaseTestCaseWithUser {
         user.addPermanentRole(RoleFactory.ORG_ADMIN);
         Server server = ServerFactoryTest.createTestServer(user, false);
 
-        ServerGroupManager manager = ServerGroupManager.getInstance();
+        ServerGroupManager manager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
         ManagedServerGroup sg1 = manager.create(user, "FooFooFOO", "Foo Description");
         manager.addServers(sg1, Collections.singleton(server), user);
 
@@ -260,7 +261,7 @@ public class VisualizationManagerTest extends BaseTestCaseWithUser {
         // information as we rely on errata cache in our query
         ErrataCacheManager.insertNeededErrataCache(server.getId(), e.getId(), p.getId());
 
-        ServerGroupManager manager = ServerGroupManager.getInstance();
+        ServerGroupManager manager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
         ManagedServerGroup sg1 = manager.create(user, "FooFooFOO", "Foo Description");
         manager.addServers(sg1, Collections.singleton(server), user);
 

--- a/java/code/src/com/redhat/rhn/manager/visualization/test/VisualizationManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/visualization/test/VisualizationManagerTest.java
@@ -15,7 +15,6 @@
 
 package com.redhat.rhn.manager.visualization.test;
 
-import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.errata.Errata;
@@ -226,7 +225,7 @@ public class VisualizationManagerTest extends BaseTestCaseWithUser {
         user.addPermanentRole(RoleFactory.ORG_ADMIN);
         Server server = ServerFactoryTest.createTestServer(user, false);
 
-        ServerGroupManager manager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
+        ServerGroupManager manager = new ServerGroupManager();
         ManagedServerGroup sg1 = manager.create(user, "FooFooFOO", "Foo Description");
         manager.addServers(sg1, Collections.singleton(server), user);
 
@@ -261,7 +260,7 @@ public class VisualizationManagerTest extends BaseTestCaseWithUser {
         // information as we rely on errata cache in our query
         ErrataCacheManager.insertNeededErrataCache(server.getId(), e.getId(), p.getId());
 
-        ServerGroupManager manager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
+        ServerGroupManager manager = new ServerGroupManager();
         ManagedServerGroup sg1 = manager.create(user, "FooFooFOO", "Foo Description");
         manager.addServers(sg1, Collections.singleton(server), user);
 

--- a/java/code/src/com/redhat/rhn/taskomatic/core/SchedulerKernel.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/core/SchedulerKernel.java
@@ -16,6 +16,7 @@ package com.redhat.rhn.taskomatic.core;
 
 import static java.util.stream.Collectors.toSet;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.conf.ConfigException;
@@ -23,8 +24,6 @@ import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.common.messaging.MessageQueue;
 import com.redhat.rhn.domain.org.Org;
 import com.redhat.rhn.domain.org.OrgFactory;
-import com.redhat.rhn.manager.formula.FormulaManager;
-import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.taskomatic.TaskoFactory;
 import com.redhat.rhn.taskomatic.TaskoQuartzHelper;
 import com.redhat.rhn.taskomatic.TaskoXmlRpcServer;
@@ -32,15 +31,8 @@ import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.taskomatic.domain.TaskoRun;
 import com.redhat.rhn.taskomatic.domain.TaskoSchedule;
 
-import com.suse.manager.clusters.ClusterManager;
 import com.suse.manager.metrics.PrometheusExporter;
-import com.suse.manager.utils.SaltUtils;
-import com.suse.manager.webui.services.SaltServerActionService;
-import com.suse.manager.webui.services.iface.SaltApi;
-import com.suse.manager.webui.services.iface.SystemQuery;
-import com.suse.manager.webui.services.impl.SaltService;
 
-import com.suse.manager.webui.utils.MinionActionUtils;
 import org.apache.log4j.Logger;
 import org.quartz.Scheduler;
 import org.quartz.SchedulerException;
@@ -70,26 +62,6 @@ public class SchedulerKernel {
     private String dataSourceConfigPath = "org.quartz.jobStore.dataSource";
     private String dataSourcePrefix = "org.quartz.dataSource";
     private String defaultDataSource = "rhnDs";
-
-    /*
-    This is more or less the entry point for taskomatic where all instances are
-    initialized and passed on. The only code that should access those instances directly
-    is job classes which seem to have no way right now to pass parameters on construction.
-     */
-    public static final SystemQuery SYSTEM_QUERY = SaltService.INSTANCE;
-    public static final SaltApi SALT_API = SaltService.INSTANCE_SALT_API;
-    public static final ServerGroupManager SERVER_GROUP_MANAGER = ServerGroupManager.getInstance();
-    public static final FormulaManager FORMULA_MANAGER = new FormulaManager(SALT_API);
-    public static final ClusterManager CLUSTER_MANAGER = new ClusterManager(
-            SALT_API, SYSTEM_QUERY, SERVER_GROUP_MANAGER, FORMULA_MANAGER
-    );
-    public static final SaltUtils SALT_UTILS = new SaltUtils(
-            SYSTEM_QUERY, SALT_API, CLUSTER_MANAGER);
-    public static final SaltServerActionService SALT_SERVER_ACTION_SERVICE =
-            new SaltServerActionService(SchedulerKernel.SYSTEM_QUERY, SALT_UTILS, CLUSTER_MANAGER);
-    public static final MinionActionUtils MINION_ACTION_UTILS = new MinionActionUtils(
-            SALT_SERVER_ACTION_SERVICE, SYSTEM_QUERY, SALT_UTILS);
-
 
     /**
      * Kernel main driver behind Taskomatic
@@ -169,7 +141,7 @@ public class SchedulerKernel {
             throw new TaskomaticException("HibernateFactory failed to initialize");
         }
         MessageQueue.startMessaging();
-        MessageQueue.configureDefaultActions(SYSTEM_QUERY, SaltService.INSTANCE_SALT_API);
+        MessageQueue.configureDefaultActions(GlobalInstanceHolder.SYSTEM_QUERY, GlobalInstanceHolder.SALT_API);
         try {
             SchedulerKernel.scheduler.start();
             initializeAllSatSchedules();

--- a/java/code/src/com/redhat/rhn/taskomatic/core/SchedulerKernel.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/core/SchedulerKernel.java
@@ -40,6 +40,7 @@ import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.manager.webui.services.impl.SaltService;
 
+import com.suse.manager.webui.utils.MinionActionUtils;
 import org.apache.log4j.Logger;
 import org.quartz.Scheduler;
 import org.quartz.SchedulerException;
@@ -86,6 +87,8 @@ public class SchedulerKernel {
             SYSTEM_QUERY, SALT_API, CLUSTER_MANAGER);
     public static final SaltServerActionService SALT_SERVER_ACTION_SERVICE =
             new SaltServerActionService(SchedulerKernel.SYSTEM_QUERY, SALT_UTILS);
+    public static final MinionActionUtils MINION_ACTION_UTILS = new MinionActionUtils(
+            SALT_SERVER_ACTION_SERVICE, SYSTEM_QUERY, SALT_UTILS);
 
 
     /**

--- a/java/code/src/com/redhat/rhn/taskomatic/core/SchedulerKernel.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/core/SchedulerKernel.java
@@ -86,7 +86,7 @@ public class SchedulerKernel {
     public static final SaltUtils SALT_UTILS = new SaltUtils(
             SYSTEM_QUERY, SALT_API, CLUSTER_MANAGER);
     public static final SaltServerActionService SALT_SERVER_ACTION_SERVICE =
-            new SaltServerActionService(SchedulerKernel.SYSTEM_QUERY, SALT_UTILS);
+            new SaltServerActionService(SchedulerKernel.SYSTEM_QUERY, SALT_UTILS, CLUSTER_MANAGER);
     public static final MinionActionUtils MINION_ACTION_UTILS = new MinionActionUtils(
             SALT_SERVER_ACTION_SERVICE, SYSTEM_QUERY, SALT_UTILS);
 

--- a/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionChainCleanup.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionChainCleanup.java
@@ -14,7 +14,8 @@
  */
 package com.redhat.rhn.taskomatic.task;
 
-import com.suse.manager.webui.services.impl.SaltService;
+import com.redhat.rhn.taskomatic.core.SchedulerKernel;
+import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.manager.webui.utils.MinionActionUtils;
 import org.quartz.JobExecutionContext;
 
@@ -23,6 +24,8 @@ import org.quartz.JobExecutionContext;
  * Finds and cleans up Salt Action Chains for which we missed the JobReturnEvent.
  */
 public class MinionActionChainCleanup extends RhnJavaJob {
+
+    private final SystemQuery systemQuery = SchedulerKernel.SYSTEM_QUERY;
 
     /**
      * @param context the job execution context
@@ -36,7 +39,7 @@ public class MinionActionChainCleanup extends RhnJavaJob {
 
         // Measure time and calculate the total duration
         long start = System.currentTimeMillis();
-        MinionActionUtils.cleanupMinionActionChains(SaltService.INSTANCE);
+        MinionActionUtils.cleanupMinionActionChains(systemQuery);
 
         if (log.isDebugEnabled()) {
             long duration = System.currentTimeMillis() - start;

--- a/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionChainCleanup.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionChainCleanup.java
@@ -14,7 +14,7 @@
  */
 package com.redhat.rhn.taskomatic.task;
 
-import com.redhat.rhn.taskomatic.core.SchedulerKernel;
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.suse.manager.webui.utils.MinionActionUtils;
 import org.quartz.JobExecutionContext;
 
@@ -24,7 +24,7 @@ import org.quartz.JobExecutionContext;
  */
 public class MinionActionChainCleanup extends RhnJavaJob {
 
-    private final MinionActionUtils minionActionUtils = SchedulerKernel.MINION_ACTION_UTILS;
+    private final MinionActionUtils minionActionUtils = GlobalInstanceHolder.MINION_ACTION_UTILS;
 
     /**
      * @param context the job execution context

--- a/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionChainCleanup.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionChainCleanup.java
@@ -15,7 +15,6 @@
 package com.redhat.rhn.taskomatic.task;
 
 import com.redhat.rhn.taskomatic.core.SchedulerKernel;
-import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.manager.webui.utils.MinionActionUtils;
 import org.quartz.JobExecutionContext;
 
@@ -25,7 +24,7 @@ import org.quartz.JobExecutionContext;
  */
 public class MinionActionChainCleanup extends RhnJavaJob {
 
-    private final SystemQuery systemQuery = SchedulerKernel.SYSTEM_QUERY;
+    private final MinionActionUtils minionActionUtils = SchedulerKernel.MINION_ACTION_UTILS;
 
     /**
      * @param context the job execution context
@@ -39,7 +38,7 @@ public class MinionActionChainCleanup extends RhnJavaJob {
 
         // Measure time and calculate the total duration
         long start = System.currentTimeMillis();
-        MinionActionUtils.cleanupMinionActionChains(systemQuery);
+        minionActionUtils.cleanupMinionActionChains();
 
         if (log.isDebugEnabled()) {
             long duration = System.currentTimeMillis() - start;

--- a/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionChainExecutor.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionChainExecutor.java
@@ -38,7 +38,7 @@ public class MinionActionChainExecutor extends RhnJavaJob {
     private static final int ACTION_DATABASE_GRACE_TIME = 10000;
     private static final long MAXIMUM_TIMEDELTA_FOR_SCHEDULED_ACTIONS = 24; // hours
 
-    private SaltServerActionService saltServerActionService = new SaltServerActionService(SchedulerKernel.SYSTEM_QUERY);
+    private final SaltServerActionService saltServerActionService = SchedulerKernel.SALT_SERVER_ACTION_SERVICE;
 
     /**
      * @param context the job execution context

--- a/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionChainExecutor.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionChainExecutor.java
@@ -14,11 +14,11 @@
  */
 package com.redhat.rhn.taskomatic.task;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.action.ActionChain;
 import com.redhat.rhn.domain.action.ActionChainEntry;
 import com.redhat.rhn.domain.action.ActionChainFactory;
-import com.redhat.rhn.taskomatic.core.SchedulerKernel;
 import com.suse.manager.webui.services.SaltServerActionService;
 
 import java.time.Duration;
@@ -38,7 +38,7 @@ public class MinionActionChainExecutor extends RhnJavaJob {
     private static final int ACTION_DATABASE_GRACE_TIME = 10000;
     private static final long MAXIMUM_TIMEDELTA_FOR_SCHEDULED_ACTIONS = 24; // hours
 
-    private final SaltServerActionService saltServerActionService = SchedulerKernel.SALT_SERVER_ACTION_SERVICE;
+    private final SaltServerActionService saltServerActionService = GlobalInstanceHolder.SALT_SERVER_ACTION_SERVICE;
 
     /**
      * @param context the job execution context

--- a/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionCleanup.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionCleanup.java
@@ -14,6 +14,7 @@
  */
 package com.redhat.rhn.taskomatic.task;
 
+import com.redhat.rhn.taskomatic.core.SchedulerKernel;
 import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.manager.webui.utils.MinionActionUtils;
 
@@ -27,6 +28,8 @@ import org.quartz.JobExecutionContext;
  */
 public class MinionActionCleanup extends RhnJavaJob {
 
+    private final MinionActionUtils minionActionUtils = SchedulerKernel.MINION_ACTION_UTILS;
+
     /**
      * @param context the job execution context
      * @see org.quartz.Job#execute(JobExecutionContext)
@@ -39,11 +42,11 @@ public class MinionActionCleanup extends RhnJavaJob {
 
         // Measure time and calculate the total duration
         long start = System.currentTimeMillis();
-        MinionActionUtils.cleanupMinionActions(SaltService.INSTANCE);
+        minionActionUtils.cleanupMinionActions();
 
         // Delete script files for script actions that have completed
         try {
-            MinionActionUtils.cleanupScriptActions();
+            minionActionUtils.cleanupScriptActions();
         }
         catch (IOException e) {
             log.error("Could not cleanup script files: " + e.getMessage(), e);

--- a/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionCleanup.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionCleanup.java
@@ -14,7 +14,7 @@
  */
 package com.redhat.rhn.taskomatic.task;
 
-import com.redhat.rhn.taskomatic.core.SchedulerKernel;
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.suse.manager.webui.utils.MinionActionUtils;
 
 import java.io.IOException;
@@ -27,7 +27,7 @@ import org.quartz.JobExecutionContext;
  */
 public class MinionActionCleanup extends RhnJavaJob {
 
-    private final MinionActionUtils minionActionUtils = SchedulerKernel.MINION_ACTION_UTILS;
+    private final MinionActionUtils minionActionUtils = GlobalInstanceHolder.MINION_ACTION_UTILS;
 
     /**
      * @param context the job execution context

--- a/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionCleanup.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionCleanup.java
@@ -15,7 +15,6 @@
 package com.redhat.rhn.taskomatic.task;
 
 import com.redhat.rhn.taskomatic.core.SchedulerKernel;
-import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.manager.webui.utils.MinionActionUtils;
 
 import java.io.IOException;

--- a/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionExecutor.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionExecutor.java
@@ -14,6 +14,7 @@
  */
 package com.redhat.rhn.taskomatic.task;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionFactory;
 
@@ -23,7 +24,6 @@ import com.redhat.rhn.domain.server.MinionServerFactory;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.domain.user.UserFactory;
 import com.redhat.rhn.manager.system.SystemManager;
-import com.redhat.rhn.taskomatic.core.SchedulerKernel;
 import com.suse.manager.webui.services.SaltServerActionService;
 
 import org.quartz.JobExecutionContext;
@@ -44,7 +44,7 @@ public class MinionActionExecutor extends RhnJavaJob {
     private static final int ACTION_DATABASE_POLL_TIME = 100;
     private static final long MAXIMUM_TIMEDELTA_FOR_SCHEDULED_ACTIONS = 24; // hours
 
-    private SaltServerActionService saltServerActionService = SchedulerKernel.SALT_SERVER_ACTION_SERVICE;
+    private SaltServerActionService saltServerActionService = GlobalInstanceHolder.SALT_SERVER_ACTION_SERVICE;
 
     /**
      * @param context the job execution context

--- a/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionExecutor.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionExecutor.java
@@ -44,7 +44,7 @@ public class MinionActionExecutor extends RhnJavaJob {
     private static final int ACTION_DATABASE_POLL_TIME = 100;
     private static final long MAXIMUM_TIMEDELTA_FOR_SCHEDULED_ACTIONS = 24; // hours
 
-    private SaltServerActionService saltServerActionService = new SaltServerActionService(SchedulerKernel.SYSTEM_QUERY);
+    private SaltServerActionService saltServerActionService = SchedulerKernel.SALT_SERVER_ACTION_SERVICE;
 
     /**
      * @param context the job execution context

--- a/java/code/src/com/redhat/rhn/taskomatic/task/MinionCheckin.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/MinionCheckin.java
@@ -14,10 +14,10 @@
  */
 package com.redhat.rhn.taskomatic.task;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.taskomatic.task.checkin.CheckinCandidatesResolver;
 import com.redhat.rhn.taskomatic.task.checkin.SystemSummary;
 
-import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.salt.netapi.datatypes.target.MinionList;
 import com.suse.salt.netapi.exception.SaltException;
@@ -33,7 +33,7 @@ import org.quartz.JobExecutionContext;
  */
 public class MinionCheckin extends RhnJavaJob {
 
-    private SystemQuery systemQuery = SaltService.INSTANCE;
+    private SystemQuery systemQuery = GlobalInstanceHolder.SYSTEM_QUERY;
 
     /**
      * @param context the job execution context

--- a/java/code/src/com/redhat/rhn/taskomatic/task/RebootActionCleanup.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/RebootActionCleanup.java
@@ -14,6 +14,7 @@
  */
 package com.redhat.rhn.taskomatic.task;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.db.datasource.ModeFactory;
 import com.redhat.rhn.common.db.datasource.DataResult;
 import com.redhat.rhn.common.db.datasource.SelectMode;
@@ -26,7 +27,6 @@ import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.server.Server;
 
 import com.suse.manager.utils.MinionServerUtils;
-import com.suse.manager.webui.services.impl.SaltService;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 
@@ -108,7 +108,7 @@ public class RebootActionCleanup extends RhnJavaJob {
             s.asMinionServer()
                     .filter(MinionServerUtils::isSshPushMinion)
                     .ifPresent(minion ->
-                        SaltService.INSTANCE.getSaltSSHService().cleanPendingActionChainAsync(minion));
+                        GlobalInstanceHolder.SYSTEM_QUERY.getSaltSSHService().cleanPendingActionChainAsync(minion));
         }
 
         return aIds;

--- a/java/code/src/com/redhat/rhn/taskomatic/task/TokenCleanup.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/TokenCleanup.java
@@ -14,12 +14,13 @@
  */
 package com.redhat.rhn.taskomatic.task;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.domain.channel.AccessTokenFactory;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.MinionServerFactory;
-import com.suse.manager.webui.services.impl.SaltService;
+import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.manager.webui.services.pillar.MinionPillarManager;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
@@ -35,6 +36,8 @@ import java.util.stream.Stream;
  * @version $Rev$
  */
 public class TokenCleanup extends RhnJavaJob {
+
+    private final SystemQuery systemQuery = GlobalInstanceHolder.SYSTEM_QUERY;
 
     /**
      * {@inheritDoc}
@@ -66,7 +69,7 @@ public class TokenCleanup extends RhnJavaJob {
 
             List<String> changedMinionIds = changedMinions.map(m -> m.getMinionId()).collect(Collectors.toList());
             if (Config.get().getBoolean(ConfigDefaults.TOKEN_REFRESH_AUTO_DEPLOY)) {
-                SaltService.INSTANCE.deployChannels(changedMinionIds);
+                systemQuery.deployChannels(changedMinionIds);
             }
             else {
                 log.warn("The following minions got channel tokens changed and" +

--- a/java/code/src/com/redhat/rhn/taskomatic/task/gatherer/VirtualHostManagerProcessor.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/gatherer/VirtualHostManagerProcessor.java
@@ -15,6 +15,7 @@
 
 package com.redhat.rhn.taskomatic.task.gatherer;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.server.CPU;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.ServerFactory;
@@ -49,7 +50,7 @@ public class VirtualHostManagerProcessor {
     private Set<Server> serversToDelete;
     private Set<VirtualHostManagerNodeInfo> nodesToDelete;
     private Logger log;
-    private SystemEntitlementManager systemEntitlementManager = SystemEntitlementManager.INSTANCE;
+    private SystemEntitlementManager systemEntitlementManager = GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER;
 
     /**
      * Instantiates a new virtual host manager processor, will update a virtual

--- a/java/code/src/com/redhat/rhn/taskomatic/task/sshpush/SSHPushDriver.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/sshpush/SSHPushDriver.java
@@ -23,9 +23,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionFactory;
-import com.redhat.rhn.taskomatic.core.SchedulerKernel;
 import com.suse.manager.utils.SaltUtils;
 import org.apache.log4j.Logger;
 
@@ -180,10 +180,10 @@ public class SSHPushDriver implements QueueDriver {
         // Create a Salt worker if the system has a minion id
         if (system.getMinionId() != null) {
             return new SSHPushWorkerSalt(getLogger(), system,
-                    SchedulerKernel.SYSTEM_QUERY,
-                    SchedulerKernel.SYSTEM_QUERY.getSaltSSHService(),
-                    SchedulerKernel.SALT_SERVER_ACTION_SERVICE,
-                    SchedulerKernel.SALT_UTILS);
+                    GlobalInstanceHolder.SYSTEM_QUERY,
+                    GlobalInstanceHolder.SYSTEM_QUERY.getSaltSSHService(),
+                    GlobalInstanceHolder.SALT_SERVER_ACTION_SERVICE,
+                    GlobalInstanceHolder.SALT_UTILS);
         }
         else {
             return new SSHPushWorker(getLogger(), remotePort, system);

--- a/java/code/src/com/redhat/rhn/taskomatic/task/sshpush/SSHPushDriver.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/sshpush/SSHPushDriver.java
@@ -25,6 +25,7 @@ import java.util.Set;
 
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionFactory;
+import com.redhat.rhn.taskomatic.core.SchedulerKernel;
 import com.suse.manager.utils.SaltUtils;
 import org.apache.log4j.Logger;
 
@@ -178,7 +179,11 @@ public class SSHPushDriver implements QueueDriver {
 
         // Create a Salt worker if the system has a minion id
         if (system.getMinionId() != null) {
-            return new SSHPushWorkerSalt(getLogger(), system);
+            return new SSHPushWorkerSalt(getLogger(), system,
+                    SchedulerKernel.SYSTEM_QUERY,
+                    SchedulerKernel.SYSTEM_QUERY.getSaltSSHService(),
+                    SchedulerKernel.SALT_SERVER_ACTION_SERVICE,
+                    SchedulerKernel.SALT_UTILS);
         }
         else {
             return new SSHPushWorker(getLogger(), remotePort, system);

--- a/java/code/src/com/redhat/rhn/taskomatic/task/sshpush/SSHPushWorkerSalt.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/sshpush/SSHPushWorkerSalt.java
@@ -26,7 +26,6 @@ import com.suse.manager.reactor.messaging.ApplyStatesEventMessage;
 import com.suse.manager.utils.SaltUtils;
 import com.suse.manager.webui.services.SaltServerActionService;
 import com.suse.manager.webui.services.impl.SaltSSHService;
-import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.manager.webui.utils.salt.custom.SystemInfo;
 import com.suse.salt.netapi.calls.LocalCall;
@@ -58,19 +57,8 @@ public class SSHPushWorkerSalt implements QueueWorker {
     private SystemQuery systemQuery;
     private SaltSSHService saltSSHService;
     private SaltServerActionService saltServerActionService;
+    private SaltUtils saltUtils;
 
-    /**
-     * Constructor.
-     * @param logger Logger for this instance
-     * @param systemIn the system to work with
-     */
-    public SSHPushWorkerSalt(Logger logger, SystemSummary systemIn) {
-        log = logger;
-        system = systemIn;
-        systemQuery = SaltService.INSTANCE;
-        saltSSHService = SaltService.INSTANCE.getSaltSSHService();
-        saltServerActionService = new SaltServerActionService(systemQuery);
-    }
 
     /**
      * Constructor.
@@ -79,15 +67,17 @@ public class SSHPushWorkerSalt implements QueueWorker {
      * @param saltServiceIn the salt service to work with
      * @param saltSSHServiceIn the {@link SaltSSHService} to work with
      * @param saltServerActionServiceIn the {@link SaltServerActionService} to work with
+     * @param saltUtilsIn
      */
     public SSHPushWorkerSalt(Logger logger, SystemSummary systemIn,
             SystemQuery saltServiceIn, SaltSSHService saltSSHServiceIn,
-            SaltServerActionService saltServerActionServiceIn) {
+            SaltServerActionService saltServerActionServiceIn, SaltUtils saltUtilsIn) {
         log = logger;
         system = systemIn;
         systemQuery = saltServiceIn;
         saltSSHService = saltSSHServiceIn;
         saltServerActionService = saltServerActionServiceIn;
+        saltUtils = saltUtilsIn;
     }
 
     /**
@@ -221,7 +211,7 @@ public class SSHPushWorkerSalt implements QueueWorker {
             log.error("Could not resume pending action chain execution, no next_chunk returned by " +
                     "mgractionchains.get_pending_resume for ssh minion " + minion.getMinionId());
             saltSSHService.cleanPendingActionChainAsync(minion);
-            SaltServerActionService.failActionChain(minion.getMinionId(), nextActionId,
+            saltServerActionService.failActionChain(minion.getMinionId(), nextActionId,
                     Optional.of("Could not resume pending action chain execution, no next_chunk returned by " +
                             "mgractionchains.get_pending_resume"));
             return false;
@@ -231,7 +221,7 @@ public class SSHPushWorkerSalt implements QueueWorker {
             log.error("Could not resume pending action chain execution, no ssh_extra_filerefs returned by " +
                     "mgractionchains.get_pending_resume for ssh minion " + minion.getMinionId());
             saltSSHService.cleanPendingActionChainAsync(minion);
-            SaltServerActionService.failActionChain(minion.getMinionId(), nextActionId,
+            saltServerActionService.failActionChain(minion.getMinionId(), nextActionId,
                     Optional.of("Could not resume pending action chain execution, no ssh_extra_filerefs " +
                             "returned by mgractionchains.get_pending_resume"));
             return false;
@@ -303,7 +293,7 @@ public class SSHPushWorkerSalt implements QueueWorker {
                             }
                     )).orElse("Unknown error");
 
-                    SaltServerActionService.failActionChain(minion.getMinionId(), nextActionId,
+                    saltServerActionService.failActionChain(minion.getMinionId(), nextActionId,
                             Optional.of("Error handling action chain execution: " + errMsg));
                 }
             }
@@ -351,7 +341,7 @@ public class SSHPushWorkerSalt implements QueueWorker {
             Map<String, Result<SystemInfo>> systemInfoMap = saltSSHService.callSyncSSH(systeminfo, minionTarget);
             systemInfoMap.entrySet().stream().forEach(entry-> entry.getValue().result().ifPresent(si-> {
                 Optional<MinionServer> minionServer = MinionServerFactory.findByMinionId(entry.getKey());
-                minionServer.ifPresent(minion -> SaltUtils.INSTANCE.updateSystemInfo(si, minion));
+                minionServer.ifPresent(minion -> saltUtils.updateSystemInfo(si, minion));
             }));
         }
         catch (SaltException ex) {

--- a/java/code/src/com/redhat/rhn/taskomatic/task/sshpush/test/SSHPushWorkerSaltTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/sshpush/test/SSHPushWorkerSaltTest.java
@@ -31,6 +31,7 @@ import com.redhat.rhn.taskomatic.task.threaded.TaskQueue;
 import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
 import com.redhat.rhn.testing.TestUtils;
 import com.suse.manager.clusters.ClusterManager;
+import com.suse.manager.utils.SaltKeyUtils;
 import com.suse.manager.utils.SaltUtils;
 import com.suse.manager.webui.controllers.utils.test.SSHMinionBootstrapperTest;
 import com.suse.manager.webui.services.SaltServerActionService;
@@ -313,12 +314,13 @@ public class SSHPushWorkerSaltTest extends JMockBaseTestCaseWithUser {
         FormulaManager formulaManager = new FormulaManager(saltApi);
         ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);
         SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, clusterManager, formulaManager);
+        SaltKeyUtils saltKeyUtils = new SaltKeyUtils(systemQuery);
         return new SSHPushWorkerSalt(
                 logger,
                 sshPushSystemMock,
                 systemQuery,
                 saltSSHServiceMock,
-                new SaltServerActionService(systemQuery, saltUtils, clusterManager, formulaManager),
+                new SaltServerActionService(systemQuery, saltUtils, clusterManager, formulaManager, saltKeyUtils),
                 saltUtils
         );
     }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/sshpush/test/SSHPushWorkerSaltTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/sshpush/test/SSHPushWorkerSaltTest.java
@@ -27,6 +27,7 @@ import com.redhat.rhn.taskomatic.task.sshpush.SSHPushWorkerSalt;
 import com.redhat.rhn.taskomatic.task.threaded.TaskQueue;
 import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
 import com.redhat.rhn.testing.TestUtils;
+import com.suse.manager.utils.SaltUtils;
 import com.suse.manager.webui.controllers.utils.test.SSHMinionBootstrapperTest;
 import com.suse.manager.webui.services.SaltServerActionService;
 import com.suse.manager.webui.services.impl.SaltSSHService;
@@ -303,12 +304,14 @@ public class SSHPushWorkerSaltTest extends JMockBaseTestCaseWithUser {
     }
 
     private SSHPushWorkerSalt successWorker(SystemQuery saltServiceMock) {
+        SaltUtils saltUtils = new SaltUtils();
         return new SSHPushWorkerSalt(
                 logger,
                 sshPushSystemMock,
                 saltServiceMock,
                 saltSSHServiceMock,
-                new SaltServerActionService(new SaltService())
+                new SaltServerActionService(new SaltService(), saltUtils),
+                saltUtils
         );
     }
 }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/sshpush/test/SSHPushWorkerSaltTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/sshpush/test/SSHPushWorkerSaltTest.java
@@ -14,7 +14,6 @@
  */
 package com.redhat.rhn.taskomatic.task.sshpush.test;
 
-import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionFactory;
 import com.redhat.rhn.domain.action.ActionStatus;
@@ -310,7 +309,7 @@ public class SSHPushWorkerSaltTest extends JMockBaseTestCaseWithUser {
     }
 
     private SSHPushWorkerSalt successWorker(SystemQuery systemQuery, SaltApi saltApi) {
-        ServerGroupManager serverGroupManager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
+        ServerGroupManager serverGroupManager = new ServerGroupManager();
         FormulaManager formulaManager = new FormulaManager(saltApi);
         ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);
         SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, clusterManager, formulaManager, serverGroupManager);

--- a/java/code/src/com/redhat/rhn/taskomatic/task/sshpush/test/SSHPushWorkerSaltTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/sshpush/test/SSHPushWorkerSaltTest.java
@@ -318,7 +318,7 @@ public class SSHPushWorkerSaltTest extends JMockBaseTestCaseWithUser {
                 sshPushSystemMock,
                 systemQuery,
                 saltSSHServiceMock,
-                new SaltServerActionService(systemQuery, saltUtils, clusterManager),
+                new SaltServerActionService(systemQuery, saltUtils, clusterManager, formulaManager),
                 saltUtils
         );
     }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/sshpush/test/SSHPushWorkerSaltTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/sshpush/test/SSHPushWorkerSaltTest.java
@@ -35,8 +35,9 @@ import com.suse.manager.utils.SaltUtils;
 import com.suse.manager.webui.controllers.utils.test.SSHMinionBootstrapperTest;
 import com.suse.manager.webui.services.SaltServerActionService;
 import com.suse.manager.webui.services.iface.SaltApi;
+import com.suse.manager.webui.services.test.TestSaltApi;
+import com.suse.manager.webui.services.test.TestSystemQuery;
 import com.suse.manager.webui.services.impl.SaltSSHService;
-import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.manager.webui.utils.salt.custom.SystemInfo;
 import com.suse.salt.netapi.calls.LocalCall;
@@ -109,14 +110,14 @@ public class SSHPushWorkerSaltTest extends JMockBaseTestCaseWithUser {
         ServerAction serverAction = createChildServerAction(action,
                 ActionFactory.STATUS_PICKED_UP, 5L);
         ActionFactory.save(action);
-        SaltService saltService = new SaltService() {
+        SystemQuery systemQuery = new TestSystemQuery() {
             @Override
             public Optional<Boolean> ping(String minionId) {
                 return Optional.of(true);
             }
         };
 
-        SSHPushWorkerSalt worker = successWorker(saltService, saltService);
+        SSHPushWorkerSalt worker = successWorker(systemQuery, new TestSaltApi());
 
         context().checking(new Expectations() {{
            
@@ -180,13 +181,13 @@ public class SSHPushWorkerSaltTest extends JMockBaseTestCaseWithUser {
                 ActionFactory.STATUS_PICKED_UP, 5L);
         ActionFactory.save(upcomingAction);
 
-        SaltService saltService = new SaltService() {
+        SystemQuery systemQuery = new TestSystemQuery() {
             @Override
             public Optional<Boolean> ping(String minionId) {
                 return Optional.of(true);
             }
         };
-        SSHPushWorkerSalt worker = successWorker(saltService, saltService);
+        SSHPushWorkerSalt worker = successWorker(systemQuery, new TestSaltApi());
 
         context().checking(new Expectations() {{
 
@@ -228,7 +229,7 @@ public class SSHPushWorkerSaltTest extends JMockBaseTestCaseWithUser {
                 ActionFactory.STATUS_PICKED_UP, 5L);
         ActionFactory.save(upcomingAction);
 
-        SaltService saltService = new SaltService() {
+        SystemQuery systemQuery = new TestSystemQuery() {
             @Override
             public Optional<Boolean> ping(String minionId) {
                 return Optional.of(true);
@@ -246,7 +247,7 @@ public class SSHPushWorkerSaltTest extends JMockBaseTestCaseWithUser {
             }
         };
 
-        SSHPushWorkerSalt worker = successWorker(saltService, saltService);
+        SSHPushWorkerSalt worker = successWorker(systemQuery, new TestSaltApi());
 
         context().checking(new Expectations() {{
             oneOf(saltSSHServiceMock).cleanPendingActionChainAsync(with(any(MinionServer.class)));

--- a/java/code/src/com/redhat/rhn/taskomatic/task/sshpush/test/SSHPushWorkerSaltTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/sshpush/test/SSHPushWorkerSaltTest.java
@@ -312,7 +312,7 @@ public class SSHPushWorkerSaltTest extends JMockBaseTestCaseWithUser {
         ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
         FormulaManager formulaManager = new FormulaManager(saltApi);
         ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);
-        SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, clusterManager);
+        SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, clusterManager, formulaManager);
         return new SSHPushWorkerSalt(
                 logger,
                 sshPushSystemMock,

--- a/java/code/src/com/redhat/rhn/taskomatic/task/sshpush/test/SSHPushWorkerSaltTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/sshpush/test/SSHPushWorkerSaltTest.java
@@ -14,6 +14,7 @@
  */
 package com.redhat.rhn.taskomatic.task.sshpush.test;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionFactory;
 import com.redhat.rhn.domain.action.ActionStatus;
@@ -21,7 +22,6 @@ import com.redhat.rhn.domain.action.server.ServerAction;
 import com.redhat.rhn.domain.action.test.ActionFactoryTest;
 import com.redhat.rhn.domain.org.OrgFactory;
 import com.redhat.rhn.domain.server.MinionServer;
-import com.redhat.rhn.domain.server.ServerGroup;
 import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
 import com.redhat.rhn.manager.formula.FormulaManager;
 import com.redhat.rhn.manager.system.ServerGroupManager;
@@ -310,10 +310,10 @@ public class SSHPushWorkerSaltTest extends JMockBaseTestCaseWithUser {
     }
 
     private SSHPushWorkerSalt successWorker(SystemQuery systemQuery, SaltApi saltApi) {
-        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        ServerGroupManager serverGroupManager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
         FormulaManager formulaManager = new FormulaManager(saltApi);
         ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);
-        SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, clusterManager, formulaManager);
+        SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, clusterManager, formulaManager, serverGroupManager);
         SaltKeyUtils saltKeyUtils = new SaltKeyUtils(systemQuery);
         return new SSHPushWorkerSalt(
                 logger,

--- a/java/code/src/com/redhat/rhn/taskomatic/task/sshpush/test/SSHPushWorkerSaltTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/sshpush/test/SSHPushWorkerSaltTest.java
@@ -21,7 +21,10 @@ import com.redhat.rhn.domain.action.server.ServerAction;
 import com.redhat.rhn.domain.action.test.ActionFactoryTest;
 import com.redhat.rhn.domain.org.OrgFactory;
 import com.redhat.rhn.domain.server.MinionServer;
+import com.redhat.rhn.domain.server.ServerGroup;
 import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
+import com.redhat.rhn.manager.formula.FormulaManager;
+import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.taskomatic.task.checkin.SystemSummary;
 import com.redhat.rhn.taskomatic.task.sshpush.SSHPushWorkerSalt;
 import com.redhat.rhn.taskomatic.task.threaded.TaskQueue;
@@ -306,13 +309,16 @@ public class SSHPushWorkerSaltTest extends JMockBaseTestCaseWithUser {
     }
 
     private SSHPushWorkerSalt successWorker(SystemQuery systemQuery, SaltApi saltApi) {
-        SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, ClusterManager.instance());
+        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        FormulaManager formulaManager = new FormulaManager(saltApi);
+        ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);
+        SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, clusterManager);
         return new SSHPushWorkerSalt(
                 logger,
                 sshPushSystemMock,
                 systemQuery,
                 saltSSHServiceMock,
-                new SaltServerActionService(systemQuery, saltUtils),
+                new SaltServerActionService(systemQuery, saltUtils, clusterManager),
                 saltUtils
         );
     }

--- a/java/code/src/com/redhat/rhn/testing/ImageTestUtils.java
+++ b/java/code/src/com/redhat/rhn/testing/ImageTestUtils.java
@@ -15,6 +15,7 @@
 
 package com.redhat.rhn.testing;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.credentials.Credentials;
 import com.redhat.rhn.domain.credentials.CredentialsFactory;
@@ -47,7 +48,7 @@ import java.util.Set;
  */
 public class ImageTestUtils {
 
-    private static SystemEntitlementManager systemEntitlementManager = SystemEntitlementManager.INSTANCE;
+    private static SystemEntitlementManager systemEntitlementManager = GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER;
 
     private ImageTestUtils() { }
 

--- a/java/code/src/com/redhat/rhn/testing/JMockBaseTestCaseWithUser.java
+++ b/java/code/src/com/redhat/rhn/testing/JMockBaseTestCaseWithUser.java
@@ -14,10 +14,10 @@
  */
 package com.redhat.rhn.testing;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.kickstart.test.KickstartDataTest;
 import com.redhat.rhn.domain.user.User;
 
-import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.suse.manager.webui.services.SaltStateGeneratorService;
 import com.suse.manager.webui.services.pillar.MinionGeneralPillarGenerator;
 import com.suse.manager.webui.services.pillar.MinionGroupMembershipPillarGenerator;
@@ -59,7 +59,7 @@ public abstract class JMockBaseTestCaseWithUser extends RhnJmockBaseTestCase {
         SaltStateGeneratorService.INSTANCE.setSuseManagerStatesFilesRoot(tmpSaltRoot
                 .toAbsolutePath());
         Files.createDirectory(tmpSaltRoot.resolve(SALT_CONFIG_STATES_DIR));
-        ServerGroupManager.getInstance()
+        GlobalInstanceHolder.SERVER_GROUP_MANAGER
                 .setMinionGroupMembershipPillarFileManager(minionGroupMembershipPillarFileManager);
     }
 

--- a/java/code/src/com/redhat/rhn/testing/RhnBaseTestCase.java
+++ b/java/code/src/com/redhat/rhn/testing/RhnBaseTestCase.java
@@ -19,7 +19,8 @@ import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.common.messaging.MessageQueue;
 import com.redhat.rhn.common.util.Asserts;
 
-import com.suse.manager.webui.services.impl.SaltService;
+import com.suse.manager.webui.services.test.TestSaltApi;
+import com.suse.manager.webui.services.test.TestSystemQuery;
 
 import org.apache.commons.beanutils.PropertyUtils;
 import org.apache.log4j.Level;
@@ -45,7 +46,6 @@ import junit.framework.TestCase;
  */
 public abstract class RhnBaseTestCase extends TestCase {
 
-    private final SaltService saltService = new SaltService();
     /**
      * Constructs a TestCase with the given name.
      * @param name Name of TestCase.
@@ -59,7 +59,7 @@ public abstract class RhnBaseTestCase extends TestCase {
      */
     public RhnBaseTestCase() {
         super();
-        MessageQueue.configureDefaultActions(saltService, saltService);
+        MessageQueue.configureDefaultActions(new TestSystemQuery(), new TestSaltApi());
     }
 
     /**
@@ -78,7 +78,6 @@ public abstract class RhnBaseTestCase extends TestCase {
     protected void tearDown() throws Exception {
         super.tearDown();
         TestCaseHelper.tearDownHelper();
-        saltService.close();
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/testing/ServerGroupTestUtils.java
+++ b/java/code/src/com/redhat/rhn/testing/ServerGroupTestUtils.java
@@ -14,13 +14,13 @@
  */
 package com.redhat.rhn.testing;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.org.Org;
 import com.redhat.rhn.domain.server.EntitlementServerGroup;
 import com.redhat.rhn.domain.server.ManagedServerGroup;
 import com.redhat.rhn.domain.server.ServerGroupType;
 import com.redhat.rhn.domain.server.test.ServerGroupTest;
 import com.redhat.rhn.domain.user.User;
-import com.redhat.rhn.manager.system.ServerGroupManager;
 
 
 /**
@@ -52,7 +52,7 @@ public class ServerGroupTestUtils {
      */
     public static ManagedServerGroup createManaged(User user) {
         ServerGroupTest.checkSysGroupAdminRole(user);
-        return ServerGroupManager.getInstance().
+        return GlobalInstanceHolder.SERVER_GROUP_MANAGER.
                                         create(user, NAME + TestUtils.randomString(),
                                                     DESCRIPTION);
     }

--- a/java/code/src/com/redhat/rhn/testing/ServerTestUtils.java
+++ b/java/code/src/com/redhat/rhn/testing/ServerTestUtils.java
@@ -14,6 +14,7 @@
  */
 package com.redhat.rhn.testing;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.errata.Errata;
@@ -320,7 +321,7 @@ public class ServerTestUtils {
         Server existingHost = ServerTestUtils.createTestSystem(user);
         existingHost.setName(TestUtils.randomString());
         existingHost.setDigitalServerId(digitalServerId);
-        SystemEntitlementManager.INSTANCE.setBaseEntitlement(existingHost,
+        GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER.setBaseEntitlement(existingHost,
                 EntitlementManager.getByName("foreign_entitled"));
         ServerFactory.save(existingHost);
         return existingHost;

--- a/java/code/src/com/redhat/rhn/webapp/RhnServletListener.java
+++ b/java/code/src/com/redhat/rhn/webapp/RhnServletListener.java
@@ -16,11 +16,16 @@ package com.redhat.rhn.webapp;
 
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.common.messaging.MessageQueue;
+import com.redhat.rhn.manager.formula.FormulaManager;
 import com.redhat.rhn.manager.satellite.StartupTasksCommand;
 import com.redhat.rhn.manager.satellite.UpgradeCommand;
 
+import com.redhat.rhn.manager.system.ServerGroupManager;
+import com.suse.manager.clusters.ClusterManager;
 import com.suse.manager.reactor.SaltReactor;
 
+import com.suse.manager.utils.SaltUtils;
+import com.suse.manager.webui.services.SaltServerActionService;
 import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.manager.webui.services.impl.SaltService;
@@ -55,9 +60,17 @@ public class RhnServletListener implements ServletContextListener {
     private boolean loggingStarted = false;
     private final SystemQuery systemQuery = SaltService.INSTANCE;
     private final SaltApi saltApi = SaltService.INSTANCE_SALT_API;
+    private final ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+    private final FormulaManager formulaManager = FormulaManager.getInstance();
+    private final ClusterManager clusterManager = new ClusterManager(
+            saltApi, systemQuery, serverGroupManager, formulaManager
+    );
+    private final SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, clusterManager);
+    private final SaltServerActionService saltServerActionService = new SaltServerActionService(
+            systemQuery, saltUtils);
 
     // Salt event reactor instance
-    private final SaltReactor saltReactor = new SaltReactor(saltApi, systemQuery);
+    private final SaltReactor saltReactor = new SaltReactor(saltApi, systemQuery, saltServerActionService);
 
     private void startMessaging() {
         // Start the MessageQueue thread listening for

--- a/java/code/src/com/redhat/rhn/webapp/RhnServletListener.java
+++ b/java/code/src/com/redhat/rhn/webapp/RhnServletListener.java
@@ -70,7 +70,7 @@ public class RhnServletListener implements ServletContextListener {
             systemQuery, saltUtils);
 
     // Salt event reactor instance
-    private final SaltReactor saltReactor = new SaltReactor(saltApi, systemQuery, saltServerActionService);
+    private final SaltReactor saltReactor = new SaltReactor(saltApi, systemQuery, saltServerActionService, saltUtils);
 
     private void startMessaging() {
         // Start the MessageQueue thread listening for

--- a/java/code/src/com/redhat/rhn/webapp/RhnServletListener.java
+++ b/java/code/src/com/redhat/rhn/webapp/RhnServletListener.java
@@ -120,7 +120,9 @@ public class RhnServletListener implements ServletContextListener {
     /** {@inheritDoc} */
     public void contextInitialized(ServletContextEvent sce) {
         //Setting globally available instances needed by jsp pages
-        sce.getServletContext().setAttribute("menuTree", GlobalInstanceHolder.MENU_TREE);
+        if (sce != null) {
+            sce.getServletContext().setAttribute("menuTree", GlobalInstanceHolder.MENU_TREE);
+        }
 
         startMessaging();
         logStart("Messaging");

--- a/java/code/src/com/redhat/rhn/webapp/RhnServletListener.java
+++ b/java/code/src/com/redhat/rhn/webapp/RhnServletListener.java
@@ -67,7 +67,7 @@ public class RhnServletListener implements ServletContextListener {
     );
     private final SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, clusterManager);
     private final SaltServerActionService saltServerActionService = new SaltServerActionService(
-            systemQuery, saltUtils);
+            systemQuery, saltUtils, clusterManager);
 
     // Salt event reactor instance
     private final SaltReactor saltReactor = new SaltReactor(saltApi, systemQuery, saltServerActionService, saltUtils);

--- a/java/code/src/com/redhat/rhn/webapp/RhnServletListener.java
+++ b/java/code/src/com/redhat/rhn/webapp/RhnServletListener.java
@@ -14,25 +14,14 @@
  */
 package com.redhat.rhn.webapp;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.common.messaging.MessageQueue;
-import com.redhat.rhn.common.security.acl.Access;
-import com.redhat.rhn.common.security.acl.AclFactory;
-import com.redhat.rhn.frontend.taglibs.helpers.RenderUtils;
-import com.redhat.rhn.manager.formula.FormulaManager;
 import com.redhat.rhn.manager.satellite.StartupTasksCommand;
 import com.redhat.rhn.manager.satellite.UpgradeCommand;
 
-import com.redhat.rhn.manager.system.ServerGroupManager;
-import com.suse.manager.clusters.ClusterManager;
 import com.suse.manager.reactor.SaltReactor;
 
-import com.suse.manager.utils.SaltUtils;
-import com.suse.manager.webui.menu.MenuTree;
-import com.suse.manager.webui.services.SaltServerActionService;
-import com.suse.manager.webui.services.iface.SaltApi;
-import com.suse.manager.webui.services.iface.SystemQuery;
-import com.suse.manager.webui.services.impl.SaltService;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 
@@ -63,29 +52,17 @@ public class RhnServletListener implements ServletContextListener {
     private boolean hibernateStarted = false;
     private boolean loggingStarted = false;
 
-    private static final SystemQuery SYSTEM_QUERY = SaltService.INSTANCE;
-    private static final SaltApi SALT_API = SaltService.INSTANCE_SALT_API;
-    private static final ServerGroupManager SERVER_GROUP_MANAGER = ServerGroupManager.getInstance();
-    private static final FormulaManager FORMULA_MANAGER = FormulaManager.getInstance();
-    public static final ClusterManager CLUSTER_MANAGER = new ClusterManager(
-            SALT_API, SYSTEM_QUERY, SERVER_GROUP_MANAGER, FORMULA_MANAGER
-    );
-    private static final SaltUtils SALT_UTILS = new SaltUtils(SYSTEM_QUERY, SALT_API, CLUSTER_MANAGER);
-    private static final SaltServerActionService SALT_SERVER_ACTION_SERVICE = new SaltServerActionService(
-            SYSTEM_QUERY, SALT_UTILS, CLUSTER_MANAGER);
-    private static final Access ACCESS = new Access(CLUSTER_MANAGER);
-    public static final AclFactory ACL_FACTORY = new AclFactory(ACCESS);
-    private static final MenuTree MENU_TREE = new MenuTree(ACL_FACTORY);
-    public static final RenderUtils RENDER_UTILS = new RenderUtils(ACL_FACTORY);
-
     // Salt event reactor instance
-    private final SaltReactor saltReactor = new SaltReactor(SALT_API, SYSTEM_QUERY, SALT_SERVER_ACTION_SERVICE, SALT_UTILS);
+    private final SaltReactor saltReactor = new SaltReactor(
+            GlobalInstanceHolder.SALT_API, GlobalInstanceHolder.SYSTEM_QUERY,
+            GlobalInstanceHolder.SALT_SERVER_ACTION_SERVICE,
+            GlobalInstanceHolder.SALT_UTILS);
 
     private void startMessaging() {
         // Start the MessageQueue thread listening for
         // Events
         MessageQueue.startMessaging();
-        MessageQueue.configureDefaultActions(SYSTEM_QUERY, SALT_API);
+        MessageQueue.configureDefaultActions(GlobalInstanceHolder.SYSTEM_QUERY, GlobalInstanceHolder.SALT_API);
     }
 
     private void stopMessaging() {
@@ -143,7 +120,7 @@ public class RhnServletListener implements ServletContextListener {
     /** {@inheritDoc} */
     public void contextInitialized(ServletContextEvent sce) {
         //Setting globally available instances needed by jsp pages
-        sce.getServletContext().setAttribute("menuTree", MENU_TREE);
+        sce.getServletContext().setAttribute("menuTree", GlobalInstanceHolder.MENU_TREE);
 
         startMessaging();
         logStart("Messaging");

--- a/java/code/src/com/redhat/rhn/webapp/RhnServletListener.java
+++ b/java/code/src/com/redhat/rhn/webapp/RhnServletListener.java
@@ -119,11 +119,6 @@ public class RhnServletListener implements ServletContextListener {
 
     /** {@inheritDoc} */
     public void contextInitialized(ServletContextEvent sce) {
-        //Setting globally available instances needed by jsp pages
-        if (sce != null) {
-            sce.getServletContext().setAttribute("menuTree", GlobalInstanceHolder.MENU_TREE);
-        }
-
         startMessaging();
         logStart("Messaging");
 

--- a/java/code/src/com/suse/manager/clusters/ClusterManager.java
+++ b/java/code/src/com/suse/manager/clusters/ClusterManager.java
@@ -44,7 +44,6 @@ import com.suse.manager.reactor.utils.OptionalTypeAdapterFactory;
 import com.suse.manager.reactor.utils.ValueMap;
 import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.SystemQuery;
-import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.salt.netapi.datatypes.target.MinionList;
 import com.suse.utils.Opt;
 

--- a/java/code/src/com/suse/manager/clusters/ClusterManager.java
+++ b/java/code/src/com/suse/manager/clusters/ClusterManager.java
@@ -84,25 +84,10 @@ public class ClusterManager {
             .create();
 
 
-    private static volatile ClusterManager instance;
     private final SaltApi saltApi;
     private final SystemQuery systemQuery;
     private final ServerGroupManager serverGroupManager;
     private final FormulaManager formulaManager;
-
-    /**
-     * @return the instance
-     */
-    public static ClusterManager instance() {
-        if (instance == null) {
-            synchronized (ClusterManager.class) {
-                if (instance == null) {
-                    instance = new ClusterManager();
-                }
-            }
-        }
-        return instance;
-    }
 
     /**
      *
@@ -119,14 +104,6 @@ public class ClusterManager {
         this.systemQuery = systemQueryIn;
         this.formulaManager = formulaManagerIn;
         this.serverGroupManager = serverGroupManagerIn;
-    }
-
-    /**
-     * No arg constructor.
-     */
-    public ClusterManager() {
-        this(SaltService.INSTANCE_SALT_API, SaltService.INSTANCE,
-                ServerGroupManager.getInstance(), FormulaManager.getInstance());
     }
 
     /**

--- a/java/code/src/com/suse/manager/clusters/ClusterManager.java
+++ b/java/code/src/com/suse/manager/clusters/ClusterManager.java
@@ -85,10 +85,10 @@ public class ClusterManager {
 
 
     private static volatile ClusterManager instance;
-    private SaltApi saltApi;
-    private SystemQuery systemQuery;
-    private ServerGroupManager serverGroupManager;
-    private FormulaManager formulaManager;
+    private final SaltApi saltApi;
+    private final SystemQuery systemQuery;
+    private final ServerGroupManager serverGroupManager;
+    private final FormulaManager formulaManager;
 
     /**
      * @return the instance
@@ -105,13 +105,28 @@ public class ClusterManager {
     }
 
     /**
+     *
+     * @param saltApiIn
+     * @param systemQueryIn
+     * @param serverGroupManagerIn
+     * @param formulaManagerIn
+     */
+    public ClusterManager(SaltApi saltApiIn,
+                          SystemQuery systemQueryIn,
+                          ServerGroupManager serverGroupManagerIn,
+                          FormulaManager formulaManagerIn) {
+        this.saltApi = saltApiIn;
+        this.systemQuery = systemQueryIn;
+        this.formulaManager = formulaManagerIn;
+        this.serverGroupManager = serverGroupManagerIn;
+    }
+
+    /**
      * No arg constructor.
      */
     public ClusterManager() {
-        this.saltApi = SaltService.INSTANCE_SALT_API;
-        this.systemQuery = SaltService.INSTANCE;
-        this.serverGroupManager = ServerGroupManager.getInstance();
-        this.formulaManager = FormulaManager.getInstance();
+        this(SaltService.INSTANCE_SALT_API, SaltService.INSTANCE,
+                ServerGroupManager.getInstance(), FormulaManager.getInstance());
     }
 
     /**

--- a/java/code/src/com/suse/manager/matcher/test/MatcherJsonIOTest.java
+++ b/java/code/src/com/suse/manager/matcher/test/MatcherJsonIOTest.java
@@ -20,6 +20,7 @@ import com.redhat.rhn.domain.server.virtualhostmanager.VirtualHostManagerFactory
 import com.redhat.rhn.manager.content.ContentSyncManager;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.manager.formula.FormulaMonitoringManager;
+import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitler;
 import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
@@ -81,9 +82,12 @@ public class MatcherJsonIOTest extends JMockBaseTestCaseWithUser {
             public void updateLibvirtEngine(MinionServer minion) {
             }
         };
+        ServerGroupManager serverGroupManager = new ServerGroupManager();
         systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(virtManager, new FormulaMonitoringManager()),
-                new SystemEntitler(new SaltService(), virtManager, new FormulaMonitoringManager())
+                new SystemUnentitler(virtManager, new FormulaMonitoringManager(),
+                        serverGroupManager),
+                new SystemEntitler(new SaltService(), virtManager, new FormulaMonitoringManager(),
+                        serverGroupManager)
         );
     }
 

--- a/java/code/src/com/suse/manager/matcher/test/MatcherJsonIOTest.java
+++ b/java/code/src/com/suse/manager/matcher/test/MatcherJsonIOTest.java
@@ -30,8 +30,8 @@ import com.redhat.rhn.testing.TestUtils;
 
 import com.suse.manager.matcher.MatcherJsonIO;
 import com.suse.manager.virtualization.test.TestVirtManager;
+import com.suse.manager.webui.services.test.TestSystemQuery;
 import com.suse.manager.webui.services.iface.VirtManager;
-import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.matcher.json.MatchJson;
 import com.suse.matcher.json.ProductJson;
 import com.suse.matcher.json.SubscriptionJson;
@@ -86,7 +86,7 @@ public class MatcherJsonIOTest extends JMockBaseTestCaseWithUser {
         systemEntitlementManager = new SystemEntitlementManager(
                 new SystemUnentitler(virtManager, new FormulaMonitoringManager(),
                         serverGroupManager),
-                new SystemEntitler(new SaltService(), virtManager, new FormulaMonitoringManager(),
+                new SystemEntitler(new TestSystemQuery(), virtManager, new FormulaMonitoringManager(),
                         serverGroupManager)
         );
     }

--- a/java/code/src/com/suse/manager/reactor/SaltReactor.java
+++ b/java/code/src/com/suse/manager/reactor/SaltReactor.java
@@ -42,6 +42,11 @@ import com.suse.manager.reactor.messaging.LibvirtEnginePoolRefreshMessage;
 import com.suse.manager.reactor.messaging.MinionStartEventDatabaseMessage;
 import com.suse.manager.reactor.messaging.MinionStartEventMessage;
 import com.suse.manager.reactor.messaging.MinionStartEventMessageAction;
+import com.suse.manager.virtualization.VirtManagerSalt;
+import com.suse.manager.webui.services.SaltServerActionService;
+import com.suse.manager.webui.services.iface.SaltApi;
+import com.suse.manager.webui.services.iface.VirtManager;
+import com.suse.manager.webui.utils.salt.MinionStartupGrains;
 import com.suse.manager.reactor.messaging.RefreshGeneratedSaltFilesEventMessage;
 import com.suse.manager.reactor.messaging.RefreshGeneratedSaltFilesEventMessageAction;
 import com.suse.manager.reactor.messaging.RegisterMinionEventMessage;
@@ -52,13 +57,9 @@ import com.suse.manager.reactor.messaging.SystemIdGenerateEventMessage;
 import com.suse.manager.reactor.messaging.SystemIdGenerateEventMessageAction;
 import com.suse.manager.reactor.messaging.VirtpollerBeaconEventMessage;
 import com.suse.manager.reactor.messaging.VirtpollerBeaconEventMessageAction;
-import com.suse.manager.virtualization.VirtManagerSalt;
-import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.SystemQuery;
-import com.suse.manager.webui.services.iface.VirtManager;
 import com.suse.manager.webui.utils.salt.ImageDeployedEvent;
 import com.suse.manager.webui.utils.salt.MinionStartEvent;
-import com.suse.manager.webui.utils.salt.MinionStartupGrains;
 import com.suse.manager.webui.utils.salt.SystemIdGenerateEvent;
 import com.suse.manager.webui.utils.salt.custom.VirtpollerData;
 import com.suse.salt.netapi.datatypes.Event;
@@ -84,6 +85,7 @@ public class SaltReactor {
     // Reference to the SaltService instance
     private final SaltApi saltApi;
     private final SystemQuery systemQuery;
+    private final SaltServerActionService saltServerActionService;
 
     // The event stream object
     private EventStream eventStream;
@@ -97,10 +99,13 @@ public class SaltReactor {
      * Processing salt events
      * @param saltApiIn instance to talk to salt
      * @param systemQueryIn instance to get system information.
+     * @param saltServerActionServiceIn
      */
-    public SaltReactor(SaltApi saltApiIn, SystemQuery systemQueryIn) {
+    public SaltReactor(SaltApi saltApiIn, SystemQuery systemQueryIn,
+                       SaltServerActionService saltServerActionServiceIn) {
         this.saltApi = saltApiIn;
         this.systemQuery = systemQueryIn;
+        this.saltServerActionService = saltServerActionServiceIn;
     }
 
     /**
@@ -118,7 +123,7 @@ public class SaltReactor {
                 MinionStartEventDatabaseMessage.class);
         MessageQueue.registerAction(new ApplyStatesEventMessageAction(),
                 ApplyStatesEventMessage.class);
-        MessageQueue.registerAction(new JobReturnEventMessageAction(),
+        MessageQueue.registerAction(new JobReturnEventMessageAction(saltServerActionService),
                 JobReturnEventMessage.class);
         MessageQueue.registerAction(new RefreshGeneratedSaltFilesEventMessageAction(),
                 RefreshGeneratedSaltFilesEventMessage.class);

--- a/java/code/src/com/suse/manager/reactor/SaltReactor.java
+++ b/java/code/src/com/suse/manager/reactor/SaltReactor.java
@@ -42,6 +42,7 @@ import com.suse.manager.reactor.messaging.LibvirtEnginePoolRefreshMessage;
 import com.suse.manager.reactor.messaging.MinionStartEventDatabaseMessage;
 import com.suse.manager.reactor.messaging.MinionStartEventMessage;
 import com.suse.manager.reactor.messaging.MinionStartEventMessageAction;
+import com.suse.manager.utils.SaltUtils;
 import com.suse.manager.virtualization.VirtManagerSalt;
 import com.suse.manager.webui.services.SaltServerActionService;
 import com.suse.manager.webui.services.iface.SaltApi;
@@ -86,6 +87,7 @@ public class SaltReactor {
     private final SaltApi saltApi;
     private final SystemQuery systemQuery;
     private final SaltServerActionService saltServerActionService;
+    private final SaltUtils saltUtils;
 
     // The event stream object
     private EventStream eventStream;
@@ -100,12 +102,14 @@ public class SaltReactor {
      * @param saltApiIn instance to talk to salt
      * @param systemQueryIn instance to get system information.
      * @param saltServerActionServiceIn
+     * @param saltUtilsIn
      */
-    public SaltReactor(SaltApi saltApiIn, SystemQuery systemQueryIn,
-                       SaltServerActionService saltServerActionServiceIn) {
+    public SaltReactor(SaltApi saltApiIn, SystemQuery systemQueryIn, SaltServerActionService saltServerActionServiceIn,
+                       SaltUtils saltUtilsIn) {
         this.saltApi = saltApiIn;
         this.systemQuery = systemQueryIn;
         this.saltServerActionService = saltServerActionServiceIn;
+        this.saltUtils = saltUtilsIn;
     }
 
     /**
@@ -123,7 +127,7 @@ public class SaltReactor {
                 MinionStartEventDatabaseMessage.class);
         MessageQueue.registerAction(new ApplyStatesEventMessageAction(),
                 ApplyStatesEventMessage.class);
-        MessageQueue.registerAction(new JobReturnEventMessageAction(saltServerActionService),
+        MessageQueue.registerAction(new JobReturnEventMessageAction(saltServerActionService, saltUtils),
                 JobReturnEventMessage.class);
         MessageQueue.registerAction(new RefreshGeneratedSaltFilesEventMessageAction(),
                 RefreshGeneratedSaltFilesEventMessage.class);

--- a/java/code/src/com/suse/manager/reactor/hardware/HardwareMapper.java
+++ b/java/code/src/com/suse/manager/reactor/hardware/HardwareMapper.java
@@ -14,6 +14,7 @@
  */
 package com.suse.manager.reactor.hardware;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.org.OrgFactory;
 import com.redhat.rhn.domain.server.CPU;
 import com.redhat.rhn.domain.server.CPUArch;
@@ -33,7 +34,6 @@ import com.redhat.rhn.domain.server.VirtualInstanceState;
 import com.redhat.rhn.domain.server.VirtualInstanceType;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.manager.system.VirtualInstanceManager;
-import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 
 import com.suse.manager.reactor.utils.ValueMap;
 import com.suse.manager.utils.SaltUtils;
@@ -458,7 +458,7 @@ public class HardwareMapper {
 
                 ServerFactory.save(zhost);
 
-                SystemEntitlementManager.INSTANCE.setBaseEntitlement(zhost, EntitlementManager
+                GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER.setBaseEntitlement(zhost, EntitlementManager
                         .getByName(EntitlementManager.FOREIGN_ENTITLED));
                 LOG.debug("New host created: " + identifier);
             }

--- a/java/code/src/com/suse/manager/reactor/messaging/JobReturnEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/JobReturnEventMessageAction.java
@@ -16,10 +16,6 @@ package com.suse.manager.reactor.messaging;
 
 import com.redhat.rhn.common.messaging.EventMessage;
 import com.redhat.rhn.common.messaging.MessageAction;
-import com.redhat.rhn.domain.action.Action;
-import com.redhat.rhn.domain.action.ActionFactory;
-import com.redhat.rhn.domain.action.kickstart.KickstartAction;
-import com.redhat.rhn.domain.action.server.ServerAction;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.MinionServerFactory;
 import com.redhat.rhn.domain.server.VirtualInstance;
@@ -31,10 +27,10 @@ import com.google.gson.JsonParseException;
 import com.google.gson.JsonSyntaxException;
 import com.google.gson.reflect.TypeToken;
 import com.suse.manager.reactor.hardware.CpuArchUtil;
-import com.suse.manager.utils.SaltKeyUtils;
 import com.suse.manager.utils.SaltUtils;
 import com.suse.manager.utils.SaltUtils.PackageChangeOutcome;
 import com.suse.manager.webui.services.SaltActionChainGeneratorService;
+import com.suse.manager.webui.services.SaltServerActionService;
 import com.suse.manager.webui.utils.salt.custom.ScheduleMetadata;
 import com.suse.manager.webui.utils.salt.custom.SystemInfo;
 import com.suse.salt.netapi.event.JobReturnEvent;
@@ -44,15 +40,10 @@ import com.suse.utils.Json;
 
 import org.apache.log4j.Logger;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Stack;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 
@@ -60,6 +51,15 @@ import java.util.stream.Collectors;
  * Handler class for {@link JobReturnEventMessage}.
  */
 public class JobReturnEventMessageAction implements MessageAction {
+
+    private final SaltServerActionService saltServerActionService;
+
+    /**
+     * @param saltServerActionServiceIn
+     */
+    public JobReturnEventMessageAction(SaltServerActionService saltServerActionServiceIn) {
+        this.saltServerActionService = saltServerActionServiceIn;
+    }
 
     /**
      * Converts an event to json
@@ -108,7 +108,7 @@ public class JobReturnEventMessageAction implements MessageAction {
                 ScheduleMetadata::getSumaActionId);
         actionId.filter(id -> id > 0).ifPresent(id -> {
                 jobResult.ifPresent(result ->
-                    handleAction(id,
+                    saltServerActionService.handleAction(id,
                             jobReturnEvent.getMinionId(),
                             jobReturnEvent.getData().getRetcode(),
                             jobReturnEvent.getData().isSuccess(),
@@ -145,7 +145,7 @@ public class JobReturnEventMessageAction implements MessageAction {
                 throw e;
             }
 
-            handleActionChainResult(jobReturnEvent.getMinionId(),
+            saltServerActionService.handleActionChainResult(jobReturnEvent.getMinionId(),
                     jobReturnEvent.getJobId(),
                     jobReturnEvent.getData().getRetcode(),
                     jobReturnEvent.getData().isSuccess(),
@@ -196,111 +196,6 @@ public class JobReturnEventMessageAction implements MessageAction {
         }
     }
 
-    /**
-     * Handle action chain Salt result.
-     *
-     * @param minionId the minion id
-     * @param jobId the job id
-     * @param retCode the ret code
-     * @param success whether result is successful or not
-     * @param actionChainResult job result
-     * @param skipFunction function to check if a result should be skipped from handling
-     */
-    public static void handleActionChainResult(
-            String minionId, String jobId, int retCode, boolean success,
-            Map<String, StateApplyResult<Ret<JsonElement>>> actionChainResult,
-            Function<StateApplyResult<Ret<JsonElement>>, Boolean> skipFunction) {
-        int chunk = 1;
-        Long retActionChainId = null;
-        boolean actionChainFailed = false;
-        List<Long> failedActionIds = new ArrayList<>();
-        for (Map.Entry<String, StateApplyResult<Ret<JsonElement>>> entry : actionChainResult.entrySet()) {
-            String key = entry.getKey();
-            StateApplyResult<Ret<JsonElement>> actionStateApply = entry.getValue();
-
-            Optional<SaltActionChainGeneratorService.ActionChainStateId> stateId =
-                    SaltActionChainGeneratorService.parseActionChainStateId(key);
-            if (stateId.isPresent()) {
-                retActionChainId = stateId.get().getActionChainId();
-                chunk = stateId.get().getChunk();
-                Long actionId = stateId.get().getActionId();
-                if (skipFunction.apply(actionStateApply)) {
-                    continue; // skip this state from handling
-                }
-
-                if (!actionStateApply.isResult()) {
-                    actionChainFailed = true;
-                    failedActionIds.add(actionId);
-                    // don't stop handling the result entries if there's a failed action
-                    // the result entries are not returned in order
-                }
-                handleAction(actionId,
-                        minionId,
-                        actionStateApply.isResult() ? 0 : -1,
-                        actionStateApply.isResult(),
-                        jobId,
-                        actionStateApply.getChanges().getRet(),
-                        actionStateApply.getName());
-            }
-            else if (!key.contains("schedule_next_chunk")) {
-                LOG.warn("Could not find action id in action chain state key: " + key);
-            }
-        }
-
-        if (retActionChainId != null) {
-            if (actionChainFailed) {
-                long firstFailedActionId = failedActionIds.stream().min(Long::compare).get();
-                // Set rest of actions as FAILED due to failed prerequisite
-                failDependentServerActions(firstFailedActionId, minionId, Optional.empty());
-            }
-            // Removing the generated SLS file
-            SaltActionChainGeneratorService.INSTANCE.removeActionChainSLSFiles(
-                    retActionChainId, minionId, chunk, actionChainFailed);
-        }
-    }
-
-    /**
-     * Set the given action to FAILED if not already in that state and also the dependent actions.
-     * @param actionId the action id
-     * @param minionId the minion id
-     * @param message the result message to set in the server action
-     */
-    public static void failDependentServerActions(long actionId, String minionId, Optional<String> message) {
-        Optional<MinionServer> minion = MinionServerFactory.findByMinionId(
-               minionId);
-        if (minion.isPresent()) {
-            // set first action to failed if not already in that state
-            Action action = ActionFactory.lookupById(actionId);
-            Optional.ofNullable(action)
-                    .ifPresent(firstAction ->
-                            firstAction.getServerActions().stream()
-                                    .filter(sa -> sa.getServerId().equals(minion.get().getId()))
-                                    .filter(sa -> !ActionFactory.STATUS_FAILED.equals(sa.getStatus()))
-                                    .filter(sa -> !ActionFactory.STATUS_COMPLETED.equals(sa.getStatus()))
-                                    .findFirst()
-                                    .ifPresent(sa -> sa.fail(message.orElse("Prerequisite failed"))));
-
-            // walk dependent server actions recursively and set them to failed
-            Stack<Long> actionIdsDependencies = new Stack<>();
-            actionIdsDependencies.push(actionId);
-            List<ServerAction> serverActions = ActionFactory
-                    .listServerActionsForServer(minion.get(),
-                            Arrays.asList(ActionFactory.STATUS_QUEUED, ActionFactory.STATUS_PICKED_UP,
-                            ActionFactory.STATUS_FAILED), action.getCreated());
-
-            while (!actionIdsDependencies.empty()) {
-               Long acId = actionIdsDependencies.pop();
-                List<ServerAction> serverActionsWithPrereq = serverActions.stream()
-                   .filter(s -> s.getParentAction().getPrerequisite() != null)
-                   .filter(s -> s.getParentAction().getPrerequisite().getId().equals(acId))
-                   .collect(Collectors.toList());
-               for (ServerAction sa : serverActionsWithPrereq) {
-                   actionIdsDependencies.push(sa.getParentAction().getId());
-                   sa.fail("Prerequisite failed");
-               }
-           }
-       }
-    }
 
     /**
      * This method does two things
@@ -350,88 +245,7 @@ public class JobReturnEventMessageAction implements MessageAction {
             }
         });
     }
-    /**
-     * Update the action properly based on the Job results from Salt.
-     *
-     * @param actionId the ID of the Action to handle
-     * @param minionId the ID of the Minion who performed the action
-     * @param retcode the retcode returned
-     * @param success indicates if the job executed successfully
-     * @param jobId the ID of the Salt job.
-     * @param jsonResult the json results from the Salt job.
-     * @param function the Salt function executed.
-     */
-    public static void handleAction(long actionId, String minionId, int retcode, boolean success,
-                              String jobId, JsonElement jsonResult, String function) {
-        // Lookup the corresponding action
-        Optional<Action> action = Optional.ofNullable(ActionFactory.lookupById(actionId));
-        if (action.isPresent()) {
 
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Matched salt job with action (id=" + actionId + ")");
-            }
-
-            Optional<MinionServer> minionServerOpt = MinionServerFactory.findByMinionId(minionId);
-            minionServerOpt.ifPresent(minionServer -> {
-                Optional<ServerAction> serverAction = action.get()
-                        .getServerActions()
-                        .stream()
-                        .filter(sa -> sa.getServer().equals(minionServer)).findFirst();
-
-
-                serverAction.ifPresent(sa -> {
-                    if (LOG.isDebugEnabled()) {
-                        LOG.debug("Updating action for server: " + minionServer.getId());
-                    }
-                    try {
-                        // Reboot has been scheduled so set reboot action to PICKED_UP.
-                        // Wait until next "minion/start/event" to set it to COMPLETED.
-                        if (action.get().getActionType().equals(ActionFactory.TYPE_REBOOT) &&
-                                success && retcode == 0) {
-                            sa.setStatus(ActionFactory.STATUS_PICKED_UP);
-                            sa.setPickupTime(new Date());
-                            return;
-                        }
-                        else if (action.get().getActionType().equals(ActionFactory.TYPE_KICKSTART_INITIATE) &&
-                                success) {
-                            KickstartAction ksAction = (KickstartAction) action.get();
-                            if (!ksAction.getKickstartActionDetails().getUpgrade()) {
-                                // Delete salt key from master
-                                SaltKeyUtils.deleteSaltKey(action.get().getSchedulerUser(), minionId);
-                            }
-                        }
-                        SaltUtils.INSTANCE.updateServerAction(sa,
-                                retcode,
-                                success,
-                                jobId,
-                                jsonResult,
-                                function);
-                        ActionFactory.save(sa);
-                    }
-                    catch (Exception e) {
-                        LOG.error("Error processing Salt job return", e);
-                        // DB exceptions cause the transaction to go into rollback-only
-                        // state. We need to rollback this transaction first.
-                        ActionFactory.rollbackTransaction();
-
-                        sa.fail("An unexpected error has occurred. Please check the server logs.");
-
-                        ActionFactory.save(sa);
-                        // When we throw the exception again, the current transaction
-                        // will be set to rollback-only, so we explicitly commit the
-                        // transaction here
-                        ActionFactory.commitTransaction();
-
-                        // We don't actually want to catch any exceptions
-                        throw e;
-                    }
-                });
-            });
-        }
-        else {
-            LOG.warn("Action referenced from Salt job was not found: " + actionId);
-        }
-    }
 
     private Optional<Boolean> isActionChainResult(JobReturnEvent event) {
         return event.getData().getMetadata(ScheduleMetadata.class).map(ScheduleMetadata::isActionChain);

--- a/java/code/src/com/suse/manager/reactor/messaging/JobReturnEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/JobReturnEventMessageAction.java
@@ -179,7 +179,7 @@ public class JobReturnEventMessageAction implements MessageAction {
                     .ifPresent(minion -> jobResult
                             .ifPresent(result-> {
                                 SystemInfo systemInfo = Json.GSON.fromJson(result, SystemInfo.class);
-                                SaltUtils.INSTANCE.updateSystemInfo(systemInfo, minion);
+                                saltUtils.updateSystemInfo(systemInfo, minion);
                             }));
         }
       // For all jobs: update minion last checkin

--- a/java/code/src/com/suse/manager/reactor/messaging/JobReturnEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/JobReturnEventMessageAction.java
@@ -53,12 +53,15 @@ import java.util.stream.Collectors;
 public class JobReturnEventMessageAction implements MessageAction {
 
     private final SaltServerActionService saltServerActionService;
+    private final SaltUtils saltUtils;
 
     /**
      * @param saltServerActionServiceIn
+     * @param saltUtilsIn
      */
-    public JobReturnEventMessageAction(SaltServerActionService saltServerActionServiceIn) {
+    public JobReturnEventMessageAction(SaltServerActionService saltServerActionServiceIn, SaltUtils saltUtilsIn) {
         this.saltServerActionService = saltServerActionServiceIn;
+        this.saltUtils = saltUtilsIn;
     }
 
     /**
@@ -215,7 +218,7 @@ public class JobReturnEventMessageAction implements MessageAction {
                     boolean fullPackageRefreshNeeded = false;
                     try {
                         if (forcePackageListRefresh(jobReturnEvent) ||
-                                SaltUtils.handlePackageChanges(function, result,
+                                saltUtils.handlePackageChanges(function, result,
                                         minionServer) ==  PackageChangeOutcome.NEEDS_REFRESHING) {
                             fullPackageRefreshNeeded = true;
                         }

--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -20,6 +20,7 @@ import static java.util.Optional.of;
 import static java.util.Optional.ofNullable;
 
 import com.google.gson.reflect.TypeToken;
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.messaging.EventMessage;
 import com.redhat.rhn.common.messaging.MessageAction;
 import com.redhat.rhn.common.messaging.MessageQueue;
@@ -52,7 +53,6 @@ import com.redhat.rhn.frontend.dto.EssentialChannelDto;
 import com.redhat.rhn.manager.distupgrade.DistUpgradeManager;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.manager.system.SystemManager;
-import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 
 import com.suse.manager.reactor.utils.ValueMap;
 import com.suse.manager.webui.services.impl.MinionPendingRegistrationService;
@@ -389,7 +389,7 @@ public class RegisterMinionEventMessageAction implements MessageAction {
             giveCapabilities(minion);
 
             // Assign the Salt base entitlement by default
-            SystemEntitlementManager.INSTANCE.setBaseEntitlement(minion, EntitlementManager.SALT);
+            GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER.setBaseEntitlement(minion, EntitlementManager.SALT);
 
             // apply activation key properties that need to be set after saving the minion
             activationKey.ifPresent(ak -> RegistrationUtils.applyActivationKeyProperties(minion, ak, grains));

--- a/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
@@ -21,6 +21,7 @@ import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.partitioningBy;
 import static java.util.stream.Collectors.toSet;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.messaging.MessageQueue;
 import com.redhat.rhn.common.validator.ValidatorResult;
 import com.redhat.rhn.domain.channel.Channel;
@@ -55,7 +56,6 @@ import com.suse.manager.webui.controllers.StatesAPI;
 import com.suse.manager.webui.controllers.channels.ChannelsUtils;
 import com.suse.manager.webui.services.iface.RedhatProductInfo;
 import com.suse.manager.webui.services.iface.SystemQuery;
-import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.manager.webui.services.pillar.MinionPillarManager;
 import com.suse.salt.netapi.calls.modules.Zypper;
 import com.suse.utils.Opt;
@@ -88,9 +88,9 @@ public class RegistrationUtils {
     private static final Logger LOG = Logger.getLogger(RegistrationUtils.class);
 
     private static SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
-            new SystemUnentitler(new VirtManagerSalt(SaltService.INSTANCE_SALT_API),
+            new SystemUnentitler(new VirtManagerSalt(GlobalInstanceHolder.SALT_API),
                     new FormulaMonitoringManager()),
-            new SystemEntitler(SaltService.INSTANCE, new VirtManagerSalt(SaltService.INSTANCE_SALT_API),
+            new SystemEntitler(GlobalInstanceHolder.SYSTEM_QUERY, new VirtManagerSalt(GlobalInstanceHolder.SALT_API),
                     new FormulaMonitoringManager())
     );
 

--- a/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
@@ -42,16 +42,12 @@ import com.redhat.rhn.domain.token.ActivationKey;
 import com.redhat.rhn.domain.token.ActivationKeyFactory;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.action.ActionManager;
-import com.redhat.rhn.manager.formula.FormulaMonitoringManager;
 import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
-import com.redhat.rhn.manager.system.entitling.SystemEntitler;
-import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
 
 import com.suse.manager.reactor.utils.RhelUtils;
 import com.suse.manager.reactor.utils.ValueMap;
-import com.suse.manager.virtualization.VirtManagerSalt;
 import com.suse.manager.webui.controllers.StatesAPI;
 import com.suse.manager.webui.controllers.channels.ChannelsUtils;
 import com.suse.manager.webui.services.iface.RedhatProductInfo;
@@ -87,12 +83,7 @@ public class RegistrationUtils {
 
     private static final Logger LOG = Logger.getLogger(RegistrationUtils.class);
 
-    private static SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
-            new SystemUnentitler(new VirtManagerSalt(GlobalInstanceHolder.SALT_API),
-                    new FormulaMonitoringManager()),
-            new SystemEntitler(GlobalInstanceHolder.SYSTEM_QUERY, new VirtManagerSalt(GlobalInstanceHolder.SALT_API),
-                    new FormulaMonitoringManager())
-    );
+    private static SystemEntitlementManager systemEntitlementManager = GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER;
 
     private RegistrationUtils() {
     }

--- a/java/code/src/com/suse/manager/reactor/messaging/test/ImageDeployedEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/ImageDeployedEventMessageActionTest.java
@@ -27,6 +27,7 @@ import com.redhat.rhn.testing.TestUtils;
 import com.suse.manager.reactor.messaging.ImageDeployedEventMessage;
 import com.suse.manager.reactor.messaging.ImageDeployedEventMessageAction;
 import com.suse.manager.reactor.utils.ValueMap;
+import com.suse.manager.webui.services.test.TestSystemQuery;
 import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.manager.webui.utils.salt.ImageDeployedEvent;
@@ -78,7 +79,7 @@ public class ImageDeployedEventMessageActionTest extends JMockBaseTestCaseWithUs
         ChannelFamily channelFamily = ErrataTestUtils.createTestChannelFamily();
         SUSEProduct product = SUSEProductTestUtils.createTestSUSEProduct(channelFamily);
         baseChannelX8664 = setupBaseAndRequiredChannels(channelFamily, product);
-        systemQuery = new SaltService() {
+        systemQuery = new TestSystemQuery() {
             @Override
             public Optional<List<Zypper.ProductInfo>> getProducts(String minionId) {
                 List<Zypper.ProductInfo> pil = new ArrayList<>();

--- a/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
@@ -145,6 +145,10 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
     private SaltService saltServiceMock;
     private SystemEntitlementManager systemEntitlementManager;
     protected Path metadataDirOfficial;
+    private ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+    private SaltUtils saltUtils;
+    private SaltServerActionService saltServerActionService;
+    private ClusterManager clusterManager;
     protected Path formulaDataDir;
 
 
@@ -160,6 +164,14 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 new SystemEntitler(saltServiceMock, new VirtManagerSalt(saltServiceMock),
                         new FormulaMonitoringManager())
         );
+        FormulaManager formulaManager = new FormulaManager(saltServiceMock);
+        clusterManager = new ClusterManager(
+                saltServiceMock, saltServiceMock, serverGroupManager, formulaManager
+        );
+        saltUtils = new SaltUtils(
+                saltServiceMock, saltServiceMock, clusterManager, formulaManager
+        );
+        saltServerActionService = new SaltServerActionService(saltServiceMock, saltUtils, clusterManager);
         metadataDirOfficial = Files.createTempDirectory("meta");
         formulaDataDir = Files.createTempDirectory("data");
         FormulaFactory.setMetadataDirOfficial(metadataDirOfficial.toString());
@@ -189,17 +201,6 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 getJobReturnEvent("packages.profileupdate.json", action.getId()));
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
 
-        SystemQuery systemQuery = SaltService.INSTANCE;
-        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
-        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
-        FormulaManager formulaManager = new FormulaManager(saltApi);
-        ClusterManager clusterManager = new ClusterManager(
-                saltApi, systemQuery, serverGroupManager, formulaManager
-        );
-        SaltUtils saltUtils = new SaltUtils(
-                systemQuery, saltApi, clusterManager
-        );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         // Process the event message
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
@@ -327,17 +328,6 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 .parse(getJobReturnEvent("packages.profileupdate.allversions.json", action.getId()))
                 .get());
 
-        SystemQuery systemQuery = SaltService.INSTANCE;
-        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
-        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
-        FormulaManager formulaManager = new FormulaManager(saltApi);
-        ClusterManager clusterManager = new ClusterManager(
-                saltApi, systemQuery, serverGroupManager, formulaManager
-        );
-        SaltUtils saltUtils = new SaltUtils(
-                systemQuery, saltApi, clusterManager
-        );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
 
@@ -405,17 +395,6 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 .parse(getJobReturnEvent("packages.profileupdate.json", action.getId()))
                 .get());
 
-        SystemQuery systemQuery = SaltService.INSTANCE;
-        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
-        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
-        FormulaManager formulaManager = new FormulaManager(saltApi);
-        ClusterManager clusterManager = new ClusterManager(
-                saltApi, systemQuery, serverGroupManager, formulaManager
-        );
-        SaltUtils saltUtils = new SaltUtils(
-                systemQuery, saltApi, clusterManager
-        );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
 
@@ -490,17 +469,6 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 .parse(getJobReturnEvent("packages.profileupdate.json", action.getId()))
                 .get());
 
-        SystemQuery systemQuery = SaltService.INSTANCE;
-        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
-        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
-        FormulaManager formulaManager = new FormulaManager(saltApi);
-        ClusterManager clusterManager = new ClusterManager(
-                saltApi, systemQuery, serverGroupManager, formulaManager
-        );
-        SaltUtils saltUtils = new SaltUtils(
-                systemQuery, saltApi, clusterManager
-        );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         // Process the event message
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
@@ -551,17 +519,6 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 getJobReturnEvent("packages.profileupdate.rhel7res.json", action.getId()));
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
 
-        SystemQuery systemQuery = SaltService.INSTANCE;
-        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
-        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
-        FormulaManager formulaManager = new FormulaManager(saltApi);
-        ClusterManager clusterManager = new ClusterManager(
-                saltApi, systemQuery, serverGroupManager, formulaManager
-        );
-        SaltUtils saltUtils = new SaltUtils(
-                systemQuery, saltApi, clusterManager
-        );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         // Process the event message
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
@@ -627,17 +584,6 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 getJobReturnEvent("packages.profileupdate.ubuntu.json", action.getId()));
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
 
-        SystemQuery systemQuery = SaltService.INSTANCE;
-        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
-        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
-        FormulaManager formulaManager = new FormulaManager(saltApi);
-        ClusterManager clusterManager = new ClusterManager(
-                saltApi, systemQuery, serverGroupManager, formulaManager
-        );
-        SaltUtils saltUtils = new SaltUtils(
-                systemQuery, saltApi, clusterManager
-        );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         // Process the event message
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
@@ -702,17 +648,6 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 getJobReturnEvent("packages.profileupdate.caasp-node.json", action.getId()));
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
 
-        SystemQuery systemQuery = saltServiceMock;
-        SaltApi saltApi = saltServiceMock;
-        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
-        FormulaManager formulaManager = new FormulaManager(saltApi);
-        ClusterManager clusterManager = new ClusterManager(
-                saltApi, systemQuery, serverGroupManager, formulaManager
-        );
-        SaltUtils saltUtils = new SaltUtils(
-                systemQuery, saltApi, clusterManager
-        );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
 
@@ -750,17 +685,6 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 getJobReturnEvent("packages.profileupdate.caasp-node.json", action.getId()));
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
 
-        SystemQuery systemQuery = saltServiceMock;
-        SaltApi saltApi = saltServiceMock;
-        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
-        FormulaManager formulaManager = new FormulaManager(saltApi);
-        ClusterManager clusterManager = new ClusterManager(
-                saltApi, systemQuery, serverGroupManager, formulaManager
-        );
-        SaltUtils saltUtils = new SaltUtils(
-                systemQuery, saltApi, clusterManager
-        );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
 
@@ -799,17 +723,6 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 getJobReturnEvent("packages.profileupdate.caasp-management.json", action.getId()));
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
 
-        SystemQuery systemQuery = saltServiceMock;
-        SaltApi saltApi = saltServiceMock;
-        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
-        FormulaManager formulaManager = new FormulaManager(saltApi);
-        ClusterManager clusterManager = new ClusterManager(
-                saltApi, systemQuery, serverGroupManager, formulaManager
-        );
-        SaltUtils saltUtils = new SaltUtils(
-                systemQuery, saltApi, clusterManager
-        );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
 
@@ -1108,17 +1021,6 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 getJobReturnEvent("hardware.profileupdate.ip_change_ipv4ipv6.x86.json", action.getId()));
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
 
-        SystemQuery systemQuery = SaltService.INSTANCE;
-        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
-        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
-        FormulaManager formulaManager = new FormulaManager(saltApi);
-        ClusterManager clusterManager = new ClusterManager(
-                saltApi, systemQuery, serverGroupManager, formulaManager
-        );
-        SaltUtils saltUtils = new SaltUtils(
-                systemQuery, saltApi, clusterManager
-        );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         // Process the event message
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
@@ -1165,17 +1067,6 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 getJobReturnEvent("hardware.profileupdate.primary_ips_ipv4ipv6.x86.json", action.getId()));
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
 
-        SystemQuery systemQuery = SaltService.INSTANCE;
-        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
-        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
-        FormulaManager formulaManager = new FormulaManager(saltApi);
-        ClusterManager clusterManager = new ClusterManager(
-                saltApi, systemQuery, serverGroupManager, formulaManager
-        );
-        SaltUtils saltUtils = new SaltUtils(
-                systemQuery, saltApi, clusterManager
-        );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         // Process the event message
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
@@ -1195,12 +1086,6 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
         Set<NetworkInterface> oldIfs = new HashSet<>();
         oldIfs.addAll(server.getNetworkInterfaces());
-
-        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
-        FormulaManager formulaManager = new FormulaManager(saltServiceMock);
-        ClusterManager clusterManager = new ClusterManager(saltServiceMock, saltServiceMock, serverGroupManager,
-                formulaManager);
-        SaltUtils saltUtils = new SaltUtils(saltServiceMock, saltServiceMock, clusterManager);
 
         saltUtils.updateServerAction(sa, 0L, true, "n/a", element, "state.apply");
 
@@ -1304,17 +1189,6 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 getJobReturnEvent(jsonFile, action.getId()));
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
 
-        SystemQuery systemQuery = SaltService.INSTANCE;
-        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
-        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
-        FormulaManager formulaManager = new FormulaManager(saltApi);
-        ClusterManager clusterManager = new ClusterManager(
-                saltApi, systemQuery, serverGroupManager, formulaManager
-        );
-        SaltUtils saltUtils = new SaltUtils(
-                systemQuery, saltApi, clusterManager
-        );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         // Process the event message
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
@@ -1419,17 +1293,6 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         } });
 
 
-        SystemQuery systemQuery = SaltService.INSTANCE;
-        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
-        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
-        FormulaManager formulaManager = new FormulaManager(saltApi);
-        ClusterManager clusterManager = new ClusterManager(
-                saltApi, systemQuery, serverGroupManager, formulaManager
-        );
-        SaltUtils saltUtils = new SaltUtils(
-                systemQuery, saltApi, clusterManager
-        );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         // Process the event message
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
@@ -1467,17 +1330,6 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 getJobReturnEvent("openscap.xccdf.success.json", action.getId()));
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
 
-        SystemQuery systemQuery = SaltService.INSTANCE;
-        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
-        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
-        FormulaManager formulaManager = new FormulaManager(saltApi);
-        ClusterManager clusterManager = new ClusterManager(
-                saltApi, systemQuery, serverGroupManager, formulaManager
-        );
-        SaltUtils saltUtils = new SaltUtils(
-                systemQuery, saltApi, clusterManager
-        );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
 
         File scapFile = new File(TestUtils.findTestDataInDir(
@@ -1507,7 +1359,6 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         }});
 
         saltUtils.setXccdfResumeXsl(resumeXsl);
-        saltUtils.setSystemQuery(saltServiceMock);
         messageAction.execute(message);
 
         assertEquals(ActionFactory.STATUS_COMPLETED, sa.getStatus());
@@ -1717,17 +1568,6 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                         ));
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
 
-        SystemQuery systemQuery = SaltService.INSTANCE;
-        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
-        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
-        FormulaManager formulaManager = new FormulaManager(saltApi);
-        ClusterManager clusterManager = new ClusterManager(
-                saltApi, systemQuery, serverGroupManager, formulaManager
-        );
-        SaltUtils saltUtils = new SaltUtils(
-                systemQuery, saltApi, clusterManager
-        );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
 
@@ -1750,17 +1590,6 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                         Collections.singletonMap("$IMAGE$", imageName)));
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
 
-        SystemQuery systemQuery = SaltService.INSTANCE;
-        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
-        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
-        FormulaManager formulaManager = new FormulaManager(saltApi);
-        ClusterManager clusterManager = new ClusterManager(
-                saltApi, systemQuery, serverGroupManager, formulaManager
-        );
-        SaltUtils saltUtils = new SaltUtils(
-                systemQuery, saltApi, clusterManager
-        );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
 
@@ -1791,17 +1620,6 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                         placeholders
                 ));
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
-        SystemQuery systemQuery = SaltService.INSTANCE;
-        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
-        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
-        FormulaManager formulaManager = new FormulaManager(saltApi);
-        ClusterManager clusterManager = new ClusterManager(
-                saltApi, systemQuery, serverGroupManager, formulaManager
-        );
-        SaltUtils saltUtils = new SaltUtils(
-                systemQuery, saltApi, clusterManager
-        );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
 
@@ -1908,17 +1726,6 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 JobReturnEvent.parse(getJobReturnEvent("image.build.kiwi.json", actionId));
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
 
-        SystemQuery systemQuery = saltServiceMock;
-        SaltApi saltApi = saltServiceMock;
-        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
-        FormulaManager formulaManager = new FormulaManager(saltApi);
-        ClusterManager clusterManager = new ClusterManager(
-                saltApi, systemQuery, serverGroupManager, formulaManager
-        );
-        SaltUtils saltUtils = new SaltUtils(
-                systemQuery, saltApi, clusterManager
-        );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
 
@@ -1955,17 +1762,6 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 .parse(getJobReturnEvent("image.inspect.kiwi.json", actionId));
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
 
-        SystemQuery systemQuery = SaltService.INSTANCE;
-        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
-        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
-        FormulaManager formulaManager = new FormulaManager(saltApi);
-        ClusterManager clusterManager = new ClusterManager(
-                saltApi, systemQuery, serverGroupManager, formulaManager
-        );
-        SaltUtils saltUtils = new SaltUtils(
-                systemQuery, saltApi, clusterManager
-        );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
 
@@ -1998,17 +1794,6 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 getJobReturnEvent("openscap.xccdf.success.json", 123));
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
 
-        SystemQuery systemQuery = SaltService.INSTANCE;
-        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
-        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
-        FormulaManager formulaManager = new FormulaManager(saltApi);
-        ClusterManager clusterManager = new ClusterManager(
-                saltApi, systemQuery, serverGroupManager, formulaManager
-        );
-        SaltUtils saltUtils = new SaltUtils(
-                systemQuery, saltApi, clusterManager
-        );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         // Process the event message
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
@@ -2022,18 +1807,6 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         context().checking(new Expectations() { {
             allowing(taskomaticMock).scheduleSubscribeChannels(with(any(User.class)), with(any(SubscribeChannelsAction.class)));
         } });
-
-        SystemQuery systemQuery = SaltService.INSTANCE;
-        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
-        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
-        FormulaManager formulaManager = new FormulaManager(saltApi);
-        ClusterManager clusterManager = new ClusterManager(
-                saltApi, systemQuery, serverGroupManager, formulaManager
-        );
-        SaltUtils saltUtils = new SaltUtils(
-                systemQuery, saltApi, clusterManager
-        );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(new SaltService(), saltUtils, clusterManager);
 
         MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
         minion.setMinionId("dev-minsles12sp2.test.local");
@@ -2095,17 +1868,6 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
             allowing(taskomaticMock).scheduleSubscribeChannels(with(any(User.class)),
                     with(any(SubscribeChannelsAction.class)));
         } });
-        SystemQuery systemQuery = SaltService.INSTANCE;
-        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
-        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
-        FormulaManager formulaManager = new FormulaManager(saltApi);
-        ClusterManager clusterManager = new ClusterManager(
-                saltApi, systemQuery, serverGroupManager, formulaManager
-        );
-        SaltUtils saltUtils = new SaltUtils(
-                systemQuery, saltApi, clusterManager
-        );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(new SaltService(), saltUtils, clusterManager);
 
         MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
         minion.setMinionId("dev-minsles12sp2.test.local");
@@ -2178,17 +1940,6 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
         applyStateAction.getServerActions().stream().findFirst().get().setStatus(ActionFactory.STATUS_FAILED);
 
-        SystemQuery systemQuery = SaltService.INSTANCE;
-        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
-        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
-        FormulaManager formulaManager = new FormulaManager(saltApi);
-        ClusterManager clusterManager = new ClusterManager(
-                saltApi, systemQuery, serverGroupManager, formulaManager
-        );
-        SaltUtils saltUtils = new SaltUtils(
-                systemQuery, saltApi, clusterManager
-        );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(new SaltService(), saltUtils, clusterManager);
         saltServerActionService.failDependentServerActions(applyStateAction.getId(),
                 minion.getMinionId(), Optional.empty());
 
@@ -2251,17 +2002,6 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                         placeholders));
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
 
-        SystemQuery systemQuery = SaltService.INSTANCE;
-        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
-        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
-        FormulaManager formulaManager = new FormulaManager(saltApi);
-        ClusterManager clusterManager = new ClusterManager(
-                saltApi, systemQuery, serverGroupManager, formulaManager
-        );
-        SaltUtils saltUtils = new SaltUtils(
-                systemQuery, saltApi, clusterManager
-        );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(new SaltService(), saltUtils, clusterManager);
         // Process the event message
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
@@ -2319,17 +2059,6 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                         placeholders));
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
 
-        SystemQuery systemQuery = SaltService.INSTANCE;
-        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
-        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
-        FormulaManager formulaManager = new FormulaManager(saltApi);
-        ClusterManager clusterManager = new ClusterManager(
-                saltApi, systemQuery, serverGroupManager, formulaManager
-        );
-        SaltUtils saltUtils = new SaltUtils(
-                systemQuery, saltApi, clusterManager
-        );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(new SaltService(), saltUtils, clusterManager);
         // Process the event message
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
@@ -2366,17 +2095,6 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 placeholders));
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
 
-        SystemQuery systemQuery = SaltService.INSTANCE;
-        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
-        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
-        FormulaManager formulaManager = new FormulaManager(saltApi);
-        ClusterManager clusterManager = new ClusterManager(
-                saltApi, systemQuery, serverGroupManager, formulaManager
-        );
-        SaltUtils saltUtils = new SaltUtils(
-                systemQuery, saltApi, clusterManager
-        );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         // Process the event message
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
@@ -2397,17 +2115,6 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                         placeholders));
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
 
-        SystemQuery systemQuery = SaltService.INSTANCE;
-        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
-        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
-        FormulaManager formulaManager = new FormulaManager(saltApi);
-        ClusterManager clusterManager = new ClusterManager(
-                saltApi, systemQuery, serverGroupManager, formulaManager
-        );
-        SaltUtils saltUtils = new SaltUtils(
-                systemQuery, saltApi, clusterManager
-        );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         // Process the event message
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
@@ -2429,17 +2136,6 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
         MinionServer nodeToJoin = MinionServerFactoryTest.createTestMinionServer(user);
 
-        SystemQuery systemQuery = SaltService.INSTANCE;
-        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
-        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
-        FormulaManager formulaManager = new FormulaManager(saltApi);
-        ClusterManager clusterManager = new ClusterManager(
-                saltApi, systemQuery, serverGroupManager, formulaManager
-        );
-        SaltUtils saltUtils = new SaltUtils(
-                systemQuery, saltApi, clusterManager
-        );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         Map<String, Object> params = new HashMap<>();
         params.put("skuba_cluster_path", "/opt/mycluster");
         params.put("map", Collections.singletonMap("key", "value"));
@@ -2501,17 +2197,6 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
         MinionServer nodeToJoin = MinionServerFactoryTest.createTestMinionServer(user);
 
-        SystemQuery systemQuery = SaltService.INSTANCE;
-        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
-        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
-        FormulaManager formulaManager = new FormulaManager(saltApi);
-        ClusterManager clusterManager = new ClusterManager(
-                saltApi, systemQuery, serverGroupManager, formulaManager
-        );
-        SaltUtils saltUtils = new SaltUtils(
-                systemQuery, saltApi, clusterManager
-        );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         Map<String, Object> params = new HashMap<>();
 
         BaseClusterModifyNodesAction action = clusterManager.modifyClusterNodes(ActionFactory.TYPE_CLUSTER_JOIN_NODE, cluster, Arrays.asList(nodeToJoin.getId()), params, new Date(), user);
@@ -2590,18 +2275,6 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
         MinionServer nodeToJoin = MinionServerFactoryTest.createTestMinionServer(user);
 
-        SystemQuery systemQuery = SaltService.INSTANCE;
-        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
-        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
-        FormulaManager formulaManager = new FormulaManager(saltApi);
-        ClusterManager clusterManager = new ClusterManager(
-                saltApi, systemQuery, serverGroupManager, formulaManager
-        );
-        SaltUtils saltUtils = new SaltUtils(
-                systemQuery, saltApi, clusterManager
-        );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils,
-                clusterManager);
         Map<String, Object> params = new HashMap<>();
         params.put("skuba_cluster_path", "/opt/mycluster");
         params.put("map", Collections.singletonMap("key", "value"));
@@ -2654,18 +2327,6 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
         MinionServer nodeToJoin = MinionServerFactoryTest.createTestMinionServer(user);
 
-        SystemQuery systemQuery = SaltService.INSTANCE;
-        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
-        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
-        FormulaManager formulaManager = new FormulaManager(saltApi);
-        ClusterManager clusterManager = new ClusterManager(
-                saltApi, systemQuery, serverGroupManager, formulaManager
-        );
-        SaltUtils saltUtils = new SaltUtils(
-                systemQuery, saltApi, clusterManager
-        );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils,
-                clusterManager);
         Map<String, Object> params = new HashMap<>();
 
         BaseClusterModifyNodesAction action = clusterManager.modifyClusterNodes(ActionFactory.TYPE_CLUSTER_REMOVE_NODE, cluster, Arrays.asList(nodeToJoin.getId()), params, new Date(), user);
@@ -2717,17 +2378,6 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         MinionServer managementNode = MinionServerFactoryTest.createTestMinionServer(user);
         Cluster cluster = ClusterActionTest.createTestCluster(user, managementNode);
 
-        SystemQuery systemQuery = SaltService.INSTANCE;
-        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
-        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
-        FormulaManager formulaManager = new FormulaManager(saltApi);
-        ClusterManager clusterManager = new ClusterManager(
-                saltApi, systemQuery, serverGroupManager, formulaManager
-        );
-        SaltUtils saltUtils = new SaltUtils(
-                systemQuery, saltApi, clusterManager
-        );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         Map<String, Object> params = new HashMap<>();
         params.put("skuba_cluster_path", "/opt/mycluster");
         params.put("map", Collections.singletonMap("key", "value"));
@@ -2782,17 +2432,6 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         MinionServer managementNode = MinionServerFactoryTest.createTestMinionServer(user);
         Cluster cluster = ClusterActionTest.createTestCluster(user, managementNode);
 
-        SystemQuery systemQuery = SaltService.INSTANCE;
-        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
-        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
-        FormulaManager formulaManager = new FormulaManager(saltApi);
-        ClusterManager clusterManager = new ClusterManager(
-                saltApi, systemQuery, serverGroupManager, formulaManager
-        );
-        SaltUtils saltUtils = new SaltUtils(
-                systemQuery, saltApi, clusterManager
-        );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         Map<String, Object> params = new HashMap<>();
         params.put("skuba_cluster_path", "/opt/mycluster");
         params.put("map", Collections.singletonMap("key", "value"));

--- a/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
@@ -145,7 +145,6 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
     private SaltService saltServiceMock;
     private SystemEntitlementManager systemEntitlementManager;
     protected Path metadataDirOfficial;
-    private ServerGroupManager serverGroupManager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
     private SaltUtils saltUtils;
     private SaltServerActionService saltServerActionService;
     private ClusterManager clusterManager;

--- a/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
@@ -171,7 +171,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         saltUtils = new SaltUtils(
                 saltServiceMock, saltServiceMock, clusterManager, formulaManager
         );
-        saltServerActionService = new SaltServerActionService(saltServiceMock, saltUtils, clusterManager);
+        saltServerActionService = new SaltServerActionService(saltServiceMock, saltUtils, clusterManager, formulaManager);
         metadataDirOfficial = Files.createTempDirectory("meta");
         formulaDataDir = Files.createTempDirectory("data");
         FormulaFactory.setMetadataDirOfficial(metadataDirOfficial.toString());

--- a/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
@@ -1196,7 +1196,11 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         Set<NetworkInterface> oldIfs = new HashSet<>();
         oldIfs.addAll(server.getNetworkInterfaces());
 
-        SaltUtils saltUtils = new SaltUtils(saltServiceMock, saltServiceMock, ClusterManager.instance());
+        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        FormulaManager formulaManager = new FormulaManager(saltServiceMock);
+        ClusterManager clusterManager = new ClusterManager(saltServiceMock, saltServiceMock, serverGroupManager,
+                formulaManager);
+        SaltUtils saltUtils = new SaltUtils(saltServiceMock, saltServiceMock, clusterManager);
 
         saltUtils.updateServerAction(sa, 0L, true, "n/a", element, "state.apply");
 

--- a/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
@@ -14,6 +14,7 @@
  */
 package com.suse.manager.reactor.messaging.test;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
@@ -82,8 +83,6 @@ import com.suse.manager.utils.SaltKeyUtils;
 import com.suse.manager.utils.SaltUtils;
 import com.suse.manager.virtualization.VirtManagerSalt;
 import com.suse.manager.webui.services.SaltServerActionService;
-import com.suse.manager.webui.services.iface.SaltApi;
-import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.manager.webui.services.impl.SaltSSHService;
 import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.manager.webui.services.impl.runner.MgrUtilRunner;
@@ -146,7 +145,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
     private SaltService saltServiceMock;
     private SystemEntitlementManager systemEntitlementManager;
     protected Path metadataDirOfficial;
-    private ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+    private ServerGroupManager serverGroupManager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
     private SaltUtils saltUtils;
     private SaltServerActionService saltServerActionService;
     private ClusterManager clusterManager;
@@ -160,17 +159,19 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         Config.get().setString("server.secret_key",
                 DigestUtils.sha256Hex(TestUtils.randomString()));
         saltServiceMock = context().mock(SaltService.class);
+        ServerGroupManager serverGroupManager = new ServerGroupManager();
         systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(new VirtManagerSalt(saltServiceMock), new FormulaMonitoringManager()),
+                new SystemUnentitler(new VirtManagerSalt(saltServiceMock), new FormulaMonitoringManager(),
+                        serverGroupManager),
                 new SystemEntitler(saltServiceMock, new VirtManagerSalt(saltServiceMock),
-                        new FormulaMonitoringManager())
+                        new FormulaMonitoringManager(), serverGroupManager)
         );
         FormulaManager formulaManager = new FormulaManager(saltServiceMock);
         clusterManager = new ClusterManager(
                 saltServiceMock, saltServiceMock, serverGroupManager, formulaManager
         );
         saltUtils = new SaltUtils(
-                saltServiceMock, saltServiceMock, clusterManager, formulaManager
+                saltServiceMock, saltServiceMock, clusterManager, formulaManager, serverGroupManager
         );
         saltServerActionService = new SaltServerActionService(saltServiceMock, saltUtils, clusterManager,
                 formulaManager, new SaltKeyUtils(saltServiceMock));

--- a/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
@@ -692,8 +692,6 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         context().checking(new Expectations() {{
             oneOf(saltServiceMock).refreshPillar(with(any(MinionList.class)));
         }});
-        SaltUtils.INSTANCE.setSystemQuery(saltServiceMock);
-        SaltUtils.INSTANCE.setSaltApi(saltServiceMock);
 
         Action action = ActionFactoryTest.createAction(
                 user, ActionFactory.TYPE_PACKAGES_REFRESH_LIST);
@@ -704,8 +702,8 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 getJobReturnEvent("packages.profileupdate.caasp-node.json", action.getId()));
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
 
-        SystemQuery systemQuery = SaltService.INSTANCE;
-        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
+        SystemQuery systemQuery = saltServiceMock;
+        SaltApi saltApi = saltServiceMock;
         ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
         FormulaManager formulaManager = new FormulaManager(saltApi);
         ClusterManager clusterManager = new ClusterManager(
@@ -742,7 +740,6 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
         context().checking(new Expectations() {{  }});
 
-        SaltUtils.INSTANCE.setSystemQuery(saltServiceMock);
 
         Action action = ActionFactoryTest.createAction(
                 user, ActionFactory.TYPE_PACKAGES_REFRESH_LIST);
@@ -753,8 +750,8 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 getJobReturnEvent("packages.profileupdate.caasp-node.json", action.getId()));
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
 
-        SystemQuery systemQuery = SaltService.INSTANCE;
-        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
+        SystemQuery systemQuery = saltServiceMock;
+        SaltApi saltApi = saltServiceMock;
         ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
         FormulaManager formulaManager = new FormulaManager(saltApi);
         ClusterManager clusterManager = new ClusterManager(
@@ -792,7 +789,6 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         context().checking(new Expectations() {{
             allowing(saltServiceMock).refreshPillar(with(any(MinionList.class)));
         }});
-        SaltUtils.INSTANCE.setSystemQuery(saltServiceMock);
 
         Action action = ActionFactoryTest.createAction(
                 user, ActionFactory.TYPE_PACKAGES_REFRESH_LIST);
@@ -803,8 +799,8 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 getJobReturnEvent("packages.profileupdate.caasp-management.json", action.getId()));
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
 
-        SystemQuery systemQuery = SaltService.INSTANCE;
-        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
+        SystemQuery systemQuery = saltServiceMock;
+        SaltApi saltApi = saltServiceMock;
         ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
         FormulaManager formulaManager = new FormulaManager(saltApi);
         ClusterManager clusterManager = new ClusterManager(
@@ -1200,7 +1196,9 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         Set<NetworkInterface> oldIfs = new HashSet<>();
         oldIfs.addAll(server.getNetworkInterfaces());
 
-        SaltUtils.INSTANCE.updateServerAction(sa, 0L, true, "n/a", element, "state.apply");
+        SaltUtils saltUtils = new SaltUtils(saltServiceMock, saltServiceMock, ClusterManager.instance());
+
+        saltUtils.updateServerAction(sa, 0L, true, "n/a", element, "state.apply");
 
         Map<String, NetworkInterface> ethNames = server.getNetworkInterfaces().stream().collect(Collectors.toMap(
                 eth -> eth.getName(),
@@ -1504,8 +1502,8 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
             will(returnValue(result));
         }});
 
-        SaltUtils.INSTANCE.setXccdfResumeXsl(resumeXsl);
-        SaltUtils.INSTANCE.setSystemQuery(saltServiceMock);
+        saltUtils.setXccdfResumeXsl(resumeXsl);
+        saltUtils.setSystemQuery(saltServiceMock);
         messageAction.execute(message);
 
         assertEquals(ActionFactory.STATUS_COMPLETED, sa.getStatus());
@@ -1828,7 +1826,6 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                     with(equal(String.format("/srv/www/os-images/%d/", user.getOrg().getId()))));
             will(returnValue(Optional.of(mockResult)));
         }});
-        SaltUtils.INSTANCE.setSystemQuery(saltServiceMock);
 
         systemEntitlementManager.addEntitlementToServer(server, EntitlementManager.OSIMAGE_BUILD_HOST);
 
@@ -1859,7 +1856,6 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                     with(equal(String.format("/srv/www/os-images/%d/", user.getOrg().getId()))));
             will(returnValue(Optional.of(mockResult)));
         }});
-        SaltUtils.INSTANCE.setSystemQuery(saltServiceMock);
 
         systemEntitlementManager.addEntitlementToServer(server, EntitlementManager.OSIMAGE_BUILD_HOST);
 

--- a/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
@@ -201,7 +201,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         );
         SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
         // Process the event message
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
 
         // Verify the results
@@ -338,7 +338,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 systemQuery, saltApi, clusterManager
         );
         SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
 
         // Verify names and versions
@@ -416,7 +416,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 systemQuery, saltApi, clusterManager
         );
         SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
 
         // Verify names and versions
@@ -502,7 +502,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         );
         SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
         // Process the event message
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
 
         // Verify no live patching version is returned
@@ -563,7 +563,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         );
         SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
         // Process the event message
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
 
         // Verify the results
@@ -639,7 +639,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         );
         SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
         // Process the event message
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
 
         // Verify the results
@@ -715,7 +715,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 systemQuery, saltApi, clusterManager
         );
         SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
 
         assertTrue(minion.getPackages().stream().anyMatch(p -> p.getName().getName().contains(SaltUtils.CAASP_PATTERN_IDENTIFIER)));
@@ -764,7 +764,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 systemQuery, saltApi, clusterManager
         );
         SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
 
         assertTrue(minion.getPackages().stream().anyMatch(
@@ -814,7 +814,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 systemQuery, saltApi, clusterManager
         );
         SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
 
         assertFalse(minion.getPackages().stream().anyMatch(
@@ -1124,7 +1124,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         );
         SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
         // Process the event message
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
 
         HibernateFactory.getSession().flush();
@@ -1181,7 +1181,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         );
         SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
         // Process the event message
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
     }
 
@@ -1314,7 +1314,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         );
         SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
         // Process the event message
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
 
         assertions.accept(server);
@@ -1429,7 +1429,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         );
         SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
         // Process the event message
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
 
         assertEquals(
@@ -1476,7 +1476,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 systemQuery, saltApi, clusterManager
         );
         SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
 
         File scapFile = new File(TestUtils.findTestDataInDir(
                 "/com/redhat/rhn/manager/audit/test/openscap/minionsles12sp1.test.local/results.xml").getPath());
@@ -1726,7 +1726,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 systemQuery, saltApi, clusterManager
         );
         SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
 
         // assertions after inspect
@@ -1759,7 +1759,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 systemQuery, saltApi, clusterManager
         );
         SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
 
         // assert we have the same initial ImageInfo even after processing the event
@@ -1800,7 +1800,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 systemQuery, saltApi, clusterManager
         );
         SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
 
         assertTrue(ImageInfoFactory.lookupByName(imageName, imageVersion, store.getId()).isPresent());
@@ -1919,7 +1919,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 systemQuery, saltApi, clusterManager
         );
         SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
 
         // assert we have the same initial ImageInfo even after processing the event
@@ -1966,7 +1966,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 systemQuery, saltApi, clusterManager
         );
         SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
 
         assertTrue(ImageInfoFactory.lookupById(imgInfoBuild.get().getId()).isPresent());
@@ -2010,7 +2010,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         );
         SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
         // Process the event message
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
 
         assertEquals(initialMessageCount, MessageQueue.getMessageCount());
@@ -2072,7 +2072,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
 
         // Process the event message
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
 
         assertEquals(ActionFactory.STATUS_COMPLETED, sa.getStatus());
@@ -2146,7 +2146,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
 
         // Process the event message
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
 
         // check that tokens are really gone
@@ -2263,7 +2263,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         );
         SaltServerActionService saltServerActionService = new SaltServerActionService(new SaltService(), saltUtils);
         // Process the event message
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
 
         applyHighstate = (ApplyStatesAction)ActionFactory.lookupById(applyHighstate.getId());
@@ -2331,7 +2331,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         );
         SaltServerActionService saltServerActionService = new SaltServerActionService(new SaltService(), saltUtils);
         // Process the event message
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
         List<Action> serversActions = ActionFactory.listActionsForServer(user, minion);
         //Verify that there are 2 actions scheduled, one apply state that we scheduled above and
@@ -2378,7 +2378,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         );
         SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
         // Process the event message
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
         List<Action> serversActions = ActionFactory.listActionsForServer(user, minion);
         //Verify that there is only one action scheduled, the apply state one that we scheduled above
@@ -2409,7 +2409,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         );
         SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
         // Process the event message
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
         assertEquals(name, minion.getName());
         assertNotSame(runningKernel, minion.getRunningKernel());
@@ -2459,7 +2459,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                         placeholders));
 
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
 
         action = (ClusterJoinNodeAction)ActionFactory.lookupById(action.getId());
@@ -2530,7 +2530,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                         placeholders));
 
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
 
         action = (ClusterJoinNodeAction)ActionFactory.lookupById(action.getId());
@@ -2620,7 +2620,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                         placeholders));
 
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
 
         action = (ClusterRemoveNodeAction)ActionFactory.lookupById(action.getId());
@@ -2682,7 +2682,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                         placeholders));
 
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
 
         action = (ClusterRemoveNodeAction)ActionFactory.lookupById(action.getId());
@@ -2746,7 +2746,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                         placeholders));
 
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
 
         action = (ClusterUpgradeAction)ActionFactory.lookupById(action.getId());
@@ -2811,7 +2811,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                         placeholders));
 
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
 
         action = (ClusterUpgradeAction)ActionFactory.lookupById(action.getId());

--- a/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
@@ -60,7 +60,9 @@ import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.action.ActionChainManager;
 import com.redhat.rhn.manager.action.ActionManager;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
+import com.redhat.rhn.manager.formula.FormulaManager;
 import com.redhat.rhn.manager.formula.FormulaMonitoringManager;
+import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitler;
@@ -79,6 +81,8 @@ import com.suse.manager.reactor.utils.test.RhelUtilsTest;
 import com.suse.manager.utils.SaltUtils;
 import com.suse.manager.virtualization.VirtManagerSalt;
 import com.suse.manager.webui.services.SaltServerActionService;
+import com.suse.manager.webui.services.iface.SaltApi;
+import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.manager.webui.services.impl.SaltSSHService;
 import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.manager.webui.services.impl.runner.MgrUtilRunner;
@@ -185,8 +189,19 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 getJobReturnEvent("packages.profileupdate.json", action.getId()));
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
 
+        SystemQuery systemQuery = SaltService.INSTANCE;
+        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
+        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        FormulaManager formulaManager = new FormulaManager(saltApi);
+        ClusterManager clusterManager = new ClusterManager(
+                saltApi, systemQuery, serverGroupManager, formulaManager
+        );
+        SaltUtils saltUtils = new SaltUtils(
+                systemQuery, saltApi, clusterManager
+        );
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
         // Process the event message
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction();
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
         messageAction.execute(message);
 
         // Verify the results
@@ -311,7 +326,19 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         JobReturnEventMessage message = new JobReturnEventMessage(JobReturnEvent
                 .parse(getJobReturnEvent("packages.profileupdate.allversions.json", action.getId()))
                 .get());
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction();
+
+        SystemQuery systemQuery = SaltService.INSTANCE;
+        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
+        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        FormulaManager formulaManager = new FormulaManager(saltApi);
+        ClusterManager clusterManager = new ClusterManager(
+                saltApi, systemQuery, serverGroupManager, formulaManager
+        );
+        SaltUtils saltUtils = new SaltUtils(
+                systemQuery, saltApi, clusterManager
+        );
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
         messageAction.execute(message);
 
         // Verify names and versions
@@ -377,7 +404,19 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         JobReturnEventMessage message = new JobReturnEventMessage(JobReturnEvent
                 .parse(getJobReturnEvent("packages.profileupdate.json", action.getId()))
                 .get());
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction();
+
+        SystemQuery systemQuery = SaltService.INSTANCE;
+        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
+        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        FormulaManager formulaManager = new FormulaManager(saltApi);
+        ClusterManager clusterManager = new ClusterManager(
+                saltApi, systemQuery, serverGroupManager, formulaManager
+        );
+        SaltUtils saltUtils = new SaltUtils(
+                systemQuery, saltApi, clusterManager
+        );
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
         messageAction.execute(message);
 
         // Verify names and versions
@@ -451,8 +490,19 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 .parse(getJobReturnEvent("packages.profileupdate.json", action.getId()))
                 .get());
 
+        SystemQuery systemQuery = SaltService.INSTANCE;
+        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
+        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        FormulaManager formulaManager = new FormulaManager(saltApi);
+        ClusterManager clusterManager = new ClusterManager(
+                saltApi, systemQuery, serverGroupManager, formulaManager
+        );
+        SaltUtils saltUtils = new SaltUtils(
+                systemQuery, saltApi, clusterManager
+        );
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
         // Process the event message
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction();
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
         messageAction.execute(message);
 
         // Verify no live patching version is returned
@@ -501,8 +551,19 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 getJobReturnEvent("packages.profileupdate.rhel7res.json", action.getId()));
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
 
+        SystemQuery systemQuery = SaltService.INSTANCE;
+        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
+        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        FormulaManager formulaManager = new FormulaManager(saltApi);
+        ClusterManager clusterManager = new ClusterManager(
+                saltApi, systemQuery, serverGroupManager, formulaManager
+        );
+        SaltUtils saltUtils = new SaltUtils(
+                systemQuery, saltApi, clusterManager
+        );
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
         // Process the event message
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction();
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
         messageAction.execute(message);
 
         // Verify the results
@@ -566,8 +627,19 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 getJobReturnEvent("packages.profileupdate.ubuntu.json", action.getId()));
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
 
+        SystemQuery systemQuery = SaltService.INSTANCE;
+        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
+        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        FormulaManager formulaManager = new FormulaManager(saltApi);
+        ClusterManager clusterManager = new ClusterManager(
+                saltApi, systemQuery, serverGroupManager, formulaManager
+        );
+        SaltUtils saltUtils = new SaltUtils(
+                systemQuery, saltApi, clusterManager
+        );
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
         // Process the event message
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction();
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
         messageAction.execute(message);
 
         // Verify the results
@@ -632,7 +704,18 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 getJobReturnEvent("packages.profileupdate.caasp-node.json", action.getId()));
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
 
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction();
+        SystemQuery systemQuery = SaltService.INSTANCE;
+        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
+        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        FormulaManager formulaManager = new FormulaManager(saltApi);
+        ClusterManager clusterManager = new ClusterManager(
+                saltApi, systemQuery, serverGroupManager, formulaManager
+        );
+        SaltUtils saltUtils = new SaltUtils(
+                systemQuery, saltApi, clusterManager
+        );
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
         messageAction.execute(message);
 
         assertTrue(minion.getPackages().stream().anyMatch(p -> p.getName().getName().contains(SaltUtils.CAASP_PATTERN_IDENTIFIER)));
@@ -670,7 +753,18 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 getJobReturnEvent("packages.profileupdate.caasp-node.json", action.getId()));
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
 
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction();
+        SystemQuery systemQuery = SaltService.INSTANCE;
+        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
+        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        FormulaManager formulaManager = new FormulaManager(saltApi);
+        ClusterManager clusterManager = new ClusterManager(
+                saltApi, systemQuery, serverGroupManager, formulaManager
+        );
+        SaltUtils saltUtils = new SaltUtils(
+                systemQuery, saltApi, clusterManager
+        );
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
         messageAction.execute(message);
 
         assertTrue(minion.getPackages().stream().anyMatch(
@@ -709,7 +803,18 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 getJobReturnEvent("packages.profileupdate.caasp-management.json", action.getId()));
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
 
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction();
+        SystemQuery systemQuery = SaltService.INSTANCE;
+        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
+        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        FormulaManager formulaManager = new FormulaManager(saltApi);
+        ClusterManager clusterManager = new ClusterManager(
+                saltApi, systemQuery, serverGroupManager, formulaManager
+        );
+        SaltUtils saltUtils = new SaltUtils(
+                systemQuery, saltApi, clusterManager
+        );
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
         messageAction.execute(message);
 
         assertFalse(minion.getPackages().stream().anyMatch(
@@ -1007,8 +1112,19 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 getJobReturnEvent("hardware.profileupdate.ip_change_ipv4ipv6.x86.json", action.getId()));
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
 
+        SystemQuery systemQuery = SaltService.INSTANCE;
+        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
+        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        FormulaManager formulaManager = new FormulaManager(saltApi);
+        ClusterManager clusterManager = new ClusterManager(
+                saltApi, systemQuery, serverGroupManager, formulaManager
+        );
+        SaltUtils saltUtils = new SaltUtils(
+                systemQuery, saltApi, clusterManager
+        );
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
         // Process the event message
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction();
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
         messageAction.execute(message);
 
         HibernateFactory.getSession().flush();
@@ -1053,8 +1169,19 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 getJobReturnEvent("hardware.profileupdate.primary_ips_ipv4ipv6.x86.json", action.getId()));
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
 
+        SystemQuery systemQuery = SaltService.INSTANCE;
+        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
+        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        FormulaManager formulaManager = new FormulaManager(saltApi);
+        ClusterManager clusterManager = new ClusterManager(
+                saltApi, systemQuery, serverGroupManager, formulaManager
+        );
+        SaltUtils saltUtils = new SaltUtils(
+                systemQuery, saltApi, clusterManager
+        );
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
         // Process the event message
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction();
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
         messageAction.execute(message);
     }
 
@@ -1175,8 +1302,19 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 getJobReturnEvent(jsonFile, action.getId()));
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
 
+        SystemQuery systemQuery = SaltService.INSTANCE;
+        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
+        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        FormulaManager formulaManager = new FormulaManager(saltApi);
+        ClusterManager clusterManager = new ClusterManager(
+                saltApi, systemQuery, serverGroupManager, formulaManager
+        );
+        SaltUtils saltUtils = new SaltUtils(
+                systemQuery, saltApi, clusterManager
+        );
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
         // Process the event message
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction();
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
         messageAction.execute(message);
 
         assertions.accept(server);
@@ -1279,8 +1417,19 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         } });
 
 
+        SystemQuery systemQuery = SaltService.INSTANCE;
+        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
+        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        FormulaManager formulaManager = new FormulaManager(saltApi);
+        ClusterManager clusterManager = new ClusterManager(
+                saltApi, systemQuery, serverGroupManager, formulaManager
+        );
+        SaltUtils saltUtils = new SaltUtils(
+                systemQuery, saltApi, clusterManager
+        );
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
         // Process the event message
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction();
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
         messageAction.execute(message);
 
         assertEquals(
@@ -1316,7 +1465,18 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 getJobReturnEvent("openscap.xccdf.success.json", action.getId()));
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
 
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction();
+        SystemQuery systemQuery = SaltService.INSTANCE;
+        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
+        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        FormulaManager formulaManager = new FormulaManager(saltApi);
+        ClusterManager clusterManager = new ClusterManager(
+                saltApi, systemQuery, serverGroupManager, formulaManager
+        );
+        SaltUtils saltUtils = new SaltUtils(
+                systemQuery, saltApi, clusterManager
+        );
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
 
         File scapFile = new File(TestUtils.findTestDataInDir(
                 "/com/redhat/rhn/manager/audit/test/openscap/minionsles12sp1.test.local/results.xml").getPath());
@@ -1555,7 +1715,18 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                         ));
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
 
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction();
+        SystemQuery systemQuery = SaltService.INSTANCE;
+        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
+        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        FormulaManager formulaManager = new FormulaManager(saltApi);
+        ClusterManager clusterManager = new ClusterManager(
+                saltApi, systemQuery, serverGroupManager, formulaManager
+        );
+        SaltUtils saltUtils = new SaltUtils(
+                systemQuery, saltApi, clusterManager
+        );
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
         messageAction.execute(message);
 
         // assertions after inspect
@@ -1577,7 +1748,18 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                         Collections.singletonMap("$IMAGE$", imageName)));
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
 
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction();
+        SystemQuery systemQuery = SaltService.INSTANCE;
+        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
+        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        FormulaManager formulaManager = new FormulaManager(saltApi);
+        ClusterManager clusterManager = new ClusterManager(
+                saltApi, systemQuery, serverGroupManager, formulaManager
+        );
+        SaltUtils saltUtils = new SaltUtils(
+                systemQuery, saltApi, clusterManager
+        );
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
         messageAction.execute(message);
 
         // assert we have the same initial ImageInfo even after processing the event
@@ -1607,7 +1789,18 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                         placeholders
                 ));
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction();
+        SystemQuery systemQuery = SaltService.INSTANCE;
+        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
+        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        FormulaManager formulaManager = new FormulaManager(saltApi);
+        ClusterManager clusterManager = new ClusterManager(
+                saltApi, systemQuery, serverGroupManager, formulaManager
+        );
+        SaltUtils saltUtils = new SaltUtils(
+                systemQuery, saltApi, clusterManager
+        );
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
         messageAction.execute(message);
 
         assertTrue(ImageInfoFactory.lookupByName(imageName, imageVersion, store.getId()).isPresent());
@@ -1715,7 +1908,18 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 JobReturnEvent.parse(getJobReturnEvent("image.build.kiwi.json", actionId));
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
 
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction();
+        SystemQuery systemQuery = SaltService.INSTANCE;
+        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
+        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        FormulaManager formulaManager = new FormulaManager(saltApi);
+        ClusterManager clusterManager = new ClusterManager(
+                saltApi, systemQuery, serverGroupManager, formulaManager
+        );
+        SaltUtils saltUtils = new SaltUtils(
+                systemQuery, saltApi, clusterManager
+        );
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
         messageAction.execute(message);
 
         // assert we have the same initial ImageInfo even after processing the event
@@ -1751,7 +1955,18 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 .parse(getJobReturnEvent("image.inspect.kiwi.json", actionId));
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
 
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction();
+        SystemQuery systemQuery = SaltService.INSTANCE;
+        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
+        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        FormulaManager formulaManager = new FormulaManager(saltApi);
+        ClusterManager clusterManager = new ClusterManager(
+                saltApi, systemQuery, serverGroupManager, formulaManager
+        );
+        SaltUtils saltUtils = new SaltUtils(
+                systemQuery, saltApi, clusterManager
+        );
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
         messageAction.execute(message);
 
         assertTrue(ImageInfoFactory.lookupById(imgInfoBuild.get().getId()).isPresent());
@@ -1783,8 +1998,19 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 getJobReturnEvent("openscap.xccdf.success.json", 123));
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
 
+        SystemQuery systemQuery = SaltService.INSTANCE;
+        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
+        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        FormulaManager formulaManager = new FormulaManager(saltApi);
+        ClusterManager clusterManager = new ClusterManager(
+                saltApi, systemQuery, serverGroupManager, formulaManager
+        );
+        SaltUtils saltUtils = new SaltUtils(
+                systemQuery, saltApi, clusterManager
+        );
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
         // Process the event message
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction();
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
         messageAction.execute(message);
 
         assertEquals(initialMessageCount, MessageQueue.getMessageCount());
@@ -1797,7 +2023,17 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
             allowing(taskomaticMock).scheduleSubscribeChannels(with(any(User.class)), with(any(SubscribeChannelsAction.class)));
         } });
 
-        SaltServerActionService saltServerActionService = new SaltServerActionService(new SaltService());
+        SystemQuery systemQuery = SaltService.INSTANCE;
+        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
+        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        FormulaManager formulaManager = new FormulaManager(saltApi);
+        ClusterManager clusterManager = new ClusterManager(
+                saltApi, systemQuery, serverGroupManager, formulaManager
+        );
+        SaltUtils saltUtils = new SaltUtils(
+                systemQuery, saltApi, clusterManager
+        );
+        SaltServerActionService saltServerActionService = new SaltServerActionService(new SaltService(), saltUtils);
 
         MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
         minion.setMinionId("dev-minsles12sp2.test.local");
@@ -1836,7 +2072,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
 
         // Process the event message
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction();
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
         messageAction.execute(message);
 
         assertEquals(ActionFactory.STATUS_COMPLETED, sa.getStatus());
@@ -1859,7 +2095,17 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
             allowing(taskomaticMock).scheduleSubscribeChannels(with(any(User.class)),
                     with(any(SubscribeChannelsAction.class)));
         } });
-        SaltServerActionService saltServerActionService = new SaltServerActionService(new SaltService());
+        SystemQuery systemQuery = SaltService.INSTANCE;
+        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
+        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        FormulaManager formulaManager = new FormulaManager(saltApi);
+        ClusterManager clusterManager = new ClusterManager(
+                saltApi, systemQuery, serverGroupManager, formulaManager
+        );
+        SaltUtils saltUtils = new SaltUtils(
+                systemQuery, saltApi, clusterManager
+        );
+        SaltServerActionService saltServerActionService = new SaltServerActionService(new SaltService(), saltUtils);
 
         MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
         minion.setMinionId("dev-minsles12sp2.test.local");
@@ -1900,7 +2146,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
 
         // Process the event message
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction();
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
         messageAction.execute(message);
 
         // check that tokens are really gone
@@ -1916,7 +2162,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
     public void testFailDependentServerActions() throws Exception {
         MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
         Action applyStateAction = ActionFactoryTest.createAction(user, ActionFactory.TYPE_APPLY_STATES);
-        Action rebootAction = ActionFactoryTest.createAction(user,ActionFactory.TYPE_REBOOT);
+        Action rebootAction = ActionFactoryTest.createAction(user, ActionFactory.TYPE_REBOOT);
         Action runScriptAction = ActionFactoryTest.createAction(user, ActionFactory.TYPE_SCRIPT_RUN);
         //Add dependency
         rebootAction.setPrerequisite(applyStateAction);
@@ -1932,7 +2178,18 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
         applyStateAction.getServerActions().stream().findFirst().get().setStatus(ActionFactory.STATUS_FAILED);
 
-        JobReturnEventMessageAction.failDependentServerActions(applyStateAction.getId(),
+        SystemQuery systemQuery = SaltService.INSTANCE;
+        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
+        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        FormulaManager formulaManager = new FormulaManager(saltApi);
+        ClusterManager clusterManager = new ClusterManager(
+                saltApi, systemQuery, serverGroupManager, formulaManager
+        );
+        SaltUtils saltUtils = new SaltUtils(
+                systemQuery, saltApi, clusterManager
+        );
+        SaltServerActionService saltServerActionService = new SaltServerActionService(new SaltService(), saltUtils);
+        saltServerActionService.failDependentServerActions(applyStateAction.getId(),
                 minion.getMinionId(), Optional.empty());
 
         applyStateAction =  ActionFactory.lookupById(applyStateAction.getId());
@@ -1994,8 +2251,19 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                         placeholders));
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
 
+        SystemQuery systemQuery = SaltService.INSTANCE;
+        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
+        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        FormulaManager formulaManager = new FormulaManager(saltApi);
+        ClusterManager clusterManager = new ClusterManager(
+                saltApi, systemQuery, serverGroupManager, formulaManager
+        );
+        SaltUtils saltUtils = new SaltUtils(
+                systemQuery, saltApi, clusterManager
+        );
+        SaltServerActionService saltServerActionService = new SaltServerActionService(new SaltService(), saltUtils);
         // Process the event message
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction();
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
         messageAction.execute(message);
 
         applyHighstate = (ApplyStatesAction)ActionFactory.lookupById(applyHighstate.getId());
@@ -2051,8 +2319,19 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                         placeholders));
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
 
+        SystemQuery systemQuery = SaltService.INSTANCE;
+        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
+        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        FormulaManager formulaManager = new FormulaManager(saltApi);
+        ClusterManager clusterManager = new ClusterManager(
+                saltApi, systemQuery, serverGroupManager, formulaManager
+        );
+        SaltUtils saltUtils = new SaltUtils(
+                systemQuery, saltApi, clusterManager
+        );
+        SaltServerActionService saltServerActionService = new SaltServerActionService(new SaltService(), saltUtils);
         // Process the event message
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction();
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
         messageAction.execute(message);
         List<Action> serversActions = ActionFactory.listActionsForServer(user, minion);
         //Verify that there are 2 actions scheduled, one apply state that we scheduled above and
@@ -2087,8 +2366,19 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 placeholders));
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
 
+        SystemQuery systemQuery = SaltService.INSTANCE;
+        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
+        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        FormulaManager formulaManager = new FormulaManager(saltApi);
+        ClusterManager clusterManager = new ClusterManager(
+                saltApi, systemQuery, serverGroupManager, formulaManager
+        );
+        SaltUtils saltUtils = new SaltUtils(
+                systemQuery, saltApi, clusterManager
+        );
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
         // Process the event message
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction();
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
         messageAction.execute(message);
         List<Action> serversActions = ActionFactory.listActionsForServer(user, minion);
         //Verify that there is only one action scheduled, the apply state one that we scheduled above
@@ -2107,8 +2397,19 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                         placeholders));
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
 
+        SystemQuery systemQuery = SaltService.INSTANCE;
+        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
+        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        FormulaManager formulaManager = new FormulaManager(saltApi);
+        ClusterManager clusterManager = new ClusterManager(
+                saltApi, systemQuery, serverGroupManager, formulaManager
+        );
+        SaltUtils saltUtils = new SaltUtils(
+                systemQuery, saltApi, clusterManager
+        );
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
         // Process the event message
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction();
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
         messageAction.execute(message);
         assertEquals(name, minion.getName());
         assertNotSame(runningKernel, minion.getRunningKernel());
@@ -2128,7 +2429,17 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
         MinionServer nodeToJoin = MinionServerFactoryTest.createTestMinionServer(user);
 
-        ClusterManager clusterManager = ClusterManager.instance();
+        SystemQuery systemQuery = SaltService.INSTANCE;
+        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
+        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        FormulaManager formulaManager = new FormulaManager(saltApi);
+        ClusterManager clusterManager = new ClusterManager(
+                saltApi, systemQuery, serverGroupManager, formulaManager
+        );
+        SaltUtils saltUtils = new SaltUtils(
+                systemQuery, saltApi, clusterManager
+        );
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
         Map<String, Object> params = new HashMap<>();
         params.put("skuba_cluster_path", "/opt/mycluster");
         params.put("map", Collections.singletonMap("key", "value"));
@@ -2148,7 +2459,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                         placeholders));
 
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction();
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
         messageAction.execute(message);
 
         action = (ClusterJoinNodeAction)ActionFactory.lookupById(action.getId());
@@ -2190,7 +2501,17 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
         MinionServer nodeToJoin = MinionServerFactoryTest.createTestMinionServer(user);
 
-        ClusterManager clusterManager = ClusterManager.instance();
+        SystemQuery systemQuery = SaltService.INSTANCE;
+        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
+        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        FormulaManager formulaManager = new FormulaManager(saltApi);
+        ClusterManager clusterManager = new ClusterManager(
+                saltApi, systemQuery, serverGroupManager, formulaManager
+        );
+        SaltUtils saltUtils = new SaltUtils(
+                systemQuery, saltApi, clusterManager
+        );
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
         Map<String, Object> params = new HashMap<>();
 
         BaseClusterModifyNodesAction action = clusterManager.modifyClusterNodes(ActionFactory.TYPE_CLUSTER_JOIN_NODE, cluster, Arrays.asList(nodeToJoin.getId()), params, new Date(), user);
@@ -2209,7 +2530,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                         placeholders));
 
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction();
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
         messageAction.execute(message);
 
         action = (ClusterJoinNodeAction)ActionFactory.lookupById(action.getId());
@@ -2269,7 +2590,17 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
         MinionServer nodeToJoin = MinionServerFactoryTest.createTestMinionServer(user);
 
-        ClusterManager clusterManager = ClusterManager.instance();
+        SystemQuery systemQuery = SaltService.INSTANCE;
+        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
+        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        FormulaManager formulaManager = new FormulaManager(saltApi);
+        ClusterManager clusterManager = new ClusterManager(
+                saltApi, systemQuery, serverGroupManager, formulaManager
+        );
+        SaltUtils saltUtils = new SaltUtils(
+                systemQuery, saltApi, clusterManager
+        );
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
         Map<String, Object> params = new HashMap<>();
         params.put("skuba_cluster_path", "/opt/mycluster");
         params.put("map", Collections.singletonMap("key", "value"));
@@ -2289,7 +2620,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                         placeholders));
 
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction();
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
         messageAction.execute(message);
 
         action = (ClusterRemoveNodeAction)ActionFactory.lookupById(action.getId());
@@ -2322,7 +2653,17 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
 
         MinionServer nodeToJoin = MinionServerFactoryTest.createTestMinionServer(user);
 
-        ClusterManager clusterManager = ClusterManager.instance();
+        SystemQuery systemQuery = SaltService.INSTANCE;
+        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
+        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        FormulaManager formulaManager = new FormulaManager(saltApi);
+        ClusterManager clusterManager = new ClusterManager(
+                saltApi, systemQuery, serverGroupManager, formulaManager
+        );
+        SaltUtils saltUtils = new SaltUtils(
+                systemQuery, saltApi, clusterManager
+        );
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
         Map<String, Object> params = new HashMap<>();
 
         BaseClusterModifyNodesAction action = clusterManager.modifyClusterNodes(ActionFactory.TYPE_CLUSTER_REMOVE_NODE, cluster, Arrays.asList(nodeToJoin.getId()), params, new Date(), user);
@@ -2341,7 +2682,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                         placeholders));
 
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction();
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
         messageAction.execute(message);
 
         action = (ClusterRemoveNodeAction)ActionFactory.lookupById(action.getId());
@@ -2374,7 +2715,17 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         MinionServer managementNode = MinionServerFactoryTest.createTestMinionServer(user);
         Cluster cluster = ClusterActionTest.createTestCluster(user, managementNode);
 
-        ClusterManager clusterManager = ClusterManager.instance();
+        SystemQuery systemQuery = SaltService.INSTANCE;
+        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
+        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        FormulaManager formulaManager = new FormulaManager(saltApi);
+        ClusterManager clusterManager = new ClusterManager(
+                saltApi, systemQuery, serverGroupManager, formulaManager
+        );
+        SaltUtils saltUtils = new SaltUtils(
+                systemQuery, saltApi, clusterManager
+        );
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
         Map<String, Object> params = new HashMap<>();
         params.put("skuba_cluster_path", "/opt/mycluster");
         params.put("map", Collections.singletonMap("key", "value"));
@@ -2395,7 +2746,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                         placeholders));
 
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction();
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
         messageAction.execute(message);
 
         action = (ClusterUpgradeAction)ActionFactory.lookupById(action.getId());
@@ -2429,7 +2780,17 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         MinionServer managementNode = MinionServerFactoryTest.createTestMinionServer(user);
         Cluster cluster = ClusterActionTest.createTestCluster(user, managementNode);
 
-        ClusterManager clusterManager = ClusterManager.instance();
+        SystemQuery systemQuery = SaltService.INSTANCE;
+        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
+        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        FormulaManager formulaManager = new FormulaManager(saltApi);
+        ClusterManager clusterManager = new ClusterManager(
+                saltApi, systemQuery, serverGroupManager, formulaManager
+        );
+        SaltUtils saltUtils = new SaltUtils(
+                systemQuery, saltApi, clusterManager
+        );
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
         Map<String, Object> params = new HashMap<>();
         params.put("skuba_cluster_path", "/opt/mycluster");
         params.put("map", Collections.singletonMap("key", "value"));
@@ -2450,7 +2811,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                         placeholders));
 
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
-        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction();
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService);
         messageAction.execute(message);
 
         action = (ClusterUpgradeAction)ActionFactory.lookupById(action.getId());

--- a/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
@@ -78,6 +78,7 @@ import com.suse.manager.reactor.messaging.ApplyStatesEventMessage;
 import com.suse.manager.reactor.messaging.JobReturnEventMessage;
 import com.suse.manager.reactor.messaging.JobReturnEventMessageAction;
 import com.suse.manager.reactor.utils.test.RhelUtilsTest;
+import com.suse.manager.utils.SaltKeyUtils;
 import com.suse.manager.utils.SaltUtils;
 import com.suse.manager.virtualization.VirtManagerSalt;
 import com.suse.manager.webui.services.SaltServerActionService;
@@ -171,7 +172,8 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         saltUtils = new SaltUtils(
                 saltServiceMock, saltServiceMock, clusterManager, formulaManager
         );
-        saltServerActionService = new SaltServerActionService(saltServiceMock, saltUtils, clusterManager, formulaManager);
+        saltServerActionService = new SaltServerActionService(saltServiceMock, saltUtils, clusterManager,
+                formulaManager, new SaltKeyUtils(saltServiceMock));
         metadataDirOfficial = Files.createTempDirectory("meta");
         formulaDataDir = Files.createTempDirectory("data");
         FormulaFactory.setMetadataDirOfficial(metadataDirOfficial.toString());

--- a/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
@@ -1904,8 +1904,8 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 JobReturnEvent.parse(getJobReturnEvent("image.build.kiwi.json", actionId));
         JobReturnEventMessage message = new JobReturnEventMessage(event.get());
 
-        SystemQuery systemQuery = SaltService.INSTANCE;
-        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
+        SystemQuery systemQuery = saltServiceMock;
+        SaltApi saltApi = saltServiceMock;
         ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
         FormulaManager formulaManager = new FormulaManager(saltApi);
         ClusterManager clusterManager = new ClusterManager(

--- a/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
@@ -199,7 +199,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         SaltUtils saltUtils = new SaltUtils(
                 systemQuery, saltApi, clusterManager
         );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         // Process the event message
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
@@ -337,7 +337,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         SaltUtils saltUtils = new SaltUtils(
                 systemQuery, saltApi, clusterManager
         );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
 
@@ -415,7 +415,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         SaltUtils saltUtils = new SaltUtils(
                 systemQuery, saltApi, clusterManager
         );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
 
@@ -500,7 +500,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         SaltUtils saltUtils = new SaltUtils(
                 systemQuery, saltApi, clusterManager
         );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         // Process the event message
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
@@ -561,7 +561,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         SaltUtils saltUtils = new SaltUtils(
                 systemQuery, saltApi, clusterManager
         );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         // Process the event message
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
@@ -637,7 +637,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         SaltUtils saltUtils = new SaltUtils(
                 systemQuery, saltApi, clusterManager
         );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         // Process the event message
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
@@ -712,7 +712,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         SaltUtils saltUtils = new SaltUtils(
                 systemQuery, saltApi, clusterManager
         );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
 
@@ -760,7 +760,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         SaltUtils saltUtils = new SaltUtils(
                 systemQuery, saltApi, clusterManager
         );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
 
@@ -809,7 +809,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         SaltUtils saltUtils = new SaltUtils(
                 systemQuery, saltApi, clusterManager
         );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
 
@@ -1118,7 +1118,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         SaltUtils saltUtils = new SaltUtils(
                 systemQuery, saltApi, clusterManager
         );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         // Process the event message
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
@@ -1175,7 +1175,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         SaltUtils saltUtils = new SaltUtils(
                 systemQuery, saltApi, clusterManager
         );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         // Process the event message
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
@@ -1310,7 +1310,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         SaltUtils saltUtils = new SaltUtils(
                 systemQuery, saltApi, clusterManager
         );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         // Process the event message
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
@@ -1425,7 +1425,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         SaltUtils saltUtils = new SaltUtils(
                 systemQuery, saltApi, clusterManager
         );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         // Process the event message
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
@@ -1473,7 +1473,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         SaltUtils saltUtils = new SaltUtils(
                 systemQuery, saltApi, clusterManager
         );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
 
         File scapFile = new File(TestUtils.findTestDataInDir(
@@ -1723,7 +1723,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         SaltUtils saltUtils = new SaltUtils(
                 systemQuery, saltApi, clusterManager
         );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
 
@@ -1756,7 +1756,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         SaltUtils saltUtils = new SaltUtils(
                 systemQuery, saltApi, clusterManager
         );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
 
@@ -1797,7 +1797,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         SaltUtils saltUtils = new SaltUtils(
                 systemQuery, saltApi, clusterManager
         );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
 
@@ -1914,7 +1914,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         SaltUtils saltUtils = new SaltUtils(
                 systemQuery, saltApi, clusterManager
         );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
 
@@ -1961,7 +1961,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         SaltUtils saltUtils = new SaltUtils(
                 systemQuery, saltApi, clusterManager
         );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
 
@@ -2004,7 +2004,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         SaltUtils saltUtils = new SaltUtils(
                 systemQuery, saltApi, clusterManager
         );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         // Process the event message
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
@@ -2029,7 +2029,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         SaltUtils saltUtils = new SaltUtils(
                 systemQuery, saltApi, clusterManager
         );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(new SaltService(), saltUtils);
+        SaltServerActionService saltServerActionService = new SaltServerActionService(new SaltService(), saltUtils, clusterManager);
 
         MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
         minion.setMinionId("dev-minsles12sp2.test.local");
@@ -2101,7 +2101,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         SaltUtils saltUtils = new SaltUtils(
                 systemQuery, saltApi, clusterManager
         );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(new SaltService(), saltUtils);
+        SaltServerActionService saltServerActionService = new SaltServerActionService(new SaltService(), saltUtils, clusterManager);
 
         MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
         minion.setMinionId("dev-minsles12sp2.test.local");
@@ -2184,7 +2184,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         SaltUtils saltUtils = new SaltUtils(
                 systemQuery, saltApi, clusterManager
         );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(new SaltService(), saltUtils);
+        SaltServerActionService saltServerActionService = new SaltServerActionService(new SaltService(), saltUtils, clusterManager);
         saltServerActionService.failDependentServerActions(applyStateAction.getId(),
                 minion.getMinionId(), Optional.empty());
 
@@ -2257,7 +2257,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         SaltUtils saltUtils = new SaltUtils(
                 systemQuery, saltApi, clusterManager
         );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(new SaltService(), saltUtils);
+        SaltServerActionService saltServerActionService = new SaltServerActionService(new SaltService(), saltUtils, clusterManager);
         // Process the event message
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
@@ -2325,7 +2325,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         SaltUtils saltUtils = new SaltUtils(
                 systemQuery, saltApi, clusterManager
         );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(new SaltService(), saltUtils);
+        SaltServerActionService saltServerActionService = new SaltServerActionService(new SaltService(), saltUtils, clusterManager);
         // Process the event message
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
@@ -2372,7 +2372,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         SaltUtils saltUtils = new SaltUtils(
                 systemQuery, saltApi, clusterManager
         );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         // Process the event message
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
@@ -2403,7 +2403,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         SaltUtils saltUtils = new SaltUtils(
                 systemQuery, saltApi, clusterManager
         );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         // Process the event message
         JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
         messageAction.execute(message);
@@ -2435,7 +2435,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         SaltUtils saltUtils = new SaltUtils(
                 systemQuery, saltApi, clusterManager
         );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         Map<String, Object> params = new HashMap<>();
         params.put("skuba_cluster_path", "/opt/mycluster");
         params.put("map", Collections.singletonMap("key", "value"));
@@ -2507,7 +2507,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         SaltUtils saltUtils = new SaltUtils(
                 systemQuery, saltApi, clusterManager
         );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         Map<String, Object> params = new HashMap<>();
 
         BaseClusterModifyNodesAction action = clusterManager.modifyClusterNodes(ActionFactory.TYPE_CLUSTER_JOIN_NODE, cluster, Arrays.asList(nodeToJoin.getId()), params, new Date(), user);
@@ -2596,7 +2596,8 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         SaltUtils saltUtils = new SaltUtils(
                 systemQuery, saltApi, clusterManager
         );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils,
+                clusterManager);
         Map<String, Object> params = new HashMap<>();
         params.put("skuba_cluster_path", "/opt/mycluster");
         params.put("map", Collections.singletonMap("key", "value"));
@@ -2659,7 +2660,8 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         SaltUtils saltUtils = new SaltUtils(
                 systemQuery, saltApi, clusterManager
         );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils,
+                clusterManager);
         Map<String, Object> params = new HashMap<>();
 
         BaseClusterModifyNodesAction action = clusterManager.modifyClusterNodes(ActionFactory.TYPE_CLUSTER_REMOVE_NODE, cluster, Arrays.asList(nodeToJoin.getId()), params, new Date(), user);
@@ -2721,7 +2723,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         SaltUtils saltUtils = new SaltUtils(
                 systemQuery, saltApi, clusterManager
         );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         Map<String, Object> params = new HashMap<>();
         params.put("skuba_cluster_path", "/opt/mycluster");
         params.put("map", Collections.singletonMap("key", "value"));
@@ -2786,7 +2788,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         SaltUtils saltUtils = new SaltUtils(
                 systemQuery, saltApi, clusterManager
         );
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         Map<String, Object> params = new HashMap<>();
         params.put("skuba_cluster_path", "/opt/mycluster");
         params.put("map", Collections.singletonMap("key", "value"));

--- a/java/code/src/com/suse/manager/reactor/messaging/test/LibvirtEngineDomainLifecycleMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/LibvirtEngineDomainLifecycleMessageActionTest.java
@@ -34,8 +34,8 @@ import com.suse.manager.reactor.messaging.AbstractLibvirtEngineMessage;
 import com.suse.manager.reactor.messaging.LibvirtEngineDomainLifecycleMessageAction;
 import com.suse.manager.virtualization.GuestDefinition;
 import com.suse.manager.virtualization.test.TestVirtManager;
+import com.suse.manager.webui.services.test.TestSystemQuery;
 import com.suse.manager.webui.services.iface.VirtManager;
-import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.salt.netapi.datatypes.Event;
 import com.suse.salt.netapi.event.EngineEvent;
 import com.suse.salt.netapi.parser.JsonParser;
@@ -102,7 +102,7 @@ public class LibvirtEngineDomainLifecycleMessageActionTest extends JMockBaseTest
         ServerGroupManager serverGroupManager = new ServerGroupManager();
         SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
                 new SystemUnentitler(virtManager, new FormulaMonitoringManager(), serverGroupManager),
-                new SystemEntitler(new SaltService(), virtManager, new FormulaMonitoringManager(),
+                new SystemEntitler(new TestSystemQuery(), virtManager, new FormulaMonitoringManager(),
                         serverGroupManager)
         );
 

--- a/java/code/src/com/suse/manager/reactor/messaging/test/LibvirtEngineDomainLifecycleMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/LibvirtEngineDomainLifecycleMessageActionTest.java
@@ -21,6 +21,7 @@ import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.VirtualInstanceFactory;
 import com.redhat.rhn.frontend.dto.VirtualSystemOverview;
 import com.redhat.rhn.manager.formula.FormulaMonitoringManager;
+import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitler;
@@ -97,9 +98,12 @@ public class LibvirtEngineDomainLifecycleMessageActionTest extends JMockBaseTest
             }
         };
 
+
+        ServerGroupManager serverGroupManager = new ServerGroupManager();
         SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(virtManager, new FormulaMonitoringManager()),
-                new SystemEntitler(new SaltService(), virtManager, new FormulaMonitoringManager())
+                new SystemUnentitler(virtManager, new FormulaMonitoringManager(), serverGroupManager),
+                new SystemEntitler(new SaltService(), virtManager, new FormulaMonitoringManager(),
+                        serverGroupManager)
         );
 
         host = ServerTestUtils.createVirtHostWithGuests(user, 1, true, systemEntitlementManager);

--- a/java/code/src/com/suse/manager/reactor/messaging/test/MinionActionCleanupTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/MinionActionCleanupTest.java
@@ -14,6 +14,7 @@
  */
 package com.suse.manager.reactor.messaging.test;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionChain;
@@ -122,10 +123,10 @@ public class MinionActionCleanupTest extends JMockBaseTestCaseWithUser {
             }
         } });
 
-        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        ServerGroupManager serverGroupManager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
         FormulaManager formulaManager = new FormulaManager(saltServiceMock);
         ClusterManager clusterManager = new ClusterManager(saltServiceMock, saltServiceMock, serverGroupManager, formulaManager);
-        SaltUtils saltUtils = new SaltUtils(saltServiceMock, saltServiceMock, clusterManager, formulaManager);
+        SaltUtils saltUtils = new SaltUtils(saltServiceMock, saltServiceMock, clusterManager, formulaManager, serverGroupManager);
         SaltServerActionService saltServerActionService = new SaltServerActionService(saltServiceMock, saltUtils,
                 clusterManager, formulaManager, new SaltKeyUtils(saltServiceMock));
         MinionActionUtils minionActionUtils = new MinionActionUtils(saltServerActionService, saltServiceMock,
@@ -272,11 +273,11 @@ public class MinionActionCleanupTest extends JMockBaseTestCaseWithUser {
 
         ActionChainFactory.delete(actionChain);
 
-        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        ServerGroupManager serverGroupManager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
         FormulaManager formulaManager = new FormulaManager(saltServiceMock);
         ClusterManager clusterManager =  new ClusterManager(saltServiceMock, saltServiceMock, serverGroupManager,
                 formulaManager);
-        SaltUtils saltUtils = new SaltUtils(saltServiceMock, saltServiceMock, clusterManager, formulaManager);
+        SaltUtils saltUtils = new SaltUtils(saltServiceMock, saltServiceMock, clusterManager, formulaManager, serverGroupManager);
         SaltServerActionService saltServerActionService = new SaltServerActionService(saltServiceMock, saltUtils,
                 clusterManager, formulaManager, new SaltKeyUtils(saltServiceMock));
         MinionActionUtils minionActionUtils = new MinionActionUtils(saltServerActionService, saltServiceMock,

--- a/java/code/src/com/suse/manager/reactor/messaging/test/MinionActionCleanupTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/MinionActionCleanupTest.java
@@ -37,6 +37,7 @@ import com.google.gson.reflect.TypeToken;
 import com.suse.manager.clusters.ClusterManager;
 import com.suse.manager.reactor.messaging.ApplyStatesEventMessage;
 import com.suse.manager.reactor.messaging.JobReturnEventMessageAction;
+import com.suse.manager.utils.SaltKeyUtils;
 import com.suse.manager.utils.SaltUtils;
 import com.suse.manager.webui.services.SaltServerActionService;
 import com.suse.manager.webui.services.impl.SaltService;
@@ -126,7 +127,7 @@ public class MinionActionCleanupTest extends JMockBaseTestCaseWithUser {
         ClusterManager clusterManager = new ClusterManager(saltServiceMock, saltServiceMock, serverGroupManager, formulaManager);
         SaltUtils saltUtils = new SaltUtils(saltServiceMock, saltServiceMock, clusterManager, formulaManager);
         SaltServerActionService saltServerActionService = new SaltServerActionService(saltServiceMock, saltUtils,
-                clusterManager, formulaManager);
+                clusterManager, formulaManager, new SaltKeyUtils(saltServiceMock));
         MinionActionUtils minionActionUtils = new MinionActionUtils(saltServerActionService, saltServiceMock,
                 saltUtils);
         minionActionUtils.cleanupMinionActions();
@@ -277,7 +278,7 @@ public class MinionActionCleanupTest extends JMockBaseTestCaseWithUser {
                 formulaManager);
         SaltUtils saltUtils = new SaltUtils(saltServiceMock, saltServiceMock, clusterManager, formulaManager);
         SaltServerActionService saltServerActionService = new SaltServerActionService(saltServiceMock, saltUtils,
-                clusterManager, formulaManager);
+                clusterManager, formulaManager, new SaltKeyUtils(saltServiceMock));
         MinionActionUtils minionActionUtils = new MinionActionUtils(saltServerActionService, saltServiceMock,
                 saltUtils);
         minionActionUtils.cleanupMinionActionChains();

--- a/java/code/src/com/suse/manager/reactor/messaging/test/MinionActionCleanupTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/MinionActionCleanupTest.java
@@ -125,7 +125,8 @@ public class MinionActionCleanupTest extends JMockBaseTestCaseWithUser {
         FormulaManager formulaManager = new FormulaManager(saltServiceMock);
         ClusterManager clusterManager = new ClusterManager(saltServiceMock, saltServiceMock, serverGroupManager, formulaManager);
         SaltUtils saltUtils = new SaltUtils(saltServiceMock, saltServiceMock, clusterManager, formulaManager);
-        SaltServerActionService saltServerActionService = new SaltServerActionService(saltServiceMock, saltUtils, clusterManager);
+        SaltServerActionService saltServerActionService = new SaltServerActionService(saltServiceMock, saltUtils,
+                clusterManager, formulaManager);
         MinionActionUtils minionActionUtils = new MinionActionUtils(saltServerActionService, saltServiceMock,
                 saltUtils);
         minionActionUtils.cleanupMinionActions();
@@ -276,7 +277,7 @@ public class MinionActionCleanupTest extends JMockBaseTestCaseWithUser {
                 formulaManager);
         SaltUtils saltUtils = new SaltUtils(saltServiceMock, saltServiceMock, clusterManager, formulaManager);
         SaltServerActionService saltServerActionService = new SaltServerActionService(saltServiceMock, saltUtils,
-                clusterManager);
+                clusterManager, formulaManager);
         MinionActionUtils minionActionUtils = new MinionActionUtils(saltServerActionService, saltServiceMock,
                 saltUtils);
         minionActionUtils.cleanupMinionActionChains();

--- a/java/code/src/com/suse/manager/reactor/messaging/test/MinionActionCleanupTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/MinionActionCleanupTest.java
@@ -32,8 +32,11 @@ import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
 import com.redhat.rhn.testing.TestUtils;
 
 import com.google.gson.reflect.TypeToken;
+import com.suse.manager.clusters.ClusterManager;
 import com.suse.manager.reactor.messaging.ApplyStatesEventMessage;
 import com.suse.manager.reactor.messaging.JobReturnEventMessageAction;
+import com.suse.manager.utils.SaltUtils;
+import com.suse.manager.webui.services.SaltServerActionService;
 import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.manager.webui.utils.MinionActionUtils;
 import com.suse.manager.webui.utils.YamlHelper;
@@ -116,7 +119,11 @@ public class MinionActionCleanupTest extends JMockBaseTestCaseWithUser {
             }
         } });
 
-        MinionActionUtils.cleanupMinionActions(saltServiceMock);
+        SaltUtils saltUtils = new SaltUtils(saltServiceMock, saltServiceMock, ClusterManager.instance());
+        SaltServerActionService saltServerActionService = new SaltServerActionService(saltServiceMock, saltUtils);
+        MinionActionUtils minionActionUtils = new MinionActionUtils(saltServerActionService, saltServiceMock,
+                saltUtils);
+        minionActionUtils.cleanupMinionActions();
 
         if (!MinionActionUtils.POSTGRES) {
             action.getServerActions().stream().forEach(sa -> {
@@ -258,7 +265,11 @@ public class MinionActionCleanupTest extends JMockBaseTestCaseWithUser {
 
         ActionChainFactory.delete(actionChain);
 
-        MinionActionUtils.cleanupMinionActionChains(saltServiceMock);
+        SaltUtils saltUtils = new SaltUtils(saltServiceMock, saltServiceMock, ClusterManager.instance());
+        SaltServerActionService saltServerActionService = new SaltServerActionService(saltServiceMock, saltUtils);
+        MinionActionUtils minionActionUtils = new MinionActionUtils(saltServerActionService, saltServiceMock,
+                saltUtils);
+        minionActionUtils.cleanupMinionActionChains();
         
         if (!MinionActionUtils.POSTGRES) {
             assertActionCompleted(action1_1);

--- a/java/code/src/com/suse/manager/reactor/messaging/test/MinionActionCleanupTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/MinionActionCleanupTest.java
@@ -123,7 +123,7 @@ public class MinionActionCleanupTest extends JMockBaseTestCaseWithUser {
             }
         } });
 
-        ServerGroupManager serverGroupManager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
+        ServerGroupManager serverGroupManager = new ServerGroupManager();
         FormulaManager formulaManager = new FormulaManager(saltServiceMock);
         ClusterManager clusterManager = new ClusterManager(saltServiceMock, saltServiceMock, serverGroupManager, formulaManager);
         SaltUtils saltUtils = new SaltUtils(saltServiceMock, saltServiceMock, clusterManager, formulaManager, serverGroupManager);
@@ -273,7 +273,7 @@ public class MinionActionCleanupTest extends JMockBaseTestCaseWithUser {
 
         ActionChainFactory.delete(actionChain);
 
-        ServerGroupManager serverGroupManager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
+        ServerGroupManager serverGroupManager = new ServerGroupManager();
         FormulaManager formulaManager = new FormulaManager(saltServiceMock);
         ClusterManager clusterManager =  new ClusterManager(saltServiceMock, saltServiceMock, serverGroupManager,
                 formulaManager);

--- a/java/code/src/com/suse/manager/reactor/messaging/test/MinionActionCleanupTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/MinionActionCleanupTest.java
@@ -121,10 +121,10 @@ public class MinionActionCleanupTest extends JMockBaseTestCaseWithUser {
             }
         } });
 
-        SaltUtils saltUtils = new SaltUtils(saltServiceMock, saltServiceMock, ClusterManager.instance());
         ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
         FormulaManager formulaManager = new FormulaManager(saltServiceMock);
         ClusterManager clusterManager = new ClusterManager(saltServiceMock, saltServiceMock, serverGroupManager, formulaManager);
+        SaltUtils saltUtils = new SaltUtils(saltServiceMock, saltServiceMock, clusterManager);
         SaltServerActionService saltServerActionService = new SaltServerActionService(saltServiceMock, saltUtils, clusterManager);
         MinionActionUtils minionActionUtils = new MinionActionUtils(saltServerActionService, saltServiceMock,
                 saltUtils);
@@ -274,7 +274,7 @@ public class MinionActionCleanupTest extends JMockBaseTestCaseWithUser {
         FormulaManager formulaManager = new FormulaManager(saltServiceMock);
         ClusterManager clusterManager =  new ClusterManager(saltServiceMock, saltServiceMock, serverGroupManager,
                 formulaManager);
-        SaltUtils saltUtils = new SaltUtils(saltServiceMock, saltServiceMock, ClusterManager.instance());
+        SaltUtils saltUtils = new SaltUtils(saltServiceMock, saltServiceMock, clusterManager);
         SaltServerActionService saltServerActionService = new SaltServerActionService(saltServiceMock, saltUtils,
                 clusterManager);
         MinionActionUtils minionActionUtils = new MinionActionUtils(saltServerActionService, saltServiceMock,

--- a/java/code/src/com/suse/manager/reactor/messaging/test/MinionActionCleanupTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/MinionActionCleanupTest.java
@@ -124,7 +124,7 @@ public class MinionActionCleanupTest extends JMockBaseTestCaseWithUser {
         ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
         FormulaManager formulaManager = new FormulaManager(saltServiceMock);
         ClusterManager clusterManager = new ClusterManager(saltServiceMock, saltServiceMock, serverGroupManager, formulaManager);
-        SaltUtils saltUtils = new SaltUtils(saltServiceMock, saltServiceMock, clusterManager);
+        SaltUtils saltUtils = new SaltUtils(saltServiceMock, saltServiceMock, clusterManager, formulaManager);
         SaltServerActionService saltServerActionService = new SaltServerActionService(saltServiceMock, saltUtils, clusterManager);
         MinionActionUtils minionActionUtils = new MinionActionUtils(saltServerActionService, saltServiceMock,
                 saltUtils);
@@ -274,7 +274,7 @@ public class MinionActionCleanupTest extends JMockBaseTestCaseWithUser {
         FormulaManager formulaManager = new FormulaManager(saltServiceMock);
         ClusterManager clusterManager =  new ClusterManager(saltServiceMock, saltServiceMock, serverGroupManager,
                 formulaManager);
-        SaltUtils saltUtils = new SaltUtils(saltServiceMock, saltServiceMock, clusterManager);
+        SaltUtils saltUtils = new SaltUtils(saltServiceMock, saltServiceMock, clusterManager, formulaManager);
         SaltServerActionService saltServerActionService = new SaltServerActionService(saltServiceMock, saltUtils,
                 clusterManager);
         MinionActionUtils minionActionUtils = new MinionActionUtils(saltServerActionService, saltServiceMock,

--- a/java/code/src/com/suse/manager/reactor/messaging/test/MinionActionCleanupTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/MinionActionCleanupTest.java
@@ -26,6 +26,8 @@ import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
 import com.redhat.rhn.manager.action.ActionChainManager;
 import com.redhat.rhn.manager.action.ActionManager;
+import com.redhat.rhn.manager.formula.FormulaManager;
+import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
@@ -120,7 +122,10 @@ public class MinionActionCleanupTest extends JMockBaseTestCaseWithUser {
         } });
 
         SaltUtils saltUtils = new SaltUtils(saltServiceMock, saltServiceMock, ClusterManager.instance());
-        SaltServerActionService saltServerActionService = new SaltServerActionService(saltServiceMock, saltUtils);
+        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        FormulaManager formulaManager = new FormulaManager(saltServiceMock);
+        ClusterManager clusterManager = new ClusterManager(saltServiceMock, saltServiceMock, serverGroupManager, formulaManager);
+        SaltServerActionService saltServerActionService = new SaltServerActionService(saltServiceMock, saltUtils, clusterManager);
         MinionActionUtils minionActionUtils = new MinionActionUtils(saltServerActionService, saltServiceMock,
                 saltUtils);
         minionActionUtils.cleanupMinionActions();
@@ -265,8 +270,13 @@ public class MinionActionCleanupTest extends JMockBaseTestCaseWithUser {
 
         ActionChainFactory.delete(actionChain);
 
+        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        FormulaManager formulaManager = new FormulaManager(saltServiceMock);
+        ClusterManager clusterManager =  new ClusterManager(saltServiceMock, saltServiceMock, serverGroupManager,
+                formulaManager);
         SaltUtils saltUtils = new SaltUtils(saltServiceMock, saltServiceMock, ClusterManager.instance());
-        SaltServerActionService saltServerActionService = new SaltServerActionService(saltServiceMock, saltUtils);
+        SaltServerActionService saltServerActionService = new SaltServerActionService(saltServiceMock, saltUtils,
+                clusterManager);
         MinionActionUtils minionActionUtils = new MinionActionUtils(saltServerActionService, saltServiceMock,
                 saltUtils);
         minionActionUtils.cleanupMinionActionChains();

--- a/java/code/src/com/suse/manager/utils/SaltKeyUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltKeyUtils.java
@@ -14,7 +14,6 @@
  */
 package com.suse.manager.utils;
 
-import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.server.MinionServerFactory;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.xmlrpc.PermissionCheckFailureException;
@@ -29,9 +28,14 @@ import java.util.stream.Stream;
  */
 public class SaltKeyUtils {
 
-    private static final SystemQuery SALT_SERVICE = GlobalInstanceHolder.SYSTEM_QUERY;
+    private final SystemQuery systemQuery;
 
-    private SaltKeyUtils() { }
+    /**
+     * @param systemQueryIn
+     */
+    public SaltKeyUtils(SystemQuery systemQueryIn) {
+        this.systemQuery = systemQueryIn;
+    }
 
     /**
      * Delete a salt key
@@ -40,11 +44,11 @@ public class SaltKeyUtils {
      * @return true on success otherwise false
      * @throws PermissionCheckFailureException requires org admin privileges
      */
-    public static boolean deleteSaltKey(User user, String minionId)
+    public boolean deleteSaltKey(User user, String minionId)
             throws PermissionCheckFailureException {
 
         //Note: since salt only allows globs we have to do our own strict matching
-        Key.Names keys = SALT_SERVICE.getKeys();
+        Key.Names keys = systemQuery.getKeys();
         boolean exists = Stream.concat(
                 Stream.concat(
                         keys.getDeniedMinions().stream(),
@@ -57,14 +61,14 @@ public class SaltKeyUtils {
         if (exists) {
             return MinionServerFactory.findByMinionId(minionId).map(minionServer -> {
                 if (minionServer.getOrg().equals(user.getOrg())) {
-                    SALT_SERVICE.deleteKey(minionId);
+                    systemQuery.deleteKey(minionId);
                     return true;
                 }
                 else {
                     return false;
                 }
             }).orElseGet(() -> {
-                SALT_SERVICE.deleteKey(minionId);
+                systemQuery.deleteKey(minionId);
                 return true;
             });
         }

--- a/java/code/src/com/suse/manager/utils/SaltKeyUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltKeyUtils.java
@@ -14,11 +14,11 @@
  */
 package com.suse.manager.utils;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.server.MinionServerFactory;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.xmlrpc.PermissionCheckFailureException;
 
-import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.salt.netapi.calls.wheel.Key;
 
@@ -29,7 +29,7 @@ import java.util.stream.Stream;
  */
 public class SaltKeyUtils {
 
-    private static final SystemQuery SALT_SERVICE = SaltService.INSTANCE;
+    private static final SystemQuery SALT_SERVICE = GlobalInstanceHolder.SYSTEM_QUERY;
 
     private SaltKeyUtils() { }
 

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -206,9 +206,10 @@ public class SaltUtils {
 
     private Path scriptsDir = Paths.get(SUMA_STATE_FILES_ROOT_PATH, SCRIPTS_DIR);
 
-    private SystemQuery systemQuery;
-    private SaltApi saltApi;
+    private final SystemQuery systemQuery;
+    private final SaltApi saltApi;
     private final ClusterManager clusterManager;
+    private final FormulaManager formulaManager;
 
     private String xccdfResumeXsl = "/usr/share/susemanager/scap/xccdf-resume.xslt.in";
 
@@ -235,12 +236,14 @@ public class SaltUtils {
      * @param systemQueryIn
      * @param saltApiIn
      * @param clusterManagerIn
+     * @param formulaManagerIn
      */
     public SaltUtils(SystemQuery systemQueryIn, SaltApi saltApiIn,
-                     ClusterManager clusterManagerIn) {
+                     ClusterManager clusterManagerIn, FormulaManager formulaManagerIn) {
         this.saltApi = saltApiIn;
         this.systemQuery = systemQueryIn;
         this.clusterManager = clusterManagerIn;
+        this.formulaManager = formulaManagerIn;
     }
 
     /**
@@ -1432,7 +1435,7 @@ public class SaltUtils {
                     "grains.items"
             ));
             try {
-                FormulaManager.getInstance().enableFormula(server.getMinionId(), SYSTEM_LOCK_FORMULA);
+                formulaManager.enableFormula(server.getMinionId(), SYSTEM_LOCK_FORMULA);
                 FormulaFactory.saveServerFormulaData(data, server.getMinionId(), SYSTEM_LOCK_FORMULA);
                 saltApi.refreshPillar(new MinionList(server.getMinionId()));
             }
@@ -1879,22 +1882,6 @@ public class SaltUtils {
             return true;
         }
         return prerequisiteIsCompleted(action.getPrerequisite(), prereqType, systemId);
-    }
-
-    /**
-     * For unit testing only.
-     * @param systemQueryIn the {@link SaltService} to set
-     */
-    public void setSystemQuery(SystemQuery systemQueryIn) {
-        this.systemQuery = systemQueryIn;
-    }
-
-    /**
-     * For unit testing only.
-     * @param saltApiIn the {@link SaltApi} to set
-     */
-    public void setSaltApi(SaltApi saltApiIn) {
-        this.saltApi = saltApiIn;
     }
 
     /**

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -201,16 +201,20 @@ public class SaltUtils {
     private static final Logger LOG = Logger.getLogger(SaltUtils.class);
     private static final TaskomaticApi TASKOMATIC_API = new TaskomaticApi();
 
-    public static final SaltUtils INSTANCE = new SaltUtils();
+    public static final SaltUtils INSTANCE = new SaltUtils(
+            SaltService.INSTANCE,
+            SaltService.INSTANCE_SALT_API,
+            ClusterManager.instance()
+    );
 
     public static final String CAASP_PATTERN_IDENTIFIER = "patterns-caasp-Node";
     public static final String SYSTEM_LOCK_FORMULA = "system-lock";
 
     private Path scriptsDir = Paths.get(SUMA_STATE_FILES_ROOT_PATH, SCRIPTS_DIR);
 
-    private SystemQuery systemQuery = SaltService.INSTANCE;
-    private SaltApi saltApi = SaltService.INSTANCE_SALT_API;
-    private ClusterManager clusterManager = ClusterManager.instance();
+    private SystemQuery systemQuery;
+    private SaltApi saltApi;
+    private final ClusterManager clusterManager;
 
     private String xccdfResumeXsl = "/usr/share/susemanager/scap/xccdf-resume.xslt.in";
 
@@ -233,8 +237,24 @@ public class SaltUtils {
 
     /**
      * Constructor for testing purposes.
+     *
+     * @param systemQueryIn
+     * @param saltApiIn
+     * @param clusterManagerIn
      */
-    public SaltUtils() { }
+    public SaltUtils(SystemQuery systemQueryIn, SaltApi saltApiIn,
+                     ClusterManager clusterManagerIn) {
+        this.saltApi = saltApiIn;
+        this.systemQuery = systemQueryIn;
+        this.clusterManager = clusterManagerIn;
+    }
+
+    /**
+     *
+     */
+    public SaltUtils() {
+        this(SaltService.INSTANCE, SaltService.INSTANCE_SALT_API, ClusterManager.instance());
+    }
 
     /**
      * Figure out if the list of packages has changed based on the result of a Salt call

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -296,7 +296,7 @@ public class SaltUtils {
      * @param server server to update
      * @return an outcome
      */
-    public static PackageChangeOutcome handlePackageChanges(String function,
+    public PackageChangeOutcome handlePackageChanges(String function,
             JsonElement callResult, Server server) {
         final PackageChangeOutcome outcome;
 

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -201,12 +201,6 @@ public class SaltUtils {
     private static final Logger LOG = Logger.getLogger(SaltUtils.class);
     private static final TaskomaticApi TASKOMATIC_API = new TaskomaticApi();
 
-    public static final SaltUtils INSTANCE = new SaltUtils(
-            SaltService.INSTANCE,
-            SaltService.INSTANCE_SALT_API,
-            ClusterManager.instance()
-    );
-
     public static final String CAASP_PATTERN_IDENTIFIER = "patterns-caasp-Node";
     public static final String SYSTEM_LOCK_FORMULA = "system-lock";
 

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -209,6 +209,7 @@ public class SaltUtils {
     private final SaltApi saltApi;
     private final ClusterManager clusterManager;
     private final FormulaManager formulaManager;
+    private final ServerGroupManager serverGroupManager;
 
     private String xccdfResumeXsl = "/usr/share/susemanager/scap/xccdf-resume.xslt.in";
 
@@ -236,13 +237,16 @@ public class SaltUtils {
      * @param saltApiIn
      * @param clusterManagerIn
      * @param formulaManagerIn
+     * @param serverGroupManagerIn
      */
     public SaltUtils(SystemQuery systemQueryIn, SaltApi saltApiIn,
-                     ClusterManager clusterManagerIn, FormulaManager formulaManagerIn) {
+                     ClusterManager clusterManagerIn, FormulaManager formulaManagerIn,
+                     ServerGroupManager serverGroupManagerIn) {
         this.saltApi = saltApiIn;
         this.systemQuery = systemQueryIn;
         this.clusterManager = clusterManagerIn;
         this.formulaManager = formulaManagerIn;
+        this.serverGroupManager = serverGroupManagerIn;
     }
 
     /**
@@ -739,7 +743,7 @@ public class SaltUtils {
         List<Server> nodesToRemove = cluster.getGroup().getServers().stream()
                 .filter(s -> !s.getId().equals(cluster.getManagementNode().getId()))
                 .collect(Collectors.toList());
-        ServerGroupManager.getInstance().removeServers(cluster.getGroup(), nodesToRemove);
+        serverGroupManager.removeServers(cluster.getGroup(), nodesToRemove);
 
         // add new nodes if matching registered systems are found
         List<ClusterNode> clusterNodes = new ArrayList<>();
@@ -753,7 +757,7 @@ public class SaltUtils {
                 .map(n -> n.getServer().get())
                 .collect(Collectors.toList());
 
-        ServerGroupManager.getInstance().addServers(cluster.getGroup(), matchedMinions, action.getSchedulerUser());
+        serverGroupManager.addServers(cluster.getGroup(), matchedMinions, action.getSchedulerUser());
     }
 
     private void handleClusterJoinNode(ServerAction serverAction, JsonElement jsonResult, Action action) {

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -244,13 +244,6 @@ public class SaltUtils {
     }
 
     /**
-     *
-     */
-    public SaltUtils() {
-        this(SaltService.INSTANCE, SaltService.INSTANCE_SALT_API, ClusterManager.instance());
-    }
-
-    /**
      * Figure out if the list of packages has changed based on the result of a Salt call
      * given as JsonElement. This information is used to decide if we should trigger a
      * package list refresh.

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -103,7 +103,6 @@ import com.suse.manager.reactor.utils.ValueMap;
 import com.suse.manager.webui.services.SaltStateGeneratorService;
 import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.SystemQuery;
-import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.manager.webui.services.impl.runner.MgrUtilRunner;
 import com.suse.manager.webui.utils.YamlHelper;
 import com.suse.manager.webui.utils.salt.custom.ClusterOperationsSlsResult;

--- a/java/code/src/com/suse/manager/webui/Router.java
+++ b/java/code/src/com/suse/manager/webui/Router.java
@@ -96,7 +96,7 @@ public class Router implements SparkApplication {
         SaltApi saltApi = GlobalInstanceHolder.SALT_API;
         KubernetesManager kubernetesManager = GlobalInstanceHolder.KUBERNETES_MANAGER;
         VirtManager virtManager = GlobalInstanceHolder.VIRT_MANAGER;
-        RegularMinionBootstrapper regularMinionBootstrapper = RegularMinionBootstrapper.getInstance(systemQuery);
+        RegularMinionBootstrapper regularMinionBootstrapper = GlobalInstanceHolder.REGULAR_MINION_BOOTSTRAPPER;
         SSHMinionBootstrapper sshMinionBootstrapper = SSHMinionBootstrapper.getInstance(systemQuery);
         FormulaManager formulaManager = GlobalInstanceHolder.FORMULA_MANAGER;
         ClusterManager clusterManager = GlobalInstanceHolder.CLUSTER_MANAGER;

--- a/java/code/src/com/suse/manager/webui/Router.java
+++ b/java/code/src/com/suse/manager/webui/Router.java
@@ -23,6 +23,7 @@ import static spark.Spark.post;
 
 import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.manager.formula.FormulaManager;
+import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.suse.manager.clusters.ClusterManager;
 import com.suse.manager.kubernetes.KubernetesManager;
@@ -100,13 +101,14 @@ public class Router implements SparkApplication {
         FormulaManager formulaManager = GlobalInstanceHolder.FORMULA_MANAGER;
         ClusterManager clusterManager = GlobalInstanceHolder.CLUSTER_MANAGER;
         SaltKeyUtils saltKeyUtils = GlobalInstanceHolder.SALT_KEY_UTILS;
+        ServerGroupManager serverGroupManager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
 
         SystemsController systemsController = new SystemsController(systemQuery);
         SaltSSHController saltSSHController = new SaltSSHController(systemQuery);
         NotificationMessageController notificationMessageController = new NotificationMessageController(systemQuery);
         MinionsAPI minionsAPI = new MinionsAPI(systemQuery, sshMinionBootstrapper, regularMinionBootstrapper,
                 saltKeyUtils);
-        StatesAPI statesAPI = new StatesAPI(systemQuery, taskomaticApi);
+        StatesAPI statesAPI = new StatesAPI(systemQuery, taskomaticApi, serverGroupManager);
         FormulaController formulaController = new FormulaController(systemQuery, saltApi);
         ClustersController clustersController = new ClustersController(clusterManager, formulaManager);
 

--- a/java/code/src/com/suse/manager/webui/Router.java
+++ b/java/code/src/com/suse/manager/webui/Router.java
@@ -21,7 +21,10 @@ import static spark.Spark.get;
 import static spark.Spark.notFound;
 import static spark.Spark.post;
 
+import com.redhat.rhn.manager.formula.FormulaManager;
+import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
+import com.suse.manager.clusters.ClusterManager;
 import com.suse.manager.kubernetes.KubernetesManager;
 import com.suse.manager.virtualization.VirtManagerSalt;
 import com.suse.manager.webui.controllers.ActivationKeysController;
@@ -95,6 +98,9 @@ public class Router implements SparkApplication {
         VirtManager virtManager = new VirtManagerSalt(saltApi);
         RegularMinionBootstrapper regularMinionBootstrapper = RegularMinionBootstrapper.getInstance(systemQuery);
         SSHMinionBootstrapper sshMinionBootstrapper = SSHMinionBootstrapper.getInstance(systemQuery);
+        FormulaManager formulaManager = new FormulaManager(saltApi);
+        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);
 
         SystemsController systemsController = new SystemsController(systemQuery);
         SaltSSHController saltSSHController = new SaltSSHController(systemQuery);
@@ -102,6 +108,7 @@ public class Router implements SparkApplication {
         MinionsAPI minionsAPI = new MinionsAPI(systemQuery, sshMinionBootstrapper, regularMinionBootstrapper);
         StatesAPI statesAPI = new StatesAPI(systemQuery, taskomaticApi);
         FormulaController formulaController = new FormulaController(systemQuery, saltApi);
+        ClustersController clustersController = new ClustersController(clusterManager, formulaManager);
 
         post("/manager/frontend-log", withUser(FrontendLogController::log));
 
@@ -181,7 +188,7 @@ public class Router implements SparkApplication {
         SSOController.initRoutes();
 
         // Clusters
-        ClustersController.initRoutes(jade);
+        clustersController.initRoutes(jade);
 
     }
 

--- a/java/code/src/com/suse/manager/webui/Router.java
+++ b/java/code/src/com/suse/manager/webui/Router.java
@@ -26,6 +26,7 @@ import com.redhat.rhn.manager.formula.FormulaManager;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.suse.manager.clusters.ClusterManager;
 import com.suse.manager.kubernetes.KubernetesManager;
+import com.suse.manager.utils.SaltKeyUtils;
 import com.suse.manager.webui.controllers.ActivationKeysController;
 import com.suse.manager.webui.controllers.CVEAuditController;
 import com.suse.manager.webui.controllers.clusters.ClustersController;
@@ -98,11 +99,13 @@ public class Router implements SparkApplication {
         SSHMinionBootstrapper sshMinionBootstrapper = GlobalInstanceHolder.SSH_MINION_BOOTSTRAPPER;
         FormulaManager formulaManager = GlobalInstanceHolder.FORMULA_MANAGER;
         ClusterManager clusterManager = GlobalInstanceHolder.CLUSTER_MANAGER;
+        SaltKeyUtils saltKeyUtils = GlobalInstanceHolder.SALT_KEY_UTILS;
 
         SystemsController systemsController = new SystemsController(systemQuery);
         SaltSSHController saltSSHController = new SaltSSHController(systemQuery);
         NotificationMessageController notificationMessageController = new NotificationMessageController(systemQuery);
-        MinionsAPI minionsAPI = new MinionsAPI(systemQuery, sshMinionBootstrapper, regularMinionBootstrapper);
+        MinionsAPI minionsAPI = new MinionsAPI(systemQuery, sshMinionBootstrapper, regularMinionBootstrapper,
+                saltKeyUtils);
         StatesAPI statesAPI = new StatesAPI(systemQuery, taskomaticApi);
         FormulaController formulaController = new FormulaController(systemQuery, saltApi);
         ClustersController clustersController = new ClustersController(clusterManager, formulaManager);

--- a/java/code/src/com/suse/manager/webui/Router.java
+++ b/java/code/src/com/suse/manager/webui/Router.java
@@ -21,6 +21,7 @@ import static spark.Spark.get;
 import static spark.Spark.notFound;
 import static spark.Spark.post;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.manager.formula.FormulaManager;
 import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
@@ -65,7 +66,6 @@ import com.suse.manager.webui.controllers.virtualization.VirtualPoolsController;
 import com.suse.manager.webui.errors.NotFoundException;
 import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.VirtManager;
-import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.manager.webui.services.iface.SystemQuery;
 import org.apache.http.HttpStatus;
 
@@ -92,8 +92,8 @@ public class Router implements SparkApplication {
         initNotFoundRoutes(jade);
 
         TaskomaticApi taskomaticApi = new TaskomaticApi();
-        SystemQuery systemQuery = SaltService.INSTANCE;
-        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
+        SystemQuery systemQuery = GlobalInstanceHolder.SYSTEM_QUERY;
+        SaltApi saltApi = GlobalInstanceHolder.SALT_API;
         KubernetesManager kubernetesManager = new KubernetesManager(systemQuery);
         VirtManager virtManager = new VirtManagerSalt(saltApi);
         RegularMinionBootstrapper regularMinionBootstrapper = RegularMinionBootstrapper.getInstance(systemQuery);

--- a/java/code/src/com/suse/manager/webui/Router.java
+++ b/java/code/src/com/suse/manager/webui/Router.java
@@ -94,13 +94,12 @@ public class Router implements SparkApplication {
         TaskomaticApi taskomaticApi = new TaskomaticApi();
         SystemQuery systemQuery = GlobalInstanceHolder.SYSTEM_QUERY;
         SaltApi saltApi = GlobalInstanceHolder.SALT_API;
-        KubernetesManager kubernetesManager = new KubernetesManager(systemQuery);
-        VirtManager virtManager = new VirtManagerSalt(saltApi);
+        KubernetesManager kubernetesManager = GlobalInstanceHolder.KUBERNETES_MANAGER;
+        VirtManager virtManager = GlobalInstanceHolder.VIRT_MANAGER;
         RegularMinionBootstrapper regularMinionBootstrapper = RegularMinionBootstrapper.getInstance(systemQuery);
         SSHMinionBootstrapper sshMinionBootstrapper = SSHMinionBootstrapper.getInstance(systemQuery);
-        FormulaManager formulaManager = new FormulaManager(saltApi);
-        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
-        ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);
+        FormulaManager formulaManager = GlobalInstanceHolder.FORMULA_MANAGER;
+        ClusterManager clusterManager = GlobalInstanceHolder.CLUSTER_MANAGER;
 
         SystemsController systemsController = new SystemsController(systemQuery);
         SaltSSHController saltSSHController = new SaltSSHController(systemQuery);

--- a/java/code/src/com/suse/manager/webui/Router.java
+++ b/java/code/src/com/suse/manager/webui/Router.java
@@ -23,11 +23,9 @@ import static spark.Spark.post;
 
 import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.manager.formula.FormulaManager;
-import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.suse.manager.clusters.ClusterManager;
 import com.suse.manager.kubernetes.KubernetesManager;
-import com.suse.manager.virtualization.VirtManagerSalt;
 import com.suse.manager.webui.controllers.ActivationKeysController;
 import com.suse.manager.webui.controllers.CVEAuditController;
 import com.suse.manager.webui.controllers.clusters.ClustersController;
@@ -97,7 +95,7 @@ public class Router implements SparkApplication {
         KubernetesManager kubernetesManager = GlobalInstanceHolder.KUBERNETES_MANAGER;
         VirtManager virtManager = GlobalInstanceHolder.VIRT_MANAGER;
         RegularMinionBootstrapper regularMinionBootstrapper = GlobalInstanceHolder.REGULAR_MINION_BOOTSTRAPPER;
-        SSHMinionBootstrapper sshMinionBootstrapper = SSHMinionBootstrapper.getInstance(systemQuery);
+        SSHMinionBootstrapper sshMinionBootstrapper = GlobalInstanceHolder.SSH_MINION_BOOTSTRAPPER;
         FormulaManager formulaManager = GlobalInstanceHolder.FORMULA_MANAGER;
         ClusterManager clusterManager = GlobalInstanceHolder.CLUSTER_MANAGER;
 

--- a/java/code/src/com/suse/manager/webui/controllers/MinionsAPI.java
+++ b/java/code/src/com/suse/manager/webui/controllers/MinionsAPI.java
@@ -68,6 +68,7 @@ public class MinionsAPI {
     private final SystemQuery systemQuery;
     private final SSHMinionBootstrapper sshMinionBootstrapper;
     private final RegularMinionBootstrapper regularMinionBootstrapper;
+    private final SaltKeyUtils saltKeyUtils;
 
     public static final Gson GSON = new GsonBuilder()
             .registerTypeAdapter(Date.class, new ECMAScriptDateAdapter())
@@ -81,13 +82,15 @@ public class MinionsAPI {
      * @param systemQueryIn instance to use.
      * @param regularMinionBootstrapperIn regular bootstrapper
      * @param sshMinionBootstrapperIn ssh bootstrapper
+     * @param saltKeyUtilsIn
      */
     public MinionsAPI(SystemQuery systemQueryIn, SSHMinionBootstrapper sshMinionBootstrapperIn,
-                      RegularMinionBootstrapper regularMinionBootstrapperIn) {
+                      RegularMinionBootstrapper regularMinionBootstrapperIn,
+                      SaltKeyUtils saltKeyUtilsIn) {
         this.systemQuery = systemQueryIn;
-        sshMinionBootstrapper = sshMinionBootstrapperIn;
-        regularMinionBootstrapper = regularMinionBootstrapperIn;
-
+        this.sshMinionBootstrapper = sshMinionBootstrapperIn;
+        this.regularMinionBootstrapper = regularMinionBootstrapperIn;
+        this.saltKeyUtils = saltKeyUtilsIn;
     }
 
     /**
@@ -175,7 +178,7 @@ public class MinionsAPI {
         if (!user.hasRole(RoleFactory.ORG_ADMIN)) {
             throw new PermissionCheckFailureException(RoleFactory.ORG_ADMIN);
         }
-        return json(response, SaltKeyUtils.deleteSaltKey(user, target));
+        return json(response, saltKeyUtils.deleteSaltKey(user, target));
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/controllers/StatesAPI.java
+++ b/java/code/src/com/suse/manager/webui/controllers/StatesAPI.java
@@ -118,6 +118,7 @@ public class StatesAPI {
     private static final Logger LOG = Logger.getLogger(StatesAPI.class);
     private final TaskomaticApi taskomaticApi;
     private final SystemQuery systemQuery;
+    private final ServerGroupManager serverGroupManager;
 
     private static final Gson GSON = new GsonBuilder().create();
     public static final String SALT_PACKAGE_FILES = "packages";
@@ -133,10 +134,13 @@ public class StatesAPI {
     /**
      * @param systemQueryIn instance to use.
      * @param taskomaticApiIn instance to use.
+     * @param serverGroupManagerIn instance to use.
      */
-    public StatesAPI(SystemQuery systemQueryIn, TaskomaticApi taskomaticApiIn) {
+    public StatesAPI(SystemQuery systemQueryIn, TaskomaticApi taskomaticApiIn,
+                     ServerGroupManager serverGroupManagerIn) {
         this.taskomaticApi = taskomaticApiIn;
         this.systemQuery = systemQueryIn;
+        this.serverGroupManager = serverGroupManagerIn;
     }
 
     /**
@@ -341,9 +345,9 @@ public class StatesAPI {
 
     private void checkUserHasPermissionsOnServerGroup(User user, ServerGroup group) {
         try {
-            ServerGroupManager.getInstance().validateAccessCredentials(user, group,
+            serverGroupManager.validateAccessCredentials(user, group,
                     group.getName());
-            ServerGroupManager.getInstance().validateAdminCredentials(user);
+            serverGroupManager.validateAdminCredentials(user);
         }
         catch (PermissionException | LookupException e) {
             Spark.halt(HttpStatus.SC_FORBIDDEN);

--- a/java/code/src/com/suse/manager/webui/controllers/utils/RegularMinionBootstrapper.java
+++ b/java/code/src/com/suse/manager/webui/controllers/utils/RegularMinionBootstrapper.java
@@ -37,7 +37,6 @@ import java.util.Optional;
  */
 public class RegularMinionBootstrapper extends AbstractMinionBootstrapper {
 
-    private static RegularMinionBootstrapper instance;
     private static final Logger LOG = Logger.getLogger(RegularMinionBootstrapper.class);
 
     /**
@@ -47,18 +46,6 @@ public class RegularMinionBootstrapper extends AbstractMinionBootstrapper {
      */
     public RegularMinionBootstrapper(SystemQuery systemQueryIn) {
         super(systemQueryIn);
-    }
-
-    /**
-     * Get instance of the RegularMinionBootstrapper
-     * @param systemQuery instance to get system information.
-     * @return instance of the RegularMinionBootstrapper
-     */
-    public static synchronized RegularMinionBootstrapper getInstance(SystemQuery systemQuery) {
-        if (instance == null) {
-            instance = new RegularMinionBootstrapper(systemQuery);
-        }
-        return instance;
     }
 
     @Override

--- a/java/code/src/com/suse/manager/webui/controllers/utils/SSHMinionBootstrapper.java
+++ b/java/code/src/com/suse/manager/webui/controllers/utils/SSHMinionBootstrapper.java
@@ -43,7 +43,6 @@ import static com.suse.manager.webui.services.impl.SaltSSHService.getSSHUser;
  */
 public class SSHMinionBootstrapper extends AbstractMinionBootstrapper {
 
-    private static SSHMinionBootstrapper instance;
     private static final Logger LOG = Logger.getLogger(SSHMinionBootstrapper.class);
 
     /**
@@ -53,18 +52,6 @@ public class SSHMinionBootstrapper extends AbstractMinionBootstrapper {
      */
     public SSHMinionBootstrapper(SystemQuery systemQueryIn) {
         super(systemQueryIn);
-    }
-
-    /**
-     * Get instance of the SSHMinionBootstrapper
-     * @param systemQuery systemQuery to use
-     * @return the instance of the SSHMinionBootstrapper
-     */
-    public static synchronized SSHMinionBootstrapper getInstance(SystemQuery systemQuery) {
-        if (instance == null) {
-            instance = new SSHMinionBootstrapper(systemQuery);
-        }
-        return instance;
     }
 
     @Override

--- a/java/code/src/com/suse/manager/webui/controllers/virtualization/test/VirtualGuestsControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/virtualization/test/VirtualGuestsControllerTest.java
@@ -42,8 +42,8 @@ import com.suse.manager.virtualization.VmInfoJson;
 import com.suse.manager.virtualization.test.TestVirtManager;
 import com.suse.manager.webui.controllers.test.BaseControllerTestCase;
 import com.suse.manager.webui.controllers.virtualization.VirtualGuestsController;
+import com.suse.manager.webui.services.test.TestSystemQuery;
 import com.suse.manager.webui.services.iface.VirtManager;
-import com.suse.manager.webui.services.impl.SaltService;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -121,7 +121,7 @@ public class VirtualGuestsControllerTest extends BaseControllerTestCase {
         SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
                 new SystemUnentitler(virtManager, new FormulaMonitoringManager(),
                         serverGroupManager),
-                new SystemEntitler(new SaltService(), virtManager, new FormulaMonitoringManager(),
+                new SystemEntitler(new TestSystemQuery(), virtManager, new FormulaMonitoringManager(),
                         serverGroupManager)
         );
 

--- a/java/code/src/com/suse/manager/webui/controllers/virtualization/test/VirtualGuestsControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/virtualization/test/VirtualGuestsControllerTest.java
@@ -27,6 +27,7 @@ import com.redhat.rhn.domain.server.VirtualInstance;
 import com.redhat.rhn.frontend.dto.ScheduledAction;
 import com.redhat.rhn.manager.action.ActionManager;
 import com.redhat.rhn.manager.formula.FormulaMonitoringManager;
+import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.manager.system.VirtualizationActionCommand;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitler;
@@ -116,9 +117,12 @@ public class VirtualGuestsControllerTest extends BaseControllerTestCase {
             }
         };
 
+        ServerGroupManager serverGroupManager = new ServerGroupManager();
         SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(virtManager, new FormulaMonitoringManager()),
-                new SystemEntitler(new SaltService(), virtManager, new FormulaMonitoringManager())
+                new SystemUnentitler(virtManager, new FormulaMonitoringManager(),
+                        serverGroupManager),
+                new SystemEntitler(new SaltService(), virtManager, new FormulaMonitoringManager(),
+                        serverGroupManager)
         );
 
         host = ServerTestUtils.createVirtHostWithGuests(user, 2, true, systemEntitlementManager);

--- a/java/code/src/com/suse/manager/webui/controllers/virtualization/test/VirtualNetsControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/virtualization/test/VirtualNetsControllerTest.java
@@ -24,6 +24,7 @@ import com.redhat.rhn.frontend.context.Context;
 import com.redhat.rhn.frontend.dto.ScheduledAction;
 import com.redhat.rhn.manager.action.ActionManager;
 import com.redhat.rhn.manager.formula.FormulaMonitoringManager;
+import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.manager.system.VirtualizationActionCommand;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitler;
@@ -88,9 +89,10 @@ public class VirtualNetsControllerTest extends BaseControllerTestCase {
             }
         };
 
+        ServerGroupManager serverGroupManager = new ServerGroupManager();
         SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(virtManager, new FormulaMonitoringManager()),
-                new SystemEntitler(new SaltService(), virtManager, new FormulaMonitoringManager())
+                new SystemUnentitler(virtManager, new FormulaMonitoringManager(), serverGroupManager),
+                new SystemEntitler(new SaltService(), virtManager, new FormulaMonitoringManager(), serverGroupManager)
         );
 
         host = ServerTestUtils.createVirtHostWithGuests(user, 1, true, systemEntitlementManager);

--- a/java/code/src/com/suse/manager/webui/controllers/virtualization/test/VirtualNetsControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/virtualization/test/VirtualNetsControllerTest.java
@@ -37,8 +37,8 @@ import com.suse.manager.virtualization.test.TestVirtManager;
 import com.suse.manager.webui.controllers.test.BaseControllerTestCase;
 import com.suse.manager.webui.controllers.virtualization.VirtualNetsController;
 import com.suse.manager.webui.controllers.virtualization.gson.VirtualNetworkInfoJson;
+import com.suse.manager.webui.services.test.TestSystemQuery;
 import com.suse.manager.webui.services.iface.VirtManager;
-import com.suse.manager.webui.services.impl.SaltService;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -92,7 +92,7 @@ public class VirtualNetsControllerTest extends BaseControllerTestCase {
         ServerGroupManager serverGroupManager = new ServerGroupManager();
         SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
                 new SystemUnentitler(virtManager, new FormulaMonitoringManager(), serverGroupManager),
-                new SystemEntitler(new SaltService(), virtManager, new FormulaMonitoringManager(), serverGroupManager)
+                new SystemEntitler(new TestSystemQuery(), virtManager, new FormulaMonitoringManager(), serverGroupManager)
         );
 
         host = ServerTestUtils.createVirtHostWithGuests(user, 1, true, systemEntitlementManager);

--- a/java/code/src/com/suse/manager/webui/controllers/virtualization/test/VirtualPoolsControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/virtualization/test/VirtualPoolsControllerTest.java
@@ -30,6 +30,7 @@ import com.redhat.rhn.frontend.context.Context;
 import com.redhat.rhn.frontend.dto.ScheduledAction;
 import com.redhat.rhn.manager.action.ActionManager;
 import com.redhat.rhn.manager.formula.FormulaMonitoringManager;
+import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.manager.system.VirtualizationActionCommand;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitler;
@@ -114,9 +115,12 @@ public class VirtualPoolsControllerTest extends BaseControllerTestCase {
                         new TypeToken<PoolCapabilitiesJson>() { });
             }
         };
+        ServerGroupManager serverGroupManager = new ServerGroupManager();
         systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(virtManager, new FormulaMonitoringManager()),
-                new SystemEntitler(new SaltService(), virtManager, new FormulaMonitoringManager())
+                new SystemUnentitler(virtManager, new FormulaMonitoringManager(),
+                        serverGroupManager),
+                new SystemEntitler(new SaltService(), virtManager, new FormulaMonitoringManager(),
+                        serverGroupManager)
         );
 
         host = ServerTestUtils.createVirtHostWithGuests(user, 1, true, systemEntitlementManager);

--- a/java/code/src/com/suse/manager/webui/controllers/virtualization/test/VirtualPoolsControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/virtualization/test/VirtualPoolsControllerTest.java
@@ -45,8 +45,8 @@ import com.suse.manager.virtualization.test.TestVirtManager;
 import com.suse.manager.webui.controllers.test.BaseControllerTestCase;
 import com.suse.manager.webui.controllers.virtualization.VirtualPoolsController;
 import com.suse.manager.webui.controllers.virtualization.gson.VirtualStoragePoolInfoJson;
+import com.suse.manager.webui.services.test.TestSystemQuery;
 import com.suse.manager.webui.services.iface.VirtManager;
-import com.suse.manager.webui.services.impl.SaltService;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -119,7 +119,7 @@ public class VirtualPoolsControllerTest extends BaseControllerTestCase {
         systemEntitlementManager = new SystemEntitlementManager(
                 new SystemUnentitler(virtManager, new FormulaMonitoringManager(),
                         serverGroupManager),
-                new SystemEntitler(new SaltService(), virtManager, new FormulaMonitoringManager(),
+                new SystemEntitler(new TestSystemQuery(), virtManager, new FormulaMonitoringManager(),
                         serverGroupManager)
         );
 

--- a/java/code/src/com/suse/manager/webui/menu/MenuTree.java
+++ b/java/code/src/com/suse/manager/webui/menu/MenuTree.java
@@ -36,13 +36,23 @@ import javax.servlet.jsp.PageContext;
  * The UI Menu Tree.
  */
 public class MenuTree {
+
+    private final AclFactory aclFactory;
+
+    /**
+     * @param aclFactoryIn
+     */
+    public  MenuTree(AclFactory aclFactoryIn) {
+        this.aclFactory = aclFactoryIn;
+    }
+
     /**
      * Generate a List of {@link MenuItem}.
      *
      * @param pageContext the PageContext object
      * @return the full menu tree as a List of {@link MenuItem}
      */
-    public static List<MenuItem> getMenuTree(PageContext pageContext) {
+    public List<MenuItem> getMenuTree(PageContext pageContext) {
         HttpServletRequest request = (HttpServletRequest) pageContext.getRequest();
         User user = new RequestContext(request).getCurrentUser();
         String url = request.getRequestURI();
@@ -465,10 +475,10 @@ public class MenuTree {
      * @param aclMixin acls to evaluate
      * @return the acl evaluated result
      */
-    public static boolean checkAcl(User user, String aclMixin) {
+    public boolean checkAcl(User user, String aclMixin) {
         Map<String, Object> aclContext = new HashMap<>();
         aclContext.put("user", user);
-        Acl acl = AclFactory.getInstance().getAcl(Access.class.getName());
+        Acl acl = aclFactory.getAcl(Access.class.getName());
         return acl.evalAcl(aclContext, aclMixin);
     }
 
@@ -519,7 +529,7 @@ public class MenuTree {
      * @param url the current URL
      * @return the current active {@link MenuItem}
      */
-    public static List<MenuItem> getBestActiveDirs(List<MenuItem> nodes, String url) {
+    public List<MenuItem> getBestActiveDirs(List<MenuItem> nodes, String url) {
         Integer depthPrecision = 0;
         List<MenuItem> bestActiveItems = new LinkedList<>();
         for (MenuItem item1 : nodes) {
@@ -569,7 +579,7 @@ public class MenuTree {
      * @param pageContext the context of the request
      * @return the page title
      */
-    public static String getTitlePage(PageContext pageContext) {
+    public String getTitlePage(PageContext pageContext) {
         String title = "";
         Optional<MenuItem> activeItem = getMenuTree(pageContext).stream()
                 .filter(node -> node.getActive()).findFirst();
@@ -589,7 +599,7 @@ public class MenuTree {
      * @param pageContext the current PageContext
      * @return the JSON String as for output
      */
-    public static String getJsonMenu(PageContext pageContext) {
+    public String getJsonMenu(PageContext pageContext) {
         return new GsonBuilder().create().toJson(getMenuTree(pageContext));
     }
 

--- a/java/code/src/com/suse/manager/webui/menu/test/MenuTreeTest.java
+++ b/java/code/src/com/suse/manager/webui/menu/test/MenuTreeTest.java
@@ -15,7 +15,6 @@
 
 package com.suse.manager.webui.menu.test;
 
-import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.security.acl.Access;
 import com.redhat.rhn.common.security.acl.AclFactory;
 import com.redhat.rhn.manager.formula.FormulaManager;
@@ -28,7 +27,10 @@ import com.suse.manager.webui.menu.MenuTree.MenuItemList;
 import java.util.List;
 
 
-import com.suse.manager.webui.services.impl.SaltService;
+import com.suse.manager.webui.services.iface.SaltApi;
+import com.suse.manager.webui.services.iface.SystemQuery;
+import com.suse.manager.webui.services.test.TestSaltApi;
+import com.suse.manager.webui.services.test.TestSystemQuery;
 import junit.framework.TestCase;
 
 public class MenuTreeTest extends TestCase {
@@ -87,9 +89,10 @@ public class MenuTreeTest extends TestCase {
                     .withPrimaryUrl("/rhn/errata/manage/CloneErrata.do")
                     .withDir("/rhn/errata/manage/clone")));
 
-        SaltService saltService = new SaltService();
+        SystemQuery systemQuery = new TestSystemQuery();
+        SaltApi saltApi = new TestSaltApi();
         MenuTree menuTree = new MenuTree(new AclFactory(new Access(new ClusterManager(
-                saltService, saltService, new ServerGroupManager(), new FormulaManager(saltService)
+                saltApi, systemQuery, new ServerGroupManager(), new FormulaManager(saltApi)
         ))));
 
         // the TESTED method

--- a/java/code/src/com/suse/manager/webui/menu/test/MenuTreeTest.java
+++ b/java/code/src/com/suse/manager/webui/menu/test/MenuTreeTest.java
@@ -15,10 +15,10 @@
 
 package com.suse.manager.webui.menu.test;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.security.acl.Access;
 import com.redhat.rhn.common.security.acl.AclFactory;
 import com.redhat.rhn.manager.formula.FormulaManager;
-import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.suse.manager.clusters.ClusterManager;
 import com.suse.manager.webui.menu.MenuItem;
 import com.suse.manager.webui.menu.MenuTree;
@@ -88,7 +88,7 @@ public class MenuTreeTest extends TestCase {
 
         SaltService saltService = new SaltService();
         MenuTree menuTree = new MenuTree(new AclFactory(new Access(new ClusterManager(
-                saltService, saltService, ServerGroupManager.getInstance(), new FormulaManager(saltService)
+                saltService, saltService, GlobalInstanceHolder.SERVER_GROUP_MANAGER, new FormulaManager(saltService)
         ))));
 
         // the TESTED method

--- a/java/code/src/com/suse/manager/webui/menu/test/MenuTreeTest.java
+++ b/java/code/src/com/suse/manager/webui/menu/test/MenuTreeTest.java
@@ -15,6 +15,11 @@
 
 package com.suse.manager.webui.menu.test;
 
+import com.redhat.rhn.common.security.acl.Access;
+import com.redhat.rhn.common.security.acl.AclFactory;
+import com.redhat.rhn.manager.formula.FormulaManager;
+import com.redhat.rhn.manager.system.ServerGroupManager;
+import com.suse.manager.clusters.ClusterManager;
 import com.suse.manager.webui.menu.MenuItem;
 import com.suse.manager.webui.menu.MenuTree;
 import com.suse.manager.webui.menu.MenuTree.MenuItemList;
@@ -22,6 +27,7 @@ import com.suse.manager.webui.menu.MenuTree.MenuItemList;
 import java.util.List;
 
 
+import com.suse.manager.webui.services.impl.SaltService;
 import junit.framework.TestCase;
 
 public class MenuTreeTest extends TestCase {
@@ -80,8 +86,13 @@ public class MenuTreeTest extends TestCase {
                     .withPrimaryUrl("/rhn/errata/manage/CloneErrata.do")
                     .withDir("/rhn/errata/manage/clone")));
 
+        SaltService saltService = new SaltService();
+        MenuTree menuTree = new MenuTree(new AclFactory(new Access(new ClusterManager(
+                saltService, saltService, ServerGroupManager.getInstance(), new FormulaManager(saltService)
+        ))));
+
         // the TESTED method
-        List<MenuItem> bestActiveDir = MenuTree.getBestActiveDirs(nodes, url);
+        List<MenuItem> bestActiveDir = menuTree.getBestActiveDirs(nodes, url);
 
         // check if all returned levels are flagged as active
         for (MenuItem menuItem : bestActiveDir) {

--- a/java/code/src/com/suse/manager/webui/menu/test/MenuTreeTest.java
+++ b/java/code/src/com/suse/manager/webui/menu/test/MenuTreeTest.java
@@ -19,6 +19,7 @@ import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.security.acl.Access;
 import com.redhat.rhn.common.security.acl.AclFactory;
 import com.redhat.rhn.manager.formula.FormulaManager;
+import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.suse.manager.clusters.ClusterManager;
 import com.suse.manager.webui.menu.MenuItem;
 import com.suse.manager.webui.menu.MenuTree;
@@ -88,7 +89,7 @@ public class MenuTreeTest extends TestCase {
 
         SaltService saltService = new SaltService();
         MenuTree menuTree = new MenuTree(new AclFactory(new Access(new ClusterManager(
-                saltService, saltService, GlobalInstanceHolder.SERVER_GROUP_MANAGER, new FormulaManager(saltService)
+                saltService, saltService, new ServerGroupManager(), new FormulaManager(saltService)
         ))));
 
         // the TESTED method

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -225,16 +225,17 @@ public class SaltServerActionService {
     private SaltSSHService saltSSHService = SaltService.INSTANCE.getSaltSSHService();
     private SaltUtils saltUtils;
     private FormulaManager formulaManager = FormulaManager.getInstance();
-    private ClusterManager clusterManager = ClusterManager.instance();
+    private final ClusterManager clusterManager;
     private boolean skipCommandScriptPerms;
 
     /**
      * @param systemQueryIn instance for getting information from a system.
      * @param saltUtilsIn
      */
-    public SaltServerActionService(SystemQuery systemQueryIn, SaltUtils saltUtilsIn) {
+    public SaltServerActionService(SystemQuery systemQueryIn, SaltUtils saltUtilsIn, ClusterManager clusterManagerIn) {
         this.systemQuery = systemQueryIn;
         this.saltUtils = saltUtilsIn;
+        this.clusterManager = clusterManagerIn;
     }
 
     private Action unproxy(Action entity) {

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -25,6 +25,7 @@ import static java.util.Optional.ofNullable;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
@@ -117,7 +118,6 @@ import com.suse.manager.utils.SaltKeyUtils;
 import com.suse.manager.utils.SaltUtils;
 import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.manager.webui.services.impl.SaltSSHService;
-import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.manager.webui.services.pillar.MinionGeneralPillarGenerator;
 import com.suse.manager.webui.services.pillar.MinionPillarManager;
 import com.suse.manager.webui.utils.DownloadTokenBuilder;
@@ -222,7 +222,7 @@ public class SaltServerActionService {
             SaltActionChainGeneratorService.INSTANCE;
 
     private SystemQuery systemQuery;
-    private SaltSSHService saltSSHService = SaltService.INSTANCE.getSaltSSHService();
+    private SaltSSHService saltSSHService = GlobalInstanceHolder.SYSTEM_QUERY.getSaltSSHService();
     private SaltUtils saltUtils;
     private FormulaManager formulaManager = FormulaManager.getInstance();
     private final ClusterManager clusterManager;
@@ -2092,7 +2092,7 @@ public class SaltServerActionService {
 
             ScheduleMetadata metadata = ScheduleMetadata.getMetadataForRegularMinionActions(
                     isStagingJob, forcePackageListRefresh, actionIn.getId());
-            List<String> results = SaltService.INSTANCE
+            List<String> results = GlobalInstanceHolder.SYSTEM_QUERY
                     .callAsync(call, new MinionList(minionIds), Optional.of(metadata))
                     .get().getMinions();
 

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -47,6 +47,7 @@ import com.redhat.rhn.domain.action.config.ConfigRevisionAction;
 import com.redhat.rhn.domain.action.dup.DistUpgradeAction;
 import com.redhat.rhn.domain.action.dup.DistUpgradeChannelTask;
 import com.redhat.rhn.domain.action.errata.ErrataAction;
+import com.redhat.rhn.domain.action.kickstart.KickstartAction;
 import com.redhat.rhn.domain.action.kickstart.KickstartActionDetails;
 import com.redhat.rhn.domain.action.kickstart.KickstartInitiateAction;
 import com.redhat.rhn.domain.action.rhnpackage.PackageRemoveAction;
@@ -112,7 +113,7 @@ import com.redhat.rhn.taskomatic.TaskomaticApiException;
 import com.suse.manager.clusters.ClusterManager;
 import com.suse.manager.model.clusters.Cluster;
 import com.suse.manager.reactor.messaging.ApplyStatesEventMessage;
-import com.suse.manager.reactor.messaging.JobReturnEventMessageAction;
+import com.suse.manager.utils.SaltKeyUtils;
 import com.suse.manager.utils.SaltUtils;
 import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.manager.webui.services.impl.SaltSSHService;
@@ -182,6 +183,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.Stack;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -221,16 +223,18 @@ public class SaltServerActionService {
 
     private SystemQuery systemQuery;
     private SaltSSHService saltSSHService = SaltService.INSTANCE.getSaltSSHService();
-    private SaltUtils saltUtils = SaltUtils.INSTANCE;
+    private SaltUtils saltUtils;
     private FormulaManager formulaManager = FormulaManager.getInstance();
     private ClusterManager clusterManager = ClusterManager.instance();
     private boolean skipCommandScriptPerms;
 
     /**
      * @param systemQueryIn instance for getting information from a system.
+     * @param saltUtilsIn
      */
-    public SaltServerActionService(SystemQuery systemQueryIn) {
+    public SaltServerActionService(SystemQuery systemQueryIn, SaltUtils saltUtilsIn) {
         this.systemQuery = systemQueryIn;
+        this.saltUtils = saltUtilsIn;
     }
 
     private Action unproxy(Action entity) {
@@ -693,7 +697,7 @@ public class SaltServerActionService {
                     failActionChain(minionId, firstChunkActionId, Optional.of("Unexpected response: " + msg));
                     return false;
                 }
-                JobReturnEventMessageAction.handleActionChainResult(minionId, "", 0, true,
+                handleActionChainResult(minionId, "", 0, true,
                         actionChainResult,
                         // skip reboot, needs special handling
                         stateResult -> SYSTEM_REBOOT.equals(stateResult.getName()));
@@ -779,14 +783,14 @@ public class SaltServerActionService {
      * @param failedActionId the failed action id
      * @param message the message to set to the failed action
      */
-    public static void failActionChain(String minionId, Optional<Long> failedActionId, Optional<String> message) {
+    public void failActionChain(String minionId, Optional<Long> failedActionId, Optional<String> message) {
         failActionChain(minionId, Optional.empty(), failedActionId, message);
     }
 
-    private static void failActionChain(String minionId, Optional<Long> actionChainId, Optional<Long> failedActionId,
+    private void failActionChain(String minionId, Optional<Long> actionChainId, Optional<Long> failedActionId,
                                         Optional<String> message) {
         failedActionId.ifPresent(last ->
-                JobReturnEventMessageAction.failDependentServerActions(last, minionId, message));
+                failDependentServerActions(last, minionId, message));
         MinionServerFactory.findByMinionId(minionId).ifPresent(minion -> {
             SaltActionChainGeneratorService.INSTANCE.removeActionChainSLSFilesForMinion(minion, actionChainId);
         });
@@ -2262,6 +2266,195 @@ public class SaltServerActionService {
                                                 state.equals(s.getStatus()))
                                 .findAny())
                 .isPresent();
+    }
+
+    /**
+     * Set the given action to FAILED if not already in that state and also the dependent actions.
+     * @param actionId the action id
+     * @param minionId the minion id
+     * @param message the result message to set in the server action
+     */
+    public void failDependentServerActions(long actionId, String minionId, Optional<String> message) {
+        Optional<MinionServer> minion = MinionServerFactory.findByMinionId(
+                minionId);
+        if (minion.isPresent()) {
+            // set first action to failed if not already in that state
+            Action action = ActionFactory.lookupById(actionId);
+            Optional.ofNullable(action)
+                    .ifPresent(firstAction ->
+                            firstAction.getServerActions().stream()
+                                    .filter(sa -> sa.getServerId().equals(minion.get().getId()))
+                                    .filter(sa -> !ActionFactory.STATUS_FAILED.equals(sa.getStatus()))
+                                    .filter(sa -> !ActionFactory.STATUS_COMPLETED.equals(sa.getStatus()))
+                                    .findFirst()
+                                    .ifPresent(sa -> sa.fail(message.orElse("Prerequisite failed"))));
+
+            // walk dependent server actions recursively and set them to failed
+            Stack<Long> actionIdsDependencies = new Stack<>();
+            actionIdsDependencies.push(actionId);
+            List<ServerAction> serverActions = ActionFactory
+                    .listServerActionsForServer(minion.get(),
+                            Arrays.asList(ActionFactory.STATUS_QUEUED, ActionFactory.STATUS_PICKED_UP,
+                                    ActionFactory.STATUS_FAILED), action.getCreated());
+
+            while (!actionIdsDependencies.empty()) {
+                Long acId = actionIdsDependencies.pop();
+                List<ServerAction> serverActionsWithPrereq = serverActions.stream()
+                        .filter(s -> s.getParentAction().getPrerequisite() != null)
+                        .filter(s -> s.getParentAction().getPrerequisite().getId().equals(acId))
+                        .collect(Collectors.toList());
+                for (ServerAction sa : serverActionsWithPrereq) {
+                    actionIdsDependencies.push(sa.getParentAction().getId());
+                    sa.fail("Prerequisite failed");
+                }
+            }
+        }
+    }
+
+    /**
+     * Update the action properly based on the Job results from Salt.
+     *
+     * @param actionId the ID of the Action to handle
+     * @param minionId the ID of the Minion who performed the action
+     * @param retcode the retcode returned
+     * @param success indicates if the job executed successfully
+     * @param jobId the ID of the Salt job.
+     * @param jsonResult the json results from the Salt job.
+     * @param function the Salt function executed.
+     */
+    public void handleAction(long actionId, String minionId, int retcode, boolean success,
+                                    String jobId, JsonElement jsonResult, String function) {
+        // Lookup the corresponding action
+        Optional<Action> action = Optional.ofNullable(ActionFactory.lookupById(actionId));
+        if (action.isPresent()) {
+
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("Matched salt job with action (id=" + actionId + ")");
+            }
+
+            Optional<MinionServer> minionServerOpt = MinionServerFactory.findByMinionId(minionId);
+            minionServerOpt.ifPresent(minionServer -> {
+                Optional<ServerAction> serverAction = action.get()
+                        .getServerActions()
+                        .stream()
+                        .filter(sa -> sa.getServer().equals(minionServer)).findFirst();
+
+
+                serverAction.ifPresent(sa -> {
+                    if (LOG.isDebugEnabled()) {
+                        LOG.debug("Updating action for server: " + minionServer.getId());
+                    }
+                    try {
+                        // Reboot has been scheduled so set reboot action to PICKED_UP.
+                        // Wait until next "minion/start/event" to set it to COMPLETED.
+                        if (action.get().getActionType().equals(ActionFactory.TYPE_REBOOT) &&
+                                success && retcode == 0) {
+                            sa.setStatus(ActionFactory.STATUS_PICKED_UP);
+                            sa.setPickupTime(new Date());
+                            return;
+                        }
+                        else if (action.get().getActionType().equals(ActionFactory.TYPE_KICKSTART_INITIATE) &&
+                                success) {
+                            KickstartAction ksAction = (KickstartAction) action.get();
+                            if (!ksAction.getKickstartActionDetails().getUpgrade()) {
+                                // Delete salt key from master
+                                SaltKeyUtils.deleteSaltKey(action.get().getSchedulerUser(), minionId);
+                            }
+                        }
+                        SaltUtils.INSTANCE.updateServerAction(sa,
+                                retcode,
+                                success,
+                                jobId,
+                                jsonResult,
+                                function);
+                        ActionFactory.save(sa);
+                    }
+                    catch (Exception e) {
+                        LOG.error("Error processing Salt job return", e);
+                        // DB exceptions cause the transaction to go into rollback-only
+                        // state. We need to rollback this transaction first.
+                        ActionFactory.rollbackTransaction();
+
+                        sa.fail("An unexpected error has occurred. Please check the server logs.");
+
+                        ActionFactory.save(sa);
+                        // When we throw the exception again, the current transaction
+                        // will be set to rollback-only, so we explicitly commit the
+                        // transaction here
+                        ActionFactory.commitTransaction();
+
+                        // We don't actually want to catch any exceptions
+                        throw e;
+                    }
+                });
+            });
+        }
+        else {
+            LOG.warn("Action referenced from Salt job was not found: " + actionId);
+        }
+    }
+
+    /**
+     * Handle action chain Salt result.
+     *
+     * @param minionId the minion id
+     * @param jobId the job id
+     * @param retCode the ret code
+     * @param success whether result is successful or not
+     * @param actionChainResult job result
+     * @param skipFunction function to check if a result should be skipped from handling
+     */
+    public void handleActionChainResult(
+            String minionId, String jobId, int retCode, boolean success,
+            Map<String, StateApplyResult<Ret<JsonElement>>> actionChainResult,
+            Function<StateApplyResult<Ret<JsonElement>>, Boolean> skipFunction) {
+        int chunk = 1;
+        Long retActionChainId = null;
+        boolean actionChainFailed = false;
+        List<Long> failedActionIds = new ArrayList<>();
+        for (Map.Entry<String, StateApplyResult<Ret<JsonElement>>> entry : actionChainResult.entrySet()) {
+            String key = entry.getKey();
+            StateApplyResult<Ret<JsonElement>> actionStateApply = entry.getValue();
+
+            Optional<SaltActionChainGeneratorService.ActionChainStateId> stateId =
+                    SaltActionChainGeneratorService.parseActionChainStateId(key);
+            if (stateId.isPresent()) {
+                retActionChainId = stateId.get().getActionChainId();
+                chunk = stateId.get().getChunk();
+                Long actionId = stateId.get().getActionId();
+                if (skipFunction.apply(actionStateApply)) {
+                    continue; // skip this state from handling
+                }
+
+                if (!actionStateApply.isResult()) {
+                    actionChainFailed = true;
+                    failedActionIds.add(actionId);
+                    // don't stop handling the result entries if there's a failed action
+                    // the result entries are not returned in order
+                }
+                handleAction(actionId,
+                        minionId,
+                        actionStateApply.isResult() ? 0 : -1,
+                        actionStateApply.isResult(),
+                        jobId,
+                        actionStateApply.getChanges().getRet(),
+                        actionStateApply.getName());
+            }
+            else if (!key.contains("schedule_next_chunk")) {
+                LOG.warn("Could not find action id in action chain state key: " + key);
+            }
+        }
+
+        if (retActionChainId != null) {
+            if (actionChainFailed) {
+                long firstFailedActionId = failedActionIds.stream().min(Long::compare).get();
+                // Set rest of actions as FAILED due to failed prerequisite
+                failDependentServerActions(firstFailedActionId, minionId, Optional.empty());
+            }
+            // Removing the generated SLS file
+            SaltActionChainGeneratorService.INSTANCE.removeActionChainSLSFiles(
+                    retActionChainId, minionId, chunk, actionChainFailed);
+        }
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -224,6 +224,7 @@ public class SaltServerActionService {
     private SystemQuery systemQuery;
     private SaltSSHService saltSSHService = GlobalInstanceHolder.SYSTEM_QUERY.getSaltSSHService();
     private SaltUtils saltUtils;
+    private SaltKeyUtils saltKeyUtils;
     private final FormulaManager formulaManager;
     private final ClusterManager clusterManager;
     private boolean skipCommandScriptPerms;
@@ -233,13 +234,16 @@ public class SaltServerActionService {
      * @param saltUtilsIn
      * @param clusterManagerIn
      * @param formulaManagerIn
+     * @param saltKeyUtilsIn
      */
     public SaltServerActionService(SystemQuery systemQueryIn, SaltUtils saltUtilsIn,
-                                   ClusterManager clusterManagerIn, FormulaManager formulaManagerIn) {
+                                   ClusterManager clusterManagerIn, FormulaManager formulaManagerIn,
+                                   SaltKeyUtils saltKeyUtilsIn) {
         this.systemQuery = systemQueryIn;
         this.saltUtils = saltUtilsIn;
         this.clusterManager = clusterManagerIn;
         this.formulaManager = formulaManagerIn;
+        this.saltUtils = saltUtilsIn;
     }
 
     private Action unproxy(Action entity) {
@@ -2363,7 +2367,7 @@ public class SaltServerActionService {
                             KickstartAction ksAction = (KickstartAction) action.get();
                             if (!ksAction.getKickstartActionDetails().getUpgrade()) {
                                 // Delete salt key from master
-                                SaltKeyUtils.deleteSaltKey(action.get().getSchedulerUser(), minionId);
+                                saltKeyUtils.deleteSaltKey(action.get().getSchedulerUser(), minionId);
                             }
                         }
                         saltUtils.updateServerAction(sa,

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -2361,7 +2361,7 @@ public class SaltServerActionService {
                                 SaltKeyUtils.deleteSaltKey(action.get().getSchedulerUser(), minionId);
                             }
                         }
-                        SaltUtils.INSTANCE.updateServerAction(sa,
+                        saltUtils.updateServerAction(sa,
                                 retcode,
                                 success,
                                 jobId,

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -224,18 +224,22 @@ public class SaltServerActionService {
     private SystemQuery systemQuery;
     private SaltSSHService saltSSHService = GlobalInstanceHolder.SYSTEM_QUERY.getSaltSSHService();
     private SaltUtils saltUtils;
-    private FormulaManager formulaManager = FormulaManager.getInstance();
+    private final FormulaManager formulaManager;
     private final ClusterManager clusterManager;
     private boolean skipCommandScriptPerms;
 
     /**
      * @param systemQueryIn instance for getting information from a system.
      * @param saltUtilsIn
+     * @param clusterManagerIn
+     * @param formulaManagerIn
      */
-    public SaltServerActionService(SystemQuery systemQueryIn, SaltUtils saltUtilsIn, ClusterManager clusterManagerIn) {
+    public SaltServerActionService(SystemQuery systemQueryIn, SaltUtils saltUtilsIn,
+                                   ClusterManager clusterManagerIn, FormulaManager formulaManagerIn) {
         this.systemQuery = systemQueryIn;
         this.saltUtils = saltUtilsIn;
         this.clusterManager = clusterManagerIn;
+        this.formulaManager = formulaManagerIn;
     }
 
     private Action unproxy(Action entity) {

--- a/java/code/src/com/suse/manager/webui/services/impl/SaltSSHService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltSSHService.java
@@ -14,6 +14,7 @@
  */
 package com.suse.manager.webui.services.impl;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.CommonConstants;
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
@@ -550,7 +551,7 @@ public class SaltSSHService {
 
         try {
             tmpKeyFileAbsolutePath.ifPresent(p -> parameters.getPrivateKey().ifPresent(k ->
-                    SaltService.INSTANCE.storeSshKeyFile(p, k)));
+                    GlobalInstanceHolder.SYSTEM_QUERY.storeSshKeyFile(p, k)));
             SaltRoster roster = new SaltRoster();
             roster.addHost(parameters.getHost(),
                     parameters.getUser(),
@@ -585,7 +586,7 @@ public class SaltSSHService {
     }
 
     private void cleanUpTempKeyFile(Path path) {
-        SaltService.INSTANCE
+        GlobalInstanceHolder.SYSTEM_QUERY
                 .removeFile(path)
                 .orElseThrow(() -> new IllegalStateException("Can't remove file " + path));
     }
@@ -782,7 +783,7 @@ public class SaltSSHService {
         Map<String, String> options = new HashMap<>();
         options.put("StrictHostKeyChecking", "no");
         options.put("ConnectTimeout", ConfigDefaults.get().getSaltSSHConnectTimeout() + "");
-        Optional<MgrUtilRunner.ExecResult> ret = SaltService.INSTANCE
+        Optional<MgrUtilRunner.ExecResult> ret = GlobalInstanceHolder.SYSTEM_QUERY
                 .chainSSHCommand(proxyPath,
                         SSH_KEY_PATH,
                         PROXY_SSH_PUSH_KEY,

--- a/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
@@ -130,13 +130,6 @@ public class SaltService implements SystemQuery, SaltApi {
 
     private final Batch defaultBatch;
 
-    /**
-     * Singleton instance of this class
-     */
-    private static final SaltService INSTANCE_SALT_SERVICE = new SaltService();
-    public static final SystemQuery INSTANCE = INSTANCE_SALT_SERVICE;
-    public static final SaltApi INSTANCE_SALT_API = INSTANCE_SALT_SERVICE;
-
     // Logger
     private static final Logger LOG = Logger.getLogger(SaltService.class);
 

--- a/java/code/src/com/suse/manager/webui/services/impl/test/SaltServiceTest.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/test/SaltServiceTest.java
@@ -1,5 +1,6 @@
 package com.suse.manager.webui.services.impl.test;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
@@ -85,7 +86,7 @@ public class SaltServiceTest extends JMockBaseTestCaseWithUser {
     public void testGenerateSSHKeyExists() throws IOException {
         Path keyFile = Files.createFile(tempDir.resolve("mgr_ssh_id.pub"));
         String keyPath = keyFile.toFile().getCanonicalPath();
-        Optional<MgrUtilRunner.ExecResult> res = SaltService.INSTANCE
+        Optional<MgrUtilRunner.ExecResult> res = GlobalInstanceHolder.SYSTEM_QUERY
                 .generateSSHKey(keyPath.substring(0, keyPath.length() - 4));
         assertTrue(res.isPresent());
         assertEquals(0, res.get().getReturnCode());

--- a/java/code/src/com/suse/manager/webui/services/impl/test/SaltServiceTest.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/test/SaltServiceTest.java
@@ -1,12 +1,12 @@
 package com.suse.manager.webui.services.impl.test;
 
-import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
 import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
 
 import com.suse.manager.webui.controllers.utils.ContactMethodUtil;
+import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.manager.webui.services.impl.MinionPendingRegistrationService;
 import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.manager.webui.services.impl.runner.MgrUtilRunner;
@@ -86,7 +86,8 @@ public class SaltServiceTest extends JMockBaseTestCaseWithUser {
     public void testGenerateSSHKeyExists() throws IOException {
         Path keyFile = Files.createFile(tempDir.resolve("mgr_ssh_id.pub"));
         String keyPath = keyFile.toFile().getCanonicalPath();
-        Optional<MgrUtilRunner.ExecResult> res = GlobalInstanceHolder.SYSTEM_QUERY
+        SystemQuery systemQuery = new SaltService();
+        Optional<MgrUtilRunner.ExecResult> res = systemQuery
                 .generateSSHKey(keyPath.substring(0, keyPath.length() - 4));
         assertTrue(res.isPresent());
         assertEquals(0, res.get().getReturnCode());

--- a/java/code/src/com/suse/manager/webui/services/impl/test/SaltServiceTest.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/test/SaltServiceTest.java
@@ -7,6 +7,7 @@ import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
 
 import com.suse.manager.webui.controllers.utils.ContactMethodUtil;
 import com.suse.manager.webui.services.iface.SystemQuery;
+import com.suse.manager.webui.services.test.TestSystemQuery;
 import com.suse.manager.webui.services.impl.MinionPendingRegistrationService;
 import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.manager.webui.services.impl.runner.MgrUtilRunner;
@@ -86,11 +87,12 @@ public class SaltServiceTest extends JMockBaseTestCaseWithUser {
     public void testGenerateSSHKeyExists() throws IOException {
         Path keyFile = Files.createFile(tempDir.resolve("mgr_ssh_id.pub"));
         String keyPath = keyFile.toFile().getCanonicalPath();
-        SystemQuery systemQuery = new SaltService();
+        SaltService systemQuery = new SaltService();
         Optional<MgrUtilRunner.ExecResult> res = systemQuery
                 .generateSSHKey(keyPath.substring(0, keyPath.length() - 4));
         assertTrue(res.isPresent());
         assertEquals(0, res.get().getReturnCode());
+        systemQuery.close();
     }
 
     @Override

--- a/java/code/src/com/suse/manager/webui/services/pillar/test/MinionVirtualizationPillarGeneratorTest.java
+++ b/java/code/src/com/suse/manager/webui/services/pillar/test/MinionVirtualizationPillarGeneratorTest.java
@@ -30,8 +30,8 @@ import com.redhat.rhn.testing.BaseTestCaseWithUser;
 import com.suse.manager.virtualization.GuestDefinition;
 import com.suse.manager.virtualization.PoolCapabilitiesJson;
 import com.suse.manager.virtualization.PoolDefinition;
+import com.suse.manager.webui.services.test.TestSystemQuery;
 import com.suse.manager.webui.services.iface.VirtManager;
-import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.manager.webui.services.pillar.MinionPillarFileManager;
 import com.suse.manager.webui.services.pillar.MinionVirtualizationPillarGenerator;
 
@@ -106,7 +106,7 @@ public class MinionVirtualizationPillarGeneratorTest extends BaseTestCaseWithUse
         systemEntitlementManager = new SystemEntitlementManager(
                 new SystemUnentitler(virtManager, new FormulaMonitoringManager(),
                         serverGroupManager),
-                new SystemEntitler(new SaltService(), virtManager, new FormulaMonitoringManager(),
+                new SystemEntitler(new TestSystemQuery(), virtManager, new FormulaMonitoringManager(),
                         serverGroupManager)
         );
     }

--- a/java/code/src/com/suse/manager/webui/services/pillar/test/MinionVirtualizationPillarGeneratorTest.java
+++ b/java/code/src/com/suse/manager/webui/services/pillar/test/MinionVirtualizationPillarGeneratorTest.java
@@ -21,6 +21,7 @@ import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.manager.formula.FormulaMonitoringManager;
+import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitler;
 import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
@@ -101,9 +102,12 @@ public class MinionVirtualizationPillarGeneratorTest extends BaseTestCaseWithUse
             }
         };
 
+        ServerGroupManager serverGroupManager =  new ServerGroupManager();
         systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(virtManager, new FormulaMonitoringManager()),
-                new SystemEntitler(new SaltService(), virtManager, new FormulaMonitoringManager())
+                new SystemUnentitler(virtManager, new FormulaMonitoringManager(),
+                        serverGroupManager),
+                new SystemEntitler(new SaltService(), virtManager, new FormulaMonitoringManager(),
+                        serverGroupManager)
         );
     }
 

--- a/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
+++ b/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
@@ -149,7 +149,7 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
         SaltUtils saltUtils = new SaltUtils(
                 systemQuery, saltApi, clusterManager
         );
-        SaltServerActionService service = new SaltServerActionService(systemQuery, saltUtils);
+        SaltServerActionService service = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         service.setSkipCommandScriptPerms(true);
         return service;
     }
@@ -844,9 +844,10 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
 
     private void successWorker() throws IOException {
         SaltService saltService = new SaltService();
-        SystemQuery systemQuery = saltService;
-        SaltApi saltApi = saltService;
-        SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, ClusterManager.instance()) {
+        FormulaManager formulaManager = new FormulaManager(saltService);
+        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        ClusterManager clusterManager = new ClusterManager(saltService, saltService, serverGroupManager, formulaManager);
+        SaltUtils saltUtils = new SaltUtils(saltService, saltService, clusterManager) {
             @Override
             public boolean shouldRefreshPackageList(String function,
                                                     Optional<JsonElement> callResult) {

--- a/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
+++ b/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
@@ -843,7 +843,10 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
     }
 
     private void successWorker() throws IOException {
-        SaltUtils saltUtils = new SaltUtils() {
+        SaltService saltService = new SaltService();
+        SystemQuery systemQuery = saltService;
+        SaltApi saltApi = saltService;
+        SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, ClusterManager.instance()) {
             @Override
             public boolean shouldRefreshPackageList(String function,
                                                     Optional<JsonElement> callResult) {

--- a/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
+++ b/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
@@ -50,7 +50,9 @@ import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
 import com.redhat.rhn.domain.server.test.ServerFactoryTest;
 import com.redhat.rhn.manager.action.ActionChainManager;
 import com.redhat.rhn.manager.action.ActionManager;
+import com.redhat.rhn.manager.formula.FormulaManager;
 import com.redhat.rhn.manager.formula.FormulaMonitoringManager;
+import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitler;
@@ -64,10 +66,12 @@ import com.redhat.rhn.testing.RhnBaseTestCase;
 import com.redhat.rhn.testing.ServerTestUtils;
 import com.redhat.rhn.testing.TestUtils;
 
+import com.suse.manager.clusters.ClusterManager;
 import com.suse.manager.utils.SaltUtils;
 import com.suse.manager.virtualization.test.TestVirtManager;
 import com.suse.manager.webui.services.SaltActionChainGeneratorService;
 import com.suse.manager.webui.services.SaltServerActionService;
+import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.manager.webui.services.iface.VirtManager;
 import com.suse.manager.webui.services.impl.SaltService;
@@ -136,7 +140,16 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
     }
 
     private SaltServerActionService createSaltServerActionService(SystemQuery systemQuery) {
-        SaltServerActionService service = new SaltServerActionService(systemQuery);
+        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
+        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        FormulaManager formulaManager = new FormulaManager(saltApi);
+        ClusterManager clusterManager = new ClusterManager(
+                saltApi, systemQuery, serverGroupManager, formulaManager
+        );
+        SaltUtils saltUtils = new SaltUtils(
+                systemQuery, saltApi, clusterManager
+        );
+        SaltServerActionService service = new SaltServerActionService(systemQuery, saltUtils);
         service.setSkipCommandScriptPerms(true);
         return service;
     }

--- a/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
+++ b/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
@@ -19,7 +19,6 @@ import static com.redhat.rhn.domain.action.ActionFactory.STATUS_FAILED;
 import static com.redhat.rhn.domain.action.ActionFactory.STATUS_PICKED_UP;
 import static com.redhat.rhn.domain.action.ActionFactory.STATUS_QUEUED;
 
-import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionChain;
@@ -409,8 +408,9 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
     }
 
     public void testExecuteActionChain() throws Exception {
-        SystemQuery systemQuery = GlobalInstanceHolder.SYSTEM_QUERY;
-        SaltApi saltApi = GlobalInstanceHolder.SALT_API;
+        SaltService saltService = new SaltService();
+        SystemQuery systemQuery = saltService;
+        SaltApi saltApi = saltService;
         ServerGroupManager serverGroupManager = new ServerGroupManager();
         FormulaManager formulaManager = new FormulaManager(saltApi);
         ClusterManager clusterManager = new ClusterManager(

--- a/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
+++ b/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
@@ -404,7 +404,17 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
     }
 
     public void testExecuteActionChain() throws Exception {
-        SaltUtils.INSTANCE.setScriptsDir(Files.createTempDirectory("actionscripts"));
+        SystemQuery systemQuery = SaltService.INSTANCE;
+        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
+        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        FormulaManager formulaManager = new FormulaManager(saltApi);
+        ClusterManager clusterManager = new ClusterManager(
+                saltApi, systemQuery, serverGroupManager, formulaManager
+        );
+        SaltUtils saltUtils = new SaltUtils(
+                systemQuery, saltApi, clusterManager
+        );
+        saltUtils.setScriptsDir(Files.createTempDirectory("actionscripts"));
 
         SaltActionChainGeneratorService generatorService = new SaltActionChainGeneratorService() {
             @Override

--- a/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
+++ b/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
@@ -149,7 +149,8 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
         SaltUtils saltUtils = new SaltUtils(
                 systemQuery, saltApi, clusterManager, formulaManager
         );
-        SaltServerActionService service = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
+        SaltServerActionService service = new SaltServerActionService(systemQuery, saltUtils, clusterManager,
+                formulaManager);
         service.setSkipCommandScriptPerms(true);
         return service;
     }

--- a/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
+++ b/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
@@ -133,22 +133,25 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
         minion = MinionServerFactoryTest.createTestMinionServer(user);
 
         saltServerActionService = createSaltServerActionService(saltService, saltService);
+        ServerGroupManager serverGroupManager = new ServerGroupManager();
         systemEntitlementManager = new SystemEntitlementManager(
-                new SystemUnentitler(virtManager, new FormulaMonitoringManager()),
-                new SystemEntitler(saltService, virtManager, new FormulaMonitoringManager())
+                new SystemUnentitler(virtManager, new FormulaMonitoringManager(),
+                        serverGroupManager),
+                new SystemEntitler(saltService, virtManager, new FormulaMonitoringManager(),
+                        serverGroupManager)
         );
 
         sshPushSystemMock = mock(SystemSummary.class);
     }
 
     private SaltServerActionService createSaltServerActionService(SystemQuery systemQuery, SaltApi saltApi) {
-        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        ServerGroupManager serverGroupManager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
         FormulaManager formulaManager = new FormulaManager(saltApi);
         ClusterManager clusterManager = new ClusterManager(
                 saltApi, systemQuery, serverGroupManager, formulaManager
         );
         SaltUtils saltUtils = new SaltUtils(
-                systemQuery, saltApi, clusterManager, formulaManager
+                systemQuery, saltApi, clusterManager, formulaManager, serverGroupManager
         );
         SaltServerActionService service = new SaltServerActionService(systemQuery, saltUtils, clusterManager,
                 formulaManager, new SaltKeyUtils(systemQuery));
@@ -408,13 +411,13 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
     public void testExecuteActionChain() throws Exception {
         SystemQuery systemQuery = GlobalInstanceHolder.SYSTEM_QUERY;
         SaltApi saltApi = GlobalInstanceHolder.SALT_API;
-        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        ServerGroupManager serverGroupManager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
         FormulaManager formulaManager = new FormulaManager(saltApi);
         ClusterManager clusterManager = new ClusterManager(
                 saltApi, systemQuery, serverGroupManager, formulaManager
         );
         SaltUtils saltUtils = new SaltUtils(
-                systemQuery, saltApi, clusterManager, formulaManager
+                systemQuery, saltApi, clusterManager, formulaManager, serverGroupManager
         );
         saltUtils.setScriptsDir(Files.createTempDirectory("actionscripts"));
 
@@ -847,9 +850,9 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
     private void successWorker() throws IOException {
         SaltService saltService = new SaltService();
         FormulaManager formulaManager = new FormulaManager(saltService);
-        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        ServerGroupManager serverGroupManager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
         ClusterManager clusterManager = new ClusterManager(saltService, saltService, serverGroupManager, formulaManager);
-        SaltUtils saltUtils = new SaltUtils(saltService, saltService, clusterManager, formulaManager) {
+        SaltUtils saltUtils = new SaltUtils(saltService, saltService, clusterManager, formulaManager, serverGroupManager) {
             @Override
             public boolean shouldRefreshPackageList(String function,
                                                     Optional<JsonElement> callResult) {

--- a/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
+++ b/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
@@ -145,7 +145,7 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
     }
 
     private SaltServerActionService createSaltServerActionService(SystemQuery systemQuery, SaltApi saltApi) {
-        ServerGroupManager serverGroupManager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
+        ServerGroupManager serverGroupManager = new ServerGroupManager();
         FormulaManager formulaManager = new FormulaManager(saltApi);
         ClusterManager clusterManager = new ClusterManager(
                 saltApi, systemQuery, serverGroupManager, formulaManager
@@ -411,7 +411,7 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
     public void testExecuteActionChain() throws Exception {
         SystemQuery systemQuery = GlobalInstanceHolder.SYSTEM_QUERY;
         SaltApi saltApi = GlobalInstanceHolder.SALT_API;
-        ServerGroupManager serverGroupManager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
+        ServerGroupManager serverGroupManager = new ServerGroupManager();
         FormulaManager formulaManager = new FormulaManager(saltApi);
         ClusterManager clusterManager = new ClusterManager(
                 saltApi, systemQuery, serverGroupManager, formulaManager
@@ -850,7 +850,7 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
     private void successWorker() throws IOException {
         SaltService saltService = new SaltService();
         FormulaManager formulaManager = new FormulaManager(saltService);
-        ServerGroupManager serverGroupManager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
+        ServerGroupManager serverGroupManager = new ServerGroupManager();
         ClusterManager clusterManager = new ClusterManager(saltService, saltService, serverGroupManager, formulaManager);
         SaltUtils saltUtils = new SaltUtils(saltService, saltService, clusterManager, formulaManager, serverGroupManager) {
             @Override

--- a/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
+++ b/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
@@ -68,6 +68,7 @@ import com.redhat.rhn.testing.ServerTestUtils;
 import com.redhat.rhn.testing.TestUtils;
 
 import com.suse.manager.clusters.ClusterManager;
+import com.suse.manager.utils.SaltKeyUtils;
 import com.suse.manager.utils.SaltUtils;
 import com.suse.manager.virtualization.test.TestVirtManager;
 import com.suse.manager.webui.services.SaltActionChainGeneratorService;
@@ -150,7 +151,7 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
                 systemQuery, saltApi, clusterManager, formulaManager
         );
         SaltServerActionService service = new SaltServerActionService(systemQuery, saltUtils, clusterManager,
-                formulaManager);
+                formulaManager, new SaltKeyUtils(systemQuery));
         service.setSkipCommandScriptPerms(true);
         return service;
     }

--- a/java/code/src/com/suse/manager/webui/services/test/TestSaltApi.java
+++ b/java/code/src/com/suse/manager/webui/services/test/TestSaltApi.java
@@ -1,0 +1,25 @@
+package com.suse.manager.webui.services.test;
+
+import com.suse.manager.webui.services.iface.SaltApi;
+import com.suse.salt.netapi.calls.LocalCall;
+import com.suse.salt.netapi.datatypes.target.MinionList;
+import com.suse.salt.netapi.event.EventStream;
+
+import java.util.Optional;
+
+public class TestSaltApi implements SaltApi {
+    @Override
+    public EventStream getEventStream() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <R> Optional<R> callSync(LocalCall<R> call, String minionId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void refreshPillar(MinionList minionList) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/java/code/src/com/suse/manager/webui/services/test/TestSystemQuery.java
+++ b/java/code/src/com/suse/manager/webui/services/test/TestSystemQuery.java
@@ -1,0 +1,279 @@
+package com.suse.manager.webui.services.test;
+
+import com.google.gson.JsonElement;
+import com.google.gson.reflect.TypeToken;
+import com.redhat.rhn.domain.server.MinionServer;
+import com.suse.manager.clusters.ClusterProviderParameters;
+import com.suse.manager.webui.services.iface.RedhatProductInfo;
+import com.suse.manager.webui.services.iface.SystemQuery;
+import com.suse.manager.webui.services.impl.SaltSSHService;
+import com.suse.manager.webui.services.impl.SaltService;
+import com.suse.manager.webui.services.impl.runner.MgrK8sRunner;
+import com.suse.manager.webui.services.impl.runner.MgrUtilRunner;
+import com.suse.manager.webui.utils.gson.BootstrapParameters;
+import com.suse.manager.webui.utils.salt.custom.ScheduleMetadata;
+import com.suse.salt.netapi.calls.LocalAsyncResult;
+import com.suse.salt.netapi.calls.LocalCall;
+import com.suse.salt.netapi.calls.modules.SaltUtil;
+import com.suse.salt.netapi.calls.modules.State;
+import com.suse.salt.netapi.calls.modules.Zypper;
+import com.suse.salt.netapi.calls.runner.Jobs;
+import com.suse.salt.netapi.calls.wheel.Key;
+import com.suse.salt.netapi.datatypes.target.MinionList;
+import com.suse.salt.netapi.datatypes.target.Target;
+import com.suse.salt.netapi.errors.GenericError;
+import com.suse.salt.netapi.exception.SaltException;
+import com.suse.salt.netapi.results.Result;
+import com.suse.salt.netapi.results.SSHResult;
+
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+public class TestSystemQuery implements SystemQuery {
+
+    @Override
+    public Optional<Boolean> ping(String minionId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Key.Names getKeys() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean keyExists(String id, SaltService.KeyStatus... statusIn) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Key.Fingerprints getFingerprints() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Key.Pair generateKeysAndAccept(String id, boolean force) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<String> getMachineId(String minionId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void deleteKey(String minionId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void acceptKey(String match) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void rejectKey(String minionId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<MgrUtilRunner.ExecResult> deleteRejectedKey(String minionId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<String, Result<String>> runRemoteCommand(MinionList target, String cmd) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<String, CompletionStage<Result<String>>> runRemoteCommandAsync(
+            MinionList target, String cmd, CompletableFuture<GenericError> cancel) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<String, Result<List<SaltUtil.RunningInfo>>> running(MinionList target) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<Jobs.Info> listJob(String jid) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<Map<String, Map<String, Object>>> listClusterNodes(
+            MinionServer managementNode, ClusterProviderParameters clusterProviderParameters) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<String, CompletionStage<Result<Boolean>>> matchAsync(
+            String target, CompletableFuture<GenericError> cancel) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<CompletionStage<Map<String, Result<Boolean>>>> matchAsyncSSH(
+            String target, CompletableFuture<GenericError> cancel) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void syncGrains(MinionList minionList) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void syncModules(MinionList minionList) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void syncAll(MinionList minionList) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<LocalAsyncResult<String>> checkIn(MinionList targetIn) throws SaltException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateSystemInfo(MinionList minionTarget) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<String> getMasterHostname(String minionId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Result<SSHResult<Map<String, State.ApplyResult>>> bootstrapMinion(
+            BootstrapParameters parameters, List<String> bootstrapMods,
+            Map<String, Object> pillarData) throws SaltException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<Boolean, String> storeMinionScapFiles(MinionServer minion, String uploadDir, Long actionId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<MgrUtilRunner.ExecResult> generateSSHKey(String path) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<MgrUtilRunner.ExecResult> chainSSHCommand(
+            List<String> hosts, String clientKey, String proxyKey, String user, Map<String, String> options,
+            String command, String outputfile) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<List<MgrK8sRunner.Container>> getAllContainers(String kubeconfig, String context) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<List<String>> cleanupMinion(MinionServer minion, int timeout) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void notifySystemIdGenerated(MinionServer minion) throws InstantiationException, SaltException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<String, Result<Map<String, String>>> getPendingResume(List<String> minionIds) throws SaltException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<String, Result<Object>> showHighstate(String minionId) throws SaltException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<List<Zypper.ProductInfo>> getProducts(String minionId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> Optional<LocalAsyncResult<T>> callAsync(
+            LocalCall<T> callIn, Target<?> target, Optional<ScheduleMetadata> metadataIn) throws SaltException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void deployChannels(List<String> minionIds) throws SaltException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<MgrUtilRunner.ExecResult> collectKiwiImage(
+            MinionServer minion, String filepath, String imageStore) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<JsonElement> rawJsonCall(LocalCall<?> call, String minionId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<Map<String, Jobs.ListJobsEntry>> jobsByMetadata(Object metadata) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<Map<String, Jobs.ListJobsEntry>> jobsByMetadata(
+            Object metadata, LocalDateTime startTime, LocalDateTime endTime) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> Optional<T> getGrains(String minionId, TypeToken<T> type, String... grainNames) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<Map<String, Object>> getGrains(String minionId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SaltSSHService getSaltSSHService() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<RedhatProductInfo> redhatProductInfo(String minionId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void storeSshKeyFile(Path path, String contents) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<Boolean> removeFile(Path path) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<String> matchCompoundSync(String target) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/java/code/src/com/suse/manager/webui/utils/MinionActionUtils.java
+++ b/java/code/src/com/suse/manager/webui/utils/MinionActionUtils.java
@@ -34,7 +34,6 @@ import com.suse.manager.utils.SaltUtils;
 import com.suse.manager.webui.services.SaltActionChainGeneratorService;
 import com.suse.manager.webui.services.SaltServerActionService;
 import com.suse.manager.webui.services.iface.SystemQuery;
-import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.manager.webui.utils.salt.custom.ScheduleMetadata;
 import com.suse.salt.netapi.calls.modules.SaltUtil;
 import com.suse.salt.netapi.calls.runner.Jobs;
@@ -78,6 +77,13 @@ public class MinionActionUtils {
     private final SystemQuery systemQuery;
     private final SaltUtils saltUtils;
 
+    /**
+     * Utilities for minion actions
+     *
+     * @param saltServerActionServiceIn
+     * @param systemQueryIn
+     * @param saltUtilsIn
+     */
     public MinionActionUtils(SaltServerActionService saltServerActionServiceIn, SystemQuery systemQueryIn,
                              SaltUtils saltUtilsIn) {
         this.saltServerActionService = saltServerActionServiceIn;

--- a/java/code/src/com/suse/manager/webui/utils/ViewHelper.java
+++ b/java/code/src/com/suse/manager/webui/utils/ViewHelper.java
@@ -21,6 +21,7 @@ import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.frontend.context.Context;
 import com.redhat.rhn.frontend.taglibs.helpers.RenderUtils;
 
+import com.redhat.rhn.webapp.RhnServletListener;
 import com.suse.manager.clusters.ClusterManager;
 import com.suse.manager.webui.controllers.utils.ContactMethodUtil;
 import org.apache.commons.lang3.text.WordUtils;
@@ -47,6 +48,9 @@ public enum ViewHelper {
      * Singleton instance
      */
     INSTANCE;
+
+    private static final RenderUtils RENDER_UTILS = RhnServletListener.RENDER_UTILS;
+    private static final ClusterManager CLUSTER_MANAGER = RhnServletListener.CLUSTER_MANAGER;
 
     ViewHelper() { }
 
@@ -93,7 +97,7 @@ public enum ViewHelper {
         try {
             Map<String, String> sparkParams = request.params().entrySet().stream().collect(
                     Collectors.toMap(entry -> entry.getKey().substring(1), entry -> entry.getValue()));
-            return RenderUtils.INSTANCE.renderNavigationMenu(
+            return RENDER_UTILS.renderNavigationMenu(
                     request.raw(), menuDefinition, rendererClass, 0, 3, sparkParams, additionalParams);
         }
         catch (Exception e) {
@@ -186,6 +190,6 @@ public enum ViewHelper {
      * @return true if the group is owned by a cluster
      */
     public boolean isClusterGroup(String groupId) {
-        return ClusterManager.instance().isClusterGroup(Long.parseLong(groupId));
+        return CLUSTER_MANAGER.isClusterGroup(Long.parseLong(groupId));
     }
 }

--- a/java/code/src/com/suse/manager/webui/utils/ViewHelper.java
+++ b/java/code/src/com/suse/manager/webui/utils/ViewHelper.java
@@ -15,13 +15,13 @@
 
 package com.suse.manager.webui.utils;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.formula.FormulaFactory;
 import com.redhat.rhn.domain.server.MinionServerFactory;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.frontend.context.Context;
 import com.redhat.rhn.frontend.taglibs.helpers.RenderUtils;
 
-import com.redhat.rhn.webapp.RhnServletListener;
 import com.suse.manager.clusters.ClusterManager;
 import com.suse.manager.webui.controllers.utils.ContactMethodUtil;
 import org.apache.commons.lang3.text.WordUtils;
@@ -49,8 +49,8 @@ public enum ViewHelper {
      */
     INSTANCE;
 
-    private static final RenderUtils RENDER_UTILS = RhnServletListener.RENDER_UTILS;
-    private static final ClusterManager CLUSTER_MANAGER = RhnServletListener.CLUSTER_MANAGER;
+    private static final RenderUtils RENDER_UTILS = GlobalInstanceHolder.RENDER_UTILS;
+    private static final ClusterManager CLUSTER_MANAGER = GlobalInstanceHolder.CLUSTER_MANAGER;
 
     ViewHelper() { }
 

--- a/java/code/src/com/suse/manager/webui/utils/test/InputValidatorTest.java
+++ b/java/code/src/com/suse/manager/webui/utils/test/InputValidatorTest.java
@@ -17,7 +17,7 @@ package com.suse.manager.webui.utils.test;
 import com.suse.manager.webui.controllers.MinionsAPI;
 import com.suse.manager.webui.controllers.utils.RegularMinionBootstrapper;
 import com.suse.manager.webui.services.iface.SystemQuery;
-import com.suse.manager.webui.services.impl.SaltService;
+import com.suse.manager.webui.services.test.TestSystemQuery;
 import com.suse.manager.webui.utils.InputValidator;
 import com.suse.manager.webui.utils.gson.BootstrapHostsJson;
 import com.suse.manager.webui.utils.gson.BootstrapParameters;
@@ -37,7 +37,7 @@ public class InputValidatorTest extends TestCase {
     private static final String PORT_ERROR_MESSAGE = "Port must be a number within range" +
             " 1-65535.";
 
-    private SystemQuery systemQuery = new SaltService();
+    private SystemQuery systemQuery = new TestSystemQuery();
 
     /**
      * Test the check for required fields.

--- a/java/code/src/com/suse/manager/webui/utils/test/InputValidatorTest.java
+++ b/java/code/src/com/suse/manager/webui/utils/test/InputValidatorTest.java
@@ -45,7 +45,7 @@ public class InputValidatorTest extends TestCase {
     public void testValidateBootstrapInputUserEmpty() {
         String json = "{user: ''}";
         BootstrapHostsJson input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
-        BootstrapParameters params = RegularMinionBootstrapper.getInstance(systemQuery).createBootstrapParams(input);
+        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery).createBootstrapParams(input);
         List<String> validationErrors = InputValidator.INSTANCE.validateBootstrapInput(params);
         assertTrue(validationErrors.size() == 2);
         assertTrue(validationErrors.contains(HOST_ERROR_MESSAGE));
@@ -58,7 +58,7 @@ public class InputValidatorTest extends TestCase {
     public void testValidateBootstrapInputUserLettersNumbers() {
         String json = "{user: 'Admin1', host: 'host.domain.com'}";
         BootstrapHostsJson input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
-        BootstrapParameters params = RegularMinionBootstrapper.getInstance(systemQuery).createBootstrapParams(input);
+        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery).createBootstrapParams(input);
         List<String> validationErrors = InputValidator.INSTANCE.validateBootstrapInput(params);
         assertTrue(validationErrors.isEmpty());
     }
@@ -69,7 +69,7 @@ public class InputValidatorTest extends TestCase {
     public void testValidateBootstrapInputUserDot() {
         String json = "{user: 'my.admin', host: 'host.domain.com'}";
         BootstrapHostsJson input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
-        BootstrapParameters params = RegularMinionBootstrapper.getInstance(systemQuery).createBootstrapParams(input);
+        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery).createBootstrapParams(input);
         List<String> validationErrors = InputValidator.INSTANCE.validateBootstrapInput(params);
         assertTrue(validationErrors.isEmpty());
     }
@@ -80,7 +80,7 @@ public class InputValidatorTest extends TestCase {
     public void testValidateBootstrapInputUserBackslash() {
         String json = "{user: 'domain\\\\admin', host: 'host.domain.com'}";
         BootstrapHostsJson input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
-        BootstrapParameters params = RegularMinionBootstrapper.getInstance(systemQuery).createBootstrapParams(input);
+        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery).createBootstrapParams(input);
         List<String> validationErrors = InputValidator.INSTANCE.validateBootstrapInput(params);
         assertTrue(validationErrors.isEmpty());
     }
@@ -91,7 +91,7 @@ public class InputValidatorTest extends TestCase {
     public void testValidateBootstrapInputUserDash() {
         String json = "{user: 'my-admin', host: 'host.domain.com'}";
         BootstrapHostsJson input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
-        BootstrapParameters params = RegularMinionBootstrapper.getInstance(systemQuery).createBootstrapParams(input);
+        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery).createBootstrapParams(input);
         List<String> validationErrors = InputValidator.INSTANCE.validateBootstrapInput(params);
         assertTrue(validationErrors.isEmpty());
     }
@@ -102,7 +102,7 @@ public class InputValidatorTest extends TestCase {
     public void testValidateBootstrapInputUserUnderscore() {
         String json = "{user: 'my_admin', host: 'host.domain.com'}";
         BootstrapHostsJson input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
-        BootstrapParameters params = RegularMinionBootstrapper.getInstance(systemQuery).createBootstrapParams(input);
+        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery).createBootstrapParams(input);
         List<String> validationErrors = InputValidator.INSTANCE.validateBootstrapInput(params);
         assertTrue(validationErrors.isEmpty());
     }
@@ -113,7 +113,7 @@ public class InputValidatorTest extends TestCase {
     public void testValidateBootstrapInputUserInvalid() {
         String json = "{user: '$(execme)', host: 'host.domain.com'}";
         BootstrapHostsJson input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
-        BootstrapParameters params = RegularMinionBootstrapper.getInstance(systemQuery).createBootstrapParams(input);
+        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery).createBootstrapParams(input);
         List<String> validationErrors = InputValidator.INSTANCE.validateBootstrapInput(params);
         assertTrue(validationErrors.size() == 1);
         assertTrue(validationErrors.contains(USER_ERROR_MESSAGE));
@@ -125,7 +125,7 @@ public class InputValidatorTest extends TestCase {
     public void testValidateBootstrapInputHostInvalid() {
         String json = "{user: 'toor', host: '`execme`'}";
         BootstrapHostsJson input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
-        BootstrapParameters params = RegularMinionBootstrapper.getInstance(systemQuery).createBootstrapParams(input);
+        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery).createBootstrapParams(input);
         List<String> validationErrors = InputValidator.INSTANCE.validateBootstrapInput(params);
         assertTrue(validationErrors.size() == 1);
         assertTrue(validationErrors.contains(HOST_ERROR_MESSAGE));
@@ -137,7 +137,7 @@ public class InputValidatorTest extends TestCase {
     public void testValidateBootstrapInputHostIPv4() {
         String json = "{user: 'toor', host: '192.168.1.1'}";
         BootstrapHostsJson input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
-        BootstrapParameters params = RegularMinionBootstrapper.getInstance(systemQuery).createBootstrapParams(input);
+        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery).createBootstrapParams(input);
         List<String> validationErrors = InputValidator.INSTANCE.validateBootstrapInput(params);
         assertTrue(validationErrors.isEmpty());
     }
@@ -148,7 +148,7 @@ public class InputValidatorTest extends TestCase {
     public void testValidateBootstrapInputHostIPv6() {
         String json = "{user: 'toor', host: '[2001:0db8:0000:0000:0000:0000:1428:57ab]'}";
         BootstrapHostsJson input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
-        BootstrapParameters params = RegularMinionBootstrapper.getInstance(systemQuery).createBootstrapParams(input);
+        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery).createBootstrapParams(input);
         List<String> validationErrors = InputValidator.INSTANCE.validateBootstrapInput(params);
         assertTrue(validationErrors.isEmpty());
     }
@@ -159,7 +159,7 @@ public class InputValidatorTest extends TestCase {
     public void testValidateBootstrapInputDefaultUser() {
         String json = "{}";
         BootstrapHostsJson input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
-        BootstrapParameters params = RegularMinionBootstrapper.getInstance(systemQuery).createBootstrapParams(input);
+        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery).createBootstrapParams(input);
         List<String> validationErrors = InputValidator.INSTANCE.validateBootstrapInput(params);
         assertTrue(validationErrors.size() == 1);
         assertTrue(validationErrors.contains(HOST_ERROR_MESSAGE));
@@ -171,7 +171,7 @@ public class InputValidatorTest extends TestCase {
     public void testValidateBootstrapInputMinimal() {
         String json = "{host: 'host.domain.com', user: 'root'}";
         BootstrapHostsJson input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
-        BootstrapParameters params = RegularMinionBootstrapper.getInstance(systemQuery).createBootstrapParams(input);
+        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery).createBootstrapParams(input);
         List<String> validationErrors = InputValidator.INSTANCE.validateBootstrapInput(params);
         assertTrue(validationErrors.isEmpty());
     }
@@ -182,7 +182,7 @@ public class InputValidatorTest extends TestCase {
     public void testValidateBootstrapInputPortEmpty() {
         String json = "{host: 'host.domain.com', user: 'root', port: ''}";
         BootstrapHostsJson input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
-        BootstrapParameters params = RegularMinionBootstrapper.getInstance(systemQuery).createBootstrapParams(input);
+        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery).createBootstrapParams(input);
         List<String> validationErrors = InputValidator.INSTANCE.validateBootstrapInput(params);
         assertTrue(validationErrors.isEmpty());
     }
@@ -193,14 +193,14 @@ public class InputValidatorTest extends TestCase {
     public void testValidateBootstrapInputPortRange() {
         String json = "{host: 'host.domain.com', user: 'root', port: '99999'}";
         BootstrapHostsJson input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
-        BootstrapParameters params = RegularMinionBootstrapper.getInstance(systemQuery).createBootstrapParams(input);
+        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery).createBootstrapParams(input);
         List<String> validationErrors = InputValidator.INSTANCE.validateBootstrapInput(params);
         assertTrue(validationErrors.size() == 1);
         assertTrue(validationErrors.contains(PORT_ERROR_MESSAGE));
 
         json = "{host: 'host.domain.com', user: 'root', port: '-1'}";
         input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
-        params = RegularMinionBootstrapper.getInstance(systemQuery).createBootstrapParams(input);
+        params = new RegularMinionBootstrapper(systemQuery).createBootstrapParams(input);
         validationErrors = InputValidator.INSTANCE.validateBootstrapInput(params);
         assertTrue(validationErrors.size() == 1);
         assertTrue(validationErrors.contains(PORT_ERROR_MESSAGE));
@@ -212,7 +212,7 @@ public class InputValidatorTest extends TestCase {
     public void testValidateBootstrapInputPortValid() {
         String json = "{host: 'host.domain.com', user: 'root', port: '8888'}";
         BootstrapHostsJson input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
-        BootstrapParameters params = RegularMinionBootstrapper.getInstance(systemQuery).createBootstrapParams(input);
+        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery).createBootstrapParams(input);
         List<String> validationErrors = InputValidator.INSTANCE.validateBootstrapInput(params);
         assertTrue(validationErrors.isEmpty());
     }

--- a/java/code/src/com/suse/manager/webui/utils/test/MinionActionUtilsTest.java
+++ b/java/code/src/com/suse/manager/webui/utils/test/MinionActionUtilsTest.java
@@ -28,6 +28,7 @@ import com.redhat.rhn.manager.formula.FormulaManager;
 import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
 import com.suse.manager.clusters.ClusterManager;
+import com.suse.manager.utils.SaltKeyUtils;
 import com.suse.manager.utils.SaltUtils;
 import com.suse.manager.webui.services.SaltServerActionService;
 import com.suse.manager.webui.services.iface.SaltApi;
@@ -50,8 +51,9 @@ public class MinionActionUtilsTest extends BaseTestCaseWithUser {
         ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
         ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);
         SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, clusterManager, formulaManager);
+        SaltKeyUtils saltKeyUtils = new SaltKeyUtils(systemQuery);
         SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils,
-                clusterManager, formulaManager);
+                clusterManager, formulaManager, saltKeyUtils);
         MinionActionUtils minionActionUtils = new MinionActionUtils(saltServerActionService, systemQuery,
                 saltUtils);
 
@@ -83,8 +85,9 @@ public class MinionActionUtilsTest extends BaseTestCaseWithUser {
         ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
         ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);
         SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, clusterManager, formulaManager);
+        SaltKeyUtils saltKeyUtils = new SaltKeyUtils(systemQuery);
         SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils,
-                clusterManager, formulaManager);
+                clusterManager, formulaManager, saltKeyUtils);
         MinionActionUtils minionActionUtils = new MinionActionUtils(saltServerActionService, systemQuery,
                 saltUtils);
         saltUtils.setScriptsDir(Files.createTempDirectory("scripts"));
@@ -108,8 +111,9 @@ public class MinionActionUtilsTest extends BaseTestCaseWithUser {
         ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
         ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);
         SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, clusterManager, formulaManager);
+        SaltKeyUtils saltKeyUtils = new SaltKeyUtils(systemQuery);
         SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils,
-                clusterManager, formulaManager);
+                clusterManager, formulaManager, saltKeyUtils);
         MinionActionUtils minionActionUtils = new MinionActionUtils(saltServerActionService, systemQuery,
                 saltUtils);
         saltUtils.setScriptsDir(Files.createTempDirectory("scripts"));

--- a/java/code/src/com/suse/manager/webui/utils/test/MinionActionUtilsTest.java
+++ b/java/code/src/com/suse/manager/webui/utils/test/MinionActionUtilsTest.java
@@ -23,6 +23,8 @@ import com.redhat.rhn.domain.action.ActionFactory;
 import com.redhat.rhn.domain.action.server.ServerAction;
 import com.redhat.rhn.domain.action.test.ActionFactoryTest;
 import com.redhat.rhn.domain.server.test.ServerFactoryTest;
+import com.redhat.rhn.manager.formula.FormulaManager;
+import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
 import com.suse.manager.clusters.ClusterManager;
 import com.suse.manager.utils.SaltUtils;
@@ -43,8 +45,12 @@ public class MinionActionUtilsTest extends BaseTestCaseWithUser {
     public void testCleanupScriptActions() throws Exception {
         SystemQuery systemQuery = SaltService.INSTANCE;
         SaltApi saltApi = SaltService.INSTANCE_SALT_API;
-        SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, ClusterManager.instance());
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
+
+        FormulaManager formulaManager = new FormulaManager(saltApi);
+        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);
+        SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, clusterManager);
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         MinionActionUtils minionActionUtils = new MinionActionUtils(saltServerActionService, systemQuery,
                 saltUtils);
 
@@ -72,8 +78,12 @@ public class MinionActionUtilsTest extends BaseTestCaseWithUser {
     public void testCleanupScriptWithoutAction() throws Exception {
         SystemQuery systemQuery = SaltService.INSTANCE;
         SaltApi saltApi = SaltService.INSTANCE_SALT_API;
-        SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, ClusterManager.instance());
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
+        FormulaManager formulaManager = new FormulaManager(saltApi);
+        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);
+        SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, clusterManager);
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils,
+                clusterManager);
         MinionActionUtils minionActionUtils = new MinionActionUtils(saltServerActionService, systemQuery,
                 saltUtils);
         saltUtils.setScriptsDir(Files.createTempDirectory("scripts"));
@@ -93,8 +103,12 @@ public class MinionActionUtilsTest extends BaseTestCaseWithUser {
     public void testCleanupScriptActionsPickedUp() throws Exception {
         SystemQuery systemQuery = SaltService.INSTANCE;
         SaltApi saltApi = SaltService.INSTANCE_SALT_API;
-        SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, ClusterManager.instance());
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils);
+        FormulaManager formulaManager = new FormulaManager(saltApi);
+        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);
+        SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, clusterManager);
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils,
+                clusterManager);
         MinionActionUtils minionActionUtils = new MinionActionUtils(saltServerActionService, systemQuery,
                 saltUtils);
         saltUtils.setScriptsDir(Files.createTempDirectory("scripts"));

--- a/java/code/src/com/suse/manager/webui/utils/test/MinionActionUtilsTest.java
+++ b/java/code/src/com/suse/manager/webui/utils/test/MinionActionUtilsTest.java
@@ -48,7 +48,7 @@ public class MinionActionUtilsTest extends BaseTestCaseWithUser {
         SaltApi saltApi = GlobalInstanceHolder.SALT_API;
 
         FormulaManager formulaManager = new FormulaManager(saltApi);
-        ServerGroupManager serverGroupManager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
+        ServerGroupManager serverGroupManager = new ServerGroupManager();
         ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);
         SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, clusterManager, formulaManager, serverGroupManager);
         SaltKeyUtils saltKeyUtils = new SaltKeyUtils(systemQuery);
@@ -82,7 +82,7 @@ public class MinionActionUtilsTest extends BaseTestCaseWithUser {
         SystemQuery systemQuery = GlobalInstanceHolder.SYSTEM_QUERY;
         SaltApi saltApi = GlobalInstanceHolder.SALT_API;
         FormulaManager formulaManager = new FormulaManager(saltApi);
-        ServerGroupManager serverGroupManager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
+        ServerGroupManager serverGroupManager = new ServerGroupManager();
         ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);
         SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, clusterManager, formulaManager, serverGroupManager);
         SaltKeyUtils saltKeyUtils = new SaltKeyUtils(systemQuery);
@@ -108,7 +108,7 @@ public class MinionActionUtilsTest extends BaseTestCaseWithUser {
         SystemQuery systemQuery = GlobalInstanceHolder.SYSTEM_QUERY;
         SaltApi saltApi = GlobalInstanceHolder.SALT_API;
         FormulaManager formulaManager = new FormulaManager(saltApi);
-        ServerGroupManager serverGroupManager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
+        ServerGroupManager serverGroupManager = new ServerGroupManager();
         ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);
         SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, clusterManager, formulaManager, serverGroupManager);
         SaltKeyUtils saltKeyUtils = new SaltKeyUtils(systemQuery);

--- a/java/code/src/com/suse/manager/webui/utils/test/MinionActionUtilsTest.java
+++ b/java/code/src/com/suse/manager/webui/utils/test/MinionActionUtilsTest.java
@@ -48,9 +48,9 @@ public class MinionActionUtilsTest extends BaseTestCaseWithUser {
         SaltApi saltApi = GlobalInstanceHolder.SALT_API;
 
         FormulaManager formulaManager = new FormulaManager(saltApi);
-        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        ServerGroupManager serverGroupManager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
         ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);
-        SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, clusterManager, formulaManager);
+        SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, clusterManager, formulaManager, serverGroupManager);
         SaltKeyUtils saltKeyUtils = new SaltKeyUtils(systemQuery);
         SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils,
                 clusterManager, formulaManager, saltKeyUtils);
@@ -82,9 +82,9 @@ public class MinionActionUtilsTest extends BaseTestCaseWithUser {
         SystemQuery systemQuery = GlobalInstanceHolder.SYSTEM_QUERY;
         SaltApi saltApi = GlobalInstanceHolder.SALT_API;
         FormulaManager formulaManager = new FormulaManager(saltApi);
-        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        ServerGroupManager serverGroupManager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
         ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);
-        SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, clusterManager, formulaManager);
+        SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, clusterManager, formulaManager, serverGroupManager);
         SaltKeyUtils saltKeyUtils = new SaltKeyUtils(systemQuery);
         SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils,
                 clusterManager, formulaManager, saltKeyUtils);
@@ -108,9 +108,9 @@ public class MinionActionUtilsTest extends BaseTestCaseWithUser {
         SystemQuery systemQuery = GlobalInstanceHolder.SYSTEM_QUERY;
         SaltApi saltApi = GlobalInstanceHolder.SALT_API;
         FormulaManager formulaManager = new FormulaManager(saltApi);
-        ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
+        ServerGroupManager serverGroupManager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
         ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);
-        SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, clusterManager, formulaManager);
+        SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, clusterManager, formulaManager, serverGroupManager);
         SaltKeyUtils saltKeyUtils = new SaltKeyUtils(systemQuery);
         SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils,
                 clusterManager, formulaManager, saltKeyUtils);

--- a/java/code/src/com/suse/manager/webui/utils/test/MinionActionUtilsTest.java
+++ b/java/code/src/com/suse/manager/webui/utils/test/MinionActionUtilsTest.java
@@ -32,7 +32,8 @@ import com.suse.manager.utils.SaltUtils;
 import com.suse.manager.webui.services.SaltServerActionService;
 import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.SystemQuery;
-import com.suse.manager.webui.services.impl.SaltService;
+import com.suse.manager.webui.services.test.TestSaltApi;
+import com.suse.manager.webui.services.test.TestSystemQuery;
 import com.suse.manager.webui.utils.MinionActionUtils;
 
 /**
@@ -40,9 +41,8 @@ import com.suse.manager.webui.utils.MinionActionUtils;
  */
 public class MinionActionUtilsTest extends BaseTestCaseWithUser {
 
-    private final SaltService saltService = new SaltService();
-    private final SystemQuery systemQuery = saltService;
-    private final SaltApi saltApi = saltService;
+    private final SystemQuery systemQuery = new TestSystemQuery();
+    private final SaltApi saltApi = new TestSaltApi();
 
     /**
      * Verify script is deleted in case all servers are finished (COMPLETED or FAILED).

--- a/java/code/src/com/suse/manager/webui/utils/test/MinionActionUtilsTest.java
+++ b/java/code/src/com/suse/manager/webui/utils/test/MinionActionUtilsTest.java
@@ -50,7 +50,8 @@ public class MinionActionUtilsTest extends BaseTestCaseWithUser {
         ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
         ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);
         SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, clusterManager, formulaManager);
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
+        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils,
+                clusterManager, formulaManager);
         MinionActionUtils minionActionUtils = new MinionActionUtils(saltServerActionService, systemQuery,
                 saltUtils);
 
@@ -83,7 +84,7 @@ public class MinionActionUtilsTest extends BaseTestCaseWithUser {
         ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);
         SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, clusterManager, formulaManager);
         SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils,
-                clusterManager);
+                clusterManager, formulaManager);
         MinionActionUtils minionActionUtils = new MinionActionUtils(saltServerActionService, systemQuery,
                 saltUtils);
         saltUtils.setScriptsDir(Files.createTempDirectory("scripts"));
@@ -108,7 +109,7 @@ public class MinionActionUtilsTest extends BaseTestCaseWithUser {
         ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);
         SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, clusterManager, formulaManager);
         SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils,
-                clusterManager);
+                clusterManager, formulaManager);
         MinionActionUtils minionActionUtils = new MinionActionUtils(saltServerActionService, systemQuery,
                 saltUtils);
         saltUtils.setScriptsDir(Files.createTempDirectory("scripts"));

--- a/java/code/src/com/suse/manager/webui/utils/test/MinionActionUtilsTest.java
+++ b/java/code/src/com/suse/manager/webui/utils/test/MinionActionUtilsTest.java
@@ -17,7 +17,6 @@ package com.suse.manager.webui.utils.test;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.util.FileUtils;
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionFactory;
@@ -33,6 +32,7 @@ import com.suse.manager.utils.SaltUtils;
 import com.suse.manager.webui.services.SaltServerActionService;
 import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.SystemQuery;
+import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.manager.webui.utils.MinionActionUtils;
 
 /**
@@ -40,12 +40,14 @@ import com.suse.manager.webui.utils.MinionActionUtils;
  */
 public class MinionActionUtilsTest extends BaseTestCaseWithUser {
 
+    private final SaltService saltService = new SaltService();
+    private final SystemQuery systemQuery = saltService;
+    private final SaltApi saltApi = saltService;
+
     /**
      * Verify script is deleted in case all servers are finished (COMPLETED or FAILED).
      */
     public void testCleanupScriptActions() throws Exception {
-        SystemQuery systemQuery = GlobalInstanceHolder.SYSTEM_QUERY;
-        SaltApi saltApi = GlobalInstanceHolder.SALT_API;
 
         FormulaManager formulaManager = new FormulaManager(saltApi);
         ServerGroupManager serverGroupManager = new ServerGroupManager();
@@ -79,8 +81,6 @@ public class MinionActionUtilsTest extends BaseTestCaseWithUser {
      * Verify script is deleted in case no Action is there at all.
      */
     public void testCleanupScriptWithoutAction() throws Exception {
-        SystemQuery systemQuery = GlobalInstanceHolder.SYSTEM_QUERY;
-        SaltApi saltApi = GlobalInstanceHolder.SALT_API;
         FormulaManager formulaManager = new FormulaManager(saltApi);
         ServerGroupManager serverGroupManager = new ServerGroupManager();
         ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);
@@ -105,8 +105,6 @@ public class MinionActionUtilsTest extends BaseTestCaseWithUser {
      * Verify script is not deleted as long as not all servers have finished (e.g. PICKED_UP).
      */
     public void testCleanupScriptActionsPickedUp() throws Exception {
-        SystemQuery systemQuery = GlobalInstanceHolder.SYSTEM_QUERY;
-        SaltApi saltApi = GlobalInstanceHolder.SALT_API;
         FormulaManager formulaManager = new FormulaManager(saltApi);
         ServerGroupManager serverGroupManager = new ServerGroupManager();
         ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);

--- a/java/code/src/com/suse/manager/webui/utils/test/MinionActionUtilsTest.java
+++ b/java/code/src/com/suse/manager/webui/utils/test/MinionActionUtilsTest.java
@@ -17,6 +17,7 @@ package com.suse.manager.webui.utils.test;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.util.FileUtils;
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionFactory;
@@ -31,7 +32,6 @@ import com.suse.manager.utils.SaltUtils;
 import com.suse.manager.webui.services.SaltServerActionService;
 import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.SystemQuery;
-import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.manager.webui.utils.MinionActionUtils;
 
 /**
@@ -43,13 +43,13 @@ public class MinionActionUtilsTest extends BaseTestCaseWithUser {
      * Verify script is deleted in case all servers are finished (COMPLETED or FAILED).
      */
     public void testCleanupScriptActions() throws Exception {
-        SystemQuery systemQuery = SaltService.INSTANCE;
-        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
+        SystemQuery systemQuery = GlobalInstanceHolder.SYSTEM_QUERY;
+        SaltApi saltApi = GlobalInstanceHolder.SALT_API;
 
         FormulaManager formulaManager = new FormulaManager(saltApi);
         ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
         ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);
-        SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, clusterManager);
+        SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, clusterManager, formulaManager);
         SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils, clusterManager);
         MinionActionUtils minionActionUtils = new MinionActionUtils(saltServerActionService, systemQuery,
                 saltUtils);
@@ -76,12 +76,12 @@ public class MinionActionUtilsTest extends BaseTestCaseWithUser {
      * Verify script is deleted in case no Action is there at all.
      */
     public void testCleanupScriptWithoutAction() throws Exception {
-        SystemQuery systemQuery = SaltService.INSTANCE;
-        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
+        SystemQuery systemQuery = GlobalInstanceHolder.SYSTEM_QUERY;
+        SaltApi saltApi = GlobalInstanceHolder.SALT_API;
         FormulaManager formulaManager = new FormulaManager(saltApi);
         ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
         ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);
-        SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, clusterManager);
+        SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, clusterManager, formulaManager);
         SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils,
                 clusterManager);
         MinionActionUtils minionActionUtils = new MinionActionUtils(saltServerActionService, systemQuery,
@@ -101,12 +101,12 @@ public class MinionActionUtilsTest extends BaseTestCaseWithUser {
      * Verify script is not deleted as long as not all servers have finished (e.g. PICKED_UP).
      */
     public void testCleanupScriptActionsPickedUp() throws Exception {
-        SystemQuery systemQuery = SaltService.INSTANCE;
-        SaltApi saltApi = SaltService.INSTANCE_SALT_API;
+        SystemQuery systemQuery = GlobalInstanceHolder.SYSTEM_QUERY;
+        SaltApi saltApi = GlobalInstanceHolder.SALT_API;
         FormulaManager formulaManager = new FormulaManager(saltApi);
         ServerGroupManager serverGroupManager = ServerGroupManager.getInstance();
         ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);
-        SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, clusterManager);
+        SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, clusterManager, formulaManager);
         SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils,
                 clusterManager);
         MinionActionUtils minionActionUtils = new MinionActionUtils(saltServerActionService, systemQuery,

--- a/java/code/src/com/suse/manager/webui/websocket/RemoteMinionCommands.java
+++ b/java/code/src/com/suse/manager/webui/websocket/RemoteMinionCommands.java
@@ -14,6 +14,7 @@
  */
 package com.suse.manager.webui.websocket;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.google.gson.JsonObject;
 import com.redhat.rhn.common.util.StringUtil;
@@ -26,7 +27,6 @@ import com.redhat.rhn.frontend.servlets.LocalizedEnvironmentFilter;
 import com.redhat.rhn.manager.system.SystemManager;
 import com.suse.manager.webui.services.FutureUtils;
 import com.suse.manager.webui.services.iface.SystemQuery;
-import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.manager.webui.websocket.json.AsyncJobStartEventDto;
 import com.suse.manager.webui.websocket.json.ExecuteMinionActionDto;
 import com.suse.manager.webui.websocket.json.MinionMatchResultEventDto;
@@ -80,7 +80,7 @@ public class RemoteMinionCommands {
     private CompletableFuture failAfter;
     private List<String> previewedMinions;
     private static ExecutorService eventHistoryExecutor = Executors.newCachedThreadPool();
-    private static SystemQuery systemQuery = SaltService.INSTANCE;
+    private static SystemQuery systemQuery = GlobalInstanceHolder.SYSTEM_QUERY;
 
     /**
      * Callback executed when the websocket is opened.

--- a/java/code/webapp/WEB-INF/decorators/layout_head.jsp
+++ b/java/code/webapp/WEB-INF/decorators/layout_head.jsp
@@ -2,7 +2,6 @@
 <%@ taglib uri="http://rhn.redhat.com/rhn" prefix="rhn"%>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://struts.apache.org/tags-bean" prefix="bean"%>
-<%@ page import="com.suse.manager.webui.menu.MenuTree" %>
 <%@ page import="com.redhat.rhn.common.conf.ConfigDefaults"%>
 
 <!-- enclosing head tags in layout_c.jsp -->
@@ -18,7 +17,7 @@
     <meta http-equiv="content-type" content="text/html;charset=UTF-8"/>
     <title>
       <bean:message key="layout.jsp.productname"/>
-      <%= MenuTree.getTitlePage(pageContext) %>
+      <%= menuTree.getTitlePage(pageContext) %>
     </title>
     <link rel="shortcut icon" href="/img/favicon.ico" />
 

--- a/java/code/webapp/WEB-INF/decorators/layout_head.jsp
+++ b/java/code/webapp/WEB-INF/decorators/layout_head.jsp
@@ -3,6 +3,7 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c"%>
 <%@ taglib uri="http://struts.apache.org/tags-bean" prefix="bean"%>
 <%@ page import="com.redhat.rhn.common.conf.ConfigDefaults"%>
+<%@ page import="com.redhat.rhn.GlobalInstanceHolder" %>
 
 <!-- enclosing head tags in layout_c.jsp -->
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
@@ -17,7 +18,7 @@
     <meta http-equiv="content-type" content="text/html;charset=UTF-8"/>
     <title>
       <bean:message key="layout.jsp.productname"/>
-      <%= menuTree.getTitlePage(pageContext) %>
+      <%= GlobalInstanceHolder.MENU_TREE.getTitlePage(pageContext) %>
     </title>
     <link rel="shortcut icon" href="/img/favicon.ico" />
 

--- a/java/code/webapp/WEB-INF/includes/leftnav.jsp
+++ b/java/code/webapp/WEB-INF/includes/leftnav.jsp
@@ -1,10 +1,9 @@
 <%@page import="com.redhat.rhn.common.conf.Config"%>
 <%@ taglib uri="http://rhn.redhat.com/rhn" prefix="rhn" %>
-<%@ page import="com.suse.manager.webui.menu.MenuTree" %>
 
 <div id="left-menu-data">
     <script type="text/javascript">
-        window.JSONMenu = <%= MenuTree.getJsonMenu(pageContext) %>;
+        window.JSONMenu = <%= menuTree.getJsonMenu(pageContext) %>;
         window._IS_UYUNI = <%= Config.get().getString("product_name").compareToIgnoreCase("Uyuni") == 0 %>;
     </script>
 </div>

--- a/java/code/webapp/WEB-INF/includes/leftnav.jsp
+++ b/java/code/webapp/WEB-INF/includes/leftnav.jsp
@@ -1,9 +1,10 @@
 <%@page import="com.redhat.rhn.common.conf.Config"%>
 <%@ taglib uri="http://rhn.redhat.com/rhn" prefix="rhn" %>
+<%@ page import="com.redhat.rhn.GlobalInstanceHolder" %>
 
 <div id="left-menu-data">
     <script type="text/javascript">
-        window.JSONMenu = <%= menuTree.getJsonMenu(pageContext) %>;
+        window.JSONMenu = <%= GlobalInstanceHolder.MENU_TREE.getJsonMenu(pageContext) %>;
         window._IS_UYUNI = <%= Config.get().getString("product_name").compareToIgnoreCase("Uyuni") == 0 %>;
     </script>
 </div>


### PR DESCRIPTION
## What does this PR change?

This PR continues to parameterize more classes and remove static global instances and singletons. It introduces the `GlobalInstanceHolder` class as a temporary solution to distribute the same set of instances across different entry point of the program. The `GlobalInstanceHolder` should only be used by old code thats not refactored yet, program entry points and classes that are initialized via reflection. 

![current dependency tree](https://user-images.githubusercontent.com/688888/87014779-e7858d80-c1cc-11ea-90ec-6f5b25cd5922.png)


## GUI diff


No difference.


- [x] **DONE**

## Documentation
- No documentation needed: no feature change

- [x] **DONE**

## Test coverage
- No tests: no new functionality

- [x] **DONE**

## Links

This partially addresses https://github.com/SUSE/spacewalk/issues/10719 

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
