### PR TITLE
update numbers as we changed postgreql-jdbc jar we test

### DIFF
--- a/java/code/src/com/redhat/rhn/common/finder/test/JarFinderTest.java
+++ b/java/code/src/com/redhat/rhn/common/finder/test/JarFinderTest.java
@@ -28,12 +28,12 @@ public class JarFinderTest extends TestCase {
     // Sigh.
     // At least make it clear what we're looking for...
 
-    // Currently used jarfile: postgresql-jdbc-9.4.jar
+    // Currently used jarfile: postgresql-jdbc-42.2.10.jar
     // (previously redstone.xmlrpc could find either redstone-xmlrpc.jar or
     //  redstone-xmlrpc-client.jar, making test-results indeterminate)
     private static final String TESTJAR = "org.postgresql";
-    private static final int NUM_CLASSES_IN_TESTJAR = 339;
-    private static final int NUM_SUBDIRS_IN_TESTJAR = 339;
+    private static final int NUM_CLASSES_IN_TESTJAR = 343;
+    private static final int NUM_SUBDIRS_IN_TESTJAR = 343;
 
     public void testGetFinder() throws Exception {
         Finder f = FinderFactory.getFinder(TESTJAR);


### PR DESCRIPTION
## What does this PR change?

The postgresql-jdbc package was updated this change the number of classes we use in a test.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- Unit tests were fixed

- [x] **DONE**

## Links

Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
