### PR TITLE
Cucumber tests installer updates

### DIFF
--- a/testsuite/features/reposync/srv_check_installer_updates.feature
+++ b/testsuite/features/reposync/srv_check_installer_updates.feature
@@ -1,0 +1,13 @@
+# Copyright (c) 2020 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+Feature: Check Installer Update repositories
+  In order to use installer updates
+  As root user
+  I want to check that Installer-Updates Channels got synced when adding the product
+
+@scc_credentials
+  Scenario: Check installer updates channels got enabled during add product
+    When I execute mgr-sync "list channels" with user "admin" and password "admin"
+    Then I should get "    [I] SLES12-SP2-Installer-Updates for x86_64 SUSE Linux Enterprise Server 12 SP2 x86_64 [sles12-sp2-installer-updates-x86_64]"
+    And I should get "    [I] SLE15-Installer-Updates for x86_64 SUSE Linux Enterprise Server 15 x86_64 [sle15-installer-updates-x86_64]"

--- a/testsuite/features/secondary/srv_distro_cobbler.feature
+++ b/testsuite/features/secondary/srv_distro_cobbler.feature
@@ -20,6 +20,20 @@ Feature: Cobbler and distribution autoinstallation
     Then I should see a "testprofile" text
     And I should see a "testdistro" text
 
+  Scenario: Create SUSE Distibution with installer updates
+    When I install package "tftpboot-installation-SLE-15-SP2-x86_64" on this "server"
+    And I follow the left menu "Systems > Autoinstallation > Distributions"
+    And I follow "Create Distribution"
+    When I enter "SLE-15-SP2-x86_64" as "label"
+    And I enter "/usr/share/tftpboot-installation/SLE-15-SP2-x86_64/" as "basepath"
+    And I select "SLE-Product-SLES15-Pool for x86_64" from "channelid"
+    And I select "SUSE Linux Enterprise 15" from "installtype"
+    And I click on "Create Autoinstallable Distribution"
+    Then I should see a "Autoinstallable Distributions" text
+    And I should see a "SLE-15-SP2-x86_64" link
+    When I follow "SLE-15-SP2-x86_64"
+    Then textfield "kernelopts" should contain "self_update=http://"
+
   Scenario: Create a distribution via the UI
     When I follow the left menu "Systems > Autoinstallation > Distributions"
     And I follow "Create Distribution"

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -1210,3 +1210,7 @@ When(/^I add "([^\"]*)" calendar file as url$/) do |file|
   puts "URL: #{url}"
   step %(I enter "#{url}" as "calendar-data-text")
 end
+
+Then(/^textfield "([^\"]*)" should contain "([^\"]*)"$/) do |field, text|
+  raise "'#{text}' not found in #{field}" unless find_field(field, with: /#{text}/).visible?
+end

--- a/testsuite/run_sets/reposync.yml
+++ b/testsuite/run_sets/reposync.yml
@@ -12,6 +12,7 @@
 - features/reposync/srv_sync_channels.feature
 - features/reposync/srv_sync_products.feature
 - features/reposync/srv_enable_sync_products.feature
+- features/reposync/srv_check_installer_updates.feature
 - features/reposync/srv_abort_all_sync.feature
 - features/reposync/srv_check_reposync.feature
 


### PR DESCRIPTION
## What does this PR change?

Tests for installer_updates feature:

- If a product has installer update channels they will get mirrored when adding the product, even if they not mandatory
- When creating a distribution and selecting a base channel which has an installer update channel as child, it will be configured automatically 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **tests only**

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
