### PR TITLE
Maintenance schedules system assignment UI

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
@@ -2419,6 +2419,17 @@ ORDER BY UPPER(COALESCE(X.SERVER_NAME, '(none)')), X.ID
   <elaborator name="entitlements" />
 </mode>
 
+<mode name="target_systems_for_maintenance_schedule" class="com.redhat.rhn.frontend.dto.EssentialServerDto">
+    <query params="user_id, schedule_id">
+        SELECT s.id, s.name
+        FROM rhnServer s JOIN rhnUserServerPerms usp on s.id = usp.server_id
+        WHERE usp.user_id = :user_id
+            AND (s.maintenance_schedule_id IS NULL OR
+                s.maintenance_schedule_id != :schedule_id)
+        ORDER BY UPPER(COALESCE(s.name, '(none)')), s.id
+    </query>
+</mode>
+
 <write-mode name="bulk_remove_custom_values">
   <query params="user_id, set_label, key_id">
 DELETE FROM rhnServerCustomDataValue

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemDetailsEditAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemDetailsEditAction.java
@@ -37,6 +37,8 @@ import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 import com.redhat.rhn.manager.user.UserManager;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
 
+import com.suse.manager.maintenance.MaintenanceManager;
+import com.suse.manager.model.maintenance.MaintenanceSchedule;
 import org.apache.log4j.Logger;
 import org.apache.struts.action.ActionErrors;
 import org.apache.struts.action.ActionForm;
@@ -46,6 +48,7 @@ import org.apache.struts.action.DynaActionForm;
 import org.apache.struts.util.LabelValueBean;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -70,6 +73,9 @@ public class SystemDetailsEditAction extends RhnAction {
     public static final String AUTO_UPDATE = "auto_update";
     public static final String CONTACT_METHODS = "contact_methods";
     public static final String CONTACT_METHOD = "contact_method_id";
+    public static final String MAINTENANCE_SCHEDULES = "schedules";
+    public static final String MAINTENANCE_SCHEDULE = "schedule_id";
+    public static final String MAINTENANCE_CANCEL_AFFECTED = "cancel_affected_actions";
     public static final String DESCRIPTION = "description";
     public static final String ADDRESS_ONE = "address1";
     public static final String ADDRESS_TWO = "address2";
@@ -81,6 +87,7 @@ public class SystemDetailsEditAction extends RhnAction {
     public static final String RACK = "rack";
     public static final String UNENTITLE = "unentitle";
 
+    private static MaintenanceManager maintenanceManager = new MaintenanceManager();
     private SystemEntitlementManager systemEntitlementManager = SystemEntitlementManager.INSTANCE;
 
     /** {@inheritDoc} */
@@ -134,6 +141,7 @@ public class SystemDetailsEditAction extends RhnAction {
             DynaActionForm daForm, User user, Server s) {
 
         boolean success = true;
+        ActionErrors errors = new ActionErrors();
 
         s.setName(daForm.getString(NAME));
         s.setDescription(daForm.getString(DESCRIPTION));
@@ -167,6 +175,31 @@ public class SystemDetailsEditAction extends RhnAction {
         s.getLocation().setRoom(daForm.getString(ROOM));
         s.getLocation().setRack(daForm.getString(RACK));
 
+        // Assign maintenance schedule
+        Long scheduleId = (Long) daForm.get(MAINTENANCE_SCHEDULE);
+
+        if (scheduleId != null && scheduleId != 0) {
+            // Assign schedule
+            MaintenanceSchedule schedule = maintenanceManager.lookupScheduleByUserAndId(user, scheduleId).get();
+            boolean cancelAffected = Boolean.TRUE.equals(daForm.get(MAINTENANCE_CANCEL_AFFECTED));
+            try {
+                maintenanceManager.assignScheduleToSystems(user, schedule, Collections.singleton(s.getId()),
+                        cancelAffected);
+                log.debug(String.format("System %s assigned to schedule %s.", s.getId(), schedule.getName()));
+            }
+            catch (IllegalArgumentException e) {
+                log.debug(e);
+                getStrutsDelegate().addError("maintenance.action.assign.error.fail", errors);
+                success = false;
+            }
+        }
+        else if (s.getMaintenanceScheduleOpt().isPresent()) {
+            // Retract schedule
+            String scheduleName = s.getMaintenanceScheduleOpt().get().getName();
+            maintenanceManager.retractScheduleFromSystems(user, Collections.singleton(s.getId()));
+            log.debug(String.format("System %s unassigned from schedule %s.", s.getId(), scheduleName));
+        }
+
         /* If the server does not have a Base Entitlement
          * the user should not be updating these values
          * no matter what the form they are submitting looks
@@ -187,9 +220,7 @@ public class SystemDetailsEditAction extends RhnAction {
                 catch (TaskomaticApiException e) {
                     log.error("Could not schedule errata update:");
                     log.error(e);
-                    ActionErrors errors = new ActionErrors();
                     getStrutsDelegate().addError("taskscheduler.down", errors);
-                    getStrutsDelegate().saveMessages(request, errors);
                     success = false;
                 }
             }
@@ -218,9 +249,10 @@ public class SystemDetailsEditAction extends RhnAction {
                 log.debug("looping on addon entitlements");
             }
 
-            success = applyAddonEntitlementChanges(request, daForm, s, user);
+            success &= applyAddonEntitlementChanges(request, daForm, s, user);
         }
 
+        getStrutsDelegate().saveMessages(request, errors);
         return success;
     }
 
@@ -351,6 +383,10 @@ public class SystemDetailsEditAction extends RhnAction {
                    s.getAutoUpdate().equals("Y") ? Boolean.TRUE : Boolean.FALSE);
 
         daForm.set(CONTACT_METHOD, s.getContactMethod().getId());
+
+        // Assigned maintenance schedule
+        request.setAttribute(MAINTENANCE_SCHEDULES, maintenanceManager.listSchedulesByUser(user));
+        daForm.set(MAINTENANCE_SCHEDULE, s.getMaintenanceScheduleOpt().map(MaintenanceSchedule::getId).orElse(null));
 
         daForm.set(DESCRIPTION, s.getDescription());
 

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemOverviewAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemOverviewAction.java
@@ -100,7 +100,6 @@ public class SystemOverviewAction extends RhnAction {
         int nonCriticalErrataCount =
             SystemManager.countNoncriticalErrataForSystem(user, sid);
 
-
         // Upgradable Packages
         int upgradablePackagesCount = PackageManager.countUpgradable(sid);
 
@@ -126,16 +125,17 @@ public class SystemOverviewAction extends RhnAction {
                         (e1.isBase() ? -1 : 1))
                 .collect(Collectors.toList());
 
-        request.setAttribute("rebootRequired", Boolean.valueOf(rebootRequired));
-        request.setAttribute("unentitled", Boolean.valueOf(s.getEntitlements().isEmpty()));
+        request.setAttribute("rebootRequired", rebootRequired);
+        request.setAttribute("unentitled", s.getEntitlements().isEmpty());
         request.setAttribute("entitlements", entitlements);
-        request.setAttribute("systemInactive", Boolean.valueOf(s.isInactive()));
+        request.setAttribute("systemInactive", s.isInactive());
         request.setAttribute("criticalErrataCount", criticalErrataCount);
         request.setAttribute("nonCriticalErrataCount", nonCriticalErrataCount);
         request.setAttribute("upgradablePackagesCount", upgradablePackagesCount);
         request.setAttribute("hasUpdates", hasUpdates);
         request.setAttribute("baseChannel", baseChannel);
         request.setAttribute("childChannels", childChannels);
+        request.setAttribute("maintenanceSchedule", s.getMaintenanceScheduleOpt().orElse(null));
         request.setAttribute("description", description);
         request.setAttribute("installedProducts", s.getInstalledProductSet().orElse(null));
         request.setAttribute("prefs", findUserServerPreferences(user, s));

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -8924,6 +8924,12 @@ Alternatively, you will want to download &lt;strong&gt;Incremental Channel Conte
       <trans-unit id="maintenance.action.reschedule.error.fail">
         <source>Operation could not be performed. There are scheduled actions on systems</source>
       </trans-unit>
+      <trans-unit id="maintenance.action.assign.error.fail">
+        <source>Operation could not be performed. There are scheduled actions on systems</source>
+      </trans-unit>
+      <trans-unit id="maintenance.action.assign.error.systemnotfound">
+        <source>Some of the specified servers cannot be found</source>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -17265,6 +17265,18 @@ The Tree Path, Base Channel, and Installer Generation should always match. This 
           <context context-type="sourcefile">/systems/details/Overview.do</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="sdc.details.overview.schedule">
+        <source>Maintenance Schedule:</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/systems/details/Overview.do</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sdc.details.overview.schedule.none">
+        <source>(none)</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/systems/details/Overview.do</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="sdc.details.overview.description">
         <source>Description:</source>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -4453,6 +4453,9 @@ organization. You may grant or remove the organization administrator role in the
         <trans-unit id="ssm.overview.groups.create">
           <source>&lt;a href="/rhn/systems/ssm/groups/Create.do"&gt;Create&lt;/a&gt; and &lt;a href="/rhn/systems/ssm/groups/Manage.do"&gt;manage&lt;/a&gt; groups</source>
         </trans-unit>
+        <trans-unit id="ssm.overview.schedule.assign">
+          <source>&lt;a href="/rhn/manager/systems/ssm/maintenance"&gt;Assign&lt;/a&gt; a maintenance schedule to selected systems</source>
+        </trans-unit>
         <trans-unit id="ssm.overview.channels">
           <source>Channels</source>
         </trans-unit>
@@ -4672,6 +4675,9 @@ organization. You may grant or remove the organization administrator role in the
         </trans-unit>
         <trans-unit id="ssm.misc.index.tabs.preferences">
           <source>Preferences</source>
+        </trans-unit>
+        <trans-unit id="ssm.misc.index.tabs.maintenanceschedule">
+          <source>Maintenance Windows</source>
         </trans-unit>
         <trans-unit id="ssm.misc.index.tabs.custom">
           <source>Custom Values</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -17747,6 +17747,24 @@ The Tree Path, Base Channel, and Installer Generation should always match. This 
           <context context-type="sourcefile">/systems/details/Edit.do</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="sdc.details.edit.schedule">
+        <source>Maintenance Schedule:</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/systems/details/Edit.do</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sdc.details.edit.schedule.none">
+        <source>None</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/systems/details/Edit.do</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sdc.details.edit.schedule.cancelaffected">
+        <source>Cancel affected actions</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/systems/details/Edit.do</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="sdc.details.edit.description">
         <source>Description:</source>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -105,6 +105,7 @@ import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 import com.redhat.rhn.manager.user.UserManager;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
 
+import com.suse.manager.model.maintenance.MaintenanceSchedule;
 import com.suse.manager.reactor.messaging.ChannelsChangedEventMessage;
 import com.suse.manager.webui.controllers.StatesAPI;
 import com.suse.manager.webui.services.SaltStateGeneratorService;
@@ -136,6 +137,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import static java.util.Collections.emptyMap;
 
 /**
  * SystemManager
@@ -1236,6 +1239,22 @@ public class SystemManager extends BaseManager {
         params.put("sgid", sgid);
         Map<String, Object> elabParams = new HashMap<String, Object>();
         return makeDataResult(params, elabParams, null, m, SystemOverview.class);
+    }
+
+    /**
+     * Returns the list of systems that are not assigned to a specific maintenance schedule.
+     * @param user currently logged in user
+     * @param schedule a maintenance schedule
+     * @param pc PageControl
+     * @return list of SystemOverview objects
+     */
+    public static DataResult<EssentialServerDto> systemsNotInSchedule(User user, MaintenanceSchedule schedule,
+            PageControl pc) {
+        SelectMode m = ModeFactory.getMode("System_queries", "target_systems_for_maintenance_schedule");
+        Map<String, Object> params = new HashMap<String, Object>();
+        params.put("user_id", user.getId());
+        params.put("schedule_id", schedule.getId());
+        return makeDataResult(params, emptyMap(), pc, m, EssentialServerDto.class);
     }
 
     /**

--- a/java/code/src/com/suse/manager/maintenance/MaintenanceManager.java
+++ b/java/code/src/com/suse/manager/maintenance/MaintenanceManager.java
@@ -429,13 +429,29 @@ public class MaintenanceManager {
      */
     public int assignScheduleToSystems(User user, MaintenanceSchedule schedule, Set<Long> systemIds,
             boolean cancelAffectedActions) {
+        return assignScheduleToSystems(user, schedule, systemIds,
+                cancelAffectedActions ? Collections.singletonList(new CancelRescheduleStrategy()) :
+                        Collections.emptyList());
+    }
+
+    /**
+     * Assign {@link MaintenanceSchedule} to given set of {@link Server}s.
+     *
+     * @param user the user
+     * @param schedule the {@link MaintenanceSchedule}
+     * @param systemIds the set of {@link Server} IDs
+     * @param strategies a chain of strategies to be used for rescheduling actions
+     * @throws PermissionException if the user does not have access to given servers
+     * @throws IllegalArgumentException if systems have pending maintenance-only actions
+     * @return the number of involved {@link Server}s
+     */
+    public int assignScheduleToSystems(User user, MaintenanceSchedule schedule, Set<Long> systemIds,
+            List<RescheduleStrategy> strategies) {
         ensureOrgAdmin(user);
         ensureSystemsAccessible(user, systemIds);
         ensureScheduleAccessible(user, schedule);
 
-        RescheduleResult result = manageAffectedScheduledActionsForSystems(user, systemIds, schedule,
-                cancelAffectedActions ? Collections.singletonList(new CancelRescheduleStrategy()) :
-                        Collections.emptyList());
+        RescheduleResult result = manageAffectedScheduledActionsForSystems(user, systemIds, schedule, strategies);
 
         if (!result.isSuccess()) {
             throw new IllegalArgumentException("Some systems have pending maintenance-only actions");

--- a/java/code/src/com/suse/manager/maintenance/test/MaintenanceManagerScheduleActionsTest.java
+++ b/java/code/src/com/suse/manager/maintenance/test/MaintenanceManagerScheduleActionsTest.java
@@ -100,7 +100,7 @@ public class MaintenanceManagerScheduleActionsTest extends JMockBaseTestCaseWith
         assertTrue(mm.isSystemInMaintenanceMode(sys1));
         assertTrue(mm.isSystemInMaintenanceMode(sys2));
 
-        mm.assignScheduleToSystems(user, schedule, Set.of(sys1.getId()));
+        mm.assignScheduleToSystems(user, schedule, Set.of(sys1.getId()), false);
 
         try {
             ActionChainManager.scheduleApplyStates(user, List.of(sys1.getId(), sys2.getId()), empty(), new Date(12345), null);
@@ -130,7 +130,7 @@ public class MaintenanceManagerScheduleActionsTest extends JMockBaseTestCaseWith
         MaintenanceSchedule schedule = mm.createSchedule(user, "test-schedule-2", SINGLE, of(mc));
 
         MinionServer sys1 = MinionServerFactoryTest.createTestMinionServer(user);
-        mm.assignScheduleToSystems(user, schedule, Set.of(sys1.getId()));
+        mm.assignScheduleToSystems(user, schedule, Set.of(sys1.getId()), false);
         assertTrue(mm.isSystemInMaintenanceMode(sys1));
 
         try {
@@ -158,7 +158,7 @@ public class MaintenanceManagerScheduleActionsTest extends JMockBaseTestCaseWith
 
         Server sys1 = MinionServerFactoryTest.createTestMinionServer(user);
 
-        mm.assignScheduleToSystems(user, schedule, Set.of(sys1.getId()));
+        mm.assignScheduleToSystems(user, schedule, Set.of(sys1.getId()), false);
 
         try {
             ActionManager.scheduleHardwareRefreshAction(user, sys1, new Date(12345));
@@ -177,7 +177,7 @@ public class MaintenanceManagerScheduleActionsTest extends JMockBaseTestCaseWith
 
         Server sys1 = MinionServerFactoryTest.createTestMinionServer(user);
 
-        mm.assignScheduleToSystems(user, schedule, Set.of(sys1.getId()));
+        mm.assignScheduleToSystems(user, schedule, Set.of(sys1.getId()), false);
 
         try {
             ActionManager.scheduleApplyStates(user, Collections.singletonList(sys1.getId()),

--- a/java/code/src/com/suse/manager/maintenance/test/MaintenanceManagerTest.java
+++ b/java/code/src/com/suse/manager/maintenance/test/MaintenanceManagerTest.java
@@ -210,7 +210,7 @@ public class MaintenanceManagerTest extends BaseTestCaseWithUser {
         Server withSchedule = MinionServerFactoryTest.createTestMinionServer(user);
         Server withoutSchedule = MinionServerFactoryTest.createTestMinionServer(user);
 
-        mm.assignScheduleToSystems(user, schedule, Set.of(withSchedule.getId()));
+        mm.assignScheduleToSystems(user, schedule, Set.of(withSchedule.getId()), false);
 
         assertEquals(
                 List.of(withSchedule.getId()),
@@ -232,7 +232,7 @@ public class MaintenanceManagerTest extends BaseTestCaseWithUser {
         // assign the schedule to both systems
         Server system1 = MinionServerFactoryTest.createTestMinionServer(user);
         Server system2 = MinionServerFactoryTest.createTestMinionServer(user);
-        mm.assignScheduleToSystems(user, schedule, Set.of(system1.getId(), system2.getId()));
+        mm.assignScheduleToSystems(user, schedule, Set.of(system1.getId(), system2.getId()), false);
 
         // retract it from one system
         mm.retractScheduleFromSystems(user, Set.of(system1.getId()));
@@ -262,14 +262,14 @@ public class MaintenanceManagerTest extends BaseTestCaseWithUser {
         // assign an action not tied to maintenance mode
         Action allowedAction = MaintenanceTestUtils
                 .createActionForServerAt(user, ActionFactory.TYPE_VIRTUALIZATION_START, sys1, "2020-04-13T08:15:00+02:00");
-        assertEquals(1, mm.assignScheduleToSystems(user, schedule, Set.of(sys1.getId())));
+        assertEquals(1, mm.assignScheduleToSystems(user, schedule, Set.of(sys1.getId()), false));
 
         // assign an offending action to one system
         Action disallowedAction = ActionFactoryTest.createAction(user, ActionFactory.TYPE_APPLY_STATES);
         ServerActionTest.createServerAction(sys2, disallowedAction);
 
         assertExceptionThrown(
-                () -> mm.assignScheduleToSystems(user, schedule, Set.of(sys1.getId(), sys2.getId())),
+                () -> mm.assignScheduleToSystems(user, schedule, Set.of(sys1.getId(), sys2.getId()), false),
                 IllegalArgumentException.class);
     }
 
@@ -295,7 +295,7 @@ public class MaintenanceManagerTest extends BaseTestCaseWithUser {
 
         // user 2 assigns schedule 1
         assertExceptionThrown(
-                () -> mm.assignScheduleToSystems(user2, schedule1, Set.of(system2.getId())),
+                () -> mm.assignScheduleToSystems(user2, schedule1, Set.of(system2.getId()), false),
                 PermissionException.class);
 
         // user 2 retracts from system1
@@ -305,7 +305,7 @@ public class MaintenanceManagerTest extends BaseTestCaseWithUser {
 
         // user 2 assigns to system 1
         assertExceptionThrown(
-                () -> mm.assignScheduleToSystems(user2, schedule2, Set.of(system1.getId())),
+                () -> mm.assignScheduleToSystems(user2, schedule2, Set.of(system1.getId()), false),
                 PermissionException.class);
 
         // user 2 lists systems with schedule 1
@@ -376,8 +376,8 @@ public class MaintenanceManagerTest extends BaseTestCaseWithUser {
         MaintenanceSchedule sapSchedule = mm.createSchedule(user, "SAP Maintenance Window", ScheduleType.MULTI, Optional.of(mcal));
         MaintenanceSchedule coreSchedule = mm.createSchedule(user, "Core Server Window", ScheduleType.MULTI, Optional.of(mcal));
 
-        mm.assignScheduleToSystems(user, sapSchedule, Collections.singleton(sapServer.getId()));
-        mm.assignScheduleToSystems(user, coreSchedule, Collections.singleton(coreServer.getId()));
+        mm.assignScheduleToSystems(user, sapSchedule, Collections.singleton(sapServer.getId()), false);
+        mm.assignScheduleToSystems(user, coreSchedule, Collections.singleton(coreServer.getId()), false);
 
         Action sapAction1 = MaintenanceTestUtils.createActionForServerAt(
                 user, ActionFactory.TYPE_ERRATA, sapServer, "2020-04-13T08:15:00+02:00"); //moved
@@ -444,8 +444,8 @@ public class MaintenanceManagerTest extends BaseTestCaseWithUser {
         MaintenanceSchedule sapSchedule = mm.createSchedule(user, "SAP Maintenance Window", ScheduleType.MULTI, Optional.of(mcal));
         MaintenanceSchedule coreSchedule = mm.createSchedule(user, "Core Server Window", ScheduleType.MULTI, Optional.of(mcal));
 
-        mm.assignScheduleToSystems(user, sapSchedule, Collections.singleton(sapServer.getId()));
-        mm.assignScheduleToSystems(user, coreSchedule, Collections.singleton(coreServer.getId()));
+        mm.assignScheduleToSystems(user, sapSchedule, Collections.singleton(sapServer.getId()), false);
+        mm.assignScheduleToSystems(user, coreSchedule, Collections.singleton(coreServer.getId()), false);
 
         // Action Chain which start inside of the window, but has parts outside of the window
         // Expected Result: No change
@@ -551,7 +551,7 @@ public class MaintenanceManagerTest extends BaseTestCaseWithUser {
         Server withSchedule = MinionServerFactoryTest.createTestMinionServer(user);
         Server withoutSchedule = MinionServerFactoryTest.createTestMinionServer(user);
 
-        mm.assignScheduleToSystems(user, schedule, Set.of(withSchedule.getId()));
+        mm.assignScheduleToSystems(user, schedule, Set.of(withSchedule.getId()), false);
 
         assertEquals(
                 Set.of(schedule),

--- a/java/code/src/com/suse/manager/maintenance/test/MaintenanceManagerTest.java
+++ b/java/code/src/com/suse/manager/maintenance/test/MaintenanceManagerTest.java
@@ -259,18 +259,18 @@ public class MaintenanceManagerTest extends BaseTestCaseWithUser {
         Server sys1 = MinionServerFactoryTest.createTestMinionServer(user);
         Server sys2 = MinionServerFactoryTest.createTestMinionServer(user);
 
+        // assign an action not tied to maintenance mode
+        Action allowedAction = MaintenanceTestUtils
+                .createActionForServerAt(user, ActionFactory.TYPE_VIRTUALIZATION_START, sys1, "2020-04-13T08:15:00+02:00");
+        assertEquals(1, mm.assignScheduleToSystems(user, schedule, Set.of(sys1.getId())));
+
         // assign an offending action to one system
         Action disallowedAction = ActionFactoryTest.createAction(user, ActionFactory.TYPE_APPLY_STATES);
-        ServerActionTest.createServerAction(sys1, disallowedAction);
+        ServerActionTest.createServerAction(sys2, disallowedAction);
 
         assertExceptionThrown(
                 () -> mm.assignScheduleToSystems(user, schedule, Set.of(sys1.getId(), sys2.getId())),
                 IllegalArgumentException.class);
-
-        // assign an action not tied to maintenance mode
-        Action allowedAction = MaintenanceTestUtils
-                .createActionForServerAt(user, ActionFactory.TYPE_VIRTUALIZATION_START, sys2, "2020-04-13T08:15:00+02:00");
-        assertEquals(1, mm.assignScheduleToSystems(user, schedule, Set.of(sys2.getId())));
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/controllers/SystemsController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/SystemsController.java
@@ -37,6 +37,8 @@ import com.redhat.rhn.manager.rhnset.RhnSetDecl;
 import com.redhat.rhn.manager.rhnset.RhnSetManager;
 import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
+import com.suse.manager.maintenance.MaintenanceManager;
+import com.suse.manager.model.maintenance.MaintenanceSchedule;
 import com.suse.manager.reactor.utils.LocalDateTimeISOAdapter;
 import com.suse.manager.reactor.utils.OptionalTypeAdapterFactory;
 import com.suse.manager.webui.services.iface.SystemQuery;
@@ -54,6 +56,7 @@ import org.apache.struts.action.ActionMessages;
 
 import spark.Request;
 import spark.Response;
+import spark.Spark;
 
 import javax.servlet.http.HttpServletRequest;
 import java.time.LocalDateTime;
@@ -108,6 +111,8 @@ public class SystemsController {
         post("/manager/api/systems/:sid/channels", withUser(systemsController::subscribeChannels));
         get("/manager/api/systems/:sid/channels/:channelId/accessible-children",
                 withUser(systemsController::getAccessibleChannelChildren));
+        get("/manager/api/systems/targetforschedule/:schedule_id",
+                withUser(systemsController::getTargetSystemsForSchedule));
     }
 
     /**
@@ -417,4 +422,20 @@ public class SystemsController {
         });
     }
 
+    /**
+     * Get a list of assignable systems for a maintenance schedule
+     *
+     * @param request the request
+     * @param response the response
+     * @param user the user
+     * @return the json response
+     */
+    public String getTargetSystemsForSchedule(Request request, Response response, User user) {
+        response.type("application/json");
+        MaintenanceSchedule schedule = new MaintenanceManager()
+                .lookupScheduleByUserAndId(user, Long.parseLong(request.params("schedule_id")))
+                .orElseThrow(() -> Spark.halt(HttpStatus.SC_NOT_FOUND));
+
+        return json(response, SystemManager.systemsNotInSchedule(user, schedule, null));
+    }
 }

--- a/java/code/src/com/suse/manager/webui/controllers/maintenance/MaintenanceScheduleController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/maintenance/MaintenanceScheduleController.java
@@ -33,6 +33,7 @@ import com.redhat.rhn.manager.EntityNotExistsException;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.suse.manager.maintenance.IcalUtils;
+import com.redhat.rhn.manager.ssm.SsmManager;
 import com.suse.manager.maintenance.MaintenanceManager;
 import com.suse.manager.maintenance.rescheduling.RescheduleResult;
 import com.suse.manager.maintenance.rescheduling.RescheduleStrategy;
@@ -85,6 +86,8 @@ public class MaintenanceScheduleController {
         get("/manager/schedule/maintenance/schedules",
                 withUserPreferences(withCsrfToken(withUser(MaintenanceScheduleController::maintenanceSchedules))),
                 jade);
+        get("/manager/systems/ssm/maintenance", withCsrfToken(withUser(MaintenanceScheduleController::ssmSchedules)),
+                jade);
         get("/manager/api/maintenance/schedule/list", withUser(MaintenanceScheduleController::list));
         get("/manager/api/maintenance/schedule/:id/details", withUser(MaintenanceScheduleController::details));
         post("/manager/api/maintenance/schedule/:id/assign", withUser(MaintenanceScheduleController::assign));
@@ -106,6 +109,22 @@ public class MaintenanceScheduleController {
         params.put("type", "schedule");
         params.put("isAdmin", user.hasRole(RoleFactory.ORG_ADMIN));
         return new ModelAndView(params, "templates/schedule/maintenance-windows.jade");
+    }
+
+    /**
+     * Handler for the SSM schedule assignment page.
+     *
+     * @param request the request object
+     * @param response the response object
+     * @param user the current user
+     * @return the ModelAndView object to render the page
+     */
+    public static ModelAndView ssmSchedules(Request request, Response response, User user) {
+        List<Long> systemIds = SsmManager.listServerIds(user);
+
+        Map<String, Object> data = new HashMap<>();
+        data.put("systems", GSON.toJson(systemIds));
+        return new ModelAndView(data, "templates/ssm/schedules.jade");
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/templates/ssm/schedules.jade
+++ b/java/code/src/com/suse/manager/webui/templates/ssm/schedules.jade
@@ -1,0 +1,16 @@
+.spacewalk-toolbar-h1
+  h1
+    i.fa.spacewalk-icon-system-groups
+    | #{' System Set Manager Overview '}
+    a(href="/docs/reference/systems/ssm-menu.html", target="_blank")
+      i.fa.fa-question-circle.spacewalk-help-link
+
+!{h.renderNavigationMenu(request, "/WEB-INF/nav/ssm.xml")}
+#maintenance-schedules
+
+script(type='text/javascript').
+    window.csrfToken = "#{csrf_token}";
+
+script(type='text/javascript').
+    spaImportReactPage('maintenance/system-assignment')
+        .then(function(module) { module.renderer('maintenance-schedules', !{systems}) });

--- a/java/code/src/com/suse/manager/xmlrpc/maintenance/MaintenanceHandler.java
+++ b/java/code/src/com/suse/manager/xmlrpc/maintenance/MaintenanceHandler.java
@@ -445,7 +445,8 @@ public class MaintenanceHandler extends BaseHandler {
 
         Set<Long> longIds = systemIds.stream().map(id -> id.longValue()).collect(Collectors.toSet());
         try {
-            return mm.assignScheduleToSystems(loggedInUser, schedule, longIds);
+            //TODO: Add flag param to allow cancelling affected actions
+            return mm.assignScheduleToSystems(loggedInUser, schedule, longIds, false);
         }
         catch (PermissionException e) {
             throw new PermissionCheckFailureException(e);

--- a/java/code/src/com/suse/manager/xmlrpc/maintenance/test/MaintenanceHandlerTest.java
+++ b/java/code/src/com/suse/manager/xmlrpc/maintenance/test/MaintenanceHandlerTest.java
@@ -40,6 +40,8 @@ import java.util.Map;
 
 import redstone.xmlrpc.XmlRpcSerializer;
 
+import static java.util.Collections.emptyList;
+
 public class MaintenanceHandlerTest extends BaseHandlerTestCase {
 
     private MaintenanceHandler handler = new MaintenanceHandler();
@@ -66,8 +68,8 @@ public class MaintenanceHandlerTest extends BaseHandlerTestCase {
         MaintenanceSchedule sapSchedule = handler.createSchedule(admin, "SAP Maintenance Window", "multi", mcal.getLabel());
         MaintenanceSchedule coreSchedule = handler.createSchedule(admin, "Core Server Window", "multi", mcal.getLabel());
 
-        handler.assignScheduleToSystems(admin, sapSchedule.getName(), Collections.singletonList(sapServer.getId().intValue()));
-        handler.assignScheduleToSystems(admin, coreSchedule.getName(), Collections.singletonList(coreServer.getId().intValue()));
+        handler.assignScheduleToSystems(admin, sapSchedule.getName(), Collections.singletonList(sapServer.getId().intValue()), emptyList());
+        handler.assignScheduleToSystems(admin, coreSchedule.getName(), Collections.singletonList(coreServer.getId().intValue()), emptyList());
 
 
         Action sapAction1 = MaintenanceTestUtils.createActionForServerAt(

--- a/java/code/webapp/WEB-INF/nav/ssm.xml
+++ b/java/code/webapp/WEB-INF/nav/ssm.xml
@@ -115,6 +115,7 @@
                 acl="all_systems_in_set_have_feature(ftr_hardware_refresh)"/>
         <rhn-tab name="ssm.misc.index.tabs.software" url="/rhn/systems/ssm/misc/SoftwareRefresh.do"
                 acl="all_systems_in_set_have_feature(ftr_package_refresh)"/>
+        <rhn-tab name="ssm.misc.index.tabs.maintenanceschedule" url="/rhn/manager/systems/ssm/maintenance"/>
         <rhn-tab name="Remote Command" url="/rhn/systems/ssm/provisioning/RemoteCommand.do"
                 acl="all_systems_in_set_have_feature(ftr_remote_command)"/>
         <rhn-tab name="ssm.misc.index.tabs.custom" url="/rhn/systems/ssm/misc/CustomValue.do"

--- a/java/code/webapp/WEB-INF/pages/ssm/ssmindex.jsp
+++ b/java/code/webapp/WEB-INF/pages/ssm/ssmindex.jsp
@@ -173,6 +173,7 @@
                         <rhn:require acl="all_systems_in_set_have_feature(ftr_package_refresh)">
                             <li><bean:message key="ssm.overview.misc.packageprofiles"/></li>
                         </rhn:require>
+                        <li><bean:message key="ssm.overview.schedule.assign"/></li>
                         <rhn:require acl="all_systems_in_set_have_feature(ftr_remote_command)">
                             <li><bean:message key="ssm.overview.provisioning.remotecommands"/></li>
                         </rhn:require>

--- a/java/code/webapp/WEB-INF/pages/systems/sdc/details.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/sdc/details.jsp
@@ -158,6 +158,24 @@
                     </rhn:require>
 
                     <div class="form-group">
+                        <label for="maintenance-schedule" class="col-lg-3 control-label">
+                            <bean:message key="sdc.details.edit.schedule"/>
+                        </label>
+                        <div class="col-lg-2">
+                            <html:select property="schedule_id" styleId="maintenance-schedule" styleClass="form-control">
+                                <html:option value="0" key="sdc.details.edit.schedule.none"/>
+                                <html:options collection="schedules" property="id" labelProperty="name"/>
+                            </html:select>
+                            <div class="checkbox">
+                                <label for="cancel-affected">
+                                    <html:checkbox property="cancel_affected_actions" styleId="cancel-affected"/>
+                                    <bean:message key="sdc.details.edit.schedule.cancelaffected"/>
+                                </label>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="form-group">
                         <label for="description" class="col-lg-3 control-label">
                             <bean:message key="sdc.details.edit.description" />
                         </label>

--- a/java/code/webapp/WEB-INF/pages/systems/sdc/overview.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/sdc/overview.jsp
@@ -376,6 +376,21 @@
           </tr>
           </rhn:require>
           <tr>
+            <td><bean:message key="sdc.details.overview.schedule"/></td>
+            <c:choose>
+              <c:when test="${maintenanceSchedule == null}">
+                <td><bean:message key="sdc.details.overview.schedule.none"/></td>
+              </c:when>
+              <c:otherwise>
+                <td>
+                  <a href="/rhn/manager/schedule/maintenance/schedules#/details/${maintenanceSchedule.id}" target="_blank">
+                    <c:out value="${maintenanceSchedule.name}"/>
+                  </a>
+                </td>
+              </c:otherwise>
+            </c:choose>
+          </tr>
+          <tr>
             <td><bean:message key="sdc.details.overview.sysname"/></td>
             <td><c:out value="${system.name}"/></td>
           </tr>

--- a/java/code/webapp/WEB-INF/struts-config.xml
+++ b/java/code/webapp/WEB-INF/struts-config.xml
@@ -900,6 +900,8 @@
       <form-property name="include_in_daily_summary" type="java.lang.Boolean"/>
       <form-property name="auto_update" type="java.lang.Boolean"/>
       <form-property name="contact_method_id" type="java.lang.Long"/>
+      <form-property name="schedule_id" type="java.lang.Long"/>
+      <form-property name="cancel_affected_actions" type="java.lang.Boolean"/>
       <form-property name="description" type="java.lang.String"/>
       <form-property name="address1" type="java.lang.String"/>
       <form-property name="address2" type="java.lang.String"/>

--- a/web/html/src/components/buttons.js
+++ b/web/html/src/components/buttons.js
@@ -65,7 +65,7 @@ export class AsyncButton extends _ButtonBase {
     let style = "btn ";
     switch (this.state.value) {
         case "failure": style += "btn-danger"; break;
-        case "waiting": style += "btn-default"; break;
+        case "waiting":
         case "initial": style += this.props.defaultType ? this.props.defaultType : "btn-default"; break;
         default: style += this.props.defaultType ? this.props.defaultType : "btn-default"; break;
     }

--- a/web/html/src/components/dialog/DangerDialog.js
+++ b/web/html/src/components/dialog/DangerDialog.js
@@ -12,13 +12,14 @@ import { Dialog } from "./Dialog";
  * This 'item' will be passed to the 'onConfirm' and 'onClosePopUp' handlers.
  */
 export function DangerDialog(props) {
+    const btnClass = props.btnClass || "btn-danger";
     const buttons = <div>
         {props.onConfirmAsync ?
             <AsyncButton
                 text={props.submitText}
                 title={props.submitText}
                 icon={props.submitIcon}
-                defaultType="btn-danger"
+                defaultType={btnClass}
                 action={() => {
                     props.onConfirmAsync(true);
                     $('#' + props.id).modal('hide');
@@ -27,7 +28,7 @@ export function DangerDialog(props) {
         }
         {props.onConfirm ?
             <Button
-                className="btn-danger"
+                className={btnClass}
                 text={props.submitText}
                 title={props.submitText}
                 icon={props.submitIcon}
@@ -72,4 +73,5 @@ DangerDialog.propTypes = {
     onConfirmAsync: PropTypes.func,
     submitText: PropTypes.string,
     submitIcon: PropTypes.string,
+    btnClass: PropTypes.string
 };

--- a/web/html/src/components/tab-container.js
+++ b/web/html/src/components/tab-container.js
@@ -60,7 +60,7 @@ class TabContainer extends React.Component {
 
 const TabLabel = (props) =>
   <li className={props.active ? "active" : ""}>
-    <a className="js-spa" href={props.hash} onClick={props.onClick}>{props.text}</a>
+    <a className="js-spa" href={props.hash || "#"} onClick={props.onClick}>{props.text}</a>
   </li>
 ;
 

--- a/web/html/src/core/spa/spa-renderer.js
+++ b/web/html/src/core/spa/spa-renderer.js
@@ -26,7 +26,10 @@ function hasReactApp() {
   return window.pageRenderers.spa.reactAppsName.length > 0;
 }
 
-function renderGlobalReact(element: ReactElement<any>, container: Element) {
+function renderGlobalReact(element: ReactElement<any>, container: ?Element) {
+  if (container == null) {
+    throw new Error('The DOM element is not present.');
+  }
 
   function registerGlobalRender(instance) {
     window.pageRenderers.spa.globalRenderersToUpdate.push(instance);
@@ -35,7 +38,11 @@ function renderGlobalReact(element: ReactElement<any>, container: Element) {
   ReactDOM.render(elementWithRef, container);
 }
 
-function renderNavigationReact(element: ReactElement<any>, container: Element) {
+function renderNavigationReact(element: ReactElement<any>, container: ?Element) {
+  if (container == null) {
+    throw new Error('The DOM element is not present.');
+  }
+
   window.pageRenderers.spa.reactRenderers.push({
     element,
     container,

--- a/web/html/src/manager/maintenance/details/maintenance-windows-details.js
+++ b/web/html/src/manager/maintenance/details/maintenance-windows-details.js
@@ -58,11 +58,13 @@ const MaintenanceWindowsDetails = (props: MaintenanceDetailsProps) => {
             {
                 type === "schedule" &&
                 <MaintenanceScheduleDetails
+                    id={props.data.id}
                     name={props.data.name}
                     calendarName={props.data.calendarName}
                     type={props.data.type}
                     maintenanceWindows={props.data.maintenanceWindows}
                     onDelete={props.onDelete}
+                    onMessage={props.onMessage}
                 /> ||
                 type === "calendar" &&
                 <MaintenanceCalendarDetails

--- a/web/html/src/manager/maintenance/details/schedule-details.js
+++ b/web/html/src/manager/maintenance/details/schedule-details.js
@@ -1,21 +1,45 @@
-/* eslint-disable */
-'use strict';
+// @flow
 
-import React from "react";
+import React, {useState, useEffect} from "react";
+
+import {Utils} from "utils/functions";
+import * as Network from "utils/network";
+
+import {AsyncButton} from "components/buttons";
+import {DeleteDialog} from "components/dialog/DeleteDialog";
+import {ModalButton} from "components/dialog/ModalButton";
+import {SystemLink} from "components/links";
+import {Utils as MessagesUtils} from "components/messages";
 import {BootstrapPanel} from "components/panels/BootstrapPanel";
+import {InnerPanel} from "components/panels/InnerPanel";
+import {TabLabel} from "components/tab-container";
 import {Table} from "components/table/Table";
 import {Column} from "components/table/Column";
-import {DeleteDialog} from "components/dialog/DeleteDialog";
+import {Toggler} from "components/toggler";
 
-type ScheduleDetailsProps = {
+import CancelActionsDialog from "../shared/cancel-actions-dialog";
+
+import type {MessageType} from "components/messages";
+
+declare var userPrefPageSize: number;
+
+type MaintenanceWindowType = {
+    start: string,
+    end: string
+}
+
+type MaintenanceScheduleDetailsProps = {
+    id: number,
     name: string,
-    calendarName: string,
     type: 'SINGLE' | 'MULTI',
-    maintenanceWindows?: Array,
-    onDelete: () => void
+    calendarName: string,
+    maintenanceWindows?: MaintenanceWindowType[],
+    onDelete: (item: {name: string}) => Promise<any>,
+    onMessage: (messages: MessageType[]) => void
 };
 
-const MaintenanceScheduleDetails = (props: ScheduleDetailsProps) => {
+const MaintenanceScheduleDetails = (props: MaintenanceScheduleDetailsProps) => {
+    const [activeTab, setActiveTab] = useState("overview");
     return (
         <>
             <DeleteDialog
@@ -29,12 +53,35 @@ const MaintenanceScheduleDetails = (props: ScheduleDetailsProps) => {
                 }
                 onConfirm={() => props.onDelete({name: props.name})}
             />
-            <MaintenanceScheduleOverview
-                name={props.name}
-                calendarName={props.calendarName}
-                type={props.type}
-                maintenanceWindows={props.maintenanceWindows}
-            />
+            <div className="spacewalk-content-nav">
+                <ul className="nav nav-tabs">
+                    <TabLabel
+                        active={activeTab === "overview"}
+                        text={t("Overview")}
+                        onClick={() => setActiveTab("overview")}
+                    />
+                    <TabLabel
+                        active={activeTab === "assignment"}
+                        text={t("Assign Systems")}
+                        onClick={() => setActiveTab("assignment")}
+                    />
+                </ul>
+            </div>
+            { activeTab === "overview" &&
+                <MaintenanceScheduleOverview
+                    name={props.name}
+                    calendarName={props.calendarName}
+                    type={props.type}
+                    maintenanceWindows={props.maintenanceWindows}
+                />
+            }
+            { activeTab === "assignment" &&
+                <SystemPicker
+                    scheduleId={props.id}
+                    onAssign={() => setActiveTab("overview")}
+                    onMessage={props.onMessage}
+                />
+            }
         </>
     );
 }
@@ -43,8 +90,8 @@ type OverviewProps = {
     name: string,
     calendarName: string,
     type: 'SINGLE' | 'MULTI',
-    maintenanceWindows?: Array
-}
+    maintenanceWindows?: MaintenanceWindowType[]
+};
 
 const MaintenanceScheduleOverview = (props: OverviewProps) => {
     const tableData = [
@@ -69,8 +116,8 @@ const MaintenanceScheduleOverview = (props: OverviewProps) => {
                 props.maintenanceWindows && props.maintenanceWindows.length > 0 &&
                 <BootstrapPanel title={t("Upcoming Maintenance Windows")}>
                     <Table
-                        data={props.maintenanceWindows}
-                        identifier={row => props.maintenanceWindows.indexOf(row)}
+                        data={props.maintenanceWindows || []}
+                        identifier={row => (props.maintenanceWindows || []).indexOf(row)}
                         initialItemsPerPage={0}
                     >
                         <Column header={t("Start")} columnKey="start" cell={row => row.start}/>
@@ -79,6 +126,88 @@ const MaintenanceScheduleOverview = (props: OverviewProps) => {
                 </BootstrapPanel>
             }
         </div>
+    );
+}
+
+type SystemPickerProps = {
+    scheduleId: number,
+    onAssign: () => void,
+    onMessage: (messages: MessageType[]) => void
+};
+
+const SystemPicker = (props: SystemPickerProps) => {
+    const [systems, setSystems] = useState([]);
+    const [selectedSystems, setSelectedSystems] = useState([]);
+    const [isCancelActions, setCancelActions] = useState(false);
+    const [isLoading, setLoading] = useState(false);
+
+    useEffect(() => {
+        setLoading(true);
+        Network.get(`/rhn/manager/api/systems/targetforschedule/${props.scheduleId}`).promise
+            .then(setSystems)
+            .catch(xhr => props.onMessage(
+                MessagesUtils.error(Network.errorMessageByStatus(xhr.status))))
+            .finally(() => setLoading(false));
+    }, [props.scheduleId]);
+
+    const onAssign = () => {
+        return Network.post(`/rhn/manager/api/maintenance/schedule/${props.scheduleId}/assign`,
+                JSON.stringify({systemIds: selectedSystems, cancelActions: isCancelActions}),
+                "application/json", false).promise
+            .then(() => props.onMessage(
+                MessagesUtils.success(t("Maintenance schedule has been assigned to {0} system(s)", selectedSystems.length))))
+            .then(props.onAssign)
+            .catch(xhr => props.onMessage(
+                MessagesUtils.error(Network.errorMessageByStatus(xhr.status))));
+    };
+
+    return (
+        <>
+            <InnerPanel
+                title={t("Assign Systems")}
+                icon="fa-desktop"
+                buttons={[
+                    <Toggler
+                        text={t("Cancel affected actions")}
+                        className="btn"
+                        handler={() => setCancelActions(!isCancelActions)}
+                        value={isCancelActions}
+                    />,
+                    ( isCancelActions ?
+                        <ModalButton
+                            target="cancel-confirm"
+                            text={t("Assign")}
+                            className="btn-success"
+                            disabled={selectedSystems.length === 0}
+                        /> :
+                        <AsyncButton
+                            action={onAssign}
+                            defaultType="btn-success"
+                            text={t("Assign")}
+                            disabled={selectedSystems.length === 0}
+                        />
+                    )
+                ]}
+            >
+                <Table
+                    data={systems}
+                    identifier={system => system.id}
+                    selectable
+                    selectedItems={selectedSystems}
+                    onSelect={setSelectedSystems}
+                    loading={isLoading}
+                    initialItemsPerPage={userPrefPageSize}
+                >
+                    <Column
+                        columnKey="systemName"
+                        comparator={Utils.sortByText}
+                        header={t("System")}
+                        cell={system => <SystemLink id={system.id} newWindow>{system.name}</SystemLink>}
+                    />
+                </Table>
+            </InnerPanel>
+            <CancelActionsDialog id="cancel-confirm" onConfirmAsync={onAssign}/>
+        </>
     );
 }
 

--- a/web/html/src/manager/maintenance/index.js
+++ b/web/html/src/manager/maintenance/index.js
@@ -1,3 +1,4 @@
 export default {
   'maintenance/maintenance-windows': () => import('./maintenance-windows'),
+  'maintenance/system-assignment': () => import('./ssm/system-assignment')
 }

--- a/web/html/src/manager/maintenance/maintenance-windows.js
+++ b/web/html/src/manager/maintenance/maintenance-windows.js
@@ -176,6 +176,7 @@ const MaintenanceWindows = () => {
                                            data={selected}
                                            onCancel={handleForwardAction}
                                            onEdit={handleEditAction}
+                                           onMessage={setMessages}
                                            onDelete={deleteItem}
                 />
                 : (action === 'edit' || action === 'create') && isAdmin ?

--- a/web/html/src/manager/maintenance/shared/cancel-actions-dialog.js
+++ b/web/html/src/manager/maintenance/shared/cancel-actions-dialog.js
@@ -1,0 +1,29 @@
+// @flow
+
+import React from "react";
+
+import {DangerDialog} from "components/dialog/DangerDialog";
+
+type Props = {
+  id: string,
+  onConfirmAsync: () => Promise<any>
+};
+
+export default function CancelActionsDialog(props: Props) {
+  return (
+    <DangerDialog
+      id={props.id}
+      title={t("Cancel affected actions")}
+      onConfirmAsync={props.onConfirmAsync}
+      submitText={t("Confirm")}
+      submitIcon="fa-check"
+      btnClass="btn-success"
+      content={
+        <>
+          <p>{t("Any pending maintenance-only actions for these systems will be cancelled unless they are inside the new maintenance windows.")}</p>
+          <p>{t("Are you sure you want to proceed?")}</p>
+        </>
+      }
+    />
+  );
+}

--- a/web/html/src/manager/maintenance/ssm/schedule-picker.js
+++ b/web/html/src/manager/maintenance/ssm/schedule-picker.js
@@ -1,0 +1,149 @@
+// @flow
+
+import React, {useState, useEffect, useContext} from "react";
+
+import {AsyncButton} from "components/buttons";
+import {ModalButton} from "components/dialog/ModalButton";
+import {Form, FormContext} from "components/input/Form";
+import {Select} from "components/input/Select";
+import {Check} from "components/input/Check";
+import {Utils as MessagesUtils} from "components/messages";
+
+import CancelActionsDialog from "../shared/cancel-actions-dialog";
+
+import type {Node} from 'react';
+import type {MessageType} from "components/messages";
+
+const Network = require("utils/network");
+
+type ScheduleType = {
+  scheduleId: number,
+  scheduleName: string
+};
+
+type WithMaintenanceSchedulesProps = {
+  systems: string[],
+  onMessage: (messages: MessageType[]) => void,
+  children: (
+    schedules: ScheduleType[],
+    onAssign: (scheduleId: number, cancelActions: boolean) => Promise<any>
+  ) => Node
+};
+
+export function WithMaintenanceSchedules(props: WithMaintenanceSchedulesProps) {
+  const [schedules, setSchedules] = useState([]);
+
+  const onAssign = (scheduleId: number, cancelActions: boolean): Promise<any> => {
+    let uri;
+    let data;
+    let successMsg;
+    if (scheduleId === 0) {
+      uri = "/rhn/manager/api/maintenance/schedule/unassign";
+      successMsg = t("Maintenance schedule has been cleared");
+      data = props.systems;
+    }
+    else {
+      uri = `/rhn/manager/api/maintenance/schedule/${scheduleId}/assign`;
+      successMsg = t("Maintenance schedule has been assigned");
+      data = {
+        systemIds: props.systems,
+        cancelActions: cancelActions
+      };
+    }
+
+    return Network.post(uri, JSON.stringify(data), "application/json", false).promise
+      .then(() => props.onMessage(MessagesUtils.success(successMsg)))
+      .catch(xhr => props.onMessage(
+        MessagesUtils.error(Network.errorMessageByStatus(xhr.status))));
+  };
+
+  useEffect(() => {
+    Network.get("/rhn/manager/api/maintenance/schedule/list").promise
+      .then(setSchedules);
+  }, []);
+
+  return props.children(schedules, onAssign);
+}
+
+type SchedulePickerFormProps = {
+  schedules: ScheduleType[],
+  onAssign: (scheduleId: number, cancelActions: boolean) => Promise<any>
+};
+
+export function SchedulePickerForm(props: SchedulePickerFormProps) {
+  const [model, setModel] = useState({});
+  const [isValid, setValid] = useState(false);
+  const onSubmit = () => props.onAssign(parseInt(model.scheduleId), model.cancelActions);
+  const onChange = (model) => setModel(Object.assign({}, model));
+
+  return (
+    <>
+      <Form model={model} onChange={onChange} onValidate={setValid}>
+        <SchedulePicker schedules={props.schedules}/>
+        <div className="form-group">
+          <div className="col-md-offset-3 col-md-6">
+            {
+              model.scheduleId === "0" ?
+                <AsyncButton
+                  id="submit-btn"
+                  text={t("Clear All")}
+                  icon={t("fa-times")}
+                  action={onSubmit}
+                  defaultType="btn-danger"
+                  className="pull-right"
+                  disabled={!isValid}
+                /> :
+                ( model.cancelActions ?
+                  <ModalButton
+                    id="submit-btn"
+                    target="cancel-confirm"
+                    text={t("Assign All")}
+                    icon={t("fa-edit")}
+                    className="btn-success pull-right"
+                    disabled={!isValid}
+                  /> :
+                  <AsyncButton
+                    id="submit-btn"
+                    text={t("Assign All")}
+                    icon={t("fa-edit")}
+                    action={onSubmit}
+                    defaultType="btn-success"
+                    className="pull-right"
+                    disabled={!isValid}
+                  />
+                )
+            }
+          </div>
+        </div>
+      </Form>
+      <CancelActionsDialog id="cancel-confirm" onConfirmAsync={onSubmit}/>
+    </>
+  );
+}
+
+export function SchedulePicker(props: {schedules: ScheduleType[]}) {
+  const context = useContext(FormContext);
+  return (
+    <>
+      <Select
+        name="scheduleId"
+        label={t("Schedule")}
+        labelClass="col-md-3"
+        divClass="col-md-6"
+        required
+        defaultValue=""
+      >
+        <option key="-1" value="" disabled>Select a schedule</option>
+        <option key="0" value="0">None - clear schedule</option>
+        {props.schedules.map(s => <option key={s.scheduleId} value={s.scheduleId}>{s.scheduleName}</option>)}
+      </Select>
+      { context.model.scheduleId !== "0" &&
+        <Check
+          name="cancelActions"
+          label={t("Cancel affected actions")}
+          divClass="col-md-6 col-md-offset-3"
+        />
+      }
+    </>
+  );
+}

--- a/web/html/src/manager/maintenance/ssm/system-assignment.js
+++ b/web/html/src/manager/maintenance/ssm/system-assignment.js
@@ -1,0 +1,39 @@
+// @flow
+
+import React, {useState} from "react";
+import SpaRenderer from "core/spa/spa-renderer";
+
+import {Messages} from "components/messages";
+import {BootstrapPanel} from "components/panels/BootstrapPanel";
+
+import {SchedulePickerForm, WithMaintenanceSchedules} from "./schedule-picker";
+
+function SystemAssignment(props: {systems: string[]}) {
+  const [messages, setMessages] = useState([]);
+  return (
+    <>
+      <Messages items={messages}/>
+      <BootstrapPanel
+        title={t("Maintenance Schedules")}
+        icon="fa-clock-o"
+        header={
+          <div className="page-summary">
+            <p>{t("Assign a maintenance schedule to {0} system(s)", props.systems.length)}</p>
+            <p>{t("Assigning a schedule will replace any prior assignments in all of the systems in the set.")}</p>
+          </div>
+        }
+      >
+        <WithMaintenanceSchedules systems={props.systems} onMessage={setMessages}>
+          {
+            (schedules, onAssign) => <SchedulePickerForm schedules={schedules} onAssign={onAssign}/>
+          }
+        </WithMaintenanceSchedules>
+      </BootstrapPanel>
+    </>
+  );
+}
+
+export const renderer = (id: string, systems: string[]) => SpaRenderer.renderNavigationReact(
+  <SystemAssignment systems={systems}/>,
+  document.getElementById(id)
+);


### PR DESCRIPTION
Adds UI for assigning maintenance schedules to systems.

### TODO
 - [x] Add an info text to the SSM panel header
 - [x] Add "Schedule" tab and schedule assignment form to SSM interface
 - [x] Add "Assign Systems" tab to the schedule details page to pick multiple systems to assign to a specific schedule
 - [x] Implement schedule assignment UI in the system properties page
 - [x] Add a shortcut link to the SSM summary page
 - [x] Move the SSM tab under "Misc" > "Maintenance Windows"
 - [x] Implement server side pagination for the systems list table (https://github.com/SUSE/spacewalk/issues/11895)
 - [x] Elaborate the system list with assigned schedule names (https://github.com/SUSE/spacewalk/issues/11895)
 - [x] Add confirm dialogs for when canceling affected actions
 - [x] Unify the notification messages (~`toastr`~ or regular)
 - [x] Add ~a flag to cancel affected actions~ `strategies` parameter to `assignScheduleToSystems` XMLRPC endpoint
 - [x] Test user/org permissions
 - [x] Organize the code structure

## GUI diff
*Assignment from schedule details page*
![mw-schedules](https://user-images.githubusercontent.com/1103552/86944255-c62e8e00-c147-11ea-9446-d55967a4584d.png)

*Assignment from SSM*
![mw-ssm](https://user-images.githubusercontent.com/1103552/86944256-c75fbb00-c147-11ea-8257-ae6d3e86d4bd.png)

*Cancel affected actions confirmation*
![mw-ssm-confirm](https://user-images.githubusercontent.com/1103552/86944258-c75fbb00-c147-11ea-90e6-a4c4b953ee03.png)

*Assignment from system properties page*
![mw-system-properties](https://user-images.githubusercontent.com/1103552/86944259-c7f85180-c147-11ea-886e-917e496e3dcc.png)

## Documentation
- Will be covered as part of the "Maintenance Windows" feature

## Test coverage
- Unit tests were adapted

## Links

Fixes https://github.com/SUSE/spacewalk/issues/11228

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
