### PR TITLE
Fix "susemanager-sls" package build after introducing "mgrcompat.module_run"

### DIFF
--- a/susemanager-utils/susemanager-sls/susemanager-sls.spec
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.spec
@@ -101,7 +101,7 @@ py.test
 
 # Check that SLS files don't contain any call to "module.run" which has
 # been replaced by "mgrcompat.module_run" calls.
-! grep -r "module\.run" %{buildroot}/usr/share/susemanager/salt || exit 1
+! grep --include "*.sls" -r "module\.run" %{buildroot}/usr/share/susemanager/salt || exit 1
 
 %post
 # HACK! Create broken link when it will be replaces with the real file


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue when building the `susemanager-sls` package that is currently breaking the package.

We introduced a check in the specfile to ensure no `module.run` calls are used anymore, but the checks was not properly filtering code files from SLS files. That was producing false positives and breaking the package build.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **backend changes**.com/uyuni-project/uyuni-docs/pulls)

- [x] **DONE**

## Test coverage
- No tests: **backend changes**
- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
