### PR TITLE
VM create: handle pool with no volume

### DIFF
--- a/web/html/src/manager/virtualization/guests/properties/GuestDiskVolumeFields.js
+++ b/web/html/src/manager/virtualization/guests/properties/GuestDiskVolumeFields.js
@@ -85,12 +85,12 @@ export function GuestDiskVolumeFields(props: Props) : React.Node {
       >
         <option></option>
         {/* Adding the value is needed in case the pool is shut down and we don't have the volumes */}
-        { (!selected_pool || selected_pool.volumes.length === 0) && volume &&
+        { (!selected_pool || (selected_pool.volumes ||[]).length === 0) && volume &&
           <option key={volume} value={volume}>{volume}</option>
         }
         {
             selected_pool &&
-              selected_pool.volumes.map(vol => <option key={vol.name} value={vol.name}>{vol.name}</option>)
+              (selected_pool.volumes || []).map(vol => <option key={vol.name} value={vol.name}>{vol.name}</option>)
         }
       </Select>
       { Object.keys(formContext.model).includes(`disk${props.index}_editable`) &&

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Fix VM creation page when there is no volume in the default storage pool
 - Refresh virtualization pages only on events
 - Product list in the Wizard doesn't show SLE products first (bsc#1173522)
 - Cluster UI: return to overview page after scheduling actions


### PR DESCRIPTION
## What does this PR change?

When creating a VM, the default storage pool may contain no disk. We
need to handle this case in the UI to avoid a blank page.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: fixing a corner case

- [X] **DONE**

## Test coverage
- No tests: tiny corner case would need a lot of cucumber hacking to be covered

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
