### PR TITLE
Bugfix add_packages.sh

### DIFF
--- a/susemanager-utils/testing/docker/master/uyuni-master-base/add_packages.sh
+++ b/susemanager-utils/testing/docker/master/uyuni-master-base/add_packages.sh
@@ -54,5 +54,5 @@ zypper --non-interactive in ant \
              sudo \
              tar \
              system-user-wwwrun \
-             system-user-mail \
+             system-user-mail
 


### PR DESCRIPTION
## What does this PR change?
Fix script error in
https://github.com/uyuni-project/uyuni/blob/master/susemanager-utils/testing/docker/master/uyuni-master-base/add_packages.sh

**add description**
there is a Backslash too much
this PR fixes the problem

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
