### PR TITLE
Change the rest of the tests from PostgreSQL10 to PostgreSQL12

### DIFF
--- a/backend/test/docker-backend-pgsql-tests.sh
+++ b/backend/test/docker-backend-pgsql-tests.sh
@@ -1,10 +1,10 @@
 #! /bin/bash
 
 /sbin/sysctl -w kernel.shmmax=4067832832
-su - postgres -c '/usr/lib/postgresql10/bin/pg_ctl start'
+su - postgres -c '/usr/lib/postgresql12/bin/pg_ctl start'
 cp /root/rhn.conf /etc/rhn/rhn.conf
 mkdir -p /manager/backend/reports
 nosetests -v --with-xunit --xunit-file /manager/backend/reports/pgsql_tests.xml /manager/backend/test/runtests-postgresql.py
 EXIT=$?
-su - postgres -c '/usr/lib/postgresql10/bin/pg_ctl stop'
+su - postgres -c '/usr/lib/postgresql12/bin/pg_ctl stop'
 exit $?

--- a/java/scripts/docker-testing-pgsql.sh
+++ b/java/scripts/docker-testing-pgsql.sh
@@ -28,4 +28,4 @@ cp buildconf/test/rhn.conf.postgresql-example buildconf/test/rhn.conf
 ant -f manager-build.xml refresh-branding-jar $TARGET
 
 # Postgres shutdown (avoid stale memory by shmget())
-su - postgres -c "/usr/lib/postgresql10/bin/pg_ctl stop" ||:
+su - postgres -c "/usr/lib/postgresql12/bin/pg_ctl stop" ||:


### PR DESCRIPTION
## What does this PR change?

Change the rest of the tests from PostgreSQL10 to PostgreSQL12 (which is what Leap 15.2 uses)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: testing stuff.

- [x] **DONE**

## Test coverage
- No tests:  testing stuff.

- [x] **DONE**

## Links

None

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
