### PR TITLE
Fix softwarechannel_listlatestpackages throwing error on empty channels (bsc#1175889)

### DIFF
--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,5 @@
+- Fix softwarechannel_listlatestpackages throwing error on
+  empty channels (bsc#1175889)
 - Add Service Pack migration operations (bsc#1173557)
 - Fix softwarechannel update for vendor channels (bsc#1172709)
 - Update package version to 4.2.0

--- a/spacecmd/src/spacecmd/softwarechannel.py
+++ b/spacecmd/src/spacecmd/softwarechannel.py
@@ -327,7 +327,7 @@ def filter_latest_packages(pkglist):
                 latest[tuplekey] = p
 
     # Then return the dict items as a list
-    return latest.values()
+    return list(latest.values())
 
 
 def help_softwarechannel_listlatestpackages(self):


### PR DESCRIPTION
## What does this PR change?

Port of https://github.com/SUSE/spacewalk/pull/12297

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bugfix

- [x] **DONE**

## Test coverage
- No tests: **add explanation**

- [x] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/12298

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
