### PR TITLE
Pass the log level to matcher

### DIFF
--- a/java/code/src/com/suse/manager/matcher/MatcherJsonIO.java
+++ b/java/code/src/com/suse/manager/matcher/MatcherJsonIO.java
@@ -236,7 +236,7 @@ public class MatcherJsonIO {
         return ((List<PinnedSubscription>) HibernateFactory.getSession()
                 .createCriteria(PinnedSubscription.class).list()).stream()
                 .map(p -> new MatchJson(
-                    p.getSystemId(), p.getSubscriptionId(), null, null, null))
+                    p.getSystemId(), p.getSubscriptionId(), null, null))
                 .collect(toList());
     }
 

--- a/java/code/src/com/suse/manager/matcher/MatcherRunner.java
+++ b/java/code/src/com/suse/manager/matcher/MatcherRunner.java
@@ -130,8 +130,7 @@ public class MatcherRunner {
     private static ExecutorService exhaustOutputOnBackground(InputStream stream) {
         ExecutorService executorService = Executors.newSingleThreadExecutor();
         executorService.execute(() -> {
-            InputStreamReader irr = new InputStreamReader(stream);
-            try {
+            try (InputStreamReader irr = new InputStreamReader(stream)) {
                 while (irr.read() != -1) {
                     // no-op
                 }

--- a/java/code/src/com/suse/manager/matcher/MatcherRunner.java
+++ b/java/code/src/com/suse/manager/matcher/MatcherRunner.java
@@ -15,6 +15,10 @@
 
 package com.suse.manager.matcher;
 
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+
+import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.domain.iss.IssFactory;
 import com.redhat.rhn.domain.matcher.MatcherRunData;
 import com.redhat.rhn.domain.matcher.MatcherRunDataFactory;
@@ -30,6 +34,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 
 
 /**
@@ -65,6 +70,11 @@ public class MatcherRunner {
         args.add("--delimiter");
         args.add(csvDelimiter);
 
+        getLogLevel().ifPresent(level -> {
+            args.add("--log-level");
+            args.add(level);
+        });
+
         Runtime r = Runtime.getRuntime();
         try {
             Process p = r.exec(args.toArray(new String[0]));
@@ -98,6 +108,24 @@ public class MatcherRunner {
         }
         catch (InterruptedException e) {
             logger.error("execute(String[])", e);
+        }
+    }
+
+    private static Optional<String> getLogLevel() {
+        int debuglevel = Config.get().getInt("debug", 0);
+
+        switch (debuglevel) {
+            case 0:
+            case 1:
+                return empty(); // use matcher default log level
+            case 2:
+                return of("INFO");
+            case 3:
+                return of("DEBUG");
+            case 4:
+                return of("TRACE");
+            default:
+                return of("ALL");
         }
     }
 

--- a/java/code/src/com/suse/manager/webui/services/subscriptionmatching/SubscriptionMatchProcessor.java
+++ b/java/code/src/com/suse/manager/webui/services/subscriptionmatching/SubscriptionMatchProcessor.java
@@ -26,7 +26,6 @@ import com.redhat.rhn.taskomatic.TaskoFactory;
 import com.redhat.rhn.taskomatic.domain.TaskoRun;
 
 import com.suse.matcher.json.InputJson;
-import com.suse.matcher.json.MatchJson;
 import com.suse.matcher.json.MessageJson;
 import com.suse.matcher.json.OutputJson;
 

--- a/java/code/src/com/suse/manager/webui/services/subscriptionmatching/SubscriptionMatchProcessor.java
+++ b/java/code/src/com/suse/manager/webui/services/subscriptionmatching/SubscriptionMatchProcessor.java
@@ -126,7 +126,6 @@ public class SubscriptionMatchProcessor {
         }
 
         boolean satisfied = output.getMatches().stream()
-                .filter(m -> m.getConfirmed())
                 .anyMatch(m -> m.getSystemId().equals(ps.getSystemId()) &&
                     m.getSubscriptionId().equals(ps.getSubscriptionId()));
 
@@ -170,7 +169,6 @@ public class SubscriptionMatchProcessor {
         Map<Long, Integer> matchedCents = new HashMap<>();
         Map<Long, Integer> matchedQuantity = new HashMap<>();
         output.getMatches().stream()
-                .filter(m -> m.getConfirmed())
                 .forEach(m -> matchedCents.merge(m.getSubscriptionId(), m.getCents(),
                         Math::addExact));
 
@@ -187,7 +185,6 @@ public class SubscriptionMatchProcessor {
                 .collect(toSet());
 
         Set<Pair<Long, Long>> confirmedProductSystemPairs = output.getMatches().stream()
-                .filter(MatchJson::getConfirmed)
                 .map(m -> Pair.of(m.getProductId(), m.getSystemId()))
                 .collect(toSet());
 

--- a/java/code/src/com/suse/manager/webui/services/subscriptionmatching/test/SubscriptionMatchProcessorTest.java
+++ b/java/code/src/com/suse/manager/webui/services/subscriptionmatching/test/SubscriptionMatchProcessorTest.java
@@ -141,7 +141,7 @@ public class SubscriptionMatchProcessorTest extends BaseTestCaseWithUser {
         input.getSubscriptions().add(sub);
         output.getSubscriptions().add(sub);
 
-        MatchJson match = new MatchJson(20L, 1L, 100L, 200, true);
+        MatchJson match = new MatchJson(20L, 1L, 100L, 200);
         output.getMatches().add(match);
         // subscriptions with null policy will be filtered out
         setSubscriptionPolicy(1L, "my policy");
@@ -236,9 +236,9 @@ public class SubscriptionMatchProcessorTest extends BaseTestCaseWithUser {
                 new SystemJson(3L, "system 3", 1, true, false, Collections.emptySet(),
                         products3));
 
-        output.getMatches().add(new MatchJson(1L, 10L, 100L, 100, true));
-        output.getMatches().add(new MatchJson(2L, 20L, 100L, 100, true));
-        output.getMatches().add(new MatchJson(3L, 20L, 100L, 100, true));
+        output.getMatches().add(new MatchJson(1L, 10L, 100L, 100));
+        output.getMatches().add(new MatchJson(2L, 20L, 100L, 100));
+        output.getMatches().add(new MatchJson(3L, 20L, 100L, 100));
 
         MatcherUiData data = (MatcherUiData) processor.getData(of(input), of(output));
         Map<String, Product> unmatchedProducts = data.getProducts();
@@ -269,7 +269,7 @@ public class SubscriptionMatchProcessorTest extends BaseTestCaseWithUser {
         input.setSystems(Collections.singletonList(
                 new SystemJson(1L, "system name", 1, true, false, Collections.emptySet(),
                         productsIn)));
-        output.getMatches().add(new MatchJson(1L, 10L, 100L, 100, true));
+        output.getMatches().add(new MatchJson(1L, 10L, 100L, 100));
 
         MatcherUiData data = (MatcherUiData) processor
                 .getData(of(input), of(output));
@@ -313,7 +313,7 @@ public class SubscriptionMatchProcessorTest extends BaseTestCaseWithUser {
                 Collections.singleton(1004L));
         input.setSubscriptions(Arrays.asList(subscription));
         output.setSubscriptions(Arrays.asList(subscription));
-        List<MatchJson> matches = Arrays.asList(new MatchJson(100L, 10L, 1000L, 100, true));
+        List<MatchJson> matches = Arrays.asList(new MatchJson(100L, 10L, 1000L, 100));
         input.setPinnedMatches(matches);
         output.setMatches(matches);
 
@@ -343,7 +343,7 @@ public class SubscriptionMatchProcessorTest extends BaseTestCaseWithUser {
                 Collections.singleton(1004L));
         input.setSubscriptions(Arrays.asList(subscription));
         output.setSubscriptions(Arrays.asList(subscription));
-        input.setPinnedMatches(Arrays.asList(new MatchJson(100L, 10L, 1L, 100, null)));
+        input.setPinnedMatches(Arrays.asList(new MatchJson(100L, 10L, 1L, 100)));
 
         // create a corresponding pin
         PinnedSubscription newPinDb = new PinnedSubscription();
@@ -449,14 +449,14 @@ public class SubscriptionMatchProcessorTest extends BaseTestCaseWithUser {
         policies.put(104L, "one_two");
 
         List<MatchJson> confirmedMatches = output.getMatches();
-        confirmedMatches.add(new MatchJson(10L, 100L, 1000L, 100, true));
-        confirmedMatches.add(new MatchJson(20L, 100L, 1000L, 100, true));
-        confirmedMatches.add(new MatchJson(30L, 103L, 1003L, 100, true));
-        confirmedMatches.add(new MatchJson(31L, 103L, 1003L, 0, true));
-        confirmedMatches.add(new MatchJson(32L, 103L, 1003L, 0, true));
-        confirmedMatches.add(new MatchJson(33L, 100L, 1000L, 50, true));
-        confirmedMatches.add(new MatchJson(33L, 103L, 1003L, 0, true));
-        confirmedMatches.add(new MatchJson(34L, 100L, 1000L, 100, true));
+        confirmedMatches.add(new MatchJson(10L, 100L, 1000L, 100));
+        confirmedMatches.add(new MatchJson(20L, 100L, 1000L, 100));
+        confirmedMatches.add(new MatchJson(30L, 103L, 1003L, 100));
+        confirmedMatches.add(new MatchJson(31L, 103L, 1003L, 0));
+        confirmedMatches.add(new MatchJson(32L, 103L, 1003L, 0));
+        confirmedMatches.add(new MatchJson(33L, 100L, 1000L, 50));
+        confirmedMatches.add(new MatchJson(33L, 103L, 1003L, 0));
+        confirmedMatches.add(new MatchJson(34L, 100L, 1000L, 100));
 
         MatcherUiData data = (MatcherUiData) processor.getData(of(input), of(output));
         Map<String, Product> products = data.getProducts();

--- a/java/code/src/com/suse/matcher/json/MatchJson.java
+++ b/java/code/src/com/suse/matcher/json/MatchJson.java
@@ -15,7 +15,7 @@
 package com.suse.matcher.json;
 
 /**
- * JSON representation of a match.
+ * JSON representation of a confirmed match.
  */
 public class MatchJson {
 
@@ -31,9 +31,6 @@ public class MatchJson {
     /** The number of subscription cents used in this match. */
     private Integer cents;
 
-    /** True if this match has been confirmed, false if it is possible but not confirmed. */
-    private Boolean confirmed;
-
     /**
      * Standard constructor.
      *
@@ -41,15 +38,13 @@ public class MatchJson {
      * @param subscriptionIdIn the subscription id
      * @param productIdIn the product id
      * @param centsIn the number of subscription cents used in this match
-     * @param confirmedIn whether this match has been confirmed or not
      */
     public MatchJson(Long systemIdIn, Long subscriptionIdIn, Long productIdIn,
-                     Integer centsIn, Boolean confirmedIn) {
+                     Integer centsIn) {
         systemId = systemIdIn;
         subscriptionId = subscriptionIdIn;
         productId = productIdIn;
         cents = centsIn;
-        confirmed = confirmedIn;
     }
 
     /**
@@ -124,21 +119,4 @@ public class MatchJson {
         cents = centsIn;
     }
 
-    /**
-     * Checks if is confirmed.
-     *
-     * @return the boolean
-     */
-    public Boolean getConfirmed() {
-        return confirmed;
-    }
-
-    /**
-     * Sets this match confirmed.
-     *
-     * @param confirmedIn the new confirmed value
-     */
-    public void setConfirmed(Boolean confirmedIn) {
-        confirmed = confirmedIn;
-    }
 }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- pass the log level parameter to matcher
 - Detect client organization from connected proxy (bsc#1175545)
 - Add language picker to user preferences and user creation
 - Fix EntityExistsException on migration from traditional to salt minion via proxy (bsc#1175556)


### PR DESCRIPTION
Review commit-by-commit please.

- Derive the log level from the 'debug' config option and pass it to matcher.

- Align the data transfer object to the current version of matcher: remove the `confirmed` flag from `JsonMatch` .

- [x] **IMPORTANT**: This mustn't be merged before matches is able to accept the log level parameter (i.e. code from https://github.com/openSUSE/subscription-matcher/pull/18 must be released).

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- @mcalmer: I couldn't find any documentation about setting log level in gatherer - is there any?

- [ ] **DONE**

## Test coverage
- No tests: untestable

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle" 
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"