### PR TITLE
Fix unit-tests failing due to missing default locale

### DIFF
--- a/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
+++ b/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
@@ -1020,6 +1020,6 @@ public class ConfigDefaults {
      * @return the preferred locale
      */
     public String getDefaultLocale() {
-        return Config.get().getString(DEFAULT_LOCALE);
+        return Config.get().getString(DEFAULT_LOCALE, "en_US");
     }
 }


### PR DESCRIPTION
## What does this PR change?

Fix unit-tests failing due to missing default locale

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Just a fix

- [x] **DONE**

## Test coverage
- No tests: 

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
