### PR TITLE
Output something at least every now and then when waiting for events

### DIFF
--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -59,9 +59,15 @@ When(/^I wait until I see "([^"]*)" text, refreshing the page$/) do |text|
 end
 
 When(/^I wait at most (\d+) seconds until the event is completed, refreshing the page$/) do |timeout|
+  last = Time.now
   repeat_until_timeout(timeout: timeout.to_i, message: 'Event not yet completed') do
     break if has_content?("This action's status is: Completed.")
     raise 'Event failed' if has_content?("This action's status is: Failed.")
+    current = Time.now
+    if current - last > 150
+      STDOUT.puts "#{current} Still waiting for action to complete..."
+      last = current
+    end
     evaluate_script 'window.location.reload()'
   end
 end


### PR DESCRIPTION
## What does this PR change?

We are re-adding delays in jenkins to stop jobs that remain silent too long.

This PR adds some output to the longest waits, so both the human operator and jenkins know that something is happening.

## Links

Fixes SUSE/spacewalk#12029

Backports:
* 3.2:
* 4.0:
* 4.1:

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
