### PR TITLE
Warn user when multiple group formulas are active

### DIFF
--- a/web/html/src/components/FormulaForm.js
+++ b/web/html/src/components/FormulaForm.js
@@ -36,6 +36,7 @@ class FormulaForm extends React.Component {
             groupData: {},
             formulaChanged: false,
             messages: [],
+            warnings: [],
             errors: []
         };
 
@@ -73,6 +74,11 @@ class FormulaForm extends React.Component {
                     metadata: {}
                 });
             else {
+                if (data.formula_list.filter(formula => formula != "caasp-management-settings" && formula == data.formula_name).length > 1) {
+                    this.state.warnings.push(
+                        t('Multiple Group formulas detected. Only one formula for "{0}" can be used on each system!', capitalize(data.formula_name))
+                    )
+                }
                 const rawLayout = data.layout;
                 this.setState({
                     formulaName: data.formula_name,
@@ -156,6 +162,9 @@ class FormulaForm extends React.Component {
         messageItems = messageItems.concat(this.state.errors.map((msg) => {
             return { severity: "error", text: msg };
         }));
+        messageItems = messageItems.concat(this.state.warnings.map((msg) => {
+            return { severity: "warning", text: msg };
+        }))
         const messages = <Messages items={messageItems} />;
 
         if (this.state.formulaRawLayout === undefined || this.state.formulaRawLayout === null || $.isEmptyObject(this.state.formulaRawLayout)) {

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,5 @@
+- Warn when a system is in multiple groups that configure the same
+  formula in the system formula's UI (bsc#1173554)
 - Add virtual network start, stop and delete actions
 - Add virtual network list page
 - Update package version to 4.2.0


### PR DESCRIPTION
## What does this PR change?

Adds a warning when multiple groups set up the same formula and a system is in more than one of these groups. The UI shows multiple formulas

## GUI diff

Before:
![screenshot-2020-07-16_18-12-25](https://user-images.githubusercontent.com/19352524/87695570-eede0580-c78f-11ea-92c2-bea926adef67.png)


After:
![screenshot-2020-07-16_18-09-06](https://user-images.githubusercontent.com/19352524/87695401-bf2efd80-c78f-11ea-94dc-06a2c006332c.png)

CaaSP Management Settings are excluded:
![screenshot-2020-07-16_18-09-19](https://user-images.githubusercontent.com/19352524/87695458-d110a080-c78f-11ea-85d5-b0da6b83fc98.png)


## Documentation
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

**TODO**
- [ ] **DONE**

## Test coverage
- No tests: Minor UI change only, I don't think we need to automatically test it. Please correct me if I am wrong.

- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/11850

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
