### PR TITLE
Force disable SPA for non-navigation links (bsc#1175512)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/taglibs/list/CSVTag.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/list/CSVTag.java
@@ -199,7 +199,7 @@ public class CSVTag extends BodyTagSupport {
         page.append("?" + makeCSVRequestParams());
         IconTag i = new IconTag("item-download-csv");
         String exportLink = new String("<div class=\"spacewalk-csv-download\">" +
-                "<a class=\"btn btn-link\" href=\"" + page + "\">" + i.render() +
+                "<a class=\"btn btn-link no-spa\" href=\"" + page + "\">" + i.render() +
                 LocalizationService.getInstance().getMessage(
                 "listdisplay.csv") + "</a></div>");
         ListTagUtil.write(pageContext, exportLink);

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Force disable SPA for non-navigation links (bsc#1175512)
 - pass the log level parameter to matcher
 - Detect client organization from connected proxy (bsc#1175545)
 - Add language picker to user preferences and user creation

--- a/web/html/src/core/spa/spa-engine.js
+++ b/web/html/src/core/spa/spa-engine.js
@@ -59,7 +59,7 @@ window.pageRenderers.spaengine.init = function init() {
 
       let urlParser = document.createElement('a');
       urlParser.href = navigation.path;
-      if(isLoginPage(urlParser.pathname)) {
+      if(isLoginPage(urlParser.pathname) || navigation.event.target.classList.contains('no-spa')) {
         window.location = navigation.path;
       }
     })

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Force disable SPA for non-navigation links (bsc#1175512)
 - Add translation support for react t() function
 - fix striping on react tables
 - Update translation strings


### PR DESCRIPTION
## What does this PR change?

Prevent Single Page Application engine to be applied to non-navigation links.

**Known issue**: after this patch the URL still gets overwritten by the link `href` value, even if it is not intended to.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests:

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/12216
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
