### PR TITLE
Apidoc: output API version instead of hardcoded product version

### DIFF
--- a/java/buildconf/apidoc/asciidoc/api_index_hdr.txt
+++ b/java/buildconf/apidoc/asciidoc/api_index_hdr.txt
@@ -1,6 +1,6 @@
 = $productName API Documentation
 $productName
-4.0
+API version: $apiVersion
 #if ($productName == "Uyuni")
 :homepage: https://www.uyuni-project.org/
 #else

--- a/java/buildconf/apidoc/docbook/api_index_hdr.txt
+++ b/java/buildconf/apidoc/docbook/api_index_hdr.txt
@@ -6,7 +6,7 @@
   <bookinfo>
     <pubdate><?dbtimestamp?></pubdate>
     <productname>$productName</productname>
-    <productnumber>4.0</productnumber>
+    <productnumber>$apiVersion</productnumber>
 #if ($productName == "Uyuni")
     <bibliosource class="uri">https://www.uyuni-project.org/</bibliosource>
 #else

--- a/java/code/internal/src/com/redhat/rhn/internal/doclet/ApiDoclet.java
+++ b/java/code/internal/src/com/redhat/rhn/internal/doclet/ApiDoclet.java
@@ -73,6 +73,7 @@ public abstract class ApiDoclet implements Doclet {
     private String outputFolder;
     private String templateFolder;
     private String productName;
+    private String apiVersion;
 
     protected final Set<Option> getOptions() {
         return Set.of(
@@ -117,6 +118,15 @@ public abstract class ApiDoclet implements Doclet {
                     productName = arguments.get(0);
                     return true;
                 }
+            },
+            new AbstractOption("-apiversion", true,
+                    "version of the API to write in the generated docs", "version") {
+                @Override
+                public boolean process(String option,
+                                       List<String> arguments) {
+                    apiVersion = arguments.get(0);
+                    return true;
+                }
             }
         );
     }
@@ -132,13 +142,14 @@ public abstract class ApiDoclet implements Doclet {
 
     /**
      * @return The documentation writer for the Doclet implementation
-     *
      * @param outputIn the folder where the result needs to be written
      * @param templateIn the folder where the templates are located
      * @param productNameIn the name of the product to write in the docs
+     * @param apiVersionIn the version of the API to write in the docs
      * @param debugIn whether to show debug infos
      */
-    public abstract DocWriter getWriter(String outputIn, String templateIn, String productNameIn, boolean debugIn);
+    public abstract DocWriter getWriter(String outputIn, String templateIn, String productNameIn,
+                                        String apiVersionIn, boolean debugIn);
 
     @Override
     public Set<? extends Option> getSupportedOptions() {
@@ -282,7 +293,7 @@ public abstract class ApiDoclet implements Doclet {
             handlerList.add(handler);
         }
         Collections.sort(handlerList);
-        DocWriter writer = getWriter(outputFolder, templateFolder, productName, debug);
+        DocWriter writer = getWriter(outputFolder, templateFolder, productName, apiVersion, debug);
         try {
             writer.write(handlerList, serialMap);
         }

--- a/java/code/internal/src/com/redhat/rhn/internal/doclet/AsciidocDoclet.java
+++ b/java/code/internal/src/com/redhat/rhn/internal/doclet/AsciidocDoclet.java
@@ -33,8 +33,9 @@ public class AsciidocDoclet extends ApiDoclet {
     }
 
     @Override
-    public DocWriter getWriter(String outputFolder, String templateFolder, String product, boolean debug) {
-        return new AsciidocWriter(outputFolder, templateFolder, product, debug);
+    public DocWriter getWriter(String outputFolder, String templateFolder, String product,
+                               String apiVersionIn, boolean debug) {
+        return new AsciidocWriter(outputFolder, templateFolder, product, apiVersionIn, debug);
     }
 
 }

--- a/java/code/internal/src/com/redhat/rhn/internal/doclet/AsciidocWriter.java
+++ b/java/code/internal/src/com/redhat/rhn/internal/doclet/AsciidocWriter.java
@@ -29,10 +29,11 @@ public class AsciidocWriter extends DocWriter {
      * @param outputIn path to the output folder
      * @param templatesIn path to the HTML templates folder
      * @param productIn name of the product
+     * @param apiVersionIn version of the api
      * @param debugIn whether to show debugging messages
      */
-    public AsciidocWriter(String outputIn, String templatesIn, String productIn, boolean debugIn) {
-        super(outputIn, templatesIn, productIn, debugIn);
+    public AsciidocWriter(String outputIn, String templatesIn, String productIn, String apiVersionIn, boolean debugIn) {
+        super(outputIn, templatesIn, productIn, apiVersionIn, debugIn);
     }
 
     /**
@@ -54,6 +55,7 @@ public class AsciidocWriter extends DocWriter {
 
         VelocityHelper vh = new VelocityHelper(templates);
         vh.addMatch("productName", product);
+        vh.addMatch("apiVersion", apiVersion);
         for (String file : OTHER_FILES) {
             String content = vh.renderTemplateFile(file + ".txt");
             writeFile(output + file + ".adoc", content);

--- a/java/code/internal/src/com/redhat/rhn/internal/doclet/DocBookDoclet.java
+++ b/java/code/internal/src/com/redhat/rhn/internal/doclet/DocBookDoclet.java
@@ -33,7 +33,8 @@ public class DocBookDoclet extends ApiDoclet {
     }
 
     @Override
-    public DocWriter getWriter(String outputFolder, String templateFolder, String product, boolean debug) {
-        return new DocBookWriter(outputFolder, templateFolder, product, debug);
+    public DocWriter getWriter(String outputFolder, String templateFolder, String product,
+                               String apiVersionIn, boolean debug) {
+        return new DocBookWriter(outputFolder, templateFolder, product, apiVersionIn, debug);
     }
 }

--- a/java/code/internal/src/com/redhat/rhn/internal/doclet/DocBookWriter.java
+++ b/java/code/internal/src/com/redhat/rhn/internal/doclet/DocBookWriter.java
@@ -29,11 +29,12 @@ public class DocBookWriter extends DocWriter {
      * @param outputIn path to the output folder
      * @param templatesIn path to the DocBook templates folder
      * @param productIn name of the product
+     * @param apiVersionIn version of the api
      * @param debugIn whether to show debugging messages
      *
      */
-    public DocBookWriter(String outputIn, String templatesIn, String productIn, boolean debugIn) {
-        super(outputIn, templatesIn, productIn, debugIn);
+    public DocBookWriter(String outputIn, String templatesIn, String productIn, String apiVersionIn, boolean debugIn) {
+        super(outputIn, templatesIn, productIn, apiVersionIn, debugIn);
     }
 
     /**
@@ -54,6 +55,7 @@ public class DocBookWriter extends DocWriter {
 
         VelocityHelper vh = new VelocityHelper(templates);
         vh.addMatch("productName", product);
+        vh.addMatch("apiVersion", apiVersion);
         for (String file : OTHER_FILES) {
             String content = vh.renderTemplateFile(file + ".txt");
             writeFile(output + file + ".xml", content);

--- a/java/code/internal/src/com/redhat/rhn/internal/doclet/DocWriter.java
+++ b/java/code/internal/src/com/redhat/rhn/internal/doclet/DocWriter.java
@@ -34,22 +34,24 @@ public abstract class DocWriter {
     protected String output;
     protected String templates;
     protected String product;
+    protected String apiVersion;
     private boolean debug = false;
 
 
     /**
      * Constructor
-     *
      * @param outputIn path to the output folder
      * @param templatesIn path to the HTML templates folder
      * @param productIn name of the product
+     * @param apiVersionIn version of the api
      * @param debugIn whether to show debugging messages
      *
      */
-    public DocWriter(String outputIn, String templatesIn, String productIn, boolean debugIn) {
+    public DocWriter(String outputIn, String templatesIn, String productIn, String apiVersionIn, boolean debugIn) {
         output = outputIn;
         templates = templatesIn;
         product = productIn;
+        apiVersion = apiVersionIn;
         debug = debugIn;
     }
 
@@ -87,6 +89,7 @@ public abstract class DocWriter {
         VelocityHelper vh = new VelocityHelper(templateDir);
         vh.addMatch("handlers", handlers);
         vh.addMatch("productName", product);
+        vh.addMatch("apiVersion", apiVersion);
         String out = vh.renderTemplateFile(ApiDoclet.API_HEADER_FILE);
         out += vh.renderTemplateFile(ApiDoclet.API_INDEX_FILE);
         out += vh.renderTemplateFile(ApiDoclet.API_FOOTER_FILE);

--- a/java/code/internal/src/com/redhat/rhn/internal/doclet/HtmlDoclet.java
+++ b/java/code/internal/src/com/redhat/rhn/internal/doclet/HtmlDoclet.java
@@ -34,8 +34,9 @@ public class HtmlDoclet extends ApiDoclet {
     }
 
     @Override
-    public DocWriter getWriter(String outputFolder, String templateFolder, String productName, boolean debug) {
-        return new HtmlWriter(outputFolder, templateFolder, productName, debug);
+    public DocWriter getWriter(String outputFolder, String templateFolder, String productName,
+                               String apiVersionIn, boolean debug) {
+        return new HtmlWriter(outputFolder, templateFolder, productName, apiVersionIn, debug);
     }
 
 }

--- a/java/code/internal/src/com/redhat/rhn/internal/doclet/HtmlWriter.java
+++ b/java/code/internal/src/com/redhat/rhn/internal/doclet/HtmlWriter.java
@@ -30,10 +30,11 @@ public class HtmlWriter extends DocWriter {
      * @param outputIn path to the output folder
      * @param templatesIn path to the HTML templates folder
      * @param productIn name of the product
+     * @param apiVersionIn version of the api
      * @param debugIn whether to show debugging messages
      */
-    public HtmlWriter(String outputIn, String templatesIn, String productIn, boolean debugIn) {
-        super(outputIn, templatesIn, productIn, debugIn);
+    public HtmlWriter(String outputIn, String templatesIn, String productIn, String apiVersionIn, boolean debugIn) {
+        super(outputIn, templatesIn, productIn, apiVersionIn, debugIn);
     }
 
     /**
@@ -42,12 +43,8 @@ public class HtmlWriter extends DocWriter {
      */
     public void write(List<Handler> handlers,
             Map<String, String> serializers) throws Exception {
-
-
-
         //First macro-tize the serializer's docs
         renderSerializers(templates, serializers);
-
 
         //Lets do the index first
         writeFile(output + "index.html", generateIndex(handlers, templates));
@@ -60,8 +57,5 @@ public class HtmlWriter extends DocWriter {
         for (String file : OTHER_FILES) {
             writeFile(output + file + ".html", readFile(templates + file + ".txt"));
         }
-
     }
-
-
 }

--- a/java/code/internal/src/com/redhat/rhn/internal/doclet/JSPDoclet.java
+++ b/java/code/internal/src/com/redhat/rhn/internal/doclet/JSPDoclet.java
@@ -34,7 +34,8 @@ public class JSPDoclet extends ApiDoclet {
     }
 
     @Override
-    public DocWriter getWriter(String outputFolder, String templateFolder, String product, boolean debug) {
-        return new JSPWriter(outputFolder, templateFolder, product, debug);
+    public DocWriter getWriter(String outputFolder, String templateFolder, String product,
+                               String apiVersionIn, boolean debug) {
+        return new JSPWriter(outputFolder, templateFolder, product, apiVersionIn, debug);
     }
 }

--- a/java/code/internal/src/com/redhat/rhn/internal/doclet/JSPWriter.java
+++ b/java/code/internal/src/com/redhat/rhn/internal/doclet/JSPWriter.java
@@ -31,10 +31,11 @@ public class JSPWriter extends DocWriter {
      * @param outputIn path to the output folder
      * @param templatesIn path to the JSP templates folder
      * @param productIn name of the product
+     * @param apiVersionIn version of the api
      * @param debugIn whether to show debugging messages
      */
-    public JSPWriter(String outputIn, String templatesIn, String productIn, boolean debugIn) {
-        super(outputIn, templatesIn, productIn, debugIn);
+    public JSPWriter(String outputIn, String templatesIn, String productIn, String apiVersionIn, boolean debugIn) {
+        super(outputIn, templatesIn, productIn, apiVersionIn, debugIn);
     }
 
     /**
@@ -64,6 +65,5 @@ public class JSPWriter extends DocWriter {
         for (String file : OTHER_FILES) {
             writeFile(output + file + ".jsp", readFile(templates + file + ".txt"));
         }
-
     }
 }

--- a/java/code/internal/src/com/redhat/rhn/internal/doclet/SinglePageDoclet.java
+++ b/java/code/internal/src/com/redhat/rhn/internal/doclet/SinglePageDoclet.java
@@ -34,8 +34,9 @@ public class SinglePageDoclet extends ApiDoclet {
     }
 
     @Override
-    public DocWriter getWriter(String outputFolder, String templateFolder, String product, boolean debug) {
-        return new SinglePageWriter(outputFolder, templateFolder, product, debug);
+    public DocWriter getWriter(String outputFolder, String templateFolder, String product,
+                               String apiVersionIn, boolean debug) {
+        return new SinglePageWriter(outputFolder, templateFolder, product, apiVersionIn, debug);
     }
 
 }

--- a/java/code/internal/src/com/redhat/rhn/internal/doclet/SinglePageWriter.java
+++ b/java/code/internal/src/com/redhat/rhn/internal/doclet/SinglePageWriter.java
@@ -28,10 +28,12 @@ public class SinglePageWriter extends DocWriter {
      * @param outputIn path to the output folder
      * @param templatesIn path to the single page templates folder
      * @param productIn name of the product
+     * @param apiVersionIn version of the api
      * @param debugIn whether to show debugging messages
      */
-    public SinglePageWriter(String outputIn, String templatesIn, String productIn, boolean debugIn) {
-        super(outputIn, templatesIn, productIn, debugIn);
+    public SinglePageWriter(String outputIn, String templatesIn, String productIn,
+                            String apiVersionIn, boolean debugIn) {
+        super(outputIn, templatesIn, productIn, apiVersionIn, debugIn);
     }
 
     /**
@@ -40,17 +42,11 @@ public class SinglePageWriter extends DocWriter {
      */
     public void write(List<Handler> handlers,
             Map<String, String> serializers) throws Exception {
-
-
-
         //First macro-tize the serializer's docs
         renderSerializers(templates, serializers);
 
-
         //Lets do the index first
-
         StringBuffer buffer = new StringBuffer();
-
 
         buffer.append(generateIndex(handlers, templates));
 
@@ -60,11 +56,6 @@ public class SinglePageWriter extends DocWriter {
         }
 
         writeFile(output + "handlers/apilist.html", buffer.toString());
-
-        /*for (String file : OTHER_FILES) {
-            writeFile(output + file + ".html", readFile(templates + file + ".txt"));
-        }*/
-
     }
 
 
@@ -86,8 +77,4 @@ public class SinglePageWriter extends DocWriter {
 
         return out;
     }
-
-
-
-
 }

--- a/java/manager-build.xml
+++ b/java/manager-build.xml
@@ -112,6 +112,7 @@
       <src>
         <path location="code/src" />
         <path location="code/scripts/src" />
+        <path location="code/internal/src" />
       </src>
     </javac>
 

--- a/java/manager-build.xml
+++ b/java/manager-build.xml
@@ -14,6 +14,7 @@
 
   <!-- Upstream-defined properties -->
   <import file="buildconf/build-props.xml" />
+  <property file="conf/rhn_java.conf"/>
 
   <!-- Other properties -->
   <property name="deploy.host" value="deployhost" />
@@ -448,7 +449,7 @@
     <mkdir dir="${report.dir}/apidocs/${template.dir}/" />
     <mkdir dir="${report.dir}/apidocs/${template.dir}/handlers/" />
     <javadoc doclet="com.redhat.rhn.internal.doclet.${doclet.class}" docletpathref="javadocpath" classpathref="libjars" sourcepath="code/src"
-        additionalparam="-d ${apidoc.output} -templates buildconf/apidoc/${template.dir} -product '${product.name}'">
+        additionalparam="-d ${apidoc.output} -templates buildconf/apidoc/${template.dir} -product '${product.name}' -apiversion '${java.apiversion}'">
       <fileset dir="code" >
         <include name="**/src/com/redhat/rhn/frontend/xmlrpc/**/*Handler.java" />
         <include name="**/src/com/redhat/rhn/frontend/xmlrpc/serializer/*Serializer.java" />


### PR DESCRIPTION
## What does this PR change?

Changes the hardcoded product version in the apidocs by the API version.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: doc tooling fix

- [X] **DONE**

## Test coverage
- No tests: doc tooling fix

- [X] **DONE**

## Links

Fixes SUSE/spacewalk#11828

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
