### PR TITLE
Run RuboCop less often

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -50,7 +50,6 @@ If you need to re-run a test, please mark the related checkbox, it will be unche
 - [ ] Re-run test "backend_unittests_pgsql"
 - [ ] Re-run test "java_lint_checkstyle"
 - [ ] Re-run test "java_pgsql_tests"
-- [ ] Re-run test "ruby_rubocop"
 - [ ] Re-run test "schema_migration_test_oracle"
 - [ ] Re-run test "schema_migration_test_pgsql"
 - [ ] Re-run test "susemanager_unittests"

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,4 +1,4 @@
-name: Ruby checkstyle
+name: RuboCop
 
 on:
   pull_request:
@@ -6,7 +6,7 @@ on:
       - 'testsuite/features/**.rb'
 
 jobs:
-  ruby_checkstyle:
+  rubocop:
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -9,7 +9,7 @@ jobs:
   ruby_checkstyle:
 
     runs-on: ubuntu-latest
-    
+
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-ruby@v1
@@ -18,7 +18,7 @@ jobs:
 
     - name: Install RuboCop
       run: gem install rubocop -v 0.84.0
-      
+
     - name: Run RuboCop
       run: |
         cd testsuite

--- a/.github/workflows/ruby-checkstyle.yml
+++ b/.github/workflows/ruby-checkstyle.yml
@@ -11,10 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v1
-      with:
-        fetch-depth: 1
-
+    - uses: actions/checkout@v2
     - uses: actions/setup-ruby@v1
       with:
         ruby-version: '2.5'

--- a/.github/workflows/ruby-checkstyle.yml
+++ b/.github/workflows/ruby-checkstyle.yml
@@ -2,7 +2,8 @@ name: Ruby checkstyle
 
 on:
   pull_request:
-    types: [opened, edited, synchronize, reopened]
+    paths:
+      - 'testsuite/features/**.rb'
 
 jobs:
   ruby_checkstyle:


### PR DESCRIPTION
## What does this PR change?

Currently the RuboCop workflow runs on *all PRs*, no matter what path has been changed. This patch should make sure that the workflow is triggered only when ruby code in `testsuite` is actually changed. Additionally `edited` does not seem to be a relevant event as it would trigger a run in case a PR description is edited. The default for `pull_request` events should be just fine (`opened`, `synchronized` and `reopened`).

Finally as "Checkstyle" is the name of a Java-specific tool, this patch renames the file, workflow and job to "RuboCop" or "rubocop" respectively, and removes the checkbox to re-run it from the PR template (as it can be re-run from the UI).

## GUI diff

No difference, only CI is affected.

- [X] **DONE**

## Documentation

- No documentation needed, only CI is affected.

- [X] **DONE**

## Test coverage

- No tests, only CI is affected.

- [X] **DONE**

## Links

No links.

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below).

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint" (Test skipped, there are no changes to test)
- [ ] Re-run test "spacecmd_unittests"
