### PR TITLE
Fix CentOS systems detection at bootstrap to properly set the bootstrap repo (bsc#1173556)

### DIFF
--- a/spacewalk/certs-tools/rhn_bootstrap_strings.py
+++ b/spacewalk/certs-tools/rhn_bootstrap_strings.py
@@ -406,7 +406,7 @@ if [ "$INSTALLER" == yum ]; then
     CLIENT_REPO_NAME="susemanager:bootstrap"
     CLIENT_REPO_FILE="/etc/yum.repos.d/$CLIENT_REPO_NAME.repo"
 
-    # In case of CentOS, check is centos bootstrap repository is available, if not, failback to res.
+    # In case of CentOS, check is centos bootstrap repository is available, if not, fallback to res.
     if [[ "$Y_CLIENT_CODE_BASE" == centos && ! `$FETCH $CLIENT_REPO_URL/repodata/repomd.xml &> /dev/null` ]]; then
         echo "CentOS${{Y_CLIENT_CODE_VERSION}} bootstrap repository not found, using RES${{Y_CLIENT_CODE_VERSION}} bootstrap repository instead"
         CLIENT_REPO_URL="${{CLIENT_REPOS_ROOT}}/res/${{Y_CLIENT_CODE_VERSION}}/bootstrap"

--- a/spacewalk/certs-tools/rhn_bootstrap_strings.py
+++ b/spacewalk/certs-tools/rhn_bootstrap_strings.py
@@ -406,6 +406,11 @@ if [ "$INSTALLER" == yum ]; then
     CLIENT_REPO_NAME="susemanager:bootstrap"
     CLIENT_REPO_FILE="/etc/yum.repos.d/$CLIENT_REPO_NAME.repo"
 
+    # In case of CentOS, check is centos bootstrap repository is available, if not, failback to res.
+    if [[ "$Y_CLIENT_CODE_BASE" == centos && ! `$FETCH $CLIENT_REPO_URL/repodata/repomd.xml` ]]; then
+        CLIENT_REPO_URL="${{CLIENT_REPOS_ROOT}}/res/${{Y_CLIENT_CODE_VERSION}}/bootstrap"
+    fi
+
     setup_bootstrap_repo
 
     if [ -z "$Y_MISSING" ]; then

--- a/spacewalk/certs-tools/rhn_bootstrap_strings.py
+++ b/spacewalk/certs-tools/rhn_bootstrap_strings.py
@@ -407,7 +407,8 @@ if [ "$INSTALLER" == yum ]; then
     CLIENT_REPO_FILE="/etc/yum.repos.d/$CLIENT_REPO_NAME.repo"
 
     # In case of CentOS, check is centos bootstrap repository is available, if not, failback to res.
-    if [[ "$Y_CLIENT_CODE_BASE" == centos && ! `$FETCH $CLIENT_REPO_URL/repodata/repomd.xml` ]]; then
+    if [[ "$Y_CLIENT_CODE_BASE" == centos && ! `$FETCH $CLIENT_REPO_URL/repodata/repomd.xml &> /dev/null` ]]; then
+        echo "CentOS${{Y_CLIENT_CODE_VERSION}} bootstrap repository not found, using RES${{Y_CLIENT_CODE_VERSION}} bootstrap repository instead"
         CLIENT_REPO_URL="${{CLIENT_REPOS_ROOT}}/res/${{Y_CLIENT_CODE_VERSION}}/bootstrap"
     fi
 

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,4 +1,4 @@
-- Use RES bootstrap repository as failback repo when bootstrapping CentOS (bsc#1173556)
+- Use RES bootstrap repository as fallback repo when bootstrapping CentOS (bsc#1173556)
 
 -------------------------------------------------------------------
 Wed Jun 10 12:15:57 CEST 2020 - jgonzalez@suse.com

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,5 @@
+- Use RES bootstrap repository as failback repo when bootstrapping CentOS (bsc#1173556)
+
 -------------------------------------------------------------------
 Wed Jun 10 12:15:57 CEST 2020 - jgonzalez@suse.com
 

--- a/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
@@ -35,7 +35,7 @@ mgr_server_localhost_alias_absent:
 {% set bootstrap_repo_url = 'https://' ~ salt['pillar.get']('mgr_server') ~ '/pub/repositories/res/' ~ grains['osmajorrelease'] ~ '/bootstrap/' %}
 
 {%- elif salt['file.file_exists']('/etc/centos-release') %}
-{# We try CentOS bootstrap repository first. Failback to RES #}
+{# We try CentOS bootstrap repository first, if not avaiable then fallback to RES #}
 {% set bootstrap_repo_url = 'https://' ~ salt['pillar.get']('mgr_server') ~ '/pub/repositories/centos/' ~ grains['osmajorrelease'] ~ '/bootstrap/' %}
 {% set bootstrap_repo_request = salt['http.query'](bootstrap_repo_url + 'repodata/repomd.xml', status=True, verify_ssl=False) %}
 {%- if bootstrap_repo_request['status'] == 901 %}

--- a/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
@@ -28,13 +28,13 @@ mgr_server_localhost_alias_absent:
 {%- endif %}
 
 {%- elif grains['os_family'] == 'RedHat' %}
-{%- if salt['file.file_exists' ]('/etc/oracle-release') %}
+{%- if salt['file.file_exists']('/etc/oracle-release') %}
 {% set bootstrap_repo_url = 'https://' ~ salt['pillar.get']('mgr_server') ~ '/pub/repositories/oracle/' ~ grains['osmajorrelease'] ~ '/bootstrap/' %}
 
-{%- elif salt['file.file_exists' ]('/usr/share/doc/sles_es-release') %}
+{%- elif salt['file.file_exists']('/usr/share/doc/sles_es-release') %}
 {% set bootstrap_repo_url = 'https://' ~ salt['pillar.get']('mgr_server') ~ '/pub/repositories/res/' ~ grains['osmajorrelease'] ~ '/bootstrap/' %}
 
-{%- elif salt['file.file_exists' ]('/etc/centos-release') %}
+{%- elif salt['file.file_exists']('/etc/centos-release') %}
 {# We try CentOS bootstrap repository first. Failback to RES #}
 {% set bootstrap_repo_url = 'https://' ~ salt['pillar.get']('mgr_server') ~ '/pub/repositories/centos/' ~ grains['osmajorrelease'] ~ '/bootstrap/' %}
 {% set bootstrap_repo_request = salt['http.query'](bootstrap_repo_url + 'repodata/repomd.xml', status=True, verify_ssl=False) %}
@@ -44,7 +44,7 @@ mgr_server_localhost_alias_absent:
 {% set bootstrap_repo_url = 'https://' ~ salt['pillar.get']('mgr_server') ~ '/pub/repositories/res/' ~ grains['osmajorrelease'] ~ '/bootstrap/' %}
 {%- endif %}
 
-{%- elif salt['file.file_exists' ]('/etc/redhat-release') %}
+{%- elif salt['file.file_exists']('/etc/redhat-release') %}
 {% set bootstrap_repo_url = 'https://' ~ salt['pillar.get']('mgr_server') ~ '/pub/repositories/res/' ~ grains['osmajorrelease'] ~ '/bootstrap/' %}
 
 {%- else %}

--- a/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
@@ -31,6 +31,9 @@ mgr_server_localhost_alias_absent:
 {%- if salt['file.file_exists' ]('/etc/oracle-release') %}
 {% set bootstrap_repo_url = 'https://' ~ salt['pillar.get']('mgr_server') ~ '/pub/repositories/oracle/' ~ grains['osmajorrelease'] ~ '/bootstrap/' %}
 
+{%- elif salt['file.file_exists' ]('/usr/share/doc/sles_es-release') %}
+{% set bootstrap_repo_url = 'https://' ~ salt['pillar.get']('mgr_server') ~ '/pub/repositories/res/' ~ grains['osmajorrelease'] ~ '/bootstrap/' %}
+
 {%- elif salt['file.file_exists' ]('/etc/centos-release') %}
 {# We try CentOS bootstrap repository first. Failback to RES #}
 {% set bootstrap_repo_url = 'https://' ~ salt['pillar.get']('mgr_server') ~ '/pub/repositories/centos/' ~ grains['osmajorrelease'] ~ '/bootstrap/' %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Fix detection of CentOS systems to properly set bootstrap repo (bsc#1173556)
 - Do not produce syntax error on custom ssh_agent Salt module when
   executing on Python 2 instance.
 


### PR DESCRIPTION
## What does this PR change?

This PR changes the bootstrap procedure for CentOS systems to properly set the bootstrap repository and avoid possible issues depending on the particular scenario.

- Preserve same previous behavior for RHEL instances.
- Check `/etc/centos-release` to determine whether the instance is CentOS or not.
- In case of a CentOS instance, use "centos" bootstrap repo. If it does not exist, then failback to use "res" bootstrap repo. 
- Take care of the special case of SLES_ES 6, as we already do in the bootstrap script.
- Align bootstrap SLS and bootstrap script behavior

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**
- [x] **DONE**

## Test coverage
- No tests: **manually tested by QA**
- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
