### PR TITLE
obs-to-maven config adapted to Leap 15.2

### DIFF
--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -113,7 +113,7 @@
         <dependency org="javax.xml.bind" name="jaxb-api" rev="2.3.0" transitive="false"/>
         <dependency org="com.sun.xml.bind" name="jaxb-core" rev="2.3.0" transitive="false"/>
         <dependency org="com.sun.xml.bind" name="jaxb-impl" rev="2.3.0" transitive="false"/>
-        <dependency org="junit" name="junit" rev="3.8.2" transitive="false"/>
+        <dependency org="suse" name="junit" rev="4.12" transitive="false"/>
         <dependency org="org.jmock" name="jmock" rev="2.6.0" transitive="false"/>
         <dependency org="org.jmock" name="jmock-junit3" rev="2.6.0" transitive="false"/>
         <dependency org="org.jmock" name="jmock-legacy" rev="2.6.0" transitive="false"/>

--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -3,24 +3,24 @@
     <dependencies>
         <!-- Runtime dependencies -->
         <dependency org="suse" name="antlr" rev="2.7.7" />
-        <dependency org="suse" name="asm" rev="3.3.1" />
+        <dependency org="suse" name="asm" rev="3.3.2" />
         <dependency org="suse" name="bcel" rev="5.2" />
         <dependency org="suse" name="byte-buddy" rev="1.8.17" />
         <dependency org="suse" name="c3p0" rev="0.9.5.2" />
         <dependency org="suse" name="cglib" rev="2.2" />
         <dependency org="suse" name="classmate" rev="1.3.4" />
         <dependency org="suse" name="classpathx-mail-1.3.1-monolithic" rev="1.1.2" />
-        <dependency org="suse" name="commons-beanutils" rev="1.9.2" />
-        <dependency org="suse" name="commons-cli" rev="1.2" />
-        <dependency org="suse" name="commons-codec" rev="1.10" />
+        <dependency org="suse" name="commons-beanutils" rev="1.9.4" />
+        <dependency org="suse" name="commons-cli" rev="1.4" />
+        <dependency org="suse" name="commons-codec" rev="1.11" />
         <dependency org="suse" name="commons-collections" rev="3.2.2" />
         <dependency org="suse" name="commons-digester" rev="1.7" />
         <dependency org="suse" name="commons-discovery" rev="0.4" />
         <dependency org="suse" name="commons-el" rev="1.0" />
         <dependency org="suse" name="commons-fileupload" rev="1.1.1" />
-        <dependency org="suse" name="commons-io" rev="2.4" />
+        <dependency org="suse" name="commons-io" rev="2.6" />
         <dependency org="suse" name="commons-jexl" rev="2.1.1" />
-        <dependency org="suse" name="commons-lang3" rev="3.4" />
+        <dependency org="suse" name="commons-lang3" rev="3.8.1" />
         <dependency org="suse" name="commons-logging" rev="1.2" />
         <dependency org="suse" name="commons-validator" rev="1.3.1" />
         <dependency org="suse" name="concurrent" rev="1.3.4" />
@@ -28,16 +28,16 @@
         <dependency org="suse" name="dom4j" rev="1.6.1" />
         <dependency org="suse" name="dwr" rev="3.0.2" />
         <dependency org="suse" name="ehcache-core" rev="2.10.1" />
-        <dependency org="suse" name="geronimo-jta-1.1-api" rev="1.1.0" />
-        <dependency org="suse" name="google-gson" rev="2.8.2" />
+        <dependency org="suse" name="geronimo-jta-1.1-api" rev="1.2" />
+        <dependency org="suse" name="google-gson" rev="2.8.5" />
         <dependency org="suse" name="hibernate-c3p0" rev="5.3.7" />
         <dependency org="suse" name="hibernate-commons-annotations" rev="5.0.4" />
         <dependency org="suse" name="hibernate-core" rev="5.3.7" />
         <dependency org="suse" name="hibernate-ehcache" rev="5.3.7" />
         <dependency org="suse" name="httpasyncclient" rev="4.1.4" />
-        <dependency org="suse" name="httpclient" rev="4.5" />
-        <dependency org="suse" name="httpcore" rev="4.4.1" />
-        <dependency org="suse" name="httpcore-nio" rev="4.4.1" />
+        <dependency org="suse" name="httpclient" rev="4.5.6" />
+        <dependency org="suse" name="httpcore" rev="4.4.10" />
+        <dependency org="suse" name="httpcore-nio" rev="4.4.10" />
         <dependency org="suse" name="jade4j" rev="1.0.7" />
         <dependency org="suse" name="jaf" rev="1.1.1" />
         <dependency org="suse" name="jakarta-persistence-api" rev="2.2.2" />
@@ -46,10 +46,10 @@
         <dependency org="suse" name="javassist" rev="3.20.0" />
         <dependency org="suse" name="jboss-logging" rev="3.3.0" />
         <dependency org="suse" name="jcommon" rev="1.0.16" />
-        <dependency org="suse" name="jdom" rev="1.1" />
+        <dependency org="suse" name="jdom" rev="1.1.3" />
         <dependency org="suse" name="joda-time" rev="2.10.1" />
         <dependency org="suse" name="jose4j" rev="0.5.1" />
-        <dependency org="suse" name="log4j" rev="1.2.17" />
+        <dependency org="suse" name="log4j" rev="1.2.12" />
         <dependency org="suse" name="jsch" rev="0.1.55" />
         <dependency org="suse" name="netty-buffer" rev="4.1.44.Final" />
         <dependency org="suse" name="netty-codec" rev="4.1.44.Final" />
@@ -72,8 +72,8 @@
         <dependency org="suse" name="simple-core" rev="3.1.3" />
         <dependency org="suse" name="simple-xml" rev="2.6.2" />
         <dependency org="suse" name="sitemesh" rev="2.1" />
-        <dependency org="suse" name="slf4j-api" rev="1.7.12" />
-        <dependency org="suse" name="slf4j-log4j12" rev="1.7.12" />
+        <dependency org="suse" name="slf4j-api" rev="1.7.30" />
+        <dependency org="suse" name="slf4j-log4j12" rev="1.7.30" />
         <dependency org="suse" name="snakeyaml" rev="1.10" />
         <dependency org="suse" name="spark-core" rev="2.7.2" />
         <dependency org="suse" name="spark-template-jade" rev="2.3" />
@@ -89,7 +89,7 @@
         <dependency org="suse" name="woodstox-core-asl" rev="4.4.2" />
         <dependency org="suse" name="xalan-j2" rev="2.7.2" />
         <dependency org="suse" name="xalan-j2-serializer" rev="2.7.2" />
-        <dependency org="suse" name="xerces-j2" rev="2.11.0" />
+        <dependency org="suse" name="xerces-j2" rev="2.12.0" />
         <dependency org="suse" name="xmlsec" rev="2.0.7" />
         <dependency org="suse" name="velocity" rev="1.5" />
 
@@ -97,12 +97,12 @@
         <!-- <dependency org="suse" name="commons-lang" rev="2.6" /> -->
 
         <!-- Tomcat jars -->
-        <dependency org="suse" name="jasper" rev="9.0.14" />
-        <dependency org="suse" name="jasper-el" rev="9.0.14" />
-        <dependency org="suse" name="tomcat-el-3.0-api" rev="9.0.14" />
-        <dependency org="suse" name="tomcat-jsp-2.3-api" rev="9.0.14" />
-        <dependency org="suse" name="tomcat-juli" rev="9.0.14" />
-        <dependency org="suse" name="tomcat-servlet-4.0-api" rev="9.0.14" />
+        <dependency org="suse" name="jasper" rev="9.0.35" />
+        <dependency org="suse" name="jasper-el" rev="9.0.35" />
+        <dependency org="suse" name="tomcat-el-3.0-api" rev="9.0.35" />
+        <dependency org="suse" name="tomcat-jsp-2.3-api" rev="9.0.35" />
+        <dependency org="suse" name="tomcat-juli" rev="9.0.35" />
+        <dependency org="suse" name="tomcat-servlet-4.0-api" rev="9.0.35" />
 
         <!-- Compilation and testing -->
         <dependency org="checkstyle" name="checkstyle" rev="8.30" transitive="false">

--- a/java/buildconf/ivy/obs-maven-config.yaml
+++ b/java/buildconf/ivy/obs-maven-config.yaml
@@ -1,13 +1,16 @@
 repositories:
   Leap:
+    project: openSUSE:Leap:15.2
+    repository: standard
+  Leap15.1:
     project: openSUSE:Leap:15.1
     repository: standard
   Uyuni_Other:
     project: systemsmanagement:Uyuni:Master:Other
-    repository: openSUSE_Leap_15.1
+    repository: openSUSE_Leap_15.2
   Uyuni:
     project: systemsmanagement:Uyuni:Master
-    repository: openSUSE_Leap_15.1
+    repository: openSUSE_Leap_15.2
 artifacts:
   - artifact: asm
     package: asm3
@@ -22,7 +25,8 @@ artifacts:
   - artifact: c3p0
     repository: Uyuni_Other
   - artifact: cglib
-    repository: Leap
+    jar: cglib.jar
+    repository: Leap15.1
   - artifact: classmate
     repository: Uyuni_Other
   - artifact: classpathx-mail-1.3.1-monolithic
@@ -87,7 +91,7 @@ artifacts:
     rpm: geronimo-jta-1_1
     repository: Leap
   - artifact: google-gson
-    repository: Uyuni_Other
+    repository: Leap
   - artifact: hibernate-c3p0
     package: hibernate5
     jar: hibernate-c3p0
@@ -108,16 +112,17 @@ artifacts:
     repository: Uyuni_Other
   - artifact: httpclient
     package: httpcomponents-client
-    jar: httpclient-[0-9.]+
-    repository: Uyuni_Other
+    rpm: httpcomponents-client-[0-9]+
+    jar: httpclient
+    repository: Leap
   - artifact: httpcore
     package: httpcomponents-core
-    jar: httpcore-[0-9.]+
-    repository: Uyuni_Other
+    jar: httpcore.jar
+    repository: Leap
   - artifact: httpcore-nio
     package: httpcomponents-core
     jar: httpcore-nio
-    repository: Uyuni_Other
+    repository: Leap
   - artifact: jade4j
     repository: Uyuni_Other
   - artifact: jaf
@@ -147,6 +152,7 @@ artifacts:
   - artifact: jose4j
     repository: Uyuni_Other
   - artifact: log4j
+    package: log4j12
     repository: Leap
   - artifact: jsch
     repository: Uyuni_Other
@@ -172,7 +178,7 @@ artifacts:
     repository: Uyuni_Other
   - artifact: netty-transport
     package: netty
-    jar: netty-transport
+    jar: netty-transport-[0-9]
     repository: Uyuni_Other
   - artifact: netty-transport-native-unix-common
     package: netty
@@ -222,11 +228,13 @@ artifacts:
   - artifact: sitemesh
     repository: Uyuni_Other
   - artifact: slf4j-api
+    rpm: slf4j-[0-9]+
     package: slf4j
     jar: api
     repository: Leap
   - artifact: slf4j-log4j12
     package: slf4j
+    rpm: slf4j-log4j12
     jar: log4j12
     repository: Leap
   - artifact: snakeyaml
@@ -281,7 +289,6 @@ artifacts:
     repository: Leap
   - artifact: xerces-j2
     rpm: xerces-j2-[0-9.]+
-    jar: xerces-j2-[0-9.]+
     repository: Leap
   - artifact: xmlsec
     repository: Uyuni_Other
@@ -322,9 +329,10 @@ artifacts:
 
   - artifact: hamcrest-core
     package: hamcrest
-    jar: hamcrest/core
+    rpm: hamcrest-core
     repository: Leap
   - artifact: hamcrest-library
     package: hamcrest
+    rpm: hamcrest-[0-9]+
     jar: hamcrest/library
     repository: Leap

--- a/java/buildconf/ivy/obs-maven-config.yaml
+++ b/java/buildconf/ivy/obs-maven-config.yaml
@@ -336,3 +336,6 @@ artifacts:
     rpm: hamcrest-[0-9]+
     jar: hamcrest/library
     repository: Leap
+  - artifact: junit
+    package: junit
+    repository: Leap

--- a/java/code/src/com/redhat/rhn/domain/formula/FormulaFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/formula/FormulaFactory.java
@@ -123,7 +123,7 @@ public class FormulaFactory {
      * @param dataDirPath base path to where store files
      */
     public static void setDataDir(String dataDirPath) {
-        FormulaFactory.dataDir = dataDirPath;
+        FormulaFactory.dataDir = dataDirPath.endsWith(File.separator) ? dataDirPath : dataDirPath + File.separator;
     }
 
     /**
@@ -131,7 +131,8 @@ public class FormulaFactory {
      * @param metadataDirPath base path where to read metadata files from
      */
     public static void setMetadataDirOfficial(String metadataDirPath) {
-        FormulaFactory.metadataDirManager = metadataDirPath;
+        FormulaFactory.metadataDirManager =
+                metadataDirPath.endsWith(File.separator) ? metadataDirPath : metadataDirPath + File.separator;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/content/test/ContentSyncManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/content/test/ContentSyncManagerTest.java
@@ -46,9 +46,6 @@ import com.redhat.rhn.manager.content.ProductTreeEntry;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
 import com.redhat.rhn.testing.TestUtils;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.reflect.TypeToken;
 import com.suse.mgrsync.MgrSyncStatus;
 import com.suse.salt.netapi.parser.JsonParser;
 import com.suse.scc.model.ChannelFamilyJson;
@@ -56,6 +53,10 @@ import com.suse.scc.model.SCCProductJson;
 import com.suse.scc.model.SCCRepositoryJson;
 import com.suse.scc.model.SCCSubscriptionJson;
 import com.suse.scc.model.UpgradePathJson;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
 
 import org.apache.commons.io.FileUtils;
 
@@ -1283,6 +1284,7 @@ public class ContentSyncManagerTest extends BaseTestCaseWithUser {
      */
     public void testIsRefreshNeeded() throws Exception {
         SUSEProductTestUtils.createVendorSUSEProductEnvironment(user, "/com/redhat/rhn/manager/content/test/smallBase", true);
+        Config.get().remove(ContentSyncManager.RESOURCE_PATH);
         HibernateFactory.getSession().flush();
         HibernateFactory.getSession().clear();
 

--- a/java/code/src/com/redhat/rhn/manager/system/ServerGroupManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/ServerGroupManager.java
@@ -74,6 +74,14 @@ public class ServerGroupManager {
     }
 
     /**
+     * Only used for unit tests.
+     * @param pillarFileManagerIn to set
+     */
+    public void setMinionGroupMembershipPillarFileManager(MinionPillarFileManager pillarFileManagerIn) {
+        this.minionGroupMembershipPillarFileManager = pillarFileManagerIn;
+    }
+
+    /**
      * Lookup a ServerGroup by ID and organization.
      * @param id Server group id
      * @param user logged in user needed for authentication

--- a/java/code/src/com/redhat/rhn/testing/JMockBaseTestCaseWithUser.java
+++ b/java/code/src/com/redhat/rhn/testing/JMockBaseTestCaseWithUser.java
@@ -17,6 +17,7 @@ package com.redhat.rhn.testing;
 import com.redhat.rhn.domain.kickstart.test.KickstartDataTest;
 import com.redhat.rhn.domain.user.User;
 
+import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.suse.manager.webui.services.SaltStateGeneratorService;
 import com.suse.manager.webui.services.pillar.MinionGeneralPillarGenerator;
 import com.suse.manager.webui.services.pillar.MinionGroupMembershipPillarGenerator;
@@ -58,6 +59,8 @@ public abstract class JMockBaseTestCaseWithUser extends RhnJmockBaseTestCase {
         SaltStateGeneratorService.INSTANCE.setSuseManagerStatesFilesRoot(tmpSaltRoot
                 .toAbsolutePath());
         Files.createDirectory(tmpSaltRoot.resolve(SALT_CONFIG_STATES_DIR));
+        ServerGroupManager.getInstance()
+                .setMinionGroupMembershipPillarFileManager(minionGroupMembershipPillarFileManager);
     }
 
     /**

--- a/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
@@ -141,6 +141,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
     private SaltService saltServiceMock;
     private SystemEntitlementManager systemEntitlementManager;
     protected Path metadataDirOfficial;
+    protected Path formulaDataDir;
 
 
     @Override
@@ -156,7 +157,9 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                         new FormulaMonitoringManager())
         );
         metadataDirOfficial = Files.createTempDirectory("meta");
+        formulaDataDir = Files.createTempDirectory("data");
         FormulaFactory.setMetadataDirOfficial(metadataDirOfficial.toString());
+        FormulaFactory.setDataDir(formulaDataDir.toString());
         Path systemLockDir = metadataDirOfficial.resolve("system-lock");
         Path systemLockFile = Paths.get(systemLockDir.toString(),  "form.yml");
         Files.createDirectories(systemLockDir);
@@ -675,7 +678,6 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         assertTrue(action.getServerActions().stream()
                 .filter(serverAction -> serverAction.getServer().equals(minion))
                 .findAny().get().getStatus().equals(ActionFactory.STATUS_COMPLETED));
-        assertEquals(List.of("system-lock"), FormulaFactory.getFormulasByMinionId(minion.getMinionId()));
         assertEquals(false, ViewHelper.INSTANCE.formulaValueEquals(minion, "system-lock",
                 "minion_blackout", "false"));
     }


### PR DESCRIPTION
## What does this PR change?

Fetches the obs-to-maven dependencies for dev tooling in 15.2 repos rather than 15.1

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: tooling fix

- [X] **DONE**

## Test coverage
- No tests: fixes tooling

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
