### PR TITLE
Adapt official images 2

### DIFF
--- a/testsuite/features/secondary/buildhost_docker_build_image.feature
+++ b/testsuite/features/secondary/buildhost_docker_build_image.feature
@@ -48,11 +48,11 @@ Feature: Build container images
   Scenario: Build the images with and without activation key
     Given I am on the Systems overview page of this "build_host"
     When I schedule the build of image "suse_key" via XML-RPC calls
-    And I wait at most 750 seconds until event "Image Build suse_key scheduled by admin" is completed
+    And I wait at most 600 seconds until event "Image Build suse_key scheduled by admin" is completed
     And I schedule the build of image "suse_simple" via XML-RPC calls
-    And I wait at most 750 seconds until event "Image Build suse_simple scheduled by admin" is completed
+    And I wait at most 600 seconds until event "Image Build suse_simple scheduled by admin" is completed
     And I schedule the build of image "suse_real_key" via XML-RPC calls
-    And I wait at most 750 seconds until event "Image Build suse_real_key scheduled by admin" is completed
+    And I wait at most 600 seconds until event "Image Build suse_real_key scheduled by admin" is completed
 
   Scenario: Build same images with different versions
     Given I am authorized as "admin" with password "admin"

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -513,7 +513,7 @@ end
 
 Then(/^the keymap on "([^"]*)" should be "([^"]*)"$/) do |minion, keymap|
   node = get_target(minion)
-  output, _code = node.run('cat /etc/vconsole.conf')
+  output, _code = node.run("grep 'KEYMAP=' /etc/vconsole.conf")
   raise "The keymap #{keymap} is different to the output: #{output.strip}" unless output.strip == "KEYMAP=#{keymap}"
 end
 


### PR DESCRIPTION
## What does this PR change?

Adapt to official images - 2

* (piggyback) 600s are enough for building containers according to statistics at SUSE/spacewalk#12360
* better test of contents of `/etc/vconsole.conf`

## Links

Ports:
* 3.2: SUSE/spacewalk#12404
* 4.0: SUSE/spacewalk#12403
* 4.1: SUSE/spacewalk#12402

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
