### PR TITLE
Jmock update

### DIFF
--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -113,7 +113,7 @@
         <dependency org="javax.xml.bind" name="jaxb-api" rev="2.3.0" transitive="false"/>
         <dependency org="com.sun.xml.bind" name="jaxb-core" rev="2.3.0" transitive="false"/>
         <dependency org="com.sun.xml.bind" name="jaxb-impl" rev="2.3.0" transitive="false"/>
-        <dependency org="junit" name="junit" rev="3.8.2" transitive="false"/>
+        <dependency org="suse" name="junit" rev="4.12" transitive="false"/>
         <dependency org="org.jmock" name="jmock" rev="2.6.0" transitive="false"/>
         <dependency org="org.jmock" name="jmock-junit3" rev="2.6.0" transitive="false"/>
         <dependency org="org.jmock" name="jmock-legacy" rev="2.6.0" transitive="false"/>

--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -3,7 +3,7 @@
     <dependencies>
         <!-- Runtime dependencies -->
         <dependency org="suse" name="antlr" rev="2.7.7" />
-        <dependency org="suse" name="asm" rev="3.3.2" />
+        <dependency org="suse" name="asm" rev="5.2" />
         <dependency org="suse" name="bcel" rev="5.2" />
         <dependency org="suse" name="byte-buddy" rev="1.8.17" />
         <dependency org="suse" name="c3p0" rev="0.9.5.2" />

--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -3,24 +3,24 @@
     <dependencies>
         <!-- Runtime dependencies -->
         <dependency org="suse" name="antlr" rev="2.7.7" />
-        <dependency org="suse" name="asm" rev="3.3.1" />
+        <dependency org="suse" name="asm" rev="3.3.2" />
         <dependency org="suse" name="bcel" rev="5.2" />
         <dependency org="suse" name="byte-buddy" rev="1.8.17" />
         <dependency org="suse" name="c3p0" rev="0.9.5.2" />
-        <dependency org="suse" name="cglib" rev="2.2" />
+        <dependency org="suse" name="cglib" rev="3.2.4" />
         <dependency org="suse" name="classmate" rev="1.3.4" />
         <dependency org="suse" name="classpathx-mail-1.3.1-monolithic" rev="1.1.2" />
-        <dependency org="suse" name="commons-beanutils" rev="1.9.2" />
-        <dependency org="suse" name="commons-cli" rev="1.2" />
-        <dependency org="suse" name="commons-codec" rev="1.10" />
+        <dependency org="suse" name="commons-beanutils" rev="1.9.4" />
+        <dependency org="suse" name="commons-cli" rev="1.4" />
+        <dependency org="suse" name="commons-codec" rev="1.11" />
         <dependency org="suse" name="commons-collections" rev="3.2.2" />
         <dependency org="suse" name="commons-digester" rev="1.7" />
         <dependency org="suse" name="commons-discovery" rev="0.4" />
         <dependency org="suse" name="commons-el" rev="1.0" />
         <dependency org="suse" name="commons-fileupload" rev="1.1.1" />
-        <dependency org="suse" name="commons-io" rev="2.4" />
+        <dependency org="suse" name="commons-io" rev="2.6" />
         <dependency org="suse" name="commons-jexl" rev="2.1.1" />
-        <dependency org="suse" name="commons-lang3" rev="3.4" />
+        <dependency org="suse" name="commons-lang3" rev="3.8.1" />
         <dependency org="suse" name="commons-logging" rev="1.2" />
         <dependency org="suse" name="commons-validator" rev="1.3.1" />
         <dependency org="suse" name="concurrent" rev="1.3.4" />
@@ -28,16 +28,16 @@
         <dependency org="suse" name="dom4j" rev="1.6.1" />
         <dependency org="suse" name="dwr" rev="3.0.2" />
         <dependency org="suse" name="ehcache-core" rev="2.10.1" />
-        <dependency org="suse" name="geronimo-jta-1.1-api" rev="1.1.0" />
-        <dependency org="suse" name="google-gson" rev="2.8.2" />
+        <dependency org="suse" name="geronimo-jta-1.1-api" rev="1.2" />
+        <dependency org="suse" name="google-gson" rev="2.8.5" />
         <dependency org="suse" name="hibernate-c3p0" rev="5.3.7" />
         <dependency org="suse" name="hibernate-commons-annotations" rev="5.0.4" />
         <dependency org="suse" name="hibernate-core" rev="5.3.7" />
         <dependency org="suse" name="hibernate-ehcache" rev="5.3.7" />
         <dependency org="suse" name="httpasyncclient" rev="4.1.4" />
-        <dependency org="suse" name="httpclient" rev="4.5" />
-        <dependency org="suse" name="httpcore" rev="4.4.1" />
-        <dependency org="suse" name="httpcore-nio" rev="4.4.1" />
+        <dependency org="suse" name="httpclient" rev="4.5.6" />
+        <dependency org="suse" name="httpcore" rev="4.4.10" />
+        <dependency org="suse" name="httpcore-nio" rev="4.4.10" />
         <dependency org="suse" name="jade4j" rev="1.0.7" />
         <dependency org="suse" name="jaf" rev="1.1.1" />
         <dependency org="suse" name="jakarta-persistence-api" rev="2.2.2" />
@@ -46,10 +46,10 @@
         <dependency org="suse" name="javassist" rev="3.20.0" />
         <dependency org="suse" name="jboss-logging" rev="3.3.0" />
         <dependency org="suse" name="jcommon" rev="1.0.16" />
-        <dependency org="suse" name="jdom" rev="1.1" />
+        <dependency org="suse" name="jdom" rev="1.1.3" />
         <dependency org="suse" name="joda-time" rev="2.10.1" />
         <dependency org="suse" name="jose4j" rev="0.5.1" />
-        <dependency org="suse" name="log4j" rev="1.2.17" />
+        <dependency org="suse" name="log4j" rev="1.2.12" />
         <dependency org="suse" name="jsch" rev="0.1.55" />
         <dependency org="suse" name="netty-buffer" rev="4.1.44.Final" />
         <dependency org="suse" name="netty-codec" rev="4.1.44.Final" />
@@ -72,8 +72,8 @@
         <dependency org="suse" name="simple-core" rev="3.1.3" />
         <dependency org="suse" name="simple-xml" rev="2.6.2" />
         <dependency org="suse" name="sitemesh" rev="2.1" />
-        <dependency org="suse" name="slf4j-api" rev="1.7.12" />
-        <dependency org="suse" name="slf4j-log4j12" rev="1.7.12" />
+        <dependency org="suse" name="slf4j-api" rev="1.7.30" />
+        <dependency org="suse" name="slf4j-log4j12" rev="1.7.30" />
         <dependency org="suse" name="snakeyaml" rev="1.10" />
         <dependency org="suse" name="spark-core" rev="2.7.2" />
         <dependency org="suse" name="spark-template-jade" rev="2.3" />
@@ -89,7 +89,7 @@
         <dependency org="suse" name="woodstox-core-asl" rev="4.4.2" />
         <dependency org="suse" name="xalan-j2" rev="2.7.2" />
         <dependency org="suse" name="xalan-j2-serializer" rev="2.7.2" />
-        <dependency org="suse" name="xerces-j2" rev="2.11.0" />
+        <dependency org="suse" name="xerces-j2" rev="2.12.0" />
         <dependency org="suse" name="xmlsec" rev="2.0.7" />
         <dependency org="suse" name="velocity" rev="1.5" />
 
@@ -97,12 +97,12 @@
         <!-- <dependency org="suse" name="commons-lang" rev="2.6" /> -->
 
         <!-- Tomcat jars -->
-        <dependency org="suse" name="jasper" rev="9.0.14" />
-        <dependency org="suse" name="jasper-el" rev="9.0.14" />
-        <dependency org="suse" name="tomcat-el-3.0-api" rev="9.0.14" />
-        <dependency org="suse" name="tomcat-jsp-2.3-api" rev="9.0.14" />
-        <dependency org="suse" name="tomcat-juli" rev="9.0.14" />
-        <dependency org="suse" name="tomcat-servlet-4.0-api" rev="9.0.14" />
+        <dependency org="suse" name="jasper" rev="9.0.35" />
+        <dependency org="suse" name="jasper-el" rev="9.0.35" />
+        <dependency org="suse" name="tomcat-el-3.0-api" rev="9.0.35" />
+        <dependency org="suse" name="tomcat-jsp-2.3-api" rev="9.0.35" />
+        <dependency org="suse" name="tomcat-juli" rev="9.0.35" />
+        <dependency org="suse" name="tomcat-servlet-4.0-api" rev="9.0.35" />
 
         <!-- Compilation and testing -->
         <dependency org="checkstyle" name="checkstyle" rev="8.30" transitive="false">

--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -114,9 +114,10 @@
         <dependency org="com.sun.xml.bind" name="jaxb-core" rev="2.3.0" transitive="false"/>
         <dependency org="com.sun.xml.bind" name="jaxb-impl" rev="2.3.0" transitive="false"/>
         <dependency org="suse" name="junit" rev="4.12" transitive="false"/>
-        <dependency org="org.jmock" name="jmock" rev="2.6.0" transitive="false"/>
-        <dependency org="org.jmock" name="jmock-junit3" rev="2.6.0" transitive="false"/>
-        <dependency org="org.jmock" name="jmock-legacy" rev="2.6.0" transitive="false"/>
+        <dependency org="org.jmock" name="jmock" rev="2.12.0" transitive="false"/>
+        <dependency org="org.jmock" name="jmock-junit4" rev="2.12.0" transitive="false"/>
+        <dependency org="org.jmock" name="jmock-imposters" rev="2.12.0" transitive="false"/>
+        <dependency org="org.jmock" name="jmock-legacy" rev="2.12.0" transitive="false"/>
         <dependency org="mockobjects" name="mockobjects-core" rev="0.09" transitive="false"/>
         <dependency org="mockobjects" name="mockobjects-jdk1.4-j2ee1.3" rev="0.09" transitive="false"/>
         <dependency org="org.objenesis" name="objenesis" rev="1.0" transitive="false"/>

--- a/java/buildconf/ivy/obs-maven-config.yaml
+++ b/java/buildconf/ivy/obs-maven-config.yaml
@@ -333,3 +333,6 @@ artifacts:
     rpm: hamcrest-[0-9]+
     jar: hamcrest/library
     repository: Leap
+  - artifact: junit
+    package: junit
+    repository: Leap

--- a/java/buildconf/ivy/obs-maven-config.yaml
+++ b/java/buildconf/ivy/obs-maven-config.yaml
@@ -1,13 +1,13 @@
 repositories:
   Leap:
-    project: openSUSE:Leap:15.1
+    project: openSUSE:Leap:15.2
     repository: standard
   Uyuni_Other:
     project: systemsmanagement:Uyuni:Master:Other
-    repository: openSUSE_Leap_15.1
+    repository: openSUSE_Leap_15.2
   Uyuni:
     project: systemsmanagement:Uyuni:Master
-    repository: openSUSE_Leap_15.1
+    repository: openSUSE_Leap_15.2
 artifacts:
   - artifact: asm
     package: asm3
@@ -22,6 +22,7 @@ artifacts:
   - artifact: c3p0
     repository: Uyuni_Other
   - artifact: cglib
+    jar: cglib.jar
     repository: Leap
   - artifact: classmate
     repository: Uyuni_Other
@@ -87,7 +88,7 @@ artifacts:
     rpm: geronimo-jta-1_1
     repository: Leap
   - artifact: google-gson
-    repository: Uyuni_Other
+    repository: Leap
   - artifact: hibernate-c3p0
     package: hibernate5
     jar: hibernate-c3p0
@@ -108,16 +109,17 @@ artifacts:
     repository: Uyuni_Other
   - artifact: httpclient
     package: httpcomponents-client
-    jar: httpclient-[0-9.]+
-    repository: Uyuni_Other
+    rpm: httpcomponents-client-[0-9]+
+    jar: httpclient
+    repository: Leap
   - artifact: httpcore
     package: httpcomponents-core
-    jar: httpcore-[0-9.]+
-    repository: Uyuni_Other
+    jar: httpcore.jar
+    repository: Leap
   - artifact: httpcore-nio
     package: httpcomponents-core
     jar: httpcore-nio
-    repository: Uyuni_Other
+    repository: Leap
   - artifact: jade4j
     repository: Uyuni_Other
   - artifact: jaf
@@ -147,6 +149,7 @@ artifacts:
   - artifact: jose4j
     repository: Uyuni_Other
   - artifact: log4j
+    package: log4j12
     repository: Leap
   - artifact: jsch
     repository: Uyuni_Other
@@ -172,7 +175,7 @@ artifacts:
     repository: Uyuni_Other
   - artifact: netty-transport
     package: netty
-    jar: netty-transport
+    jar: netty-transport-[0-9]
     repository: Uyuni_Other
   - artifact: netty-transport-native-unix-common
     package: netty
@@ -222,11 +225,13 @@ artifacts:
   - artifact: sitemesh
     repository: Uyuni_Other
   - artifact: slf4j-api
+    rpm: slf4j-[0-9]+
     package: slf4j
     jar: api
     repository: Leap
   - artifact: slf4j-log4j12
     package: slf4j
+    rpm: slf4j-log4j12
     jar: log4j12
     repository: Leap
   - artifact: snakeyaml
@@ -281,7 +286,6 @@ artifacts:
     repository: Leap
   - artifact: xerces-j2
     rpm: xerces-j2-[0-9.]+
-    jar: xerces-j2-[0-9.]+
     repository: Leap
   - artifact: xmlsec
     repository: Uyuni_Other
@@ -322,9 +326,10 @@ artifacts:
 
   - artifact: hamcrest-core
     package: hamcrest
-    jar: hamcrest/core
+    rpm: hamcrest-core
     repository: Leap
   - artifact: hamcrest-library
     package: hamcrest
+    rpm: hamcrest-[0-9]+
     jar: hamcrest/library
     repository: Leap

--- a/java/buildconf/ivy/obs-maven-config.yaml
+++ b/java/buildconf/ivy/obs-maven-config.yaml
@@ -10,8 +10,8 @@ repositories:
     repository: openSUSE_Leap_15.2
 artifacts:
   - artifact: asm
-    package: asm3
-    jar: asm3-all
+    package: asm5
+    jar: asm5-all
     repository: Leap
   - artifact: antlr
     repository: Leap

--- a/java/code/src/com/redhat/rhn/common/errors/test/BadParameterExceptionHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/common/errors/test/BadParameterExceptionHandlerTest.java
@@ -20,6 +20,7 @@ import com.redhat.rhn.common.messaging.MessageQueue;
 import com.redhat.rhn.frontend.action.common.BadParameterException;
 import com.redhat.rhn.frontend.events.TraceBackAction;
 import com.redhat.rhn.frontend.events.TraceBackEvent;
+import com.redhat.rhn.testing.RhnJmockBaseTestCase;
 import com.redhat.rhn.testing.RhnMockDynaActionForm;
 import com.redhat.rhn.testing.RhnMockHttpServletRequest;
 import com.redhat.rhn.testing.RhnMockHttpServletResponse;
@@ -31,7 +32,7 @@ import org.apache.struts.action.ActionForward;
 import org.apache.struts.action.ActionMapping;
 import org.apache.struts.config.ExceptionConfig;
 import org.jmock.Expectations;
-import org.jmock.integration.junit3.MockObjectTestCase;
+import org.jmock.Mockery;
 import org.jmock.lib.legacy.ClassImposteriser;
 
 import java.util.Vector;
@@ -40,8 +41,9 @@ import java.util.Vector;
  * BadParameterExceptionHandlerTest
  * @version $Rev$
  */
-public class BadParameterExceptionHandlerTest extends MockObjectTestCase {
+public class BadParameterExceptionHandlerTest extends RhnJmockBaseTestCase {
 
+    protected Mockery context = new Mockery();
     private TraceBackAction tba;
 
     public void setUp() throws Exception {

--- a/java/code/src/com/redhat/rhn/common/errors/test/LookupExceptionHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/common/errors/test/LookupExceptionHandlerTest.java
@@ -20,6 +20,7 @@ import com.redhat.rhn.common.hibernate.LookupException;
 import com.redhat.rhn.common.messaging.MessageQueue;
 import com.redhat.rhn.frontend.events.TraceBackAction;
 import com.redhat.rhn.frontend.events.TraceBackEvent;
+import com.redhat.rhn.testing.RhnJmockBaseTestCase;
 import com.redhat.rhn.testing.RhnMockDynaActionForm;
 import com.redhat.rhn.testing.RhnMockHttpServletRequest;
 import com.redhat.rhn.testing.RhnMockHttpServletResponse;
@@ -31,7 +32,6 @@ import org.apache.struts.action.ActionForward;
 import org.apache.struts.action.ActionMapping;
 import org.apache.struts.config.ExceptionConfig;
 import org.jmock.Expectations;
-import org.jmock.integration.junit3.MockObjectTestCase;
 import org.jmock.lib.legacy.ClassImposteriser;
 
 import java.util.Vector;
@@ -40,7 +40,7 @@ import java.util.Vector;
  * LookupExceptionHandlerTest
  * @version $Rev$
  */
-public class LookupExceptionHandlerTest extends MockObjectTestCase {
+public class LookupExceptionHandlerTest extends RhnJmockBaseTestCase {
 
     private TraceBackAction tba;
 

--- a/java/code/src/com/redhat/rhn/common/errors/test/PermissionExceptionHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/common/errors/test/PermissionExceptionHandlerTest.java
@@ -20,6 +20,7 @@ import com.redhat.rhn.common.messaging.MessageQueue;
 import com.redhat.rhn.common.security.PermissionException;
 import com.redhat.rhn.frontend.events.TraceBackAction;
 import com.redhat.rhn.frontend.events.TraceBackEvent;
+import com.redhat.rhn.testing.RhnJmockBaseTestCase;
 import com.redhat.rhn.testing.RhnMockDynaActionForm;
 import com.redhat.rhn.testing.RhnMockHttpServletRequest;
 import com.redhat.rhn.testing.RhnMockHttpServletResponse;
@@ -31,7 +32,6 @@ import org.apache.struts.action.ActionForward;
 import org.apache.struts.action.ActionMapping;
 import org.apache.struts.config.ExceptionConfig;
 import org.jmock.Expectations;
-import org.jmock.integration.junit3.MockObjectTestCase;
 import org.jmock.lib.legacy.ClassImposteriser;
 
 import java.util.Vector;
@@ -40,7 +40,7 @@ import java.util.Vector;
  * PermissionExceptionHandlerTest
  * @version $Rev$
  */
-public class PermissionExceptionHandlerTest extends MockObjectTestCase {
+public class PermissionExceptionHandlerTest extends RhnJmockBaseTestCase {
 
     private TraceBackAction tba;
 

--- a/java/code/src/com/redhat/rhn/common/util/test/ServletUtilsTest.java
+++ b/java/code/src/com/redhat/rhn/common/util/test/ServletUtilsTest.java
@@ -16,11 +16,11 @@
 package com.redhat.rhn.common.util.test;
 
 import com.redhat.rhn.common.util.ServletUtils;
+import com.redhat.rhn.testing.RhnJmockBaseTestCase;
 import com.redhat.rhn.testing.RhnMockHttpServletRequest;
 import com.redhat.rhn.testing.ServletTestUtils;
 
 import org.jmock.Expectations;
-import org.jmock.integration.junit3.MockObjectTestCase;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
@@ -37,7 +37,7 @@ import java.util.Vector;
 
 import javax.servlet.http.HttpServletRequest;
 
-public class ServletUtilsTest extends MockObjectTestCase {
+public class ServletUtilsTest extends RhnJmockBaseTestCase {
 
     private HttpServletRequest mockRequest;
 

--- a/java/code/src/com/redhat/rhn/domain/image/test/ImageInfoFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/image/test/ImageInfoFactoryTest.java
@@ -44,9 +44,7 @@ import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
 import com.redhat.rhn.domain.token.ActivationKey;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
-import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
-import com.redhat.rhn.manager.system.entitling.SystemEntitler;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
@@ -59,7 +57,6 @@ import com.suse.manager.webui.utils.salt.custom.ImageChecksum;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
-import org.jmock.integration.junit3.JUnit3Mockery;
 import org.jmock.lib.concurrent.Synchroniser;
 import org.jmock.lib.legacy.ClassImposteriser;
 
@@ -73,7 +70,7 @@ import java.util.Set;
 
 public class ImageInfoFactoryTest extends BaseTestCaseWithUser {
 
-    private static final Mockery CONTEXT = new JUnit3Mockery() {{
+    private static final Mockery CONTEXT = new Mockery() {{
         setThreadingPolicy(new Synchroniser());
     }};
 

--- a/java/code/src/com/redhat/rhn/frontend/action/errata/test/AffectedSystemsActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/errata/test/AffectedSystemsActionTest.java
@@ -26,6 +26,7 @@ import com.redhat.rhn.frontend.action.errata.AffectedSystemsAction;
 import com.redhat.rhn.frontend.struts.RequestContext.Pagination;
 import com.redhat.rhn.frontend.struts.RhnHelper;
 import com.redhat.rhn.testing.ActionHelper;
+import com.redhat.rhn.testing.RhnJmockBaseTestCase;
 import com.redhat.rhn.testing.RhnMockDynaActionForm;
 import com.redhat.rhn.testing.RhnMockHttpServletRequest;
 import com.redhat.rhn.testing.RhnMockHttpServletResponse;
@@ -34,14 +35,13 @@ import com.redhat.rhn.testing.TestUtils;
 import org.apache.struts.action.ActionForward;
 import org.apache.struts.action.ActionMapping;
 import org.jmock.Expectations;
-import org.jmock.integration.junit3.MockObjectTestCase;
 import org.jmock.lib.legacy.ClassImposteriser;
 
 /**
  * AffectedSystemsActionTest
  * @version $Rev$
  */
-public class AffectedSystemsActionTest extends MockObjectTestCase {
+public class AffectedSystemsActionTest extends RhnJmockBaseTestCase {
 
     @Override
     protected void setUp() throws Exception {

--- a/java/code/src/com/redhat/rhn/frontend/security/test/AuthenticationServiceAbstractTestCase.java
+++ b/java/code/src/com/redhat/rhn/frontend/security/test/AuthenticationServiceAbstractTestCase.java
@@ -15,8 +15,7 @@
 package com.redhat.rhn.frontend.security.test;
 
 import com.redhat.rhn.frontend.servlets.PxtSessionDelegate;
-
-import org.jmock.integration.junit3.MockObjectTestCase;
+import com.redhat.rhn.testing.RhnJmockBaseTestCase;
 
 import java.util.Enumeration;
 import java.util.Vector;
@@ -30,7 +29,7 @@ import javax.servlet.http.HttpServletResponse;
  *
  * @version $Rev$
  */
-public abstract class AuthenticationServiceAbstractTestCase extends MockObjectTestCase {
+public abstract class AuthenticationServiceAbstractTestCase extends RhnJmockBaseTestCase {
 
     protected HttpServletRequest mockRequest;
     protected HttpServletResponse mockResponse;

--- a/java/code/src/com/redhat/rhn/frontend/servlets/test/AuthFilterTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/test/AuthFilterTest.java
@@ -16,11 +16,12 @@ package com.redhat.rhn.frontend.servlets.test;
 
 import com.redhat.rhn.frontend.security.AuthenticationService;
 import com.redhat.rhn.frontend.servlets.AuthFilter;
+import com.redhat.rhn.testing.RhnJmockBaseTestCase;
 
 import org.jmock.Expectations;
-import org.jmock.integration.junit3.MockObjectTestCase;
 
 import java.util.Vector;
+
 import javax.servlet.FilterChain;
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletException;
@@ -30,7 +31,7 @@ import javax.servlet.http.HttpServletResponse;
 /**
  * AuthFilterTest
  */
-public class AuthFilterTest extends MockObjectTestCase {
+public class AuthFilterTest extends RhnJmockBaseTestCase {
 
     private class AuthFilterStub extends AuthFilter {
         public void setAuthenticationService(AuthenticationService service) {

--- a/java/code/src/com/redhat/rhn/frontend/servlets/test/CreateRedirectURITest.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/test/CreateRedirectURITest.java
@@ -14,15 +14,17 @@
  */
 package com.redhat.rhn.frontend.servlets.test;
 
-import com.suse.manager.webui.utils.LoginHelper;
 import com.redhat.rhn.frontend.servlets.CreateRedirectURI;
+import com.redhat.rhn.testing.RhnJmockBaseTestCase;
+
+import com.suse.manager.webui.utils.LoginHelper;
 
 import org.apache.commons.lang3.StringUtils;
 import org.jmock.Expectations;
-import org.jmock.integration.junit3.MockObjectTestCase;
 
 import java.net.URLEncoder;
 import java.util.Vector;
+
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -53,7 +55,7 @@ import javax.servlet.http.HttpServletRequest;
 /**
  * CreateRedirectURITest
  */
-public class CreateRedirectURITest extends MockObjectTestCase {
+public class CreateRedirectURITest extends RhnJmockBaseTestCase {
 
     private HttpServletRequest mockRequest;
 

--- a/java/code/src/com/redhat/rhn/frontend/servlets/test/PxtCookieManagerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/test/PxtCookieManagerTest.java
@@ -17,9 +17,9 @@ package com.redhat.rhn.frontend.servlets.test;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.frontend.servlets.PxtCookieManager;
 import com.redhat.rhn.manager.session.SessionManager;
+import com.redhat.rhn.testing.RhnJmockBaseTestCase;
 
 import org.jmock.Expectations;
-import org.jmock.integration.junit3.MockObjectTestCase;
 
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
@@ -29,7 +29,7 @@ import javax.servlet.http.HttpServletRequest;
  * PxtCookieManagerTest
  * @version $Rev$
  */
-public class PxtCookieManagerTest extends MockObjectTestCase {
+public class PxtCookieManagerTest extends RhnJmockBaseTestCase {
 
     private static final int TIMEOUT = 3600;
 

--- a/java/code/src/com/redhat/rhn/frontend/servlets/test/PxtSessionDelegateImplTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/test/PxtSessionDelegateImplTest.java
@@ -14,10 +14,10 @@
  */
 package com.redhat.rhn.frontend.servlets.test;
 
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
+import com.redhat.rhn.domain.session.WebSession;
+import com.redhat.rhn.frontend.servlets.PxtCookieManager;
+import com.redhat.rhn.frontend.servlets.PxtSessionDelegateImpl;
+import com.redhat.rhn.testing.RhnJmockBaseTestCase;
 
 import org.apache.commons.collections.Transformer;
 import org.apache.commons.collections.TransformerUtils;
@@ -26,17 +26,17 @@ import org.hamcrest.Factory;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 import org.jmock.Expectations;
-import org.jmock.integration.junit3.MockObjectTestCase;
 
-import com.redhat.rhn.domain.session.WebSession;
-import com.redhat.rhn.frontend.servlets.PxtCookieManager;
-import com.redhat.rhn.frontend.servlets.PxtSessionDelegateImpl;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
 
 /**
  * PxtSessionDelegateImplTest
  * @version $Rev$
  */
-public class PxtSessionDelegateImplTest extends MockObjectTestCase {
+public class PxtSessionDelegateImplTest extends RhnJmockBaseTestCase {
 
     private class PxtSessionDelegateImplStub extends PxtSessionDelegateImpl {
         private Transformer findPxtSessionByIdCallback;

--- a/java/code/src/com/redhat/rhn/frontend/servlets/test/RedirectServletTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/test/RedirectServletTest.java
@@ -15,9 +15,9 @@
 package com.redhat.rhn.frontend.servlets.test;
 
 import com.redhat.rhn.frontend.security.RedirectServlet;
+import com.redhat.rhn.testing.RhnJmockBaseTestCase;
 
 import org.jmock.Expectations;
-import org.jmock.integration.junit3.MockObjectTestCase;
 
 import java.io.IOException;
 import java.net.URLEncoder;
@@ -30,7 +30,7 @@ import javax.servlet.http.HttpServletResponse;
  * RedirectServletTest
  * @version $Rev$
  */
-public class RedirectServletTest extends MockObjectTestCase {
+public class RedirectServletTest extends RhnJmockBaseTestCase {
 
     private class RedirectServletStub extends RedirectServlet {
         public void doGet(HttpServletRequest request, HttpServletResponse response)

--- a/java/code/src/com/redhat/rhn/frontend/servlets/test/ResourceReloadServletTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/test/ResourceReloadServletTest.java
@@ -16,11 +16,11 @@ package com.redhat.rhn.frontend.servlets.test;
 
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.frontend.servlets.ResourceReloadServlet;
+import com.redhat.rhn.testing.RhnJmockBaseTestCase;
 
 import com.mockobjects.servlet.MockServletOutputStream;
 
 import org.jmock.Expectations;
-import org.jmock.integration.junit3.MockObjectTestCase;
 
 import java.io.IOException;
 
@@ -32,7 +32,7 @@ import javax.servlet.http.HttpServletResponse;
  * SessionFilterTest
  * @version $Rev: 51260 $
  */
-public class ResourceReloadServletTest extends MockObjectTestCase {
+public class ResourceReloadServletTest extends RhnJmockBaseTestCase {
 
     private HttpServletRequest request;
     private HttpServletResponse response;

--- a/java/code/src/com/redhat/rhn/frontend/servlets/test/RhnHttpServletRequestTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/test/RhnHttpServletRequestTest.java
@@ -15,17 +15,16 @@
 package com.redhat.rhn.frontend.servlets.test;
 
 import com.redhat.rhn.frontend.servlets.RhnHttpServletRequest;
+import com.redhat.rhn.testing.RhnJmockBaseTestCase;
 import com.redhat.rhn.testing.RhnMockHttpServletRequest;
 
 import com.mockobjects.servlet.MockHttpSession;
-
-import org.jmock.integration.junit3.MockObjectTestCase;
 
 /**
  * RhnHttpServletRequestTest
  * @version $Rev$
  */
-public class RhnHttpServletRequestTest extends MockObjectTestCase {
+public class RhnHttpServletRequestTest extends RhnJmockBaseTestCase {
     private RhnMockHttpServletRequest mockRequest;
     private RhnHttpServletRequest request;
 

--- a/java/code/src/com/redhat/rhn/frontend/servlets/test/SessionFilterTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/servlets/test/SessionFilterTest.java
@@ -16,10 +16,10 @@ package com.redhat.rhn.frontend.servlets.test;
 
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.frontend.servlets.SessionFilter;
+import com.redhat.rhn.testing.RhnJmockBaseTestCase;
 
 import org.hibernate.Session;
 import org.jmock.Expectations;
-import org.jmock.integration.junit3.MockObjectTestCase;
 
 import java.io.IOException;
 
@@ -32,7 +32,7 @@ import javax.servlet.http.HttpServletResponse;
  * SessionFilterTest
  * @version $Rev$
  */
-public class SessionFilterTest extends MockObjectTestCase {
+public class SessionFilterTest extends RhnJmockBaseTestCase {
 
     private HttpServletRequest request;
     private HttpServletResponse response;

--- a/java/code/src/com/redhat/rhn/frontend/struts/test/RequestContextTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/struts/test/RequestContextTest.java
@@ -17,14 +17,14 @@ package com.redhat.rhn.frontend.struts.test;
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.frontend.struts.RequestContext;
+import com.redhat.rhn.testing.RhnJmockBaseTestCase;
 import com.redhat.rhn.testing.RhnMockHttpServletRequest;
 import com.redhat.rhn.testing.RhnMockHttpServletResponse;
 import com.redhat.rhn.testing.RhnMockHttpSession;
 import com.redhat.rhn.testing.UserTestUtils;
+
 import com.suse.manager.webui.controllers.login.LoginController;
 import com.suse.manager.webui.utils.LoginHelper;
-
-import org.jmock.integration.junit3.MockObjectTestCase;
 
 import java.net.URI;
 import java.util.HashMap;
@@ -37,7 +37,7 @@ import spark.routematch.RouteMatch;
 /**
  * RequestContextTest
  */
-public class RequestContextTest extends MockObjectTestCase {
+public class RequestContextTest extends RhnJmockBaseTestCase {
 
     /**
      *

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/list/test/CSVTagTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/list/test/CSVTagTest.java
@@ -19,10 +19,10 @@ import com.redhat.rhn.frontend.action.CSVDownloadAction;
 import com.redhat.rhn.frontend.taglibs.list.CSVTag;
 import com.redhat.rhn.frontend.taglibs.list.ListSetTag;
 import com.redhat.rhn.testing.RhnBaseTestCase;
+import com.redhat.rhn.testing.RhnJmockBaseTestCase;
 import com.redhat.rhn.testing.RhnMockJspWriter;
 
 import org.jmock.Expectations;
-import org.jmock.integration.junit3.MockObjectTestCase;
 import org.jmock.lib.legacy.ClassImposteriser;
 
 import java.util.List;
@@ -32,7 +32,7 @@ import javax.servlet.http.HttpSession;
 import javax.servlet.jsp.PageContext;
 import javax.servlet.jsp.tagext.Tag;
 
-public class CSVTagTest extends MockObjectTestCase {
+public class CSVTagTest extends RhnJmockBaseTestCase {
     private ListSetTag lst;
     private CSVTag csv;
 

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/list/test/ListTagTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/list/test/ListTagTest.java
@@ -15,30 +15,30 @@
 
 package com.redhat.rhn.frontend.taglibs.list.test;
 
+import static org.hamcrest.Matchers.containsString;
+import static org.jmock.Expectations.returnValue;
+
 import com.redhat.rhn.common.util.test.CSVWriterTest;
 import com.redhat.rhn.domain.session.WebSession;
 import com.redhat.rhn.frontend.taglibs.list.ListCommand;
 import com.redhat.rhn.frontend.taglibs.list.ListSetTag;
 import com.redhat.rhn.frontend.taglibs.list.ListTag;
 import com.redhat.rhn.testing.RhnBaseTestCase;
+import com.redhat.rhn.testing.RhnJmockBaseTestCase;
 import com.redhat.rhn.testing.RhnMockJspWriter;
-import java.io.Writer;
 
 import org.jmock.Expectations;
 import org.jmock.api.Action;
-import org.jmock.integration.junit3.MockObjectTestCase;
 import org.jmock.lib.legacy.ClassImposteriser;
 
+import java.io.Writer;
 import java.util.List;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.jsp.PageContext;
 import javax.servlet.jsp.tagext.BodyTagSupport;
 
-import static org.hamcrest.Matchers.containsString;
-import static org.jmock.Expectations.returnValue;
-
-public class ListTagTest extends MockObjectTestCase {
+public class ListTagTest extends RhnJmockBaseTestCase {
     private ListSetTag lst;
     private ListTag lt;
 

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/test/ListDisplayTagTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/test/ListDisplayTagTest.java
@@ -20,13 +20,15 @@ import com.redhat.rhn.frontend.struts.RequestContext;
 import com.redhat.rhn.frontend.taglibs.ListDisplayTag;
 import com.redhat.rhn.frontend.taglibs.ListTag;
 import com.redhat.rhn.testing.RhnBaseTestCase;
+import com.redhat.rhn.testing.RhnJmockBaseTestCase;
 import com.redhat.rhn.testing.RhnMockJspWriter;
 import com.redhat.rhn.testing.RhnMockServletOutputStream;
+
 import org.jmock.Expectations;
-import org.jmock.integration.junit3.MockObjectTestCase;
 import org.jmock.lib.legacy.ClassImposteriser;
 
 import java.io.Writer;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.jsp.JspException;
@@ -37,7 +39,7 @@ import javax.servlet.jsp.tagext.Tag;
  * ColumnTagTest
  * @version $Rev: 59372 $
  */
-public class ListDisplayTagTest extends MockObjectTestCase {
+public class ListDisplayTagTest extends RhnJmockBaseTestCase {
 
     private ListDisplayTag ldt;
     private ListTag lt;

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/test/UnpagedListDisplayTagTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/test/UnpagedListDisplayTagTest.java
@@ -20,11 +20,11 @@ import com.redhat.rhn.frontend.struts.RequestContext;
 import com.redhat.rhn.frontend.taglibs.ListTag;
 import com.redhat.rhn.frontend.taglibs.UnpagedListDisplayTag;
 import com.redhat.rhn.testing.RhnBaseTestCase;
+import com.redhat.rhn.testing.RhnJmockBaseTestCase;
 import com.redhat.rhn.testing.RhnMockJspWriter;
 import com.redhat.rhn.testing.RhnMockServletOutputStream;
 
 import org.jmock.Expectations;
-import org.jmock.integration.junit3.MockObjectTestCase;
 import org.jmock.lib.legacy.ClassImposteriser;
 
 import javax.servlet.http.HttpServletRequest;
@@ -37,7 +37,7 @@ import javax.servlet.jsp.tagext.Tag;
  * UnpagedListDisplayTagTest
  * @version $Rev$
  */
-public class UnpagedListDisplayTagTest extends MockObjectTestCase {
+public class UnpagedListDisplayTagTest extends RhnJmockBaseTestCase {
     private UnpagedListDisplayTag ldt;
     private ListTag lt;
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/test/ChannelSoftwareHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/test/ChannelSoftwareHandlerTest.java
@@ -60,13 +60,14 @@ import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
+
 import com.suse.manager.webui.controllers.utils.RegularMinionBootstrapper;
 import com.suse.manager.webui.controllers.utils.SSHMinionBootstrapper;
 import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.manager.webui.services.impl.SaltService;
+
 import org.jmock.Expectations;
 import org.jmock.Mockery;
-import org.jmock.integration.junit3.JUnit3Mockery;
 import org.jmock.lib.concurrent.Synchroniser;
 import org.jmock.lib.legacy.ClassImposteriser;
 
@@ -100,7 +101,7 @@ public class ChannelSoftwareHandlerTest extends BaseHandlerTestCase {
     private SystemManager systemManager = new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON);
     private ChannelSoftwareHandler handler = new ChannelSoftwareHandler(taskomaticApi, xmlRpcSystemHelper);
     private ErrataHandler errataHandler = new ErrataHandler();
-    private final Mockery MOCK_CONTEXT = new JUnit3Mockery() {{
+    private final Mockery MOCK_CONTEXT = new Mockery() {{
         setThreadingPolicy(new Synchroniser());
         setImposteriser(ClassImposteriser.INSTANCE);
     }};

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/test/ImageInfoHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/test/ImageInfoHandlerTest.java
@@ -68,7 +68,6 @@ import com.suse.manager.webui.services.impl.runner.MgrUtilRunner;
 
 import org.jmock.Expectations;
 import org.jmock.Mockery;
-import org.jmock.integration.junit3.JUnit3Mockery;
 import org.jmock.lib.concurrent.Synchroniser;
 import org.jmock.lib.legacy.ClassImposteriser;
 
@@ -82,7 +81,7 @@ public class ImageInfoHandlerTest extends BaseHandlerTestCase {
 
     private ImageInfoHandler handler = new ImageInfoHandler();
 
-    private static final Mockery CONTEXT = new JUnit3Mockery() {{
+    private static final Mockery CONTEXT = new Mockery() {{
         setThreadingPolicy(new Synchroniser());
     }};
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/test/IssMasterSerializerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/test/IssMasterSerializerTest.java
@@ -15,25 +15,24 @@
 
 package com.redhat.rhn.frontend.xmlrpc.serializer.test;
 
+import com.redhat.rhn.domain.iss.IssFactory;
+import com.redhat.rhn.domain.iss.IssMaster;
+import com.redhat.rhn.domain.iss.IssMasterOrg;
+import com.redhat.rhn.frontend.xmlrpc.serializer.IssMasterOrgSerializer;
+import com.redhat.rhn.frontend.xmlrpc.serializer.IssMasterSerializer;
+import com.redhat.rhn.testing.RhnJmockBaseTestCase;
+import com.redhat.rhn.testing.TestUtils;
+
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.jmock.integration.junit3.MockObjectTestCase;
-
 import redstone.xmlrpc.XmlRpcException;
 import redstone.xmlrpc.XmlRpcSerializer;
 
-import com.redhat.rhn.domain.iss.IssFactory;
-import com.redhat.rhn.domain.iss.IssMaster;
-import com.redhat.rhn.domain.iss.IssMasterOrg;
-import com.redhat.rhn.frontend.xmlrpc.serializer.IssMasterOrgSerializer;
-import com.redhat.rhn.frontend.xmlrpc.serializer.IssMasterSerializer;
-import com.redhat.rhn.testing.TestUtils;
-
-public class IssMasterSerializerTest extends MockObjectTestCase {
+public class IssMasterSerializerTest extends RhnJmockBaseTestCase {
     private String[] masterOrgNames = {"masterOrg1", "masterOrg2", "masterOrg3"};
 
     public void testMasterSerialize() throws XmlRpcException, IOException {

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/test/ManagedServerGroupSerializerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/test/ManagedServerGroupSerializerTest.java
@@ -17,9 +17,9 @@ package com.redhat.rhn.frontend.xmlrpc.serializer.test;
 import com.redhat.rhn.domain.org.Org;
 import com.redhat.rhn.domain.server.ManagedServerGroup;
 import com.redhat.rhn.frontend.xmlrpc.serializer.ManagedServerGroupSerializer;
+import com.redhat.rhn.testing.RhnJmockBaseTestCase;
 
 import org.jmock.Expectations;
-import org.jmock.integration.junit3.MockObjectTestCase;
 import org.jmock.lib.legacy.ClassImposteriser;
 
 import java.io.StringWriter;
@@ -28,7 +28,7 @@ import java.io.Writer;
 import redstone.xmlrpc.XmlRpcSerializer;
 
 
-public class ManagedServerGroupSerializerTest extends MockObjectTestCase {
+public class ManagedServerGroupSerializerTest extends RhnJmockBaseTestCase {
 
     private XmlRpcSerializer serializer;
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/test/OrgSerializerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/test/OrgSerializerTest.java
@@ -16,9 +16,8 @@ package com.redhat.rhn.frontend.xmlrpc.serializer.test;
 
 import com.redhat.rhn.domain.org.Org;
 import com.redhat.rhn.frontend.xmlrpc.serializer.OrgSerializer;
+import com.redhat.rhn.testing.RhnJmockBaseTestCase;
 import com.redhat.rhn.testing.UserTestUtils;
-
-import org.jmock.integration.junit3.MockObjectTestCase;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -28,7 +27,7 @@ import redstone.xmlrpc.XmlRpcException;
 import redstone.xmlrpc.XmlRpcSerializer;
 
 
-public class OrgSerializerTest extends MockObjectTestCase {
+public class OrgSerializerTest extends RhnJmockBaseTestCase {
 
     public void testSerialize() throws XmlRpcException, IOException {
         OrgSerializer os = new OrgSerializer();

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/config/test/ServerConfigHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/config/test/ServerConfigHandlerTest.java
@@ -46,13 +46,14 @@ import com.redhat.rhn.manager.system.test.SystemManagerTest;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.testing.ConfigTestUtils;
 import com.redhat.rhn.testing.TestUtils;
+
 import com.suse.manager.webui.controllers.utils.RegularMinionBootstrapper;
 import com.suse.manager.webui.controllers.utils.SSHMinionBootstrapper;
 import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.manager.webui.services.impl.SaltService;
+
 import org.jmock.Expectations;
 import org.jmock.Mockery;
-import org.jmock.integration.junit3.JUnit3Mockery;
 import org.jmock.lib.concurrent.Synchroniser;
 import org.jmock.lib.legacy.ClassImposteriser;
 
@@ -79,7 +80,7 @@ public class ServerConfigHandlerTest extends BaseHandlerTestCase {
             sshMinionBootstrapper
     );
     private ServerConfigHandler handler = new ServerConfigHandler(taskomaticApi, xmlRpcSystemHelper);
-    private final Mockery MOCK_CONTEXT = new JUnit3Mockery() {{
+    private final Mockery MOCK_CONTEXT = new Mockery() {{
         setThreadingPolicy(new Synchroniser());
         setImposteriser(ClassImposteriser.INSTANCE);
     }};

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
@@ -147,7 +147,6 @@ import com.suse.manager.webui.services.impl.SaltService;
 import org.apache.commons.lang3.StringUtils;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
-import org.jmock.integration.junit3.JUnit3Mockery;
 import org.jmock.lib.concurrent.Synchroniser;
 import org.jmock.lib.legacy.ClassImposteriser;
 
@@ -184,7 +183,7 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
     private SystemHandler handler =
             new SystemHandler(taskomaticApi, xmlRpcSystemHelper, systemEntitlementManager, systemManager);
 
-    private final Mockery MOCK_CONTEXT = new JUnit3Mockery() {{
+    private final Mockery MOCK_CONTEXT = new Mockery() {{
         setThreadingPolicy(new Synchroniser());
         setImposteriser(ClassImposteriser.INSTANCE);
     }};

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/test/XmlRpcServletTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/test/XmlRpcServletTest.java
@@ -17,14 +17,13 @@ package com.redhat.rhn.frontend.xmlrpc.test;
 
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.user.User;
-import com.redhat.rhn.frontend.xmlrpc.HandlerFactory;
 import com.redhat.rhn.frontend.xmlrpc.XmlRpcServlet;
+import com.redhat.rhn.testing.RhnJmockBaseTestCase;
 import com.redhat.rhn.testing.UserTestUtils;
 
 import com.mockobjects.servlet.MockServletInputStream;
 
 import org.jmock.Expectations;
-import org.jmock.integration.junit3.MockObjectTestCase;
 
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -33,7 +32,7 @@ import java.util.Random;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-public class XmlRpcServletTest extends MockObjectTestCase {
+public class XmlRpcServletTest extends RhnJmockBaseTestCase {
 
     protected void setUp() throws Exception {
         super.setUp();

--- a/java/code/src/com/redhat/rhn/manager/action/test/ActionManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/action/test/ActionManagerTest.java
@@ -100,7 +100,6 @@ import org.hibernate.Session;
 import org.hibernate.query.Query;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
-import org.jmock.integration.junit3.JUnit3Mockery;
 import org.jmock.lib.concurrent.Synchroniser;
 import org.jmock.lib.legacy.ClassImposteriser;
 
@@ -127,7 +126,7 @@ public class ActionManagerTest extends JMockBaseTestCaseWithUser {
     private static TaskomaticApi taskomaticApi;
     private SystemEntitlementManager systemEntitlementManager = SystemEntitlementManager.INSTANCE;
 
-    private final Mockery MOCK_CONTEXT = new JUnit3Mockery() {{
+    private final Mockery MOCK_CONTEXT = new Mockery() {{
         setThreadingPolicy(new Synchroniser());
         setImposteriser(ClassImposteriser.INSTANCE);
     }};

--- a/java/code/src/com/redhat/rhn/manager/channel/test/ChannelManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/test/ChannelManagerTest.java
@@ -17,7 +17,6 @@ package com.redhat.rhn.manager.channel.test;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.db.datasource.DataResult;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
-import com.redhat.rhn.common.security.PermissionException;
 import com.redhat.rhn.common.validator.ValidatorException;
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.channel.AccessTokenFactory;
@@ -70,9 +69,9 @@ import com.redhat.rhn.testing.ChannelTestUtils;
 import com.redhat.rhn.testing.ServerTestUtils;
 import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
+
 import org.jmock.Expectations;
 import org.jmock.Mockery;
-import org.jmock.integration.junit3.JUnit3Mockery;
 import org.jmock.lib.concurrent.Synchroniser;
 import org.jmock.lib.legacy.ClassImposteriser;
 
@@ -94,7 +93,7 @@ public class ChannelManagerTest extends BaseTestCaseWithUser {
 
     private static final String TEST_OS = "TEST RHEL AS";
     private static final String MAP_RELEASE = "4AS";
-    private final Mockery MOCK_CONTEXT = new JUnit3Mockery() {{
+    private final Mockery MOCK_CONTEXT = new Mockery() {{
         setThreadingPolicy(new Synchroniser());
         setImposteriser(ClassImposteriser.INSTANCE);
     }};

--- a/java/code/src/com/redhat/rhn/manager/configuration/test/ConfigurationManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/configuration/test/ConfigurationManagerTest.java
@@ -63,7 +63,6 @@ import com.redhat.rhn.testing.UserTestUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
-import org.jmock.integration.junit3.JUnit3Mockery;
 import org.jmock.lib.concurrent.Synchroniser;
 import org.jmock.lib.legacy.ClassImposteriser;
 
@@ -85,7 +84,7 @@ public class ConfigurationManagerTest extends BaseTestCaseWithUser {
     private static final ConfigFileCount EXPECTED_COUNT =
                                     ConfigFileCount.create(3, 0, 1, 0);
 
-    private static final Mockery CONTEXT = new JUnit3Mockery() {{
+    private static final Mockery CONTEXT = new Mockery() {{
         setThreadingPolicy(new Synchroniser());
     }};
 

--- a/java/code/src/com/redhat/rhn/manager/distupgrade/test/DistUpgradeManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/distupgrade/test/DistUpgradeManagerTest.java
@@ -59,18 +59,24 @@ import com.redhat.rhn.testing.TestUtils;
 
 import org.jmock.Expectations;
 import org.jmock.Mockery;
-import org.jmock.integration.junit3.JUnit3Mockery;
 import org.jmock.lib.concurrent.Synchroniser;
 import org.jmock.lib.legacy.ClassImposteriser;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
 
 /**
  * Tests for {@link DistUpgradeManager} methods.
  */
 public class DistUpgradeManagerTest extends BaseTestCaseWithUser {
 
-    private static final Mockery CONTEXT = new JUnit3Mockery() {{
+    private static final Mockery CONTEXT = new Mockery() {{
         setThreadingPolicy(new Synchroniser());
     }};
 

--- a/java/code/src/com/redhat/rhn/manager/recurringactions/test/RecurringActionManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/recurringactions/test/RecurringActionManagerTest.java
@@ -27,7 +27,6 @@ import com.redhat.rhn.testing.UserTestUtils;
 
 import org.jmock.Expectations;
 import org.jmock.Mockery;
-import org.jmock.integration.junit3.JUnit3Mockery;
 import org.jmock.lib.concurrent.Synchroniser;
 import org.jmock.lib.legacy.ClassImposteriser;
 
@@ -38,7 +37,7 @@ import java.util.List;
  */
 public class RecurringActionManagerTest extends BaseTestCaseWithUser {
 
-    private static final Mockery CONTEXT = new JUnit3Mockery() {{
+    private static final Mockery CONTEXT = new Mockery() {{
         setThreadingPolicy(new Synchroniser());
     }};
 

--- a/java/code/src/com/redhat/rhn/testing/RhnJmockBaseTestCase.java
+++ b/java/code/src/com/redhat/rhn/testing/RhnJmockBaseTestCase.java
@@ -14,13 +14,27 @@
  */
 package com.redhat.rhn.testing;
 
-import org.jmock.integration.junit3.MockObjectTestCase;
+import org.jmock.Mockery;
+import org.jmock.api.Imposteriser;
+
+import junit.framework.TestCase;
 
 /**
  * RhnJmockBaseTestCase - This is the same thing as {@link RhnBaseTestCase}
- * but it extends from {@link MockObjectTestCase}.
+ * but it encapsulates a JMock context
  */
-public abstract class RhnJmockBaseTestCase extends MockObjectTestCase {
+public abstract class RhnJmockBaseTestCase extends TestCase {
+    protected Mockery context = new Mockery();
+
+    public RhnJmockBaseTestCase() {
+    }
+
+    /**
+     * @param name The test case name
+     */
+    public RhnJmockBaseTestCase(String name) {
+        super(name);
+    }
 
     /**
      * Called once per test method.
@@ -39,5 +53,25 @@ public abstract class RhnJmockBaseTestCase extends MockObjectTestCase {
     protected void tearDown() throws Exception {
         super.tearDown();
         TestCaseHelper.tearDownHelper();
+    }
+
+    protected Mockery context() {
+        return context;
+    }
+
+    protected void setImposteriser(Imposteriser imposteriser) {
+        context.setImposteriser(imposteriser);
+    }
+
+    protected <T> T mock(Class<T> typeToMock) {
+        return context.mock(typeToMock);
+    }
+
+    protected <T> T mock(Class<T> typeToMock, String name) {
+        return context.mock(typeToMock, name);
+    }
+
+    protected void verify() {
+        context.assertIsSatisfied();
     }
 }

--- a/java/code/src/com/suse/manager/webui/utils/gson/test/SaltMinionTestJson.java
+++ b/java/code/src/com/suse/manager/webui/utils/gson/test/SaltMinionTestJson.java
@@ -15,11 +15,12 @@
 
 package com.suse.manager.webui.utils.gson.test;
 
+import com.redhat.rhn.testing.RhnJmockBaseTestCase;
+
 import com.suse.manager.webui.utils.gson.SaltMinionJson;
 import com.suse.salt.netapi.calls.wheel.Key;
 
 import org.jmock.Expectations;
-import org.jmock.integration.junit3.MockObjectTestCase;
 import org.jmock.lib.legacy.ClassImposteriser;
 
 import java.util.HashMap;
@@ -29,7 +30,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
-public class SaltMinionTestJson extends MockObjectTestCase {
+public class SaltMinionTestJson extends RhnJmockBaseTestCase {
 
     @Override
     public void setUp() throws Exception {

--- a/java/code/src/com/suse/scc/client/test/SCCClientUtilTest.java
+++ b/java/code/src/com/suse/scc/client/test/SCCClientUtilTest.java
@@ -14,6 +14,7 @@
  */
 package com.suse.scc.client.test;
 
+import com.redhat.rhn.testing.RhnJmockBaseTestCase;
 import com.redhat.rhn.testing.TestUtils;
 
 import com.suse.scc.client.SCCClientUtils;
@@ -22,7 +23,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.jmock.Expectations;
-import org.jmock.integration.junit3.MockObjectTestCase;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
@@ -35,7 +35,7 @@ import java.net.URISyntaxException;
 /**
  * Tests {@link SCCClientUtils}
  */
-public class SCCClientUtilTest extends MockObjectTestCase {
+public class SCCClientUtilTest extends RhnJmockBaseTestCase {
 
     private static final String TEST_USER_NAME = "t";
     private static final String TEST_FILE_NAME =


### PR DESCRIPTION
## What does this PR change?

Update Jmock to latest version and use the junit4 integration rather than the junit3 one.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: test framework update

- [X] **DONE**

## Test coverage
- No tests: test framework update

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
