### PR TITLE
DB schema extension for Debian10-Minions on cpuarch=aarch64,osarch=arm64, Issue #2548

### DIFF
--- a/schema/spacewalk/common/data/rhnChannelArch.sql
+++ b/schema/spacewalk/common/data/rhnChannelArch.sql
@@ -88,5 +88,8 @@ insert into rhnChannelArch (id, label, name, arch_type_id) values
 insert into rhnChannelArch (id, label, name, arch_type_id) values
 (sequence_nextval('rhn_channel_arch_id_seq'), 'channel-mips-deb', 'mips Debian', lookup_arch_type('deb'));
 
+insert into rhnChannelArch (id, label, name, arch_type_id) values
+(sequence_nextval('rhn_channel_arch_id_seq'), 'channel-arm64-deb', 'ARM64 Debian', lookup_arch_type('deb'));
+
 commit;
 

--- a/schema/spacewalk/common/data/rhnChannelPackageArchCompat.sql
+++ b/schema/spacewalk/common/data/rhnChannelPackageArchCompat.sql
@@ -345,4 +345,13 @@ values (LOOKUP_CHANNEL_ARCH('channel-x86_64'), LOOKUP_PACKAGE_ARCH('nosrc'));
 insert into rhnChannelPackageArchCompat (channel_arch_id, package_arch_id)
 values (LOOKUP_CHANNEL_ARCH('channel-ppc'), LOOKUP_PACKAGE_ARCH('nosrc'));
 
+insert into rhnChannelPackageArchCompat (channel_arch_id, package_arch_id)
+values (LOOKUP_CHANNEL_ARCH('channel-arm64-deb'), LOOKUP_PACKAGE_ARCH('arm64-deb'));
+
+insert into rhnChannelPackageArchCompat (channel_arch_id, package_arch_id)
+values (LOOKUP_CHANNEL_ARCH('channel-arm64-deb'), LOOKUP_PACKAGE_ARCH('all-deb'));
+
+insert into rhnChannelPackageArchCompat (channel_arch_id, package_arch_id)
+values (LOOKUP_CHANNEL_ARCH('channel-arm64-deb'), LOOKUP_PACKAGE_ARCH('src-deb'));
+
 commit;

--- a/schema/spacewalk/common/data/rhnChildChannelArchCompat.sql
+++ b/schema/spacewalk/common/data/rhnChildChannelArchCompat.sql
@@ -100,5 +100,8 @@ values (LOOKUP_CHANNEL_ARCH('channel-aarch64'), LOOKUP_CHANNEL_ARCH('channel-aar
 insert into rhnChildChannelArchCompat (parent_arch_id, child_arch_id)
 values (LOOKUP_CHANNEL_ARCH('channel-ppc64le'), LOOKUP_CHANNEL_ARCH('channel-ppc64le'));
 
+insert into rhnChildChannelArchCompat (parent_arch_id, child_arch_id)
+values (LOOKUP_CHANNEL_ARCH('channel-arm64-deb'), LOOKUP_CHANNEL_ARCH('channel-arm64-deb'));
+
 commit;
 

--- a/schema/spacewalk/common/data/rhnCpuArch.sql
+++ b/schema/spacewalk/common/data/rhnCpuArch.sql
@@ -78,5 +78,7 @@ insert into rhnCpuArch (id, label, name) values
 (sequence_nextval('rhn_cpu_arch_id_seq'), 'armv6hl', 'ARMv6hl');
 insert into rhnCpuArch (id, label, name) values
 (sequence_nextval('rhn_cpu_arch_id_seq'), 'cloud', 'cloud');
+insert into rhnCpuArch (id, label, name) values
+(sequence_nextval('rhn_cpu_arch_id_seq'), 'arm64', 'ARM64');
 commit;
 

--- a/schema/spacewalk/common/data/rhnPackageArch.sql
+++ b/schema/spacewalk/common/data/rhnPackageArch.sql
@@ -108,6 +108,8 @@ insert into rhnPackageArch (id, label, name, arch_type_id) values
 (sequence_nextval('rhn_package_arch_id_seq'), 'mips-deb', 'mips-deb', lookup_arch_type('deb'));
 insert into rhnPackageArch (id, label, name, arch_type_id) values
 (sequence_nextval('rhn_package_arch_id_seq'), 'amd64-deb', 'AMD64-deb', lookup_arch_type('deb'));
+insert into rhnPackageArch (id, label, name, arch_type_id) values
+(sequence_nextval('rhn_package_arch_id_seq'), 'arm64-deb', 'ARM64-deb', lookup_arch_type('deb'));
 
 commit;
 

--- a/schema/spacewalk/common/data/rhnPackageUpgradeArchCompat.sql
+++ b/schema/spacewalk/common/data/rhnPackageUpgradeArchCompat.sql
@@ -144,4 +144,9 @@ insert into rhnPackageUpgradeArchCompat (package_arch_id, package_upgrade_arch_i
 insert into rhnPackageUpgradeArchCompat (package_arch_id, package_upgrade_arch_id, created, modified) values (LOOKUP_PACKAGE_ARCH('amd64-deb'), LOOKUP_PACKAGE_ARCH('all-deb'), current_timestamp, current_timestamp);
 insert into rhnPackageUpgradeArchCompat (package_arch_id, package_upgrade_arch_id, created, modified) values (LOOKUP_PACKAGE_ARCH('amd64-deb'), LOOKUP_PACKAGE_ARCH('amd64-deb'), current_timestamp, current_timestamp);
 insert into rhnPackageUpgradeArchCompat (package_arch_id, package_upgrade_arch_id, created, modified) values (LOOKUP_PACKAGE_ARCH('all-deb'), LOOKUP_PACKAGE_ARCH('amd64-deb'), current_timestamp, current_timestamp);
+insert into rhnPackageUpgradeArchCompat (package_arch_id, package_upgrade_arch_id, created, modified) values (LOOKUP_PACKAGE_ARCH('arm64-deb'), LOOKUP_PACKAGE_ARCH('all-deb'), current_timestamp, current_timestamp);
+insert into rhnPackageUpgradeArchCompat (package_arch_id, package_upgrade_arch_id, created, modified) values (LOOKUP_PACKAGE_ARCH('arm64-deb'), LOOKUP_PACKAGE_ARCH('arm64-deb'), current_timestamp, current_timestamp);
+insert into rhnPackageUpgradeArchCompat (package_arch_id, package_upgrade_arch_id, created, modified) values (LOOKUP_PACKAGE_ARCH('all-deb'), LOOKUP_PACKAGE_ARCH('arm64-deb'), current_timestamp, current_timestamp);
+
+commit;
 

--- a/schema/spacewalk/common/data/rhnServerArch.sql
+++ b/schema/spacewalk/common/data/rhnServerArch.sql
@@ -129,5 +129,8 @@ insert into rhnServerArch (id, label, name, arch_type_id) values
 insert into rhnServerArch (id, label, name, arch_type_id) values
 (sequence_nextval('rhn_server_arch_id_seq'), 'cloud', 'cloud', lookup_arch_type('rpm'));
 
+insert into rhnServerArch (id, label, name, arch_type_id) values
+(sequence_nextval('rhn_server_arch_id_seq'), 'arm64-debian-linux', 'ARM64 Debian', lookup_arch_type('deb'));
+
 commit;
 

--- a/schema/spacewalk/common/data/rhnServerChannelArchCompat.sql
+++ b/schema/spacewalk/common/data/rhnServerChannelArchCompat.sql
@@ -132,5 +132,8 @@ insert into rhnServerChannelArchCompat (server_arch_id, channel_arch_id) values
 insert into rhnServerChannelArchCompat (server_arch_id, channel_arch_id) values
 (LOOKUP_SERVER_ARCH('armv7l-debian-linux'), LOOKUP_CHANNEL_ARCH('channel-arm-deb'));
 
+insert into rhnServerChannelArchCompat (server_arch_id, channel_arch_id) values
+(LOOKUP_SERVER_ARCH('arm64-debian-linux'), LOOKUP_CHANNEL_ARCH('channel-arm64-deb'));
+
 commit;
 

--- a/schema/spacewalk/common/data/rhnServerPackageArchCompat.sql
+++ b/schema/spacewalk/common/data/rhnServerPackageArchCompat.sql
@@ -552,5 +552,13 @@ insert into rhnServerPackageArchCompat
 (server_arch_id, package_arch_id, preference) values
 (LOOKUP_SERVER_ARCH('armv7l-debian-linux'), LOOKUP_PACKAGE_ARCH('armhf-deb'), 0);
 
+insert into rhnServerPackageArchCompat
+(server_arch_id, package_arch_id, preference) values
+(LOOKUP_SERVER_ARCH('arm64-debian-linux'), LOOKUP_PACKAGE_ARCH('arm64-deb'), 0);
+
+insert into rhnServerPackageArchCompat
+(server_arch_id, package_arch_id, preference) values
+(LOOKUP_SERVER_ARCH('arm64-debian-linux'), LOOKUP_PACKAGE_ARCH('all-deb'), 1000);
+
 commit;
 

--- a/schema/spacewalk/common/data/rhnServerServerGroupArchCompat.sql
+++ b/schema/spacewalk/common/data/rhnServerServerGroupArchCompat.sql
@@ -153,6 +153,10 @@ insert into rhnServerServerGroupArchCompat ( server_arch_id, server_group_type )
             lookup_sg_type('enterprise_entitled'));
 
 insert into rhnServerServerGroupArchCompat ( server_arch_id, server_group_type )
+	values (lookup_server_arch('arm64-debian-linux'),
+            lookup_sg_type('enterprise_entitled'));
+
+insert into rhnServerServerGroupArchCompat ( server_arch_id, server_group_type )
 	values (lookup_server_arch('ppc64iseries-redhat-linux'), 
             lookup_sg_type('enterprise_entitled'));
 
@@ -204,6 +208,10 @@ insert into rhnServerServerGroupArchCompat ( server_arch_id, server_group_type)
 
 insert into rhnServerServerGroupArchCompat ( server_arch_id, server_group_type)
     values (lookup_server_arch('amd64-debian-linux'),
+            lookup_sg_type('virtualization_host'));
+
+insert into rhnServerServerGroupArchCompat ( server_arch_id, server_group_type)
+    values (lookup_server_arch('arm64-debian-linux'),
             lookup_sg_type('virtualization_host'));
 
 insert into rhnServerServerGroupArchCompat ( server_arch_id, server_group_type)
@@ -397,6 +405,10 @@ insert into rhnServerServerGroupArchCompat ( server_arch_id, server_group_type )
             lookup_sg_type('bootstrap_entitled'));
 
 insert into rhnServerServerGroupArchCompat ( server_arch_id, server_group_type )
+	values (lookup_server_arch('arm64-debian-linux'),
+            lookup_sg_type('bootstrap_entitled'));
+
+insert into rhnServerServerGroupArchCompat ( server_arch_id, server_group_type )
 	values (lookup_server_arch('ppc64iseries-redhat-linux'), 
             lookup_sg_type('bootstrap_entitled'));
 
@@ -548,6 +560,10 @@ insert into rhnServerServerGroupArchCompat ( server_arch_id, server_group_type )
 
 insert into rhnServerServerGroupArchCompat ( server_arch_id, server_group_type )
 	values (lookup_server_arch('amd64-debian-linux'),
+            lookup_sg_type('salt_entitled'));
+
+insert into rhnServerServerGroupArchCompat ( server_arch_id, server_group_type )
+	values (lookup_server_arch('arm64-debian-linux'),
             lookup_sg_type('salt_entitled'));
 
 insert into rhnServerServerGroupArchCompat ( server_arch_id, server_group_type )
@@ -705,6 +721,10 @@ insert into rhnServerServerGroupArchCompat ( server_arch_id, server_group_type )
             lookup_sg_type('foreign_entitled'));
 
 insert into rhnServerServerGroupArchCompat ( server_arch_id, server_group_type )
+	values (lookup_server_arch('arm64-debian-linux'),
+            lookup_sg_type('foreign_entitled'));
+
+insert into rhnServerServerGroupArchCompat ( server_arch_id, server_group_type )
 	values (lookup_server_arch('ppc64iseries-redhat-linux'),
             lookup_sg_type('foreign_entitled'));
 
@@ -760,6 +780,10 @@ insert into rhnServerServerGroupArchCompat ( server_arch_id, server_group_type)
 
 insert into rhnServerServerGroupArchCompat ( server_arch_id, server_group_type)
     values (lookup_server_arch('amd64-debian-linux'),
+            lookup_sg_type('container_build_host'));
+
+insert into rhnServerServerGroupArchCompat ( server_arch_id, server_group_type)
+    values (lookup_server_arch('arm64-debian-linux'),
             lookup_sg_type('container_build_host'));
 
 insert into rhnServerServerGroupArchCompat ( server_arch_id, server_group_type)
@@ -861,6 +885,10 @@ insert into rhnServerServerGroupArchCompat ( server_arch_id, server_group_type)
 
 insert into rhnServerServerGroupArchCompat ( server_arch_id, server_group_type)
     values (lookup_server_arch('amd64-debian-linux'),
+            lookup_sg_type('monitoring_entitled'));
+
+insert into rhnServerServerGroupArchCompat ( server_arch_id, server_group_type)
+    values (lookup_server_arch('arm64-debian-linux'),
             lookup_sg_type('monitoring_entitled'));
 
 insert into rhnServerServerGroupArchCompat ( server_arch_id, server_group_type)

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,5 @@
+- Schema upgrade for Debian with ARM64v8+ (cpuach=aarch64, cpuarch=arm64) architecture
+
 -------------------------------------------------------------------
 Fri Sep 18 12:27:41 CEST 2020 - jgonzalez@suse.com
 

--- a/schema/spacewalk/upgrade/susemanager-schema-4.2.1-to-susemanager-schema-4.2.2/120-arm64.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.2.1-to-susemanager-schema-4.2.2/120-arm64.sql
@@ -1,0 +1,96 @@
+insert into rhnCpuArch (id, label, name) select
+sequence_nextval('rhn_cpu_arch_id_seq'), 'arm64', 'ARM64' from dual
+where not exists (select 1 from rhnCpuArch where label = 'arm64');
+
+
+insert into rhnPackageArch (id, label, name, arch_type_id) select
+sequence_nextval('rhn_package_arch_id_seq'), 'arm64-deb', 'ARM64-deb', lookup_arch_type('deb') from dual
+where not exists (select 1 from rhnPackageArch where label = 'arm64-deb');
+
+
+insert into rhnServerArch (id, label, name, arch_type_id) select
+sequence_nextval('rhn_server_arch_id_seq'), 'arm64-debian-linux', 'ARM64 Debian', lookup_arch_type('deb') from dual
+where not exists (select 1 from rhnServerArch where label = 'arm64-debian-linux');
+
+
+insert into rhnChannelArch (id, label, name, arch_type_id) select
+sequence_nextval('rhn_channel_arch_id_seq'), 'channel-arm64-deb', 'ARM64 Debian', lookup_arch_type('deb') from dual
+where not exists (select 1 from rhnChannelArch where label = 'channel-arm64-deb');
+
+
+insert into rhnPackageUpgradeArchCompat (package_arch_id, package_upgrade_arch_id, created, modified) select 
+LOOKUP_PACKAGE_ARCH('arm64-deb'), LOOKUP_PACKAGE_ARCH('all-deb'), current_timestamp, current_timestamp from dual
+where not exists (select 1 from rhnPackageUpgradeArchCompat where package_arch_id = LOOKUP_PACKAGE_ARCH('arm64-deb') and package_upgrade_arch_id = LOOKUP_PACKAGE_ARCH('all-deb'));
+
+insert into rhnPackageUpgradeArchCompat (package_arch_id, package_upgrade_arch_id, created, modified) select 
+LOOKUP_PACKAGE_ARCH('arm64-deb'), LOOKUP_PACKAGE_ARCH('arm64-deb'), current_timestamp, current_timestamp from dual
+where not exists (select 1 from rhnPackageUpgradeArchCompat where package_arch_id = LOOKUP_PACKAGE_ARCH('arm64-deb') and package_upgrade_arch_id = LOOKUP_PACKAGE_ARCH('arm64-deb'));
+
+insert into rhnPackageUpgradeArchCompat (package_arch_id, package_upgrade_arch_id, created, modified) select 
+LOOKUP_PACKAGE_ARCH('all-deb'), LOOKUP_PACKAGE_ARCH('arm64-deb'), current_timestamp, current_timestamp from dual
+where not exists (select 1 from rhnPackageUpgradeArchCompat where package_arch_id = LOOKUP_PACKAGE_ARCH('all-deb') and package_upgrade_arch_id = LOOKUP_PACKAGE_ARCH('arm64-deb'));
+
+
+insert into rhnChannelPackageArchCompat (channel_arch_id, package_arch_id) select 
+LOOKUP_CHANNEL_ARCH('channel-arm64-deb'), LOOKUP_PACKAGE_ARCH('arm64-deb') from dual
+where not exists (select 1 from rhnChannelPackageArchCompat where channel_arch_id = LOOKUP_CHANNEL_ARCH('channel-arm64-deb') and package_arch_id = LOOKUP_PACKAGE_ARCH('arm64-deb'));
+
+insert into rhnChannelPackageArchCompat (channel_arch_id, package_arch_id) select 
+LOOKUP_CHANNEL_ARCH('channel-arm64-deb'), LOOKUP_PACKAGE_ARCH('all-deb') from dual
+where not exists (select 1 from rhnChannelPackageArchCompat where channel_arch_id = LOOKUP_CHANNEL_ARCH('channel-arm64-deb') and package_arch_id = LOOKUP_PACKAGE_ARCH('all-deb'));
+
+insert into rhnChannelPackageArchCompat (channel_arch_id, package_arch_id) select 
+LOOKUP_CHANNEL_ARCH('channel-arm64-deb'), LOOKUP_PACKAGE_ARCH('src-deb') from dual
+where not exists (select 1 from rhnChannelPackageArchCompat where channel_arch_id = LOOKUP_CHANNEL_ARCH('channel-arm64-deb') and package_arch_id = LOOKUP_PACKAGE_ARCH('src-deb'));
+
+
+insert into rhnServerChannelArchCompat (server_arch_id, channel_arch_id) select
+LOOKUP_SERVER_ARCH('arm64-debian-linux'), LOOKUP_CHANNEL_ARCH('channel-arm64-deb') from dual
+where not exists (select 1 from rhnServerChannelArchCompat where server_arch_id = LOOKUP_SERVER_ARCH('arm64-debian-linux') and channel_arch_id = LOOKUP_CHANNEL_ARCH('channel-arm64-deb'));
+
+
+insert into rhnServerPackageArchCompat (server_arch_id, package_arch_id, preference) select
+LOOKUP_SERVER_ARCH('arm64-debian-linux'), LOOKUP_PACKAGE_ARCH('arm64-deb'), 0 from dual
+where not exists (select 1 from rhnServerPackageArchCompat where server_arch_id = LOOKUP_SERVER_ARCH('arm64-debian-linux') and package_arch_id = LOOKUP_PACKAGE_ARCH('arm64-deb'));
+
+insert into rhnServerPackageArchCompat (server_arch_id, package_arch_id, preference) select
+LOOKUP_SERVER_ARCH('arm64-debian-linux'), LOOKUP_PACKAGE_ARCH('all-deb'), 1000 from dual
+where not exists (select 1 from rhnServerPackageArchCompat where server_arch_id = LOOKUP_SERVER_ARCH('arm64-debian-linux') and package_arch_id = LOOKUP_PACKAGE_ARCH('all-deb'));
+
+
+
+insert into rhnServerServerGroupArchCompat ( server_arch_id, server_group_type) select 
+lookup_server_arch('arm64-debian-linux'), lookup_sg_type('enterprise_entitled') from dual
+where not exists (select 1 from rhnServerServerGroupArchCompat where server_arch_id = lookup_server_arch('arm64-debian-linux') and server_group_type = lookup_sg_type('enterprise_entitled'));
+
+insert into rhnServerServerGroupArchCompat ( server_arch_id, server_group_type) select 
+lookup_server_arch('arm64-debian-linux'), lookup_sg_type('virtualization_host') from dual
+where not exists (select 1 from rhnServerServerGroupArchCompat where server_arch_id = lookup_server_arch('arm64-debian-linux') and server_group_type = lookup_sg_type('virtualization_host'));
+
+insert into rhnServerServerGroupArchCompat ( server_arch_id, server_group_type) select 
+lookup_server_arch('arm64-debian-linux'), lookup_sg_type('bootstrap_entitled') from dual
+where not exists (select 1 from rhnServerServerGroupArchCompat where server_arch_id = lookup_server_arch('arm64-debian-linux') and server_group_type = lookup_sg_type('bootstrap_entitled'));
+
+insert into rhnServerServerGroupArchCompat ( server_arch_id, server_group_type) select 
+lookup_server_arch('arm64-debian-linux'), lookup_sg_type('salt_entitled') from dual
+where not exists (select 1 from rhnServerServerGroupArchCompat where server_arch_id = lookup_server_arch('arm64-debian-linux') and server_group_type = lookup_sg_type('salt_entitled'));
+
+insert into rhnServerServerGroupArchCompat ( server_arch_id, server_group_type) select 
+lookup_server_arch('arm64-debian-linux'), lookup_sg_type('foreign_entitled') from dual
+where not exists (select 1 from rhnServerServerGroupArchCompat where server_arch_id = lookup_server_arch('arm64-debian-linux') and server_group_type = lookup_sg_type('foreign_entitled'));
+
+insert into rhnServerServerGroupArchCompat ( server_arch_id, server_group_type) select 
+lookup_server_arch('arm64-debian-linux'), lookup_sg_type('container_build_host') from dual
+where not exists (select 1 from rhnServerServerGroupArchCompat where server_arch_id = lookup_server_arch('arm64-debian-linux') and server_group_type = lookup_sg_type('container_build_host'));
+
+insert into rhnServerServerGroupArchCompat ( server_arch_id, server_group_type) select 
+lookup_server_arch('arm64-debian-linux'), lookup_sg_type('monitoring_entitled') from dual
+where not exists (select 1 from rhnServerServerGroupArchCompat where server_arch_id = lookup_server_arch('arm64-debian-linux') and server_group_type = lookup_sg_type('monitoring_entitled'));
+
+
+insert into rhnChildChannelArchCompat (parent_arch_id, child_arch_id) select
+LOOKUP_CHANNEL_ARCH('channel-arm64-deb'), LOOKUP_CHANNEL_ARCH('channel-arm64-deb') from dual
+where not exists (select 1 from rhnChildChannelArchCompat where parent_arch_id = LOOKUP_CHANNEL_ARCH('channel-arm64-deb') and child_arch_id = LOOKUP_CHANNEL_ARCH('channel-arm64-deb'));
+
+commit;
+


### PR DESCRIPTION
## What does this PR change?
DB schema extension for Debian10-Minions on cpuarch=aarch64,osarch=arm64, Issue #2548

        modified:   schema/spacewalk/common/data/rhnChannelArch.sql
        modified:   schema/spacewalk/common/data/rhnChannelPackageArchCompat.sql
        modified:   schema/spacewalk/common/data/rhnChildChannelArchCompat.sql
        modified:   schema/spacewalk/common/data/rhnCpuArch.sql
        modified:   schema/spacewalk/common/data/rhnPackageArch.sql
        modified:   schema/spacewalk/common/data/rhnPackageUpgradeArchCompat.sql
        modified:   schema/spacewalk/common/data/rhnServerArch.sql
        modified:   schema/spacewalk/common/data/rhnServerChannelArchCompat.sql
        modified:   schema/spacewalk/common/data/rhnServerPackageArchCompat.sql
        modified:   schema/spacewalk/common/data/rhnServerServerGroupArchCompat.sql
        modified:   schema/spacewalk/susemanager-schema.changes
        new file:   schema/spacewalk/upgrade/susemanager-schema-4.2.0-to-susemanager-schema-4.2.1/120-arm64.sql

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links
Issue #2548
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
