### PR TITLE
Limit checkstyle workflow to push events on master

### DIFF
--- a/.github/workflows/java-checkstyle.yml
+++ b/.github/workflows/java-checkstyle.yml
@@ -1,7 +1,11 @@
 name: Java checkstyle
 
 on:
-  pull_request:
+  # Limit this workflow to push events on the master branch, encrypted secrets
+  # cannot currently be used from actions triggered by PRs created from a fork.
+  push:
+    branches:
+      - master
     paths:
       - 'java/**.java'
 


### PR DESCRIPTION
## What does this PR change?

This PR limits the execution of the `checkstyle` workflow to `push` events on the master branch, if java code is changed. Unfortunately encrypted secrets that are used for accessing the OBS for dependency resolution (`osc getbinaries` in `obs-to-maven`) are not accessible for PRs created from a fork of the repo which is an important use-case for us.

## GUI diff

No difference.

- [X] **DONE**

## Documentation

- No documentation needed, only CI is affected.

- [X] **DONE**

## Test coverage

- No tests needed, only CI is affected.

- [X] **DONE**

## Links

Follow-up to #1434.

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below).

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
