### PR TITLE
Fix icon  alignment on entitlement page

### DIFF
--- a/java/code/webapp/WEB-INF/pages/systems/entitlements/entitlements.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/entitlements/entitlements.jsp
@@ -32,7 +32,7 @@
          >
         <rhn:set value="${current.id}" disabled="${not current.selectable}"/>
             <rhn:column header="systemlist.jsp.status"
-                        style="text-align: center;">
+                        style="text-align: left;">
                 ${current.statusDisplay}
             </rhn:column>
             <rhn:column header="systemlist.jsp.system"

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- fix alignment on icon on entitlement page
 - support installer update channels during autoinstallation
 - filter machines not in maintenance mode for remote commands
 - Upgrade jQuery and adapt the code - CVE-2020-11022 (bsc#1172831)


### PR DESCRIPTION
## What does this PR change?
Fix icon  alignment on entitlement page


## GUI diff


Before:
![image](https://user-images.githubusercontent.com/729087/90522047-8c4f9f00-e16b-11ea-90c7-105ff4d2e6cb.png)

After:
![image](https://user-images.githubusercontent.com/729087/90522118-a12c3280-e16b-11ea-8ed4-16fcd627c823.png)

- [ ] **DONE**

## Documentation
- No documentation needed: 

- [ ] **DONE**

## Test coverage
- No tests: 

- [ ] **DONE**

## Links

Fixes #
https://github.com/SUSE/spacewalk/issues/11943
Need to port to 4.1, 4.0
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
