### PR TITLE
Clone installer update flag

### DIFF
--- a/backend/satellite_tools/disk_dumper/dumper.py
+++ b/backend/satellite_tools/disk_dumper/dumper.py
@@ -785,7 +785,7 @@ class ChannelsDumper(exportLib.ChannelsDumper):
         select c.id, c.org_id,
                c.label, ca.label channel_arch, c.basedir, c.name,
                c.summary, c.description, c.gpg_key_url, c.update_tag,
-               ct.label checksum_type,
+               c.installer_updates, ct.label checksum_type,
                TO_CHAR(c.last_modified, 'YYYYMMDDHH24MISS') last_modified,
                pc.label parent_channel, c.channel_access
           from rhnChannel c left outer join rhnChannel pc on c.parent_channel = pc.id
@@ -821,7 +821,7 @@ class ChannelsDumper(exportLib.ChannelsDumper):
 class ChannelsDumperEx(CachedDumper, exportLib.ChannelsDumper):
     iterator_query = rhnSQL.Statement("""
         select c.id, c.label, ca.label channel_arch, c.basedir, c.name,
-               c.summary, c.description, c.gpg_key_url, c.update_tag, c.org_id,
+               c.summary, c.description, c.gpg_key_url, c.installer_updates, c.update_tag, c.org_id,
                TO_CHAR(c.last_modified, 'YYYYMMDDHH24MISS') last_modified,
                c.channel_product_id,
                pc.label parent_channel,

--- a/backend/satellite_tools/exporter/exportLib.py
+++ b/backend/satellite_tools/exporter/exportLib.py
@@ -342,6 +342,7 @@ class _ChannelDumper(BaseRowDumper):
             ('rhn-channel-gpg-key-url', 'gpg_key_url'),
             ('rhn-channel-checksum-type', 'checksum_type'),
             ('rhn-channel-update-tag', 'update_tag'),
+            ('rhn-channel-installer-updates', 'installer_updates'),
         ]
         for k, v in mappings:
             arr.append(SimpleDumper(self._writer, k, self._row.get(v)))
@@ -925,7 +926,8 @@ class _SCCRepositoryDumper(BaseRowDumper):
             'distro-target': self._row['distro_target'],
             'description': self._row['description'],
             'url': self._row['url'],
-            'signed': self._row['signed']
+            'signed': self._row['signed'],
+            'installer_updates': self._row['installer_updates']
             }
 
 class SCCRepositoryDumper(BaseQueryDumper):
@@ -933,7 +935,7 @@ class SCCRepositoryDumper(BaseQueryDumper):
     iterator_query = """
     SELECT scc_id AS sccid,
            autorefresh, name, distro_target,
-           description, url, signed
+           description, url, signed, installer_updates
       FROM suseSCCRepository
     """
 

--- a/backend/satellite_tools/xmlSource.py
+++ b/backend/satellite_tools/xmlSource.py
@@ -503,6 +503,7 @@ class ChannelItem(BaseItem):
         'sharing': 'channel_access',
         'rhn-channel-trusted-orgs': 'trust_list',
         'rhn-channel-update-tag': 'update_tag',
+        'rhn-channel-installer-updates': 'installer_updates',
         'suse-data': 'package_keywords',
     }
 
@@ -889,7 +890,8 @@ class SCCRepositoryItem(BaseItem):
             'distro-target': 'distro_target',
             'description': 'description',
             'url': 'url',
-            'signed': 'signed'
+            'signed': 'signed',
+            'installer_updates': 'installer_updates'
     }
 addItem(SCCRepositoryItem)
 

--- a/backend/server/importlib/backendOracle.py
+++ b/backend/server/importlib/backendOracle.py
@@ -362,6 +362,7 @@ class OracleBackend(Backend):
                   'checksum_type_id': DBint(),
                   'channel_access': DBstring(10),
                   'update_tag': DBstring(128),
+                  'installer_updates': DBstring(1)
               },
               pk=['label'],
               severityHash={

--- a/backend/server/importlib/importLib.py
+++ b/backend/server/importlib/importLib.py
@@ -239,7 +239,8 @@ class SCCRepository(Information):
         'distro_target': StringType,
         'description'  : StringType,
         'url'          : StringType,
-        'signed'       : StringType
+        'signed'       : StringType,
+        'installer_updates' : StringType
     }
 
 class SuseSubscription(Information):
@@ -322,6 +323,7 @@ class Channel(Information):
         'modules_last_modified': DateType,
         'gpg_key_url'       : StringType,
         'update_tag'        : StringType,
+        'installer_updates' : StringType,
         'product_name_id'   : IntType,
         'channel_product_id': IntType,
         'receiving_updates': StringType,

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- support installer_updates flag in ISS
 - Take care of SCC auth tokens on DEB repos GPG checks (bsc#1175485)
 - Use spacewalk keyring for GPG checks on DEB repos (bsc#1175485)
 - Remove duplicate languages and update translation strings

--- a/java/code/src/com/redhat/rhn/domain/channel/Channel.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/Channel.java
@@ -892,9 +892,6 @@ public class Channel extends BaseDomainHelper implements Comparable<Channel> {
      * @return Returns the installerUpdates.
      */
     public boolean isInstallerUpdates() {
-        if (isCloned()) {
-            return getOriginal().isInstallerUpdates();
-        }
         return installerUpdates;
     }
 

--- a/java/code/src/com/redhat/rhn/manager/channel/CloneChannelCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/CloneChannelCommand.java
@@ -110,6 +110,7 @@ public class CloneChannelCommand extends CreateChannelCommand {
         // cloned channel stuff
         c.setProductName(original.getProductName());
         c.setUpdateTag(original.getUpdateTag());
+        c.setInstallerUpdates(original.isInstallerUpdates());
         c.setOriginal(original);
 
         // need to save before calling stored procs below


### PR DESCRIPTION
## What does this PR change?

Clone the installer_updates flag when cloning a channel and transfer the flag when doing Inter-Server-Sync

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **already handled for the original PR**

- [x] **DONE**

## Test coverage
- No tests: **already covered**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/12223

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"  
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
