### PR TITLE
Testsuite: Add missing anchors in some step regexs

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1163,7 +1163,7 @@ When(/^I delete all "([^"]*)" volumes from "([^"]*)" pool on "([^"]*)" without e
   output.each_line { |volume| node.run("virsh vol-delete #{volume} #{pool}", false) }
 end
 
-When(/I refresh the "([^"]*)" storage pool of this "([^"]*)"/) do |pool, host|
+When(/^I refresh the "([^"]*)" storage pool of this "([^"]*)"$/) do |pool, host|
   node = get_target(host)
   node.run("virsh pool-refresh #{pool}")
 end

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -272,7 +272,7 @@ When(/^I attach the file "(.*)" to "(.*)"$/) do |path, field|
   attach_file(field, canonical_path)
 end
 
-When(/I view system with id "([^"]*)"/) do |arg1|
+When(/^I view system with id "([^"]*)"$/) do |arg1|
   visit Capybara.app_host + '/rhn/systems/details/Overview.do?sid=' + arg1
 end
 
@@ -461,7 +461,7 @@ When(/^I select "([^\"]*)" as a product$/) do |product|
   raise "xpath: #{xpath} not found" unless find(:xpath, xpath).set(true)
 end
 
-When(/I wait until the tree item "([^"]+)" has no sub-list/) do |item|
+When(/^I wait until the tree item "([^"]+)" has no sub-list$/) do |item|
   repeat_until_timeout(message: "could still find a sub list for tree item #{item}") do
     xpath = "//span[contains(text(), '#{item}')]/ancestor::div[contains(@class, 'product-details-wrapper')]/div/i[contains(@class, 'fa-angle-')]"
     begin


### PR DESCRIPTION
## What does this PR change?
Add missing anchors in some regexps matching steps.

The regexs matching the steps are prefixed with ^
and suffixed with $.
- testsuite/features/step_definitions/command_steps.rb
- testsuite/features/step_definitions/common_steps.rb


## Links
### Ports
- Manager-3.2: https://github.com/SUSE/spacewalk/pull/11865
- Manager-4.0: https://github.com/SUSE/spacewalk/pull/11866

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)
