### PR TITLE
Clarify action behind Repository button

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -7920,7 +7920,7 @@ Please note that some manual configuration of these scripts may still be require
         <source>Repository Information</source>
       </trans-unit>
       <trans-unit id="repos.jsp.update.channel">
-        <source>Update Repositories</source>
+        <source>Save Repositories</source>
       </trans-unit>
       <trans-unit id="repos.jsp.channel.header">
         <source>Repository</source>

--- a/java/code/webapp/WEB-INF/pages/channel/manage/channelrepos.jsp
+++ b/java/code/webapp/WEB-INF/pages/channel/manage/channelrepos.jsp
@@ -22,7 +22,7 @@
         <div class="spacewalk-section-toolbar">
             <div class="action-button-wrapper">
                 <div class="btn-group">
-                    <input class="btn btn-default" type="submit" name="dispatch"
+                    <input class="btn btn-success" type="submit" name="dispatch"
                            value="<bean:message key='repos.jsp.update.channel'/>"/>
                     <a href="/rhn/channels/manage/repos/RepoCreate.do?cid=${cid}" class="btn btn-default">
                         <rhn:icon type="item-add"/>

--- a/testsuite/features/core/srv_create_repository.feature
+++ b/testsuite/features/core/srv_create_repository.feature
@@ -32,7 +32,7 @@ Feature: Add a repository to a channel
     And I follow "Test-Channel-x86_64"
     And I follow "Repositories" in the content area
     And I select the "Test-Repository-x86_64" repo
-    And I click on "Update Repositories"
+    And I click on "Save Repositories"
     Then I should see a "Test-Channel-x86_64 repository information was successfully updated" text
 
   Scenario: Synchronize the repository in the x86_64 channel
@@ -61,7 +61,7 @@ Feature: Add a repository to a channel
     And I follow "Test-Channel-i586"
     And I follow "Repositories" in the content area
     And I select the "Test-Repository-i586" repo
-    And I click on "Update Repositories"
+    And I click on "Save Repositories"
     Then I should see a "Test-Channel-i586 repository information was successfully updated" text
 
   Scenario: Synchronize the repository in the i586 channel
@@ -98,7 +98,7 @@ Feature: Add a repository to a channel
     And I follow "Test-Channel-Deb-AMD64"
     And I follow "Repositories" in the content area
     And I select the "Test-Repository-Deb" repo
-    And I click on "Update Repositories"
+    And I click on "Save Repositories"
     Then I should see a "Test-Channel-Deb-AMD64 repository information was successfully updated" text
 
 @ubuntu_minion

--- a/testsuite/features/qam/add_custom_repositories/add_ceos6_repositories.feature
+++ b/testsuite/features/qam/add_custom_repositories/add_ceos6_repositories.feature
@@ -34,7 +34,7 @@ Feature: Adding the CentOS 6 distribution custom repositories
     And I follow "Custom Channel for CentOS 6 DVD"
     And I follow "Repositories" in the content area
     And I select the "centos-6-iso" repo
-    And I click on "Update Repositories"
+    And I click on "Save Repositories"
     Then I should see a "repository information was successfully updated" text
 
   Scenario: Synchronize the repository in the Custom Channel for <label>

--- a/testsuite/features/qam/add_custom_repositories/add_ceos7_repositories.feature
+++ b/testsuite/features/qam/add_custom_repositories/add_ceos7_repositories.feature
@@ -34,7 +34,7 @@ Feature: Adding the CentOS 7 distribution custom repositories
     And I follow "Custom Channel for CentOS 7 DVD"
     And I follow "Repositories" in the content area
     And I select the "centos-7-iso" repo
-    And I click on "Update Repositories"
+    And I click on "Save Repositories"
     Then I should see a "repository information was successfully updated" text
 
   Scenario: Synchronize the repository in the Custom Channel for <label>

--- a/testsuite/features/qam/add_custom_repositories/add_mu_repository.template
+++ b/testsuite/features/qam/add_custom_repositories/add_mu_repository.template
@@ -31,7 +31,7 @@ Feature: Adding a Maintenance Update custom channel and repository for <client>
     And I follow "Custom Channel for <client>"
     And I follow "Repositories" in the content area
     And I select the "custom_repo_<client>" repo
-    And I click on "Update Repositories"
+    And I click on "Save Repositories"
     Then I should see a "repository information was successfully updated" text
 
   Scenario: Synchronize the repository in the Custom Channel for <client>

--- a/testsuite/features/qam/add_custom_repositories/add_ubuntu1604_repositories.feature
+++ b/testsuite/features/qam/add_custom_repositories/add_ubuntu1604_repositories.feature
@@ -54,7 +54,7 @@ Feature: Adding the Ubuntu 16.04 distribution custom repositories
     And I follow "Custom Channel for ubuntu-xenial-main"
     And I follow "Repositories" in the content area
     And I select the "ubuntu-xenial-main" repo
-    And I click on "Update Repositories"
+    And I click on "Save Repositories"
     Then I should see a "repository information was successfully updated" text
 
   Scenario: Add the repository to the Custom Channel for ubuntu-xenial-main-updates
@@ -63,7 +63,7 @@ Feature: Adding the Ubuntu 16.04 distribution custom repositories
     And I follow "Custom Channel for ubuntu-xenial-main-updates"
     And I follow "Repositories" in the content area
     And I select the "ubuntu-xenial-main-updates" repo
-    And I click on "Update Repositories"
+    And I click on "Save Repositories"
     Then I should see a "repository information was successfully updated" text
 
   Scenario: Synchronize the repository in the Custom Channel for ubuntu-xenial-main

--- a/testsuite/features/qam/add_custom_repositories/add_ubuntu1804_repositories.feature
+++ b/testsuite/features/qam/add_custom_repositories/add_ubuntu1804_repositories.feature
@@ -54,7 +54,7 @@ Feature: Adding the Ubuntu 18.04 distribution custom repositories
     And I follow "Custom Channel for ubuntu-bionic-main"
     And I follow "Repositories" in the content area
     And I select the "ubuntu-bionic-main" repo
-    And I click on "Update Repositories"
+    And I click on "Save Repositories"
     Then I should see a "repository information was successfully updated" text
 
   Scenario: Add the repository to the Custom Channel for ubuntu-bionic-main-updates
@@ -63,7 +63,7 @@ Feature: Adding the Ubuntu 18.04 distribution custom repositories
     And I follow "Custom Channel for ubuntu-bionic-main-updates"
     And I follow "Repositories" in the content area
     And I select the "ubuntu-bionic-main-updates" repo
-    And I click on "Update Repositories"
+    And I click on "Save Repositories"
     Then I should see a "repository information was successfully updated" text
 
   Scenario: Synchronize the repository in the Custom Channel for ubuntu-bionic-main


### PR DESCRIPTION
## What does this PR change?

Clarify the behavior of `Save Repositories` button in channel details.

## GUI diff

Before:
![Screenshot from 2020-08-21 15-59-19](https://user-images.githubusercontent.com/7080830/90898902-6e7e7600-e3c7-11ea-98d2-882917f656a7.png)


After:
![Screenshot from 2020-08-21 15-59-43](https://user-images.githubusercontent.com/7080830/90898910-71796680-e3c7-11ea-9c0a-6b5e7193ab59.png)



- [x] **DONE**

## Documentation
- No documentation needed: @Loquacity I don't think there is a need for a documentation change or retaking a screenshot, isn't it?

- [x] **DONE**

## Test coverage
- No tests: style change only, fixed cucumber tests only

- [x] **DONE**

## Links

Fixes #
Tracks # https://github.com/SUSE/spacewalk/pull/12330 https://github.com/SUSE/spacewalk/pull/12331

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
