### PR TITLE
Fix softwarechannel update for vendor channels (bsc#1172709)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandler.java
@@ -730,6 +730,7 @@ public class ChannelSoftwareHandler extends BaseHandler {
         validKeys.add("gpg_key_id");
         validKeys.add("gpg_key_fp");
         validKeys.add("gpg_check");
+        validKeys.add("vendor_channel");
         validateMap(validKeys, details);
 
         UpdateChannelCommand ucc = new UpdateChannelCommand(loggedInUser, channel);
@@ -804,6 +805,10 @@ public class ChannelSoftwareHandler extends BaseHandler {
 
         if (details.containsKey("gpg_check")) {
             command.setGpgCheck(Boolean.parseBoolean(details.get("gpg_check")));
+        }
+
+        if (details.containsKey("vendor_channel")) {
+            command.setVendorChannel(Boolean.parseBoolean(details.get("vendor_channel")));
         }
 
         if (details.containsKey("maintainer_name")) {

--- a/java/code/src/com/redhat/rhn/manager/channel/CreateChannelCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/CreateChannelCommand.java
@@ -67,6 +67,7 @@ public class CreateChannelCommand {
     protected String gpgKeyFp;
     protected boolean gpgCheck = true;
     protected String checksum;
+    protected boolean vendorChannel = false;
 
 
     protected String maintainerName;
@@ -162,6 +163,13 @@ public class CreateChannelCommand {
      */
     public void setGpgCheck(boolean gpgCheckIn) {
         gpgCheck = gpgCheckIn;
+    }
+
+    /**
+     * @param vendorChannelIn vendorChannel flag
+     */
+    public void setVendorChannel(boolean vendorChannelIn) {
+        vendorChannel = vendorChannelIn;
     }
 
     /**

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix softwarechannel update for vendor channels (bsc#1172709)
 - Add modular repository warning message to system overview page (bsc#1173959)
 - Change system list header text to something better (bsc#1173982)
 - set CPU and memory info for virtual instances (bsc#1170244)

--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,4 @@
+- Fix softwarechannel update for vendor channels (bsc#1172709)
 - Update package version to 4.2.0
 
 -------------------------------------------------------------------

--- a/spacecmd/src/spacecmd/softwarechannel.py
+++ b/spacecmd/src/spacecmd/softwarechannel.py
@@ -779,57 +779,62 @@ def do_softwarechannel_update(self, args):
 
     (args, options) = parse_command_arguments(args, arg_parser)
 
+    vendor_channel = False
+
     if is_interactive(options):
-       options.label = prompt_user('Channel Label:', noblank=True)
 
-       print('')
-       print('New Name (blank to keep unchanged)')
-       print('------------')
-       print('')
-       options.name = prompt_user('Name:')
+        options.label = prompt_user('Channel Label:', noblank=True)
+        vendor_channel = is_vendor_channel(self, options.label)
 
-       print('')
-       print('New Summary (blank to keep unchanged)')
-       print('------------')
-       print('')
-       options.summary = prompt_user('Summary:')
+        if not vendor_channel:
+            print('')
+            print('New Name (blank to keep unchanged)')
+            print('------------')
+            print('')
+            options.name = prompt_user('Name:')
 
-       print('')
-       print('New Description (blank to keep unchanged)')
-       print('------------')
-       print('')
-       options.description = prompt_user('Description:')
+            print('')
+            print('New Summary (blank to keep unchanged)')
+            print('------------')
+            print('')
+            options.summary = prompt_user('Summary:')
 
-       print('')
-       print('New Checksum type (blank to keep unchanged)')
-       print('------------')
-       print('\n'.join(sorted(self.CHECKSUM)))
-       print('')
-       options.checksum = prompt_user('Select:')
+            print('')
+            print('New Description (blank to keep unchanged)')
+            print('------------')
+            print('')
+            options.description = prompt_user('Description:')
 
-       print('')
-       print('New GPG URL (blank to keep unchanged)')
-       print('------------')
-       print('')
-       options.gpg_url = prompt_user('GPG URL:')
+            print('')
+            print('New Checksum type (blank to keep unchanged)')
+            print('------------')
+            print('\n'.join(sorted(self.CHECKSUM)))
+            print('')
+            options.checksum = prompt_user('Select:')
 
-       print('')
-       print('New GPG ID (blank to keep unchanged)')
-       print('------------')
-       print('')
-       options.gpg_id = prompt_user('GPG ID:')
+            print('')
+            print('New GPG URL (blank to keep unchanged)')
+            print('------------')
+            print('')
+            options.gpg_url = prompt_user('GPG URL:')
 
-       print('')
-       print('New GPG Fingerprint (blank to keep unchanged)')
-       print('------------')
-       print('')
-       options.gpg_fingerprint = prompt_user('GPG Fingerprint:')
+            print('')
+            print('New GPG ID (blank to keep unchanged)')
+            print('------------')
+            print('')
+            options.gpg_id = prompt_user('GPG ID:')
 
-       print('')
-       print('Disable GPG CHECK (blank to keep unchanged)')
-       print('------------')
-       print('')
-       options.disable_gpg_check = prompt_user('Disable GPG Check [yes/no]? ')
+            print('')
+            print('New GPG Fingerprint (blank to keep unchanged)')
+            print('------------')
+            print('')
+            options.gpg_fingerprint = prompt_user('GPG Fingerprint:')
+
+        print('')
+        print('Disable GPG CHECK (blank to keep unchanged)')
+        print('------------')
+        print('')
+        options.disable_gpg_check = prompt_user('Disable GPG Check [yes/no]? ')
 
     if not options.label:
         logging.error('A channel label is required to identify the channel')
@@ -838,6 +843,9 @@ def do_softwarechannel_update(self, args):
         logging.error('Only [yes/no] values are acceptable for --disable_gpg_check')
         return 1
     details = {}
+    if not vendor_channel:
+        vendor_channel = is_vendor_channel(self, options.label)
+
     if options.name:
         details['name'] = options.name
 
@@ -861,6 +869,8 @@ def do_softwarechannel_update(self, args):
 
     if options.disable_gpg_check:
         details['gpg_check'] = str(not options.disable_gpg_check.lower() == "yes")
+
+    details['vendor_channel'] = str(vendor_channel)
 
     self.client.channel.software.setDetails(self.session, options.label, details)
 

--- a/spacecmd/src/spacecmd/utils.py
+++ b/spacecmd/src/spacecmd/utils.py
@@ -839,6 +839,11 @@ def string_to_bool(input_string):
 
     return input_string.lower().strip() in ['true', 'yes']
 
+def is_vendor_channel(self, label):
+    """Return true if channel is vendor channel false otherwise"""
+    vendor_channels = self.client.channel.listVendorChannels(self.session)
+    return any(channel["label"] == label for channel in vendor_channels)
+
 
 class DictToDefault:
     """


### PR DESCRIPTION
## What does this PR change?

Fixes a bug stating that the channel label is reserved when trying to update a vendor channel via `spacecmd softwarechannel_update` (even though there is nothing that changed).

The only parameter that is supposed to be mutable for vendor channels is
the `GPGCheck` flag.
Add  a new `vendorChannel` parameter to  identify if the channel to
update is a vendor channel.
If so skip parsing immutable parameters.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: 

- [x] **DONE**

## Test coverage
- No tests: 

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/11888
https://bugzilla.suse.com/show_bug.cgi?id=1172709

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"  
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
