### PR TITLE
Fix osad dependencies

### DIFF
--- a/client/tools/mgr-osad/mgr-osad.changes
+++ b/client/tools/mgr-osad/mgr-osad.changes
@@ -1,3 +1,6 @@
+- move uyuni-base-common dependency from mgr-osad to mgr-osa-dispatcher
+  (bsc#1174405)
+
 -------------------------------------------------------------------
 Wed Jan 22 12:09:22 CET 2020 - jgonzalez@suse.com
 

--- a/client/tools/mgr-osad/mgr-osad.spec
+++ b/client/tools/mgr-osad/mgr-osad.spec
@@ -69,8 +69,6 @@ BuildRequires:  perl
 Requires:       %{pythonX}-%{name} = %{version}-%{release}
 Conflicts:      mgr-osa-dispatcher < %{version}-%{release}
 Conflicts:      mgr-osa-dispatcher > %{version}-%{release}
-BuildRequires:  uyuni-base-common
-Requires(pre):  uyuni-base-common
 %if 0%{?suse_version} >= 1210
 BuildRequires:  systemd
 %{?systemd_requires}
@@ -188,6 +186,8 @@ Summary:        OSA dispatcher
 Group:          System Environment/Daemons
 Obsoletes:      osa-dispatcher < %{oldversion}
 Provides:       osa-dispatcher = %{oldversion}
+BuildRequires:  uyuni-base-common
+Requires(pre):  uyuni-base-common
 Requires:       lsof
 Requires:       %{pythonX}-mgr-osa-dispatcher = %{version}-%{release}
 Requires:       spacewalk-backend-server >= 1.2.32


### PR DESCRIPTION
## What does this PR change?

Dependency wrongly set to mgr-osad (client) while we would need it on the server component (mgr-osa-dispatcher)

uyuni-base-common is a common package for server and proxy usage. It provide common paths like /etc/rhn and 
/share/rhn/config-defaults which group owner should be `www`. 
This path is required by mgr-osa-dispatcher (server component) but not for mgr-osad (client component).
The dependency was simply set on the wrong sub-package.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **no changes needed**

- [x] **DONE**

## Test coverage
- No tests: **dependency errors not tested**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/12004

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
