### PR TITLE
Test openscap for Ubuntu/CentOS salt in a separated feature

### DIFF
--- a/testsuite/features/secondary/min_centos_openscap.feature
+++ b/testsuite/features/secondary/min_centos_openscap.feature
@@ -1,0 +1,53 @@
+# Copyright (c) 2017-2020 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+Feature: openSCAP audit of CentOS Salt minion
+  In order to audit a CentOS Salt minion
+  As an authorized user
+  I want to run an openSCAP scan on it
+
+@centos_minion
+  Scenario: Prepare the CentOS minion
+    Given I am authorized
+    When I enable SUSE Manager tools repositories on "ceos_minion"
+    And  I enable repository "CentOS-Base" on this "ceos_minion"
+    And  I install package "hwdata m2crypto wget" on this "ceos_minion"
+    And  I install package "spacewalk-client-tools spacewalk-check spacewalk-client-setup mgr-daemon mgr-osad mgr-cfg-actions" on this "ceos_minion"
+    And  I install package "spacewalk-oscap scap-security-guide" on this "ceos_minion"
+
+@centos_minion
+  Scenario: Schedule an OpenSCAP audit job for the CentOS minion
+    Given I am on the Systems overview page of this "ceos_minion"
+    When I follow "Audit" in the content area
+    And I follow "Schedule" in the content area
+    And I enter "--profile standard" as "params"
+    And I enter "/usr/share/xml/scap/ssg/content/ssg-centos7-xccdf.xml" as "path"
+    And I click on "Schedule"
+    Then I should see a "XCCDF scan has been scheduled" text
+    And I wait until event "OpenSCAP xccdf scanning" is completed
+
+@centos_minion
+  Scenario: Run a remote command on the CentOS minion
+    Given I am authorized as "testing" with password "testing"
+    When I follow the left menu "Salt > Remote Commands"
+    Then I should see a "Remote Commands" text in the content area
+    When I enter command "cat /etc/os-release"
+    And I enter target "*centos*"
+    And I click on preview
+    And I click on run
+    Then I should see "ceos_minion" hostname
+    When I wait for "15" seconds
+    And I expand the results for "ceos_minion"
+    Then I should see a "rhel fedora" text
+    And I should see a "REDHAT_SUPPORT_PRODUCT" text
+
+@centos_minion
+  Scenario: Check the results of the OpenSCAP scan on the CentOS minion
+    Given I am on the Systems overview page of this "ceos_minion"
+    When I follow "Audit" in the content area
+    And I follow "xccdf_org.open-scap_testresult_standard"
+    Then I should see a "Details of XCCDF Scan" text
+    And I should see a "RHEL-7" text
+    And I should see a "XCCDF Rule Results" text
+    And I should see a "pass" text
+    And I should see a "rpm_" link

--- a/testsuite/features/secondary/min_centos_ssh.feature
+++ b/testsuite/features/secondary/min_centos_ssh.feature
@@ -3,8 +3,7 @@
 #
 # 1) delete CentOS minion and register as Centos SSH minion
 # 2) run a remote command
-# 3) try an openscap scan
-# 4) delete CentOS SSH minion client and register as Centos minion
+# 3) delete CentOS SSH minion client and register as Centos minion
 
 Feature: Bootstrap a SSH-managed CentOS minion and do some basic operations on it
 
@@ -63,29 +62,9 @@ Feature: Bootstrap a SSH-managed CentOS minion and do some basic operations on i
     And I wait until event "Subscribe channels scheduled by admin" is completed
 
 @centos_minion
-  Scenario: Prepare the SSH-managed CentOS minion
-    Given I am authorized
-    When I enable SUSE Manager tools repositories on "ceos_ssh_minion"
-    And  I enable repository "CentOS-Base" on this "ceos_ssh_minion"
-    And  I install package "hwdata m2crypto wget" on this "ceos_ssh_minion"
-    And  I install package "spacewalk-client-tools spacewalk-check spacewalk-client-setup mgr-daemon mgr-osad mgr-cfg-actions" on this "ceos_ssh_minion"
-    And  I install package "spacewalk-oscap scap-security-guide" on this "ceos_ssh_minion"
-
-@centos_minion
   Scenario: Check events history for failures on SSH-managed CentOS minion
     Given I am on the Systems overview page of this "ceos_ssh_minion"
     Then I check for failed events on history event page
-
-@centos_minion
-  Scenario: Schedule an OpenSCAP audit job for the SSH-managed CentOS minion
-    Given I am on the Systems overview page of this "ceos_ssh_minion"
-    When I follow "Audit" in the content area
-    And I follow "Schedule" in the content area
-    And I enter "--profile standard" as "params"
-    And I enter "/usr/share/xml/scap/ssg/content/ssg-centos7-xccdf.xml" as "path"
-    And I click on "Schedule"
-    Then I should see a "XCCDF scan has been scheduled" text
-    And I wait until event "OpenSCAP xccdf scanning" is completed
 
 @centos_minion
   Scenario: Run a remote command on the SSH-managed CentOS minion
@@ -101,17 +80,6 @@ Feature: Bootstrap a SSH-managed CentOS minion and do some basic operations on i
     And I expand the results for "ceos_ssh_minion"
     Then I should see a "rhel fedora" text
     And I should see a "REDHAT_SUPPORT_PRODUCT" text
-
-@centos_minion
-  Scenario: Check the results of the OpenSCAP scan on the SSH-managed CentOS minion
-    Given I am on the Systems overview page of this "ceos_ssh_minion"
-    When I follow "Audit" in the content area
-    And I follow "xccdf_org.open-scap_testresult_standard"
-    Then I should see a "Details of XCCDF Scan" text
-    And I should see a "RHEL-7" text
-    And I should see a "XCCDF Rule Results" text
-    And I should see a "pass" text
-    And I should see a "rpm_" link
 
 @centos_minion
   Scenario: Check events history for failures on SSH-managed CentOS minion

--- a/testsuite/features/secondary/min_ubuntu_openscap.feature
+++ b/testsuite/features/secondary/min_ubuntu_openscap.feature
@@ -1,0 +1,44 @@
+# Copyright (c) 2017-2020 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+Feature: openSCAP audit of Ubuntu Salt minion
+  In order to audit an Ubuntu Salt minion
+  As an authorized user
+  I want to run an openSCAP scan on it
+
+@ubuntu_minion
+  Scenario: Schedule an OpenSCAP audit job for the Ubuntu minion
+    Given I am on the Systems overview page of this "ubuntu_minion"
+    When I follow "Audit" in the content area
+    And I follow "Schedule" in the content area
+    And I enter "--profile common" as "params"
+    And I enter "/usr/share/scap-security-guide/ssg-ubuntu1604-xccdf.xml" as "path"
+    And I click on "Schedule"
+    Then I should see a "XCCDF scan has been scheduled" text
+    And I wait until event "OpenSCAP xccdf scanning" is completed
+
+@ubuntu_minion
+  Scenario: Run a remote command on the Ubuntu minion
+    Given I am authorized
+    When I follow the left menu "Salt > Remote Commands"
+    Then I should see a "Remote Commands" text in the content area
+    When I enter command "cat /etc/os-release"
+    And I enter target "*ubuntu*"
+    And I click on preview
+    And I click on run
+    Then I should see "ubuntu_minion" hostname
+    When I wait until I see "show response" text
+    And I expand the results for "ubuntu_minion"
+    Then I should see a "ID=ubuntu" text
+
+@ubuntu_minion
+  Scenario: Check the results of the OpenSCAP scan on the Ubuntu minion
+    Given I am on the Systems overview page of this "ubuntu_minion"
+    When I follow "Audit" in the content area
+    And I follow "xccdf_org.open-scap_testresult_common"
+    Then I should see a "Details of XCCDF Scan" text
+    And I should see a "Ubuntu" text
+    And I should see a "XCCDF Rule Results" text
+    And I should see a "pass" text or "notapplicable" text
+    And I should see a "report.html" link
+    And I should see a "results.xml" link

--- a/testsuite/features/secondary/min_ubuntu_ssh.feature
+++ b/testsuite/features/secondary/min_ubuntu_ssh.feature
@@ -3,8 +3,7 @@
 #
 # 1) delete Ubuntu minion and register as Ubuntu SSH minion
 # 2) run a remote command
-# 3) try an openscap scan
-# 4) delete Ubuntu SSH minion and register as Ubuntu minion
+# 3) delete Ubuntu SSH minion and register as Ubuntu minion
 
 Feature: Bootstrap a SSH-managed Ubuntu minion and do some basic operations on it
 
@@ -68,17 +67,6 @@ Feature: Bootstrap a SSH-managed Ubuntu minion and do some basic operations on i
     Then I check for failed events on history event page
 
 @ubuntu_minion
-  Scenario: Schedule an OpenSCAP audit job for the SSH-managed Ubuntu minion
-    Given I am on the Systems overview page of this "ubuntu_ssh_minion"
-    When I follow "Audit" in the content area
-    And I follow "Schedule" in the content area
-    And I enter "--profile common" as "params"
-    And I enter "/usr/share/scap-security-guide/ssg-ubuntu1604-xccdf.xml" as "path"
-    And I click on "Schedule"
-    Then I should see a "XCCDF scan has been scheduled" text
-    And I wait until event "OpenSCAP xccdf scanning" is completed
-
-@ubuntu_minion
   Scenario: Run a remote command on the SSH-managed Ubuntu minion
     Given I am authorized
     When I follow the left menu "Salt > Remote Commands"
@@ -91,18 +79,6 @@ Feature: Bootstrap a SSH-managed Ubuntu minion and do some basic operations on i
     When I wait until I see "show response" text
     And I expand the results for "ubuntu_ssh_minion"
     Then I should see a "ID=ubuntu" text
-
-@ubuntu_minion
-  Scenario: Check the results of the OpenSCAP scan on the SSH-managed Ubuntu minion
-    Given I am on the Systems overview page of this "ubuntu_ssh_minion"
-    When I follow "Audit" in the content area
-    And I follow "xccdf_org.open-scap_testresult_common"
-    Then I should see a "Details of XCCDF Scan" text
-    And I should see a "Ubuntu" text
-    And I should see a "XCCDF Rule Results" text
-    And I should see a "pass" text or "notapplicable" text
-    And I should see a "report.html" link
-    And I should see a "results.xml" link
 
 @ubuntu_minion
   Scenario: Check events history for failures on SSH-managed Ubuntu minion

--- a/testsuite/run_sets/secondary.yml
+++ b/testsuite/run_sets/secondary.yml
@@ -13,8 +13,10 @@
 - features/secondary/allcli_reboot.feature
 - features/secondary/trad_config_channel.feature
 - features/secondary/trad_lock_packages.feature
+- features/secondary/min_centos_openscap.feature
 - features/secondary/min_centos_ssh.feature
 - features/secondary/trad_centos_client.feature
+- features/secondary/min_ubuntu_openscap.feature
 - features/secondary/min_ubuntu_ssh.feature
 - features/secondary/minssh_bootstrap_xmlrpc.feature
 - features/secondary/min_bootstrap_ssh_key.feature


### PR DESCRIPTION
## What does this PR change?

Openscap is not supported for SSH salt minions.
Create specific feature files to test openscap for
Ubuntu/CentOS salt minions.

- testsuite/features/secondary/min_ubuntu_ssh.feature
- testsuite/features/secondary/min_centos_ssh.feature
Delete openscap tests.

- features/secondary/min_ubuntu_openscap.feature:
- features/secondary/min_centos_openscap.feature
New file; move here the openscap tests.  Test here
'run a remote command feature'  as well.

- testsuite/run_sets/secondary.yml: Add the new files.

## Links
### Ports
- manager-3.2: https://github.com/SUSE/spacewalk/pull/12098
- manager-4.0: https://github.com/SUSE/spacewalk/pull/12097
- Manager-4.1: https://github.com/SUSE/spacewalk/pull/12096

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)
