### PR TITLE
Fix Python 2 syntax error on "ssh_agent" custom Salt module

### DIFF
--- a/susemanager-utils/susemanager-sls/src/modules/ssh_agent.py
+++ b/susemanager-utils/susemanager-sls/src/modules/ssh_agent.py
@@ -56,7 +56,8 @@ def start_agent(**kwargs):
     variables = dict()
     for line in ssh_agent_lines:
         if line.startswith('SSH'):
-            var, *rest = line.split(';')
+            line_content_list = line.split(';')
+            var, rest = line_content_list[0], line_content_list[1:]
             key, val = var.strip().split("=", 1)
             variables[key] = val
 

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,6 @@
+- Do not produce syntax error on custom ssh_agent Salt module when
+  executing on Python 2 instance.
+
 -------------------------------------------------------------------
 Tue Jun 23 17:24:45 CEST 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

This PR fixes a syntax error happening in our custom `ssh_agent` Salt module. There a syntax on that file that is not supported on Python 2.

The usage of this `ssh_agent` is done in the context of cluster awareness, so currently only used on SLE15SP1 instances (Python3), but it produces tracebacks on minion while being loaded as Salt module even if it's not used:

```
2020-06-30 16:41:05,709 [salt.loader      ][ERROR   ][29134] Failed to import module ssh_agent, this is due most likely to a syntax error:
Traceback (most recent call last):
  File "/var/tmp/.root_54c8a3_salt/py26/pyall/salt/loader.py", line 1334, in _load_module
    mod = imp.load_module(mod_namespace, fn_, fpath, desc)
  File "/var/tmp/.root_54c8a3_salt/running_data/var/cache/salt/minion/extmods/modules/ssh_agent.py", line 59
     var, *rest = line.split(';')
          ^
 SyntaxError: invalid syntax
```

This PR simply refactors the failing syntax to be Python 2 / 3 compatible.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **backend changes**
- [x] **DONE**

## Test coverage
- No tests: **cosmetic**
- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle" (Test skipped, there are no changes to test)
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
