### PR TITLE
Add filter during remote commands to machines only in maintenance mode

### DIFF
--- a/java/code/src/com/suse/manager/webui/websocket/RemoteMinionCommands.java
+++ b/java/code/src/com/suse/manager/webui/websocket/RemoteMinionCommands.java
@@ -25,6 +25,7 @@ import com.redhat.rhn.domain.session.WebSessionFactory;
 import com.redhat.rhn.frontend.events.TransactionHelper;
 import com.redhat.rhn.frontend.servlets.LocalizedEnvironmentFilter;
 import com.redhat.rhn.manager.system.SystemManager;
+import com.suse.manager.maintenance.MaintenanceManager;
 import com.suse.manager.webui.services.FutureUtils;
 import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.manager.webui.websocket.json.AsyncJobStartEventDto;
@@ -77,6 +78,7 @@ public class RemoteMinionCommands {
 
     private Long sessionId;
 
+    private MaintenanceManager mm = new MaintenanceManager();
     private CompletableFuture failAfter;
     private List<String> previewedMinions;
     private static ExecutorService eventHistoryExecutor = Executors.newCachedThreadPool();
@@ -135,6 +137,7 @@ public class RemoteMinionCommands {
             if (msg.isPreview()) {
                 List<String> allVisibleMinions = MinionServerFactory
                         .lookupVisibleToUser(webSession.getUser())
+                        .filter(m -> mm.isSystemInMaintenanceMode(m))
                         .map(MinionServer::getMinionId)
                         .collect(Collectors.toList());
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- filter machines not in maintenance mode for remote commands
 - Upgrade jQuery and adapt the code - CVE-2020-11022 (bsc#1172831)
 - Data null means the sync never ran yet (bsc#1174357)
 - Reset the server path on minion registration (bsc#1174254)


### PR DESCRIPTION
## What does this PR change?
Filters machines not in maintenance mode when using remote commands. 


## GUI diff



- [ ] **DONE**

## Documentation
- No documentation needed:  

- [ ] **DONE**

## Test coverage
- No tests: 

- [ ] **DONE**

## Links

No specific issue/bug, part of bigger card
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
