### PR TITLE
Testsuite - update of kiwi image profiles

### DIFF
--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_40/config.xml
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_40/config.xml
@@ -97,6 +97,7 @@
         <package name="iproute2"/>
         <package name="openssh"/>
         <package name="rsync"/>
+        <package name="plymouth-plugin-label-ft"/>
 
         <package name="kernel-default"/>
 	<package name="salt-minion"/>
@@ -109,10 +110,10 @@
         <package name="plymouth"/>
         <package name="plymouth-dracut"/>
         <package name="plymouth-branding-SLE"/>
+        <package name="plymouth-plugin-label-ft"/>
         <package name="fontconfig"/>
         <package name="fonts-config"/>
         <package name="noto-sans-fonts"/>
-        <package name="wpa_supplicant"/>
         <package name="busybox"/>
         <package name="bind-utils"/>
         <package name="kiwi-tools"/>

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_head/config.xml
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_head/config.xml
@@ -93,6 +93,7 @@
         <package name="iproute2"/>
         <package name="openssh"/>
         <package name="rsync"/>
+        <package name="plymouth-plugin-label-ft"/>
 
         <package name="kernel-default"/>
 	<package name="salt-minion"/>
@@ -105,10 +106,10 @@
         <package name="plymouth"/>
         <package name="plymouth-dracut"/>
         <package name="plymouth-branding-SLE"/>
+        <package name="plymouth-plugin-label-ft"/>
         <package name="fontconfig"/>
         <package name="fonts-config"/>
         <package name="noto-sans-fonts"/>
-        <package name="wpa_supplicant"/>
         <package name="busybox"/>
         <package name="bind-utils"/>
         <package name="kiwi-tools"/>

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -43,6 +43,8 @@ def compute_image_filename
     'Kiwi/POS_Image-JeOS6_head'
   when 'sles15sp2', 'sles15sp2o'
     'Kiwi/POS_Image-JeOS7_head'
+  when 'sles15sp1', 'sles15sp1o'
+    raise 'This is not supported image version.'
   else
     'Kiwi/POS_Image-JeOS6_head'
   end
@@ -54,6 +56,8 @@ def compute_image_name
     'POS_Image_JeOS6_head'
   when 'sles15sp2', 'sles15sp2o'
     'POS_Image_JeOS7_head'
+  when 'sles15sp1', 'sles15sp1o'
+    raise 'This is not supported image version.'
   else
     'POS_Image_JeOS6_head'
   end


### PR DESCRIPTION
## What does this PR change?

PR updates currently used kiwi profiles and obsoletes usage of SLE15SP1 based images.

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
