### PR TITLE
Longer docker and openscap timeouts

### DIFF
--- a/testsuite/features/secondary/buildhost_docker_build_image.feature
+++ b/testsuite/features/secondary/buildhost_docker_build_image.feature
@@ -48,11 +48,11 @@ Feature: Build container images
   Scenario: Build the images with and without activation key
     Given I am on the Systems overview page of this "build_host"
     When I schedule the build of image "suse_key" via XML-RPC calls
-    And I wait at most 500 seconds until event "Image Build suse_key scheduled by admin" is completed
+    And I wait at most 750 seconds until event "Image Build suse_key scheduled by admin" is completed
     And I schedule the build of image "suse_simple" via XML-RPC calls
-    And I wait at most 500 seconds until event "Image Build suse_simple scheduled by admin" is completed
+    And I wait at most 750 seconds until event "Image Build suse_simple scheduled by admin" is completed
     And I schedule the build of image "suse_real_key" via XML-RPC calls
-    And I wait at most 500 seconds until event "Image Build suse_real_key scheduled by admin" is completed
+    And I wait at most 750 seconds until event "Image Build suse_real_key scheduled by admin" is completed
 
   Scenario: Build same images with different versions
     Given I am authorized as "admin" with password "admin"

--- a/testsuite/features/secondary/min_centos_openscap.feature
+++ b/testsuite/features/secondary/min_centos_openscap.feature
@@ -24,7 +24,7 @@ Feature: openSCAP audit of CentOS Salt minion
     And I enter "/usr/share/xml/scap/ssg/content/ssg-centos7-xccdf.xml" as "path"
     And I click on "Schedule"
     Then I should see a "XCCDF scan has been scheduled" text
-    And I wait until event "OpenSCAP xccdf scanning" is completed
+    And I wait at most 500 seconds until event "OpenSCAP xccdf scanning" is completed
 
 @centos_minion
   Scenario: Run a remote command on the CentOS minion

--- a/testsuite/features/secondary/min_salt_openscap_audit.feature
+++ b/testsuite/features/secondary/min_salt_openscap_audit.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2018 SUSE LLC
+# Copyright (c) 2017-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: openSCAP audit of Salt minion
@@ -15,7 +15,7 @@ Feature: openSCAP audit of Salt minion
     And I enter "/usr/share/openscap/scap-yast2sec-xccdf.xml" as "path"
     And I click on "Schedule"
     Then I should see a "XCCDF scan has been scheduled" text
-    And I wait until event "OpenSCAP xccdf scanning" is completed
+    And I wait at most 500 seconds until event "OpenSCAP xccdf scanning" is completed
 
   Scenario: Check results of the audit job on the minion
     Given I am on the Systems overview page of this "sle_minion"

--- a/testsuite/features/secondary/min_ubuntu_openscap.feature
+++ b/testsuite/features/secondary/min_ubuntu_openscap.feature
@@ -15,7 +15,7 @@ Feature: openSCAP audit of Ubuntu Salt minion
     And I enter "/usr/share/scap-security-guide/ssg-ubuntu1604-xccdf.xml" as "path"
     And I click on "Schedule"
     Then I should see a "XCCDF scan has been scheduled" text
-    And I wait until event "OpenSCAP xccdf scanning" is completed
+    And I wait at most 500 seconds until event "OpenSCAP xccdf scanning" is completed
 
 @ubuntu_minion
   Scenario: Run a remote command on the Ubuntu minion

--- a/testsuite/features/secondary/trad_centos_client.feature
+++ b/testsuite/features/secondary/trad_centos_client.feature
@@ -70,7 +70,7 @@ Feature: Be able to register a CentOS 7 traditional client and do some basic ope
     And I click on "Schedule"
     And I run "rhn_check -vvv" on "ceos_client"
     Then I should see a "XCCDF scan has been scheduled" text
-    And I wait until event "OpenSCAP xccdf scanning" is completed
+    And I wait at most 500 seconds until event "OpenSCAP xccdf scanning" is completed
 
 @centos_minion
   Scenario: Check the results of the OpenSCAP scan on the CentOS traditional client


### PR DESCRIPTION
## What does this PR change?

This PR increases some timeouts.

Seen on 4.1 PRV:
* 499 seconds to build docker image, almost as much as the 500 seconds allocated
* 301 seconds to perform openscap scan, more than the 250 seconds allocated

## Links

4.1: SUSE/spacewalk#12373
4.0: SUSE/spacewalk#12374
3.2: SUSE/spacewalk#12360 and SUSE/spacewalk#12375

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
