### PR TITLE
Fix the KVM and Xen tests to select NAT network

### DIFF
--- a/testsuite/features/secondary/minkvm_guests.feature
+++ b/testsuite/features/secondary/minkvm_guests.feature
@@ -44,6 +44,7 @@ Feature: Be able to manage KVM virtual machines via the GUI
     Given I am on the Systems overview page of this "kvm_server"
     When I follow "Formulas" in the content area
     And I follow first "Virtualization Host" in the content area
+    And I select "NAT" in virtual network mode field
     And I enter "192.168.124.1" in virtual network IPv4 address field
     And I enter "192.168.124.2" in first IPv4 address for DHCP field
     And I enter "192.168.124.254" in last IPv4 address for DHCP field

--- a/testsuite/features/secondary/minxen_guests.feature
+++ b/testsuite/features/secondary/minxen_guests.feature
@@ -45,6 +45,7 @@ Feature: Be able to manage XEN virtual machines via the GUI
     When I follow "Formulas" in the content area
     And I follow first "Virtualization Host" in the content area
     And I select "Xen" from "hypervisor"
+    And I select "NAT" in virtual network mode field
     And I enter "192.168.124.1" in virtual network IPv4 address field
     And I enter "192.168.124.2" in first IPv4 address for DHCP field
     And I enter "192.168.124.254" in last IPv4 address for DHCP field

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -12,6 +12,7 @@ ADDRESSES = { 'network'     => '0',
 
 FIELD_IDS = { 'NIC'                             => 'branch_network#nic',
               'IP'                              => 'branch_network#ip',
+              'virtual network mode'            => 'default_net#mode',
               'domain name server'              => 'dhcpd#domain_name_servers#0',
               'network IP'                      => 'dhcpd#subnets#0#$key',
               'dynamic IP range begin'          => 'dhcpd#subnets#0#range#0',


### PR DESCRIPTION
## What does this PR change?

Since the virtualization host formula now defaults to Bridged network, the testsuite needs to select NAT.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: tests fix

- [X] **DONE**

## Test coverage
- Cucumber tests were fixed

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
