### PR TITLE
Fix issues importing RPM packages with long RPM headers (bsc#1174965)

### DIFF
--- a/uyuni/common-libs/common/rhn_rpm.py
+++ b/uyuni/common-libs/common/rhn_rpm.py
@@ -91,6 +91,9 @@ class RPM_Header:
             item = [sstr(i) if isinstance(i, bytes) else i for i in item]
         return item
 
+    def __contains__(self, name):
+        return True if name in self.hdr else False
+
     def __setitem__(self, name, item):
         self.hdr[name] = item
 

--- a/uyuni/common-libs/uyuni-common-libs.changes
+++ b/uyuni/common-libs/uyuni-common-libs.changes
@@ -1,3 +1,4 @@
+- Fix issues importing RPM packages with long RPM headers (bsc#1174965)
 - Update package version to 4.2.0
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue when dealing with long types RPM headers because of a missing `__contains__` method that produces a wrong behavior while importing long type RPM headers.

Because of this method being missing, the mechanism at https://github.com/uyuni-project/uyuni/blob/master/backend/server/importlib/headerSource.py#L63 was not working and delaying the header parsing until eventually failed with `unknown header tag` error:

```

d173:/var/log/rhn/reposync # spacewalk-repo-sync -c opensuse-leap-15.2-pool --fail | tee debug
09:49:25 ======================================
09:49:25 | Channel: opensuse-leap-15.2-pool
09:49:25 ======================================
09:49:25 Sync of channel started.
Metadaten von Repository 'opensuse-leap-15.2-pool' abrufen [...fertig]
Cache für Repository 'opensuse-leap-15.2-pool' erzeugen [....fertig]
Alle Repositorys wurden aktualisiert.
09:49:35 Repo URL: http://download.opensuse.org/distribution/leap/15.2/repo/oss/
09:49:35     Packages in repo:             38560
09:51:49     Packages already synced:      38559
09:51:49     Packages to sync:                 1
09:51:49     New packages to download:         1
09:51:49   Downloading packages:
09:51:49 Downloading total 1 files from 1 queues.
09:51:56     1/1 : kicad-packages3D-5.1.5-lp152.1.1.noarch.rpm
09:51:56 
09:51:56   Importing packages to DB:
10:45:10 unknown header tag
10:45:10 Unexpected error: <class 'ValueError'>
10:45:10 multiprocessing.pool.RemoteTraceback: 
"""
Traceback (most recent call last):
  File "/usr/lib64/python3.6/multiprocessing/pool.py", line 119, in worker
    result = (True, func(*args, **kwds))
  File "/usr/lib/python3.6/site-packages/spacewalk/satellite_tools/reposync.py", line 1216, in import_package_batch
    header_end=pack.a_pkg.header_end, channels=[])
  File "/usr/lib/python3.6/site-packages/spacewalk/server/importlib/mpmSource.py", line 107, in create_package
    header_end=header_end, channels=channels)
  File "/usr/lib/python3.6/site-packages/spacewalk/server/importlib/headerSource.py", line 536, in createPackage
    channels)
  File "/usr/lib/python3.6/site-packages/spacewalk/server/importlib/headerSource.py", line 163, in populate
    header_start, header_end)
  File "/usr/lib/python3.6/site-packages/spacewalk/server/importlib/headerSource.py", line 63, in populate
    if ('longarchivesize' in header) and (header['longarchivesize'] > 0):
  File "/usr/lib/python3.6/site-packages/uyuni/common/rhn_rpm.py", line 87, in __getitem__
    item = self.hdr[name]
ValueError: unknown header tag
"""
```
 
With this PR, the package is quickly and successfully imported.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**
- [x] **DONE**

## Test coverage
- No tests: **bugfix**
- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/12115 and https://github.com/SUSE/spacewalk/issues/12113

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
