### PR TITLE
Testsuite - temporary GPG check disable at repository level

### DIFF
--- a/testsuite/features/core/srv_create_repository.feature
+++ b/testsuite/features/core/srv_create_repository.feature
@@ -82,6 +82,12 @@ Feature: Add a repository to a channel
     And I enter "Test-Repository-Deb" as "label"
     And I select "deb" from "contenttype"
     And I enter "http://localhost/pub/TestRepoDebUpdates/" as "url"
+    # WORKAROUND
+    # GPG verification of Debian-like repos was added and the TestRepoDebUpdates repo 
+    # is signed by a GPG key that is not in the keyring. This workaround temporarily
+    # disables GPG check, before this is properly handled at sumaform/terraform level.
+    And I uncheck "metadataSigned"
+    # End of WORKAROUND    
     And I click on "Create Repository"
     Then I should see a "Repository created successfully" text
 


### PR DESCRIPTION
## What does this PR change?

Continuation of #2414, additional change is necessary at repository level.

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
