### PR TITLE
Speedup System Groups page (bsc#1172839)

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/SystemGroup_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/SystemGroup_queries.xml
@@ -65,23 +65,47 @@ ORDER BY UPPER(NAME)
     <elaborator name="most_severe_errata" />
 </mode>
 <query name="most_severe_errata" params="">
-    SELECT sgm.server_group_id AS id,
-        CASE MAX(CASE e.advisory_type
-            WHEN 'Security Advisory' THEN 3
-            WHEN 'Bug Fix Advisory' THEN 2
-            WHEN 'Product Enhancement Advisory' THEN 1
-            ELSE 0 END)
-            WHEN 3 THEN 'Security Advisory'
-            WHEN 2 THEN 'Bug Fix Advisory'
-            WHEN 1 THEN 'Product Enhancement Advisory'
-            WHEN 0 THEN 'Outdated Packages'
-        END AS most_severe_errata
-    FROM rhnServerNeededCache snpc
-        INNER JOIN rhnServerGroupMembers sgm ON sgm.server_id = snpc.server_id
-        INNER JOIN rhnServerFeaturesView sfv ON sgm.server_id = sfv.server_id
-        LEFT JOIN rhnErrata e ON e.id = snpc.errata_id
-    WHERE sgm.server_group_id IN (%s) AND sfv.label = 'ftr_system_grouping'
-    GROUP BY server_group_id
+    WITH groupAdvisoryTypes AS NOT MATERIALIZED (
+        SELECT sgm.server_group_id, e.advisory_type
+          FROM rhnServerNeededCache snpc
+              INNER JOIN rhnServerGroupMembers sgm ON sgm.server_id = snpc.server_id
+              INNER JOIN rhnServerFeaturesView sfv ON sgm.server_id = sfv.server_id
+              LEFT JOIN rhnErrata e ON e.id = snpc.errata_id
+          WHERE sfv.label = 'ftr_system_grouping'
+    )
+    SELECT rhnServerGroup.id,
+        CASE (
+            SELECT EXISTS (SELECT 1
+                FROM groupAdvisoryTypes gat
+                    WHERE gat.server_group_id = rhnServerGroup.id
+                    AND gat.advisory_type = 'Security Advisory')
+        )
+        WHEN TRUE THEN 'Security Advisory'
+        ELSE CASE (
+            SELECT EXISTS (SELECT 1
+                FROM groupAdvisoryTypes gat
+                    WHERE gat.server_group_id = rhnServerGroup.id
+                    AND gat.advisory_type = 'Bug Fix Advisory')
+        )
+        WHEN TRUE THEN 'Bug Fix Advisory'
+        ELSE CASE (
+            SELECT EXISTS (SELECT 1
+                FROM groupAdvisoryTypes gat
+                    WHERE gat.server_group_id = rhnServerGroup.id
+                    AND gat.advisory_type = 'Product Enhancement Advisory')
+        )
+        WHEN TRUE THEN 'Product Enhancement Advisory'
+        ELSE CASE (
+            SELECT EXISTS (SELECT 1
+                FROM groupAdvisoryTypes gat
+                    WHERE gat.server_group_id = rhnServerGroup.id
+                    AND gat.advisory_type IS NULL)
+        )
+        WHEN TRUE THEN 'Outdated Packages'
+        ELSE NULL
+        END END END END AS most_severe_errata
+    FROM rhnServerGroup
+    WHERE rhnServerGroup.id IN (%s)
 </query>
 <mode name="is_visible">
         <query  params="sgid, user_id">

--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/SystemGroup_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/SystemGroup_queries.xml
@@ -11,22 +11,7 @@
                  AND EXISTS ( SELECT 1
                               FROM rhnServerFeaturesView SFV
                               WHERE SFV.server_id = SGM.server_id
-                                    AND SFV.label = 'ftr_system_grouping')) AS  SERVER_COUNT,
-        (SELECT CASE MAX(CASE E.advisory_type
-                WHEN 'Security Advisory' THEN 3
-                WHEN 'Bug Fix Advisory' THEN 2
-                WHEN 'Product Enhancement Advisory' THEN 1
-                ELSE 0 END)
-            WHEN 3 THEN 'Security Advisory'
-            WHEN 2 THEN 'Bug Fix Advisory'
-            WHEN 1 THEN 'Product Enhancement Advisory'
-            WHEN 0 THEN 'Outdated Packages' END type_value
-        FROM rhnServerNeededCache SNPC
-            INNER JOIN rhnServerGroupMembers SGM on SGM.server_id = SNPC.server_id
-            INNER JOIN rhnServerFeaturesView SFV on SGM.server_id = SFV.server_id
-            LEFT JOIN rhnErrata E on E.id = SNPC.errata_id
-        WHERE SGM.server_group_id = G.id
-          AND SFV.label = 'ftr_system_grouping') as MOST_SEVERE_ERRATA
+                                    AND SFV.label = 'ftr_system_grouping')) AS  SERVER_COUNT
  FROM   rhnServerGroup G, rhnUserManagedServerGroups UMSG
  WHERE   G.ORG_ID = :org_id
    AND   UMSG.user_id = :user_id
@@ -62,7 +47,7 @@ ORDER BY UPPER(NAME)
     ) x
     ORDER BY UPPER(NAME)
   </query>
-    <elaborator name="most_severe_errata" />
+  <elaborator name="most_severe_errata" />
 </mode>
 <query name="most_severe_errata" params="">
     WITH groupAdvisoryTypes AS NOT MATERIALIZED (
@@ -122,6 +107,7 @@ ORDER BY UPPER(NAME)
 <mode name="visible_to_user" class="com.redhat.rhn.frontend.dto.SystemGroupOverview">
   <query name="visible_to_user_ids" />
   <elaborator name="visible_to_user_overview_fast" />
+  <elaborator name="most_severe_errata" />
 </mode>
 
 <mode name="managed_system_groups_by_system">

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- improve performance of the System Groups page with many clients (bsc#1172839)
 - Include number of non-patch package updates to non-critical update counts
   in system group pages (bsc#1170468)
 - bump XMLRPC API version number to distinguish from Spacewalk 2.10


### PR DESCRIPTION
## What does this PR change?

Speeds up the System Groups page and the homepage section about groups, especially when there are thousands of non-up-to-date systems.

In a particular case, I could observe a **~50x speedup** (from ~25s to ~500 ms) on the load time for the System Groups page.

The change here is about not using an aggregate (`GROUP BY`/`MAX`) to find out whether a certain group has at least one system with at least one critical/bugfix/feature applicable errata. Merely scanning the index of `rhnServerNeededCache`, which in the case I was looking at contained more than 5M rows, takes 10-20 seconds. This solution is not particularly elegant SQL-wise, but it allows not to visit the entire table/index, stopping at the first useful row match, thereby saving a lot of time.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**
- [x] **DONE**

## Test coverage
- No tests: **only tested manually, needs huge DB to reproduce**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/11718

- [x] **DONE**

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle" 
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
