### PR TITLE
Fix regexp that changes ubuntu's repositories

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -672,18 +672,35 @@ When(/^I register this client for SSH push via tunnel$/) do
 end
 
 # Repositories and packages management
-When(/^I (enable|disable) (the repositories|repository) "([^"]*)" on this "([^"]*)"((?: without error control)?)$/) do |action, _optional, repos, host, error_control|
+When(/^I enable (the repositories|repository) "([^"]*)" on this "([^"]*)"((?: without error control)?)$/) do |_optional, repos, host, error_control|
   node = get_target(host)
   os_version, os_family = get_os_version(node)
   if os_family =~ /^opensuse/ || os_family =~ /^sles/
-    cmd = "zypper mr --#{action} #{repos}"
+    cmd = "zypper mr --enable #{repos}"
   else
     cmd = repos.split(' ').map do |repo|
       if os_family =~ /^centos/
-        "sed -i 's/enabled=.*/enabled=#{action == 'enable' ? '1' : '0'}/g' /etc/yum.repos.d/#{repo}.repo; "
+        "sed -i 's/enabled=.*/enabled=1/g' /etc/yum.repos.d/#{repo}.repo; "
       elsif os_family =~ /^ubuntu/
-        "sed -i '/^#{action == 'enable' ? '#\\s*' : ''}deb.*/ s/^#{action == 'enable' ? '' : '#\\s*'}deb "\
-        "/#{action == 'enable' ? '' : '#'}deb /' /etc/apt/sources.list.d/#{repo}.list; "
+        "sed -i '/^#\\s*deb.*/ s/^#\\s*deb /deb /' /etc/apt/sources.list.d/#{repo}.list; "
+      end
+    end
+    cmd = cmd.reduce(:+)
+  end
+  node.run(cmd, error_control.empty?)
+end
+
+When(/^I disable (the repositories|repository) "([^"]*)" on this "([^"]*)"((?: without error control)?)$/) do |_optional, repos, host, error_control|
+  node = get_target(host)
+  os_version, os_family = get_os_version(node)
+  if os_family =~ /^opensuse/ || os_family =~ /^sles/
+    cmd = "zypper mr --disable #{repos}"
+  else
+    cmd = repos.split(' ').map do |repo|
+      if os_family =~ /^centos/
+        "sed -i 's/enabled=.*/enabled=0/g' /etc/yum.repos.d/#{repo}.repo; "
+      elsif os_family =~ /^ubuntu/
+        "sed -i '/^deb.*/ s/^deb /# deb /' /etc/apt/sources.list.d/#{repo}.list; "
       end
     end
     cmd = cmd.reduce(:+)


### PR DESCRIPTION
## What does this PR change?

This fixes PR #2554

There was an error in the regular expression for ubuntu : probably a byproduct of factorizing too much :smile_cat: .

Thanks to @juliogonzalez and @mbologna for the long debugging session and finding the issue :clap: .


## Links

Ports:
* 3.2: not affected
* 4.0: SUSE/spacewalk#12415
* 4.1: SUSE/spacewalk#12414


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
