### PR TITLE
Proxy bootstrap repo

### DIFF
--- a/susemanager/src/mgr-create-bootstrap-repo
+++ b/susemanager/src/mgr-create-bootstrap-repo
@@ -438,12 +438,19 @@ def create_repo(label, options, mgr_bootstrap_data, additional=[]):
         altpretty =  ', '.join("'%s'" %(e) for e in alt)
         altcount = 0
         for pkgname in alt:
+            optional = False
+            if pkgname[-1] == "*":
+                optional = True
+                pkgname = pkgname[:-1]
             altcount += 1
             h.execute(parentchannel=parentchannel, pkgname=pkgname)
             pkgs = h.fetchall_dict() or []
             log("Package {0} found {1} resulting packages:".format(
                 pkgname, len(pkgs)), 2)
             if len(pkgs) == 0:
+                if optional:
+                    log("Optional package '{0}' not found".format(pkgname))
+                    continue
                 if altcount >= len(alt):
                     if len(alt) > 1:
                         messages.append("ERROR: none of %s found" % altpretty)

--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -435,7 +435,7 @@ PKGLIST15_TRAD = [
     "python3-spacewalk-check",
     "python3-spacewalk-client-setup",
     "python3-spacewalk-client-tools",
-    "python3-uyuni-common-libs",
+    "python3-uyuni-common-libs*",
     "mgr-daemon|spacewalksd",
     "suseRegisterInfo",
     "python3-suseRegisterInfo",

--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -2,6 +2,12 @@
 # DO NOT EDIT !!!
 #
 
+# package list format
+#
+# | alternative. Example: "a|b" when package "a" cannot be found try "b". First match wins.
+#                One must be available.
+# * optional. Example: "a*" if "a" is available add it, otherwise ignore it
+
 PKGLIST10 = [
     "libaugeas0",
     "libnewt0_52",

--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -1070,6 +1070,10 @@ DATA = {
         'PDID' : [1772, 1712], 'BETAPDID' : [1928], 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15SP0SP1_SALT + PKGLIST15_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/15/1/bootstrap/'
     },
+    'SUMA-40-PROXY-x86_64' : {
+        'PDID' : [1772, 1908], 'BETAPDID' : [], 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15SP0SP1_SALT + PKGLIST15_X86_ARM,
+        'DEST' : '/srv/www/htdocs/pub/repositories/sle/15/1/bootstrap/'
+    },
     'SLE-15-SP2-aarch64' : {
         'PDID' : [1943, 1709], 'BETAPDID' : [1925], 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/15/2/bootstrap/'
@@ -1084,6 +1088,10 @@ DATA = {
     },
     'SLE-15-SP2-x86_64' : {
         'PDID' : [1946, 1712], 'BETAPDID' : [1928], 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15_X86_ARM,
+        'DEST' : '/srv/www/htdocs/pub/repositories/sle/15/2/bootstrap/'
+    },
+    'SUMA-41-PROXY-x86_64' : {
+        'PDID' : [1946, 2015], 'BETAPDID' : [], 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/15/2/bootstrap/'
     },
     'openSUSE-Leap-42.3-x86_64' : {

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- define bootstrap repo data for SUSE Manager Proxies (bsc#1174470)
 - Update package version to 4.2.0
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

SUSE Manager Proxies do not get the Tools Channel. But the missing packages are available on the Proxy Module.
To make creation of bootstrap repo work for customers which on have SUSE Manager Proxy, but no normal SLES, we need to provide extra bootstrap data for proxies which use the proxy module instead of the Tools Channel as source of packages.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **just internal**

- [x] **DONE**

## Test coverage
- No tests: **manual**

- [x] **DONE**

## Links

Fixes  https://github.com/SUSE/spacewalk/issues/12031
      https://bugzilla.suse.com/show_bug.cgi?id=1174470
Tracks 

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
