### PR TITLE
Change submission scripts to allow package lists

### DIFF
--- a/susemanager-utils/testing/automation/push-to-obs.sh
+++ b/susemanager-utils/testing/automation/push-to-obs.sh
@@ -10,20 +10,22 @@ help() {
   echo ""
   echo "Syntax: "
   echo ""
-  echo "${SCRIPT} -d <API1|PROJECT1>[,<API2|PROJECT2>...] [-v] [-t]"
+  echo "${SCRIPT} -d <API1|PROJECT1>[,<API2|PROJECT2>...] -c OSC_CFG_FILE [-p PACKAGE1,PACKAGE2,...,PACKAGEN] [-v] [-t]"
   echo ""
   echo "Where: "
   echo "  -d  Comma separated list of destionations in the format API/PROJECT,"
   echo "      for example https://api.opensuse.org|systemsmanagement:Uyuni:Master"
   echo "  -c  Path to the OSC credentials (usually ~/.osrc)"
+  echo "  -p  Comma separated list of packages. If absent, all packages are submitted"
   echo "  -v  Verbose mode"
   echo "  -t  For tito, use current branch HEAD instead of latest package tag"
   echo ""
 }
 
-while getopts ":d:c:vth" opts; do
+while getopts ":d:c:p:vth" opts; do
   case "${opts}" in
     d) DESTINATIONS=${OPTARG};;
+    p) PACKAGES=${OPTARG};;
     c) CREDENTIALS=${OPTARG};;
     v) VERBOSE="-v";;
     t) TEST="-t";;
@@ -51,7 +53,7 @@ if [ ! -f ${CREDENTIALS} ]; then
 fi
 
 INITIAL_CMD="/manager/susemanager-utils/testing/automation/initial-objects.sh"
-CMD="/manager/susemanager-utils/testing/docker/scripts/push-to-obs.sh -d '${DESTINATIONS}' -c /tmp/.oscrc ${VERBOSE} ${TEST}"
+CMD="/manager/susemanager-utils/testing/docker/scripts/push-to-obs.sh -d '${DESTINATIONS}' -c /tmp/.oscrc -p '${PACKAGES}' ${VERBOSE} ${TEST}"
 CHOWN_CMD="/manager/susemanager-utils/testing/automation/chown-objects.sh $(id -u) $(id -g)"
 
 docker pull $REGISTRY/$PUSH2OBS_CONTAINER

--- a/susemanager-utils/testing/docker/scripts/push-to-obs.sh
+++ b/susemanager-utils/testing/docker/scripts/push-to-obs.sh
@@ -8,20 +8,22 @@ help() {
   echo ""
   echo "Syntax: "
   echo ""
-  echo "${SCRIPT} -d <API1|PROJECT1>[,<API2|PROJECT2>...] [-v] [-t]"
+  echo "${SCRIPT} -d <API1|PROJECT1>[,<API2|PROJECT2>...] -c OSC_CFG_FILE [-p PACKAGE1,PACKAGE2,...,PACKAGEN] [-v] [-t]"
   echo ""
   echo "Where: "
   echo "  -d  Comma separated list of destionations in the format API/PROJECT,"
   echo "      for example https://api.opensuse.org|systemsmanagement:Uyuni:Master"
+  echo "  -p  Comma separated list of packages. If absent, all packages are submitted"
   echo "  -c  Path to the OSC credentials (usually ~/.osrc)"
   echo "  -v  Verbose mode"
   echo "  -t  For tito, use current branch HEAD instead of latest package tag"
   echo ""
 }
 
-while getopts ":d:c:vth" opts; do
+while getopts ":d:c:p:vth" opts; do
   case "${opts}" in
     d) DESTINATIONS=${OPTARG};;
+    p) PACKAGES="$(echo ${OPTARG}|tr ',' ' ')";;
     c) export OSCRC=${OPTARG};;
     v) export VERBOSE=1;;
     t) export TEST=1;;
@@ -58,12 +60,12 @@ fi
 
 # Build SRPMS
 echo "*************** BUILDING PACKAGES ***************"
-./build-packages-for-obs.sh
+./build-packages-for-obs.sh ${PACKAGES}
 
 # Submit 
 for DESTINATION in $(echo ${DESTINATIONS}|tr ',' ' '); do
   export OSCAPI=$(echo ${DESTINATION}|cut -d'|' -f1)
   export OBS_PROJ=$(echo ${DESTINATION}|cut -d'|' -f2)
   echo "*************** PUSHING TO ${OBS_PROJ} ***************"
-  ./push-packages-to-obs.sh
+  ./push-packages-to-obs.sh ${PACKAGES}
 done


### PR DESCRIPTION
## What does this PR change?

Change submission scripts to allow package lists. Required to generate patches for Uyuni, but also could be useful in the future if for some reason we want to submit individual packages.

2obs jobs would require changes.

For Uyuni we now have https://ci.suse.de/view/Manager/view/Uyuni/job/uyuni-master-2obs-patch

One caveat (that I hope we'll never have): if the list of packages is looong enough, the 
## GUI diff

No difference.

- [x] **DONE**

## Documentation

https://github.com/uyuni-project/uyuni/wiki/Releasing-Uyuni-patches

- [x] **DONE**

## Test coverage
- No tests: Changing part of the testing stuff.

- [x] **DONE**

## Links

None

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"