### PR TITLE
Use assigned proxy to detect salt client organization

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -319,28 +319,33 @@ public class RegisterMinionEventMessageAction implements MessageAction {
         Optional<String> activationKeyLabel = getActivationKeyLabelFromGrains(grains, activationKeyOverride);
         Optional<ActivationKey> activationKey = activationKeyLabel.map(ActivationKeyFactory::lookupByKey);
 
-
-        Org org = activationKey.map(ActivationKey::getOrg)
-                .orElse(creator.map(User::getOrg)
-                        .orElse(OrgFactory.getSatelliteOrg()));
-        if (minion.getOrg() == null) {
-            minion.setOrg(org);
-        }
-        else if (!minion.getOrg().equals(org)) {
-            // only log activation key ignore message when the activation key is not empty
-            String ignoreAKMessage = activationKey.map(ak -> "Ignoring activation key " + ak + ".").orElse("");
-            LOG.error("The existing server organization (" + minion.getOrg() + ") does not match the " +
-                    "organization selected for registration (" + org + "). Keeping the " +
-                    "existing server organization. " + ignoreAKMessage);
-            activationKey = empty();
-            org = minion.getOrg();
-            SystemManager.addHistoryEvent(minion, "Invalid Server Organization",
-                    "The existing server organization (" + minion.getOrg() + ") does not match the " +
-                            "organization selected for registration (" + org + "). Keeping the " +
-                            "existing server organization. " + ignoreAKMessage);
-        }
-
         try {
+            String master = saltApi
+                    .getMasterHostname(minionId)
+                    .orElseThrow(() -> new SaltException(
+                            "Master not found in minion configuration"));
+
+            Org org = activationKey.map(ActivationKey::getOrg)
+                            .orElseGet(() -> creator.map(User::getOrg)
+                            .orElseGet(() -> getProxyOrg(master, isSaltSSH, saltSSHProxyId)
+                            .orElseGet(() -> OrgFactory.getSatelliteOrg())));
+            if (minion.getOrg() == null) {
+                minion.setOrg(org);
+            }
+            else if (!minion.getOrg().equals(org)) {
+                // only log activation key ignore message when the activation key is not empty
+                String ignoreAKMessage = activationKey.map(ak -> "Ignoring activation key " + ak + ".").orElse("");
+                LOG.error("The existing server organization (" + minion.getOrg() + ") does not match the " +
+                        "organization selected for registration (" + org + "). Keeping the " +
+                        "existing server organization. " + ignoreAKMessage);
+                activationKey = empty();
+                org = minion.getOrg();
+                SystemManager.addHistoryEvent(minion, "Invalid Server Organization",
+                        "The existing server organization (" + minion.getOrg() + ") does not match the " +
+                                "organization selected for registration (" + org + "). Keeping the " +
+                                "existing server organization. " + ignoreAKMessage);
+            }
+
             // Set creator to the user who accepted the key if available
             minion.setCreator(creator.orElse(null));
 
@@ -382,11 +387,6 @@ public class RegisterMinionEventMessageAction implements MessageAction {
 
             mapHardwareGrains(minion, grains);
 
-            String master = saltApi
-                    .getMasterHostname(minionId)
-                    .orElseThrow(() -> new SaltException(
-                            "master not found in minion configuration"));
-
             setServerPaths(minion, master, isSaltSSH, saltSSHProxyId);
 
             ServerFactory.save(minion);
@@ -412,7 +412,7 @@ public class RegisterMinionEventMessageAction implements MessageAction {
         }
         catch (Throwable t) {
             LOG.error("Error registering minion id: " + minionId, t);
-            throw new RegisterMinionException(minionId, org);
+            throw new RegisterMinionException(minionId, minion.getOrg());
         }
         finally {
             if (MinionPendingRegistrationService.containsMinion(minionId)) {
@@ -445,6 +445,17 @@ public class RegisterMinionEventMessageAction implements MessageAction {
                 }
             }
         });
+    }
+
+    private Optional<Org> getProxyOrg(String master, boolean isSaltSSH, Optional<Long> saltSSHProxyId) {
+        if (isSaltSSH) {
+            return saltSSHProxyId
+                    .map(proxyId -> ServerFactory.lookupById(proxyId))
+                    .map(Server::getOrg);
+        }
+        else {
+            return ServerFactory.lookupProxyServer(master).map(Server::getOrg);
+        }
     }
 
     /**

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Detect client organization from connected proxy (bsc#1175545)
 - Add language picker to user preferences and user creation
 - Fix EntityExistsException on migration from traditional to salt minion via proxy (bsc#1175556)
 - use media.1/products from media when not specified different (bsc#1175558)


### PR DESCRIPTION
## What does this PR change?

Particularly in retail saltboot environment, initial registration is without activation key or bootstrapping user so default organization is used as an owning organization.
This does not work in multi organization scenario, but in saltboot environment proxy is always expected to be present.
This patch includes proxy organization as a hint to what org client should be assigned.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: internal logic

- [X] **DONE**

## Test coverage
- Unit tests were added

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/12190
Tracks https://github.com/SUSE/spacewalk/pull/12219

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
