### PR TITLE
fix initialization of saltKeyUtils

### DIFF
--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -243,7 +243,7 @@ public class SaltServerActionService {
         this.saltUtils = saltUtilsIn;
         this.clusterManager = clusterManagerIn;
         this.formulaManager = formulaManagerIn;
-        this.saltUtils = saltUtilsIn;
+        this.saltKeyUtils = saltKeyUtilsIn;
     }
 
     private Action unproxy(Action entity) {


### PR DESCRIPTION
## What does this PR change?

saltKeyUtils was never initialized causing a NPE on scheduling autoinstallation.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **no tests for autoinstallation**

- [x] **DONE**

## Links

- code exists only in master.

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
