### PR TITLE
Bugfixes related to the maintenance windows picker

### DIFF
--- a/java/code/webapp/WEB-INF/pages/common/fragments/schedule-options.jspf
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/schedule-options.jspf
@@ -6,6 +6,7 @@
 <script type="text/javascript" src="/javascript/schedule-options.js?cb=${rhn:getConfig('web.buildtimestamp')}"></script>
 <div class="spacewalk-scheduler">
     <div class="form-horizontal">
+        <c:set var="maintenanceWindowsEmpty" value="${maintenanceWindows != null && empty maintenanceWindows}" />
         <c:choose>
             <%-- When there are multiple schedules, we do not display date picker nor the maint. window picker --%>
             <c:when test="${maintenanceWindowsMultiSchedules}">
@@ -15,7 +16,7 @@
             </c:when>
 
             <%-- When maintenance windows are set but empty, we do not display date picker nor the maint. window picker --%>
-            <c:when test="${maintenanceWindows != null && empty maintenanceWindows}">
+            <c:when test="${maintenanceWindowsEmpty}">
                  <div class="alert alert-info">
                      <bean:message key="schedule.jsp.no_maintenance_windows" />
                  </div>
@@ -51,7 +52,7 @@
         <div class="form-group">
             <div class="col-sm-3 control-label">
                 <input type="radio" name="schedule_type" value="action_chain" id="schedule-by-action-chain"
-                    ${maintenanceWindowsMultiSchedules ? "checked" : ""}
+                    ${maintenanceWindowsMultiSchedules or maintenanceWindowsEmpty ? "checked" : ""}
                 />
                 <label for="schedule-by-action-chain"><bean:message key="schedule-options.action-chain"/></label>
             </div>

--- a/web/html/src/components/action-schedule.js
+++ b/web/html/src/components/action-schedule.js
@@ -62,7 +62,6 @@ class ActionSchedule extends React.Component<ActionScheduleProps, ActionSchedule
       earliest: props.earliest,
       isMaintenanceModeEnabled: false,
       maintenanceWindow: {},
-      maintenanceWindows: [],
       multiMaintenanceWindows: false,
       systemIds: props.systemIds ? props.systemIds : [],
       actionType: props.actionType ? props.actionType : "",
@@ -191,10 +190,17 @@ class ActionSchedule extends React.Component<ActionScheduleProps, ActionSchedule
     }
   }
 
-  renderMultiMaintWindowsWarning = () => {
+  renderMultiMaintWindowsInfo = () => {
     return (
       <div className="alert alert-info">
         {t("There are multiple maintenance schedules for selected systems. Make sure that systems in the set use at most 1 maintenance schedule if you want to schedule by date or maintenance window.")}
+    </div>);
+  }
+
+  renderEmptyMaintWindowsInfo = () => {
+    return (
+      <div className="alert alert-info">
+        {t("No upcoming maintenance windows")}
     </div>);
   }
 
@@ -254,6 +260,11 @@ class ActionSchedule extends React.Component<ActionScheduleProps, ActionSchedule
     );
   }
 
+  // maintenance windows is defined, but empty
+  emptyMaintenanceWindows = () => {
+    return this.state.maintenanceWindows && this.state.maintenanceWindows.length === 0;
+  }
+
   renderActionChainPicker = () => {
     return (
       <div className="form-group">
@@ -277,15 +288,24 @@ class ActionSchedule extends React.Component<ActionScheduleProps, ActionSchedule
     if (this.state.loading) {
       return <Loading text={t('Loading the scheduler...')}/>
     }
+
+    let pickers;
+    if (this.state.multiMaintenanceWindows) {
+      pickers = this.renderMultiMaintWindowsInfo();
+    }
+    else if (this.emptyMaintenanceWindows()) {
+      pickers = this.renderEmptyMaintWindowsInfo();
+    }
+    else {
+      pickers = this.renderPickers()
+    }
+
     return (
       <div className="spacewalk-scheduler">
         <div className="form-horizontal">
           <div className="form-group">
             {
-              this.state.multiMaintenanceWindows
-                ? this.renderMultiMaintWindowsWarning()
-                : this.renderPickers()
-
+              pickers
             }
             {
               this.state.actionChains && this.state.actionChain && this.renderActionChainPicker()

--- a/web/html/src/components/action-schedule.js
+++ b/web/html/src/components/action-schedule.js
@@ -269,7 +269,7 @@ class ActionSchedule extends React.Component<ActionScheduleProps, ActionSchedule
     return (
       <div className="form-group">
         <div className="col-sm-3 control-label">
-          <input type="radio" name="action_chain" value="false" checked={this.state.type == "actionChain"} id="schedule-by-action-chain" onChange={this.onFocusActionChain}/>
+          <input type="radio" name="action_chain" value="false" checked={this.state.type == "actionChain" || this.emptyMaintenanceWindows() || this.state.multiMaintenanceWindows} id="schedule-by-action-chain" onChange={this.onFocusActionChain}/>
           <label htmlFor="schedule-by-action-chain">{t("Add to:")}</label>
         </div>
         <div className="col-sm-3">


### PR DESCRIPTION
(i.e. the picker user sees, when scheduling action for a system (highstate apply, package install.))

1. In the React picker: If there is schedule defined, but there are empty maintenance windows (e.g. calendar not defined) -> display a warning and hide the picker (as there is nothing to pick).

1. In both (React + Struts) picker: If there is schedule defined, but there are empty maintenance windows -> pre-select the action chains radio button (as that is the only actionable option the user has).

Review commit-by-commit.

## Changelogs


- [x] No changelog needed


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"