### PR TITLE
TestSuite: Fixing wrong status in UI monitoring

### DIFF
--- a/testsuite/features/secondary/srv_monitoring.feature
+++ b/testsuite/features/secondary/srv_monitoring.feature
@@ -46,9 +46,9 @@ Feature: Enable and disable monitoring of the server
     Then I should see a "Monitoring enabled successfully." text
     And I should see a list item with text "System" and a success bullet
     And I should see a list item with text "PostgreSQL database" and a success bullet
-    And I should see a list item with text "Server self monitoring" and a success bullet
-    And I should see a list item with text "Taskomatic (Java JMX)" and a success bullet
-    And I should see a list item with text "Tomcat (Java JMX)" and a success bullet
+    And I should see a list item with text "Server self monitoring" and a pending bullet
+    And I should see a list item with text "Taskomatic (Java JMX)" and a pending bullet
+    And I should see a list item with text "Tomcat (Java JMX)" and a pending bullet
     And I should see a "Restarting Tomcat and Taskomatic is needed for the configuration changes to take effect." text
     And file "/etc/rhn/rhn.conf" should contain "prometheus_monitoring_enabled = 1" on server
     And file "/etc/sysconfig/tomcat" should contain "Dcom.sun.management.jmxremote.port=3333 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname=" on server

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -1118,7 +1118,7 @@ And(/^I check for failed events on history event page$/) do
   raise "\nFailures in event history found:\n\n#{failings}" if count_failures.nonzero?
 end
 
-Then(/^I should see a list item with text "([^"]*)" and a (success|failing|warning|refreshing) bullet$/) do |text, bullet_type|
+Then(/^I should see a list item with text "([^"]*)" and a (success|failing|warning|pending|refreshing) bullet$/) do |text, bullet_type|
   item_xpath = "//ul/li[text()='#{text}']/i[contains(@class, '#{BULLET_STYLE[bullet_type]}')]"
   find(:xpath, item_xpath)
 end

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -97,6 +97,7 @@ FIELD_IDS = { 'NIC'                             => 'branch_network#nic',
 BULLET_STYLE = { 'failing' => 'fa-times text-danger',
                  'warning' => 'fa-hand-o-right text-danger',
                  'success' => 'fa-check text-success',
+                 'pending' => 'fa-hand-o-right text-success',
                  'refreshing' => 'fa-refresh text-warning' }.freeze
 
 PATCH_BY_CLIENT = { 'ceos6_minion' => 'RHSA-2019:1774',


### PR DESCRIPTION
## What does this PR change?

Fixing a test suite mistake. During the monitoring feature, we were comparing with the wrong CSS style.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were modified

- [x] **DONE**

## Links

Need ports on spacewalk 4.0 and 4.1

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
