### PR TITLE
Add a clocks sanity check

### DIFF
--- a/testsuite/features/core/allcli_sanity.feature
+++ b/testsuite/features/core/allcli_sanity.feature
@@ -7,51 +7,61 @@ Feature: Sanity checks
 
   Scenario: The server is healthy
     Then "server" should have a FQDN
+    And the clock from "server" should be exact
 
 @sle_client
   Scenario: The traditional client is healthy
     Then "sle_client" should have a FQDN
     And "sle_client" should communicate with the server
+    And the clock from "sle_client" should be exact
 
 @sle_minion
   Scenario: The minion is healthy
     Then "sle_minion" should have a FQDN
     And "sle_minion" should communicate with the server
+    And the clock from "sle_minion" should be exact
 
 @buildhost
   Scenario: The build host is healthy
     Then "build_host" should have a FQDN
     And "build_host" should communicate with the server
+    And the clock from "build_host" should be exact
 
 @ssh_minion
   Scenario: The SSH minion is healthy
     Then "ssh_minion" should have a FQDN
     And "ssh_minion" should communicate with the server
+    And the clock from "ssh_minion" should be exact
 
 @proxy
   Scenario: The proxy is healthy
     Then "proxy" should have a FQDN
     And "proxy" should communicate with the server
+    And the clock from "proxy" should be exact
 
 @centos_minion
   Scenario: The Centos minion is healthy
     Then "ceos_ssh_minion" should have a FQDN
     And "ceos_ssh_minion" should communicate with the server
+    And the clock from "ceos_ssh_minion" should be exact
 
 @ubuntu_minion
   Scenario: The Ubuntu minion is healthy
     Then "ubuntu_ssh_minion" should have a FQDN
     And "ubuntu_ssh_minion" should communicate with the server
+    And the clock from "ubuntu_ssh_minion" should be exact
 
 @virthost_kvm
   Scenario: The KVM host is healthy
     Then "kvm_server" should have a FQDN
     And "kvm_server" should communicate with the server
+    And the clock from "kvm_server" should be exact
 
 @virthost_xen
   Scenario: The Xen host is healthy
     Then "xen_server" should have a FQDN
     And "xen_server" should communicate with the server
+    And the clock from "xen_server" should be exact
 
   Scenario: The external resources can be reached
     Then it should be possible to reach the test packages

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -21,6 +21,14 @@ Then(/^"([^"]*)" should communicate with the server$/) do |host|
   $server.run("ping -c1 #{node.full_hostname}")
 end
 
+Then(/^the clock from "([^"]*)" should be exact$/) do |host|
+  node = get_target(host)
+  clock_node, _rc = node.run("date +'%s'")
+  clock_controller = `date +'%s'`
+  difference = clock_node.to_i - clock_controller.to_i
+  raise "clocks differ by #{difference} seconds" unless difference.abs < 2
+end
+
 Then(/^it should be possible to reach the test packages$/) do
   url = 'https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Test-Packages:/Updates/rpm/x86_64/orion-dummy-1.1-1.1.x86_64.rpm'
   $server.run("curl --insecure --location #{url} --output /dev/null")


### PR DESCRIPTION
## What does this PR change?

This PR adds a sanity check to the testsuite to make sure all clocks agree.

## Links

issue: SUSE/spacewalk#11934
sumaform part: uyuni-project/sumaform#729

Ports:
* 3.2:
* 4.0: SUSE/spacewalk#11946

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
