### PR TITLE
Testsuite: Hide internal details from Cucumber

### DIFF
--- a/testsuite/features/init_clients/buildhost_bootstrap.feature
+++ b/testsuite/features/init_clients/buildhost_bootstrap.feature
@@ -26,7 +26,7 @@ Feature: Be able to bootstrap a Salt build host via the GUI
     Given I am authorized
     When I go to the minion onboarding page
     Then I should see a "accepted" text
-    When I follow the left menu "Systems > Overview"
+    When I am on the System Overview page
     And I wait until I see the name of "build_host", refreshing the page
     And I wait until onboarding is completed for "build_host"
     Then the Salt master can reach "build_host"

--- a/testsuite/features/init_clients/min_centos_salt.feature
+++ b/testsuite/features/init_clients/min_centos_salt.feature
@@ -19,7 +19,7 @@ Feature: Be able to bootstrap a CentOS minion and do some basic operations on it
     And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text
-    And I navigate to "rhn/systems/Overview.do" page
+    And I am on the System Overview page
     And I wait until I see the name of "ceos_minion", refreshing the page
     And I wait until onboarding is completed for "ceos_minion"
 

--- a/testsuite/features/init_clients/min_ubuntu_salt.feature
+++ b/testsuite/features/init_clients/min_ubuntu_salt.feature
@@ -19,7 +19,7 @@ Feature: Bootstrap an Ubuntu minion and do some basic operations on it
     And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text
-    And I navigate to "rhn/systems/Overview.do" page
+    And I am on the System Overview page
     And I wait until I see the name of "ubuntu_minion", refreshing the page
     And I wait until onboarding is completed for "ubuntu_minion"
     And I query latest Salt changes on ubuntu system "ubuntu_minion"

--- a/testsuite/features/init_clients/sle_minion.feature
+++ b/testsuite/features/init_clients/sle_minion.feature
@@ -23,7 +23,7 @@ Feature: Be able to bootstrap a Salt minion via the GUI
     Given I am authorized
     When I go to the minion onboarding page
     Then I should see a "accepted" text
-    When I navigate to "rhn/systems/Overview.do" page
+    When I am on the System Overview page
     And I wait until I see the name of "sle_minion", refreshing the page
     And I wait until onboarding is completed for "sle_minion"
     Then the Salt master can reach "sle_minion"

--- a/testsuite/features/init_clients/sle_ssh_minion.feature
+++ b/testsuite/features/init_clients/sle_ssh_minion.feature
@@ -14,7 +14,7 @@ Feature: Be able to bootstrap a Salt host managed via salt-ssh
     And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text
-    And I navigate to "rhn/systems/Overview.do" page
+    And I am on the System Overview page
     And I wait until I see the name of "ssh_minion", refreshing the page
     And I wait until onboarding is completed for "ssh_minion"
 

--- a/testsuite/features/secondary/buildhost_osimage_build_image.feature
+++ b/testsuite/features/secondary/buildhost_osimage_build_image.feature
@@ -37,9 +37,8 @@ Feature: Build OS images
   Scenario: Check the OS image built as Kiwi image administrator
     Given I am on the Systems overview page of this "build_host"
     Then I should see a "[OS Image Build Host]" text
-    When I wait at most 3300 seconds until event "Image Build suse_os_image scheduled by kiwikiwi" is completed
-    And I wait at most 300 seconds until event "Image Inspect 1//suse_os_image:latest scheduled by kiwikiwi" is completed
-    And I navigate to "os-images/1/" page
+    When I wait until the image build "suse_os_image" is completed
+    And I am on the image page of "suse_os_image"
     Then I should see the name of the image
 
 @proxy

--- a/testsuite/features/secondary/min_activationkey.feature
+++ b/testsuite/features/secondary/min_activationkey.feature
@@ -61,7 +61,7 @@ Feature: Bootstrap a Salt minion via the GUI with an activation key
     And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text
-    When I navigate to "rhn/systems/Overview.do" page
+    When I am on the System Overview page
     And I wait until I see the name of "sle_minion", refreshing the page
     And I wait until onboarding is completed for "sle_minion"
 

--- a/testsuite/features/secondary/min_bootstrap_negative.feature
+++ b/testsuite/features/secondary/min_bootstrap_negative.feature
@@ -77,7 +77,7 @@ Feature: Negative tests for bootstrapping normal minions
      And I select the hostname of "proxy" from "proxies"
      And I click on "Bootstrap"
      And I wait until I see "Successfully bootstrapped host!" text
-     And I navigate to "rhn/systems/Overview.do" page
+     And I am on the System Overview page
      And I wait until I see the name of "sle_minion", refreshing the page
 
   Scenario: Cleanup: subscribe again to base channel after negative tests

--- a/testsuite/features/secondary/min_bootstrap_script.feature
+++ b/testsuite/features/secondary/min_bootstrap_script.feature
@@ -26,7 +26,7 @@ Feature: Register a Salt minion via Bootstrap-script
 
   Scenario: Check if onboarding for the script-bootstrapped minion was successful
     Given I am authorized as "admin" with password "admin"
-    When I navigate to "rhn/systems/Overview.do" page
+    When I am on the System Overview page
     And I wait until I see the name of "sle_minion", refreshing the page
     And I wait until onboarding is completed for "sle_minion"
 

--- a/testsuite/features/secondary/min_bootstrap_xmlrpc.feature
+++ b/testsuite/features/secondary/min_bootstrap_xmlrpc.feature
@@ -21,7 +21,7 @@ Feature: Register a Salt minion via XML-RPC API
     Given I am authorized
     When I go to the minion onboarding page
     Then I should see a "accepted" text
-    When I navigate to "rhn/systems/Overview.do" page
+    When I am on the System Overview page
     And I wait until I see the name of "sle_minion", refreshing the page
     And I wait until onboarding is completed for "sle_minion"
     Then the Salt master can reach "sle_minion"

--- a/testsuite/features/secondary/min_centos_ssh.feature
+++ b/testsuite/features/secondary/min_centos_ssh.feature
@@ -27,7 +27,7 @@ Feature: Bootstrap a SSH-managed CentOS minion and do some basic operations on i
     And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text
-    And I navigate to "rhn/systems/Overview.do" page
+    And I am on the System Overview page
     And I wait until I see the name of "ceos_ssh_minion", refreshing the page
     And I wait until onboarding is completed for "ceos_ssh_minion"
 
@@ -107,7 +107,7 @@ Feature: Bootstrap a SSH-managed CentOS minion and do some basic operations on i
     And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text
-    And I navigate to "rhn/systems/Overview.do" page
+    And I am on the System Overview page
     And I wait until I see the name of "ceos_minion", refreshing the page
     And I wait until onboarding is completed for "ceos_minion"
 

--- a/testsuite/features/secondary/min_empty_system_profiles.feature
+++ b/testsuite/features/secondary/min_empty_system_profiles.feature
@@ -15,14 +15,14 @@ Feature: Empty minion profile operations
 
   Scenario: Check the created empty minion profiles in Unprovisioned Systems page
     Given I am authorized
-    And I navigate to "rhn/systems/BootstrapSystemList.do" page
+    And I follow the left menu "System > System List > Unprovisioned Systems"
     And I wait until I see "empty-profile" text, refreshing the page
     And I wait until I see "00:11:22:33:44:55" text
     And I wait until I see "empty-profile-hostname" text
 
   Scenario: Check the empty profiles has the hostname set
     Given I am authorized
-    And I navigate to "rhn/systems/BootstrapSystemList.do" page
+    And I follow the left menu "System > System List > Unprovisioned Systems"
     And I follow "empty-profile-hostname"
     Then I wait until I see "min-retail.mgr.suse.de" text, refreshing the page
 
@@ -34,7 +34,7 @@ Feature: Empty minion profile operations
 
   Scenario: Cleanup: Delete first empty minion profile
     Given I am authorized
-    When I navigate to "rhn/systems/SystemList.do" page
+    When I follow the left menu "Systems > System List"
     And I follow "empty-profile"
     And I follow "Delete System"
     Then I should see a "Confirm System Profile Deletion" text
@@ -43,7 +43,7 @@ Feature: Empty minion profile operations
 
   Scenario: Cleanup: Delete second empty minion profiles
     Given I am authorized
-    When I navigate to "rhn/systems/SystemList.do" page
+    When I follow the left menu "Systems > System List"
     And I follow "empty-profile-hostname"
     And I follow "Delete System"
     Then I should see a "Confirm System Profile Deletion" text

--- a/testsuite/features/secondary/min_salt_mgrcompat_state.feature
+++ b/testsuite/features/secondary/min_salt_mgrcompat_state.feature
@@ -49,7 +49,7 @@ Feature: Verify that Salt mgrcompat state works when the new module.run syntax i
 
   Scenario: Check if onboarding for the minion with the new module.run syntax was successful
     Given I am authorized as "admin" with password "admin"
-    When I navigate to "rhn/systems/Overview.do" page
+    When I am on the System Overview page
     And I wait until I see the name of "sle_minion", refreshing the page
     And I wait until onboarding is completed for "sle_minion"
 

--- a/testsuite/features/secondary/min_ubuntu_ssh.feature
+++ b/testsuite/features/secondary/min_ubuntu_ssh.feature
@@ -27,7 +27,7 @@ Feature: Bootstrap a SSH-managed Ubuntu minion and do some basic operations on i
     And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text
-    And I navigate to "rhn/systems/Overview.do" page
+    And I am on the System Overview page
     And I wait until I see the name of "ubuntu_ssh_minion", refreshing the page
     And I wait until onboarding is completed for "ubuntu_ssh_minion"
 
@@ -106,7 +106,7 @@ Feature: Bootstrap a SSH-managed Ubuntu minion and do some basic operations on i
     And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text
-    And I navigate to "rhn/systems/Overview.do" page
+    And I am on the System Overview page
     And I wait until I see the name of "ubuntu_minion", refreshing the page
     And I wait until onboarding is completed for "ubuntu_minion"
 

--- a/testsuite/features/secondary/minssh_bootstrap_xmlrpc.feature
+++ b/testsuite/features/secondary/minssh_bootstrap_xmlrpc.feature
@@ -22,7 +22,7 @@ Feature: Register a salt-ssh system via XML-RPC
 @ssh_minion
   Scenario: Check new XML-RPC bootstrapped salt-ssh system in System Overview page
      Given I am authorized
-     And I navigate to "rhn/systems/Overview.do" page
+     And I am on the System Overview page
      And I wait until I see the name of "ssh_minion", refreshing the page
      And I wait until onboarding is completed for "ssh_minion"
 

--- a/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
+++ b/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
@@ -232,7 +232,7 @@ Feature: PXE boot a Retail terminal
     When I reboot the PXE boot minion
     And I wait at most 180 seconds until Salt master sees "pxeboot_minion" as "unaccepted"
     And I accept "pxeboot_minion" key in the Salt master
-    And I navigate to "rhn/systems/Overview.do" page
+    And I am on the System Overview page
     And I wait until I see the name of "pxeboot_minion", refreshing the page
     And I follow this "pxeboot_minion" link
     And I wait until event "Apply states [util.syncstates, saltboot] scheduled by (none)" is completed
@@ -416,7 +416,7 @@ Feature: PXE boot a Retail terminal
     And I bootstrap pxeboot minion via bootstrap script on the proxy
     And I wait at most 180 seconds until Salt master sees "pxeboot_minion" as "unaccepted"
     And I accept key of pxeboot minion in the Salt master
-    Then I navigate to "rhn/systems/Overview.do" page
+    Then I am on the System Overview page
     And I wait until I see the name of "pxeboot_minion", refreshing the page
 
 @proxy

--- a/testsuite/features/secondary/srv_custom_system_info.feature
+++ b/testsuite/features/secondary/srv_custom_system_info.feature
@@ -16,8 +16,8 @@ Feature: Custom system info key-value pairs
     Then I should see a "Successfully added 1 custom key." text
 
   Scenario: Add a value to a system
-    When I follow the left menu "Systems > Overview"
-    When I follow this "sle_client" link
+    When I am on the System Overview page
+    And I follow this "sle_client" link
     And I follow "Custom Info"
     And I follow "Create Value"
     And I follow "key-label"
@@ -27,8 +27,8 @@ Feature: Custom system info key-value pairs
     And I should see a "key-value" link
 
   Scenario: Edit the value
-    When I follow the left menu "Systems > Overview"
-    When I follow this "sle_client" link
+    When I am on the System Overview page
+    And I follow this "sle_client" link
     And I follow "Custom Info"
     And I follow "key-value"
     And I should see a "Edit Custom Value" text

--- a/testsuite/features/secondary/srv_menu.feature
+++ b/testsuite/features/secondary/srv_menu.feature
@@ -157,7 +157,7 @@ Feature: Web UI - Main landing page menu, texts and links
     Then I should see a "Software Channel Management" text in the content area
 
   Scenario: Completeness of the side navigation bar and the content frame
-    When I follow the left menu "Systems > Overview"
+    When I am on the Systems page
     Then I should see a "System Overview" text in the content area
     And I should see a "Overview" link in the left menu
     And I should see a "Systems" link in the left menu

--- a/testsuite/features/secondary/trad_centos_client.feature
+++ b/testsuite/features/secondary/trad_centos_client.feature
@@ -113,7 +113,7 @@ Feature: Be able to register a CentOS 7 traditional client and do some basic ope
     And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text
-    And I navigate to "rhn/systems/Overview.do" page
+    And I am on the System Overview page
     And I wait until I see the name of "ceos_minion", refreshing the page
     And I wait until onboarding is completed for "ceos_minion"
 

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -47,10 +47,6 @@ Then(/^I can see all system information for "([^"]*)"$/) do |host|
   step %(I should see a "#{os_pretty}" text) if os_pretty.include? 'SUSE Linux'
 end
 
-Then(/^I should see the name of the image$/) do
-  step %(I should see a "#{compute_image_name}" text)
-end
-
 Then(/^I should see the terminals imported from the configuration file$/) do
   terminals = read_terminals_from_yaml
   terminals.each { |terminal| step %(I should see a "#{terminal}" text) }

--- a/testsuite/features/step_definitions/docker_steps.rb
+++ b/testsuite/features/step_definitions/docker_steps.rb
@@ -22,12 +22,28 @@ def retrieve_build_host_id
   build_host_id
 end
 
+# OS image build
 When(/^I navigate to images webpage$/) do
   visit("https://#{$server.full_hostname}/rhn/manager/cm/images")
 end
 
 When(/^I navigate to images build webpage$/) do
   visit("https://#{$server.full_hostname}/rhn/manager/cm/build")
+end
+
+Then(/^I wait until the image build "([^"]*)" is completed$/) do |image_name|
+  steps %(
+    When I wait at most 3300 seconds until event "Image Build #{image_name} scheduled by kiwikiwi" is completed
+    And I wait at most 300 seconds until event "Image Inspect 1//#{image_name}:latest scheduled by kiwikiwi" is completed
+  )
+end
+
+Then(/^I am on the image page of "([^"]*)"$/) do |image_name|
+  step %(I navigate to "#{compute_image_url(image_name)}" page)
+end
+
+Then(/^I should see the name of the image$/) do
+  step %(I should see a "#{compute_image_name}" text)
 end
 
 When(/^I wait at most (\d+) seconds until container "([^"]*)" is built successfully$/) do |timeout, name|

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -63,6 +63,11 @@ def compute_image_name
   end
 end
 
+def compute_image_url(image_name)
+  raise "Unknown image #{image_name}" unless image_name == 'suse_os_image'
+  'os-images/1/'
+end
+
 # compute list of reposyncs to avoid killing because they might be involved in bootstrapping
 # this is a safety net only, the best thing to do is to not start the reposync at all
 def compute_list_to_leave_running


### PR DESCRIPTION
## What does this PR change?
Drop internal details on the web UI structure from Cucumber, and other minor changes.

Consistently, use step "I am on the System Overview page" when appropriate.
Prefer step "I follow the left menu ..." over step "I navigate to ..."

- testsuite/features/step_definitions/common_steps.rb
Add steps "I wait until the image build is completed"
and "I am on the new image page".
Move stuff for os image build here.

- testsuite/features/secondary/buildhost_osimage_build_image.feature:
Use the new steps.


## Links
### Ports
- Manager-3.2: https://github.com/SUSE/spacewalk/pull/12437
- Manager-4.0: https://github.com/SUSE/spacewalk/pull/12436
- Manager-4.1: https://github.com/SUSE/spacewalk/pull/12435

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

