### PR TITLE
Use spacewalk keyring for GPG checks on DEB repos (bsc#1175485)

### DIFF
--- a/backend/common/repo.py
+++ b/backend/common/repo.py
@@ -17,6 +17,9 @@ import requests
 
 # pylint:disable=W0612,W0212,C0301
 
+SPACEWALK_LIB = '/var/lib/spacewalk'
+SPACEWALK_GPG_HOMEDIR = os.path.join(SPACEWALK_LIB, 'gpgdir')
+
 
 class GeneralRepoException(Exception):
     """
@@ -189,7 +192,7 @@ class DpkgRepo:
         """
         if response.url.endswith("InRelease"):
             process = subprocess.Popen(
-                ["gpg", "--verify"],
+                ["gpg", "--verify", "--homedir", SPACEWALK_GPG_HOMEDIR],
                 stdin=subprocess.PIPE,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
@@ -208,7 +211,8 @@ class DpkgRepo:
                 temp_signature_file.write(signature_response.content)
                 temp_signature_file.seek(0)
                 process = subprocess.Popen(
-                    ["gpg", "--verify", temp_signature_file.name, temp_release_file.name],
+                    ["gpg", "--verify", "--homedir", SPACEWALK_GPG_HOMEDIR,
+                     temp_signature_file.name, temp_release_file.name],
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
                 )

--- a/backend/common/test/unit-test/test_repo.py
+++ b/backend/common/test/unit-test/test_repo.py
@@ -213,8 +213,10 @@ class TestCommonRepo:
             gpg_args = mock_popen.call_args[0][0]
             assert gpg_args[0] == "gpg"
             assert gpg_args[1] == "--verify"
-            assert gpg_args[2].beginswith("/tmp/")
-            assert gpg_args[3].beginswith("/tmp/")
+            assert gpg_args[2] == "--homedir"
+            assert gpg_args[3] == "/var/lib/spacewalk/gpgdir"
+            assert gpg_args[4].beginswith("/tmp/")
+            assert gpg_args[5].beginswith("/tmp/")
 
     def test_has_valid_gpg_signature_returns_false_if_gpg_verify_fails(self):
         """

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Use spacewalk keyring for GPG checks on DEB repos (bsc#1175485)
 - Remove duplicate languages and update translation strings
 - Update package version to 4.2.0
 


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue doing GPG checks on DEB repositories because not being using the spacewalk GPG keyring.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**
- [x] **DONE**

## Test coverage
- No tests: **bugfix**
- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/12202

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
