### PR TITLE
Cert common name too long

### DIFF
--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,4 @@
+- strip SSL Certificate Common Name after 63 Characters (bsc#1173535)
 - Update package version to 4.2.0
 
 -------------------------------------------------------------------

--- a/spacewalk/certs-tools/sslToolConfig.py
+++ b/spacewalk/certs-tools/sslToolConfig.py
@@ -450,7 +450,7 @@ def gen_req_distinguished_name(d):
     keys = ('C', 'ST', 'L', 'O', 'OU', 'CN', 'emailAddress')
     for key in keys:
         if key in d and d[key].strip():
-            s = s + key + (24-len(key))*' ' + '= %s\n' % d[key].strip()
+            s = s + key + (24-len(key))*' ' + '= %s\n' % d[key].strip()[:63]
         else:
             s = s + '#' + key + (24-len(key))*' ' + '= ""\n'
 


### PR DESCRIPTION
## What does this PR change?

SSL Certificates have a limit of 64 Characters for Common Name (and other options).
Strip values after 63 Characters to prevent crashes.
In case the hostname is longer than 64 Characters it appears in Subject Alternative Name in full length.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **not available**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/11855
Tracks 

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
