### PR TITLE
Fix striping on tables in react pages.  

### DIFF
--- a/branding/css/tables.less
+++ b/branding/css/tables.less
@@ -143,6 +143,13 @@ th.descSort a:after {
   font-family: 'FontAwesome';
 }
 
+.table-striped > tbody > tr:nth-child(odd) > td, .table-striped > tbody > tr:nth-child(odd) > th {
+    background-color: #f9f9f9;
+}
+.list-row-odd, .list-row-odd td.sortedCol {
+    background-color: #f9f9f9 !important;
+}
+
 .list-row-even td.sortedCol {
   background-color: transparent !important;
 }

--- a/web/html/src/components/table/Table.js
+++ b/web/html/src/components/table/Table.js
@@ -66,7 +66,7 @@ export function Table(props: TableProps): React.Node {
             }
 
             const rowClass = props.cssClassFunction ? props.cssClassFunction(datum, index) : "";
-            const evenOddClass = (index % 2) === 0 ? "list-row-even" : "list-row-odd";
+            const evenOddClass = (index % 2) === 0 ? "list-row-odd" : "list-row-even";
             return (
               <tr className={rowClass + " " + evenOddClass}
                 key={props.identifier(datum)}

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- fix striping on react tables
 - Update translation strings
 - Upgrade jQuery and adapt the code - CVE-2020-11022 (bsc#1172831)
 - Fix JS linting errors/warnings


### PR DESCRIPTION
## What does this PR change?
This fixes the css and a react bit to make it match the struts pages.  


## GUI diff

Before:
![image](https://user-images.githubusercontent.com/729087/90832662-9083e400-e346-11ea-9f6a-685e1dd8bbeb.png)

After:
![image](https://user-images.githubusercontent.com/729087/90832252-a6dd7000-e345-11ea-981f-94bc8ac9fe8d.png)

![image](https://user-images.githubusercontent.com/729087/90832683-a09bc380-e346-11ea-899e-f272ad9abca0.png)


- [ ] **DONE**

## Documentation
- No documentation needed:   @Loquacity   We'll have to update screen shots.... 

- [ ] **DONE**

## Test coverage


- [ ] **DONE**

## Links

Fixes #
https://github.com/SUSE/spacewalk/issues/11769

Needs to be ported to 4.1

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
