### PR TITLE
Bug fixed, use file_extract() again

### DIFF
--- a/testsuite/features/finishing/srv_debug.feature
+++ b/testsuite/features/finishing/srv_debug.feature
@@ -1,7 +1,7 @@
 # Copyright (c) 2015-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-Feature: Debug the serverafter the testsuite has run
+Feature: Debug the server after the testsuite has run
 
   Scenario: Call spacewalk-debug on server
     When I execute spacewalk-debug on the server

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -301,11 +301,8 @@ end
 
 When(/^I execute spacewalk-debug on the server$/) do
   $server.run('spacewalk-debug')
-  cmd = "echo | scp -o StrictHostKeyChecking=no root@#{$server.ip}:/tmp/spacewalk-debug.tar.bz2 . 2>&1"
-  command_output = `#{cmd}`
-  unless $CHILD_STATUS.success?
-    raise "Execute command failed: #{$ERROR_INFO}: #{command_output}"
-  end
+  code = file_extract($server, "/tmp/spacewalk-debug.tar.bz2", "spacewalk-debug.tar.bz2")
+  raise "Download debug file failed" unless code.zero?
 end
 
 Then(/^I get logfiles from "([^"]*)"$/) do |target|


### PR DESCRIPTION
## What does this PR change?

There was a bug making extraction of big files randomly fail in the test suite. This bug is fixed now in https://github.com/openSUSE/twopence/pull/61

This PR removes the workaround that were added to avoid the issue.

It also fixes a typo.


## Links

* port to 4.0: SUSE/spacewalk#11916
* port to 3.2: SUSE/spacewalk#11917

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
