### PR TITLE
Resynchronize all branches

### DIFF
--- a/testsuite/documentation/pitfalls.md
+++ b/testsuite/documentation/pitfalls.md
@@ -261,7 +261,7 @@ Look at this one:
 
 ```ruby
 Then /^I shall not see "([^"]*)" when I call user\.list_roles\(\) with "([^"]*)" uid$/ do |rolename, luser|
-  
+
   roles = rpctest.get_user_roles(luser)
   fail if roles != nil ? roles.length != 0 : false
 end

--- a/testsuite/documentation/static-run.md
+++ b/testsuite/documentation/static-run.md
@@ -1,7 +1,7 @@
 ### Static run
 
 #### Warning
- 
+
 If you want to run the testsuite without sumaform, you have to create and configure the machines.
 You may do that manually, or with the help of Salt states.
 

--- a/testsuite/features/core/allcli_sanity.feature
+++ b/testsuite/features/core/allcli_sanity.feature
@@ -40,13 +40,13 @@ Feature: Sanity checks
     And the clock from "proxy" should be exact
 
 @centos_minion
-  Scenario: The Centos minion is healthy
+  Scenario: The CentOS SSH minion is healthy
     Then "ceos_ssh_minion" should have a FQDN
     And "ceos_ssh_minion" should communicate with the server
     And the clock from "ceos_ssh_minion" should be exact
 
 @ubuntu_minion
-  Scenario: The Ubuntu minion is healthy
+  Scenario: The Ubuntu SSH minion is healthy
     Then "ubuntu_ssh_minion" should have a FQDN
     And "ubuntu_ssh_minion" should communicate with the server
     And the clock from "ubuntu_ssh_minion" should be exact

--- a/testsuite/features/core/proxy_branch_network.feature
+++ b/testsuite/features/core/proxy_branch_network.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2019 SUSE LLC
+# Copyright (c) 2018-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # The scenarios in this feature are skipped if there is no proxy

--- a/testsuite/features/core/srv_channels_add.feature
+++ b/testsuite/features/core/srv_channels_add.feature
@@ -95,7 +95,7 @@ Feature: Adding channels
     And I enter "Test-Channel-Deb-AMD64 for testing" as "Channel Summary"
     And I enter "No more description for base channel." as "Channel Description"
     # WORKAROUND
-    # GPG verification of Debian-like repos was added and the TestRepoDebUpdates repo 
+    # GPG verification of Debian-like repos was added and the TestRepoDebUpdates repo
     # is signed by a GPG key that is not in the keyring. This workaround temporarily
     # disables GPG check, before this is properly handled at sumaform/terraform level.
     And I uncheck "gpg_check"

--- a/testsuite/features/core/srv_create_repository.feature
+++ b/testsuite/features/core/srv_create_repository.feature
@@ -38,7 +38,7 @@ Feature: Add a repository to a channel
   Scenario: Synchronize the repository in the x86_64 channel
     Given I am authorized as "testing" with password "testing"
     When I enable source package syncing
-    When I follow the left menu "Software > Manage > Channels"
+    And I follow the left menu "Software > Manage > Channels"
     And I follow "Test-Channel-x86_64"
     And I follow "Repositories" in the content area
     And I follow "Sync"
@@ -83,11 +83,11 @@ Feature: Add a repository to a channel
     And I select "deb" from "contenttype"
     And I enter "http://localhost/pub/TestRepoDebUpdates/" as "url"
     # WORKAROUND
-    # GPG verification of Debian-like repos was added and the TestRepoDebUpdates repo 
+    # GPG verification of Debian-like repos was added and the TestRepoDebUpdates repo
     # is signed by a GPG key that is not in the keyring. This workaround temporarily
     # disables GPG check, before this is properly handled at sumaform/terraform level.
     And I uncheck "metadataSigned"
-    # End of WORKAROUND    
+    # End of WORKAROUND
     And I click on "Create Repository"
     Then I should see a "Repository created successfully" text
 

--- a/testsuite/features/finishing/allcli_debug.feature
+++ b/testsuite/features/finishing/allcli_debug.feature
@@ -16,11 +16,11 @@ Feature: Debug the clients after the testsuite has run
     When I get logfiles from "sle_minion"
 
 @centos_minion
-  Scenario: Get client logs for CentOS minion
+  Scenario: Get client logs for CentOS SSH minion
     When I get logfiles from "ceos_minion"
 
 @ubuntu_minion
-  Scenario: Get client logs for Ubuntu minion
+  Scenario: Get client logs for Ubuntu SSH minion
     When I get logfiles from "ubuntu_minion"
 
 @ssh_minion

--- a/testsuite/features/init_clients/sle_ssh_minion.feature
+++ b/testsuite/features/init_clients/sle_ssh_minion.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2019 SUSE LLC
+# Copyright (c) 2016-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Be able to bootstrap a Salt host managed via salt-ssh

--- a/testsuite/features/reposync/srv_sync_channels.feature
+++ b/testsuite/features/reposync/srv_sync_channels.feature
@@ -28,7 +28,7 @@ Feature: Be able to list available channels and enable them
 
 @scc_credentials
 @susemanager
-  Scenario: List all products
+  Scenario: List all products for SUSE Manager
     When I execute mgr-sync "list products --expand"
     Then I should get "[ ] SUSE Linux Enterprise Server 12 x86_64"
     And I should get "[ ] SUSE Manager Proxy 2.1 x86_64"
@@ -37,7 +37,7 @@ Feature: Be able to list available channels and enable them
 
 @scc_credentials
 @uyuni
-  Scenario: List all products
+  Scenario: List all products for Uyuni
     When I execute mgr-sync "list products --expand"
     Then I should get "[ ] SUSE Linux Enterprise Server 12 x86_64"
     And I should get "[ ] SUSE Manager Proxy 2.1 x86_64"

--- a/testsuite/features/secondary/allcli_action_chain.feature
+++ b/testsuite/features/secondary/allcli_action_chain.feature
@@ -45,7 +45,7 @@ Feature: Action chains on several systems at once
     Then I should see a "bunch was scheduled" text
     And I wait until the table contains "FINISHED" or "SKIPPED" followed by "FINISHED" in its first rows
 
-  Scenario: Pre-requisite: remove all action chains before testing on Salt minion
+  Scenario: Pre-requisite: remove all action chains before testing on several systems
     Given I am logged in via XML-RPC actionchain as user "admin" and password "admin"
     When I delete all action chains
     And I cancel all scheduled actions

--- a/testsuite/features/secondary/allcli_reboot.feature
+++ b/testsuite/features/secondary/allcli_reboot.feature
@@ -37,22 +37,19 @@ Feature: Reboot systems managed by SUSE Manager
     And I run "rhn_check -vvv" on "sle_client"
     Then I wait and check that "sle_client" has rebooted
 
-# WORKAROUND
-#    This scenario is disabled as long as we have failures during CentOS reboots
-#
-#@centos_minion
-#  Scenario: Reboot the CentOS minion and wait until reboot is completed
-#    Given I am on the Systems overview page of this "ceos_ssh_minion"
-#    When I follow first "Schedule System Reboot"
-#    Then I should see a "System Reboot Confirmation" text
-#    And I should see a "Reboot system" button
-#    When I click on "Reboot system"
-#    Then I should see a "Reboot scheduled for system" text
-#    When I wait at most 600 seconds until event "System reboot scheduled by admin" is completed
-#    Then I should see a "Reboot completed." text
+@centos_minion
+  Scenario: Reboot the CentOS SSH-managed minion and wait until reboot is completed
+    Given I am on the Systems overview page of this "ceos_ssh_minion"
+    When I follow first "Schedule System Reboot"
+    Then I should see a "System Reboot Confirmation" text
+    And I should see a "Reboot system" button
+    When I click on "Reboot system"
+    Then I should see a "Reboot scheduled for system" text
+    When I wait at most 600 seconds until event "System reboot scheduled by admin" is completed
+    Then I should see a "Reboot completed." text
 
 @ubuntu_minion
-  Scenario: Reboot the Ubuntu minion and wait until reboot is completed
+  Scenario: Reboot the Ubuntu SSH-managed minion and wait until reboot is completed
     Given I am on the Systems overview page of this "ubuntu_ssh_minion"
     When I follow first "Schedule System Reboot"
     Then I should see a "System Reboot Confirmation" text

--- a/testsuite/features/secondary/allcli_software_channels.feature
+++ b/testsuite/features/secondary/allcli_software_channels.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2019 SUSE LLC
+# Copyright (c) 2018-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Chanel subscription via SSM
@@ -136,7 +136,7 @@ Feature: Chanel subscription via SSM
     And channel "Test Child Channel" should be enabled on "sle_client"
 
 @centos_minion
-  Scenario: System default channel can't be determined
+  Scenario: System default channel can't be determined on the CentOS SSH minion
     Given I am authorized as "admin" with password "admin"
     When I am on the System Overview page
     And I follow "Clear"
@@ -160,14 +160,14 @@ Feature: Chanel subscription via SSM
     And I follow "Clear"
 
 @centos_minion
-  Scenario: Cleanup: make sure the CentOS minion is still unchanged
+  Scenario: Cleanup: make sure the CentOS SSH minion is still unchanged
     Given I am on the Systems overview page of this "ceos_ssh_minion"
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     Then radio button "Test Base Channel" is checked
 
 @ubuntu_minion
-  Scenario: System default channel can't be determined
+  Scenario: System default channel can't be determined on the Ubuntu SSH minion
     Given I am authorized as "admin" with password "admin"
     When I am on the System Overview page
     And I follow "Clear"
@@ -191,7 +191,7 @@ Feature: Chanel subscription via SSM
     And I follow "Clear"
 
 @ubuntu_minion
-  Scenario: Cleanup: make sure the Ubuntu minion is still unchanged
+  Scenario: Cleanup: make sure the Ubuntu SSH minion is still unchanged
     Given I am on the Systems overview page of this "ubuntu_ssh_minion"
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area

--- a/testsuite/features/secondary/allcli_system_group.feature
+++ b/testsuite/features/secondary/allcli_system_group.feature
@@ -109,7 +109,7 @@ Feature: Manage a group of systems
     Then I should see a "1 system groups removed." text
 
   # CentOS minion is intentionally not removed from group
- 
+
   Scenario: Cleanup: uninstall formula from the server
     Given I am authorized
     When I manually uninstall the "locale" formula from the server

--- a/testsuite/features/secondary/min_bootstrap_negative.feature
+++ b/testsuite/features/secondary/min_bootstrap_negative.feature
@@ -3,7 +3,7 @@
 
 @sle_minion
 Feature: Negative tests for bootstrapping normal minions
-  In order to register only valid minions 
+  In order to register only valid minions
   As an authorized user
   I want to avoid registration with invalid input parameters
 

--- a/testsuite/features/secondary/min_bootstrap_ssh_key.feature
+++ b/testsuite/features/secondary/min_bootstrap_ssh_key.feature
@@ -15,7 +15,7 @@ Feature: Bootstrap a Salt minion via the GUI using SSH key
   Scenario: Prepare the minion for SSH key authentication
     When I backup the SSH authorized_keys file of host "sle_minion"
     And I add pre-generated SSH public key to authorized_keys of host "sle_minion"
-  
+
   Scenario: Bootstrap a SLES minion using SSH key with wrong passphrase
     Given I am authorized
     When I go to the bootstrapping page
@@ -55,6 +55,6 @@ Feature: Bootstrap a Salt minion via the GUI using SSH key
   Scenario: Also check contact method of this minion
     Given I am on the Systems overview page of this "sle_minion"
     Then I should see a "Default" text
-  
+
   Scenario: Cleanup: restore authorized keys
     When I restore the SSH authorized_keys file of host "sle_minion"

--- a/testsuite/features/secondary/min_change_software_channel.feature
+++ b/testsuite/features/secondary/min_change_software_channel.feature
@@ -1,10 +1,10 @@
 # Copyright (c) 2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-Feature: Assign child channel to system
+Feature: Assign child channel to a system
 
 @sle_minion
-  Scenario: Check SLES minion is still subscribed to old channels before channel change completes
+  Scenario: Check the system is still subscribed to old channels before channel change completes
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
@@ -15,13 +15,13 @@ Feature: Assign child channel to system
 
 
 @sle_minion
-  Scenario: Check old channels are still enabled on SLES minion before channel change completes
+  Scenario: Check old channels are still enabled on the system before channel change completes
     When I refresh the metadata for "sle_minion"
     Then "1" channels should be enabled on "sle_minion"
     And channel "Test-Channel-x86_64" should be enabled on "sle_minion"
 
 @sle_minion
-  Scenario: Assign a child channel to system
+  Scenario: Assign a child channel to the system
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
@@ -38,13 +38,13 @@ Feature: Assign child channel to system
     Then channel "Test-Channel-x86_64 Child Channel" should be enabled on "sle_minion"
 
 @sle_minion
-  Scenario: Check channel change has completed for the SLES minion
+  Scenario: Check channel change has completed for the system
     Given I am on the Systems overview page of this "sle_minion"
     When I wait until event "Subscribe channels scheduled by admin" is completed
     Then I should see a "The client completed this action on" text
 
 @sle_minion
-  Scenario: Check the SLES minion is subscribed to the new channels
+  Scenario: Check the system is subscribed to the new channels
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
@@ -54,14 +54,14 @@ Feature: Assign child channel to system
     And I should see "Test-Channel-x86_64 Child Channel" as checked
 
 @sle_minion
-  Scenario: Check the new channels are enabled on the SLES minion
+  Scenario: Check the new channels are enabled on the system
     When I refresh the metadata for "sle_minion"
     Then "2" channels should be enabled on "sle_minion"
     And channel "Test-Channel-x86_64" should be enabled on "sle_minion"
     And channel "Test-Channel-x86_64 Child Channel" should be enabled on "sle_minion"
 
 @sle_minion
-  Scenario: Cleanup: subscribe the SLES minion back to previous channels
+  Scenario: Cleanup: subscribe the system back to previous channels
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area

--- a/testsuite/features/secondary/min_custom_pkg_download_endpoint.feature
+++ b/testsuite/features/secondary/min_custom_pkg_download_endpoint.feature
@@ -1,7 +1,7 @@
-# Copyright (c) 2019 SUSE LLC
+# Copyright (c) 2019-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
-# In order to use different end-point to download rpms other than the manager instance itself, one can do so with 
+# In order to use different end-point to download rpms other than the manager instance itself, one can do so with
 # setting pillar data values as mentioned in upload_files/rpm_enpoint.sls. These scenarios test this feature
 
 Feature: Repos file generation based on custom pillar data
@@ -20,19 +20,19 @@ Feature: Repos file generation based on custom pillar data
     Then I should see a "Changing the channels has been scheduled." text
     When I follow "scheduled" in the content area
     And I wait until I see "1 system successfully completed this action." text, refreshing the page
-  
+
   Scenario: Check the default RPM download point values
     Given I am on the Systems overview page of this "sle_minion"
     Then the susemanager repo file should exist on the "sle_minion"
     And I should see "https", "proxy" and "443" in the repo file on the "sle_minion"
- 
+
   Scenario: Set the custom RPM download point
     Given I am on the Systems overview page of this "sle_minion"
     When I install a salt pillar top file for "pkg_endpoint" with target "*" on the server
     And I wait for "1" seconds
     And I install a salt pillar file with name "pkg_endpoint.sls" on the server
     And I refresh the pillar data
-  
+
   Scenario: Subscribe the SLES minion to a channel again so new RPM end-point will be taken into account
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Software" in the content area
@@ -46,20 +46,20 @@ Feature: Repos file generation based on custom pillar data
     When I click on "Confirm"
     Then I should see a "Changing the channels has been scheduled." text
     When I follow "scheduled" in the content area
-    And I wait until I see "1 system successfully completed this action." text, refreshing the page      
-  
+    And I wait until I see "1 system successfully completed this action." text, refreshing the page
+
   Scenario: Check the channel.repo file to see the custom RPM download point
     Given I am on the Systems overview page of this "sle_minion"
     Then the susemanager repo file should exist on the "sle_minion"
     And I should see "ftp", "scc.com" and "445" in the repo file on the "sle_minion"
-  
-  Scenario: Remove the custom RPM download point
+
+  Scenario: Cleanup: remove the custom RPM download point
     Given I am on the Systems overview page of this "sle_minion"
     When I delete a salt "pillar" file with name "pkg_endpoint.sls" on the server
-    When I delete a salt "pillar" file with name "top.sls" on the server   
+    When I delete a salt "pillar" file with name "top.sls" on the server
     And I refresh the pillar data
-  
-  Scenario: Subscribe the SLES minion to a channel
+
+  Scenario: Cleanup: subscribe the SLES minion to a channel
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
@@ -72,10 +72,10 @@ Feature: Repos file generation based on custom pillar data
     When I click on "Confirm"
     Then I should see a "Changing the channels has been scheduled." text
     When I follow "scheduled" in the content area
-    And I wait until I see "1 system successfully completed this action." text, refreshing the page  
-  
-  Scenario: ReCheck the default RPM download point values
+    And I wait until I see "1 system successfully completed this action." text, refreshing the page
+
+  Scenario: Cleanup: recheck the default RPM download point values
     Given I am on the Systems overview page of this "sle_minion"
     Then the susemanager repo file should exist on the "sle_minion"
     And I should see "https", "proxy" and "443" in the repo file on the "sle_minion"
-    
+

--- a/testsuite/features/secondary/min_empty_system_profiles.feature
+++ b/testsuite/features/secondary/min_empty_system_profiles.feature
@@ -19,7 +19,7 @@ Feature: Empty minion profile operations
     And I wait until I see "empty-profile" text, refreshing the page
     And I wait until I see "00:11:22:33:44:55" text
     And I wait until I see "empty-profile-hostname" text
-  
+
   Scenario: Check the empty profiles has the hostname set
     Given I am authorized
     And I navigate to "rhn/systems/BootstrapSystemList.do" page

--- a/testsuite/features/secondary/min_salt_install_with_staging.feature
+++ b/testsuite/features/secondary/min_salt_install_with_staging.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2019 SUSE LLC
+# Copyright (c) 2017-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # This feature relies on having properly configured

--- a/testsuite/features/secondary/min_salt_mgrcompat_state.feature
+++ b/testsuite/features/secondary/min_salt_mgrcompat_state.feature
@@ -24,7 +24,7 @@ Feature: Verify that Salt mgrcompat state works when the new module.run syntax i
     Then I should see a "You have successfully scheduled a hardware profile refresh" text
     And I wait until event "Hardware List Refresh scheduled by admin" is completed
 
-  Scenario: Delete SLES minion system profile before script bootstrap test
+  Scenario: Delete SLES minion system profile before mgrcompat test
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Delete System"
     Then I should see a "Confirm System Profile Deletion" text
@@ -53,7 +53,7 @@ Feature: Verify that Salt mgrcompat state works when the new module.run syntax i
     And I wait until I see the name of "sle_minion", refreshing the page
     And I wait until onboarding is completed for "sle_minion"
 
-  Scenario: Check that installed packages are visible
+  Scenario: Check that installed packages are visible with the new module.run syntax
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Software" in the content area
     And I follow "List / Remove"
@@ -77,7 +77,7 @@ Feature: Verify that Salt mgrcompat state works when the new module.run syntax i
     And I cleanup minion "sle_minion"
     Then "sle_minion" should not be registered
 
-  Scenario: Cleanup: bootstrap again the minion
+  Scenario: Cleanup: bootstrap again the minion after mgrcompat tests
     Given I am authorized
     When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
@@ -90,7 +90,7 @@ Feature: Verify that Salt mgrcompat state works when the new module.run syntax i
     And I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "sle_minion"
 
-  Scenario: Cleanup: restore channels on the minion
+  Scenario: Cleanup: restore channels on the minion after mgrcompat tests
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Software" in the content area
     Then I follow "Software Channels" in the content area

--- a/testsuite/features/secondary/minssh_bootstrap_xmlrpc.feature
+++ b/testsuite/features/secondary/minssh_bootstrap_xmlrpc.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2019 SUSE LLC.
+# Copyright (c) 2017-2020 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 Feature: Register a salt-ssh system via XML-RPC

--- a/testsuite/features/secondary/minssh_centos_salt_install_package_and_patch.feature
+++ b/testsuite/features/secondary/minssh_centos_salt_install_package_and_patch.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2019 SUSE LLC
+# Copyright (c) 2015-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Install a patch on the CentOS SSH minion via Salt through the UI

--- a/testsuite/features/secondary/minssh_salt_install_package.feature
+++ b/testsuite/features/secondary/minssh_salt_install_package.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 SUSE LLC
+# Copyright (c) 2019-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Install a package on the SSH minion via Salt through the UI

--- a/testsuite/features/secondary/srv_clone_channel_npn.feature
+++ b/testsuite/features/secondary/srv_clone_channel_npn.feature
@@ -1,4 +1,4 @@
-# COPYRIGHT (c) 2017 SUSE LLC
+# Copyright (c) 2017 SUSE LLC
 # License under the terms of the MIT License.
 
 Feature: Clone a channel

--- a/testsuite/features/secondary/srv_datepicker.feature
+++ b/testsuite/features/secondary/srv_datepicker.feature
@@ -1,4 +1,4 @@
-# COPYRIGHT (c) 2017 SUSE LLC
+# Copyright (c) 2017 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Pick dates

--- a/testsuite/features/secondary/srv_delete_channel_from_ui.feature
+++ b/testsuite/features/secondary/srv_delete_channel_from_ui.feature
@@ -1,4 +1,4 @@
-# COPYRIGHT (c) 2019 SUSE LLC
+# Copyright (c) 2019 SUSE LLC
 # Licensed under the terms of the MIT License.
 
 Feature: Delete channels with child or clone is not allowed

--- a/testsuite/features/secondary/srv_delete_channel_with_tool.feature
+++ b/testsuite/features/secondary/srv_delete_channel_with_tool.feature
@@ -1,4 +1,4 @@
-# COPYRIGHT (c) 2019 SUSE LLC
+# Copyright (c) 2019 SUSE LLC
 # Licensed under the terms of the MIT License.
 
 Feature: Deleting channels with children or clones is not allowed

--- a/testsuite/features/secondary/srv_distro_cobbler.feature
+++ b/testsuite/features/secondary/srv_distro_cobbler.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2019 SUSE LLC.
+# Copyright (c) 2010-2020 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 Feature: Cobbler and distribution autoinstallation

--- a/testsuite/features/secondary/srv_docker_cve_audit.feature
+++ b/testsuite/features/secondary/srv_docker_cve_audit.feature
@@ -2,7 +2,7 @@
 # Licensed under the terms of the MIT license.
 
 Feature: CVE audit for content management
-  I want to see images that need to be patched or not 
+  I want to see images that need to be patched or not
 
   Background:
     Given I am authorized as "admin" with password "admin"

--- a/testsuite/features/secondary/srv_menu.feature
+++ b/testsuite/features/secondary/srv_menu.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2019 SUSE LLC
+# Copyright (c) 2017-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Web UI - Main landing page menu, texts and links
@@ -57,7 +57,7 @@ Feature: Web UI - Main landing page menu, texts and links
     And I should see a "CVE Audit" link in the left menu
     And I should see a "Subscription Matching" link in the left menu
     And I should see a "OpenSCAP" link in the left menu
- 
+
   Scenario: The OpenSCAP submenu menu
     When I follow the left menu "Audit > OpenSCAP"
     Then I should see a "OpenSCAP Scans" text

--- a/testsuite/features/secondary/srv_monitoring.feature
+++ b/testsuite/features/secondary/srv_monitoring.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 SUSE LLC
+# Copyright (c) 2019-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Enable and disable monitoring of the server
@@ -21,7 +21,7 @@ Feature: Enable and disable monitoring of the server
     And file "/etc/sysconfig/tomcat" should not contain "Dcom.sun.management.jmxremote.port=3333 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname=" on server
     And file "/etc/rhn/taskomatic.conf" should not contain "Dcom.sun.management.jmxremote.port=3334 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname=" on server
 
-  Scenario: Restart spacewalk services to apply monitoring config changes
+  Scenario: Restart spacewalk services to apply config changes after disabling monitoring
     When I restart the spacewalk service
 
   Scenario: Check that monitoring is disabled using the UI
@@ -54,7 +54,7 @@ Feature: Enable and disable monitoring of the server
     And file "/etc/sysconfig/tomcat" should contain "Dcom.sun.management.jmxremote.port=3333 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname=" on server
     And file "/etc/rhn/taskomatic.conf" should contain "Dcom.sun.management.jmxremote.port=3334 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname=" on server
 
-  Scenario: Restart spacewalk services to apply monitoring config changes
+  Scenario: Restart spacewalk services to apply config changes after enabling monitoring
     When I restart the spacewalk service
 
   Scenario: Check that monitoring is enabled using the UI

--- a/testsuite/features/secondary/srv_notifications.feature
+++ b/testsuite/features/secondary/srv_notifications.feature
@@ -2,7 +2,7 @@
 # Licensed under the terms of the MIT license.
 
 Feature: Test the notification/notification-messages feature
-  
+
   Scenario: Check the unread notification counter is correct
     Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Home > Notification Messages"

--- a/testsuite/features/secondary/srv_users.feature
+++ b/testsuite/features/secondary/srv_users.feature
@@ -1,10 +1,10 @@
-# Copyright (c) 2015-16 SUSE LLC
+# Copyright (c) 2015-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 #  1) check users page
 #  2) create and delete users
 #  3) Change permissions and roles in web UI
- 
+
 Feature: Manage users
 
   Scenario: Display active users page

--- a/testsuite/features/secondary/trad_action_chain.feature
+++ b/testsuite/features/secondary/trad_action_chain.feature
@@ -105,7 +105,7 @@ Feature: Action chain on traditional clients
 
   Scenario: Subscribe system to configuration channel for testing action chain on traditional client
     Given I am on the Systems overview page of this "sle_client"
-    And I follow "Configuration" in the content area
+    When I follow "Configuration" in the content area
     And I follow "Manage Configuration Channels" in the content area
     And I follow first "Subscribe to Channels" in the content area
     And I check "Action Chain Channel" in the list
@@ -150,11 +150,11 @@ Feature: Action chain on traditional clients
     Then I should not see a "new action chain" link
 
   Scenario: Delete the action chain for traditional client
-     Given I am authorized as "admin" with password "admin"
-     When I follow the left menu "Schedule > Action Chains"
-     And I follow "new action chain"
-     And I follow "delete action chain" in the content area
-     Then I click on "Delete"
+    Given I am authorized as "admin" with password "admin"
+    When I follow the left menu "Schedule > Action Chains"
+    And I follow "new action chain"
+    And I follow "delete action chain" in the content area
+    And I click on "Delete"
 
   Scenario: Add a remote command to the new action chain on traditional client
     Given I am on the Systems overview page of this "sle_client"
@@ -172,28 +172,28 @@ Feature: Action chain on traditional clients
     Given I am on the Systems overview page of this "sle_client"
     When I follow the left menu "Schedule > Action Chains"
     And I follow "new action chain"
-    And I should see a "1. Run a remote command on 1 system" text
-    Then I click on "Save and Schedule"
-    And I should see a "Action Chain new action chain has been scheduled for execution." text
+    Then I should see a "1. Run a remote command on 1 system" text
+    When I click on "Save and Schedule"
+    Then I should see a "Action Chain new action chain has been scheduled for execution." text
     When I run "rhn_check -vvv" on "sle_client"
 
   Scenario: Create an action chain via XML-RPC
     Given I am logged in via XML-RPC actionchain as user "admin" and password "admin"
     When I call XML-RPC createChain with chainLabel "throwaway_chain"
     And I call actionchain.list_chains() if label "throwaway_chain" is there
-    Then I delete the action chain
-    And there should be no action chain with the label "throwaway_chain"
+    And I delete the action chain
+    Then there should be no action chain with the label "throwaway_chain"
     When I call XML-RPC createChain with chainLabel "throwaway_chain"
-    Then I call actionchain.rename_chain() to rename it from "throwaway_chain" to "throwaway_chain_renamed"
-    And there should be a new action chain with the label "throwaway_chain_renamed"
-    And I delete an action chain, labeled "throwaway_chain_renamed"
-    And there should be no action chain with the label "throwaway_chain_renamed"
+    And I call actionchain.rename_chain() to rename it from "throwaway_chain" to "throwaway_chain_renamed"
+    Then there should be a new action chain with the label "throwaway_chain_renamed"
+    When I delete an action chain, labeled "throwaway_chain_renamed"
+    Then there should be no action chain with the label "throwaway_chain_renamed"
     And no action chain with the label "throwaway_chain"
 
   Scenario: Add operations to the action chain via XML-RPC for traditional client
     Given I am logged in via XML-RPC actionchain as user "admin" and password "admin"
-    And I want to operate on this "sle_client"
-    When I call XML-RPC createChain with chainLabel "throwaway_chain"
+    When I want to operate on this "sle_client"
+    And I call XML-RPC createChain with chainLabel "throwaway_chain"
     And I call actionchain.add_package_install()
     And I call actionchain.add_package_removal()
     And I call actionchain.add_package_upgrade()
@@ -207,14 +207,14 @@ Feature: Action chain on traditional clients
 
   Scenario: Run and cancel an action chain via XML-RPC
     Given I am logged in via XML-RPC actionchain as user "admin" and password "admin"
-    And I want to operate on this "sle_client"
-    When I call XML-RPC createChain with chainLabel "throwaway_chain"
+    When I want to operate on this "sle_client"
+    And I call XML-RPC createChain with chainLabel "throwaway_chain"
     And I call actionchain.add_system_reboot()
     Then I should be able to see all these actions in the action chain
     When I schedule the action chain
-    Then I wait until there are no more action chains
-    And I should see scheduled action, called "System reboot scheduled by admin"
-    Then I cancel all scheduled actions
+    And I wait until there are no more action chains
+    Then I should see scheduled action, called "System reboot scheduled by admin"
+    When I cancel all scheduled actions
     And I wait until there are no more scheduled actions
     And I delete the action chain
 

--- a/testsuite/features/secondary/trad_baremetal_discovery.feature
+++ b/testsuite/features/secondary/trad_baremetal_discovery.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2019 SUSE LLC
+# Copyright (c) 2015-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Bare metal discovery

--- a/testsuite/features/secondary/trad_cve_id_new_syntax.feature
+++ b/testsuite/features/secondary/trad_cve_id_new_syntax.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 SUSE LLC
+# Copyright (c) 2015-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Support for new CVE-ID syntax

--- a/testsuite/features/secondary/trad_lock_packages.feature
+++ b/testsuite/features/secondary/trad_lock_packages.feature
@@ -2,7 +2,7 @@
 # Licensed under the terms of the MIT license.
 
 Feature: Lock packages on traditional client
- 
+
   Background:
     Given I am on the Systems overview page of this "sle_client"
 

--- a/testsuite/features/secondary/trad_mgr_bootstrap.feature
+++ b/testsuite/features/secondary/trad_mgr_bootstrap.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2019 SUSE LLC
+# Copyright (c) 2015-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Generate a bootstrap script and use it to register a client

--- a/testsuite/features/secondary/trad_need_reboot.feature
+++ b/testsuite/features/secondary/trad_need_reboot.feature
@@ -1,4 +1,4 @@
-# COPYRIGHT (c) 2017-2020 SUSE LLC
+# Copyright (c) 2017-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 # TODO: This feature must run before install a patch in the client

--- a/testsuite/features/secondary/trad_ssh_push.feature
+++ b/testsuite/features/secondary/trad_ssh_push.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2019 SUSE LLC
+# Copyright (c) 2016-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Register a traditional system to be managed via SSH push
@@ -73,7 +73,7 @@ Feature: Register a traditional system to be managed via SSH push
     And I run "sed -i '/127.0.1.1/d' /etc/hosts" on "sle_client"
     And I run "rm /srv/www/htdocs/pub/bootstrap/bootstrap-ssh-push-tunnel.sh" on "server"
     And I remove server hostname from hosts file on "sle_client"
- 
+
   Scenario: Cleanup: register a traditional client after SSH push tests
     When I bootstrap traditional client "sle_client" using bootstrap script with activation key "1-SUSE-DEV-x86_64" from the proxy
     Then I should see "sle_client" via spacecmd

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -956,7 +956,7 @@ When(/^I create "([^"]*)" virtual machine on "([^"]*)"$/) do |vm_name, host|
   # Actually define the VM, but don't start it
   raise 'not found: virt-install' unless file_exists?(node, '/usr/bin/virt-install')
   node.run("virt-install --name #{vm_name} --memory 512 --vcpus 1 --disk path=#{disk_path} "\
-           " --network network=test-net0 --graphics vnc "\
+           "--network network=test-net0 --graphics vnc "\
            "--serial file,path=/tmp/#{vm_name}.console.log "\
            "--import --hvm --noautoconsole --noreboot")
 end

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -454,7 +454,7 @@ end
 Then(/^I am logged in$/) do
   raise 'User is not logged in' unless find(:xpath, "//a[@href='/rhn/Logout.do']").visible?
   text = 'You have just created your first $PRODUCT user. To finalize your installation please use the Setup Wizard'
-  text.gsub! '$PRODUCT', $product # TODO: Rid of this substitution, using another step
+  text.gsub! '$PRODUCT', $product # TODO: Get rid of this substitution, using another step
   raise 'The welcome message is not shown' unless has_content?(text)
 end
 
@@ -526,7 +526,7 @@ end
 # Test for a text in the whole page
 #
 Then(/^I should see a "([^"]*)" text$/) do |text|
-  text.gsub! '$PRODUCT', $product # TODO: Rid of this substitution, using another step
+  text.gsub! '$PRODUCT', $product # TODO: Get rid of this substitution, using another step
   raise "Text #{text} not found" unless has_content?(text)
 end
 

--- a/testsuite/features/step_definitions/smdba_steps.rb
+++ b/testsuite/features/step_definitions/smdba_steps.rb
@@ -1,4 +1,4 @@
-# Copyright 2011-2018 SUSE LLC.
+# Copyright 2011-2020 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 Given(/^a postgresql database is running$/) do

--- a/testsuite/features/step_definitions/xmlrpc_common.rb
+++ b/testsuite/features/step_definitions/xmlrpc_common.rb
@@ -1,4 +1,4 @@
-# COPYRIGHT 2015-2019 SUSE LLC
+# Copyright 2015-2019 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 require 'json'

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 SUSE LLC
+# Copyright (c) 2019-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 ADDRESSES = { 'network'     => '0',

--- a/testsuite/features/support/lavanda.rb
+++ b/testsuite/features/support/lavanda.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2019 SUSE LLC.
+# Copyright (c) 2016-2020 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 require 'twopence'

--- a/testsuite/run_sets/init_clients.yml
+++ b/testsuite/run_sets/init_clients.yml
@@ -12,4 +12,5 @@
 - features/init_clients/centos_ssh_minion.feature
 - features/init_clients/ubuntu_ssh_minion.feature
 - features/init_clients/buildhost_bootstrap.feature
+
 ## Post run Core - Initialize clients END ##

--- a/testsuite/run_sets/sanity_check.yml
+++ b/testsuite/run_sets/sanity_check.yml
@@ -6,8 +6,6 @@
 
 ## Sanity Check BEGIN ###
 
-# IMMUTABLE ORDER
-
 - features/core/allcli_sanity.feature
 
 ## Sanity Check END ###


### PR DESCRIPTION
## What does this PR change?

Synchronization between 3.2, 4.0, and uyuni:
 * forgotten temporary changes and workarounds
    * reactivated CentOS reboots on uyuni branch
    * back to 500 seconds to build portus profile on 4.0 branch
 * forgotten backports
    * also 5 seconds for AJAX transitions on 3.2 branch

Sanitization:
 * duplicate scenario names
 * `When`, `Then`, `And` usage
 * whitespace changes
 * copyright notices

## Links:

* issue: SUSE/spacewalk#11969
* 4.0: SUSE/spacewalk#11964
* 3.2: SUSE/spacewalk#11965

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
