### PR TITLE
More log retrieving pillar data

### DIFF
--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -543,6 +543,7 @@ Then(/^the pillar data for "([^"]*)" should (be|contain|not contain) "([^"]*)" o
     raise 'Invalid target'
   end
   output, _code = $server.run("#{cmd} '#{system_name}' pillar.get '#{key}' #{extra_cmd}")
+  STDOUT.puts "#{cmd} '#{system_name}' pillar.get '#{key}' #{extra_cmd} => #{output}"
   if verb == 'be' && value == ''
     raise "Output has more than one line: #{output}" unless output.split("\n").length == 1
   elsif verb == 'be'


### PR DESCRIPTION
## What does this PR change?

Adding more log when we retrieve pillar data in our tests. It will be useful to understand issues in the test report.

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

Relevant branches (GitHub automatic links expected below):
 - Manager-4.0 https://github.com/SUSE/spacewalk/pull/12263
 - Manager-4.1 https://github.com/SUSE/spacewalk/pull/12262

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
