### PR TITLE
Fix JS linting errors/warnings

### DIFF
--- a/web/html/src/components/table/TableDataHandler.js
+++ b/web/html/src/components/table/TableDataHandler.js
@@ -220,11 +220,11 @@ export class TableDataHandler extends React.Component<Props, State> {
           this.setSelection(arr);
       };
 
-        const allSelected = currIds.length > 0 && currIds.every(id => this.state.selectedItems.includes(id));
-        const checkbox = <Header key="check"><input type="checkbox" checked={allSelected} onChange={(e) => handleSelectAll(e.target.checked)}/></Header>;
-        headers.unshift(checkbox);
+      const allSelected = currIds.length > 0 && currIds.every(id => this.state.selectedItems.includes(id));
+      const checkbox = <Header key="check"><input type="checkbox" checked={allSelected} onChange={(e) => handleSelectAll(e.target.checked)}/></Header>;
+      headers && headers.unshift(checkbox);
     }
-    
+
     const handleSelect = (id, sel) => {
         let arr = this.state.selectedItems;
         if (sel) {

--- a/web/html/src/manager/maintenance/ssm/schedule-picker.js
+++ b/web/html/src/manager/maintenance/ssm/schedule-picker.js
@@ -17,8 +17,8 @@ import type {MessageType} from "components/messages";
 const Network = require("utils/network");
 
 type ScheduleType = {
-  scheduleId: number,
-  scheduleName: string
+  id: number,
+  name: string
 };
 
 type WithMaintenanceSchedulesProps = {

--- a/web/html/src/manager/virtualization/guests/edit/guests-edit.js
+++ b/web/html/src/manager/virtualization/guests/edit/guests-edit.js
@@ -7,7 +7,6 @@ const { hot } = require('react-hot-loader');
 const React = require('react');
 const _isEqual = require('lodash/isEqual');
 const { TopPanel } = require('components/panels/TopPanel');
-const MessagesUtils = require('components/messages').Utils;
 const { Loading } = require('components/utils/Loading');
 const { getOrderedItemsFromModel } = require('components/input/FormMultiInput');
 const { GuestProperties } = require('../GuestProperties');

--- a/web/html/src/manager/virtualization/pools/list/pools-list.js
+++ b/web/html/src/manager/virtualization/pools/list/pools-list.js
@@ -148,14 +148,7 @@ export function PoolsList(props: Props) {
   const [selected, setSelected] = React.useState({});
   const [errors, setErrors] = React.useState([]);
 
-  const refresh = (type: string) => {
-    if (type === "pool") {
-      setLastRefresh(Date.now());
-    }
-  };
-
-  const [actionsResults, setActionsResults] = useVirtNotification(errors, setErrors,
-                                                                  props.serverId, refresh);
+  const [actionsResults, setActionsResults] = useVirtNotification(errors, setErrors, props.serverId, () => {});
 
   const actionCallback = (results: Object) => {
     const newActions = Object.keys(results).reduce((actions, poolName) => {

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Fix JS linting errors/warnings
 - Enable Nutanix AHV virtual host gatherer.
 - Web UI: Implement managing maintenance schedules and calendars
 - Warn when a system is in multiple groups that configure the same


### PR DESCRIPTION
Fix eslint errors/warnings, except for the `anchor-is-valid` rule, which we can consider disabling altogether.

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
