### PR TITLE
Fix the fallback to RES bootstrap repo for Centos

### DIFF
--- a/spacewalk/certs-tools/rhn_bootstrap_strings.py
+++ b/spacewalk/certs-tools/rhn_bootstrap_strings.py
@@ -407,9 +407,12 @@ if [ "$INSTALLER" == yum ]; then
     CLIENT_REPO_FILE="/etc/yum.repos.d/$CLIENT_REPO_NAME.repo"
 
     # In case of CentOS, check is centos bootstrap repository is available, if not, fallback to res.
-    if [ "$Y_CLIENT_CODE_BASE" == centos -a ! `$FETCH $CLIENT_REPO_URL/repodata/repomd.xml &> /dev/null` ]; then
-        echo "CentOS${{Y_CLIENT_CODE_VERSION}} bootstrap repository not found, using RES${{Y_CLIENT_CODE_VERSION}} bootstrap repository instead"
-        CLIENT_REPO_URL="${{CLIENT_REPOS_ROOT}}/res/${{Y_CLIENT_CODE_VERSION}}/bootstrap"
+    if [ "$Y_CLIENT_CODE_BASE" == centos ]; then
+        $FETCH $CLIENT_REPO_URL/repodata/repomd.xml &> /dev/null
+        if [ $? -ne 0 ]; then
+            echo "CentOS${{Y_CLIENT_CODE_VERSION}} bootstrap repository not found, using RES${{Y_CLIENT_CODE_VERSION}} bootstrap repository instead"
+            CLIENT_REPO_URL="${{CLIENT_REPOS_ROOT}}/res/${{Y_CLIENT_CODE_VERSION}}/bootstrap"
+        fi
     fi
 
     setup_bootstrap_repo

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,4 @@
+- Fix the fallback to RES bootstrap repo for Centos (bsc#1174423)
 - strip SSL Certificate Common Name after 63 Characters (bsc#1173535)
 - Update package version to 4.2.0
 


### PR DESCRIPTION
The 'and' condition it the test didn't work for centos (it lead to a
shell error).  Fixed by splitting into 2 separate tests (the 2nd one
testing the $? variable contents).

The behavior can be demonstrated using this code:

```bash
export Y_CLIENT_CODE_BASE=centos
export FETCH='/usr/bin/wget -nv -r -nd --no-check-certificate'
export CLIENT_REPO_URL=https://<MY_SERVER>/pub/repositories/empty

# In case of CentOS, check is centos bootstrap repository is available, if not, fallback to res.
if [ "$Y_CLIENT_CODE_BASE" == centos -a ! `$FETCH $CLIENT_REPO_URL/repodata/repomd.xml &> /dev/null` ]; then
    echo "CentOS${Y_CLIENT_CODE_VERSION} bootstrap repository not found, using RES${Y_CLIENT_CODE_VERSION} bootstrap repository instead"
    CLIENT_REPO_URL="${CLIENT_REPOS_ROOT}/res/${Y_CLIENT_CODE_VERSION}/bootstrap"                                                                    
fi

bash: [: argument expected # result
```

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"