### PR TITLE
Do not try to set uneditable fields

### DIFF
--- a/testsuite/features/secondary/min_centos_ssh.feature
+++ b/testsuite/features/secondary/min_centos_ssh.feature
@@ -24,8 +24,6 @@ Feature: Bootstrap a SSH-managed CentOS minion and do some basic operations on i
     Then I should see a "Bootstrap Minions" text
     When I check "manageWithSSH"
     And I enter the hostname of "ceos_ssh_minion" as "hostname"
-    And I enter "22" as "port"
-    And I enter "root" as "user"
     And I enter "linux" as "password"
     And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"


### PR DESCRIPTION
## What does this PR change?
Prevent from trying to edit one uneditable field.

- testsuite/features/secondary/min_centos_ssh.feature:
Port is not editable for a SSH-managed minion.

## Links
### Ports
- Manager-3.2: https://github.com/SUSE/spacewalk/pull/12081
- Manager-4.0: https://github.com/SUSE/spacewalk/pull/12080
- Manager-4.1: https://github.com/SUSE/spacewalk/pull/12079

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)
