### PR TITLE
Manager - fix ISE when rollbacking a serve to a snapshot (bsc#1173997)

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/server/Server.java
+++ b/java/code/src/com/redhat/rhn/domain/server/Server.java
@@ -150,12 +150,19 @@ public class Server extends BaseDomainHelper implements Identifiable {
 
 
     /**
+     * Retrieves an unmodifiable collection containing the server groups.
      * @return Returns the groups.
      */
-    protected Set<ServerGroup> getGroups() {
-        return groups;
+    public Set<ServerGroup> getUnmodifiableGroups() {
+        return  Collections.unmodifiableSet(new HashSet<>(groups));
     }
 
+    /**
+     * @return Returns the groups.
+     */
+    public Set<ServerGroup> getGroups() {
+        return groups;
+    }
 
     /**
      * @param groupsIn The groups to set.

--- a/java/code/src/com/redhat/rhn/domain/server/ServerSnapshot.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerSnapshot.java
@@ -367,11 +367,7 @@ public class ServerSnapshot extends BaseDomainHelper {
      */
     public void rollbackGroups() {
         // remove from all groups
-        Long sid = this.server.getId();
-        Set<ServerGroup> grps = this.server.getGroups();
-        for (ServerGroup grp : grps) {
-            ServerFactory.removeServerFromGroup(server, grp);
-        }
+        this.server.getUnmodifiableGroups().stream().forEach(grp ->ServerFactory.removeServerFromGroup(server, grp));
         // add to appropriate groups
         for (ServerGroup grp : getGroups()) {
             ServerFactory.addServerToGroup(this.server, grp);

--- a/java/code/src/com/redhat/rhn/domain/server/test/ServerSnapshotTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/ServerSnapshotTest.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2020 SUSE LLC.
+ * <p>
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ * <p>
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.domain.server.test;
+
+import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerGroup;
+import com.redhat.rhn.domain.server.ServerGroupFactory;
+import com.redhat.rhn.domain.server.ServerSnapshot;
+import com.redhat.rhn.testing.BaseTestCaseWithUser;
+import com.redhat.rhn.testing.ServerTestUtils;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Test class for ServerSnapshot
+ */
+public class ServerSnapshotTest extends BaseTestCaseWithUser {
+
+    public void testRollbackGroups() throws Exception {
+        Server server = ServerTestUtils.createTestSystem(user);
+
+        assertNotEmpty(server.getGroups());
+
+        ServerSnapshot snapshot = new ServerSnapshot();
+        snapshot.setServer(server);
+        snapshot.setOrg(server.getOrg());
+        snapshot.setReason("snapshotReason");
+
+        Set<ServerGroup> serverGroupsForSnapshot = new HashSet<ServerGroup>();
+        serverGroupsForSnapshot.add(ServerGroupFactory.create("serverGroupName1", "serverGroupDescription1",
+                server.getOrg()));
+        serverGroupsForSnapshot.add(ServerGroupFactory.create("serverGroupName2", "serverGroupDescription2",
+                server.getOrg()));
+        snapshot.setGroups(serverGroupsForSnapshot);
+
+        assertFalse(serverGroupsForSnapshot.equals(server.getGroups()));
+
+        snapshot.rollbackGroups();
+
+        assertEquals(server.getGroups(), serverGroupsForSnapshot);
+    }
+
+}

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- fix error when rolling back a system to a snapshot (bsc#1173997)
 - Implement maintenance windows backend
 - Add check for maintainence window during executing recurring actions
 - Implement maintenance windows in struts


### PR DESCRIPTION
## What does this PR change?

When rollbacking a server to a snapshot, first we remove the server from the system groups it belongs to. Removing a system from a system group is done with mode queries, but nevertheless we need to keep the "in memory" Server instance updated, for hibernate, so the "groups" instance variable from the server class which maps the system groups, is updated.

The problem occurs when iterating over the "groups" from a server and removing them. This fails cause the "groups" are being updated while iterating on them.

This PR offers a patch for it.

The real solution (IMO) would be either to get rid of hibernate for good, or to get rid of the "mode queries" for good. Implementing some features with one framework and some others with the other one leads to this kind of troubles.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bugfixing
- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/11912
Tracks https://github.com/SUSE/spacewalk/pull/12099

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
