### PR TITLE
Add modular repository warning to the system overview page (bsc#1173959)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/BaseSystemPackagesAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/BaseSystemPackagesAction.java
@@ -98,14 +98,7 @@ public abstract class BaseSystemPackagesAction extends RhnAction {
         ListTagHelper.bindSetDeclTo(LIST_NAME, getDecl(sid), request);
         TagHelper.bindElaboratorTo(LIST_NAME, dataSet.getElaborator(), request);
 
-        boolean hasModules = false;
-        for (Channel channel : server.getChannels()) {
-            if (channel.getModules() != null) {
-                hasModules = true;
-                break;
-            }
-        }
-        if (hasModules) {
+        if (server.getChannels().stream().anyMatch(Channel::isModular)) {
             createErrorMessage(request, "packagelist.jsp.modulespresent", null);
         }
         return mapping.findForward(RhnHelper.DEFAULT_FORWARD);

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemOverviewAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemOverviewAction.java
@@ -25,6 +25,7 @@ import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.entitlement.Entitlement;
 import com.redhat.rhn.domain.server.MinionServer;
 import org.apache.commons.lang3.StringEscapeUtils;
@@ -125,6 +126,10 @@ public class SystemOverviewAction extends RhnAction {
                         e1.getHumanReadableLabel().compareTo(e2.getHumanReadableLabel()) :
                         (e1.isBase() ? -1 : 1))
                 .collect(Collectors.toList());
+
+        if (s.getChannels().stream().anyMatch(Channel::isModular)) {
+            createErrorMessage(request, "packagelist.jsp.modulespresent", null);
+        }
 
         request.setAttribute("rebootRequired", Boolean.valueOf(rebootRequired));
         request.setAttribute("unentitled", Boolean.valueOf(s.getEntitlements().isEmpty()));

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/test/SystemOverviewActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/test/SystemOverviewActionTest.java
@@ -14,6 +14,7 @@
  */
 package com.redhat.rhn.frontend.action.systems.sdc.test;
 
+import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.errata.Errata;
 import com.redhat.rhn.domain.errata.ErrataFactory;
 import com.redhat.rhn.domain.errata.test.ErrataFactoryTest;
@@ -27,6 +28,7 @@ import com.redhat.rhn.domain.server.ServerConstants;
 import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
 import com.redhat.rhn.domain.server.test.ServerFactoryTest;
 import com.redhat.rhn.domain.user.UserFactory;
+import com.redhat.rhn.manager.contentmgmt.test.MockModulemdApi;
 import com.redhat.rhn.manager.errata.cache.ErrataCacheManager;
 import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
@@ -37,6 +39,7 @@ import com.redhat.rhn.testing.TestUtils;
 
 import java.sql.Timestamp;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.Date;
 
 /**
@@ -146,5 +149,16 @@ public class SystemOverviewActionTest extends RhnMockStrutsTestCase {
         actionPerform();
 
         assertEquals(kernelLiveVersion, request.getAttribute("kernelLiveVersion"));
+    }
+
+    public void testModularRepositoryMessage() throws Exception {
+        actionPerform();
+        verifyNoActionErrors();
+
+        Channel modular = MockModulemdApi.createModularTestChannel(user);
+        s.setChannels(Collections.singleton(modular));
+        actionPerform();
+
+        verifyActionErrors(new String[]{"packagelist.jsp.modulespresent"});
     }
 }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add modular repository warning message to system overview page (bsc#1173959)
 - Change system list header text to something better (bsc#1173982)
 - set CPU and memory info for virtual instances (bsc#1170244)
 - Add virtual network Start, Stop and Delete actions


### PR DESCRIPTION
Extend the existing modular repository warning message in package install/update pages to the system overview page.

See also: https://bugzilla.suse.com/1173959

Fixes https://github.com/SUSE/spacewalk/issues/11974

## GUI diff

After:
![modrepo-system-overview](https://user-images.githubusercontent.com/1103552/88559030-9c70d480-d02c-11ea-8660-3235ec1ee2d1.png)

## Test coverage
- Unit tests were added

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
