### PR TITLE
Change config column name to something more accurate

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -4936,7 +4936,7 @@ organization. You may grant or remove the organization administrator role in the
         </context-group>
       </trans-unit>
       <trans-unit id="systemlist.jsp.configfiles">
-        <source>Configs</source>
+        <source>Config Diffs</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/SystemList</context>
         </context-group>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Change system list header text to something better (bsc#1173982)
 - set CPU and memory info for virtual instances (bsc#1170244)
 - Add virtual network Start, Stop and Delete actions
 - Add virtual network list page


### PR DESCRIPTION
## What does this PR change?
port of https://github.com/SUSE/spacewalk/pull/12036
fixes l3 https://bugzilla.suse.com/show_bug.cgi?id=1173982

Changes the config column name on the systems list from Configs -> Config Diffs.

## GUI diff

Before:
![config_name_bef](https://user-images.githubusercontent.com/729087/88635565-17330180-d0b8-11ea-9a66-dadb373bc6c9.png)

After:
![config_name_aft](https://user-images.githubusercontent.com/729087/88635576-1bf7b580-d0b8-11ea-8c09-2705fc2dc6fb.png)

- [ ] **DONE**

## Documentation
- No documentation needed: doc people pinged

- [ ] **DONE**

## Test coverage
- No tests: none needed


- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
