### PR TITLE
Adding step definition to go to products page after authorized as admin (Port from Spacewalk)

### DIFF
--- a/testsuite/documentation/cucumber-steps.md
+++ b/testsuite/documentation/cucumber-steps.md
@@ -109,16 +109,16 @@ To check for the initial log in, prefer ```Then I am logged in```.
   When I follow the left menu "Systems > System List > System Currency"
 ```
 
-* Go to Admin => Setup Wizard
+* Go to Admin => Setup Wizard => Products
 
 ```cucumber
-  When I am on the Admin page
+  Given I am on the Products page
 ```
 
 * Go to Admin => Organizations
 
 ```cucumber
-  When I am on the Organizations page
+  Given I am on the Organizations page
 ```
 
 * Go to Patches => Patches => Relevant

--- a/testsuite/features/qam/reposync/srv_sync_qam_products.feature
+++ b/testsuite/features/qam/reposync/srv_sync_qam_products.feature
@@ -4,56 +4,43 @@
 Feature: Synchronize products in the products page of the Setup Wizard
 
   Scenario: Refresh SCC
-    Given I am on the Admin page
     When I refresh SCC
-    When I follow "SUSE Products" in the content area
-    And I wait until I see "Product Description" text
 
-#  Scenario: Add Ubuntu 16.04
-#    Given I am on the Admin page
-#    When I follow "SUSE Products" in the content area
-#    And I wait until I see "Product Description" text
-#    And I enter "Ubuntu 16.04" as the filtered product description
-#    And I select "Ubuntu 16.04" as a product
-#    Then I should see the "Ubuntu 16.04" selected
-#    When I click the Add Product button
-#    And I wait until I see "Ubuntu 16.04" product has been added
+  Scenario: Add Ubuntu 16.04
+    Given I am on the Products page
+    When I enter "Ubuntu 16.04" as the filtered product description
+    And I select "Ubuntu 16.04" as a product
+    Then I should see the "Ubuntu 16.04" selected
+    When I click the Add Product button
+    And I wait until I see "Ubuntu 16.04" product has been added
 
   Scenario: Add Ubuntu 18.04
-    Given I am on the Admin page
-    When I follow "SUSE Products" in the content area
-    And I wait until I see "Product Description" text
-    And I enter "Ubuntu 18.04" as the filtered product description
+    Given I am on the Products page
+    When I enter "Ubuntu 18.04" as the filtered product description
     And I select "Ubuntu 18.04" as a product
     Then I should see the "Ubuntu 18.04" selected
     When I click the Add Product button
     And I wait until I see "Ubuntu 18.04" product has been added
 
   Scenario: SUSE Linux Enterprise Server 12 SP4
-    Given I am on the Admin page
-    When I follow "SUSE Products" in the content area
-    And I wait until I see "Product Description" text
-    And I enter "SUSE Linux Enterprise Server 12 SP4" as the filtered product description
+    Given I am on the Products page
+    When I enter "SUSE Linux Enterprise Server 12 SP4" as the filtered product description
     And I select "SUSE Linux Enterprise Server 12 SP4 x86_64" as a product
     Then I should see the "SUSE Linux Enterprise Server 12 SP4 x86_64" selected
     When I click the Add Product button
     And I wait until I see "SUSE Linux Enterprise Server 12 SP4 x86_64" product has been added
 
   Scenario: SUSE Linux Enterprise Server 11 SP3
-    Given I am on the Admin page
-    When I follow "SUSE Products" in the content area
-    And I wait until I see "Product Description" text
-    And I enter "SUSE Linux Enterprise Server 11 SP3 i586" as the filtered product description
+    Given I am on the Products page
+    When I enter "SUSE Linux Enterprise Server 11 SP3 i586" as the filtered product description
     And I select "SUSE Linux Enterprise Server 11 SP3 i586" as a product
     Then I should see the "SUSE Linux Enterprise Server 11 SP3 i586" selected
     When I click the Add Product button
     And I wait until I see "SUSE Linux Enterprise Server 11 SP3 i586" product has been added
 
   Scenario: SUSE Linux Enterprise Server 11 SP4
-    Given I am on the Admin page
-    When I follow "SUSE Products" in the content area
-    And I wait until I see "Product Description" text
-    And I enter "SUSE Linux Enterprise Server 11 SP4" as the filtered product description
+    Given I am on the Products page
+    When I enter "SUSE Linux Enterprise Server 11 SP4" as the filtered product description
     And I select "SUSE Linux Enterprise Server 11 SP4 x86_64" as a product
     Then I should see the "SUSE Linux Enterprise Server 11 SP4 x86_64" selected
     And I open the sub-list of the product "SUSE Linux Enterprise Server 11 SP4 x86_64"
@@ -63,10 +50,8 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I wait until I see "SUSE Linux Enterprise Server 11 SP4 x86_64" product has been added
 
   Scenario: SUSE Linux Enterprise Server 15
-    Given I am on the Admin page
-    When I follow "SUSE Products" in the content area
-    And I wait until I see "Product Description" text
-    And I enter "SUSE Linux Enterprise Server 15" as the filtered product description
+    Given I am on the Products page
+    When I enter "SUSE Linux Enterprise Server 15" as the filtered product description
     And I select "SUSE Linux Enterprise Server 15 x86_64" as a product
     Then I should see the "SUSE Linux Enterprise Server 15 x86_64" selected
     When I open the sub-list of the product "SUSE Linux Enterprise Server 15 x86_64"
@@ -75,20 +60,16 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I wait until I see "SUSE Linux Enterprise Server 15 x86_64" product has been added
 
   Scenario: SUSE Linux Enterprise Server 15 SP1
-    Given I am on the Admin page
-    When I follow "SUSE Products" in the content area
-    And I wait until I see "Product Description" text
-    And I enter "SUSE Linux Enterprise Server 15 SP1" as the filtered product description
+    Given I am on the Products page
+    When I enter "SUSE Linux Enterprise Server 15 SP1" as the filtered product description
     And I select "SUSE Linux Enterprise Server 15 SP1 x86_64" as a product
     Then I should see the "SUSE Linux Enterprise Server 15 SP1 x86_64" selected
     When I click the Add Product button
     And I wait until I see "SUSE Linux Enterprise Server 15 SP1 x86_64" product has been added
 
   Scenario: SUSE Linux Enterprise Server 15 SP2
-    Given I am on the Admin page
-    When I follow "SUSE Products" in the content area
-    And I wait until I see "Product Description" text
-    And I enter "SUSE Linux Enterprise Server 15 SP2" as the filtered product description
+    Given I am on the Products page
+    When I enter "SUSE Linux Enterprise Server 15 SP2" as the filtered product description
     And I select "SUSE Linux Enterprise Server 15 SP2 x86_64" as a product
     Then I should see the "SUSE Linux Enterprise Server 15 SP2 x86_64" selected
     When I open the sub-list of the product "SUSE Linux Enterprise Server 15 SP2 x86_64"
@@ -102,20 +83,15 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I wait until I see "SUSE Linux Enterprise Server 15 SP2 x86_64" product has been added
 
 #  Scenario: Add RHEL Expanded Support 6
-#    Given I am on the Admin page
-#    When I follow "SUSE Products" in the content area
-#    And I wait until I see "Product Description" text
+#    Given I am on the Products page
 #    And I enter "RHEL Expanded Support 6" as the filtered product description
 #    And I select "RHEL Expanded Support 6" as a product
 #    Then I should see the "RHEL Expanded Support 6" selected
 #    When I click the Add Product button
 #    And I wait until I see "RHEL Expanded Support 6" product has been added
-
+#
 #  Scenario: Add RHEL Expanded Support 7
-#    Given I am on the Admin page
-#    When I follow "SUSE Products" in the content area
-#    And I wait until I see "Product Description" text
-#    Given I am on the SUSE Products page
+#    Given I am on the Products page
 #    And I enter "RHEL Expanded Support 7" as the filtered product description
 #    And I select "RHEL Expanded Support 7" as a product
 #    Then I should see the "RHEL Expanded Support 7" selected

--- a/testsuite/features/reposync/srv_sync_products.feature
+++ b/testsuite/features/reposync/srv_sync_products.feature
@@ -16,18 +16,14 @@ Feature: Synchronize products in the products page of the Setup Wizard
 
 @scc_credentials
   Scenario: Use the products filter
-    Given I am authorized for the "Admin" section
-    When I follow the left menu "Admin > Setup Wizard > Products"
-    And I wait until I see "Product Description" text
-    And I enter "RHEL7" as the filtered product description
+    Given I am on the Products page
+    When I enter "RHEL7" as the filtered product description
     Then I should see a "RHEL7 Base x86_64" text
 
 @scc_credentials
   Scenario: View the channels list in the products page
-    Given I am authorized for the "Admin" section
-    When I follow the left menu "Admin > Setup Wizard > Products"
-    And I wait until I see "Product Description" text
-    And I enter "SUSE Linux Enterprise Server for SAP Applications 15 x86_64" as the filtered product description
+    Given I am on the Products page
+    When I enter "SUSE Linux Enterprise Server for SAP Applications 15 x86_64" as the filtered product description
     And I click the channel list of product "SUSE Linux Enterprise Server for SAP Applications 15 x86_64"
     Then I should see a "Product Channels" text
     And I should see a "Mandatory Channels" text
@@ -35,10 +31,8 @@ Feature: Synchronize products in the products page of the Setup Wizard
 
 @scc_credentials
   Scenario: Add a product and one of its modules
-    Given I am authorized for the "Admin" section
-    When I follow the left menu "Admin > Setup Wizard > Products"
-    And I wait until I see "Product Description" text
-    And I enter "SUSE Linux Enterprise Server 12 SP2" as the filtered product description
+    Given I am on the Products page
+    When I enter "SUSE Linux Enterprise Server 12 SP2" as the filtered product description
     And I select "x86_64" in the dropdown list of the architecture filter
     And I select "SUSE Linux Enterprise Server 12 SP2 x86_64" as a product
     Then I should see the "SUSE Linux Enterprise Server 12 SP2 x86_64" selected
@@ -53,10 +47,8 @@ Feature: Synchronize products in the products page of the Setup Wizard
 
 @scc_credentials
   Scenario: Add a product with recommended enabled
-    Given I am authorized for the "Admin" section
-    When I follow the left menu "Admin > Setup Wizard > Products"
-    And I wait until I see "Product Description" text
-    And I enter "SUSE Linux Enterprise Server 15" as the filtered product description
+    Given I am on the Products page
+    When I enter "SUSE Linux Enterprise Server 15" as the filtered product description
     And I select "x86_64" in the dropdown list of the architecture filter
     And I open the sub-list of the product "SUSE Linux Enterprise Server 15 x86_64"
     Then I should see a "Basesystem Module 15 x86_64" text

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -73,9 +73,7 @@ end
 # events
 
 When(/^I wait until event "([^"]*)" is completed$/) do |event|
-  steps %(
-    When I wait at most #{DEFAULT_TIMEOUT} seconds until event "#{event}" is completed
-  )
+  step %(I wait at most #{DEFAULT_TIMEOUT} seconds until event "#{event}" is completed)
 end
 
 When(/^I wait at most (\d+) seconds until event "([^"]*)" is completed$/) do |final_timeout, event|
@@ -236,7 +234,7 @@ When(/^I trigger cobbler system record$/) do
       And I click on "Create PXE installation configuration"
       And I click on "Continue"
       And I wait until file "/srv/tftpboot/pxelinux.cfg/01-*" contains "ks=" on server
-      )
+    )
   end
 end
 
@@ -373,7 +371,7 @@ Then(/^I should see package "([^"]*)" in channel "([^"]*)"$/) do |pkg, channel|
     And I follow "#{channel}"
     And I follow "Packages"
     Then I should see package "#{pkg}"
-    )
+  )
 end
 
 # setup wizard

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -328,16 +328,17 @@ Given(/^I am authorized for the "([^"]*)" section$/) do |section|
   end
 end
 
-When(/^I am on the Organizations page$/) do
+Given(/^I am on the Organizations page$/) do
   steps %(
     Given I am authorized for the "Admin" section
     When I follow the left menu "Admin > Organizations"
-    )
+  )
 end
 
-Given(/^I am on the SUSE Products page$/) do
+Given(/^I am on the Products page$/) do
   steps %(
-    When I navigate to "rhn/manager/admin/setup/products" page
+    Given I am authorized for the "Admin" section
+    When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I see "Product Description" text
   )
 end
@@ -397,14 +398,14 @@ Given(/^I am on the groups page$/) do
   steps %(
     Given I am on the Systems page
     When I follow the left menu "Systems > System Groups"
-    )
+  )
 end
 
 Given(/^I am on the active Users page$/) do
   steps %(
     Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Users > User List > Active"
-    )
+  )
 end
 
 Then(/^table row for "([^"]*)" should contain "([^"]*)"$/) do |arg1, arg2|
@@ -530,7 +531,7 @@ Then(/^I should see something$/) do
   steps %(
     Given I should see a "Sign In" text
     And I should see a "About" text
-    )
+  )
 end
 
 Then(/^I should see "([^"]*)" systems selected for SSM$/) do |arg|

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -621,30 +621,22 @@ When(/^I accept "([^"]*)" key$/) do |host|
 end
 
 When(/^I go to the minion onboarding page$/) do
-  steps %(
-    When I follow the left menu "Salt > Keys"
-    )
+  step %(I follow the left menu "Salt > Keys")
 end
 
 When(/^I go to the bootstrapping page$/) do
-  steps %(
-    When I follow the left menu "Systems > Bootstrapping"
-    )
+  step %(I follow the left menu "Systems > Bootstrapping")
 end
 
 When(/^I refresh page until I see "(.*?)" hostname as text$/) do |minion|
   within('#spacewalk-content') do
-    steps %(
-     And I wait until I see the name of "#{minion}", refreshing the page
-      )
+    step %(I wait until I see the name of "#{minion}", refreshing the page)
   end
 end
 
 When(/^I refresh page until I do not see "(.*?)" hostname as text$/) do |minion|
   within('#spacewalk-content') do
-    steps %(
-     And I wait until I do not see the name of "#{minion}", refreshing the page
-      )
+    step %(I wait until I do not see the name of "#{minion}", refreshing the page)
   end
 end
 

--- a/testsuite/features/step_definitions/xmlrpc_common.rb
+++ b/testsuite/features/step_definitions/xmlrpc_common.rb
@@ -69,7 +69,7 @@ When(/^I unsubscribe "([^"]*)" and "([^"]*)" from configuration channel "([^"]*)
   steps %(
       When I unsubscribe "#{host1}" from configuration channel "#{channel}"
       And I unsubscribe "#{host2}" from configuration channel "#{channel}"
-        )
+  )
 end
 
 When(/^I create a System Record$/) do


### PR DESCRIPTION
## What does this PR change?

Adding a step to authorize as admin and then go to the Setup Wizard > Products page.
QAM scenarios were using `Given I am on the Admin page`, but this step was removed in the Uyuni branch here https://github.com/uyuni-project/uyuni/pull/1518/ . That wasn't ported to 4.0, where we were developing the QAM automated tests since last month. Now that moving to 4.1, we find that this method doesn't exist, and it didn't exist in Uyuni.

- Creating a new step definition to wrap the actions to login and go to Products page
- In addition, I fixed some wrong identation.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed, it is already documented.

- [x] **DONE**

## Test coverage
- QAM Tests using it

- [x] **DONE**

## Links

- Manager 4.1 https://github.com/SUSE/spacewalk/pull/12364

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:
https://github.com/SUSE/spacewalk/pull/12364/
- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
