### PR TITLE
Prevent stuck Hardware Refresh actions on Salt 2016.11.10 based SSH minions (bsc#1173169)

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/hardware/profileupdate.sls
+++ b/susemanager-utils/susemanager-sls/salt/hardware/profileupdate.sls
@@ -129,6 +129,8 @@ mainframe-sysinfo:
       - mgrcompat: sync_states
 {%- endif %}
 {% endif %}
+
+{%- if grains['saltversioninfo'][0] >= 2018 %}
 {% if 'network.fqdns' in salt %}
 fqdns:
   mgrcompat.module_run:
@@ -140,6 +142,7 @@ fqdns:
       - mgrcompat: sync_states
 {%- endif %}
 {% endif%}
+{%- endif%}
 
 include:
   - util.syncstates

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Prevent stuck Hardware Refresh actions on Salt 2016.11.10 based SSH minions (bsc#1173169)
 - Require PyYAML version >= 5.1
 - Log out of Docker registries after image build (bsc#1165572)
 - Prevent "module.run" deprecation warnings by using custom mgrcompat module


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue happening on SSH minions using Python 2.6, like CentOS 6, RHEL 6 or SLE11SP4, where the Salt version used is 2016.11.10. The "Hardware Refresh" actions are pending forever.

This stacktrace is produce:

```
2020-06-19 15:08:04,461 [DefaultQuartzScheduler_Worker-7] ERROR com.redhat.rhn.taskomatic.task.MinionActionExecutor  - Executing a task threw an exception: java.lang.NullPointerException
2020-06-19 15:08:04,462 [DefaultQuartzScheduler_Worker-7] ERROR com.redhat.rhn.taskomatic.task.MinionActionExecutor  - Message: null
2020-06-19 15:08:04,462 [DefaultQuartzScheduler_Worker-7] ERROR com.redhat.rhn.taskomatic.task.MinionActionExecutor  - Cause: null
2020-06-19 15:08:04,462 [DefaultQuartzScheduler_Worker-7] ERROR com.redhat.rhn.taskomatic.task.MinionActionExecutor  - Stack trace:java.lang.NullPointerException
	at java.base/java.util.Objects.requireNonNull(Objects.java:221)
	at java.base/java.util.Optional.<init>(Optional.java:107)
	at java.base/java.util.Optional.of(Optional.java:120)
	at com.suse.manager.utils.SaltUtils.handleHardwareProfileUpdate(SaltUtils.java:1553)
	at com.suse.manager.utils.SaltUtils.lambda$updateServerAction$22(SaltUtils.java:624)
	at java.base/java.util.Optional.ifPresent(Optional.java:183)
	at com.suse.manager.utils.SaltUtils.updateServerAction(SaltUtils.java:623)
	at com.suse.manager.webui.services.SaltServerActionService.lambda$executeSSHAction$100(SaltServerActionService.java:2190)
	at java.base/java.util.Optional.ifPresent(Optional.java:183)
	at com.suse.manager.webui.services.SaltServerActionService.executeSSHAction(SaltServerActionService.java:2178)
	at com.suse.manager.webui.services.SaltServerActionService.execute(SaltServerActionService.java:476)
	at com.redhat.rhn.taskomatic.task.MinionActionExecutor.execute(MinionActionExecutor.java:125)
	at com.redhat.rhn.taskomatic.task.RhnJavaJob.execute(RhnJavaJob.java:88)
	at com.redhat.rhn.taskomatic.TaskoJob.execute(TaskoJob.java:199)
	at org.quartz.core.JobRunShell.run(JobRunShell.java:202)
	at org.quartz.simpl.SimpleThreadPool$WorkerThread.run(SimpleThreadPool.java:573)
```

It seems Salt 2016.11.10 does not evaluate properly Jinja magic like: `{% if 'network.fqdns' in salt %}` when the state runs in the context of Salt SSH, as we see the following as part of the return from the `hardware.profileupdate` state:

```
        "module_|-fqdns_|-network.fqdns_|-run": {
            "__id__": "fqdns",
            "__run_num__": 11,
            "changes": {},
            "comment": "Module function network.fqdns is not available",
            "duration": 5.491,
            "name": "network.fqdns",
            "result": false,
            "start_time": "11:59:24.847164"
        },
```

The same logic works as expected for normal minions.

So, this PR changes the `hardware.profileupdate` to not even try to check for the `network.fqdns` on Salt versions < 2018 where this feature was never backported. 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**
- [x] **DONE**

## Test coverage
- No tests: **bugfix**
- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/10626

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
