### PR TITLE
Fix strings, mostly old "Satellite" ocurrences

### DIFF
--- a/backend/satellite_exporter/satexport.py
+++ b/backend/satellite_exporter/satexport.py
@@ -220,7 +220,7 @@ class ApacheServer(BaseApacheServer):
 
     def auth_system(self, req):
         if CFG.DISABLE_ISS:
-            raise rhnFault(2005, _('ISS is disabled on this satellite.'))
+            raise rhnFault(2005, _('ISS is disabled on this server.'))
 
         remote_hostname = req.get_remote_host(apache.REMOTE_DOUBLE_REV)
         row = rhnSQL.fetchone_dict("""

--- a/backend/server/handlers/sat/auth.py
+++ b/backend/server/handlers/sat/auth.py
@@ -42,7 +42,7 @@ class Authentication(rhnHandler):
 
     def auth_system(self):
         if CFG.DISABLE_ISS:
-            raise rhnFault(2005, _('ISS is disabled on this satellite.'))
+            raise rhnFault(2005, _('ISS is disabled on this server.'))
 
         if not rhnSQL.fetchone_dict("select 1 from rhnISSSlave where slave = :hostname and enabled = 'Y'",
                                     hostname=idn_puny_to_unicode(self.remote_hostname)):

--- a/backend/server/handlers/xmlrpc/proxy.py
+++ b/backend/server/handlers/xmlrpc/proxy.py
@@ -62,7 +62,7 @@ class rhnProxyHandler(rhnHandler):
             # we require entitlement for this functionality
             log_error("Server not entitled for Proxy", self.server_id)
             raise rhnFault(1002, _(
-                'Spacewalk Proxy service not enabled for server profile: "%s"')
+                'SUSE Manager Proxy service not enabled for server profile: "%s"')
                 % server.server["name"])
         # we're fine...
         return server

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -3,6 +3,7 @@
 - Take care of SCC auth tokens on DEB repos GPG checks (bsc#1175485)
 - Use spacewalk keyring for GPG checks on DEB repos (bsc#1175485)
 - Remove duplicate languages and update translation strings
+- Fix strings (mentions of Satellite, replace SUSE Manager with PRODUCT_NAME, etc)
 - Update package version to 4.2.0
 
 -------------------------------------------------------------------

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -1085,13 +1085,13 @@
         </context-group>
       </trans-unit>
       <trans-unit id="user.satadmin.remove">
-        <source>Removed SUSE Manager Administrator role from {0}</source>
+        <source>Removed @@PRODUCT_NAME@@ Administrator role from {0}</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/admin/multiorg/Users</context>
         </context-group>
       </trans-unit>
       <trans-unit id="user.satadmin.add">
-        <source>Added SUSE Manager Administrator role to {0}</source>
+        <source>Added @@PRODUCT_NAME@@ Administrator role to {0}</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/admin/multiorg/Users</context>
         </context-group>
@@ -1103,7 +1103,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="user.cannot.delete.last.sat.admin">
-        <source>Cannot delete the last remaining SUSE Manager administrator.</source>
+        <source>Cannot delete the last remaining @@PRODUCT_NAME@@ administrator.</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/users/DeleteUser</context>
         </context-group>
@@ -1140,7 +1140,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="taskomatic notif subject">
-        <source>SUSE MANAGER TASKOMATIC NOTIFICATION</source>
+        <source>@@PRODUCT_NAME@@ TASKOMATIC NOTIFICATION</source>
         <context-group name="ctx">
           <context context-type="sourcefile">Traceback Email Notifications</context>
         </context-group>
@@ -1928,7 +1928,7 @@ entitlements for the 'rhn-tools' software channel from your @@PRODUCT_NAME@@ adm
 &lt;li&gt;
 Make sure that the 'rhn-tools' child channel for this kickstart profile's base
 channel is available to your @@PRODUCT_NAME@@. If it is not, please contact your
-SUSE Manager administrator and request a satellite-sync for the rhn-tools channel
+@@PRODUCT_NAME@@ administrator and request a mgr-inter-sync for the rhn-tools channel
 and try again.
 &lt;/li&gt;
 &lt;li&gt;
@@ -1959,7 +1959,7 @@ entitlements for the 'appstream' software channel from your @@PRODUCT_NAME@@ adm
 &lt;li&gt;
 Make sure that the 'appstream' child channel for this kickstart profile's base
 channel is available to your @@PRODUCT_NAME@@. If it is not, please contact your
-satellite administrator and request a cdn-sync for the appstream channel
+@@PRODUCT_NAME@@ administrator and request a cdn-sync for the appstream channel
 and try again.
 &lt;/li&gt;
 &lt;/ul&gt;
@@ -7363,7 +7363,7 @@ Follow this url to see the full list of inactive systems:
         <source>User in organization {0} is not allowed to retrieve or modify {1} properties in organization {2}.</source>
       </trans-unit>
       <trans-unit id="api.org.cannotperformonsatelliteorg">
-        <source>Cannot perform this operation on the satellite organization. (Org ID 1)</source>
+        <source>Cannot perform this operation on the @@PRODUCT_NAME@@ organization. (Org ID 1)</source>
       </trans-unit>
       <trans-unit id="api.errata.invaliderrata">
         <source>Invalid patch: {0}</source>
@@ -7393,7 +7393,7 @@ Follow this url to see the full list of inactive systems:
         <source>Unable to locate or access server group: "{0}"</source>
       </trans-unit>
       <trans-unit id="api.systemgroup.accessChangeDenied">
-        <source>Changing administrator access is not allowed for Satellite and Organization administrators.  These users are granted access by default; therefore, the following users should be removed from the input: {0}</source>
+        <source>Changing administrator access is not allowed for @@PRODUCT_NAME@@ and Organization administrators.  These users are granted access by default; therefore, the following users should be removed from the input: {0}</source>
       </trans-unit>
       <trans-unit id="api.system.invalidprofilelabel">
         <source>Invalid profile label specified: {0}</source>
@@ -7516,10 +7516,10 @@ Follow this url to see the full list of inactive systems:
         <source>A required patch attribute ({0}) was missing.</source>
       </trans-unit>
       <trans-unit id="api.iss.duplicatemaster">
-        <source>A record for Master satellite {0} already exists</source>
+        <source>A record for Master @@PRODUCT_NAME@@ {0} already exists</source>
       </trans-unit>
       <trans-unit id="api.iss.duplicateslave">
-        <source>A record for Slave satellite {0} already exists</source>
+        <source>A record for Slave @@PRODUCT_NAME@@ {0} already exists</source>
       </trans-unit>
       <trans-unit id="securityErrata">
         <source>Security Patches</source>
@@ -8490,13 +8490,13 @@ Alternatively, you will want to download &lt;strong&gt;Incremental Channel Conte
         <source>@@PRODUCT_NAME@@ Advanced Topics Guide</source>
       </trans-unit>
       <trans-unit id="system_entitlement_details.access_grant_desc.enterprise_entitled">
-        <source>A single base type is required for all systems registered to SUSE Manager</source>
+        <source>A single base type is required for all systems registered to @@PRODUCT_NAME@@</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/admin/multiorg/SystemEntitlementDetails</context>
         </context-group>
       </trans-unit>
       <trans-unit id="bunch.jsp.description.satcert-check-bunch">
-        <source>Checks whether SUSE Manager certificate has not expired</source>
+        <source>Checks whether the @@PRODUCT_NAME@@ certificate has not expired</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/admin/BunchDetail.do</context>
         </context-group>
@@ -8517,13 +8517,13 @@ Alternatively, you will want to download &lt;strong&gt;Incremental Channel Conte
         <source>Your @@PRODUCT_NAME@@ certificate has expired.  Please contact @@VENDOR_NAME@@ for a new certificate.</source>
       </trans-unit>
       <trans-unit id="satellite.expired.restricted">
-        <source>Your @@PRODUCT_NAME@@ Certificate has expired. Your @@PRODUCT_NAME@@ is on day {0} of {1} day restricted period and will soon stop functioning. Please contact SUSE for a new certificate.</source>
+        <source>Your @@PRODUCT_NAME@@ Certificate has expired. Your @@PRODUCT_NAME@@ is on day {0} of {1} day restricted period and will soon stop functioning. Please contact @@VENDOR_NAME@@ for a new certificate.</source>
       </trans-unit>
       <trans-unit id="satellite.graceperiod">
-        <source>Your @@PRODUCT_NAME@@ certificate has expired.  Please contact @@VENDOR_NAME@@ for a new certificate.  Your SUSE Manager will become inactive in {0} day(s).</source>
+        <source>Your @@PRODUCT_NAME@@ certificate has expired.  Please contact @@VENDOR_NAME@@ for a new certificate.  Your @@PRODUCT_NAME@@ will become inactive in {0} day(s).</source>
       </trans-unit>
       <trans-unit id="restricted.forbidden">
-        <source>You are not allowed to perform this action until your @@PRODUCT_NAME@@ Certificate is renewed. Your @@PRODUCT_NAME@@ is on day {0} of the {1} restricted period and will soon stop functioning. Please contact SUSE for a new certificate.</source>
+        <source>You are not allowed to perform this action until your @@PRODUCT_NAME@@ Certificate is renewed. Your @@PRODUCT_NAME@@ is on day {0} of the {1} restricted period and will soon stop functioning. Please contact @@VENDOR_NAME@@ for a new certificate.</source>
       </trans-unit>
       <trans-unit id="org.entitlements.system.defaultorg">
         <source>You are not allowed to update entitlements in the Default Org.  These entitlements are determined by your @@PRODUCT_NAME@@ certificate file.</source>
@@ -8568,10 +8568,10 @@ Alternatively, you will want to download &lt;strong&gt;Incremental Channel Conte
         <source>Cleanup channel tokens</source>
       </trans-unit>
       <trans-unit id="bunch.jsp.description.mgr-register-bunch">
-        <source>Registers SUSE Manager clients</source>
+        <source>Registers @@PRODUCT_NAME@@ clients</source>
       </trans-unit>
       <trans-unit id="bunch.jsp.description.repo-sync-bunch">
-        <source>Synchronizes SUSE Manager repositories</source>
+        <source>Synchronizes @@PRODUCT_NAME@@ repositories</source>
       </trans-unit>
       <trans-unit id="bunch.jsp.description.ssh-push-bunch">
         <source>Manages clients via SSH Server Push</source>
@@ -8856,7 +8856,7 @@ Alternatively, you will want to download &lt;strong&gt;Incremental Channel Conte
         <source>Get started with setting up a @@PRODUCT_NAME@@ server</source>
       </trans-unit>
       <trans-unit id="help.jsp.bestpractices">
-        <source>This document describes SUSE recommended best practices for @@PRODUCT_NAME@@</source>
+        <source>This document describes @@VENDOR_NAME@@ recommended best practices for @@PRODUCT_NAME@@</source>
       </trans-unit>
       <trans-unit id="help.jsp.advancedtopics">
         <source>Advanced Topics on @@PRODUCT_NAME@@</source>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -23,6 +23,7 @@
 - Add virtual network Start, Stop and Delete actions
 - Add virtual network list page
 - update default product tree tag and set Beta tag again
+- Fix strings (mentions of Satellite, replace SUSE Manager with PRODUCT_NAME, etc)
 - Update package version to 4.2.0
 
 -------------------------------------------------------------------

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,6 +1,7 @@
 - support installer update channels during autoinstallation
 - migrate all occurrences of kickstart to autoinstall in cobbler database (bsc#1169780)
 - define bootstrap repo data for SUSE Manager Proxies (bsc#1174470)
+- Fix strings (mentions of Satellite, replace SUSE Manager with PRODUCT_NAME, etc)
 - Update package version to 4.2.0
 
 -------------------------------------------------------------------

--- a/susemanager/yast/susemanager_cert.rb
+++ b/susemanager/yast/susemanager_cert.rb
@@ -129,7 +129,7 @@ module Yast
 
       # help text
       @help_text = _(
-        "<p>Here, enter data needed for the creation of an SSL certificate. The certificate is used for a number of purposes like connections to a proxy, HTTPS protocol in browsers, and more.</p>"
+        "<p>Here, enter data needed for the creation of an SSL certificate. The certificate is used for a number of purposes like connections to a SUSE Manager Proxy server, HTTPS protocol in browsers, and more.</p>"
       )
 
       # dialog caption

--- a/susemanager/yast/susemanager_manager.rb
+++ b/susemanager/yast/susemanager_manager.rb
@@ -91,7 +91,7 @@ module Yast
             Id("MANAGER_ADMIN_EMAIL"),
             Opt(:hstretch),
             # text entry label
-            _("#{@product_name} &Administrator E-mail Address"),
+            _("#{@product_name} &Administrator e-mail address"),
             Ops.get(@settings, "MANAGER_ADMIN_EMAIL", "")
           ),
           VSpacing(0.5),
@@ -109,7 +109,7 @@ module Yast
 
       # help text
       @help_text = _(
-        "<p>Fill in <b>Administrator E-mail Address</b>. It is used for notifications by #{@product_name}.</p>
+        "<p>Fill in <b>Administrator e-mail address</b>. It is used for notifications by #{@product_name}.</p>
          <p>By checking SLP (Service Location Protocol) #{@product_name} will advertise its service in the
            network so it can easily be found by client systems.</p>"
       )
@@ -149,7 +149,7 @@ module Yast
                 Builtins.find(@email, "@") == 0 ||
                 Builtins.find(@email, "@") ==
                   Ops.subtract(Builtins.size(@email), 1)
-              Popup.Error(_("The Administrator E-mail Address is not valid."))
+              Popup.Error(_("The Administrator e-mail address is not valid."))
               UI.SetFocus(Id("MANAGER_ADMIN_EMAIL"))
               next
             end

--- a/susemanager/yast/susemanager_reqs.rb
+++ b/susemanager/yast/susemanager_reqs.rb
@@ -155,9 +155,9 @@ module Yast
       )
       if Ops.get_integer(@f_out, "exit", -1) != 0
         if !Popup.AnyQuestionRichText(
-            _("hostname command failed"),
+            _("Hostname command failed"),
             _(
-              "the execution of 'hostname -f' failed. The product will not install correctly."
+              "The execution of 'hostname -f' failed. The product will not install correctly."
             ),
             40,
             10,
@@ -175,9 +175,9 @@ module Yast
           2
         )
         if !Popup.AnyQuestionRichText(
-            _("illegal FQHN"),
+            _("Illegal FQHN"),
             _(
-              "the FQHN must contain at least 2 dots. The product will not function correctly."
+              "The FQHN must contain at least 2 dots. The product will not function correctly."
             ),
             40,
             10,
@@ -195,9 +195,9 @@ module Yast
           0
         )
         if !Popup.AnyQuestionRichText(
-            _("illegal FQHN"),
+            _("Illegal FQHN"),
             _(
-              "the FQHN must not contain the '_' (undersorce) character. The product will not function correctly."
+              "The FQHN must not contain the '_' (undersorce) character. The product will not function correctly."
             ),
             40,
             10,
@@ -235,9 +235,9 @@ module Yast
         ) !=
           Ops.get_string(@f_out, "stdout", "x")
         if !Popup.AnyQuestionRichText(
-            _("illegal FQHN"),
+            _("Illegal FQHN"),
             _(
-              "the output of 'hostname -f' does not match the real hostname. The product will not install correctly."
+              "The output of 'hostname -f' does not match the real hostname. The product will not install correctly."
             ),
             40,
             10,


### PR DESCRIPTION
## What does this PR change?

Fixes some uses of "Satellite", and others

- 'proxy' refers to SUSE Manager Proxy not to some random HTTP proxy, or any other kind of proxy. Make that explicit.
- Uppercase where needed
- Use PRODUCT_NAME and VENDOR_NAME intead of SUSE Manager and SUSE, and replace Satellite with PRODUCT_NAME

## GUI diff

This will impact translations.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
