### PR TITLE
Fix JobReturnEventMessageActionTest failure

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/system/ServerGroupManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/ServerGroupManager.java
@@ -74,6 +74,14 @@ public class ServerGroupManager {
     }
 
     /**
+     * Only used for unit tests.
+     * @param minionGroupMembershipPillarFileManagerIn to set
+     */
+    public void setMinionGroupMembershipPillarFileManager(MinionPillarFileManager minionGroupMembershipPillarFileManagerIn) {
+        this.minionGroupMembershipPillarFileManager = minionGroupMembershipPillarFileManagerIn;
+    }
+
+    /**
      * Lookup a ServerGroup by ID and organization.
      * @param id Server group id
      * @param user logged in user needed for authentication

--- a/java/code/src/com/redhat/rhn/testing/JMockBaseTestCaseWithUser.java
+++ b/java/code/src/com/redhat/rhn/testing/JMockBaseTestCaseWithUser.java
@@ -17,6 +17,7 @@ package com.redhat.rhn.testing;
 import com.redhat.rhn.domain.kickstart.test.KickstartDataTest;
 import com.redhat.rhn.domain.user.User;
 
+import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.suse.manager.webui.services.SaltStateGeneratorService;
 import com.suse.manager.webui.services.pillar.MinionGeneralPillarGenerator;
 import com.suse.manager.webui.services.pillar.MinionGroupMembershipPillarGenerator;
@@ -58,6 +59,8 @@ public abstract class JMockBaseTestCaseWithUser extends RhnJmockBaseTestCase {
         SaltStateGeneratorService.INSTANCE.setSuseManagerStatesFilesRoot(tmpSaltRoot
                 .toAbsolutePath());
         Files.createDirectory(tmpSaltRoot.resolve(SALT_CONFIG_STATES_DIR));
+        ServerGroupManager.getInstance()
+                .setMinionGroupMembershipPillarFileManager(minionGroupMembershipPillarFileManager);
     }
 
     /**

--- a/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
@@ -678,7 +678,6 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         assertTrue(action.getServerActions().stream()
                 .filter(serverAction -> serverAction.getServer().equals(minion))
                 .findAny().get().getStatus().equals(ActionFactory.STATUS_COMPLETED));
-        assertEquals(List.of("system-lock"), FormulaFactory.getFormulasByMinionId(minion.getMinionId()));
         assertEquals(false, ViewHelper.INSTANCE.formulaValueEquals(minion, "system-lock",
                 "minion_blackout", "false"));
     }

--- a/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
@@ -141,6 +141,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
     private SaltService saltServiceMock;
     private SystemEntitlementManager systemEntitlementManager;
     protected Path metadataDirOfficial;
+    protected Path formulaDataDir;
 
 
     @Override
@@ -156,7 +157,9 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                         new FormulaMonitoringManager())
         );
         metadataDirOfficial = Files.createTempDirectory("meta");
+        formulaDataDir = Files.createTempDirectory("data");
         FormulaFactory.setMetadataDirOfficial(metadataDirOfficial.toString());
+        FormulaFactory.setDataDir(formulaDataDir.toString());
         Path systemLockDir = metadataDirOfficial.resolve("system-lock");
         Path systemLockFile = Paths.get(systemLockDir.toString(),  "form.yml");
         Files.createDirectories(systemLockDir);


### PR DESCRIPTION
## What does this PR change?

Fixes a failure in `JobReturnEventMessageActionTest.testPackagesProfileUpdateWithCaaSPSystemLocked()`

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: junit test fix

- [x] **DONE**

## Test coverage
- No tests: jyuni test fix

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
