### PR TITLE
Fix autoinstall rh8

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/kickstart/KickstartFormatter.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/KickstartFormatter.java
@@ -585,9 +585,14 @@ public class KickstartFormatter {
           buf.append("@ Network Support" + NEWLINE);
           buf.append("openssh-server" + NEWLINE);
         }
-
-        // packages necessary for RHEL 7 and Fedora
-        if (this.ksdata.isRhel7OrGreater() || this.ksdata.isFedora()) {
+        if (ConfigDefaults.get().getUserSelectedSaltInstallTypeLabels().contains(ksdata.getInstallType().getLabel())) {
+         // packages necessary for RHEL 6+ and Fedora (salt)
+            buf.append("perl" + NEWLINE);
+            buf.append("wget" + NEWLINE);
+            buf.append("salt-minion" + NEWLINE);
+        }
+        else if (this.ksdata.isRhel7OrGreater() || this.ksdata.isFedora()) {
+            // packages necessary for RHEL 7 and Fedora (traditional)
             buf.append("perl" + NEWLINE);
             buf.append("wget" + NEWLINE);
             buf.append("rhn-setup" + NEWLINE);

--- a/java/code/src/com/redhat/rhn/manager/kickstart/KickstartScheduleCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/KickstartScheduleCommand.java
@@ -1181,6 +1181,10 @@ public class KickstartScheduleCommand extends BaseSystemOperation {
                 // found zypp-plugin-spacewalk - returning
                 return null;
             }
+            if (pli.getName().equals("salt-minion")) {
+                // found salt-minion - returning
+                return null;
+            }
 
             if (pli.getName().equals("up2date")) {
                 log.debug("    found up2date ...");

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- fix up2date detection on RH8 when salt-minion is used for registration
 - improve performance of the System Groups page with many clients (bsc#1172839)
 - Include number of non-patch package updates to non-critical update counts
   in system group pages (bsc#1170468)


### PR DESCRIPTION
## What does this PR change?

Fix detection of up2date package when salt-minion is used to register a RH8/CentOS8/OL8.

## GUI diff

No difference.

Before:

![image](https://user-images.githubusercontent.com/1038917/87224450-ccaa4900-c385-11ea-9e79-ef4d72305cf2.png)

After:

- [x] **DONE**

## Documentation
- No documentation needed: **schuld just work as expected**

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
