### PR TITLE
Only regenerate bootstrap repositories when linking new packages (bsc#1174636)

### DIFF
--- a/backend/satellite_tools/reposync.py
+++ b/backend/satellite_tools/reposync.py
@@ -400,6 +400,7 @@ class RepoSync(object):
         self.available_packages = {}
         self.ks_install_type = None
         self.show_packages_only = show_packages_only
+        self.regenerate_bootstrap_repo = False
 
         initCFG('server.susemanager')
         rhnSQL.initDB()
@@ -671,7 +672,8 @@ class RepoSync(object):
             taskomatic.add_to_erratacache_queue(self.channel_label)
         self.update_date()
         rhnSQL.commit()
-        if CFG.AUTO_GENERATE_BOOTSTRAP_REPO:
+        if CFG.AUTO_GENERATE_BOOTSTRAP_REPO and self.regenerate_bootstrap_repo:
+            log(0, '  Regenerating bootstrap repositories.')
             subprocess.call(["/usr/sbin/mgr-create-bootstrap-repo", "--auto"])
 
         # update permissions
@@ -1108,6 +1110,7 @@ class RepoSync(object):
                 count += len(import_batch)
                 log(0, "    {} packages linked".format(count))
             self.regen = True
+            self.regenerate_bootstrap_repo = True
         self._normalize_orphan_vendor_packages()
         return failed_packages
 

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Only regenerate bootstrap repositories when linking new packages (bsc#1174636)
 - support installer_updates flag in ISS
 - Take care of SCC auth tokens on DEB repos GPG checks (bsc#1175485)
 - Use spacewalk keyring for GPG checks on DEB repos (bsc#1175485)


### PR DESCRIPTION
## What does this PR change?

This PR makes `spacewalk-repo-sync` to only trigger bootstrap repositories regeneration in case a new package is linked in the syncing channel.

This makes `spacewalk-repo-sync` to run much faster in case there is nothing to sync from the channel.

Before this PR, every reposync execution triggers bootstrap repositories regeneration. This situation gets really worse when you have lot of channels and bootstrap repositories.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**
- [x] **DONE**

## Test coverage
- No tests: **bugfix**
- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/12090

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
