### PR TITLE
move most salt specific methods to SaltApi

### DIFF
--- a/java/code/src/com/redhat/rhn/GlobalInstanceHolder.java
+++ b/java/code/src/com/redhat/rhn/GlobalInstanceHolder.java
@@ -60,25 +60,26 @@ public class GlobalInstanceHolder {
     );
     public static final SaltUtils SALT_UTILS = new SaltUtils(SYSTEM_QUERY, SALT_API,
             CLUSTER_MANAGER, FORMULA_MANAGER, SERVER_GROUP_MANAGER);
-    public static final SaltKeyUtils SALT_KEY_UTILS = new SaltKeyUtils(SYSTEM_QUERY);
+    public static final SaltKeyUtils SALT_KEY_UTILS = new SaltKeyUtils(SALT_API);
     public static final SaltServerActionService SALT_SERVER_ACTION_SERVICE = new SaltServerActionService(
-            SYSTEM_QUERY, SALT_UTILS, CLUSTER_MANAGER, FORMULA_MANAGER, SALT_KEY_UTILS);
+            SALT_API, SALT_UTILS, CLUSTER_MANAGER, FORMULA_MANAGER, SALT_KEY_UTILS);
     public static final Access ACCESS = new Access(CLUSTER_MANAGER);
     public static final AclFactory ACL_FACTORY = new AclFactory(ACCESS);
     // Referenced from JSP
     public static final MenuTree MENU_TREE = new MenuTree(ACL_FACTORY);
     public static final RenderUtils RENDER_UTILS = new RenderUtils(ACL_FACTORY);
     public static final MinionActionUtils MINION_ACTION_UTILS = new MinionActionUtils(
-            SALT_SERVER_ACTION_SERVICE, SYSTEM_QUERY, SALT_UTILS);
-    public static final KubernetesManager KUBERNETES_MANAGER = new KubernetesManager(SYSTEM_QUERY);
+            SALT_SERVER_ACTION_SERVICE, SALT_API, SALT_UTILS);
+    public static final KubernetesManager KUBERNETES_MANAGER = new KubernetesManager(SALT_API);
     public static final VirtManager VIRT_MANAGER = new VirtManagerSalt(SALT_API);
     public static final RegularMinionBootstrapper REGULAR_MINION_BOOTSTRAPPER =
-            new RegularMinionBootstrapper(SYSTEM_QUERY);
-    public static final SSHMinionBootstrapper SSH_MINION_BOOTSTRAPPER = new SSHMinionBootstrapper(SYSTEM_QUERY);
+            new RegularMinionBootstrapper(SYSTEM_QUERY, SALT_API);
+    public static final SSHMinionBootstrapper SSH_MINION_BOOTSTRAPPER =
+            new SSHMinionBootstrapper(SYSTEM_QUERY, SALT_API);
     public static final MonitoringManager MONITORING_MANAGER = new FormulaMonitoringManager();
     public static final SystemEntitlementManager SYSTEM_ENTITLEMENT_MANAGER = new SystemEntitlementManager(
             new SystemUnentitler(VIRT_MANAGER, MONITORING_MANAGER, SERVER_GROUP_MANAGER),
-            new SystemEntitler(SYSTEM_QUERY, VIRT_MANAGER, MONITORING_MANAGER,
+            new SystemEntitler(SALT_API, VIRT_MANAGER, MONITORING_MANAGER,
                     SERVER_GROUP_MANAGER)
     );
 }

--- a/java/code/src/com/redhat/rhn/common/security/acl/test/AccessTest.java
+++ b/java/code/src/com/redhat/rhn/common/security/acl/test/AccessTest.java
@@ -68,7 +68,7 @@ public class AccessTest extends BaseTestCaseWithUser {
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager();
     private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
             new SystemUnentitler(virtManager, monitoringManager, serverGroupManager),
-            new SystemEntitler(systemQuery, virtManager, monitoringManager, serverGroupManager)
+            new SystemEntitler(saltApi, virtManager, monitoringManager, serverGroupManager)
     );
 
     @Override

--- a/java/code/src/com/redhat/rhn/domain/entitlement/test/BaseEntitlementTestCase.java
+++ b/java/code/src/com/redhat/rhn/domain/entitlement/test/BaseEntitlementTestCase.java
@@ -44,7 +44,7 @@ public abstract class BaseEntitlementTestCase extends BaseTestCaseWithUser {
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager();
     private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
             new SystemUnentitler(virtManager, monitoringManager, serverGroupManager),
-            new SystemEntitler(systemQuery, virtManager, monitoringManager, serverGroupManager)
+            new SystemEntitler(saltApi, virtManager, monitoringManager, serverGroupManager)
     );
 
     @Override

--- a/java/code/src/com/redhat/rhn/domain/entitlement/test/ContainerBuildHostEntitlementTest.java
+++ b/java/code/src/com/redhat/rhn/domain/entitlement/test/ContainerBuildHostEntitlementTest.java
@@ -37,14 +37,13 @@ import java.util.Map;
 
 public class ContainerBuildHostEntitlementTest extends BaseEntitlementTestCase {
 
-    private final SystemQuery systemQuery = new TestSystemQuery();
     private final SaltApi saltApi = new TestSaltApi();
     private final ServerGroupManager serverGroupManager = new ServerGroupManager();
     private final VirtManager virtManager = new VirtManagerSalt(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager();
     private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
             new SystemUnentitler(virtManager, monitoringManager, serverGroupManager),
-            new SystemEntitler(systemQuery, virtManager, monitoringManager, serverGroupManager)
+            new SystemEntitler(saltApi, virtManager, monitoringManager, serverGroupManager)
     );
 
     @Override

--- a/java/code/src/com/redhat/rhn/domain/entitlement/test/OSImageBuildHostEntitlementTest.java
+++ b/java/code/src/com/redhat/rhn/domain/entitlement/test/OSImageBuildHostEntitlementTest.java
@@ -26,7 +26,7 @@ public class OSImageBuildHostEntitlementTest extends BaseEntitlementTestCase {
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager();
     private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
             new SystemUnentitler(virtManager, monitoringManager, serverGroupManager),
-            new SystemEntitler(systemQuery, virtManager, monitoringManager, serverGroupManager)
+            new SystemEntitler(saltApi, virtManager, monitoringManager, serverGroupManager)
     );
 
     @Override public void setUp() throws Exception {

--- a/java/code/src/com/redhat/rhn/domain/entitlement/test/VirtualizationEntitlementTest.java
+++ b/java/code/src/com/redhat/rhn/domain/entitlement/test/VirtualizationEntitlementTest.java
@@ -44,7 +44,7 @@ public class VirtualizationEntitlementTest extends BaseEntitlementTestCase {
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager();
     private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
             new SystemUnentitler(virtManager, monitoringManager, serverGroupManager),
-            new SystemEntitler(systemQuery, virtManager, monitoringManager, serverGroupManager)
+            new SystemEntitler(saltApi, virtManager, monitoringManager, serverGroupManager)
     );
 
     @Override

--- a/java/code/src/com/redhat/rhn/domain/image/test/ImageInfoFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/image/test/ImageInfoFactoryTest.java
@@ -91,7 +91,7 @@ public class ImageInfoFactoryTest extends BaseTestCaseWithUser {
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager();
     private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
             new SystemUnentitler(virtManager, monitoringManager, serverGroupManager),
-            new SystemEntitler(systemQuery, virtManager, monitoringManager, serverGroupManager)
+            new SystemEntitler(saltApi, virtManager, monitoringManager, serverGroupManager)
     );
 
     @Override

--- a/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
@@ -135,9 +135,9 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
     private static final FormulaManager formulaManager = new FormulaManager(saltApi);
     private static final ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);
     private static final SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, clusterManager, formulaManager, serverGroupManager);
-    private static final SaltKeyUtils saltKeyUtils = new SaltKeyUtils(systemQuery);
+    private static final SaltKeyUtils saltKeyUtils = new SaltKeyUtils(saltApi);
     private static final SaltServerActionService saltServerActionService = new SaltServerActionService(
-            systemQuery,
+            saltApi,
             saltUtils,
             clusterManager,
             formulaManager,
@@ -147,7 +147,7 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
     private static final MonitoringManager monitoringManager = new FormulaMonitoringManager();
     private static final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
             new SystemUnentitler(virtManager, monitoringManager, serverGroupManager),
-            new SystemEntitler(systemQuery, virtManager, monitoringManager, serverGroupManager)
+            new SystemEntitler(saltApi, virtManager, monitoringManager, serverGroupManager)
     );
 
     @Override

--- a/java/code/src/com/redhat/rhn/domain/server/test/ServerTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/ServerTest.java
@@ -56,7 +56,6 @@ import java.util.Optional;
  */
 public class ServerTest extends BaseTestCaseWithUser {
 
-    private final SystemQuery systemQuery = new TestSystemQuery();
     private final SaltApi saltApi = new TestSaltApi();
     private final ServerGroupManager serverGroupManager = new ServerGroupManager();
     private final VirtManager virtManager = new VirtManagerSalt(saltApi);
@@ -65,7 +64,7 @@ public class ServerTest extends BaseTestCaseWithUser {
             virtManager, monitoringManager, serverGroupManager);
     private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
             systemUnentitler,
-            new SystemEntitler(systemQuery, virtManager, monitoringManager, serverGroupManager)
+            new SystemEntitler(saltApi, virtManager, monitoringManager, serverGroupManager)
     );
 
     public void testIsInactive() throws Exception {

--- a/java/code/src/com/redhat/rhn/domain/server/test/VirtualInstanceFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/VirtualInstanceFactoryTest.java
@@ -30,6 +30,7 @@ import com.redhat.rhn.testing.ServerTestUtils;
 import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
 import com.suse.manager.virtualization.test.TestVirtManager;
+import com.suse.manager.webui.services.test.TestSaltApi;
 import com.suse.manager.webui.services.test.TestSystemQuery;
 import org.apache.commons.collections.CollectionUtils;
 import org.hibernate.Session;
@@ -60,7 +61,7 @@ public class VirtualInstanceFactoryTest extends RhnBaseTestCase {
         ServerGroupManager serverGroupManager = new ServerGroupManager();
         systemEntitlementManager = new SystemEntitlementManager(
                 new SystemUnentitler(new TestVirtManager(), new FormulaMonitoringManager(), serverGroupManager),
-                new SystemEntitler(new TestSystemQuery(), new TestVirtManager(), new FormulaMonitoringManager(),
+                new SystemEntitler(new TestSaltApi(), new TestVirtManager(), new FormulaMonitoringManager(),
                         serverGroupManager)
         );
     }

--- a/java/code/src/com/redhat/rhn/frontend/action/renderers/TasksRenderer.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/renderers/TasksRenderer.java
@@ -39,7 +39,7 @@ public class TasksRenderer extends BaseFragmentRenderer {
         request.setAttribute(TASKS, Boolean.TRUE);
         request.setAttribute("documentation", ConfigDefaults.get().isDocAvailable());
         request.setAttribute("amountOfMinions",
-                GlobalInstanceHolder.SYSTEM_QUERY.getKeys().getUnacceptedMinions().size());
+                GlobalInstanceHolder.SALT_API.getKeys().getUnacceptedMinions().size());
         request.setAttribute("requiringReboot", SystemManager.requiringRebootList(user).size());
         RendererHelper.setTableStyle(request, null);
     }

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/entitlements/test/SystemEntitlementsSubmitActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/entitlements/test/SystemEntitlementsSubmitActionTest.java
@@ -59,7 +59,7 @@ public class SystemEntitlementsSubmitActionTest extends RhnPostMockStrutsTestCas
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager();
     private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
             new SystemUnentitler(virtManager, monitoringManager, serverGroupManager),
-            new SystemEntitler(systemQuery, virtManager, monitoringManager, serverGroupManager)
+            new SystemEntitler(saltApi, virtManager, monitoringManager, serverGroupManager)
     );
 
 

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/test/SystemDetailsEditActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/test/SystemDetailsEditActionTest.java
@@ -56,7 +56,7 @@ public class SystemDetailsEditActionTest extends RhnPostMockStrutsTestCase {
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager();
     private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
             new SystemUnentitler(virtManager, monitoringManager, serverGroupManager),
-            new SystemEntitler(systemQuery, virtManager, monitoringManager, serverGroupManager)
+            new SystemEntitler(saltApi, virtManager, monitoringManager, serverGroupManager)
     );
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/test/SystemOverviewActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/test/SystemOverviewActionTest.java
@@ -55,14 +55,13 @@ import java.util.Date;
 public class SystemOverviewActionTest extends RhnMockStrutsTestCase {
 
     protected Server s;
-    private final SystemQuery systemQuery = new TestSystemQuery();
     private final SaltApi saltApi = new TestSaltApi();
     private final ServerGroupManager serverGroupManager = new ServerGroupManager();
     private final VirtManager virtManager = new VirtManagerSalt(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager();
     private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
             new SystemUnentitler(virtManager, monitoringManager, serverGroupManager),
-            new SystemEntitler(systemQuery, virtManager, monitoringManager, serverGroupManager)
+            new SystemEntitler(saltApi, virtManager, monitoringManager, serverGroupManager)
     );
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/virtualization/test/ProvisionVirtualizationWizardActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/virtualization/test/ProvisionVirtualizationWizardActionTest.java
@@ -65,14 +65,13 @@ import junit.framework.AssertionFailedError;
 public class ProvisionVirtualizationWizardActionTest extends RhnMockStrutsTestCase {
 
     private Server s;
-    private final SystemQuery systemQuery = new TestSystemQuery();
     private final SaltApi saltApi = new TestSaltApi();
     private final ServerGroupManager serverGroupManager = new ServerGroupManager();
     private final VirtManager virtManager = new VirtManagerSalt(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager();
     private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
             new SystemUnentitler(virtManager, monitoringManager, serverGroupManager),
-            new SystemEntitler(systemQuery, virtManager, monitoringManager, serverGroupManager)
+            new SystemEntitler(saltApi, virtManager, monitoringManager, serverGroupManager)
     );
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/test/ChannelSoftwareHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/test/ChannelSoftwareHandlerTest.java
@@ -98,8 +98,8 @@ public class ChannelSoftwareHandlerTest extends BaseHandlerTestCase {
     private final SystemQuery systemQuery = new TestSystemQuery();
     private final SaltApi saltApi = new TestSaltApi();
     private final ServerGroupManager serverGroupManager = new ServerGroupManager();
-    private RegularMinionBootstrapper regularMinionBootstrapper = new RegularMinionBootstrapper(systemQuery);
-    private SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery);
+    private RegularMinionBootstrapper regularMinionBootstrapper = new RegularMinionBootstrapper(systemQuery, saltApi);
+    private SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery, saltApi);
     private XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
             regularMinionBootstrapper,
             sshMinionBootstrapper
@@ -108,7 +108,7 @@ public class ChannelSoftwareHandlerTest extends BaseHandlerTestCase {
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager();
     private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
             new SystemUnentitler(virtManager, monitoringManager, serverGroupManager),
-            new SystemEntitler(systemQuery, virtManager, monitoringManager, serverGroupManager)
+            new SystemEntitler(saltApi, virtManager, monitoringManager, serverGroupManager)
     );
     private SystemManager systemManager = new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON);
     private SystemHandler systemHandler = new SystemHandler(taskomaticApi, xmlRpcSystemHelper, systemEntitlementManager, systemManager,

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/test/ImageInfoHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/test/ImageInfoHandlerTest.java
@@ -91,14 +91,13 @@ public class ImageInfoHandlerTest extends BaseHandlerTestCase {
     }};
 
     private static TaskomaticApi taskomaticApi;
-    private final SystemQuery systemQuery = new TestSystemQuery();
     private final SaltApi saltApi = new TestSaltApi();
     private final ServerGroupManager serverGroupManager = new ServerGroupManager();
     private final VirtManager virtManager = new VirtManagerSalt(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager();
     private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
             new SystemUnentitler(virtManager, monitoringManager, serverGroupManager),
-            new SystemEntitler(systemQuery, virtManager, monitoringManager, serverGroupManager)
+            new SystemEntitler(saltApi, virtManager, monitoringManager, serverGroupManager)
     );
 
     @Override

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/proxy/test/ProxyHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/proxy/test/ProxyHandlerTest.java
@@ -33,7 +33,9 @@ import com.redhat.rhn.testing.RhnBaseTestCase;
 import com.redhat.rhn.testing.UserTestUtils;
 import com.suse.manager.webui.controllers.utils.RegularMinionBootstrapper;
 import com.suse.manager.webui.controllers.utils.SSHMinionBootstrapper;
+import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.SystemQuery;
+import com.suse.manager.webui.services.test.TestSaltApi;
 import com.suse.manager.webui.services.test.TestSystemQuery;
 
 import java.util.List;
@@ -41,9 +43,10 @@ import java.util.Set;
 
 public class ProxyHandlerTest extends RhnBaseTestCase {
 
+    private SaltApi saltApi = new TestSaltApi();
     private SystemQuery systemQuery = new TestSystemQuery();
-    private RegularMinionBootstrapper regularMinionBootstrapper = new RegularMinionBootstrapper(systemQuery);
-    private SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery);
+    private RegularMinionBootstrapper regularMinionBootstrapper = new RegularMinionBootstrapper(systemQuery, saltApi);
+    private SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery, saltApi);
     private XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
             regularMinionBootstrapper,
             sshMinionBootstrapper

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/satellite/test/SatelliteHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/satellite/test/SatelliteHandlerTest.java
@@ -22,16 +22,19 @@ import com.redhat.rhn.frontend.xmlrpc.system.XmlRpcSystemHelper;
 import com.redhat.rhn.frontend.xmlrpc.test.BaseHandlerTestCase;
 import com.suse.manager.webui.controllers.utils.RegularMinionBootstrapper;
 import com.suse.manager.webui.controllers.utils.SSHMinionBootstrapper;
+import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.SystemQuery;
+import com.suse.manager.webui.services.test.TestSaltApi;
 import com.suse.manager.webui.services.test.TestSystemQuery;
 
 import java.util.Map;
 
 public class SatelliteHandlerTest extends BaseHandlerTestCase {
 
+    private SaltApi saltApi = new TestSaltApi();
     private SystemQuery systemQuery = new TestSystemQuery();
-    private RegularMinionBootstrapper regularMinionBootstrapper = new RegularMinionBootstrapper(systemQuery);
-    private SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery);
+    private RegularMinionBootstrapper regularMinionBootstrapper = new RegularMinionBootstrapper(systemQuery, saltApi);
+    private SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery, saltApi);
     private XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
             regularMinionBootstrapper,
             sshMinionBootstrapper

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/config/test/ServerConfigHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/config/test/ServerConfigHandlerTest.java
@@ -48,7 +48,10 @@ import com.redhat.rhn.testing.ConfigTestUtils;
 import com.redhat.rhn.testing.TestUtils;
 import com.suse.manager.webui.controllers.utils.RegularMinionBootstrapper;
 import com.suse.manager.webui.controllers.utils.SSHMinionBootstrapper;
+import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.SystemQuery;
+import com.suse.manager.webui.services.impl.SaltService;
+import com.suse.manager.webui.services.test.TestSaltApi;
 import com.suse.manager.webui.services.test.TestSystemQuery;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
@@ -71,9 +74,10 @@ import java.util.Set;
  */
 public class ServerConfigHandlerTest extends BaseHandlerTestCase {
     private TaskomaticApi taskomaticApi = new TaskomaticApi();
+    private SaltApi saltApi = new TestSaltApi();
     private SystemQuery systemQuery = new TestSystemQuery();
-    private RegularMinionBootstrapper regularMinionBootstrapper = new RegularMinionBootstrapper(systemQuery);
-    private SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery);
+    private RegularMinionBootstrapper regularMinionBootstrapper = new RegularMinionBootstrapper(systemQuery, saltApi);
+    private SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery, saltApi);
     private XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
             regularMinionBootstrapper,
             sshMinionBootstrapper
@@ -465,9 +469,10 @@ public class ServerConfigHandlerTest extends BaseHandlerTestCase {
 
     private ServerConfigHandler getMockedHandler() throws Exception {
         TaskomaticApi taskomaticMock = MOCK_CONTEXT.mock(TaskomaticApi.class);
+        SaltApi saltApi = new TestSaltApi();
         SystemQuery systemQuery = new TestSystemQuery();
-        RegularMinionBootstrapper regularMinionBootstrapper = new RegularMinionBootstrapper(systemQuery);
-        SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery);
+        RegularMinionBootstrapper regularMinionBootstrapper = new RegularMinionBootstrapper(systemQuery, saltApi);
+        SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery, saltApi);
         XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
                 regularMinionBootstrapper,
                 sshMinionBootstrapper

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/provisioning/snapshot/test/SnapshotHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/provisioning/snapshot/test/SnapshotHandlerTest.java
@@ -29,7 +29,9 @@ import com.redhat.rhn.testing.ServerGroupTestUtils;
 import com.redhat.rhn.testing.TestUtils;
 import com.suse.manager.webui.controllers.utils.RegularMinionBootstrapper;
 import com.suse.manager.webui.controllers.utils.SSHMinionBootstrapper;
+import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.SystemQuery;
+import com.suse.manager.webui.services.test.TestSaltApi;
 import com.suse.manager.webui.services.test.TestSystemQuery;
 
 import java.util.HashMap;
@@ -42,9 +44,10 @@ import java.util.Set;
  */
 public class SnapshotHandlerTest extends BaseHandlerTestCase {
 
+    private SaltApi saltApi = new TestSaltApi();
     private SystemQuery systemQuery = new TestSystemQuery();
-    private RegularMinionBootstrapper regularMinionBootstrapper = new RegularMinionBootstrapper(systemQuery);
-    private SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery);
+    private RegularMinionBootstrapper regularMinionBootstrapper = new RegularMinionBootstrapper(systemQuery, saltApi);
+    private SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery, saltApi);
     private XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
             regularMinionBootstrapper,
             sshMinionBootstrapper

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/ServerGroupHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/ServerGroupHandlerTest.java
@@ -34,7 +34,9 @@ import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
 import com.suse.manager.webui.controllers.utils.RegularMinionBootstrapper;
 import com.suse.manager.webui.controllers.utils.SSHMinionBootstrapper;
+import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.SystemQuery;
+import com.suse.manager.webui.services.test.TestSaltApi;
 import com.suse.manager.webui.services.test.TestSystemQuery;
 
 import java.util.ArrayList;
@@ -48,9 +50,10 @@ import java.util.List;
  * @version $Rev$
  */
 public class ServerGroupHandlerTest extends BaseHandlerTestCase {
+    private SaltApi saltApi = new TestSaltApi();
     private SystemQuery systemQuery = new TestSystemQuery();
-    private RegularMinionBootstrapper regularMinionBootstrapper = new RegularMinionBootstrapper(systemQuery);
-    private SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery);
+    private RegularMinionBootstrapper regularMinionBootstrapper = new RegularMinionBootstrapper(systemQuery, saltApi);
+    private SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery, saltApi);
     private XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
             regularMinionBootstrapper,
             sshMinionBootstrapper

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
@@ -175,8 +175,8 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
     private TaskomaticApi taskomaticApi = new TaskomaticApi();
     private final SystemQuery systemQuery = new TestSystemQuery();
     private final SaltApi saltApi = new TestSaltApi();
-    private RegularMinionBootstrapper regularMinionBootstrapper = new RegularMinionBootstrapper(systemQuery);
-    private SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery);
+    private RegularMinionBootstrapper regularMinionBootstrapper = new RegularMinionBootstrapper(systemQuery, saltApi);
+    private SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery, saltApi);
     private XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
             regularMinionBootstrapper,
             sshMinionBootstrapper
@@ -186,7 +186,7 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager();
     private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
             new SystemUnentitler(virtManager, monitoringManager, serverGroupManager),
-            new SystemEntitler(systemQuery, virtManager, monitoringManager, serverGroupManager)
+            new SystemEntitler(saltApi, virtManager, monitoringManager, serverGroupManager)
     );
     private SystemManager systemManager = new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON);
     private SystemHandler handler =

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/user/external/test/UserExternalHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/user/external/test/UserExternalHandlerTest.java
@@ -28,7 +28,9 @@ import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.testing.TestUtils;
 import com.suse.manager.webui.controllers.utils.RegularMinionBootstrapper;
 import com.suse.manager.webui.controllers.utils.SSHMinionBootstrapper;
+import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.SystemQuery;
+import com.suse.manager.webui.services.test.TestSaltApi;
 import com.suse.manager.webui.services.test.TestSystemQuery;
 
 import java.util.Arrays;
@@ -116,9 +118,10 @@ public class UserExternalHandlerTest extends BaseHandlerTestCase {
         String name = "My External Group Name" + TestUtils.randomString();
         String systemGroupName = "my-system-group-name" + TestUtils.randomString();
         String desc = TestUtils.randomString();
+        SaltApi saltApi = new TestSaltApi();
         SystemQuery systemQuery = new TestSystemQuery();
-        RegularMinionBootstrapper regularMinionBootstrapper =  new RegularMinionBootstrapper(systemQuery);
-        SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery);
+        RegularMinionBootstrapper regularMinionBootstrapper =  new RegularMinionBootstrapper(systemQuery, saltApi);
+        SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery, saltApi);
         XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
                 regularMinionBootstrapper,
                 sshMinionBootstrapper

--- a/java/code/src/com/redhat/rhn/manager/action/test/ActionManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/action/test/ActionManagerTest.java
@@ -140,7 +140,7 @@ public class ActionManagerTest extends JMockBaseTestCaseWithUser {
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager();
     private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
             new SystemUnentitler(virtManager, monitoringManager, serverGroupManager),
-            new SystemEntitler(systemQuery, virtManager, monitoringManager, serverGroupManager)
+            new SystemEntitler(saltApi, virtManager, monitoringManager, serverGroupManager)
     );
 
     private final Mockery MOCK_CONTEXT = new JUnit3Mockery() {{

--- a/java/code/src/com/redhat/rhn/manager/action/test/MinionActionManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/action/test/MinionActionManagerTest.java
@@ -95,10 +95,10 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager();
     private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
             new SystemUnentitler(virtManager, monitoringManager, serverGroupManager),
-            new SystemEntitler(systemQuery, virtManager, monitoringManager, serverGroupManager)
+            new SystemEntitler(saltApi, virtManager, monitoringManager, serverGroupManager)
     );
-    private RegularMinionBootstrapper regularMinionBootstrapper = new RegularMinionBootstrapper(systemQuery);
-    private SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery);
+    private RegularMinionBootstrapper regularMinionBootstrapper = new RegularMinionBootstrapper(systemQuery, saltApi);
+    private SSHMinionBootstrapper sshMinionBootstrapper = new SSHMinionBootstrapper(systemQuery, saltApi);
     private XmlRpcSystemHelper xmlRpcSystemHelper = new XmlRpcSystemHelper(
             regularMinionBootstrapper,
             sshMinionBootstrapper

--- a/java/code/src/com/redhat/rhn/manager/org/test/MigrationManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/org/test/MigrationManagerTest.java
@@ -62,14 +62,13 @@ public class MigrationManagerTest extends BaseTestCaseWithUser {
     private Server server;  // virt host w/guests
     private Server server2; // server w/provisioning ent
 
-    private final SystemQuery systemQuery = new TestSystemQuery();
     private final SaltApi saltApi = new TestSaltApi();
     private final ServerGroupManager serverGroupManager = new ServerGroupManager();
     private final VirtManager virtManager = new VirtManagerSalt(saltApi);
     private final MonitoringManager monitoringManager = new FormulaMonitoringManager();
     private final SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
             new SystemUnentitler(virtManager, monitoringManager, serverGroupManager),
-            new SystemEntitler(systemQuery, virtManager, monitoringManager, serverGroupManager)
+            new SystemEntitler(saltApi, virtManager, monitoringManager, serverGroupManager)
     );
 
     @Override

--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -111,7 +111,7 @@ import com.suse.manager.reactor.messaging.ChannelsChangedEventMessage;
 import com.suse.manager.webui.controllers.StatesAPI;
 import com.suse.manager.webui.services.SaltStateGeneratorService;
 import com.suse.manager.webui.services.StateRevisionService;
-import com.suse.manager.webui.services.iface.SystemQuery;
+import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.utils.Opt;
 
@@ -147,7 +147,7 @@ import static java.util.Collections.emptyMap;
 public class SystemManager extends BaseManager {
 
     private static Logger log = Logger.getLogger(SystemManager.class);
-    private static SystemQuery saltServiceInstance = GlobalInstanceHolder.SYSTEM_QUERY;
+    private static SaltApi saltApi = GlobalInstanceHolder.SALT_API;
 
     public static final String CAP_CONFIGFILES_UPLOAD = "configfiles.upload";
     public static final String CAP_CONFIGFILES_DIFF = "configfiles.diff";
@@ -181,7 +181,7 @@ public class SystemManager extends BaseManager {
      * @param mockedSaltService The mocked SaltService.
      */
     public static void mockSaltService(SaltService mockedSaltService) {
-        saltServiceInstance = mockedSaltService;
+        saltApi = mockedSaltService;
     }
 
     /**
@@ -657,7 +657,7 @@ public class SystemManager extends BaseManager {
         if (!ServerCleanupType.NO_CLEANUP.equals(cleanupType)) {
             Server server = lookupByIdAndUser(sid, user);
             if (server.asMinionServer().isPresent()) {
-                Optional<List<String>> errs = saltServiceInstance
+                Optional<List<String>> errs = saltApi
                         .cleanupMinion(server.asMinionServer().get(), cleanupTimeout);
                 if (errs.isPresent() &&
                         ServerCleanupType.FAIL_ON_CLEANUP_ERR.equals(cleanupType)) {
@@ -724,7 +724,7 @@ public class SystemManager extends BaseManager {
         ServerFactory.delete(server);
 
         server.asMinionServer().ifPresent(minion -> {
-            saltServiceInstance.deleteKey(minion.getMinionId());
+            saltApi.deleteKey(minion.getMinionId());
             SaltStateGeneratorService.INSTANCE.removeServer(minion);
         });
     }

--- a/java/code/src/com/redhat/rhn/manager/system/entitling/SystemEntitler.java
+++ b/java/code/src/com/redhat/rhn/manager/system/entitling/SystemEntitler.java
@@ -39,10 +39,10 @@ import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
 
+import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.VirtManager;
 import com.suse.manager.webui.services.impl.SaltSSHService;
 import com.suse.manager.webui.services.iface.MonitoringManager;
-import com.suse.manager.webui.services.iface.SystemQuery;
 
 import org.apache.log4j.Logger;
 
@@ -60,20 +60,20 @@ public class SystemEntitler {
 
     private static final Logger LOG = Logger.getLogger(SystemEntitler.class);
 
-    private SystemQuery systemQuery;
+    private SaltApi saltApi;
     private VirtManager virtManager;
     private MonitoringManager monitoringManager;
     private ServerGroupManager serverGroupManager;
 
     /**
-     * @param systemQueryIn instance for gathering data from a system.
+     * @param saltApiIn instance for gathering data from a system.
      * @param virtManagerIn instance for managing virtual machines.
      * @param monitoringManagerIn instance for handling monitoring configuration.
      * @param serverGroupManagerIn
      */
-    public SystemEntitler(SystemQuery systemQueryIn, VirtManager virtManagerIn,
+    public SystemEntitler(SaltApi saltApiIn, VirtManager virtManagerIn,
             MonitoringManager monitoringManagerIn, ServerGroupManager serverGroupManagerIn) {
-        this.systemQuery = systemQueryIn;
+        this.saltApi = saltApiIn;
         this.virtManager = virtManagerIn;
         this.monitoringManager = monitoringManagerIn;
         this.serverGroupManager = serverGroupManagerIn;
@@ -123,7 +123,7 @@ public class SystemEntitler {
             }
         }
         else if (EntitlementManager.OSIMAGE_BUILD_HOST.equals(ent)) {
-            systemQuery.generateSSHKey(SaltSSHService.SSH_KEY_PATH);
+            saltApi.generateSSHKey(SaltSSHService.SSH_KEY_PATH);
         }
 
         entitleServer(server, ent);

--- a/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
@@ -116,6 +116,7 @@ import com.suse.manager.webui.controllers.utils.ContactMethodUtil;
 import com.suse.manager.webui.services.iface.*;
 import com.suse.manager.webui.services.impl.SaltService;
 
+import com.suse.manager.webui.services.test.TestSaltApi;
 import com.suse.manager.webui.services.test.TestSystemQuery;
 import org.apache.commons.io.FileUtils;
 import org.cobbler.test.MockConnection;
@@ -180,13 +181,13 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
                     .scheduleActionExecution(with(any(Action.class)));
             }
         });
-        SystemQuery systemQuery = new TestSystemQuery();
+        SaltApi saltApi = new TestSaltApi();
         VirtManager virtManager = new TestVirtManager();
         ServerGroupManager serverGroupManager = new ServerGroupManager();
         systemEntitlementManager = new SystemEntitlementManager(
                 new SystemUnentitler(virtManager, new FormulaMonitoringManager(),
                         serverGroupManager),
-                new SystemEntitler(systemQuery, virtManager, new FormulaMonitoringManager(),
+                new SystemEntitler(saltApi, virtManager, new FormulaMonitoringManager(),
                         serverGroupManager)
         );
         this.systemManager = new SystemManager(ServerFactory.SINGLETON, ServerGroupFactory.SINGLETON);

--- a/java/code/src/com/redhat/rhn/taskomatic/task/MinionCheckin.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/MinionCheckin.java
@@ -18,7 +18,7 @@ import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.taskomatic.task.checkin.CheckinCandidatesResolver;
 import com.redhat.rhn.taskomatic.task.checkin.SystemSummary;
 
-import com.suse.manager.webui.services.iface.SystemQuery;
+import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.salt.netapi.datatypes.target.MinionList;
 import com.suse.salt.netapi.exception.SaltException;
 
@@ -33,7 +33,7 @@ import org.quartz.JobExecutionContext;
  */
 public class MinionCheckin extends RhnJavaJob {
 
-    private SystemQuery systemQuery = GlobalInstanceHolder.SYSTEM_QUERY;
+    private SaltApi saltApi = GlobalInstanceHolder.SALT_API;
 
     /**
      * @param context the job execution context
@@ -48,7 +48,7 @@ public class MinionCheckin extends RhnJavaJob {
         List<String> minionIds = this.findCheckinCandidatesIds();
         try {
             if (!minionIds.isEmpty()) {
-                this.systemQuery.checkIn(new MinionList(minionIds));
+                this.saltApi.checkIn(new MinionList(minionIds));
             }
         }
         catch (SaltException e) {
@@ -73,9 +73,9 @@ public class MinionCheckin extends RhnJavaJob {
     /**
      * Setter for systemQuery.
      *
-     * @param systemQueryIn the systemQuery instance
+     * @param saltApiIn the systemQuery instance
      */
-    public void setSystemQuery(SystemQuery systemQueryIn) {
-        this.systemQuery = systemQueryIn;
+    public void setSaltApi(SaltApi saltApiIn) {
+        this.saltApi = saltApiIn;
     }
 }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/RebootActionCleanup.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/RebootActionCleanup.java
@@ -108,7 +108,7 @@ public class RebootActionCleanup extends RhnJavaJob {
             s.asMinionServer()
                     .filter(MinionServerUtils::isSshPushMinion)
                     .ifPresent(minion ->
-                        GlobalInstanceHolder.SYSTEM_QUERY.getSaltSSHService().cleanPendingActionChainAsync(minion));
+                        GlobalInstanceHolder.SALT_API.getSaltSSHService().cleanPendingActionChainAsync(minion));
         }
 
         return aIds;

--- a/java/code/src/com/redhat/rhn/taskomatic/task/TokenCleanup.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/TokenCleanup.java
@@ -20,7 +20,7 @@ import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.domain.channel.AccessTokenFactory;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.MinionServerFactory;
-import com.suse.manager.webui.services.iface.SystemQuery;
+import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.pillar.MinionPillarManager;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
@@ -37,7 +37,7 @@ import java.util.stream.Stream;
  */
 public class TokenCleanup extends RhnJavaJob {
 
-    private final SystemQuery systemQuery = GlobalInstanceHolder.SYSTEM_QUERY;
+    private final SaltApi saltApi = GlobalInstanceHolder.SALT_API;
 
     /**
      * {@inheritDoc}
@@ -69,7 +69,7 @@ public class TokenCleanup extends RhnJavaJob {
 
             List<String> changedMinionIds = changedMinions.map(m -> m.getMinionId()).collect(Collectors.toList());
             if (Config.get().getBoolean(ConfigDefaults.TOKEN_REFRESH_AUTO_DEPLOY)) {
-                systemQuery.deployChannels(changedMinionIds);
+                saltApi.deployChannels(changedMinionIds);
             }
             else {
                 log.warn("The following minions got channel tokens changed and" +

--- a/java/code/src/com/redhat/rhn/taskomatic/task/sshpush/SSHPushDriver.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/sshpush/SSHPushDriver.java
@@ -180,8 +180,8 @@ public class SSHPushDriver implements QueueDriver {
         // Create a Salt worker if the system has a minion id
         if (system.getMinionId() != null) {
             return new SSHPushWorkerSalt(getLogger(), system,
-                    GlobalInstanceHolder.SYSTEM_QUERY,
-                    GlobalInstanceHolder.SYSTEM_QUERY.getSaltSSHService(),
+                    GlobalInstanceHolder.SALT_API,
+                    GlobalInstanceHolder.SALT_API.getSaltSSHService(),
                     GlobalInstanceHolder.SALT_SERVER_ACTION_SERVICE,
                     GlobalInstanceHolder.SALT_UTILS);
         }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/sshpush/SSHPushWorkerSalt.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/sshpush/SSHPushWorkerSalt.java
@@ -25,8 +25,8 @@ import com.redhat.rhn.taskomatic.task.threaded.TaskQueue;
 import com.suse.manager.reactor.messaging.ApplyStatesEventMessage;
 import com.suse.manager.utils.SaltUtils;
 import com.suse.manager.webui.services.SaltServerActionService;
+import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.impl.SaltSSHService;
-import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.manager.webui.utils.salt.custom.SystemInfo;
 import com.suse.salt.netapi.calls.LocalCall;
 import com.suse.salt.netapi.calls.modules.State;
@@ -54,7 +54,7 @@ public class SSHPushWorkerSalt implements QueueWorker {
     private SystemSummary system;
     private TaskQueue parentQueue;
 
-    private SystemQuery systemQuery;
+    private SaltApi saltApi;
     private SaltSSHService saltSSHService;
     private SaltServerActionService saltServerActionService;
     private SaltUtils saltUtils;
@@ -70,11 +70,11 @@ public class SSHPushWorkerSalt implements QueueWorker {
      * @param saltUtilsIn
      */
     public SSHPushWorkerSalt(Logger logger, SystemSummary systemIn,
-            SystemQuery saltServiceIn, SaltSSHService saltSSHServiceIn,
+            SaltApi saltServiceIn, SaltSSHService saltSSHServiceIn,
             SaltServerActionService saltServerActionServiceIn, SaltUtils saltUtilsIn) {
         log = logger;
         system = systemIn;
-        systemQuery = saltServiceIn;
+        saltApi = saltServiceIn;
         saltSSHService = saltSSHServiceIn;
         saltServerActionService = saltServerActionServiceIn;
         saltUtils = saltUtilsIn;
@@ -139,7 +139,7 @@ public class SSHPushWorkerSalt implements QueueWorker {
         try {
             // first check if there's any pending action chain execution on the minion
             // fetch the extra_filerefs and next_action_id
-            pendingResume = systemQuery.getPendingResume(Collections.singletonList(minion.getMinionId()));
+            pendingResume = saltApi.getPendingResume(Collections.singletonList(minion.getMinionId()));
         }
         catch (SaltException e) {
             log.error("Could not retrive pending action chain executions for minion", e);
@@ -324,7 +324,7 @@ public class SSHPushWorkerSalt implements QueueWorker {
     private void performCheckin(MinionServer minion) {
         // Ping minion and perform check-in on success
         log.info("Performing a check-in for: " + minion.getMinionId());
-        Optional<Boolean> result = systemQuery.ping(minion.getMinionId());
+        Optional<Boolean> result = saltApi.ping(minion.getMinionId());
 
         result.ifPresent(res -> minion.updateServerInfo());
     }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/sshpush/test/SSHPushWorkerSaltTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/sshpush/test/SSHPushWorkerSaltTest.java
@@ -110,14 +110,14 @@ public class SSHPushWorkerSaltTest extends JMockBaseTestCaseWithUser {
         ServerAction serverAction = createChildServerAction(action,
                 ActionFactory.STATUS_PICKED_UP, 5L);
         ActionFactory.save(action);
-        SystemQuery systemQuery = new TestSystemQuery() {
+        SaltApi saltApi = new TestSaltApi() {
             @Override
             public Optional<Boolean> ping(String minionId) {
                 return Optional.of(true);
             }
         };
 
-        SSHPushWorkerSalt worker = successWorker(systemQuery, new TestSaltApi());
+        SSHPushWorkerSalt worker = successWorker(new TestSystemQuery(), saltApi);
 
         context().checking(new Expectations() {{
            
@@ -181,13 +181,13 @@ public class SSHPushWorkerSaltTest extends JMockBaseTestCaseWithUser {
                 ActionFactory.STATUS_PICKED_UP, 5L);
         ActionFactory.save(upcomingAction);
 
-        SystemQuery systemQuery = new TestSystemQuery() {
+        SaltApi saltApi = new TestSaltApi() {
             @Override
             public Optional<Boolean> ping(String minionId) {
                 return Optional.of(true);
             }
         };
-        SSHPushWorkerSalt worker = successWorker(systemQuery, new TestSaltApi());
+        SSHPushWorkerSalt worker = successWorker(new TestSystemQuery(), saltApi);
 
         context().checking(new Expectations() {{
 
@@ -229,7 +229,7 @@ public class SSHPushWorkerSaltTest extends JMockBaseTestCaseWithUser {
                 ActionFactory.STATUS_PICKED_UP, 5L);
         ActionFactory.save(upcomingAction);
 
-        SystemQuery systemQuery = new TestSystemQuery() {
+        SaltApi saltApi = new TestSaltApi() {
             @Override
             public Optional<Boolean> ping(String minionId) {
                 return Optional.of(true);
@@ -247,7 +247,7 @@ public class SSHPushWorkerSaltTest extends JMockBaseTestCaseWithUser {
             }
         };
 
-        SSHPushWorkerSalt worker = successWorker(systemQuery, new TestSaltApi());
+        SSHPushWorkerSalt worker = successWorker(new TestSystemQuery(), saltApi);
 
         context().checking(new Expectations() {{
             oneOf(saltSSHServiceMock).cleanPendingActionChainAsync(with(any(MinionServer.class)));
@@ -314,13 +314,13 @@ public class SSHPushWorkerSaltTest extends JMockBaseTestCaseWithUser {
         FormulaManager formulaManager = new FormulaManager(saltApi);
         ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);
         SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, clusterManager, formulaManager, serverGroupManager);
-        SaltKeyUtils saltKeyUtils = new SaltKeyUtils(systemQuery);
+        SaltKeyUtils saltKeyUtils = new SaltKeyUtils(saltApi);
         return new SSHPushWorkerSalt(
                 logger,
                 sshPushSystemMock,
-                systemQuery,
+                saltApi,
                 saltSSHServiceMock,
-                new SaltServerActionService(systemQuery, saltUtils, clusterManager, formulaManager, saltKeyUtils),
+                new SaltServerActionService(saltApi, saltUtils, clusterManager, formulaManager, saltKeyUtils),
                 saltUtils
         );
     }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/test/MinionCheckinTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/test/MinionCheckinTest.java
@@ -75,7 +75,7 @@ public class MinionCheckinTest extends JMockBaseTestCaseWithUser {
         } });
 
         MinionCheckin minionCheckinJob = new MinionCheckin();
-        minionCheckinJob.setSystemQuery(saltServiceMock);
+        minionCheckinJob.setSaltApi(saltServiceMock);
 
         minionCheckinJob.execute(null);
     }
@@ -107,7 +107,7 @@ public class MinionCheckinTest extends JMockBaseTestCaseWithUser {
         } });
 
         MinionCheckin minionCheckinJob = new MinionCheckin();
-        minionCheckinJob.setSystemQuery(saltServiceMock);
+        minionCheckinJob.setSaltApi(saltServiceMock);
 
         minionCheckinJob.execute(null);
     }

--- a/java/code/src/com/suse/manager/clusters/ClusterManager.java
+++ b/java/code/src/com/suse/manager/clusters/ClusterManager.java
@@ -209,7 +209,7 @@ public class ClusterManager {
             return Collections.emptyList();
         }
         String mgmtNodeTarget = value.get();
-        return systemQuery.matchCompoundSync(mgmtNodeTarget);
+        return saltApi.matchCompoundSync(mgmtNodeTarget);
     }
 
 

--- a/java/code/src/com/suse/manager/kubernetes/KubernetesManager.java
+++ b/java/code/src/com/suse/manager/kubernetes/KubernetesManager.java
@@ -25,8 +25,8 @@ import com.redhat.rhn.domain.server.virtualhostmanager.VirtualHostManagerConfig;
 import com.redhat.rhn.domain.server.virtualhostmanager.VirtualHostManagerFactory;
 import com.suse.manager.model.kubernetes.ContainerInfo;
 import com.suse.manager.model.kubernetes.ImageUsage;
+import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.impl.SaltService;
-import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.manager.webui.services.impl.runner.MgrK8sRunner;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
@@ -49,15 +49,15 @@ public class KubernetesManager {
     private static final Logger LOG = Logger.getLogger(KubernetesManager.class);
     private static final String DOCKER_PULLABLE = "docker-pullable://";
 
-    private final SystemQuery systemQuery;
+    private final SaltApi saltApi;
 
     /**
      * No arg constructor.
      * Configures this with the default {@link SaltService} instance.
-     * @param systemQueryIn instance for getting information from a system.
+     * @param saltApiIn instance for getting information from a system.
      */
-    public KubernetesManager(SystemQuery systemQueryIn) {
-        this.systemQuery = systemQueryIn;
+    public KubernetesManager(SaltApi saltApiIn) {
+        this.saltApi = saltApiIn;
     }
 
     /**
@@ -103,7 +103,7 @@ public class KubernetesManager {
 
                 if (kubeconfig.isPresent() && context.isPresent()) {
                     Optional<List<MgrK8sRunner.Container>> containers =
-                            systemQuery.getAllContainers(kubeconfig.get(), context.get());
+                            saltApi.getAllContainers(kubeconfig.get(), context.get());
 
                     if (!containers.isPresent()) {
                         LOG.error("No container info returned by runner call " +

--- a/java/code/src/com/suse/manager/matcher/test/MatcherJsonIOTest.java
+++ b/java/code/src/com/suse/manager/matcher/test/MatcherJsonIOTest.java
@@ -33,6 +33,7 @@ import com.redhat.rhn.testing.TestUtils;
 
 import com.suse.manager.matcher.MatcherJsonIO;
 import com.suse.manager.virtualization.test.TestVirtManager;
+import com.suse.manager.webui.services.test.TestSaltApi;
 import com.suse.manager.webui.services.test.TestSystemQuery;
 import com.suse.manager.webui.services.iface.VirtManager;
 import com.suse.matcher.json.MatchJson;
@@ -90,7 +91,7 @@ public class MatcherJsonIOTest extends JMockBaseTestCaseWithUser {
         systemEntitlementManager = new SystemEntitlementManager(
                 new SystemUnentitler(virtManager, new FormulaMonitoringManager(),
                         serverGroupManager),
-                new SystemEntitler(new TestSystemQuery(), virtManager, new FormulaMonitoringManager(),
+                new SystemEntitler(new TestSaltApi(), virtManager, new FormulaMonitoringManager(),
                         serverGroupManager)
         );
     }

--- a/java/code/src/com/suse/manager/reactor/SaltReactor.java
+++ b/java/code/src/com/suse/manager/reactor/SaltReactor.java
@@ -119,11 +119,11 @@ public class SaltReactor {
         VirtManager virtManager = new VirtManagerSalt(saltApi);
 
         // Configure message queue to handle minion registrations
-        MessageQueue.registerAction(new RegisterMinionEventMessageAction(systemQuery),
+        MessageQueue.registerAction(new RegisterMinionEventMessageAction(systemQuery, saltApi),
                 RegisterMinionEventMessage.class);
-        MessageQueue.registerAction(new MinionStartEventMessageAction(systemQuery),
+        MessageQueue.registerAction(new MinionStartEventMessageAction(saltApi),
                 MinionStartEventMessage.class);
-        MessageQueue.registerAction(new MinionStartEventMessageAction(systemQuery),
+        MessageQueue.registerAction(new MinionStartEventMessageAction(saltApi),
                 MinionStartEventDatabaseMessage.class);
         MessageQueue.registerAction(new ApplyStatesEventMessageAction(),
                 ApplyStatesEventMessage.class);

--- a/java/code/src/com/suse/manager/reactor/messaging/MinionStartEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/MinionStartEventMessageAction.java
@@ -18,6 +18,7 @@ import com.redhat.rhn.common.messaging.EventMessage;
 import com.redhat.rhn.common.messaging.MessageAction;
 import com.redhat.rhn.domain.server.MinionServerFactory;
 
+import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.salt.netapi.datatypes.target.MinionList;
 import org.apache.log4j.Logger;
@@ -32,15 +33,15 @@ public class MinionStartEventMessageAction implements MessageAction {
     private static final Logger LOG = Logger.getLogger(MinionStartEventMessageAction.class);
 
     // Reference to the SaltService instance
-    private final SystemQuery systemQuery;
+    private final SaltApi saltApi;
 
     /**
      * Constructor taking a {@link SystemQuery} instance.
      *
-     * @param systemQueryIn systemQuery instance for gathering data from a system.
+     * @param saltApiIn systemQuery instance for gathering data from a system.
      */
-    public MinionStartEventMessageAction(SystemQuery systemQueryIn) {
-        this.systemQuery = systemQueryIn;
+    public MinionStartEventMessageAction(SaltApi saltApiIn) {
+        this.saltApi = saltApiIn;
     }
 
     @Override
@@ -50,7 +51,7 @@ public class MinionStartEventMessageAction implements MessageAction {
                 .ifPresent(minion -> {
             // Sync grains, modules and beacons, also update uptime and required grains on every minion restart
             MinionList minionTarget = new MinionList(minionId);
-            systemQuery.updateSystemInfo(minionTarget);
+            saltApi.updateSystemInfo(minionTarget);
         });
     }
 

--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -55,6 +55,7 @@ import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.manager.system.SystemManager;
 
 import com.suse.manager.reactor.utils.ValueMap;
+import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.impl.MinionPendingRegistrationService;
 import com.suse.manager.webui.services.pillar.MinionPillarManager;
 import com.suse.manager.webui.utils.salt.MinionStartupGrains;
@@ -94,6 +95,7 @@ public class RegisterMinionEventMessageAction implements MessageAction {
             RegisterMinionEventMessageAction.class);
 
     // Reference to the SaltService instance
+    private final SaltApi saltApi;
     private final SystemQuery systemQuery;
 
     private static final String FQDN = "fqdn";
@@ -103,8 +105,10 @@ public class RegisterMinionEventMessageAction implements MessageAction {
      * Constructor taking a {@link SystemQuery} instance.
      *
      * @param systemQueryIn systemQuery instance for gathering data from a system.
+     * @param saltApiIn saltApi instance for gathering data from a system.
      */
-    public RegisterMinionEventMessageAction(SystemQuery systemQueryIn) {
+    public RegisterMinionEventMessageAction(SystemQuery systemQueryIn, SaltApi saltApiIn) {
+        saltApi = saltApiIn;
         systemQuery = systemQueryIn;
     }
 
@@ -115,7 +119,7 @@ public class RegisterMinionEventMessageAction implements MessageAction {
     public void execute(EventMessage msg) {
         RegisterMinionEventMessage registerMinionEventMessage = ((RegisterMinionEventMessage) msg);
         Optional<MinionStartupGrains> startupGrainsOpt = Opt.or(registerMinionEventMessage.getMinionStartupGrains(),
-                () -> systemQuery.getGrains(registerMinionEventMessage.getMinionId(),
+                () -> saltApi.getGrains(registerMinionEventMessage.getMinionId(),
                         new TypeToken<MinionStartupGrains>() { }, "machine_id", "saltboot_initrd", "susemanager"));
         registerMinion(registerMinionEventMessage.getMinionId(), false, empty(), empty(),  startupGrainsOpt);
     }
@@ -129,7 +133,7 @@ public class RegisterMinionEventMessageAction implements MessageAction {
      * @param proxyId the proxy to which the minion connects, if any
      */
     public void registerSSHMinion(String minionId, Optional<Long> proxyId, Optional<String> activationKeyOverride) {
-        Optional<MinionStartupGrains> startupGrainsOpt = systemQuery.getGrains(minionId,
+        Optional<MinionStartupGrains> startupGrainsOpt = saltApi.getGrains(minionId,
                 new TypeToken<MinionStartupGrains>() { }, "machine_id", "saltboot_initrd", "susemanager");
         registerMinion(minionId, true, proxyId, activationKeyOverride, startupGrainsOpt);
     }
@@ -271,7 +275,7 @@ public class RegisterMinionEventMessageAction implements MessageAction {
 
             migrateMinionFormula(minionId, Optional.of(oldMinionId));
 
-            systemQuery.deleteKey(oldMinionId);
+            saltApi.deleteKey(oldMinionId);
             SystemManager.addHistoryEvent(registeredMinion, "Duplicate Minion ID", "Minion '" +
                     oldMinionId + "' has been updated to '" + minionId + "'");
         }
@@ -303,7 +307,7 @@ public class RegisterMinionEventMessageAction implements MessageAction {
                                            Optional<String> activationKeyOverride,
                                            boolean isSaltSSH) {
         Optional<User> creator = MinionPendingRegistrationService.getCreator(minionId);
-        ValueMap grains = new ValueMap(systemQuery.getGrains(minionId).orElseGet(HashMap::new));
+        ValueMap grains = new ValueMap(saltApi.getGrains(minionId).orElseGet(HashMap::new));
         MinionServer minion = migrateOrCreateSystem(minionId, isSaltSSH, activationKeyOverride, machineId, grains);
         Optional<String> originalMinionId = Optional.ofNullable(minion.getMinionId());
 
@@ -378,7 +382,7 @@ public class RegisterMinionEventMessageAction implements MessageAction {
 
             mapHardwareGrains(minion, grains);
 
-            String master = systemQuery
+            String master = saltApi
                     .getMasterHostname(minionId)
                     .orElseThrow(() -> new SaltException(
                             "master not found in minion configuration"));
@@ -774,7 +778,7 @@ public class RegisterMinionEventMessageAction implements MessageAction {
         if ("redhat".equalsIgnoreCase(grains.getValueAsString("os")) ||
                 "centos".equalsIgnoreCase(grains.getValueAsString("os"))) {
             MinionList target = new MinionList(Arrays.asList(minionId));
-            Optional<Result<String>> whatprovidesRes = systemQuery.runRemoteCommand(target,
+            Optional<Result<String>> whatprovidesRes = saltApi.runRemoteCommand(target,
                     "rpm -q --whatprovides --queryformat \"%{NAME}\\n\" redhat-release")
                     .entrySet()
                     .stream()
@@ -811,7 +815,7 @@ public class RegisterMinionEventMessageAction implements MessageAction {
                 }
             })
             .flatMap(pkg ->
-                systemQuery.runRemoteCommand(target,
+                saltApi.runRemoteCommand(target,
                         "rpm -q --queryformat \"" +
                             "VERSION=%{VERSION}\\n" +
                             "PROVIDENAME=[%{PROVIDENAME},]\\n" +

--- a/java/code/src/com/suse/manager/reactor/messaging/test/LibvirtEngineDomainLifecycleMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/LibvirtEngineDomainLifecycleMessageActionTest.java
@@ -34,6 +34,7 @@ import com.suse.manager.reactor.messaging.AbstractLibvirtEngineMessage;
 import com.suse.manager.reactor.messaging.LibvirtEngineDomainLifecycleMessageAction;
 import com.suse.manager.virtualization.GuestDefinition;
 import com.suse.manager.virtualization.test.TestVirtManager;
+import com.suse.manager.webui.services.test.TestSaltApi;
 import com.suse.manager.webui.services.test.TestSystemQuery;
 import com.suse.manager.webui.services.iface.VirtManager;
 import com.suse.salt.netapi.datatypes.Event;
@@ -102,7 +103,7 @@ public class LibvirtEngineDomainLifecycleMessageActionTest extends JMockBaseTest
         ServerGroupManager serverGroupManager = new ServerGroupManager();
         SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
                 new SystemUnentitler(virtManager, new FormulaMonitoringManager(), serverGroupManager),
-                new SystemEntitler(new TestSystemQuery(), virtManager, new FormulaMonitoringManager(),
+                new SystemEntitler(new TestSaltApi(), virtManager, new FormulaMonitoringManager(),
                         serverGroupManager)
         );
 

--- a/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
@@ -311,7 +311,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
             }});
         }
 
-        RegisterMinionEventMessageAction action = new RegisterMinionEventMessageAction(saltServiceMock);
+        RegisterMinionEventMessageAction action = new RegisterMinionEventMessageAction(saltServiceMock, saltServiceMock);
         action.execute(new RegisterMinionEventMessage(MINION_ID, startupGrains));
 
         // Verify the resulting system entry
@@ -2017,7 +2017,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
         } });
 
         RegisterMinionEventMessageAction action =
-                new RegisterMinionEventMessageAction(saltService);
+                new RegisterMinionEventMessageAction(saltService, saltService);
         action.execute(new RegisterMinionEventMessage(MINION_ID, Optional.empty()));
         return saltService;
     }

--- a/java/code/src/com/suse/manager/utils/SaltKeyUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltKeyUtils.java
@@ -18,7 +18,7 @@ import com.redhat.rhn.domain.server.MinionServerFactory;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.xmlrpc.PermissionCheckFailureException;
 
-import com.suse.manager.webui.services.iface.SystemQuery;
+import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.salt.netapi.calls.wheel.Key;
 
 import java.util.stream.Stream;
@@ -28,13 +28,13 @@ import java.util.stream.Stream;
  */
 public class SaltKeyUtils {
 
-    private final SystemQuery systemQuery;
+    private final SaltApi saltApi;
 
     /**
-     * @param systemQueryIn
+     * @param saltApiIn
      */
-    public SaltKeyUtils(SystemQuery systemQueryIn) {
-        this.systemQuery = systemQueryIn;
+    public SaltKeyUtils(SaltApi saltApiIn) {
+        this.saltApi = saltApiIn;
     }
 
     /**
@@ -48,7 +48,7 @@ public class SaltKeyUtils {
             throws PermissionCheckFailureException {
 
         //Note: since salt only allows globs we have to do our own strict matching
-        Key.Names keys = systemQuery.getKeys();
+        Key.Names keys = saltApi.getKeys();
         boolean exists = Stream.concat(
                 Stream.concat(
                         keys.getDeniedMinions().stream(),
@@ -61,14 +61,14 @@ public class SaltKeyUtils {
         if (exists) {
             return MinionServerFactory.findByMinionId(minionId).map(minionServer -> {
                 if (minionServer.getOrg().equals(user.getOrg())) {
-                    systemQuery.deleteKey(minionId);
+                    saltApi.deleteKey(minionId);
                     return true;
                 }
                 else {
                     return false;
                 }
             }).orElseGet(() -> {
-                systemQuery.deleteKey(minionId);
+                saltApi.deleteKey(minionId);
                 return true;
             });
         }

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -678,7 +678,7 @@ public class SaltUtils {
                 // Make sure grains are updated after dist upgrade
                 serverAction.getServer().asMinionServer().ifPresent(minionServer -> {
                     MinionList minionTarget = new MinionList(minionServer.getMinionId());
-                    systemQuery.syncGrains(minionTarget);
+                    saltApi.syncGrains(minionTarget);
                 });
             }
 
@@ -1049,7 +1049,7 @@ public class SaltUtils {
             serverAction.getServer().asMinionServer().ifPresent(
                     minion -> {
                         try {
-                            Map<Boolean, String> moveRes = systemQuery.storeMinionScapFiles(
+                            Map<Boolean, String> moveRes = saltApi.storeMinionScapFiles(
                                     minion, openscapResult.getUploadDir(), action.getId());
                             moveRes.entrySet().stream().findFirst().ifPresent(moved -> {
                                 if (moved.getKey()) {

--- a/java/code/src/com/suse/manager/webui/Router.java
+++ b/java/code/src/com/suse/manager/webui/Router.java
@@ -108,12 +108,13 @@ public class Router implements SparkApplication {
         SaltKeyUtils saltKeyUtils = GlobalInstanceHolder.SALT_KEY_UTILS;
         ServerGroupManager serverGroupManager = GlobalInstanceHolder.SERVER_GROUP_MANAGER;
 
-        SystemsController systemsController = new SystemsController(systemQuery);
-        SaltSSHController saltSSHController = new SaltSSHController(systemQuery);
-        NotificationMessageController notificationMessageController = new NotificationMessageController(systemQuery);
-        MinionsAPI minionsAPI = new MinionsAPI(systemQuery, sshMinionBootstrapper, regularMinionBootstrapper,
+        SystemsController systemsController = new SystemsController(saltApi);
+        SaltSSHController saltSSHController = new SaltSSHController(saltApi);
+        NotificationMessageController notificationMessageController =
+                new NotificationMessageController(systemQuery, saltApi);
+        MinionsAPI minionsAPI = new MinionsAPI(saltApi, sshMinionBootstrapper, regularMinionBootstrapper,
                 saltKeyUtils);
-        StatesAPI statesAPI = new StatesAPI(systemQuery, taskomaticApi, serverGroupManager);
+        StatesAPI statesAPI = new StatesAPI(saltApi, taskomaticApi, serverGroupManager);
         FormulaController formulaController = new FormulaController(systemQuery, saltApi);
         ClustersController clustersController = new ClustersController(clusterManager, formulaManager);
 

--- a/java/code/src/com/suse/manager/webui/controllers/MinionsAPI.java
+++ b/java/code/src/com/suse/manager/webui/controllers/MinionsAPI.java
@@ -32,8 +32,8 @@ import com.suse.manager.utils.SaltKeyUtils;
 import com.suse.manager.webui.controllers.utils.ContactMethodUtil;
 import com.suse.manager.webui.controllers.utils.RegularMinionBootstrapper;
 import com.suse.manager.webui.controllers.utils.SSHMinionBootstrapper;
+import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.impl.MinionPendingRegistrationService;
-import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.manager.webui.utils.gson.BootstrapHostsJson;
 import com.suse.manager.webui.utils.gson.BootstrapParameters;
 import com.suse.manager.webui.utils.gson.SaltMinionJson;
@@ -65,7 +65,7 @@ public class MinionsAPI {
 
     public static final String SALT_CMD_RUN_TARGETS = "salt_cmd_run_targets";
 
-    private final SystemQuery systemQuery;
+    private final SaltApi saltApi;
     private final SSHMinionBootstrapper sshMinionBootstrapper;
     private final RegularMinionBootstrapper regularMinionBootstrapper;
     private final SaltKeyUtils saltKeyUtils;
@@ -79,15 +79,15 @@ public class MinionsAPI {
     private static final Logger LOG = Logger.getLogger(MinionsAPI.class);
 
     /**
-     * @param systemQueryIn instance to use.
+     * @param saltApiIn instance to use.
      * @param regularMinionBootstrapperIn regular bootstrapper
      * @param sshMinionBootstrapperIn ssh bootstrapper
      * @param saltKeyUtilsIn
      */
-    public MinionsAPI(SystemQuery systemQueryIn, SSHMinionBootstrapper sshMinionBootstrapperIn,
+    public MinionsAPI(SaltApi saltApiIn, SSHMinionBootstrapper sshMinionBootstrapperIn,
                       RegularMinionBootstrapper regularMinionBootstrapperIn,
                       SaltKeyUtils saltKeyUtilsIn) {
-        this.systemQuery = systemQueryIn;
+        this.saltApi = saltApiIn;
         this.sshMinionBootstrapper = sshMinionBootstrapperIn;
         this.regularMinionBootstrapper = regularMinionBootstrapperIn;
         this.saltKeyUtils = saltKeyUtilsIn;
@@ -113,7 +113,7 @@ public class MinionsAPI {
      * @return json result of the API call
      */
     public String listKeys(Request request, Response response, User user) {
-        Key.Fingerprints fingerprints = systemQuery.getFingerprints();
+        Key.Fingerprints fingerprints = saltApi.getFingerprints();
 
         Map<String, Object> data = new TreeMap<>();
         data.put("isOrgAdmin", user.hasRole(RoleFactory.ORG_ADMIN));
@@ -155,7 +155,7 @@ public class MinionsAPI {
         MinionPendingRegistrationService.addMinion(
                 user, target, ContactMethodUtil.DEFAULT, Optional.empty());
         try {
-            systemQuery.acceptKey(target);
+            saltApi.acceptKey(target);
         }
         catch (Exception e) {
             MinionPendingRegistrationService.removeMinion(target);
@@ -190,7 +190,7 @@ public class MinionsAPI {
      */
     public String reject(Request request, Response response, User user) {
         String target = request.params("target");
-        systemQuery.rejectKey(target);
+        saltApi.rejectKey(target);
         return json(response, true);
     }
 

--- a/java/code/src/com/suse/manager/webui/controllers/NotificationMessageController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/NotificationMessageController.java
@@ -30,6 +30,7 @@ import com.redhat.rhn.taskomatic.TaskomaticApiException;
 
 import com.suse.manager.reactor.messaging.RegisterMinionEventMessage;
 import com.suse.manager.reactor.messaging.RegisterMinionEventMessageAction;
+import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.manager.webui.utils.gson.NotificationMessageJson;
 import com.suse.manager.webui.websocket.Notification;
@@ -61,12 +62,15 @@ public class NotificationMessageController {
             .serializeNulls()
             .create();
 
+    private final SaltApi saltApi;
     private final SystemQuery systemQuery;
 
     /**
      * @param systemQueryIn instance for getting information from a system.
+     * @param saltApiIn instance for getting information from a system.
      */
-    public NotificationMessageController(SystemQuery systemQueryIn) {
+    public NotificationMessageController(SystemQuery systemQueryIn, SaltApi saltApiIn) {
+        this.saltApi = saltApiIn;
         this.systemQuery = systemQueryIn;
     }
 
@@ -217,7 +221,7 @@ public class NotificationMessageController {
         String severity = "success";
         String resultMessage = "Onboarding restarted of the minioniId '%s'";
 
-        RegisterMinionEventMessageAction action = new RegisterMinionEventMessageAction(systemQuery);
+        RegisterMinionEventMessageAction action = new RegisterMinionEventMessageAction(systemQuery, saltApi);
         action.execute(new RegisterMinionEventMessage(minionId, Optional.empty()));
 
         Map<String, String> data = new HashMap<>();

--- a/java/code/src/com/suse/manager/webui/controllers/SaltSSHController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/SaltSSHController.java
@@ -16,8 +16,8 @@ package com.suse.manager.webui.controllers;
 
 import static spark.Spark.halt;
 
+import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.impl.SaltSSHService;
-import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.manager.webui.services.impl.runner.MgrUtilRunner;
 
 import org.apache.commons.io.IOUtils;
@@ -40,13 +40,13 @@ public class SaltSSHController {
     // Logger
     private static final Logger LOG = Logger.getLogger(SaltSSHController.class);
 
-    private final SystemQuery systemQuery;
+    private final SaltApi saltApi;
 
     /**
-     * @param systemQueryIn instance for getting information from a system.
+     * @param saltApiIn instance for getting information from a system.
      */
-    public SaltSSHController(SystemQuery systemQueryIn) {
-        this.systemQuery = systemQueryIn;
+    public SaltSSHController(SaltApi saltApiIn) {
+        this.saltApi = saltApiIn;
     }
 
     /**
@@ -59,7 +59,7 @@ public class SaltSSHController {
     public synchronized byte[] getPubKey(Request request, Response response) {
         File pubKey = new File(SaltSSHService.SSH_KEY_PATH + ".pub");
 
-        Optional<MgrUtilRunner.ExecResult> res = systemQuery
+        Optional<MgrUtilRunner.ExecResult> res = saltApi
                 .generateSSHKey(SaltSSHService.SSH_KEY_PATH);
 
         if (!res.isPresent()) {

--- a/java/code/src/com/suse/manager/webui/controllers/StatesAPI.java
+++ b/java/code/src/com/suse/manager/webui/controllers/StatesAPI.java
@@ -61,7 +61,7 @@ import com.suse.manager.webui.services.ConfigChannelSaltManager;
 import com.suse.manager.webui.services.SaltConstants;
 import com.suse.manager.webui.services.SaltStateGeneratorService;
 import com.suse.manager.webui.services.StateRevisionService;
-import com.suse.manager.webui.services.iface.SystemQuery;
+import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.utils.SaltInclude;
 import com.suse.manager.webui.utils.SaltPkgInstalled;
 import com.suse.manager.webui.utils.SaltPkgLatest;
@@ -117,7 +117,7 @@ public class StatesAPI {
     /** Logger */
     private static final Logger LOG = Logger.getLogger(StatesAPI.class);
     private final TaskomaticApi taskomaticApi;
-    private final SystemQuery systemQuery;
+    private final SaltApi saltApi;
     private final ServerGroupManager serverGroupManager;
 
     private static final Gson GSON = new GsonBuilder().create();
@@ -132,14 +132,14 @@ public class StatesAPI {
             = "/etc/yum.repos.d/susemanager:channels.repo";
 
     /**
-     * @param systemQueryIn instance to use.
+     * @param saltApiIn instance to use.
      * @param taskomaticApiIn instance to use.
      * @param serverGroupManagerIn instance to use.
      */
-    public StatesAPI(SystemQuery systemQueryIn, TaskomaticApi taskomaticApiIn,
+    public StatesAPI(SaltApi saltApiIn, TaskomaticApi taskomaticApiIn,
                      ServerGroupManager serverGroupManagerIn) {
         this.taskomaticApi = taskomaticApiIn;
-        this.systemQuery = systemQueryIn;
+        this.saltApi = saltApiIn;
         this.serverGroupManager = serverGroupManagerIn;
     }
 
@@ -700,9 +700,9 @@ public class StatesAPI {
                     try {
                         MinionList minions = new MinionList(minionId);
                         // sync to minion before showing highstate
-                        systemQuery.syncAll(minions);
+                        saltApi.syncAll(minions);
 
-                        Map<String, Result<Object>> result = systemQuery.showHighstate(minionId);
+                        Map<String, Result<Object>> result = saltApi.showHighstate(minionId);
 
                         return Optional.ofNullable(result.get(minionId))
                                 .map(r -> r.fold(

--- a/java/code/src/com/suse/manager/webui/controllers/SystemsController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/SystemsController.java
@@ -41,7 +41,7 @@ import com.suse.manager.maintenance.MaintenanceManager;
 import com.suse.manager.model.maintenance.MaintenanceSchedule;
 import com.suse.manager.reactor.utils.LocalDateTimeISOAdapter;
 import com.suse.manager.reactor.utils.OptionalTypeAdapterFactory;
-import com.suse.manager.webui.services.iface.SystemQuery;
+import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.utils.FlashScopeHelper;
 import com.suse.manager.webui.utils.gson.ChannelsJson;
 import com.suse.manager.webui.utils.gson.ResultJson;
@@ -81,13 +81,13 @@ import static spark.Spark.post;
  */
 public class SystemsController {
 
-    private final SystemQuery systemQuery;
+    private final SaltApi saltApi;
 
     /**
-     * @param systemQueryIn instance for getting information from a system.
+     * @param saltApiIn instance for getting information from a system.
      */
-    public SystemsController(SystemQuery systemQueryIn) {
-        this.systemQuery = systemQueryIn;
+    public SystemsController(SaltApi saltApiIn) {
+        this.saltApi = saltApiIn;
     }
 
     // Logger for this class
@@ -138,7 +138,7 @@ public class SystemsController {
         if (server.asMinionServer().isPresent()) {
             if (!Boolean.parseBoolean(noclean) && !isEmptyProfile) {
                 Optional<List<String>> cleanupErr =
-                        systemQuery.cleanupMinion(server.asMinionServer().get(), 300);
+                        saltApi.cleanupMinion(server.asMinionServer().get(), 300);
                 if (cleanupErr.isPresent()) {
                     return json(response, ResultJson.error(cleanupErr.get()));
                 }

--- a/java/code/src/com/suse/manager/webui/controllers/utils/SSHMinionBootstrapper.java
+++ b/java/code/src/com/suse/manager/webui/controllers/utils/SSHMinionBootstrapper.java
@@ -20,6 +20,7 @@ import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.user.User;
 import com.suse.manager.reactor.messaging.ApplyStatesEventMessage;
 import com.suse.manager.reactor.messaging.RegisterMinionEventMessageAction;
+import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.impl.MinionPendingRegistrationService;
 import com.suse.manager.webui.services.impl.SaltSSHService;
 import com.suse.manager.webui.services.iface.SystemQuery;
@@ -49,9 +50,10 @@ public class SSHMinionBootstrapper extends AbstractMinionBootstrapper {
      * Standard constructor. For testing only - to obtain instance of this class, use
      * getInstance.
      * @param systemQueryIn systemQuery to use
+     * @param saltApiIn saltApi to use
      */
-    public SSHMinionBootstrapper(SystemQuery systemQueryIn) {
-        super(systemQueryIn);
+    public SSHMinionBootstrapper(SystemQuery systemQueryIn, SaltApi saltApiIn) {
+        super(systemQueryIn, saltApiIn);
     }
 
     @Override
@@ -110,7 +112,7 @@ public class SSHMinionBootstrapper extends AbstractMinionBootstrapper {
 
     // we want to override this in tests
     protected RegisterMinionEventMessageAction getRegisterAction() {
-        return new RegisterMinionEventMessageAction(systemQuery);
+        return new RegisterMinionEventMessageAction(systemQuery, saltApi);
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/controllers/utils/test/RegularMinionBootstrapperTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/utils/test/RegularMinionBootstrapperTest.java
@@ -48,7 +48,7 @@ public class RegularMinionBootstrapperTest extends AbstractMinionBootstrapperTes
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        bootstrapper = new RegularMinionBootstrapper(saltServiceMock);
+        bootstrapper = new RegularMinionBootstrapper(saltServiceMock, saltServiceMock);
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/controllers/utils/test/SSHMinionBootstrapperTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/utils/test/SSHMinionBootstrapperTest.java
@@ -23,7 +23,7 @@ public class SSHMinionBootstrapperTest extends AbstractMinionBootstrapperTestBas
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        bootstrapper = new SSHMinionBootstrapper(saltServiceMock);
+        bootstrapper = new SSHMinionBootstrapper(saltServiceMock, saltServiceMock);
     }
 
     @Override
@@ -35,7 +35,7 @@ public class SSHMinionBootstrapperTest extends AbstractMinionBootstrapperTestBas
 
     private SSHMinionBootstrapper mockRegistrationBootstrapper(
             Optional<String> activationKeyLabel) {
-        return new SSHMinionBootstrapper(saltServiceMock) {
+        return new SSHMinionBootstrapper(saltServiceMock, saltServiceMock) {
             @Override
             protected RegisterMinionEventMessageAction getRegisterAction() {
                 RegisterMinionEventMessageAction action =

--- a/java/code/src/com/suse/manager/webui/controllers/virtualization/test/VirtualGuestsControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/virtualization/test/VirtualGuestsControllerTest.java
@@ -42,6 +42,7 @@ import com.suse.manager.virtualization.VmInfoJson;
 import com.suse.manager.virtualization.test.TestVirtManager;
 import com.suse.manager.webui.controllers.test.BaseControllerTestCase;
 import com.suse.manager.webui.controllers.virtualization.VirtualGuestsController;
+import com.suse.manager.webui.services.test.TestSaltApi;
 import com.suse.manager.webui.services.test.TestSystemQuery;
 import com.suse.manager.webui.services.iface.VirtManager;
 
@@ -121,7 +122,7 @@ public class VirtualGuestsControllerTest extends BaseControllerTestCase {
         SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
                 new SystemUnentitler(virtManager, new FormulaMonitoringManager(),
                         serverGroupManager),
-                new SystemEntitler(new TestSystemQuery(), virtManager, new FormulaMonitoringManager(),
+                new SystemEntitler(new TestSaltApi(), virtManager, new FormulaMonitoringManager(),
                         serverGroupManager)
         );
 

--- a/java/code/src/com/suse/manager/webui/controllers/virtualization/test/VirtualNetsControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/virtualization/test/VirtualNetsControllerTest.java
@@ -37,6 +37,7 @@ import com.suse.manager.virtualization.test.TestVirtManager;
 import com.suse.manager.webui.controllers.test.BaseControllerTestCase;
 import com.suse.manager.webui.controllers.virtualization.VirtualNetsController;
 import com.suse.manager.webui.controllers.virtualization.gson.VirtualNetworkInfoJson;
+import com.suse.manager.webui.services.test.TestSaltApi;
 import com.suse.manager.webui.services.test.TestSystemQuery;
 import com.suse.manager.webui.services.iface.VirtManager;
 
@@ -92,7 +93,7 @@ public class VirtualNetsControllerTest extends BaseControllerTestCase {
         ServerGroupManager serverGroupManager = new ServerGroupManager();
         SystemEntitlementManager systemEntitlementManager = new SystemEntitlementManager(
                 new SystemUnentitler(virtManager, new FormulaMonitoringManager(), serverGroupManager),
-                new SystemEntitler(new TestSystemQuery(), virtManager, new FormulaMonitoringManager(), serverGroupManager)
+                new SystemEntitler(new TestSaltApi(), virtManager, new FormulaMonitoringManager(), serverGroupManager)
         );
 
         host = ServerTestUtils.createVirtHostWithGuests(user, 1, true, systemEntitlementManager);

--- a/java/code/src/com/suse/manager/webui/controllers/virtualization/test/VirtualPoolsControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/virtualization/test/VirtualPoolsControllerTest.java
@@ -45,6 +45,7 @@ import com.suse.manager.virtualization.test.TestVirtManager;
 import com.suse.manager.webui.controllers.test.BaseControllerTestCase;
 import com.suse.manager.webui.controllers.virtualization.VirtualPoolsController;
 import com.suse.manager.webui.controllers.virtualization.gson.VirtualStoragePoolInfoJson;
+import com.suse.manager.webui.services.test.TestSaltApi;
 import com.suse.manager.webui.services.test.TestSystemQuery;
 import com.suse.manager.webui.services.iface.VirtManager;
 
@@ -119,7 +120,7 @@ public class VirtualPoolsControllerTest extends BaseControllerTestCase {
         systemEntitlementManager = new SystemEntitlementManager(
                 new SystemUnentitler(virtManager, new FormulaMonitoringManager(),
                         serverGroupManager),
-                new SystemEntitler(new TestSystemQuery(), virtManager, new FormulaMonitoringManager(),
+                new SystemEntitler(new TestSaltApi(), virtManager, new FormulaMonitoringManager(),
                         serverGroupManager)
         );
 

--- a/java/code/src/com/suse/manager/webui/services/iface/SaltApi.java
+++ b/java/code/src/com/suse/manager/webui/services/iface/SaltApi.java
@@ -14,11 +14,36 @@
  */
 package com.suse.manager.webui.services.iface;
 
+import com.google.gson.JsonElement;
+import com.google.gson.reflect.TypeToken;
+import com.redhat.rhn.domain.server.MinionServer;
+import com.suse.manager.webui.services.impl.SaltSSHService;
+import com.suse.manager.webui.services.impl.SaltService;
+import com.suse.manager.webui.services.impl.runner.MgrK8sRunner;
+import com.suse.manager.webui.services.impl.runner.MgrUtilRunner;
+import com.suse.manager.webui.utils.gson.BootstrapParameters;
+import com.suse.manager.webui.utils.salt.custom.ScheduleMetadata;
+import com.suse.salt.netapi.calls.LocalAsyncResult;
 import com.suse.salt.netapi.calls.LocalCall;
+import com.suse.salt.netapi.calls.modules.SaltUtil;
+import com.suse.salt.netapi.calls.modules.State;
+import com.suse.salt.netapi.calls.runner.Jobs;
+import com.suse.salt.netapi.calls.wheel.Key;
 import com.suse.salt.netapi.datatypes.target.MinionList;
+import com.suse.salt.netapi.datatypes.target.Target;
+import com.suse.salt.netapi.errors.GenericError;
 import com.suse.salt.netapi.event.EventStream;
+import com.suse.salt.netapi.exception.SaltException;
+import com.suse.salt.netapi.results.Result;
+import com.suse.salt.netapi.results.SSHResult;
 
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 /**
  * Interface for interacting with salt.
@@ -26,11 +51,261 @@ import java.util.Optional;
 public interface SaltApi {
 
     /**
+     * Sync the channels of a list of minions
+     * @param minionIds of the targets.
+     * @throws SaltException if anything goes wrong.
+     */
+    void deployChannels(List<String> minionIds) throws SaltException;
+
+    /**
+     * Get information about all containers running in a Kubernetes cluster.
+     * @param kubeconfig path to the kubeconfig file
+     * @param context kubeconfig context to use
+     * @return a list of containers
+     */
+    Optional<List<MgrK8sRunner.Container>> getAllContainers(String kubeconfig, String context);
+
+    /**
+     * Using a RunnerCall, store given contents to given path and set the mode, so that SSH likes it
+     * (read-write for owner, nothing for others).
+     *
+     * @param path the path where key will be stored
+     * @param contents the contents of the key (PEM format)
+     * @throws IllegalStateException if something goes wrong during the operation, or if given path is not absolute
+     */
+    void storeSshKeyFile(Path path, String contents);
+
+    /**
+     * Match minions synchronously using a compound matcher.
+     * @param target compound matcher
+     * @return list of minion ids
+     */
+    List<String> matchCompoundSync(String target);
+
+    /**
+     * Remove given file using RunnerCall
+     *
+     * @param path the path of file to be removed
+     * @throws IllegalStateException if the given path is not absolute
+     * @return Optional with true if the file deletion succeeded.
+     */
+    Optional<Boolean> removeFile(Path path);
+
+    /**
+     * Performs an test.echo on a target set of minions for checkIn purpose.
+     * @param targetIn the target
+     * @return the LocalAsyncResult of the test.echo call
+     * @throws SaltException if we get a failure from Salt
+     */
+    Optional<LocalAsyncResult<String>> checkIn(MinionList targetIn) throws SaltException;
+
+    /**
+     * Apply util.systeminfo state on the specified minion list
+     * @param minionTarget minion list
+     */
+    void updateSystemInfo(MinionList minionTarget);
+
+    /**
+     * Store the files uploaded by a minion to the SCAP storage directory.
+     * @param minion the minion
+     * @param uploadDir the uploadDir
+     * @param actionId the action id
+     * @return a map with one element: @{code true} -> scap store path,
+     * {@code false} -> err message
+     *
+     */
+    Map<Boolean, String> storeMinionScapFiles(MinionServer minion, String uploadDir, Long actionId);
+
+    /**
+     * Return show highstate result.
+     * @param minionId of the target minion.
+     * @return show highstate result.
+     * @throws SaltException if anything goes wrong.
+     */
+    Map<String, Result<Object>> showHighstate(String minionId) throws SaltException;
+
+    /**
+     * Call the custom mgrutil.ssh_keygen runner if the key files are not present.
+     *
+     * @param path of the key files
+     * @return the result of the runner call as a map
+     */
+    Optional<MgrUtilRunner.ExecResult> generateSSHKey(String path);
+
+    /**
+     * Chain ssh calls over one or more hops to run a command on the last host in the chain.
+     * This calls the mgrutil.chain_ssh_command runner.
+     *
+     * @param hosts a list of hosts, where the last one is where
+     *              the command will be executed
+     * @param clientKey the ssh key to use to connect to the first host
+     * @param proxyKey the ssh key path to use for the rest of the hosts
+     * @param user the user
+     * @param options ssh options
+     * @param command the command to execute
+     * @param outputfile the file to which to dump the command stdout
+     * @return the execution result
+     */
+    Optional<MgrUtilRunner.ExecResult> chainSSHCommand(List<String> hosts, String clientKey, String proxyKey,
+                                                       String user, Map<String, String> options, String command,
+                                                       String outputfile);
+
+    /**
+     * Call 'saltutil.sync_grains' to sync the grains to the target minion(s).
+     * @param minionList minion list
+     */
+    void syncGrains(MinionList minionList);
+
+    /**
+     * Call 'saltutil.sync_modules' to sync the grains to the target minion(s).
+     * @param minionList minion list
+     */
+    void syncModules(MinionList minionList);
+
+    /**
+     * Call 'saltutil.sync_all' to sync everything to the target minion(s).
+     * @param minionList minion list
+     */
+    void syncAll(MinionList minionList);
+
+    /**
+     * call salt test.ping
+     * @param minionId id of the target minion
+     * @return true
+     */
+    Optional<Boolean> ping(String minionId);
+
+    /**
      * Return the stream of events happening in salt.
      *
      * @return the event stream
      */
     EventStream getEventStream();
+
+    /**
+     * Delete a given minion's key.
+     *
+     * @param minionId id of the minion
+     */
+    void deleteKey(String minionId);
+
+    /**
+     * Accept all keys matching the given pattern
+     *
+     * @param match a pattern for minion ids
+     */
+    void acceptKey(String match);
+
+    /**
+     * Reject a given minion's key.
+     *
+     * @param minionId id of the minion
+     */
+    void rejectKey(String minionId);
+
+    /**
+     * Get the specified grains for a given minion.
+     * @deprecated this function is too general and should be replaced by more specific functionality.
+     * @param minionId id of the target minion
+     * @param type  class type, result should be parsed into
+     * @param grainNames list of grains names
+     * @param <T> Type result should be parsed into
+     * @return Optional containing the grains parsed into specified type
+     */
+    @Deprecated
+    <T> Optional<T> getGrains(String minionId, TypeToken<T> type, String... grainNames);
+
+    /**
+     * Get the grains for a given minion.
+     *
+     * @deprecated this function is too general and should be replaced by more specific functionality.
+     * @param minionId id of the target minion
+     * @return map containing the grains
+     */
+    @Deprecated
+    Optional<Map<String, Object>> getGrains(String minionId);
+
+    /**
+     * Gets a minion's master hostname.
+     *
+     * @param minionId the minion id
+     * @return the master hostname
+     */
+    Optional<String> getMasterHostname(String minionId);
+
+    /**
+     * Run a remote command on a given minion.
+     *
+     * @param target the target
+     * @param cmd the command
+     * @return the output of the command
+     */
+    Map<String, Result<String>> runRemoteCommand(MinionList target, String cmd);
+
+    /**
+     * Delete a Salt key from the "Rejected Keys" category using the mgrutil runner.
+     *
+     * @param minionId the minionId to look for in "Rejected Keys"
+     * @return the result of the runner call as a map
+     */
+    Optional<MgrUtilRunner.ExecResult> deleteRejectedKey(String minionId);
+
+    /**
+     * Get the minion keys from salt with their respective status.
+     *
+     * @return the keys with their respective status as returned from salt
+     */
+    Key.Names getKeys();
+
+    /**
+     * Generate a key pair for the given id and accept the public key.
+     *
+     * @param id the id to use
+     * @param force set true to overwrite an already existing key
+     * @return the generated key pair
+     */
+    Key.Pair generateKeysAndAccept(String id, boolean force);
+
+    /**
+     * For a given minion id check if there is a key in any of the given status. If no status is given as parameter,
+     * all the available status are considered.
+     *
+     * @param id the id to check for
+     * @param statusIn array of key status to consider
+     * @return true if there is a key with the given id, false otherwise
+     */
+    boolean keyExists(String id, SaltService.KeyStatus... statusIn);
+
+    /**
+     * Get the minion keys from salt with their respective status and fingerprint.
+     *
+     * @return the keys with their respective status and fingerprint as returned from salt
+     */
+    Key.Fingerprints getFingerprints();
+
+    /**
+     * Remove SUSE Manager specific configuration from a Salt minion.
+     *
+     * @param minion the minion.
+     * @param timeout operation timeout
+     * @return list of error messages or empty if no error
+     */
+    Optional<List<String>> cleanupMinion(MinionServer minion, int timeout);
+
+    /**
+     * Bootstrap a system using salt-ssh.
+     *
+     * @param parameters - bootstrap parameters
+     * @param bootstrapMods - state modules to be applied during the bootstrap
+     * @param pillarData - pillar data used salt-ssh call
+     * @throws SaltException if something goes wrong during command execution or
+     * during manipulation the salt-ssh roster
+     * @return the result of the underlying ssh call for given host
+     */
+    Result<SSHResult<Map<String, State.ApplyResult>>> bootstrapMinion(
+            BootstrapParameters parameters, List<String> bootstrapMods,
+            Map<String, Object> pillarData) throws SaltException;
+
 
     /**
      * Synchronously executes a salt function on a single minion.
@@ -43,6 +318,108 @@ public interface SaltApi {
      * or empty if the minion did not respond.
      */
     <R> Optional<R> callSync(LocalCall<R> call, String minionId);
+
+    /**
+     * Run a remote command on a given minion asynchronously.
+     * @param target the target
+     * @param cmd the command to execute
+     * @param cancel a future used to cancel waiting on return events
+     * @return a map holding a {@link CompletionStage}s for each minion
+     */
+    Map<String, CompletionStage<Result<String>>> runRemoteCommandAsync(
+            MinionList target, String cmd, CompletableFuture<GenericError> cancel);
+
+    /**
+     * Returns the currently running jobs on the target
+     *
+     * @param target the target
+     * @return list of running jobs
+     */
+    Map<String, Result<List<SaltUtil.RunningInfo>>> running(MinionList target);
+
+    /**
+     * Return the result for a jobId
+     *
+     * @param jid the job id
+     * @return map from minion to result
+     */
+    Optional<Jobs.Info> listJob(String jid);
+
+    /**
+     * Match the given target expression asynchronously.
+     * @param target the target expression
+     * @param cancel  a future used to cancel waiting on return events
+     * @return a map holding a {@link CompletionStage}s for each minion
+     */
+    Map<String, CompletionStage<Result<Boolean>>> matchAsync(
+            String target, CompletableFuture<GenericError> cancel);
+
+    /**
+     * Return the jobcache filtered by metadata
+     *
+     * @param metadata search metadata
+     * @return list of running jobs
+     */
+    Optional<Map<String, Jobs.ListJobsEntry>> jobsByMetadata(Object metadata);
+
+    /**
+     * Return the jobcache filtered by metadata and start and end time.
+     *
+     * @param metadata search metadata
+     * @param startTime jobs start time
+     * @param endTime jobs end time
+     * @return list of running jobs
+     */
+    Optional<Map<String, Jobs.ListJobsEntry>> jobsByMetadata(Object metadata, LocalDateTime startTime,
+                                                             LocalDateTime endTime);
+
+    /**
+     * Executes match.glob in another thread and returns a {@link CompletionStage}.
+     * @param target the target to pass to match.glob
+     * @param cancel a future used to cancel waiting
+     * @return a future or Optional.empty if there's no ssh-push minion in the db
+     */
+    Optional<CompletionStage<Map<String, Result<Boolean>>>> matchAsyncSSH(
+            String target, CompletableFuture<GenericError> cancel);
+
+    /**
+     * Execute a LocalCall asynchronously on the default Salt client.
+     *
+     * @deprecated this function is too general and should be replaced by more specific functionality.
+     * @param <T> the return type of the call
+     * @param callIn the call to execute
+     * @param target minions targeted by the call
+     * @param metadataIn the metadata to be passed in the call
+     * @return the LocalAsyncResult of the call
+     * @throws SaltException in case of an error executing the job with Salt
+     */
+    @Deprecated
+    <T> Optional<LocalAsyncResult<T>> callAsync(LocalCall<T> callIn, Target<?> target,
+                                                Optional<ScheduleMetadata> metadataIn) throws SaltException;
+
+
+    /**
+     * Get pending resume information.
+     * @param minionIds to target.
+     * @return pending resume information.
+     * @throws SaltException if anything goes wrong.
+     */
+    Map<String, Result<Map<String, String>>> getPendingResume(List<String> minionIds) throws SaltException;
+
+    /**
+     * Execute generic salt call.
+     * @param call salt call to execute.
+     * @param minionId of the target minion.
+     * @return raw salt call result in json format.
+     */
+    Optional<JsonElement> rawJsonCall(LocalCall<?> call, String minionId);
+
+    /**
+     * @deprecated this function is too general and should be replaced by more specific functionality.
+     * @return saltSSHService to get
+     */
+    @Deprecated
+    SaltSSHService getSaltSSHService();
 
     /**
      * Call 'saltutil.refresh_pillar' to sync the grains to the target minion(s).

--- a/java/code/src/com/suse/manager/webui/services/iface/SystemQuery.java
+++ b/java/code/src/com/suse/manager/webui/services/iface/SystemQuery.java
@@ -16,36 +16,13 @@ package com.suse.manager.webui.services.iface;
 
 import com.redhat.rhn.domain.server.MinionServer;
 import com.suse.manager.clusters.ClusterProviderParameters;
-import com.suse.manager.webui.services.impl.SaltSSHService;
-import com.suse.manager.webui.services.impl.SaltService;
-import com.suse.manager.webui.services.impl.runner.MgrK8sRunner;
 import com.suse.manager.webui.services.impl.runner.MgrUtilRunner;
-import com.suse.manager.webui.utils.gson.BootstrapParameters;
-import com.suse.manager.webui.utils.salt.custom.ScheduleMetadata;
-import com.suse.salt.netapi.calls.LocalAsyncResult;
-import com.suse.salt.netapi.calls.LocalCall;
-import com.suse.salt.netapi.calls.modules.SaltUtil;
-import com.suse.salt.netapi.calls.modules.State;
 import com.suse.salt.netapi.calls.modules.Zypper;
-import com.suse.salt.netapi.calls.runner.Jobs;
-import com.suse.salt.netapi.calls.wheel.Key;
-import com.suse.salt.netapi.datatypes.target.MinionList;
-import com.suse.salt.netapi.datatypes.target.Target;
-import com.suse.salt.netapi.errors.GenericError;
 import com.suse.salt.netapi.exception.SaltException;
-import com.suse.salt.netapi.results.Result;
-import com.suse.salt.netapi.results.SSHResult;
 
-import com.google.gson.JsonElement;
-import com.google.gson.reflect.TypeToken;
-
-import java.nio.file.Path;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
 
 /**
  * Interface containing methods for directly interacting and getting information from a system.
@@ -54,116 +31,12 @@ import java.util.concurrent.CompletionStage;
 public interface SystemQuery {
 
     /**
-     * call salt test.ping
-     * @param minionId id of the target minion
-     * @return true
-     */
-    Optional<Boolean> ping(String minionId);
-
-    /**
-     * Get the minion keys from salt with their respective status.
-     *
-     * @return the keys with their respective status as returned from salt
-     */
-    Key.Names getKeys();
-
-    /**
-     * For a given minion id check if there is a key in any of the given status. If no status is given as parameter,
-     * all the available status are considered.
-     *
-     * @param id the id to check for
-     * @param statusIn array of key status to consider
-     * @return true if there is a key with the given id, false otherwise
-     */
-    boolean keyExists(String id, SaltService.KeyStatus... statusIn);
-
-    /**
-     * Get the minion keys from salt with their respective status and fingerprint.
-     *
-     * @return the keys with their respective status and fingerprint as returned from salt
-     */
-    Key.Fingerprints getFingerprints();
-
-    /**
-     * Generate a key pair for the given id and accept the public key.
-     *
-     * @param id the id to use
-     * @param force set true to overwrite an already existing key
-     * @return the generated key pair
-     */
-    Key.Pair generateKeysAndAccept(String id, boolean force);
-
-    /**
      * Get the machine id for a given minion.
      *
      * @param minionId id of the target minion
      * @return the machine id as a string
      */
     Optional<String> getMachineId(String minionId);
-
-    /**
-     * Delete a given minion's key.
-     *
-     * @param minionId id of the minion
-     */
-    void deleteKey(String minionId);
-
-    /**
-     * Accept all keys matching the given pattern
-     *
-     * @param match a pattern for minion ids
-     */
-    void acceptKey(String match);
-
-    /**
-     * Reject a given minion's key.
-     *
-     * @param minionId id of the minion
-     */
-    void rejectKey(String minionId);
-
-    /**
-     * Delete a Salt key from the "Rejected Keys" category using the mgrutil runner.
-     *
-     * @param minionId the minionId to look for in "Rejected Keys"
-     * @return the result of the runner call as a map
-     */
-    Optional<MgrUtilRunner.ExecResult> deleteRejectedKey(String minionId);
-
-    /**
-     * Run a remote command on a given minion.
-     *
-     * @param target the target
-     * @param cmd the command
-     * @return the output of the command
-     */
-    Map<String, Result<String>> runRemoteCommand(MinionList target, String cmd);
-
-    /**
-     * Run a remote command on a given minion asynchronously.
-     * @param target the target
-     * @param cmd the command to execute
-     * @param cancel a future used to cancel waiting on return events
-     * @return a map holding a {@link CompletionStage}s for each minion
-     */
-    Map<String, CompletionStage<Result<String>>> runRemoteCommandAsync(
-            MinionList target, String cmd, CompletableFuture<GenericError> cancel);
-
-    /**
-     * Returns the currently running jobs on the target
-     *
-     * @param target the target
-     * @return list of running jobs
-     */
-    Map<String, Result<List<SaltUtil.RunningInfo>>> running(MinionList target);
-
-    /**
-     * Return the result for a jobId
-     *
-     * @param jid the job id
-     * @return map from minion to result
-     */
-    Optional<Jobs.Info> listJob(String jid);
 
     /**
      * Get information about all the nodes available via a cluster.
@@ -175,131 +48,6 @@ public interface SystemQuery {
                                                                 ClusterProviderParameters clusterProviderParameters);
 
     /**
-     * Match the given target expression asynchronously.
-     * @param target the target expression
-     * @param cancel  a future used to cancel waiting on return events
-     * @return a map holding a {@link CompletionStage}s for each minion
-     */
-    Map<String, CompletionStage<Result<Boolean>>> matchAsync(
-            String target, CompletableFuture<GenericError> cancel);
-
-    /**
-     * Executes match.glob in another thread and returns a {@link CompletionStage}.
-     * @param target the target to pass to match.glob
-     * @param cancel a future used to cancel waiting
-     * @return a future or Optional.empty if there's no ssh-push minion in the db
-     */
-    Optional<CompletionStage<Map<String, Result<Boolean>>>> matchAsyncSSH(
-            String target, CompletableFuture<GenericError> cancel);
-
-    /**
-     * Call 'saltutil.sync_grains' to sync the grains to the target minion(s).
-     * @param minionList minion list
-     */
-    void syncGrains(MinionList minionList);
-
-    /**
-     * Call 'saltutil.sync_modules' to sync the grains to the target minion(s).
-     * @param minionList minion list
-     */
-    void syncModules(MinionList minionList);
-
-    /**
-     * Call 'saltutil.sync_all' to sync everything to the target minion(s).
-     * @param minionList minion list
-     */
-    void syncAll(MinionList minionList);
-
-    /**
-     * Performs an test.echo on a target set of minions for checkIn purpose.
-     * @param targetIn the target
-     * @return the LocalAsyncResult of the test.echo call
-     * @throws SaltException if we get a failure from Salt
-     */
-    Optional<LocalAsyncResult<String>> checkIn(MinionList targetIn) throws SaltException;
-
-    /**
-     * Apply util.systeminfo state on the specified minion list
-     * @param minionTarget minion list
-     */
-    void updateSystemInfo(MinionList minionTarget);
-
-    /**
-     * Gets a minion's master hostname.
-     *
-     * @param minionId the minion id
-     * @return the master hostname
-     */
-    Optional<String> getMasterHostname(String minionId);
-
-    /**
-     * Bootstrap a system using salt-ssh.
-     *
-     * @param parameters - bootstrap parameters
-     * @param bootstrapMods - state modules to be applied during the bootstrap
-     * @param pillarData - pillar data used salt-ssh call
-     * @throws SaltException if something goes wrong during command execution or
-     * during manipulation the salt-ssh roster
-     * @return the result of the underlying ssh call for given host
-     */
-    Result<SSHResult<Map<String, State.ApplyResult>>> bootstrapMinion(
-            BootstrapParameters parameters, List<String> bootstrapMods,
-            Map<String, Object> pillarData) throws SaltException;
-
-    /**
-     * Store the files uploaded by a minion to the SCAP storage directory.
-     * @param minion the minion
-     * @param uploadDir the uploadDir
-     * @param actionId the action id
-     * @return a map with one element: @{code true} -> scap store path,
-     * {@code false} -> err message
-     *
-     */
-    Map<Boolean, String> storeMinionScapFiles(MinionServer minion, String uploadDir, Long actionId);
-
-    /**
-     * Call the custom mgrutil.ssh_keygen runner if the key files are not present.
-     *
-     * @param path of the key files
-     * @return the result of the runner call as a map
-     */
-    Optional<MgrUtilRunner.ExecResult> generateSSHKey(String path);
-
-    /**
-     * Chain ssh calls over one or more hops to run a command on the last host in the chain.
-     * This calls the mgrutil.chain_ssh_command runner.
-     *
-     * @param hosts a list of hosts, where the last one is where
-     *              the command will be executed
-     * @param clientKey the ssh key to use to connect to the first host
-     * @param proxyKey the ssh key path to use for the rest of the hosts
-     * @param user the user
-     * @param options ssh options
-     * @param command the command to execute
-     * @param outputfile the file to which to dump the command stdout
-     * @return the execution result
-     */
-    Optional<MgrUtilRunner.ExecResult> chainSSHCommand(List<String> hosts, String clientKey, String proxyKey,
-            String user, Map<String, String> options, String command, String outputfile);
-
-    /**
-     * Get information about all containers running in a Kubernetes cluster.
-     * @param kubeconfig path to the kubeconfig file
-     * @param context kubeconfig context to use
-     * @return a list of containers
-     */
-    Optional<List<MgrK8sRunner.Container>> getAllContainers(String kubeconfig, String context);
-
-    /**
-     * Remove SUSE Manager specific configuration from a Salt minion.
-     *
-     * @param minion the minion.
-     * @param timeout operation timeout
-     * @return list of error messages or empty if no error
-     */
-    Optional<List<String>> cleanupMinion(MinionServer minion, int timeout);
-
-    /**
      * Send notification about a system id to be generated.
      * @param minion target minion.
      * @throws InstantiationException if signature generation fails
@@ -308,49 +56,11 @@ public interface SystemQuery {
     void notifySystemIdGenerated(MinionServer minion) throws InstantiationException, SaltException;
 
     /**
-     * Get pending resume information.
-     * @param minionIds to target.
-     * @return pending resume information.
-     * @throws SaltException if anything goes wrong.
-     */
-    Map<String, Result<Map<String, String>>> getPendingResume(List<String> minionIds) throws SaltException;
-
-    /**
-     * Return show highstate result.
-     * @param minionId of the target minion.
-     * @return show highstate result.
-     * @throws SaltException if anything goes wrong.
-     */
-    Map<String, Result<Object>> showHighstate(String minionId) throws SaltException;
-
-    /**
      * Query product information.
      * @param minionId of the target minion.
      * @return product information
      */
     Optional<List<Zypper.ProductInfo>> getProducts(String minionId);
-
-    /**
-     * Execute a LocalCall asynchronously on the default Salt client.
-     *
-     * @deprecated this function is too general and should be replaced by more specific functionality.
-     * @param <T> the return type of the call
-     * @param callIn the call to execute
-     * @param target minions targeted by the call
-     * @param metadataIn the metadata to be passed in the call
-     * @return the LocalAsyncResult of the call
-     * @throws SaltException in case of an error executing the job with Salt
-     */
-    @Deprecated
-    <T> Optional<LocalAsyncResult<T>> callAsync(LocalCall<T> callIn, Target<?> target,
-            Optional<ScheduleMetadata> metadataIn) throws SaltException;
-
-    /**
-     * Sync the channels of a list of minions
-     * @param minionIds of the targets.
-     * @throws SaltException if anything goes wrong.
-     */
-    void deployChannels(List<String> minionIds) throws SaltException;
 
     /**
      * Upload built Kiwi image to SUSE Manager
@@ -364,91 +74,9 @@ public interface SystemQuery {
             String imageStore);
 
     /**
-     * Execute generic salt call.
-     * @param call salt call to execute.
-     * @param minionId of the target minion.
-     * @return raw salt call result in json format.
-     */
-    Optional<JsonElement> rawJsonCall(LocalCall<?> call, String minionId);
-
-    /**
-     * Return the jobcache filtered by metadata
-     *
-     * @param metadata search metadata
-     * @return list of running jobs
-     */
-    Optional<Map<String, Jobs.ListJobsEntry>> jobsByMetadata(Object metadata);
-
-    /**
-     * Return the jobcache filtered by metadata and start and end time.
-     *
-     * @param metadata search metadata
-     * @param startTime jobs start time
-     * @param endTime jobs end time
-     * @return list of running jobs
-     */
-    Optional<Map<String, Jobs.ListJobsEntry>> jobsByMetadata(Object metadata, LocalDateTime startTime,
-            LocalDateTime endTime);
-
-    /**
-     * Get the specified grains for a given minion.
-     * @deprecated this function is too general and should be replaced by more specific functionality.
-     * @param minionId id of the target minion
-     * @param type  class type, result should be parsed into
-     * @param grainNames list of grains names
-     * @param <T> Type result should be parsed into
-     * @return Optional containing the grains parsed into specified type
-     */
-    @Deprecated
-    <T> Optional<T> getGrains(String minionId, TypeToken<T> type, String... grainNames);
-
-    /**
-     * Get the grains for a given minion.
-     *
-     * @deprecated this function is too general and should be replaced by more specific functionality.
-     * @param minionId id of the target minion
-     * @return map containing the grains
-     */
-    @Deprecated
-    Optional<Map<String, Object>> getGrains(String minionId);
-
-    /**
-     * @deprecated this function is too general and should be replaced by more specific functionality.
-     * @return saltSSHService to get
-     */
-    @Deprecated
-    SaltSSHService getSaltSSHService();
-
-    /**
      * Get redhat product information
      * @param minionId id of the target minion
      * @return redhat product information
      */
     Optional<RedhatProductInfo> redhatProductInfo(String minionId);
-
-    /**
-     * Using a RunnerCall, store given contents to given path and set the mode, so that SSH likes it
-     * (read-write for owner, nothing for others).
-     *
-     * @param path the path where key will be stored
-     * @param contents the contents of the key (PEM format)
-     * @throws IllegalStateException if something goes wrong during the operation, or if given path is not absolute
-     */
-    void storeSshKeyFile(Path path, String contents);
-
-    /**
-     * Remove given file using RunnerCall
-     *
-     * @param path the path of file to be removed
-     * @throws IllegalStateException if the given path is not absolute
-     * @return Optional with true if the file deletion succeeded.
-     */
-    Optional<Boolean> removeFile(Path path);
-
-    /**
-     * Match minions synchronously using a compound matcher.
-     * @param target compound matcher
-     * @return list of minion ids
-     */
-    List<String> matchCompoundSync(String target);
 }

--- a/java/code/src/com/suse/manager/webui/services/impl/SaltSSHService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltSSHService.java
@@ -551,7 +551,7 @@ public class SaltSSHService {
 
         try {
             tmpKeyFileAbsolutePath.ifPresent(p -> parameters.getPrivateKey().ifPresent(k ->
-                    GlobalInstanceHolder.SYSTEM_QUERY.storeSshKeyFile(p, k)));
+                    GlobalInstanceHolder.SALT_API.storeSshKeyFile(p, k)));
             SaltRoster roster = new SaltRoster();
             roster.addHost(parameters.getHost(),
                     parameters.getUser(),
@@ -586,7 +586,7 @@ public class SaltSSHService {
     }
 
     private void cleanUpTempKeyFile(Path path) {
-        GlobalInstanceHolder.SYSTEM_QUERY
+        GlobalInstanceHolder.SALT_API
                 .removeFile(path)
                 .orElseThrow(() -> new IllegalStateException("Can't remove file " + path));
     }
@@ -783,7 +783,7 @@ public class SaltSSHService {
         Map<String, String> options = new HashMap<>();
         options.put("StrictHostKeyChecking", "no");
         options.put("ConnectTimeout", ConfigDefaults.get().getSaltSSHConnectTimeout() + "");
-        Optional<MgrUtilRunner.ExecResult> ret = GlobalInstanceHolder.SYSTEM_QUERY
+        Optional<MgrUtilRunner.ExecResult> ret = GlobalInstanceHolder.SALT_API
                 .chainSSHCommand(proxyPath,
                         SSH_KEY_PATH,
                         PROXY_SSH_PUSH_KEY,

--- a/java/code/src/com/suse/manager/webui/services/pillar/test/MinionVirtualizationPillarGeneratorTest.java
+++ b/java/code/src/com/suse/manager/webui/services/pillar/test/MinionVirtualizationPillarGeneratorTest.java
@@ -30,6 +30,7 @@ import com.redhat.rhn.testing.BaseTestCaseWithUser;
 import com.suse.manager.virtualization.GuestDefinition;
 import com.suse.manager.virtualization.PoolCapabilitiesJson;
 import com.suse.manager.virtualization.PoolDefinition;
+import com.suse.manager.webui.services.test.TestSaltApi;
 import com.suse.manager.webui.services.test.TestSystemQuery;
 import com.suse.manager.webui.services.iface.VirtManager;
 import com.suse.manager.webui.services.pillar.MinionPillarFileManager;
@@ -106,7 +107,7 @@ public class MinionVirtualizationPillarGeneratorTest extends BaseTestCaseWithUse
         systemEntitlementManager = new SystemEntitlementManager(
                 new SystemUnentitler(virtManager, new FormulaMonitoringManager(),
                         serverGroupManager),
-                new SystemEntitler(new TestSystemQuery(), virtManager, new FormulaMonitoringManager(),
+                new SystemEntitler(new TestSaltApi(), virtManager, new FormulaMonitoringManager(),
                         serverGroupManager)
         );
     }

--- a/java/code/src/com/suse/manager/webui/services/test/TestSaltApi.java
+++ b/java/code/src/com/suse/manager/webui/services/test/TestSaltApi.java
@@ -1,20 +1,246 @@
 package com.suse.manager.webui.services.test;
 
+import com.google.gson.JsonElement;
+import com.google.gson.reflect.TypeToken;
+import com.redhat.rhn.domain.server.MinionServer;
 import com.suse.manager.webui.services.iface.SaltApi;
+import com.suse.manager.webui.services.impl.SaltSSHService;
+import com.suse.manager.webui.services.impl.SaltService;
+import com.suse.manager.webui.services.impl.runner.MgrK8sRunner;
+import com.suse.manager.webui.services.impl.runner.MgrUtilRunner;
+import com.suse.manager.webui.utils.gson.BootstrapParameters;
+import com.suse.manager.webui.utils.salt.custom.ScheduleMetadata;
+import com.suse.salt.netapi.calls.LocalAsyncResult;
 import com.suse.salt.netapi.calls.LocalCall;
+import com.suse.salt.netapi.calls.modules.SaltUtil;
+import com.suse.salt.netapi.calls.modules.State;
+import com.suse.salt.netapi.calls.runner.Jobs;
+import com.suse.salt.netapi.calls.wheel.Key;
 import com.suse.salt.netapi.datatypes.target.MinionList;
+import com.suse.salt.netapi.datatypes.target.Target;
+import com.suse.salt.netapi.errors.GenericError;
 import com.suse.salt.netapi.event.EventStream;
+import com.suse.salt.netapi.exception.SaltException;
+import com.suse.salt.netapi.results.Result;
+import com.suse.salt.netapi.results.SSHResult;
 
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
 
 public class TestSaltApi implements SaltApi {
+
+    @Override
+    public void deployChannels(List<String> minionIds) throws SaltException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<List<MgrK8sRunner.Container>> getAllContainers(String kubeconfig, String context) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void storeSshKeyFile(Path path, String contents) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<String> matchCompoundSync(String target) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<Boolean> removeFile(Path path) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<LocalAsyncResult<String>> checkIn(MinionList targetIn) throws SaltException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void updateSystemInfo(MinionList minionTarget) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<Boolean, String> storeMinionScapFiles(MinionServer minion, String uploadDir, Long actionId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<String, Result<Object>> showHighstate(String minionId) throws SaltException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<MgrUtilRunner.ExecResult> generateSSHKey(String path) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<MgrUtilRunner.ExecResult> chainSSHCommand(List<String> hosts, String clientKey, String proxyKey, String user, Map<String, String> options, String command, String outputfile) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void syncGrains(MinionList minionList) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void syncModules(MinionList minionList) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void syncAll(MinionList minionList) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<Boolean> ping(String minionId) {
+        throw new UnsupportedOperationException();
+    }
+
     @Override
     public EventStream getEventStream() {
         throw new UnsupportedOperationException();
     }
 
     @Override
+    public void deleteKey(String minionId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void acceptKey(String match) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void rejectKey(String minionId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> Optional<T> getGrains(String minionId, TypeToken<T> type, String... grainNames) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<Map<String, Object>> getGrains(String minionId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<String> getMasterHostname(String minionId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<String, Result<String>> runRemoteCommand(MinionList target, String cmd) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<MgrUtilRunner.ExecResult> deleteRejectedKey(String minionId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Key.Names getKeys() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Key.Pair generateKeysAndAccept(String id, boolean force) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean keyExists(String id, SaltService.KeyStatus... statusIn) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Key.Fingerprints getFingerprints() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<List<String>> cleanupMinion(MinionServer minion, int timeout) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Result<SSHResult<Map<String, State.ApplyResult>>> bootstrapMinion(BootstrapParameters parameters, List<String> bootstrapMods, Map<String, Object> pillarData) throws SaltException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public <R> Optional<R> callSync(LocalCall<R> call, String minionId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<String, CompletionStage<Result<String>>> runRemoteCommandAsync(MinionList target, String cmd, CompletableFuture<GenericError> cancel) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<String, Result<List<SaltUtil.RunningInfo>>> running(MinionList target) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<Jobs.Info> listJob(String jid) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map<String, CompletionStage<Result<Boolean>>> matchAsync(String target, CompletableFuture<GenericError> cancel) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<Map<String, Jobs.ListJobsEntry>> jobsByMetadata(Object metadata) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<Map<String, Jobs.ListJobsEntry>> jobsByMetadata(Object metadata, LocalDateTime startTime, LocalDateTime endTime) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<CompletionStage<Map<String, Result<Boolean>>>> matchAsyncSSH(String target, CompletableFuture<GenericError> cancel) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> Optional<LocalAsyncResult<T>> callAsync(LocalCall<T> callIn, Target<?> target, Optional<ScheduleMetadata> metadataIn) throws SaltException {
+        return Optional.empty();
+    }
+
+    @Override
+    public Map<String, Result<Map<String, String>>> getPendingResume(List<String> minionIds) throws SaltException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<JsonElement> rawJsonCall(LocalCall<?> call, String minionId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public SaltSSHService getSaltSSHService() {
         throw new UnsupportedOperationException();
     }
 

--- a/java/code/src/com/suse/manager/webui/services/test/TestSystemQuery.java
+++ b/java/code/src/com/suse/manager/webui/services/test/TestSystemQuery.java
@@ -37,73 +37,7 @@ import java.util.concurrent.CompletionStage;
 public class TestSystemQuery implements SystemQuery {
 
     @Override
-    public Optional<Boolean> ping(String minionId) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Key.Names getKeys() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public boolean keyExists(String id, SaltService.KeyStatus... statusIn) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Key.Fingerprints getFingerprints() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Key.Pair generateKeysAndAccept(String id, boolean force) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public Optional<String> getMachineId(String minionId) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void deleteKey(String minionId) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void acceptKey(String match) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void rejectKey(String minionId) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Optional<MgrUtilRunner.ExecResult> deleteRejectedKey(String minionId) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Map<String, Result<String>> runRemoteCommand(MinionList target, String cmd) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Map<String, CompletionStage<Result<String>>> runRemoteCommandAsync(
-            MinionList target, String cmd, CompletableFuture<GenericError> cancel) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Map<String, Result<List<SaltUtil.RunningInfo>>> running(MinionList target) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Optional<Jobs.Info> listJob(String jid) {
         throw new UnsupportedOperationException();
     }
 
@@ -114,109 +48,12 @@ public class TestSystemQuery implements SystemQuery {
     }
 
     @Override
-    public Map<String, CompletionStage<Result<Boolean>>> matchAsync(
-            String target, CompletableFuture<GenericError> cancel) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Optional<CompletionStage<Map<String, Result<Boolean>>>> matchAsyncSSH(
-            String target, CompletableFuture<GenericError> cancel) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void syncGrains(MinionList minionList) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void syncModules(MinionList minionList) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void syncAll(MinionList minionList) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Optional<LocalAsyncResult<String>> checkIn(MinionList targetIn) throws SaltException {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void updateSystemInfo(MinionList minionTarget) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Optional<String> getMasterHostname(String minionId) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Result<SSHResult<Map<String, State.ApplyResult>>> bootstrapMinion(
-            BootstrapParameters parameters, List<String> bootstrapMods,
-            Map<String, Object> pillarData) throws SaltException {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Map<Boolean, String> storeMinionScapFiles(MinionServer minion, String uploadDir, Long actionId) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Optional<MgrUtilRunner.ExecResult> generateSSHKey(String path) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Optional<MgrUtilRunner.ExecResult> chainSSHCommand(
-            List<String> hosts, String clientKey, String proxyKey, String user, Map<String, String> options,
-            String command, String outputfile) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Optional<List<MgrK8sRunner.Container>> getAllContainers(String kubeconfig, String context) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Optional<List<String>> cleanupMinion(MinionServer minion, int timeout) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public void notifySystemIdGenerated(MinionServer minion) throws InstantiationException, SaltException {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public Map<String, Result<Map<String, String>>> getPendingResume(List<String> minionIds) throws SaltException {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Map<String, Result<Object>> showHighstate(String minionId) throws SaltException {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public Optional<List<Zypper.ProductInfo>> getProducts(String minionId) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public <T> Optional<LocalAsyncResult<T>> callAsync(
-            LocalCall<T> callIn, Target<?> target, Optional<ScheduleMetadata> metadataIn) throws SaltException {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void deployChannels(List<String> minionIds) throws SaltException {
         throw new UnsupportedOperationException();
     }
 
@@ -227,53 +64,7 @@ public class TestSystemQuery implements SystemQuery {
     }
 
     @Override
-    public Optional<JsonElement> rawJsonCall(LocalCall<?> call, String minionId) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Optional<Map<String, Jobs.ListJobsEntry>> jobsByMetadata(Object metadata) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Optional<Map<String, Jobs.ListJobsEntry>> jobsByMetadata(
-            Object metadata, LocalDateTime startTime, LocalDateTime endTime) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public <T> Optional<T> getGrains(String minionId, TypeToken<T> type, String... grainNames) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Optional<Map<String, Object>> getGrains(String minionId) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public SaltSSHService getSaltSSHService() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
     public Optional<RedhatProductInfo> redhatProductInfo(String minionId) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void storeSshKeyFile(Path path, String contents) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public Optional<Boolean> removeFile(Path path) {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public List<String> matchCompoundSync(String target) {
         throw new UnsupportedOperationException();
     }
 }

--- a/java/code/src/com/suse/manager/webui/utils/test/InputValidatorTest.java
+++ b/java/code/src/com/suse/manager/webui/utils/test/InputValidatorTest.java
@@ -16,7 +16,9 @@ package com.suse.manager.webui.utils.test;
 
 import com.suse.manager.webui.controllers.MinionsAPI;
 import com.suse.manager.webui.controllers.utils.RegularMinionBootstrapper;
+import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.SystemQuery;
+import com.suse.manager.webui.services.test.TestSaltApi;
 import com.suse.manager.webui.services.test.TestSystemQuery;
 import com.suse.manager.webui.utils.InputValidator;
 import com.suse.manager.webui.utils.gson.BootstrapHostsJson;
@@ -37,6 +39,7 @@ public class InputValidatorTest extends TestCase {
     private static final String PORT_ERROR_MESSAGE = "Port must be a number within range" +
             " 1-65535.";
 
+    private SaltApi saltApi = new TestSaltApi();
     private SystemQuery systemQuery = new TestSystemQuery();
 
     /**
@@ -45,7 +48,7 @@ public class InputValidatorTest extends TestCase {
     public void testValidateBootstrapInputUserEmpty() {
         String json = "{user: ''}";
         BootstrapHostsJson input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
-        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery).createBootstrapParams(input);
+        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery, saltApi).createBootstrapParams(input);
         List<String> validationErrors = InputValidator.INSTANCE.validateBootstrapInput(params);
         assertTrue(validationErrors.size() == 2);
         assertTrue(validationErrors.contains(HOST_ERROR_MESSAGE));
@@ -58,7 +61,7 @@ public class InputValidatorTest extends TestCase {
     public void testValidateBootstrapInputUserLettersNumbers() {
         String json = "{user: 'Admin1', host: 'host.domain.com'}";
         BootstrapHostsJson input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
-        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery).createBootstrapParams(input);
+        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery, saltApi).createBootstrapParams(input);
         List<String> validationErrors = InputValidator.INSTANCE.validateBootstrapInput(params);
         assertTrue(validationErrors.isEmpty());
     }
@@ -69,7 +72,7 @@ public class InputValidatorTest extends TestCase {
     public void testValidateBootstrapInputUserDot() {
         String json = "{user: 'my.admin', host: 'host.domain.com'}";
         BootstrapHostsJson input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
-        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery).createBootstrapParams(input);
+        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery, saltApi).createBootstrapParams(input);
         List<String> validationErrors = InputValidator.INSTANCE.validateBootstrapInput(params);
         assertTrue(validationErrors.isEmpty());
     }
@@ -80,7 +83,7 @@ public class InputValidatorTest extends TestCase {
     public void testValidateBootstrapInputUserBackslash() {
         String json = "{user: 'domain\\\\admin', host: 'host.domain.com'}";
         BootstrapHostsJson input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
-        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery).createBootstrapParams(input);
+        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery, saltApi).createBootstrapParams(input);
         List<String> validationErrors = InputValidator.INSTANCE.validateBootstrapInput(params);
         assertTrue(validationErrors.isEmpty());
     }
@@ -91,7 +94,7 @@ public class InputValidatorTest extends TestCase {
     public void testValidateBootstrapInputUserDash() {
         String json = "{user: 'my-admin', host: 'host.domain.com'}";
         BootstrapHostsJson input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
-        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery).createBootstrapParams(input);
+        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery, saltApi).createBootstrapParams(input);
         List<String> validationErrors = InputValidator.INSTANCE.validateBootstrapInput(params);
         assertTrue(validationErrors.isEmpty());
     }
@@ -102,7 +105,7 @@ public class InputValidatorTest extends TestCase {
     public void testValidateBootstrapInputUserUnderscore() {
         String json = "{user: 'my_admin', host: 'host.domain.com'}";
         BootstrapHostsJson input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
-        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery).createBootstrapParams(input);
+        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery, saltApi).createBootstrapParams(input);
         List<String> validationErrors = InputValidator.INSTANCE.validateBootstrapInput(params);
         assertTrue(validationErrors.isEmpty());
     }
@@ -113,7 +116,7 @@ public class InputValidatorTest extends TestCase {
     public void testValidateBootstrapInputUserInvalid() {
         String json = "{user: '$(execme)', host: 'host.domain.com'}";
         BootstrapHostsJson input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
-        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery).createBootstrapParams(input);
+        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery, saltApi).createBootstrapParams(input);
         List<String> validationErrors = InputValidator.INSTANCE.validateBootstrapInput(params);
         assertTrue(validationErrors.size() == 1);
         assertTrue(validationErrors.contains(USER_ERROR_MESSAGE));
@@ -125,7 +128,7 @@ public class InputValidatorTest extends TestCase {
     public void testValidateBootstrapInputHostInvalid() {
         String json = "{user: 'toor', host: '`execme`'}";
         BootstrapHostsJson input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
-        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery).createBootstrapParams(input);
+        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery, saltApi).createBootstrapParams(input);
         List<String> validationErrors = InputValidator.INSTANCE.validateBootstrapInput(params);
         assertTrue(validationErrors.size() == 1);
         assertTrue(validationErrors.contains(HOST_ERROR_MESSAGE));
@@ -137,7 +140,7 @@ public class InputValidatorTest extends TestCase {
     public void testValidateBootstrapInputHostIPv4() {
         String json = "{user: 'toor', host: '192.168.1.1'}";
         BootstrapHostsJson input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
-        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery).createBootstrapParams(input);
+        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery, saltApi).createBootstrapParams(input);
         List<String> validationErrors = InputValidator.INSTANCE.validateBootstrapInput(params);
         assertTrue(validationErrors.isEmpty());
     }
@@ -148,7 +151,7 @@ public class InputValidatorTest extends TestCase {
     public void testValidateBootstrapInputHostIPv6() {
         String json = "{user: 'toor', host: '[2001:0db8:0000:0000:0000:0000:1428:57ab]'}";
         BootstrapHostsJson input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
-        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery).createBootstrapParams(input);
+        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery, saltApi).createBootstrapParams(input);
         List<String> validationErrors = InputValidator.INSTANCE.validateBootstrapInput(params);
         assertTrue(validationErrors.isEmpty());
     }
@@ -159,7 +162,7 @@ public class InputValidatorTest extends TestCase {
     public void testValidateBootstrapInputDefaultUser() {
         String json = "{}";
         BootstrapHostsJson input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
-        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery).createBootstrapParams(input);
+        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery, saltApi).createBootstrapParams(input);
         List<String> validationErrors = InputValidator.INSTANCE.validateBootstrapInput(params);
         assertTrue(validationErrors.size() == 1);
         assertTrue(validationErrors.contains(HOST_ERROR_MESSAGE));
@@ -171,7 +174,7 @@ public class InputValidatorTest extends TestCase {
     public void testValidateBootstrapInputMinimal() {
         String json = "{host: 'host.domain.com', user: 'root'}";
         BootstrapHostsJson input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
-        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery).createBootstrapParams(input);
+        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery, saltApi).createBootstrapParams(input);
         List<String> validationErrors = InputValidator.INSTANCE.validateBootstrapInput(params);
         assertTrue(validationErrors.isEmpty());
     }
@@ -182,7 +185,7 @@ public class InputValidatorTest extends TestCase {
     public void testValidateBootstrapInputPortEmpty() {
         String json = "{host: 'host.domain.com', user: 'root', port: ''}";
         BootstrapHostsJson input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
-        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery).createBootstrapParams(input);
+        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery, saltApi).createBootstrapParams(input);
         List<String> validationErrors = InputValidator.INSTANCE.validateBootstrapInput(params);
         assertTrue(validationErrors.isEmpty());
     }
@@ -193,14 +196,14 @@ public class InputValidatorTest extends TestCase {
     public void testValidateBootstrapInputPortRange() {
         String json = "{host: 'host.domain.com', user: 'root', port: '99999'}";
         BootstrapHostsJson input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
-        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery).createBootstrapParams(input);
+        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery, saltApi).createBootstrapParams(input);
         List<String> validationErrors = InputValidator.INSTANCE.validateBootstrapInput(params);
         assertTrue(validationErrors.size() == 1);
         assertTrue(validationErrors.contains(PORT_ERROR_MESSAGE));
 
         json = "{host: 'host.domain.com', user: 'root', port: '-1'}";
         input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
-        params = new RegularMinionBootstrapper(systemQuery).createBootstrapParams(input);
+        params = new RegularMinionBootstrapper(systemQuery, saltApi).createBootstrapParams(input);
         validationErrors = InputValidator.INSTANCE.validateBootstrapInput(params);
         assertTrue(validationErrors.size() == 1);
         assertTrue(validationErrors.contains(PORT_ERROR_MESSAGE));
@@ -212,7 +215,7 @@ public class InputValidatorTest extends TestCase {
     public void testValidateBootstrapInputPortValid() {
         String json = "{host: 'host.domain.com', user: 'root', port: '8888'}";
         BootstrapHostsJson input = MinionsAPI.GSON.fromJson(json, BootstrapHostsJson.class);
-        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery).createBootstrapParams(input);
+        BootstrapParameters params = new RegularMinionBootstrapper(systemQuery, saltApi).createBootstrapParams(input);
         List<String> validationErrors = InputValidator.INSTANCE.validateBootstrapInput(params);
         assertTrue(validationErrors.isEmpty());
     }

--- a/java/code/src/com/suse/manager/webui/utils/test/MinionActionUtilsTest.java
+++ b/java/code/src/com/suse/manager/webui/utils/test/MinionActionUtilsTest.java
@@ -53,10 +53,10 @@ public class MinionActionUtilsTest extends BaseTestCaseWithUser {
         ServerGroupManager serverGroupManager = new ServerGroupManager();
         ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);
         SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, clusterManager, formulaManager, serverGroupManager);
-        SaltKeyUtils saltKeyUtils = new SaltKeyUtils(systemQuery);
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils,
+        SaltKeyUtils saltKeyUtils = new SaltKeyUtils(saltApi);
+        SaltServerActionService saltServerActionService = new SaltServerActionService(saltApi, saltUtils,
                 clusterManager, formulaManager, saltKeyUtils);
-        MinionActionUtils minionActionUtils = new MinionActionUtils(saltServerActionService, systemQuery,
+        MinionActionUtils minionActionUtils = new MinionActionUtils(saltServerActionService, saltApi,
                 saltUtils);
 
         saltUtils.setScriptsDir(Files.createTempDirectory("scripts"));
@@ -85,10 +85,10 @@ public class MinionActionUtilsTest extends BaseTestCaseWithUser {
         ServerGroupManager serverGroupManager = new ServerGroupManager();
         ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);
         SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, clusterManager, formulaManager, serverGroupManager);
-        SaltKeyUtils saltKeyUtils = new SaltKeyUtils(systemQuery);
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils,
+        SaltKeyUtils saltKeyUtils = new SaltKeyUtils(saltApi);
+        SaltServerActionService saltServerActionService = new SaltServerActionService(saltApi, saltUtils,
                 clusterManager, formulaManager, saltKeyUtils);
-        MinionActionUtils minionActionUtils = new MinionActionUtils(saltServerActionService, systemQuery,
+        MinionActionUtils minionActionUtils = new MinionActionUtils(saltServerActionService, saltApi,
                 saltUtils);
         saltUtils.setScriptsDir(Files.createTempDirectory("scripts"));
         Path scriptFile = Files.createFile(saltUtils.getScriptPath(123456L));
@@ -109,10 +109,10 @@ public class MinionActionUtilsTest extends BaseTestCaseWithUser {
         ServerGroupManager serverGroupManager = new ServerGroupManager();
         ClusterManager clusterManager = new ClusterManager(saltApi, systemQuery, serverGroupManager, formulaManager);
         SaltUtils saltUtils = new SaltUtils(systemQuery, saltApi, clusterManager, formulaManager, serverGroupManager);
-        SaltKeyUtils saltKeyUtils = new SaltKeyUtils(systemQuery);
-        SaltServerActionService saltServerActionService = new SaltServerActionService(systemQuery, saltUtils,
+        SaltKeyUtils saltKeyUtils = new SaltKeyUtils(saltApi);
+        SaltServerActionService saltServerActionService = new SaltServerActionService(saltApi, saltUtils,
                 clusterManager, formulaManager, saltKeyUtils);
-        MinionActionUtils minionActionUtils = new MinionActionUtils(saltServerActionService, systemQuery,
+        MinionActionUtils minionActionUtils = new MinionActionUtils(saltServerActionService, saltApi,
                 saltUtils);
         saltUtils.setScriptsDir(Files.createTempDirectory("scripts"));
         Action action = ActionFactoryTest.createAction(user, ActionFactory.TYPE_SCRIPT_RUN);

--- a/java/code/src/com/suse/manager/webui/websocket/RemoteMinionCommands.java
+++ b/java/code/src/com/suse/manager/webui/websocket/RemoteMinionCommands.java
@@ -27,7 +27,7 @@ import com.redhat.rhn.frontend.servlets.LocalizedEnvironmentFilter;
 import com.redhat.rhn.manager.system.SystemManager;
 import com.suse.manager.maintenance.MaintenanceManager;
 import com.suse.manager.webui.services.FutureUtils;
-import com.suse.manager.webui.services.iface.SystemQuery;
+import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.websocket.json.AsyncJobStartEventDto;
 import com.suse.manager.webui.websocket.json.ExecuteMinionActionDto;
 import com.suse.manager.webui.websocket.json.MinionMatchResultEventDto;
@@ -82,7 +82,7 @@ public class RemoteMinionCommands {
     private CompletableFuture failAfter;
     private List<String> previewedMinions;
     private static ExecutorService eventHistoryExecutor = Executors.newCachedThreadPool();
-    private static SystemQuery systemQuery = GlobalInstanceHolder.SYSTEM_QUERY;
+    private static SaltApi saltApi = GlobalInstanceHolder.SALT_API;
 
     /**
      * Callback executed when the websocket is opened.
@@ -146,11 +146,11 @@ public class RemoteMinionCommands {
                 String target = StringUtils.trim(msg.getTarget());
 
                 Optional<CompletionStage<Map<String, Result<Boolean>>>> resSSH =
-                        systemQuery.matchAsyncSSH(target, failAfter);
+                        saltApi.matchAsyncSSH(target, failAfter);
 
                 Map<String, CompletionStage<Result<Boolean>>> res = new HashMap<>();
 
-                res = systemQuery.matchAsync(target, failAfter);
+                res = saltApi.matchAsync(target, failAfter);
                 if (res.isEmpty() && !resSSH.isPresent()) {
                     // just return, no need to wait for salt-ssh results
                     sendMessage(session, new ActionErrorEventDto(null,
@@ -261,7 +261,7 @@ public class RemoteMinionCommands {
                 this.failAfter = FutureUtils.failAfter(timeOut);
                 Map<String, CompletionStage<Result<String>>> res;
                 try {
-                    res = systemQuery
+                    res = saltApi
                             .runRemoteCommandAsync(new MinionList(previewedMinions),
                                     msg.getCommand(), failAfter);
                     LOG.info("User '" + webSession.getUser().getLogin() + "' has sent the command '" +


### PR DESCRIPTION
## What does this PR change?

Cleanup `SystemQuery` interface by moving salt specific methods to `SaltApi`

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests:

- [x] **DONE**

## Links

Fixes # https://github.com/SUSE/spacewalk/issues/10719

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
