### PR TITLE
Simplify disabling self update

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/common/DownloadFile.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/common/DownloadFile.java
@@ -619,7 +619,8 @@ public class DownloadFile extends DownloadAction {
             // my $dp = File::Spec->catfile($kickstart_mount, $tree->base_path, $path);
 
             if (child == null) {
-                if (path.contains("repodata/") && tree.getKernelOptions().contains("useonlinerepo")) {
+                if (path.contains("repodata/") && tree.getKernelOptions() != null &&
+                        tree.getKernelOptions().contains("useonlinerepo")) {
                     String[] split = StringUtils.split(path, '/');
                     if (split[0].equals("repodata")) {
                         split[0] = tree.getChannel().getLabel();

--- a/java/code/src/com/redhat/rhn/manager/kickstart/tree/TreeCreateOperation.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/tree/TreeCreateOperation.java
@@ -74,7 +74,7 @@ public class TreeCreateOperation extends BaseTreeEditOperation {
             }
             // disable YaST self update for SLE
             if (!kopts.contains("self_update=")) {
-                kOptsJoiner.add("self_update=0").add("pt.options=+self_update");
+                kOptsJoiner.add("self_update=0");
             }
         }
         else if (this.tree.getInstallType().isRhel8OrGreater()) {

--- a/java/code/src/com/redhat/rhn/manager/kickstart/tree/test/TreeCreateOperationTest.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/tree/test/TreeCreateOperationTest.java
@@ -48,7 +48,6 @@ public class TreeCreateOperationTest extends TreeOperationTestBase {
         cmd.store();
         assertContains(cmd.getKernelOptions(), "install=");
         assertContains(cmd.getKernelOptions(), "self_update=0");
-        assertContains(cmd.getKernelOptions(), "pt.options=+self_update");
     }
 
     public void testPopulateKernelOptsForSuseBreed() throws Exception {

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- fix NPE on auto installation when no kernel options are given (bsc#1173932)
 - fix issue with disabling self_update for autoyast autoupgrade (bsc#1170654)
 - Adapt expectations for jobs return events after switching Salt
   states to use 'mgrcompat.module_run' state.

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- fix issue with disabling self_update for autoyast autoupgrade (bsc#1170654)
 - Adapt expectations for jobs return events after switching Salt
   states to use 'mgrcompat.module_run' state.
 


### PR DESCRIPTION
## What does this PR change?

Changing the option pointer of linuxrc to disable yast self_update seems to be obsolete and create problems in some cases.
This PR simply remove this setting.

Additionally fixing a NPE introduced by https://github.com/uyuni-project/uyuni/pull/2344

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- Unit tests were adapted

- [x] **DONE**

## Links

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1170654
Tracks https://github.com/SUSE/spacewalk/pull/11869

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
