### PR TITLE
Workaround: Make the pgsql migration tests happy

### DIFF
--- a/schema/spacewalk/upgrade/susemanager-schema-4.2.0-to-susemanager-schema-4.2.1/100-rhnActionType.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.2.0-to-susemanager-schema-4.2.1/100-rhnActionType.sql
@@ -25,4 +25,5 @@ where label in ('packages.update', 'packages.remove', 'errata.update',
        'solarispkgs.patchRemove', 'solarispkgs.patchClusterInstall', 'solarispkgs.patchClusterRemove',
        'script.run', 'solarispkgs.refresh_list', 'clientcert.update_client_cert',
        'distupgrade.upgrade', 'states.apply', 'cluster.group_refresh_nodes', 'cluster.join_node',
-       'cluster.remove_node', 'cluster.upgrade_cluster');
+       'cluster.remove_node', 'cluster.upgrade_cluster')
+and maintenance_mode_only = 'N';


### PR DESCRIPTION
This commit has no functional impact: it's just to make the pgsql
migration tests happy. The root problem should be fixed there.


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"