### PR TITLE
Fix autoyast full iso

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/common/DownloadFile.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/common/DownloadFile.java
@@ -639,7 +639,10 @@ public class DownloadFile extends DownloadAction {
                                 File.separator + StringUtils.join(split, '/');
                     }
                 }
-                else if (path.endsWith("/media.1/products") && tree.getChannel().getMediaProducts() != null) {
+                else if (tree.getKernelOptions() != null &&
+                         tree.getKernelOptions().contains("useonlinerepo") &&
+                         path.endsWith("/media.1/products") &&
+                         tree.getChannel().getMediaProducts() != null) {
                     diskPath = Config.get().getString(ConfigDefaults.MOUNT_POINT) +
                         "/" + tree.getChannel().getMediaProducts().getRelativeFilename();
                 }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- use media.1/products from media when not specified different (bsc#1175558)
 - Fix: use quiet API method when using spacewalk-common-channels (bsc#1175529)
 - add java.allow_adding_patches_via_api to allow adding errata to vendor channels
 - fix alignment on icon on entitlement page


### PR DESCRIPTION
## What does this PR change?

When using the full SLE15 SP2 ISO we need to get the file media.1/products from the media.
Due to a bug introduced by supporting the Online Media, we get the file always stored with the Base Channel.
Change the behavior to get the file only from the online repo when kernel option "useonlinerepo" is defined.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **fix expected behavior**

- [x] **DONE**

## Test coverage
- No tests: **manual**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/12233
Tracks https://github.com/SUSE/spacewalk/pull/12234 https://github.com/SUSE/spacewalk/pull/12235

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
