### PR TITLE
Use of natural language for bullet style

### DIFF
--- a/testsuite/features/secondary/srv_monitoring.feature
+++ b/testsuite/features/secondary/srv_monitoring.feature
@@ -11,11 +11,11 @@ Feature: Enable and disable monitoring of the server
     And I click on "Disable"
     And I wait until button "Disable" becomes enabled
     Then I should see a "Monitoring disabled successfully." text
-    And I should see a list item with text "System" and bullet with style "fa-times text-danger"
-    And I should see a list item with text "PostgreSQL database" and bullet with style "fa-times text-danger"
-    And I should see a list item with text "Server self monitoring" and bullet with style "fa-hand-o-right text-danger"
-    And I should see a list item with text "Taskomatic (Java JMX)" and bullet with style "fa-hand-o-right text-danger"
-    And I should see a list item with text "Tomcat (Java JMX)" and bullet with style "fa-hand-o-right text-danger"
+    And I should see a list item with text "System" and a failing bullet
+    And I should see a list item with text "PostgreSQL database" and a failing bullet
+    And I should see a list item with text "Server self monitoring" and a warning bullet
+    And I should see a list item with text "Taskomatic (Java JMX)" and a warning bullet
+    And I should see a list item with text "Tomcat (Java JMX)" and a warning bullet
     And I should see a "Restarting Tomcat and Taskomatic is needed for the configuration changes to take effect." text
     And file "/etc/rhn/rhn.conf" should contain "prometheus_monitoring_enabled = 0" on server
     And file "/etc/sysconfig/tomcat" should not contain "Dcom.sun.management.jmxremote.port=3333 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname=" on server
@@ -30,11 +30,11 @@ Feature: Enable and disable monitoring of the server
     And I wait until I see "Server self monitoring" text
     Then I should see a "Enable" button
     And I should see a "Disable" button
-    And I should see a list item with text "System" and bullet with style "fa-times text-danger"
-    And I should see a list item with text "PostgreSQL database" and bullet with style "fa-times text-danger"
-    And I should see a list item with text "Server self monitoring" and bullet with style "fa-times text-danger"
-    And I should see a list item with text "Taskomatic (Java JMX)" and bullet with style "fa-times text-danger"
-    And I should see a list item with text "Tomcat (Java JMX)" and bullet with style "fa-times text-danger"
+    And I should see a list item with text "System" and a failing bullet
+    And I should see a list item with text "PostgreSQL database" and a failing bullet
+    And I should see a list item with text "Server self monitoring" and a failing bullet
+    And I should see a list item with text "Taskomatic (Java JMX)" and a failing bullet
+    And I should see a list item with text "Tomcat (Java JMX)" and a failing bullet
     And I should not see a "Restarting Tomcat and Taskomatic is needed for the configuration changes to take effect." text
 
   Scenario: Enable monitoring from the UI
@@ -44,11 +44,11 @@ Feature: Enable and disable monitoring of the server
     And I click on "Enable"
     And I wait until button "Enable" becomes enabled
     Then I should see a "Monitoring enabled successfully." text
-    And I should see a list item with text "System" and bullet with style "fa-check text-success"
-    And I should see a list item with text "PostgreSQL database" and bullet with style "fa-check text-success"
-    And I should see a list item with text "Server self monitoring" and bullet with style "fa-hand-o-right text-success"
-    And I should see a list item with text "Taskomatic (Java JMX)" and bullet with style "fa-hand-o-right text-success"
-    And I should see a list item with text "Tomcat (Java JMX)" and bullet with style "fa-hand-o-right text-success"
+    And I should see a list item with text "System" and a success bullet
+    And I should see a list item with text "PostgreSQL database" and a success bullet
+    And I should see a list item with text "Server self monitoring" and a success bullet
+    And I should see a list item with text "Taskomatic (Java JMX)" and a success bullet
+    And I should see a list item with text "Tomcat (Java JMX)" and a success bullet
     And I should see a "Restarting Tomcat and Taskomatic is needed for the configuration changes to take effect." text
     And file "/etc/rhn/rhn.conf" should contain "prometheus_monitoring_enabled = 1" on server
     And file "/etc/sysconfig/tomcat" should contain "Dcom.sun.management.jmxremote.port=3333 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname=" on server
@@ -63,9 +63,9 @@ Feature: Enable and disable monitoring of the server
     And I wait until I see "Server self monitoring" text
     Then I should see a "Enable" button
     And I should see a "Disable" button
-    And I should see a list item with text "System" and bullet with style "fa-check text-success"
-    And I should see a list item with text "PostgreSQL database" and bullet with style "fa-check text-success"
-    And I should see a list item with text "Server self monitoring" and bullet with style "fa-check text-success"
-    And I should see a list item with text "Taskomatic (Java JMX)" and bullet with style "fa-check text-success"
-    And I should see a list item with text "Tomcat (Java JMX)" and bullet with style "fa-check text-success"
+    And I should see a list item with text "System" and a success bullet
+    And I should see a list item with text "PostgreSQL database" and a success bullet
+    And I should see a list item with text "Server self monitoring" and a success bullet
+    And I should see a list item with text "Taskomatic (Java JMX)" and a success bullet
+    And I should see a list item with text "Tomcat (Java JMX)" and a success bullet
     And I should not see a "Restarting Tomcat and Taskomatic is needed for the configuration changes to take effect." text

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -1114,8 +1114,8 @@ And(/^I check for failed events on history event page$/) do
   raise "\nFailures in event history found:\n\n#{failings}" if count_failures.nonzero?
 end
 
-Then(/^I should see a list item with text "([^"]*)" and bullet with style "([^"]*)"$/) do |text, class_name|
-  item_xpath = "//ul/li[text()='#{text}']/i[contains(@class, '#{class_name}')]"
+Then(/^I should see a list item with text "([^"]*)" and a (success|failing|warning|refreshing) bullet$/) do |text, bullet_type|
+  item_xpath = "//ul/li[text()='#{text}']/i[contains(@class, '#{BULLET_STYLE[bullet_type]}')]"
   find(:xpath, item_xpath)
 end
 

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -94,6 +94,11 @@ FIELD_IDS = { 'NIC'                             => 'branch_network#nic',
               'language'                        => 'keyboard_and_language#language',
               'keyboard layout'                 => 'keyboard_and_language#keyboard_layout' }.freeze
 
+BULLET_STYLE = { 'failing' => 'fa-times text-danger',
+                 'warning' => 'fa-hand-o-right text-danger',
+                 'success' => 'fa-check text-success',
+                 'refreshing' => 'fa-refresh text-warning' }.freeze
+
 PATCH_BY_CLIENT = { 'ceos6_minion' => 'RHSA-2019:1774',
                     'ceos6_ssh_minion' => 'RHSA-2019:1774',
                     'ceos6_client' => 'RHSA-2019:1774',


### PR DESCRIPTION
## What does this PR change?

Related Card: https://github.com/SUSE/spacewalk/issues/11966

Get rid of a step which is not using natural language, using CSS style.
In this PR we hide this css class information inside our method, and we make it extensible by using a dictionary.
We could let it more open, just by not introducing the conditional entry in the Gherkin step, using a wildcard, but I considered it better to restrict it.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/11966

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
