### PR TITLE
Fix EntityExistsException on migration from traditional to salt minion via proxy

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
@@ -69,6 +69,7 @@ import java.util.stream.Collectors;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.JoinType;
+import javax.persistence.criteria.Path;
 import javax.persistence.criteria.Root;
 
 /**
@@ -284,28 +285,51 @@ public class ServerFactory extends HibernateFactory {
      * @param server the server
      * @param proxyServer the proxy server to which <code>server</code> connects directly
      * @param proxyHostname the proxy hostname
-     * @return a set of {@link ServerPath} objects where the proxy to which
-     * <code>server</code> connects dirrectly has position 0, the second proxy
+     * @return a set of {@link ServerPath} objects where the proxy to which the
+     * <code>server</code> connects directly has position 0, the second proxy
      * has position 1, etc
      */
     public static Set<ServerPath> createServerPaths(Server server, Server proxyServer,
                                               String proxyHostname) {
         Set<ServerPath> paths = new HashSet<>();
         for (ServerPath parentPath : proxyServer.getServerPaths()) {
-            ServerPath path = new ServerPath();
-            path.setId(new ServerPathId(server, parentPath.getId().getProxyServer()));
-            path.setPosition(parentPath.getPosition() + 1);
-            path.setHostname(parentPath.getHostname());
+            ServerPath path = findServerPath(server, parentPath.getId().getProxyServer()).orElseGet(() -> {
+                ServerPath newPath = new ServerPath();
+                newPath.setId(new ServerPathId(server, parentPath.getId().getProxyServer()));
+                newPath.setPosition(parentPath.getPosition() + 1);
+                newPath.setHostname(parentPath.getHostname());
+                return newPath;
+            });
             paths.add(path);
+
         }
-        ServerPath path = new ServerPath();
-        path.setId(new ServerPathId(server, proxyServer));
-        // the first proxy is the one to which
-        // the server connects directly
-        path.setPosition(0L);
-        path.setHostname(proxyHostname);
+        ServerPath path = findServerPath(server, proxyServer).orElseGet(() -> {
+            ServerPath newPath = new ServerPath();
+            newPath.setId(new ServerPathId(server, proxyServer));
+            // the first proxy is the one to which
+            // the server connects directly
+            newPath.setPosition(0L);
+            newPath.setHostname(proxyHostname);
+            return newPath;
+        });
         paths.add(path);
         return paths;
+    }
+
+    private static Optional<ServerPath> findServerPath(Server server, Server proxyServer) {
+        if (server.getId() == null) {
+            // not yet persisted, return empty to avoid Hibernate error
+            // on query with a transient object
+            return Optional.empty();
+        }
+        CriteriaBuilder builder = HibernateFactory.getSession().getCriteriaBuilder();
+        CriteriaQuery<ServerPath> criteria = builder.createQuery(ServerPath.class);
+        Root<ServerPath> root = criteria.from(ServerPath.class);
+        Path<ServerPathId> id = root.get("id");
+        criteria.where(builder.and(
+                builder.equal(id.get("server"), server),
+                builder.equal(id.get("proxyServer"), proxyServer)));
+        return getSession().createQuery(criteria).uniqueResultOptional();
     }
 
     /**
@@ -979,6 +1003,14 @@ public class ServerFactory extends HibernateFactory {
      */
     public static void deleteSnapshot(ServerSnapshot snap) {
         ServerFactory.getSession().delete(snap);
+    }
+
+    /**
+     * Delete a server path
+     * @param path the server path to delete
+     */
+    public static void deleteServerPath(ServerPath path) {
+        ServerFactory.getSession().delete(path);
     }
 
     /**

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix EntityExistsException on migration from traditional to salt minion via proxy (bsc#1175876)
 - use media.1/products from media when not specified different (bsc#1175558)
 - Fix: use quiet API method when using spacewalk-common-channels (bsc#1175529)
 - add java.allow_adding_patches_via_api to allow adding errata to vendor channels


### PR DESCRIPTION
## What does this PR change?

https://bugzilla.suse.com/show_bug.cgi?id=1175556
Fix `javax.persistence.EntityExistsException` when re-registering a traditional client as a Salt minion via a proxy.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bugfix

- [x] **DONE**

## Test coverage
- No tests: cucumber test exists

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
