### PR TITLE
TestSuite: Refactor enabling repos for Prometheus exporters

### DIFF
--- a/testsuite/features/secondary/min_centos_monitoring.feature
+++ b/testsuite/features/secondary/min_centos_monitoring.feature
@@ -8,7 +8,7 @@ Feature: Monitor SUMA environment with Prometheus on a CentOS minion
   I want to enable Prometheus exporters
 
   Scenario: Pre-requisite: enable Prometheus exporters repository on the CentOS minion
-    When I enable repository "tools_pool_repo" on this "ceos_minion"
+    When I enable the necessary repositories before installing Prometheus exporters on this "ceos_minion"
 
   Scenario: Apply Prometheus exporter formulas on the CentOS minion
     Given I am on the Systems overview page of this "ceos_minion"
@@ -57,4 +57,4 @@ Feature: Monitor SUMA environment with Prometheus on a CentOS minion
     And I wait until event "Apply highstate scheduled by admin" is completed
 
   Scenario: Cleanup: disable Prometheus exporters repository on the CentOS minion
-    And I disable repository "tools_pool_repo" on this "ceos_minion" without error control
+    When I disable the necessary repositories before installing Prometheus exporters on this "ceos_minion" without error control

--- a/testsuite/features/secondary/min_monitoring.feature
+++ b/testsuite/features/secondary/min_monitoring.feature
@@ -8,7 +8,7 @@ Feature: Monitor SUMA environment with Prometheus on a normal minion
   I want to enable Prometheus exporters
 
   Scenario: Pre-requisite: enable Prometheus exporters repository on the minion
-    When I "enable" Prometheus exporter repository on this "sle_minion"
+    When I enable the necessary repositories before installing Prometheus exporters on this "sle_minion"
     And I run "zypper -n ref" on "sle_minion"
 
   Scenario: Apply Prometheus and Prometheus exporter formulas
@@ -70,4 +70,4 @@ Feature: Monitor SUMA environment with Prometheus on a normal minion
     And I wait until event "Apply highstate scheduled by admin" is completed
 
   Scenario: Cleanup: disable Prometheus exporters repository
-    And I "disable" Prometheus exporter repository on this "sle_minion" without error control
+    When I disable the necessary repositories before installing Prometheus exporters on this "sle_minion" without error control

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1306,10 +1306,12 @@ Then(/^the "([^"]*)" on "([^"]*)" grains does not exist$/) do |key, client|
 end
 
 # Enable/disable repository for monitoring exporters
-When(/^I "([^"]*)" Prometheus exporter repository on this "([^"]*)"((?: without error control)?)$/) do |action, host, error_control|
-  repo_name = 'tools_additional_repo'
-  if $product == 'Uyuni'
-    repo_name = 'tools_pool_repo'
+When(/^I (enable|disable) the necessary repositories before installing Prometheus exporters on this "([^"]*)"((?: without error control)?)$/) do |action, host, error_control|
+  node = get_target(host)
+  os_version, os_family = get_os_version(node)
+  if os_family =~ /^opensuse/ || os_family =~ /^sles/
+    node.run("zypper mr --#{action} os_pool_repo os_update_repo")
   end
-  step %(I #{action} repository "#{repo_name}" on this "#{host}"#{error_control})
+  tools_repo_name = $product == 'Uyuni' ? 'tools_pool_repo' : 'tools_additional_repo'
+  step %(I #{action} repository "#{tools_repo_name}" on this "#{host}"#{error_control})
 end


### PR DESCRIPTION
## What does this PR change?

It seems that the salt state applied after add the formula for Prometheus exporters, depends on a package `sle-module-basesystem-release` which in our case, using Sumaform, is contained in the repository `os_pool_repo`. In a regular case, the product must be already installed in the SLE client. 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Fixes #
Tracks # Will need ports for 4.1 and 4.0

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
