### PR TITLE
Revert "virt pools: trigger refresh only when getting a websocket event"

### DIFF
--- a/web/html/src/manager/virtualization/guests/GuestProperties.js
+++ b/web/html/src/manager/virtualization/guests/GuestProperties.js
@@ -67,7 +67,7 @@ export function GuestProperties(props: Props) : React.Node {
           networks,
           error: netListError,
         }) => (
-          <VirtualizationPoolsListRefreshApi serverId={props.host.id} lastRefresh={Date.now()}>
+          <VirtualizationPoolsListRefreshApi serverId={props.host.id}>
             {
               ({
                 pools,

--- a/web/html/src/manager/virtualization/pools/list/pools-list.js
+++ b/web/html/src/manager/virtualization/pools/list/pools-list.js
@@ -21,6 +21,7 @@ import type {MessageType} from 'components/messages';
 
 type Props = {
   serverId: string,
+  refreshInterval: number,
   pageSize: number,
 };
 
@@ -146,7 +147,6 @@ const DeleteActionConfirm = (props) => {
 export function PoolsList(props: Props) {
   const [selected, setSelected] = React.useState({});
   const [errors, setErrors] = React.useState([]);
-  const [lastRefresh, setLastRefresh] = React.useState(Date.now());
 
   const refresh = (type: string) => {
     if (type === "pool") {
@@ -197,7 +197,7 @@ export function PoolsList(props: Props) {
         return (
           <VirtualizationPoolsListRefreshApi
             serverId={props.serverId}
-            lastRefresh={lastRefresh}
+            refreshInterval={props.refreshInterval}
           >
           {
             ({

--- a/web/html/src/manager/virtualization/pools/list/pools-list.renderer.js
+++ b/web/html/src/manager/virtualization/pools/list/pools-list.renderer.js
@@ -5,6 +5,7 @@ import SpaRenderer from "core/spa/spa-renderer";
 export const renderer = (id, { serverId, pageSize }) => {
   SpaRenderer.renderNavigationReact(
     <PoolsList
+      refreshInterval={5 * 1000}
       pageSize={pageSize}
       serverId={serverId}
     />,


### PR DESCRIPTION
## What does this PR change?

This reverts commit b3a11b9d67edfac97d988e1d2d05ec548faa8f56.

Before adding this commit we need the code from
https://github.com/openSUSE/salt/pull/248 to be available in the Salt
minions.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only an optimization revert

- [X] **DONE**

## Test coverage
- No tests: UI refresh tests are complex

- [X] **DONE**

## Links


- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
