### PR TITLE
Testsuite - fix to select proper kiwi image profile

### DIFF
--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -41,7 +41,7 @@ def compute_image_filename
   case ENV['PXEBOOT_IMAGE']
   when nil
     'Kiwi/POS_Image-JeOS6_head'
-  when 'sles15sp2'
+  when 'sles15sp2', 'sles15sp2o'
     'Kiwi/POS_Image-JeOS7_head'
   else
     'Kiwi/POS_Image-JeOS6_head'
@@ -52,7 +52,7 @@ def compute_image_name
   case ENV['PXEBOOT_IMAGE']
   when nil
     'POS_Image_JeOS6_head'
-  when 'sles15sp2'
+  when 'sles15sp2', 'sles15sp2o'
     'POS_Image_JeOS7_head'
   else
     'POS_Image_JeOS6_head'


### PR DESCRIPTION
## What does this PR change?

SLE15SP2 images are identified by the testsuite and sumaform as `sle15sp2o`, with appendix `o` at the end. This causes problem, because environment variable for pxe image at cucumber testsuite controller is filled as follows:

```
export PXEBOOT_IMAGE="sles15sp2o" 
```
As a result improper image profile is selected to be built (we test condition for exact match with `sles15sp2` string). 

This PR fixes the issue.

(Port for 4.0 will follow.)

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
