### PR TITLE
Enable and disable "Desktop-Applications" repo on SLE15, required by "Development-Tools" channel

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -721,9 +721,7 @@ When(/^I enable repositories before installing Docker$/) do
   # (we do not install Python 2 repositories in this branch
   #  because they are not needed anymore starting with version 4.1)
   if os_family =~ /^sles/ && os_version =~ /^15/
-    repos = "devel_pool_repo devel_updates_repo"
-    puts $build_host.run("zypper mr --enable #{repos}")
-    repos = "desktop_pool_repo desktop_updates_repo"
+    repos = "devel_pool_repo devel_updates_repo desktop_pool_repo desktop_updates_repo"
     puts $build_host.run("zypper mr --enable #{repos}")
   end
 
@@ -751,9 +749,7 @@ When(/^I disable repositories after installing Docker$/) do
   # (we do not install Python 2 repositories in this branch
   #  because they are not needed anymore starting with version 4.1)
   if os_family =~ /^sles/ && os_version =~ /^15/
-    repos = "devel_pool_repo devel_updates_repo"
-    puts $build_host.run("zypper mr --disable #{repos}")
-    repos = "desktop_pool_repo desktop_updates_repo"
+    repos = "devel_pool_repo devel_updates_repo desktop_pool_repo desktop_updates_repo"
     puts $build_host.run("zypper mr --disable #{repos}")
   end
 

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -717,11 +717,13 @@ When(/^I enable repositories before installing Docker$/) do
   repos, _code = $build_host.run('zypper lr | grep "tools" | cut -d"|" -f2')
   puts $build_host.run("zypper mr --enable #{repos.gsub(/\s/, ' ')}")
 
-  # Development
+  # Development and Desktop Applications (required)
   # (we do not install Python 2 repositories in this branch
   #  because they are not needed anymore starting with version 4.1)
   if os_family =~ /^sles/ && os_version =~ /^15/
     repos = "devel_pool_repo devel_updates_repo"
+    puts $build_host.run("zypper mr --enable #{repos}")
+    repos = "desktop_pool_repo desktop_updates_repo"
     puts $build_host.run("zypper mr --enable #{repos}")
   end
 
@@ -745,11 +747,13 @@ When(/^I disable repositories after installing Docker$/) do
   repos, _code = $build_host.run('zypper lr | grep "tools" | cut -d"|" -f2')
   puts $build_host.run("zypper mr --disable #{repos.gsub(/\s/, ' ')}")
 
-  # Development
+  # Development and Desktop Applications (required)
   # (we do not install Python 2 repositories in this branch
   #  because they are not needed anymore starting with version 4.1)
   if os_family =~ /^sles/ && os_version =~ /^15/
     repos = "devel_pool_repo devel_updates_repo"
+    puts $build_host.run("zypper mr --disable #{repos}")
+    repos = "desktop_pool_repo desktop_updates_repo"
     puts $build_host.run("zypper mr --disable #{repos}")
   end
 


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue in the testsuite while applying the highstate on the build host.

The "SLE-Module-Desktop-Applications" channel is required by "SLE-Module-Development-Tools" channel but we're not taking care of enable and disable it properly before and after triggering the highstate on the build host.

This PR should fix this issue and enable and disable the "Desktop-Application" repository accordingly to allow the highstate to success.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **testsuite changes**
- [x] **DONE**

## Test coverage
- No tests: **testsuite changes**
- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
