### PR TITLE
Fix JavaScript error caused by SPA navigation event with empty event field (bsc#1176503)

### DIFF
--- a/web/html/src/core/spa/spa-engine.js
+++ b/web/html/src/core/spa/spa-engine.js
@@ -59,7 +59,7 @@ window.pageRenderers.spaengine.init = function init() {
 
       let urlParser = document.createElement('a');
       urlParser.href = navigation.path;
-      if(isLoginPage(urlParser.pathname) || navigation.event.target.classList.contains('no-spa')) {
+      if(isLoginPage(urlParser.pathname) || (navigation.event && navigation.event.target.classList.contains('no-spa'))) {
         window.location = navigation.path;
       }
     })

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Fix JavaScript error caused by SPA navigation event with empty event field (bsc#1176503)
 - Force disable SPA for non-navigation links (bsc#1175512)
 - Add translation support for react t() function
 - fix striping on react tables


### PR DESCRIPTION
## What does this PR change?

https://bugzilla.suse.com/show_bug.cgi?id=1176512
When clicking the "Create" or "Delete" button in CLM the `navigation` event object has an empty `event` field . This leads to undefined type of error that's shown to the user. 
This PR checks if the `navigation.event` field is defined.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bugfix

- [x] **DONE**

## Test coverage
- No tests: **add explanation**

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
