### PR TITLE
Insert  packages in DB when registering a minion in order to avoid deadlock (bsc#1173566)

### DIFF
--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -74,6 +74,7 @@ import com.redhat.rhn.domain.rhnpackage.PackageArch;
 import com.redhat.rhn.domain.rhnpackage.PackageEvr;
 import com.redhat.rhn.domain.rhnpackage.PackageEvrFactory;
 import com.redhat.rhn.domain.rhnpackage.PackageFactory;
+import com.redhat.rhn.domain.rhnpackage.PackageName;
 import com.redhat.rhn.domain.server.InstalledPackage;
 import com.redhat.rhn.domain.server.InstalledProduct;
 import com.redhat.rhn.domain.server.MinionServer;
@@ -408,15 +409,16 @@ public class SaltUtils {
                 }
             });
 
-            newPackages.values().stream().forEach(info -> {
-                server.getPackages().add(
-                    Optional.ofNullable(
-                        currentPackages.get(packageToKey(name, info)))
-                        .orElseGet(
-                                () -> createPackageFromSalt(name, info, server)
-                        )
-                );
-            });
+            List<InstalledPackage> packagesToAdd = newPackages.values().stream()
+                    .map(info -> Optional.ofNullable(currentPackages.get(packageToKey(name, info))))
+                    .filter(Optional::isPresent).map(Optional::get).collect(Collectors.toList());
+
+            Map<String, Tuple2<String, Info>> packagesToCreate = newPackages.values().stream()
+                    .filter(info -> !currentPackages.containsKey(packageToKey(name, info)))
+                    .collect(Collectors.toMap(info -> name, info -> new Tuple2(name, info)));
+
+            packagesToAdd.addAll(createPackagesFromSalt(packagesToCreate, server));
+            server.getPackages().addAll(packagesToAdd);
         });
     }
 
@@ -1485,13 +1487,70 @@ public class SaltUtils {
         ).map(Map.Entry::getValue).collect(Collectors.toList());
         packages.retainAll(unchanged);
 
-        Collection<InstalledPackage> added = newPackageMap.entrySet().stream().filter(
-           e -> !oldPackageMap.containsKey(e.getKey())
-        ).map(
-           e -> createPackageFromSalt(e.getValue().getKey(), e.getValue().getValue(),
-                   server)
-        ).collect(Collectors.toList());
-        packages.addAll(added);
+        Map<String, Tuple2<String, Pkg.Info>> packagesToAdd = newPackageMap.entrySet().stream().filter(
+                e -> !oldPackageMap.containsKey(e.getKey())
+        ).collect(Collectors.toMap(Map.Entry::getKey, e -> new Tuple2(e.getValue().getKey(), e.getValue().getValue())));
+
+        packages.addAll(createPackagesFromSalt(packagesToAdd, server));
+    }
+
+    /**
+     * Create a list of {@link InstalledPackage} for a  {@link Server} given the package names and package information.
+     *
+     * @param packageInfoAndNameBySaltPackageKey a map that contains a package name and a package info, by the package
+     * key produced by salt
+     * @param server server this package will be added to
+     * @return a list of {@link InstalledPackage}
+     */
+    private static List<InstalledPackage> createPackagesFromSalt(
+            Map<String, Tuple2<String, Pkg.Info>> packageInfoAndNameBySaltPackageKey, Server server) {
+        List<String> names = new ArrayList<>(packageInfoAndNameBySaltPackageKey.values().stream().map(Tuple2::getA)
+                .collect(Collectors.toSet()));
+        Collections.sort(names);
+
+        Map<String, PackageName> packageNames = names.stream().collect(Collectors.toMap(Function.identity(),
+                PackageFactory::lookupOrCreatePackageByName));
+
+        String serverArchTypeLabel = server.getServerArch().getArchType().getLabel();
+        Map<String, PackageEvr> packageEvrsBySaltPackageKey = packageInfoAndNameBySaltPackageKey.entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey,
+                        e -> {
+                            Pkg.Info pkgInfo = e.getValue().getB();
+                            return parsePackageEvr(pkgInfo.getEpoch(), pkgInfo.getVersion().get(),
+                                    pkgInfo.getRelease(), serverArchTypeLabel);
+                        }));
+
+        return packageInfoAndNameBySaltPackageKey.entrySet().stream().map(e -> createInstalledPackage(
+                packageNames.get(e.getValue().getA()),
+                packageEvrsBySaltPackageKey.get(e.getKey()), e.getValue().getB(), server))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Create a {@link InstalledPackage} object from package name, evr, package info and server and return it.
+     *
+     * @param packageName the package name
+     * @param packageEvr the package evr
+     * @param pkgInfo the package info
+     * @param server server this package will be added to
+     * @return the InstalledPackage object
+     */
+    private static InstalledPackage createInstalledPackage(PackageName packageName,
+                                                           PackageEvr packageEvr,
+                                                           Pkg.Info pkgInfo, Server server) {
+        InstalledPackage pkg = new InstalledPackage();
+        pkg.setEvr(packageEvr);
+        pkg.setInstallTime(new Date(pkgInfo.getInstallDateUnixTime().get() * 1000));
+        pkg.setName(packageName);
+        pkg.setServer(server);
+
+        // Add -deb suffix to architectures for Debian systems
+        String pkgArch = pkgInfo.getArchitecture().get();
+        if ("deb".equals(server.getServerArch().getArchType().getLabel())) {
+            pkgArch += "-deb";
+        }
+        pkg.setArch(PackageFactory.lookupPackageArchByLabel(pkgArch));
+        return pkg;
     }
 
     /**
@@ -1602,34 +1661,6 @@ public class SaltUtils {
             LOG.debug("Hardware profile updated for minion: " + server.getMinionId() +
                     " (" + duration + " seconds)");
         }
-    }
-
-    /**
-     * Create a {@link InstalledPackage} object from package name and info and return it.
-     *
-     * @param name package name from salt
-     * @param info package info from salt
-     * @param server server this package will be added to
-     * @return the InstalledPackage object
-     */
-    private static InstalledPackage createPackageFromSalt(String name, Pkg.Info info, Server server) {
-
-        String serverArchTypeLabel = server.getServerArch().getArchType().getLabel();
-
-        InstalledPackage pkg = new InstalledPackage();
-        pkg.setEvr(parsePackageEvr(info.getEpoch(), info.getVersion().get(), info.getRelease(), serverArchTypeLabel));
-        pkg.setInstallTime(new Date(info.getInstallDateUnixTime().get() * 1000));
-        pkg.setName(PackageFactory.lookupOrCreatePackageByName(name));
-        pkg.setServer(server);
-
-        // Add -deb suffix to architectures for Debian systems
-        String pkgArch = info.getArchitecture().get();
-        if ("deb".equals(serverArchTypeLabel)) {
-            pkgArch += "-deb";
-        }
-        pkg.setArch(PackageFactory.lookupPackageArchByLabel(pkgArch));
-
-        return pkg;
     }
 
     private static PackageEvr parsePackageEvr(Optional<String> epoch, String version, Optional<String> release,

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- avoid deadlock when syncing channels and registering minions at the same time (bsc#1173566)
 - Fix softwarechannel update for vendor channels (bsc#1172709)
 - Add modular repository warning message to system overview page (bsc#1173959)
 - Change system list header text to something better (bsc#1173982)


### PR DESCRIPTION
## What does this PR change?

Insert packages in DB when registering a minion in order to avoid deadlock if a channel syncing is happening at the same time.

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/11927

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
