### PR TITLE
Fix SSM maintenance schedule assignment form

### DIFF
--- a/web/html/src/manager/maintenance/ssm/schedule-picker.js
+++ b/web/html/src/manager/maintenance/ssm/schedule-picker.js
@@ -135,7 +135,7 @@ export function SchedulePicker(props: {schedules: ScheduleType[]}) {
       >
         <option key="-1" value="" disabled>Select a schedule</option>
         <option key="0" value="0">None - clear schedule</option>
-        {props.schedules.map(s => <option key={s.scheduleId} value={s.scheduleId}>{s.scheduleName}</option>)}
+        {props.schedules.map(s => <option key={s.id} value={s.id}>{s.name}</option>)}
       </Select>
       { context.model.scheduleId !== "0" &&
         <Check


### PR DESCRIPTION
Fix the property names in the SSM maintenance schedule assignment form.

## Documentation
- No documentation needed: Bugfix

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
