### PR TITLE
Reset proxy path on registration

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -651,6 +651,7 @@ public class RegisterMinionEventMessageAction implements MessageAction {
 
     private void setServerPaths(MinionServer server, String master,
                                 boolean isSaltSSH, Optional<Long> saltSSHProxyId) {
+        server.getServerPaths().clear();
         if (isSaltSSH) {
             saltSSHProxyId
                 .map(proxyId -> ServerFactory.lookupById(proxyId))

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Reset the server path on minion registration (bsc#1174254)
 - fix error when rolling back a system to a snapshot (bsc#1173997)
 - Implement maintenance windows backend
 - Add check for maintainence window during executing recurring actions


### PR DESCRIPTION
## What does this PR change?

On registering (and re-registering) a minion, the server path (the path from minion to server, that goes via proxies) is not reset. If the minion was previously registered under a proxy, but it's re-registered to be directly connected to manager, the server path is not set correctly.

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed:  fix

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

todo


- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"