### PR TITLE
Limit count of rows returned by listPackagesFromId

### DIFF
--- a/search-server/spacewalk-search/src/config/com/redhat/satellite/search/db/package.xml
+++ b/search-server/spacewalk-search/src/config/com/redhat/satellite/search/db/package.xml
@@ -39,7 +39,7 @@
            and p.name_id = pn.id
            and p.package_arch_id = pa.id
            and p.id &gt; #{id}
-         ORDER by p.id ASC
+         ORDER by p.id ASC LIMIT 10000
    </select>
    <delete id="deleteLastPackage">
                 DELETE FROM rhnIndexerWork where object_type = 'package'


### PR DESCRIPTION
The count of rows returned by listPackagesFromId is limited to 10000.
This is a workaround  because the package indexer stops working with high count of packages (see  https://github.com/uyuni-project/uyuni/issues/2436)

## What does this PR change?

The package indexer stops working on high package counts. The change is limiting the count of rows for listPackagesFromId. So the indexer works, but needs multiple runs to index all packages.   

## GUI diff

No difference.

## Documentation
- No documentation needed: internal workaround

## Test coverage
- No tests: tested with own obs branch

## Links

Fixes #
Tracks # 

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
