### PR TITLE
Maintenance Windows fix assigning schedules to systems

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemDetailsEditAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemDetailsEditAction.java
@@ -175,31 +175,6 @@ public class SystemDetailsEditAction extends RhnAction {
         s.getLocation().setRoom(daForm.getString(ROOM));
         s.getLocation().setRack(daForm.getString(RACK));
 
-        // Assign maintenance schedule
-        Long scheduleId = (Long) daForm.get(MAINTENANCE_SCHEDULE);
-
-        if (scheduleId != null && scheduleId != 0) {
-            // Assign schedule
-            MaintenanceSchedule schedule = maintenanceManager.lookupScheduleByUserAndId(user, scheduleId).get();
-            boolean cancelAffected = Boolean.TRUE.equals(daForm.get(MAINTENANCE_CANCEL_AFFECTED));
-            try {
-                maintenanceManager.assignScheduleToSystems(user, schedule, Collections.singleton(s.getId()),
-                        cancelAffected);
-                log.debug(String.format("System %s assigned to schedule %s.", s.getId(), schedule.getName()));
-            }
-            catch (IllegalArgumentException e) {
-                log.debug(e);
-                getStrutsDelegate().addError("maintenance.action.assign.error.fail", errors);
-                success = false;
-            }
-        }
-        else if (s.getMaintenanceScheduleOpt().isPresent()) {
-            // Retract schedule
-            String scheduleName = s.getMaintenanceScheduleOpt().get().getName();
-            maintenanceManager.retractScheduleFromSystems(user, Collections.singleton(s.getId()));
-            log.debug(String.format("System %s unassigned from schedule %s.", s.getId(), scheduleName));
-        }
-
         /* If the server does not have a Base Entitlement
          * the user should not be updating these values
          * no matter what the form they are submitting looks
@@ -250,6 +225,31 @@ public class SystemDetailsEditAction extends RhnAction {
             }
 
             success &= applyAddonEntitlementChanges(request, daForm, s, user);
+        }
+
+        // Assign maintenance schedule
+        Long scheduleId = (Long) daForm.get(MAINTENANCE_SCHEDULE);
+
+        if (scheduleId != null && scheduleId != 0) {
+            // Assign schedule
+            MaintenanceSchedule schedule = maintenanceManager.lookupScheduleByUserAndId(user, scheduleId).get();
+            boolean cancelAffected = Boolean.TRUE.equals(daForm.get(MAINTENANCE_CANCEL_AFFECTED));
+            try {
+                maintenanceManager.assignScheduleToSystems(user, schedule, Collections.singleton(s.getId()),
+                        cancelAffected);
+                log.debug(String.format("System %s assigned to schedule %s.", s.getId(), schedule.getName()));
+            }
+            catch (IllegalArgumentException e) {
+                log.debug(e);
+                getStrutsDelegate().addError("maintenance.action.assign.error.fail", errors);
+                success = false;
+            }
+        }
+        else if (s.getMaintenanceScheduleOpt().isPresent()) {
+            // Retract schedule
+            String scheduleName = s.getMaintenanceScheduleOpt().get().getName();
+            maintenanceManager.retractScheduleFromSystems(user, Collections.singleton(s.getId()));
+            log.debug(String.format("System %s unassigned from schedule %s.", s.getId(), scheduleName));
         }
 
         if (!success) {

--- a/java/code/src/com/suse/manager/maintenance/MaintenanceManager.java
+++ b/java/code/src/com/suse/manager/maintenance/MaintenanceManager.java
@@ -41,6 +41,7 @@ import com.redhat.rhn.manager.system.SystemManager;
 import com.suse.manager.model.maintenance.CalendarAssignment;
 import com.suse.manager.model.maintenance.CalendarFactory;
 import com.suse.manager.model.maintenance.ScheduleFactory;
+import com.suse.manager.maintenance.rescheduling.FailRescheduleStrategy;
 import com.suse.manager.maintenance.rescheduling.CancelRescheduleStrategy;
 import com.suse.manager.maintenance.rescheduling.RescheduleException;
 import com.suse.manager.maintenance.rescheduling.RescheduleResult;
@@ -588,6 +589,10 @@ public class MaintenanceManager {
         Set<Long> withMaintenanceActions = ServerFactory.filterSystemsWithPendingMaintOnlyActions(serverIds);
         if (withMaintenanceActions.isEmpty()) {
             return new RescheduleResult(schedule.getName(), true);
+        }
+        // If no rescheduleStrategy is given default to 'Fail'
+        if (scheduleStrategy.isEmpty()) {
+            scheduleStrategy = Collections.singletonList(new FailRescheduleStrategy());
         }
         List<Server> servers = ServerFactory.lookupByIdsAndOrg(withMaintenanceActions, user.getOrg());
 

--- a/java/code/src/com/suse/manager/maintenance/rescheduling/FailRescheduleStrategy.java
+++ b/java/code/src/com/suse/manager/maintenance/rescheduling/FailRescheduleStrategy.java
@@ -32,8 +32,14 @@ public class FailRescheduleStrategy implements RescheduleStrategy {
     private static final Logger LOG = Logger.getLogger(CancelRescheduleStrategy.class);
 
     @Override
-    public RescheduleResult reschedule(User user, Map<Action, List<Server>> actionServer,
+    public RescheduleResult reschedule(User user, Map<Action, List<Server>> actionsServers,
             MaintenanceSchedule schedule) throws RescheduleException {
+
+        if (actionsServers.isEmpty()) {
+            RescheduleResult result = new RescheduleResult(getType().getLabel(), schedule.getName(), actionsServers);
+            result.setSuccess(true);
+            return  result;
+        }
 
         LOG.info("Rescheduling failed");
         throw new RescheduleException();

--- a/web/html/src/components/action-schedule.js
+++ b/web/html/src/components/action-schedule.js
@@ -104,6 +104,7 @@ class ActionSchedule extends React.Component<ActionScheduleProps, ActionSchedule
                 maintenanceWindows: indexed,
                 isMaintenanceModeEnabled: true
               });
+              this.onMaintenanceWindowChanged(maintenanceWindows[0]);
             }
             else {
               this.setState({

--- a/web/html/src/manager/maintenance/details/schedule-details.js
+++ b/web/html/src/manager/maintenance/details/schedule-details.js
@@ -146,7 +146,7 @@ const SystemPicker = (props: SystemPickerProps) => {
         Network.get(`/rhn/manager/api/systems/targetforschedule/${props.scheduleId}`).promise
             .then(setSystems)
             .catch(xhr => props.onMessage(
-                MessagesUtils.error(Network.errorMessageByStatus(xhr.status))))
+                Network.responseErrorMessage(xhr)))
             .finally(() => setLoading(false));
     }, [props.scheduleId]);
 
@@ -158,7 +158,7 @@ const SystemPicker = (props: SystemPickerProps) => {
                 MessagesUtils.success(t("Maintenance schedule has been assigned to {0} system(s)", selectedSystems.length))))
             .then(props.onAssign)
             .catch(xhr => props.onMessage(
-                MessagesUtils.error(Network.errorMessageByStatus(xhr.status))));
+                Network.responseErrorMessage(xhr)));
     };
 
     return (


### PR DESCRIPTION
## What does this PR change?

Fixes a couple of issues that occurred when assigning schedules to systems using the default `Fail` reschedule
strategy.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: Just bugfixes

- [x] **DONE**

## Test coverage
- No tests: **add explanation**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
