### PR TITLE
Simplify workflow to check sls files

### DIFF
--- a/.github/workflows/salt-sls-files-checks.yml
+++ b/.github/workflows/salt-sls-files-checks.yml
@@ -2,7 +2,7 @@ name: Check the content of Salt SLS files
 
 on:
   pull_request:
-    types: [opened, edited, synchronize, reopened]
+    paths: 'susemanager-utils/susemanager-sls/salt/**/*.sls'
 
 jobs:
   salt_sls_files_checks:
@@ -10,9 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v1
-      with:
-        fetch-depth: 1
+    - uses: actions/checkout@v2
 
     - uses: mattsb42/not-grep@master
       with:


### PR DESCRIPTION
## What does this PR change?

This patch brings some simplifications to the workflow to check `sls` files as previously commented [here](https://github.com/uyuni-project/uyuni/pull/2326#discussion_r449032563) and [here](https://github.com/uyuni-project/uyuni/pull/2326#discussion_r449036470):

- The workflow should be triggered only when `sls` files are actually changed.
- We can omit the types as the default `pull_request` events are just what we want.
- There is a newer version of the `checkout` action (`v2`) that uses `fetch-depth: 1` per default.

## GUI diff

No difference.

- [X] **DONE**

## Documentation

- No documentation needed, this is affecting only CI workflows.

- [X] **DONE**

## Test coverage

- No tests needed, this is affecting only CI workflows.
 
- [X] **DONE**

## Links

Original PR this workflow has been introduced: #2326 

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below).

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
