### PR TITLE
Provide comps when using onlinerepo for kickstart

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/common/DownloadFile.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/common/DownloadFile.java
@@ -621,13 +621,23 @@ public class DownloadFile extends DownloadAction {
             if (child == null) {
                 if (path.contains("repodata/") && tree.getKernelOptions() != null &&
                         tree.getKernelOptions().contains("useonlinerepo")) {
-                    String[] split = StringUtils.split(path, '/');
-                    if (split[0].equals("repodata")) {
-                        split[0] = tree.getChannel().getLabel();
+                    if (path.endsWith("/comps.xml")) {
+                        diskPath = Config.get().getString(ConfigDefaults.MOUNT_POINT) +
+                            "/" + tree.getChannel().getComps().getRelativeFilename();
                     }
-                    diskPath = Config.get().getString(ConfigDefaults.REPOMD_CACHE_MOUNT_POINT, "/pub") +
-                            File.separator + Config.get().getString("repomd_path_prefix", "rhn/repodata/") +
-                            File.separator + StringUtils.join(split, '/');
+                    else if (path.endsWith("/modules.yaml")) {
+                        diskPath = Config.get().getString(ConfigDefaults.MOUNT_POINT) +
+                            "/" + tree.getChannel().getModules().getRelativeFilename();
+                    }
+                    else {
+                        String[] split = StringUtils.split(path, '/');
+                        if (split[0].equals("repodata")) {
+                            split[0] = tree.getChannel().getLabel();
+                        }
+                        diskPath = Config.get().getString(ConfigDefaults.REPOMD_CACHE_MOUNT_POINT, "/pub") +
+                                File.separator + Config.get().getString("repomd_path_prefix", "rhn/repodata/") +
+                                File.separator + StringUtils.join(split, '/');
+                    }
                 }
                 else if (path.endsWith("/media.1/products") && tree.getChannel().getMediaProducts() != null) {
                     diskPath = Config.get().getString(ConfigDefaults.MOUNT_POINT) +

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- provide comps.xml and modules.yaml when using onlinerepo for kickstart
 - Refresh virtualization pages only on events
 - fix up2date detection on RH8 when salt-minion is used for registration
 - improve performance of the System Groups page with many clients (bsc#1172839)


### PR DESCRIPTION
## What does this PR change?

Also for CentOS it is usefull to use the new option "useonlinerepo=1" in Kernel Options.
It happens that the base repo has more packages than the media.
But for a successfull installation, anaconda requires access to comps.xml which works only
for child channels.
This PR serve the mirrored version when useonlinerepo is given.

Corner Case: for completness we do the same for modules.yaml even if a base repo should not have it.

Follow up fix for https://github.com/uyuni-project/uyuni/pull/2344

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **we want to rewrite the autoinstallation chapters anyway**

- [x] **DONE**

## Test coverage
- No tests: **manual tested**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/11979

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
