### PR TITLE
Testsuite: Add missing anchors in steps

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1066,7 +1066,7 @@ Then(/^I should not see a "([^"]*)" virtual machine on "([^"]*)"$/) do |vm, host
   end
 end
 
-Then(/"([^"]*)" virtual machine on "([^"]*)" should have ([0-9]*)MB memory and ([0-9]*) vcpus$/) do |vm, host, mem, vcpu|
+Then(/^"([^"]*)" virtual machine on "([^"]*)" should have ([0-9]*)MB memory and ([0-9]*) vcpus$/) do |vm, host, mem, vcpu|
   node = get_target(host)
   repeat_until_timeout(message: "#{vm} virtual machine on #{host} never got #{mem}MB memory and #{vcpu} vcpus") do
     output, _code = node.run("virsh dumpxml #{vm}")
@@ -1077,7 +1077,7 @@ Then(/"([^"]*)" virtual machine on "([^"]*)" should have ([0-9]*)MB memory and (
   end
 end
 
-Then(/"([^"]*)" virtual machine on "([^"]*)" should have ([a-z]*) graphics device$/) do |vm, host, type|
+Then(/^"([^"]*)" virtual machine on "([^"]*)" should have ([a-z]*) graphics device$/) do |vm, host, type|
   node = get_target(host)
   repeat_until_timeout(message: "#{vm} virtual machine on #{host} never got #{type} graphics device") do
     output, _code = node.run("virsh dumpxml #{vm}")
@@ -1257,7 +1257,7 @@ When(/^I prepare the retail configuration file on server$/) do
   $server.run("sed -i '#{sed_values}' #{dest}")
 end
 
-When(/^I import the retail configuration using retail_yaml command/) do
+When(/^I import the retail configuration using retail_yaml command$/) do
   filepath = '/tmp/massive-import-terminals.yml'
   $server.run("retail_yaml --api-user admin --api-pass admin --from-yaml #{filepath}")
 end

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -51,12 +51,12 @@ Then(/^I should see the name of the image$/) do
   step %(I should see a "#{compute_image_name}" text)
 end
 
-Then(/^I should see the terminals imported from the configuration file/) do
+Then(/^I should see the terminals imported from the configuration file$/) do
   terminals = read_terminals_from_yaml
   terminals.each { |terminal| step %(I should see a "#{terminal}" text) }
 end
 
-Then(/^I should not see any terminals imported from the configuration file/) do
+Then(/^I should not see any terminals imported from the configuration file$/) do
   terminals = read_terminals_from_yaml
   terminals.each do |terminal|
     next if (terminal.include? 'minion') || (terminal.include? 'client')
@@ -187,12 +187,12 @@ Then(/^I add "([^"]*)" channel$/) do |channel|
 end
 
 # channel steps
-When(/^I use spacewalk\-channel to add test-channel-x86_64-child-channel/) do
+When(/^I use spacewalk\-channel to add test-channel-x86_64-child-channel$/) do
   child_channel = 'test-channel-x86_64-child-channel'
   step %(I execute spacewalk\-channel and pass "--add -c #{child_channel} -u admin -p admin")
 end
 
-When(/^I use spacewalk\-channel to remove test-channel-x86_64-child-channel/) do
+When(/^I use spacewalk\-channel to remove test-channel-x86_64-child-channel$/) do
   child_channel = 'test-channel-x86_64-child-channel'
   step %(I execute spacewalk\-channel and pass "--remove -c #{child_channel} -u admin -p admin")
 end
@@ -214,7 +214,7 @@ Given(/cobblerd is running/) do
   raise 'cobblerd is not running' unless ct.running?
 end
 
-Then(/create distro "([^"]*)" as user "([^"]*)" with password "([^"]*)"/) do |distro, user, pwd|
+Then(/^create distro "([^"]*)" as user "([^"]*)" with password "([^"]*)"$/) do |distro, user, pwd|
   ct = CobblerTest.new
   ct.login(user, pwd)
   raise 'distro ' + distro + ' already exists' if ct.distro_exists(distro)
@@ -244,7 +244,7 @@ Given(/distro "([^"]*)" exists/) do |distro|
   raise 'distro ' + distro + ' does not exist' unless ct.distro_exists(distro)
 end
 
-Then(/create profile "([^"]*)" as user "([^"]*)" with password "([^"]*)"/) do |arg1, arg2, arg3|
+Then(/^create profile "([^"]*)" as user "([^"]*)" with password "([^"]*)"$/) do |arg1, arg2, arg3|
   ct = CobblerTest.new
   ct.login(arg2, arg3)
   raise 'profile ' + arg1 + ' already exists' if ct.profile_exists(arg1)
@@ -381,7 +381,7 @@ Then(/^HTTP proxy verification should have succeeded$/) do
   raise 'Success icon not found' unless find('i.text-success', wait: DEFAULT_TIMEOUT)
 end
 
-When(/^I enter the address of the HTTP proxy as "([^"]*)"/) do |hostname|
+When(/^I enter the address of the HTTP proxy as "([^"]*)"$/) do |hostname|
   step %(I enter "#{$server_http_proxy}" as "#{hostname}")
 end
 

--- a/testsuite/features/step_definitions/xmlrpc_common.rb
+++ b/testsuite/features/step_definitions/xmlrpc_common.rb
@@ -163,7 +163,7 @@ When(/^I associate repo "([^"]*)" with channel "([^"]*)"$/) do |repo_label, chan
   assert(rpctest.associate_repo(channel_label, repo_label))
 end
 
-When(/^I create the following channels:/) do |table|
+When(/^I create the following channels:$/) do |table|
   channels = table.hashes
   channels.each do |ch|
     assert_equal(1,


### PR DESCRIPTION
## What does this PR change?

Some tools get fooled when there are missing anchors.
Make all step definitions follow the canonical form:

When(/^foo$/) do
Then(/^foo$/) do

- testsuite/features/step_definitions/command_steps.rb
- testsuite/features/step_definitions/common_steps.rb
- testsuite/features/step_definitions/xmlrpc_common.rb

This is a follow up of https://github.com/uyuni-project/uyuni/pull/2389

## Links
### Ports
- Manager-3.2: https://github.com/SUSE/spacewalk/pull/12009
- Manager-4.0: https://github.com/SUSE/spacewalk/pull/12010
- Manager-4.1: https://github.com/SUSE/spacewalk/pull/12020
- qam-testsuite: https://github.com/SUSE/spacewalk/pull/12011

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed