### PR TITLE
Channels for Uyuni Proxy and Server for openSUSE Leap 15.2

### DIFF
--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -1487,6 +1487,16 @@ gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Server-POOL-x86_64-Media1/
 
+[uyuni-server-stable-leap-152]
+name     = Uyuni Server Stable for %(base_channel_name)s
+archs    = x86_64
+base_channels = opensuse_leap15_2-%(arch)s
+checksum = sha256
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Server-POOL-x86_64-Media1/repodata/repomd.xml.key
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Server-POOL-x86_64-Media1/
+
 [uyuni-server-devel-leap]
 name     = Uyuni Server Devel for %(base_channel_name)s (Development)
 archs    = x86_64
@@ -1501,6 +1511,16 @@ repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/
 name     = Uyuni Proxy Stable for %(base_channel_name)s
 archs    = x86_64
 base_channels = opensuse_leap15_1-%(arch)s
+checksum = sha256
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Proxy-POOL-x86_64-Media1/repodata/repomd.xml.key
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Proxy-POOL-x86_64-Media1/
+
+[uyuni-proxy-stable-leap-152]
+name     = Uyuni Proxy Stable for %(base_channel_name)s
+archs    = x86_64
+base_channels = opensuse_leap15_2-%(arch)s
 checksum = sha256
 gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Proxy-POOL-x86_64-Media1/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,4 @@
+- Channels for Uyuni Proxy and Server for openSUSE Leap 15.2
 - Add aarch64 for openSUSE Leap 15.1 and 15.2
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Channels for Uyuni Proxy and Server for openSUSE Leap 15.2

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- https://github.com/uyuni-project/uyuni-docs/pull/388

- [x] **DONE**

## Test coverage
- No tests: spacewalk-common-channels not covered yet.

- [x] **DONE**

## Links

Required by https://github.com/uyuni-project/uyuni-docs/pull/388

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
