### PR TITLE
Fix reporting of missing products in 'product.all_installed' (bsc#1165829)

### DIFF
--- a/susemanager-utils/susemanager-sls/src/tests/test_state_product.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_state_product.py
@@ -52,13 +52,14 @@ def test_get_missing_products():
     '''
     test_data = {
         'not_installed': {'product1': True, 'product2': True},
-        'provides-product1': {'this-provides-product1': True}
+        'provides-product1': {'product1': True, 'this-provides-product1': True},
+        'provides-product2': {'product2': True}
     }
 
     pkg_search_mock = MagicMock(side_effect=[
         test_data['not_installed'],
         test_data['provides-product1'],
-        sys.modules['salt.exceptions'].CommandExecutionError])
+        test_data['provides-product2']])
 
     with patch.dict(product.__salt__, {'pkg.search': pkg_search_mock}):
         res = product._get_missing_products(False)
@@ -83,13 +84,14 @@ def test_not_installed_provides():
     '''
     test_data = {
         'not_installed': {'product1': True, 'this-provides-product1': True},
-        'provides-product1': {'this-provides-product1': True}
+        'provides-product1': {'product1': True, 'this-provides-product1': True},
+        'provides-product2': {'this-provides-product1': True}
     }
 
     pkg_search_mock = MagicMock(side_effect=[
         test_data['not_installed'],
         test_data['provides-product1'],
-        sys.modules['salt.exceptions'].CommandExecutionError])
+        test_data['provides-product2']])
 
     with patch.dict(product.__salt__, {'pkg.search': pkg_search_mock}):
         res = product._get_missing_products(False)

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Fix reporting of missing products in product.all_installed (bsc#1165829)
 - Fix: supply a dnf base when dealing w/repos (bsc#1172504)
 - Fix: autorefresh in repos is zypper-only
 - Add virtual network state change state to handle start, stop and delete


### PR DESCRIPTION
Fix reporting of missing products in 'product.all_installed'

https://bugzilla.suse.com/1165829

## Documentation
- No documentation needed: Bugfix

## Test coverage
- Unit tests were adapted

## Links

Fixes https://github.com/SUSE/spacewalk/issues/10943

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
