### PR TITLE
Bump API version again

### DIFF
--- a/java/conf/rhn_java.conf
+++ b/java/conf/rhn_java.conf
@@ -14,7 +14,7 @@ java.customer_service_email =
 java.development_environment = 0
 
 # the version of API
-java.apiversion = 23
+java.apiversion = 24
 
 # lifetime for sandboxes, in days
 java.sandbox_lifetime = 3

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- bump XMLRPC API version number to distinguish from Spacewalk 2.10
 - Cluster UI: return to overview page after scheduling actions
 - fix NPE on auto installation when no kernel options are given (bsc#1173932)
 - fix issue with disabling self_update for autoyast autoupgrade (bsc#1170654)


### PR DESCRIPTION
## What does this PR change?

It changes the API version number.

Version 23 collided with upstream Spacewalk 2.10, and this could break third party software relying on the API version number such as cefs.

References:
https://github.com/stevemeier/cefs/commit/744a6420c03fb5a1c615ca83572f4ca82e600e3f#diff-d5e97bdc9f357018ba8691ae86324328R74
https://github.com/spacewalkproject/spacewalk/commit/5b1a7ba1099b243b30e55b8e0405e017a0034d50

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **API only**
- [x] **DONE**

## Test coverage
- No tests: **nothing to test**

- [x] **DONE**

## Links

Related to https://github.com/SUSE/spacewalk/issues/11844

- [x] **DONE**

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
