### PR TITLE
TestSuite: Fix typo, handling repos

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -680,10 +680,10 @@ When(/^I (enable|disable) (the repositories|repository) "([^"]*)" on this "([^"]
   else
     cmd = repos.split(' ').map do |repo|
       if os_family =~ /^centos/
-        "sed -i 's/enabled=.*/enabled=#{action == 'enabled' ? '1' : '0'}/g' /etc/yum.repos.d/#{repo}.repo; "
+        "sed -i 's/enabled=.*/enabled=#{action == 'enable' ? '1' : '0'}/g' /etc/yum.repos.d/#{repo}.repo; "
       elsif os_family =~ /^ubuntu/
-        "sed -i '/^#{action == 'enabled' ? '#\\s*' : ''}deb.*/ s/^#{action == 'enabled' ? '' : '#\\s*'}deb "\
-        "/#{action == 'enabled' ? '' : '#'}deb /' /etc/apt/sources.list.d/#{repo}.list; "
+        "sed -i '/^#{action == 'enable' ? '#\\s*' : ''}deb.*/ s/^#{action == 'enable' ? '' : '#\\s*'}deb "\
+        "/#{action == 'enable' ? '' : '#'}deb /' /etc/apt/sources.list.d/#{repo}.list; "
       end
     end
     cmd = cmd.reduce(:+)


### PR DESCRIPTION
## What does this PR change?

Fix a typo, which prevents handling properly the repositories of non SLE clients in our testsuite.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

That will not need port by itself, as I will include as part of the previous PR https://github.com/uyuni-project/uyuni/pull/2554

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
