### PR TITLE
QAM testsuite - configure branch server

### DIFF
--- a/testsuite/features/qam/init_clients/branch.feature
+++ b/testsuite/features/qam/init_clients/branch.feature
@@ -1,0 +1,56 @@
+# Copyright (c) 2020 SUSE LLC
+# Licensed under the terms of the MIT license.
+#
+# The scenarios in this feature are skipped if there is no proxy
+# ($proxy is nil)
+
+
+@proxy
+Feature: Setup SUSE Branch Server
+  In order to use a branch server with the SUSE manager server
+  As the system administrator
+  I want to enable and configure branch server services at proxy
+
+@proxy
+@private_net
+  Scenario: Install or update branch network formulas on the server
+    When I manually install the "branch-network" formula on the server
+    And I manually install the "dhcpd" formula on the server
+    And I manually install the "bind" formula on the server
+    And I synchronize all Salt dynamic modules on "proxy"
+
+@proxy
+@private_net
+  Scenario: Install the Retail pattern on the server
+    When I install pattern "suma_retail" on this "server"
+    And I wait for "patterns-suma_retail" to be installed on "server"
+
+@proxy
+@private_net
+  Scenario: Enable repositories for installing branch services
+    When I install package "expect" on this "proxy"
+
+@proxy
+@private_net
+  Scenario: Configure retail formulas using retail_branch_init command
+    When I set "eth1" as NIC, "id" as prefix, "rbs" as branch server name and "branch.org" as domain
+
+@proxy
+@private_net
+  Scenario: Let avahi work on the branch server
+    When I open avahi port on the proxy
+
+@proxy
+@private_net
+  Scenario: Apply the branch network formulas via the highstate
+    Given I am on the Systems overview page of this "proxy"
+    When I follow "States" in the content area
+    And I click on "Apply Highstate"
+    And I wait until event "Apply highstate scheduled by admin" is completed
+    Then service "dhcpd" is enabled on "proxy"
+    And service "dhcpd" is active on "proxy"
+    And service "named" is enabled on "proxy"
+    And service "named" is active on "proxy"
+    And service "firewalld" is enabled on "proxy"
+    And service "firewalld" is active on "proxy"
+

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -766,3 +766,12 @@ When(/^I kill remaining Salt jobs on "([^"]*)"$/) do |minion|
     puts output
   end
 end
+
+When(/^I set "([^"]*)" as NIC, "([^"]*)" as prefix, "([^"]*)" as branch server name and "([^"]*)" as domain$/) do |nic, prefix, server_name, domain|
+  net_prefix = $private_net.sub(%r{\.0+/24$}, ".")
+  cred = "--api-user admin --api-pass admin"
+  dhcp = "--dedicated-nic #{nic} --branch-ip #{net_prefix}#{ADDRESSES['proxy']} --netmask 255.255.255.0 --dyn-range #{net_prefix}#{ADDRESSES['range begin']} #{net_prefix}#{ADDRESSES['range end']}"
+  names = "--server-name #{server_name} --server-domain #{domain} --branch-prefix #{prefix}"
+  output, return_code = $server.run("retail_branch_init #{$proxy.full_hostname} #{dhcp} #{names} #{cred}")
+  raise "Command failed with following output: #{output}" unless return_code.zero?
+end

--- a/testsuite/run_sets/qam_init_proxy.yml
+++ b/testsuite/run_sets/qam_init_proxy.yml
@@ -8,5 +8,6 @@
 ## QAM Init Proxy BEGIN ###
 
 - features/qam/init_clients/proxy.feature
+- features/qam/init_clients/branch.feature
 
 ## QAM Init Proxy END ###


### PR DESCRIPTION
## What does this PR change?

PR add feature and step necessary to configure branch server via `retail_branch_init` command.

## Links

https://github.com/SUSE/spacewalk/issues/11333

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
