### PR TITLE
Testsuite - temporarily disable GPG checks for Test-Channel-Deb-AMD64 channel

### DIFF
--- a/testsuite/features/core/srv_channels_add.feature
+++ b/testsuite/features/core/srv_channels_add.feature
@@ -94,5 +94,11 @@ Feature: Adding channels
     And I select "AMD64 Debian" from "Architecture:"
     And I enter "Test-Channel-Deb-AMD64 for testing" as "Channel Summary"
     And I enter "No more description for base channel." as "Channel Description"
+    # WORKAROUND
+    # GPG verification of Debian-like repos was added and the TestRepoDebUpdates repo 
+    # is signed by a GPG key that is not in the keyring. This workaround temporarily
+    # disables GPG check, before this is properly handled at sumaform/terraform level.
+    And I uncheck "gpg_check"
+    # End of WORKAROUND
     And I click on "Create Channel"
     Then I should see a "Channel Test-Channel-Deb-AMD64 created." text


### PR DESCRIPTION
## What does this PR change?

 GPG verification of Debian-like repos was added and the TestRepoDebUpdates repo is signed by a GPG key that is not in the keyring. This workaround temporarily disables GPG check, before this is properly handled at sumaform/terraform level.

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
