### PR TITLE
Pass apidoc version while building the java package too

### DIFF
--- a/java/build.xml
+++ b/java/build.xml
@@ -5,6 +5,7 @@
 -->
 <project name="RHN" default="all" basedir=".">
   <property file="${user.home}/.java/java.conf"/>
+  <property file="conf/rhn_java.conf"/>
   <!-- External java.lib.dir property -->
   <condition property="java.lib.dir" value="${JAVA_LIBDIR}" else="/usr/share/java">
     <isset property="JAVA_LIBDIR"/>
@@ -221,7 +222,7 @@
     <mkdir dir="${report.dir}/apidocs/${template.dir}/" />
     <mkdir dir="${report.dir}/apidocs/${template.dir}/handlers/" />
     <javadoc doclet="com.redhat.rhn.internal.doclet.${doclet.class}" docletpathref="javadocpath" classpathref="buildjars" sourcepath="code/src"
-        additionalparam="-d ${apidoc.output} -templates buildconf/apidoc/${template.dir} -product ${product.name}">
+        additionalparam="-d ${apidoc.output} -templates buildconf/apidoc/${template.dir} -product ${product.name} -apiversion '${java.apiversion}'">
       <fileset dir="code" >
         <include name="**/src/com/redhat/rhn/frontend/xmlrpc/**/*Handler.java" />
         <include name="**/src/com/redhat/rhn/frontend/xmlrpc/serializer/*Serializer.java" />


### PR DESCRIPTION
## What does this PR change?

duplicate the apidoc version parameter passing in the `build.xml` for package build time.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: tooling

- [X] **DONE**

## Test coverage
- No tests: tooling

- [X] **DONE**

## Links

Follow up of #2369

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
