### PR TITLE
Testsuite - increased timeout for onboarding ubuntu minion clients

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -827,10 +827,13 @@ When(/^I wait until onboarding is completed for "([^"]*)"$/) do |host|
   if get_client_type(host) == 'traditional'
     get_target(host).run('rhn_check -vvv')
   else
+    # Ubuntu minion clients need more time to finish all onboarding events
+    onboarding_timeout = DEFAULT_TIMEOUT
+    onboarding_timeout = DEFAULT_TIMEOUT * 2 if %w[ubuntu_minion ubuntu_ssh_minion].include?(host)
     steps %(
-      And I wait until event "Hardware List Refresh" is completed
-      And I wait until event "Apply states" is completed
-      And I wait until event "Package List Refresh" is completed
+      And I wait at most #{onboarding_timeout} seconds until event "Hardware List Refresh" is completed
+      And I wait at most #{onboarding_timeout} seconds until event "Apply states" is completed
+      And I wait at most #{onboarding_timeout} seconds until event "Package List Refresh" is completed
     )
   end
 end


### PR DESCRIPTION
## What does this PR change?

PR increases default timeout for Ubuntu minion onboarding events to finish. It takes significantly longer time than in case of other types of supported clients.

## Links

https://github.com/SUSE/spacewalk/issues/11922

Port of: https://github.com/SUSE/spacewalk/pull/12074

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
