### PR TITLE
Fix SPMigration after dry run if channel is cloned (bsc#1176307)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/systems/SPMigrationAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/SPMigrationAction.java
@@ -61,6 +61,7 @@ import com.redhat.rhn.frontend.dto.ChildChannelDto;
 import com.redhat.rhn.frontend.dto.EssentialChannelDto;
 import com.redhat.rhn.frontend.struts.RequestContext;
 import com.redhat.rhn.frontend.struts.RhnAction;
+import com.redhat.rhn.manager.channel.ChannelManager;
 import com.redhat.rhn.manager.distupgrade.DistUpgradeManager;
 import com.redhat.rhn.manager.errata.ErrataManager;
 import com.redhat.rhn.manager.rhnpackage.PackageManager;
@@ -521,7 +522,9 @@ public class SPMigrationAction extends RhnAction {
         List<Long> channelIds = channels.stream().map(Channel::getId).collect(Collectors.toList());
         List<EssentialChannelDto> childChannels = getChannelDTOs(ctx, baseChannel, channelIds);
 
-        SUSEProduct baseProduct = SUSEProductFactory.lookupByChannelName(baseChannel.getName()).get(0).getRootProduct();
+        // Get name of original base channel if channel is cloned
+        String origBaseChannelName = ChannelManager.getOriginalChannel(baseChannel).getName();
+        SUSEProduct baseProduct = SUSEProductFactory.lookupByChannelName(origBaseChannelName).get(0).getRootProduct();
 
         Server server = ctx.lookupAndBindServer();
         Optional<SUSEProductSet> installedProducts = server.getInstalledProductSet();

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix SP migration after dry run for cloned channels (bsc#1176307)
 - filter not available optional channels out
 - Fix: handle version comparison corner cases in Ubuntu packages
 


### PR DESCRIPTION
## What does this PR change?

When scheduling an sp migration after a dry run through
Events -> History -> Select successful dry run -> Click run migration
an ISE was thrown if the channel is a cloned channel.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Bugfix

- [x] **DONE**

## Test coverage
- No tests: Bugfix

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/12389

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
