### PR TITLE
Fix ISE with the AppStream filter UI form (bsc#1174325)

### DIFF
--- a/susemanager-utils/mgr-libmod/mgr-libmod.changes
+++ b/susemanager-utils/mgr-libmod/mgr-libmod.changes
@@ -1,3 +1,5 @@
+- Remove unnecessary array wrap in 'list_modules' response object
+
 -------------------------------------------------------------------
 Wed Jun 10 12:13:35 CEST 2020 - jgonzalez@suse.com
 

--- a/susemanager-utils/mgr-libmod/mgrlibmod/mllib.py
+++ b/susemanager-utils/mgr-libmod/mgrlibmod/mllib.py
@@ -427,7 +427,7 @@ class MLLibmodAPI:
         :rtype: List[str]
         """
         modules: Dict = {
-            "modules": []
+            "modules": {}
         }
         self._proc.index_modules()
         mobj: Dict = {}
@@ -440,7 +440,7 @@ class MLLibmodAPI:
                     "streams": d_mod.get_streams_with_default_profiles(),
                 }
 
-        modules["modules"].append(mobj)
+        modules["modules"] = mobj
         return modules
 
     def _function__list_packages(self) -> Dict[str, List[str]]:

--- a/web/html/src/manager/content-management/list-filters/filter-form.js
+++ b/web/html/src/manager/content-management/list-filters/filter-form.js
@@ -281,7 +281,6 @@ const FilterForm = (props: Props) => {
           clmFilterOptions.STREAM.key === props.filter.type &&
           <>
             <AppStreamsForm/>
-            <input type="hidden" name="rule" value="allow"/>
           </>
         }
 

--- a/web/html/src/manager/content-management/list-filters/filter.utils.js
+++ b/web/html/src/manager/content-management/list-filters/filter.utils.js
@@ -50,6 +50,7 @@ export function mapFilterFormToRequest(filterForm: FilterFormType, projectLabel:
   } else if (filterForm.type === clmFilterOptions.STREAM.key) {
     const streamName = !_isEmpty(filterForm.moduleStream) ? `:${filterForm.moduleStream}` : '';
     requestForm.criteriaValue = `${filterForm.moduleName || ""}${streamName}`;
+    requestForm.rule = "allow";
   }
 
   return requestForm;

--- a/web/html/src/manager/content-management/list-filters/filter.utils.test.js
+++ b/web/html/src/manager/content-management/list-filters/filter.utils.test.js
@@ -173,6 +173,11 @@ describe('Testing filters form <> request mappers', () => {
     expect(mapResponseToFilterForm([mapFilterFormToRequest(filterForm)])[0])
       .toEqual(expect.objectContaining(filterForm));
 
+    // Rule should be "allow" in any case
+    filterForm.rule = "deny";
+
+    expect(mapFilterFormToRequest(filterForm).rule).toEqual("allow");
+
     // Stream name can be empty
     filterForm.moduleStream = "";
 

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Fix internal server error when creating module filters in CLM (bsc#1174325)
 - Fix VM creation page when there is no volume in the default storage pool
 - Refresh virtualization pages only on events
 - Product list in the Wizard doesn't show SLE products first (bsc#1173522)


### PR DESCRIPTION
Fixes some regressions on the AppStream filter UI form in CLM:

- Remove unnecessary single-element array wrap in `mgr-libmod` so it matches the expected input in Java
- Enforce `allow` rule in the AppStream filter form UI

https://bugzilla.suse.com/1174325

## Test coverage
- Unit tests were added

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
