### PR TITLE
QA: Refactoring enable/disable multiple repositories

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -672,27 +672,22 @@ When(/^I register this client for SSH push via tunnel$/) do
 end
 
 # Repositories and packages management
-When(/^I enable repository "([^"]*)" on this "([^"]*)"((?: without error control)?)$/) do |repo, host, error_control|
+When(/^I (enable|disable) (the repositories|repository) "([^"]*)" on this "([^"]*)"((?: without error control)?)$/) do |action, _optional, repos, host, error_control|
   node = get_target(host)
-  cmd = if host.include? 'ceos'
-    "sed -i 's/enabled=.*/enabled=1/g' /etc/yum.repos.d/#{repo}.repo"
-        elsif host.include? 'ubuntu'
-    "sed -i '/^#\\s*deb.*/ s/^#\\s*deb /deb /' /etc/apt/sources.list.d/#{repo}.list"
-        else
-    "zypper mr --enable #{repo}"
-        end
-  node.run(cmd, error_control.empty?)
-end
-
-When(/^I disable repository "([^"]*)" on this "([^"]*)"((?: without error control)?)$/) do |repo, host, error_control|
-  node = get_target(host)
-  cmd = if host.include? 'ceos'
-    "test -f /etc/yum.repos.d/#{repo}.repo && sed -i 's/enabled=.*/enabled=0/g' /etc/yum.repos.d/#{repo}.repo"
-        elsif host.include? 'ubuntu'
-    "sed -i '/^deb.*/ s/^deb /#deb /' /etc/apt/sources.list.d/#{repo}.list"
-        else
-    "zypper mr --disable #{repo}"
-        end
+  os_version, os_family = get_os_version(node)
+  if os_family =~ /^opensuse/ || os_family =~ /^sles/
+    cmd = "zypper mr --#{action} #{repos}"
+  else
+    cmd = repos.split(' ').map do |repo|
+      if os_family =~ /^centos/
+        "sed -i 's/enabled=.*/enabled=#{action == 'enabled' ? '1' : '0'}/g' /etc/yum.repos.d/#{repo}.repo; "
+      elsif os_family =~ /^ubuntu/
+        "sed -i '/^#{action == 'enabled' ? '#\\s*' : ''}deb.*/ s/^#{action == 'enabled' ? '' : '#\\s*'}deb "\
+        "/#{action == 'enabled' ? '' : '#'}deb /' /etc/apt/sources.list.d/#{repo}.list; "
+      end
+    end
+    cmd = cmd.reduce(:+)
+  end
   node.run(cmd, error_control.empty?)
 end
 
@@ -1307,11 +1302,9 @@ end
 
 # Enable/disable repository for monitoring exporters
 When(/^I (enable|disable) the necessary repositories before installing Prometheus exporters on this "([^"]*)"((?: without error control)?)$/) do |action, host, error_control|
-  node = get_target(host)
-  os_version, os_family = get_os_version(node)
-  if os_family =~ /^opensuse/ || os_family =~ /^sles/
-    node.run("zypper mr --#{action} os_pool_repo os_update_repo")
+  common_repos = 'os_pool_repo os_update_repo tools_pool_repo tools_update_repo'
+  step %(I #{action} the repositories "#{common_repos}" on this "#{host}"#{error_control})
+  unless $product == 'Uyuni'
+    step %(I #{action} repository "tools_additional_repo" on this "#{host}"#{error_control})
   end
-  tools_repo_name = $product == 'Uyuni' ? 'tools_pool_repo' : 'tools_additional_repo'
-  step %(I #{action} repository "#{tools_repo_name}" on this "#{host}"#{error_control})
 end


### PR DESCRIPTION
## What does this PR change?

- Refactoring  enable/disable multiple repositories
- Fixing the monitoring test feature on Uyuni case, where we must have `tools_update_repo` enabled

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Will need ports. Coming soon.

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
