### PR TITLE
Testsuite: Fix step name

### DIFF
--- a/testsuite/features/init_clients/min_centos_salt.feature
+++ b/testsuite/features/init_clients/min_centos_salt.feature
@@ -40,7 +40,7 @@ Feature: Be able to bootstrap a CentOS minion and do some basic operations on it
     Then I should see "ceos_minion" hostname
 
 @centos_minion
-  Scenario: Re-subscribe the CentOS minion to a base channel
+  Scenario: Subscribe the CentOS minion to a base channel
     Given I am on the Systems overview page of this "ceos_minion"
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area


### PR DESCRIPTION
## What does this PR change?
Update the name of one Cucumber scenario.

- testsuite/features/init_clients/min_centos_salt.feature:
Replace Re-subscribe with subscribe

##Links
### Ports
(Manager-4.0 is not affected)

- Manager-3.2: https://github.com/SUSE/spacewalk/pull/12062
- Manager-4.1: https://github.com/SUSE/spacewalk/pull/12061

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)
