### PR TITLE
Cpu and mem info for virtual machines

### DIFF
--- a/java/code/src/com/suse/manager/reactor/hardware/HardwareMapper.java
+++ b/java/code/src/com/suse/manager/reactor/hardware/HardwareMapper.java
@@ -552,6 +552,8 @@ public class HardwareMapper {
         String virtSubtype = grains.getValueAsString("virtual_subtype");
         String instanceId = grains.getValueAsString("instance_id");
         String virtUuid = (StringUtils.isEmpty(instanceId)) ? grains.getValueAsString("uuid") : instanceId;
+        int vCPUs = grains.getValueAsLong("total_num_cpus").orElse(0L).intValue();
+        long memory = grains.getValueAsLong("mem_total").orElse(0L);
 
         if (virtTypeLowerCase == null) {
             errors.add("Virtualization: Grain 'virtual' has no value");
@@ -655,7 +657,7 @@ public class HardwareMapper {
                     VirtualInstanceManager.addGuestVirtualInstance(
                             virtUuid, server.getName(), type,
                             VirtualInstanceFactory.getInstance().getRunningState(),
-                            null, server);
+                            null, server, vCPUs, memory);
                 }
                 else {
                     String name = virtualInstance.getName();
@@ -666,7 +668,7 @@ public class HardwareMapper {
                     }
                     VirtualInstanceManager.updateGuestVirtualInstance(virtualInstance, name,
                             VirtualInstanceFactory.getInstance().getRunningState(),
-                            virtualInstance.getHostSystem(), server);
+                            virtualInstance.getHostSystem(), server, vCPUs, memory);
                 }
             }
             else {
@@ -678,7 +680,7 @@ public class HardwareMapper {
                     }
                     VirtualInstanceManager.updateGuestVirtualInstance(virtualInstance, name,
                             VirtualInstanceFactory.getInstance().getRunningState(),
-                            virtualInstance.getHostSystem(), server);
+                            virtualInstance.getHostSystem(), server, vCPUs, memory);
                 });
             }
         }

--- a/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
@@ -774,6 +774,8 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                     server.getCpu().getFlags());
             assertEquals("42", server.getCpu().getVersion());
             assertNotNull(server.getVirtualInstance());
+            assertEquals(Integer.valueOf(1), server.getVirtualInstance().getNumberOfCPUs());
+            assertEquals(Long.valueOf(489), server.getVirtualInstance().getTotalMemory());
             assertNotNull(server.getDmi());
             assertNotNull(server.getDmi().getSystem());
             assertNotNull(server.getDmi().getProduct());

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- set CPU and memory info for virtual instances (bsc#1170244)
 - Add virtual network Start, Stop and Delete actions
 - Add virtual network list page
 - update default product tree tag and set Beta tag again


### PR DESCRIPTION
## What does this PR change?

Virtual Machines created with salt do not set CPU and Memory infos into the virtual instance into.
This PR add them.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **should now work like expected**

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/11875
Tracks 

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
