### PR TITLE
Fix spacewalk-java jar symlinks on openSUSE Leap 15.2

### DIFF
--- a/java/buildconf/build-props.xml
+++ b/java/buildconf/build-props.xml
@@ -144,11 +144,11 @@
              regexp ${jmock-jars} strutstest" / -->
 
   <!-- SUSE extra dependencies: build and runtime -->
-  <property name="suse-common-jars" value="jade4j jose4j salt-netapi-client spark-core spark-template-jade httpclient httpcore httpasyncclient httpcore-nio simpleclient simpleclient_common simpleclient_servlet simpleclient_httpserver pgjdbc-ng spy netty-common netty-buffer netty-resolver netty-transport netty-codec netty-handler netty-transport-native-unix-common java-saml java-saml-core joda-time woodstox-core-asl xmlsec stax2-api stax-api commons-jexl" />
+  <property name="suse-common-jars" value="jade4j jose4j salt-netapi-client spark-core spark-template-jade httpcomponents/httpclient httpcomponents/httpcore httpasyncclient httpcomponents/httpcore-nio simpleclient simpleclient_common simpleclient_servlet simpleclient_httpserver pgjdbc-ng spy netty-common netty-buffer netty-resolver netty-transport netty-codec netty-handler netty-transport-native-unix-common java-saml java-saml-core joda-time woodstox-core-asl xmlsec stax2-api stax-api commons-jexl" />
 
   <!-- SUSE extra dependencies: runtime only -->
   <property name="suse-runtime-jars" value="${commons-lang} concurrentlinkedhashmap-lru
-      httpcore slf4j/api slf4j/log4j12" />
+    httpcomponents/httpcore slf4j/api slf4j/log4j12" />
 
   <property name="install.build.jar.dependencies"
       value="ant ant/ant-junit ${ant-contrib.path} antlr ${jasper-jars} ${test.build.jar.dependencies}
@@ -163,7 +163,7 @@
       value="bcel ${cglib-jar} commons-beanutils commons-cli commons-codec
              commons-collections commons-digester commons-discovery
              commons-el commons-fileupload commons-io ${commons-lang} commons-logging ${commons-validator} ${hibernate}
-             ${tomcat-jars} ${javamail} jdom jsch dwr google-gson
+             ${tomcat-jars} ${javamail} jdom jsch dwr google-gson/google-gson
              ${log4j-jars} oro redstone-xmlrpc-client redstone-xmlrpc ${struts-jars}
              jcommon stringtree-json postgresql-jdbc
              taglibs-standard-impl taglibs-standard-jstlel taglibs-standard-spec quartz
@@ -175,7 +175,7 @@
              commons-collections commons-beanutils commons-cli commons-codec
              commons-digester commons-discovery commons-el commons-fileupload commons-io
              ${commons-lang} commons-logging
-             ${commons-validator} concurrent dom4j google-gson ${hibernate} ${jta11-jars}
+             ${commons-validator} concurrent dom4j google-gson/google-gson ${hibernate} ${jta11-jars}
              jaf ${jasper-jars} ${javamail} jcommon jdom ${other-jars}
              ${tomcat-jars} ${log4j-jars} redstone-xmlrpc-client redstone-xmlrpc
              oro quartz stringtree-json sitemesh ${struts-jars}

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Fix symlinks for gson, httcomponents on Leap 15.2
+
 -------------------------------------------------------------------
 Mon Jun 29 10:08:38 CEST 2020 - jgonzalez@suse.com
 

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -666,14 +666,21 @@ chown tomcat:%{apache_group} /var/log/rhn/gatherer.log
 %{jardir}/dom4j.jar
 %{jardir}/dwr.jar
 
-%{jardir}/google-gson.jar
 %{jardir}/snakeyaml.jar
 # SUSE extra runtime dependencies: spark, jade4j, salt API client + dependencies
 %{jardir}/commons-jexl.jar
 %{jardir}/commons-lang3.jar
+%if 0%{?is_opensuse}
+%{jardir}/google-gson_google-gsongson.jar
+%{jardir}/httpcomponents_httpclient.jar
+%{jardir}/httpcomponents_httpcore.jar
+%{jardir}/httpcomponents_httpcore-nio.jar
+%else
+%{jardir}/google-gson.jar
 %{jardir}/httpclient.jar
 %{jardir}/httpcore.jar
 %{jardir}/httpcore-nio.jar
+%endif
 %{jardir}/httpasyncclient.jar
 %{jardir}/jade4j.jar
 %{jardir}/jose4j.jar


### PR DESCRIPTION
## What does this PR change?

Fixes symlinks for gson, httcomponents in Leap 15.2

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bugfix

- [x] **DONE**

## Test coverage
- No tests: tomcat and taskomatic will fail to start if not correct

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
