### PR TITLE
Check that we are really on that page

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -206,6 +206,7 @@ Given(/^I am on the Systems page$/) do
   steps %(
     When I am authorized as "admin" with password "admin"
     When I follow the left menu "Systems > Overview"
+    When I wait until I see "System Overview" text
   )
 end
 


### PR DESCRIPTION
## What does this PR change?

It seems that we are sometimes not in the page we want to be.
Possible SPA error on fast server.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **testinfrastructure**

- [x] **DONE**

## Test coverage
- Cucumber tests improved

- [x] **DONE**

## Links

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
