### PR TITLE
Take care of SCC auth tokens on DEB repos GPG checks (bsc#1175485)

### DIFF
--- a/backend/common/repo.py
+++ b/backend/common/repo.py
@@ -190,7 +190,7 @@ class DpkgRepo:
 
         :return: bool
         """
-        if response.url.endswith("InRelease"):
+        if parse.urlparse(response.url).path.endswith("InRelease"):
             process = subprocess.Popen(
                 ["gpg", "--verify", "--homedir", SPACEWALK_GPG_HOMEDIR],
                 stdin=subprocess.PIPE,
@@ -199,8 +199,7 @@ class DpkgRepo:
             )
             out = process.communicate(response.content)
         else:
-            gpg_url = response.url + ".gpg"
-            signature_response = requests.get(gpg_url, proxies=self.proxies)
+            signature_response = requests.get(self._get_parent_url(response.url, 1, "Release.gpg"), proxies=self.proxies)
             if signature_response.status_code != http.HTTPStatus.OK:
                 return False
             else:

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Take care of SCC auth tokens on DEB repos GPG checks (bsc#1175485)
 - Use spacewalk keyring for GPG checks on DEB repos (bsc#1175485)
 - Remove duplicate languages and update translation strings
 - Update package version to 4.2.0


### PR DESCRIPTION
## What does this PR change?

This PR adds a leftover from https://github.com/uyuni-project/uyuni/pull/2499 in order to avoid issues when doing GPG checks on a DEB repository which is using authentication token as part of the URL. Like SCC.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**
- [x] **DONE**

## Test coverage
- No tests: **bugfix**
- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/12202

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests" (Test skipped, there are no changes to test)
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
