### PR TITLE
Testsuite: static spacewalk.css renamed to susemanager.css

### DIFF
--- a/testsuite/features/step_definitions/security_steps.rb
+++ b/testsuite/features/step_definitions/security_steps.rb
@@ -3,7 +3,7 @@ require 'uri'
 require 'openssl'
 
 Given(/^I retrieve any static resource$/) do
-  resource = ['/img/action-add.gif', '/css/spacewalk.css', '/fonts/DroidSans.ttf',
+  resource = ['/img/action-add.gif', '/css/susemanager.css', '/fonts/DroidSans.ttf',
               '/javascript/actionchain.js'].sample
   @url = Capybara.app_host + resource
   open(@url, ssl_verify_mode: OpenSSL::SSL::VERIFY_NONE) do |f|


### PR DESCRIPTION
## What does this PR change?

The static resource `/css/spacewalk.css` was renamed by `/css/susemanager.css`
This PR fix the missing content in one of our step definitions.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- A test was changed

- [x] **DONE**

## Links

Uyuni:
4.1:
4.0:

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
