### PR TITLE
Fix dnf plugin bsc1175724 

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/channels/dnf-susemanager-plugin/susemanagerplugin.py
+++ b/susemanager-utils/susemanager-sls/salt/channels/dnf-susemanager-plugin/susemanagerplugin.py
@@ -6,9 +6,9 @@ class Susemanager(dnf.Plugin):
 
     def __init__(self, base, cli):
         super(Susemanager, self).__init__(base, cli)
-        with dnf.base.Base() as base:
-            base.read_all_repos()
-        for repo in base.repos.get_matching("susemanager:*"):
+
+    def config(self):
+        for repo in self.base.repos.get_matching("susemanager:*"):
             try:
                 susemanager_token = repo.cfg.getValue(section=repo.id, key="susemanager_token")
                 repo.set_http_headers(["X-Mgr-Auth: %s" % susemanager_token])

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Fix the dnf plugin to add the token to the HTTP header (bsc#1175724)
 - Fix reporting of missing products in product.all_installed (bsc#1165829)
 - Fix: supply a dnf base when dealing w/repos (bsc#1172504)
 - Fix: autorefresh in repos is zypper-only


### PR DESCRIPTION
## What does this PR change?

Port of https://github.com/SUSE/spacewalk/pull/12264
Fixes the dnf plugin to add the token to the HTTP header.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bugfix

- [x] **DONE**

## Test coverage
- No tests: in work

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
