### PR TITLE
Spread the data before sorting it, so that the props aren't modified

### DIFF
--- a/web/html/src/manager/admin/setup/products/products.js
+++ b/web/html/src/manager/admin/setup/products/products.js
@@ -478,7 +478,7 @@ class Products extends React.Component {
     return (
       <div>
         <CustomDataHandler
-          data={this.buildRows(this.filterDataByArch(this.props.data).sort(this.compareProducts))}
+          data={this.buildRows(this.filterDataByArch([...this.props.data]).sort(this.compareProducts))}
           identifier={(raw) => raw.identifier}
           initialItemsPerPage={userPrefPageSize}
           loading={this.props.loading}


### PR DESCRIPTION
## What does this PR change?

The component in the product page mutates the `props` by calling `sort` on
them. I've changed that so that it uses spread `[...x]` now.

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"