### PR TITLE
Show pool/volume informations where possible

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/test/virt.guest.definition.xml
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/virt.guest.definition.xml
@@ -61,6 +61,16 @@
       <target dev='vdb' bus='virtio'/>
       <address type='pci' domain='0x0000' bus='0x00' slot='0x07' function='0x0'/>
     </disk>
+    <disk type='block' device='disk'>
+      <driver name='qemu' type='raw'/>
+      <source dev='/dev/disk/by-path/ip-iscsi-target.tf.local:3260-iscsi-iqn.2020-09.iscsi-target.tf.local:lun1-lun-1'/>
+      <target dev='vdc' bus='virtio'/>
+    </disk>
+    <disk type='block' device='disk'>
+      <driver name='qemu' type='raw'/>
+      <source dev='/dev/disk/by-path/pci-0000:00:0b.0-scsi-0:0:0:0'/>
+      <target dev='vdd' bus='virtio'/>
+    </disk>
     <controller type='usb' index='0' model='ich9-ehci1'>
       <alias name='usb'/>
       <address type='pci' domain='0x0000' bus='0x00' slot='0x06' function='0x7'/>

--- a/java/code/src/com/suse/manager/virtualization/GuestDiskDef.java
+++ b/java/code/src/com/suse/manager/virtualization/GuestDiskDef.java
@@ -23,6 +23,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -31,6 +33,7 @@ import java.util.stream.Collectors;
 public class GuestDiskDef {
 
     private static final List<String> NETWORK_CONVERTED_TYPES = Arrays.asList("rbd", "gluster");
+    private static final Pattern BLOCK_REGEX = Pattern.compile("([^/]+)/([^/]+)");
 
     private String type;
     private String device;
@@ -214,6 +217,15 @@ public class GuestDiskDef {
                         disk.setType("file");
                         source.clear();
                         source.put("file", info.getFile());
+                    }
+                }
+                else if (Arrays.asList("block", "file").contains(disk.getType())) {
+                    Matcher matcher = BLOCK_REGEX.matcher(info.getFile());
+                    if (matcher.matches()) {
+                        disk.setType("volume");
+                        source.clear();
+                        source.put("pool", matcher.group(1));
+                        source.put("volume", matcher.group(2));
                     }
                 }
             });

--- a/java/code/src/com/suse/manager/webui/controllers/virtualization/test/VirtualGuestsControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/virtualization/test/VirtualGuestsControllerTest.java
@@ -319,7 +319,7 @@ public class VirtualGuestsControllerTest extends BaseControllerTestCase {
         assertEquals("network", def.getInterfaces().get(0).getType());
         assertEquals("default", def.getInterfaces().get(0).getSource());
 
-        assertEquals(3, def.getDisks().size());
+        assertEquals(5, def.getDisks().size());
         assertEquals("file", def.getDisks().get(0).getType());
         assertEquals("disk", def.getDisks().get(0).getDevice());
         assertEquals("qcow2", def.getDisks().get(0).getFormat());
@@ -341,6 +341,22 @@ public class VirtualGuestsControllerTest extends BaseControllerTestCase {
         assertEquals("virtio", def.getDisks().get(2).getBus());
         assertEquals("ses-pool", def.getDisks().get(2).getSource().get("pool"));
         assertEquals("test-vol", def.getDisks().get(2).getSource().get("volume"));
+
+        assertEquals("volume", def.getDisks().get(3).getType());
+        assertEquals("disk", def.getDisks().get(3).getDevice());
+        assertEquals("raw", def.getDisks().get(3).getFormat());
+        assertEquals("vdc", def.getDisks().get(3).getTarget());
+        assertEquals("virtio", def.getDisks().get(3).getBus());
+        assertEquals("iscsi-pool", def.getDisks().get(3).getSource().get("pool"));
+        assertEquals("unit:0:0:1", def.getDisks().get(3).getSource().get("volume"));
+
+        assertEquals("block", def.getDisks().get(4).getType());
+        assertEquals("disk", def.getDisks().get(4).getDevice());
+        assertEquals("raw", def.getDisks().get(4).getFormat());
+        assertEquals("vdd", def.getDisks().get(4).getTarget());
+        assertEquals("virtio", def.getDisks().get(4).getBus());
+        assertEquals("/dev/disk/by-path/pci-0000:00:0b.0-scsi-0:0:0:0",
+                def.getDisks().get(4).getSource().get("dev"));
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/controllers/virtualization/test/virt.vm.info.json
+++ b/java/code/src/com/suse/manager/webui/controllers/virtualization/test/virt.vm.info.json
@@ -15,6 +15,16 @@
         "file": "ses-pool/test-vol",
         "type": "disk",
         "file format": "raw"
+      },
+      "vdc": {
+        "file": "iscsi-pool/unit:0:0:1",
+        "type": "disk",
+        "file format": "raw"
+      },
+      "vdd": {
+        "file": "/dev/disk/by-path/pci-0000:00:0b.0-scsi-0:0:0:0",
+        "type": "disk",
+        "file format": "raw"
       }
     },
     "graphics": {

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Take pool and volume from Salt virt.vm_info for files and blocks disks (bsc#1175987)
 - Create VM on a Salt host using a cobbler profile
 - Show cluster upgrade plan in the upgrade UI
 - Fix action chain resuming when patches updating salt-minion don't cause service to be

--- a/testsuite/features/secondary/minkvm_guests.feature
+++ b/testsuite/features/secondary/minkvm_guests.feature
@@ -129,7 +129,7 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And "test-vm" virtual machine on "kvm_server" should have spice graphics device
     And "test-vm" virtual machine on "kvm_server" should have 1 NIC using "test-net1" network
     And "test-vm" virtual machine on "kvm_server" should have a NIC with 02:34:56:78:9a:bc MAC address
-    And "test-vm" virtual machine on "kvm_server" should have a "test-vm_disk.qcow2" scsi disk
+    And "test-vm" virtual machine on "kvm_server" should have a "test-vm_disk.qcow2" SCSI disk from pool "tmp"
 
 @virthost_kvm
   Scenario: Add a network interface to a KVM virtual machine
@@ -349,7 +349,7 @@ Feature: Be able to manage KVM virtual machines via the GUI
 @scc_credentials
   Scenario: Create auto installation distribution
     Given I am authorized
-    And I install package "tftpboot-installation-SLE-15-SP2-x86_64" on this "server" 
+    And I install package "tftpboot-installation-SLE-15-SP2-x86_64" on this "server"
     And I wait for "tftpboot-installation-SLE-15-SP2-x86_64" to be installed on "server"
     When I follow the left menu "Systems > Autoinstallation > Distributions"
     And I follow "Create Distribution"

--- a/testsuite/features/secondary/minxen_guests.feature
+++ b/testsuite/features/secondary/minxen_guests.feature
@@ -157,12 +157,13 @@ Feature: Be able to manage XEN virtual machines via the GUI
     When I click on "Edit" in row "test-vm"
     And I wait until I do not see "Loading..." text
     And I click on "add_disk"
+    And I select "test-pool0" from "disk1_source_pool"
     And I click on "add_disk"
     And I select "CDROM" from "disk2_device"
     And I select "ide" from "disk2_bus"
     And I click on "Update"
     Then I should see a "Hosted Virtual Systems" text
-    And "test-vm" virtual machine on "xen_server" should have a "test-vm_disk-1" xen disk from pool "test-pool0"
+    And "test-vm" virtual machine on "xen_server" should have a "/var/lib/libvirt/images/test-pool0/test-vm_disk-1" xen disk
     And "test-vm" virtual machine on "xen_server" should have a ide cdrom
 
 @virthost_xen
@@ -199,7 +200,7 @@ Feature: Be able to manage XEN virtual machines via the GUI
     And I wait at most 500 seconds until table row for "test-vm2" contains button "Stop"
     And "test-vm2" virtual machine on "xen_server" should have 512MB memory and 1 vcpus
     And "test-vm2" virtual machine on "xen_server" should have 1 NIC using "test-net0" network
-    And "test-vm2" virtual machine on "xen_server" should have a "test-vm2_system" xen disk from pool "test-pool0"
+    And "test-vm2" virtual machine on "xen_server" should have a "/var/lib/libvirt/images/test-pool0/test-vm2_system" xen disk
 
 @virthost_xen
   Scenario: Show the Spice graphical console for Xen
@@ -224,7 +225,7 @@ Feature: Be able to manage XEN virtual machines via the GUI
     And I wait at most 500 seconds until table row for "test-vm3" contains button "Stop"
     And "test-vm3" virtual machine on "xen_server" should have 512MB memory and 1 vcpus
     And "test-vm3" virtual machine on "xen_server" should have 1 NIC using "test-net0" network
-    And "test-vm3" virtual machine on "xen_server" should have a "test-vm3_system" xen disk from pool "test-pool0"
+    And "test-vm3" virtual machine on "xen_server" should have a "/var/lib/libvirt/images/test-pool0/test-vm3_system" xen disk
 
 @virthost_xen
   Scenario: Show the virtual storage pools and volumes for Xen

--- a/testsuite/features/secondary/minxen_guests.feature
+++ b/testsuite/features/secondary/minxen_guests.feature
@@ -78,13 +78,6 @@ Feature: Be able to manage XEN virtual machines via the GUI
     Then I should see "test-vm" virtual machine running on "xen_server"
 
 @virthost_xen
-  Scenario: Show the VNC graphical console for Xen
-    Given I am on the "Virtualization" page of this "xen_server"
-    When I click on "Graphical Console" in row "test-vm"
-    And I switch to last opened window
-    Then I wait until I see the VNC graphical console
-
-@virthost_xen
   Scenario: Suspend a Xen virtual machine
     Given I am on the "Virtualization" page of this "xen_server"
     When I wait until table row for "test-vm" contains button "Suspend"
@@ -193,7 +186,7 @@ Feature: Be able to manage XEN virtual machines via the GUI
     And I enter "512" as "memory"
     And I enter "/var/testsuite-data/disk-image-template-xenpv.qcow2" as "disk0_source_template"
     And I select "test-net0" from "network0_source"
-    And I select "Spice" from "graphicsType"
+    And I select "VNC" from "graphicsType"
     And I click on "Create"
     Then I should see a "Hosted Virtual Systems" text
     When I wait until I see "test-vm2" text
@@ -203,11 +196,11 @@ Feature: Be able to manage XEN virtual machines via the GUI
     And "test-vm2" virtual machine on "xen_server" should have a "/var/lib/libvirt/images/test-pool0/test-vm2_system" xen disk
 
 @virthost_xen
-  Scenario: Show the Spice graphical console for Xen
+  Scenario: Show the VNC graphical console for Xen
     Given I am on the "Virtualization" page of this "xen_server"
     When I click on "Graphical Console" in row "test-vm2"
     And I switch to last opened window
-    Then I wait until I see the spice graphical console
+    And I wait until I see the VNC graphical console
 
 @virthost_xen
   Scenario: Create a Xen fully virtualized guest
@@ -219,13 +212,21 @@ Feature: Be able to manage XEN virtual machines via the GUI
     And I enter "512" as "memory"
     And I enter "/var/testsuite-data/disk-image-template.qcow2" as "disk0_source_template"
     And I select "test-net0" from "network0_source"
+    And I select "Spice" from "graphicsType"
     And I click on "Create"
     Then I should see a "Hosted Virtual Systems" text
     When I wait until I see "test-vm3" text
     And I wait at most 500 seconds until table row for "test-vm3" contains button "Stop"
-    And "test-vm3" virtual machine on "xen_server" should have 512MB memory and 1 vcpus
+    Then "test-vm3" virtual machine on "xen_server" should have 512MB memory and 1 vcpus
     And "test-vm3" virtual machine on "xen_server" should have 1 NIC using "test-net0" network
     And "test-vm3" virtual machine on "xen_server" should have a "/var/lib/libvirt/images/test-pool0/test-vm3_system" xen disk
+
+@virthost_xen
+  Scenario: Show the Spice graphical console for Xen
+    Given I am on the "Virtualization" page of this "xen_server"
+    When I click on "Graphical Console" in row "test-vm3"
+    And I switch to last opened window
+    And I wait until I see the spice graphical console
 
 @virthost_xen
   Scenario: Show the virtual storage pools and volumes for Xen

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1168,7 +1168,8 @@ Then(/^"([^"]*)" virtual machine on "([^"]*)" should have a "([^"]*)" ([^ ]+) di
     output, _code = node.run("virsh dumpxml #{vm}")
     tree = Nokogiri::XML(output)
     disks = tree.xpath("//disk").select do |x|
-      (x.xpath('source/@pool')[0].to_s == pool) && (x.xpath('source/@volume')[0].to_s == vol) && (x.xpath('target/@bus')[0].to_s == bus)
+      (x.xpath('source/@pool')[0].to_s == pool) && (x.xpath('source/@volume')[0].to_s == vol) &&
+        (x.xpath('target/@bus')[0].to_s == bus.downcase)
     end
     break if !disks.empty?
     sleep 3

--- a/web/html/src/manager/virtualization/guests/GuestProperties.js
+++ b/web/html/src/manager/virtualization/guests/GuestProperties.js
@@ -58,6 +58,7 @@ export function GuestProperties(props: Props) : React.Node {
   const osTypesLabels = {
     hvm: 'Fully Virtualized',
     xen: 'Para Virtualized',
+    xenpvh: 'PVH',
   };
 
   return (
@@ -249,9 +250,10 @@ export function GuestProperties(props: Props) : React.Node {
                                           name="graphicsType"
                                         >
                                           {
-                                            [{ key: 'vnc', display: 'VNC' }, { key: 'spice', display: 'Spice' }]
+                                            [{ key: 'vnc', display: 'VNC', osTypes: ['hvm', 'xen', 'xenpvh'] },
+                                             { key: 'spice', display: 'Spice', osTypes: ['hvm'] }]
                                               .filter(entry => caps !== undefined
-                                                && caps.devices.graphics.type.includes(entry.key))
+                                                && caps.devices.graphics.type.includes(entry.key) && entry.osTypes.includes(model.osType))
                                               .map(entry => (
                                                 <option key={entry.key} value={entry.key}>
                                                   {entry.display}

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Don't allow selecting spice for Xen PV and PVH guests
 - Allow creating a VM on Salt host using a cobbler profile
 - Show cluster upgrade plan in the upgrade UI
 - Enable to switch to multiple webUI theme


### PR DESCRIPTION
## What does this PR change?

At least for Xen the disks of volume types aren't supported but
converted by Salt into their file or block equivalents. In order to show
the selected volume and pool when possible, try to get those
informations from Salt's virt.vm_info output.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: fixes VM disks infos for Xen

- [X] **DONE**

## Test coverage
- Unit tests were updated

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
