### PR TITLE
Fix: dnf complains about dup channels and options (bsc#1172504)

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/channels/channels.repo
+++ b/susemanager-utils/susemanager-sls/salt/channels/channels.repo
@@ -11,7 +11,6 @@ deb {{ '[trusted=yes]' if not pillar.get('mgr_metadata_signing_enabled', false) 
 [{{ args['alias'] }}]
 name={{ args['name'] }}
 enabled={{ args['enabled'] }}
-autorefresh={{ args['autorefresh'] }}
 {%- if grains['os_family'] == 'RedHat' %}
 baseurl={{protocol}}://{{hostname}}:{{port}}/rhn/manager/download/{{ chan }}
 susemanager_token={{ args['token'] }}
@@ -24,6 +23,7 @@ gpgkey=https://{{ args['host'] }}/pub/mgr-gpg-pub.key
 module_hotfixes=1
 {%- endif %}
 {%- else %}
+autorefresh={{ args['autorefresh'] }}
 baseurl={{protocol}}://{{hostname}}:{{port}}/rhn/manager/download/{{ chan }}?{{ args['token'] }}
 gpgcheck={{ args['gpgcheck'] }}
 repo_gpgcheck={{ args['repo_gpgcheck'] }}

--- a/susemanager-utils/susemanager-sls/salt/channels/dnf-susemanager-plugin/susemanagerplugin.py
+++ b/susemanager-utils/susemanager-sls/salt/channels/dnf-susemanager-plugin/susemanagerplugin.py
@@ -6,7 +6,8 @@ class Susemanager(dnf.Plugin):
 
     def __init__(self, base, cli):
         super(Susemanager, self).__init__(base, cli)
-        base.read_all_repos()
+        with dnf.base.Base() as base:
+            base.read_all_repos()
         for repo in base.repos.get_matching("susemanager:*"):
             try:
                 susemanager_token = repo.cfg.getValue(section=repo.id, key="susemanager_token")

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,5 @@
+- Fix: supply a dnf base when dealing w/repos (bsc#1172504)
+- Fix: autorefresh in repos is zypper-only
 - Add virtual network state change state to handle start, stop and delete
 - Add virtual network state change state to handle start and stop
 - Update package version to 4.2.0


### PR DESCRIPTION
## What does this PR change?

Fix: autorefresh in repos is zypper-only
Fix: supply a dnf base when dealing w/repos (bsc#1172504)

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: internal

- [X] **DONE**

## Links

Tracks #11638 

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
