### PR TITLE
QA: Refresh the pillar data before retrieve values, after save the formula with changes

### DIFF
--- a/testsuite/features/secondary/min_salt_formulas_advanced.feature
+++ b/testsuite/features/secondary/min_salt_formulas_advanced.feature
@@ -79,7 +79,7 @@ Feature: Use advanced features of Salt formulas
      And I click on "Save Formula"
      Then I should see a "Formula saved" text
      When I refresh the pillar data
-     And the pillar data for "testing:str" should be "text1" on "sle_minion"
+     Then the pillar data for "testing:str" should be "text1" on "sle_minion"
      And the pillar data for "testing:str_def" should be "text2" on "sle_minion"
      And the pillar data for "testing:str_or_null" should be "text3" on "sle_minion"
      And the pillar data for "testing:str_opt" should be "text4" on "sle_minion"
@@ -99,7 +99,8 @@ Feature: Use advanced features of Salt formulas
      And I click on "Clear values" and confirm
      And I click on "Save Formula"
      Then I should see a "Formula saved" text
-     And the pillar data for "testing:str" should be "" on "sle_minion"
+     When I refresh the pillar data
+     Then the pillar data for "testing:str" should be "" on "sle_minion"
      And the pillar data for "testing:str_def" should be "defvalue" on "sle_minion"
      And the pillar data for "testing:str_or_null" should be "None" on "sle_minion"
      And the pillar data for "testing" should not contain "str_opt" on "sle_minion"
@@ -135,7 +136,8 @@ Feature: Use advanced features of Salt formulas
      And I enter "pw1" as "testing#pw"
      And I click on "Save Formula"
      Then I should see a "Formula saved" text
-     And the pillar data for "testing:str" should be "text1" on "sle_minion"
+     When I refresh the pillar data
+     Then the pillar data for "testing:str" should be "text1" on "sle_minion"
      And the pillar data for "testing:str_def" should be "defvalue" on "sle_minion"
      And the pillar data for "testing:str_or_null" should be "None" on "sle_minion"
      And the pillar data for "testing" should not contain "str_opt" on "sle_minion"
@@ -153,6 +155,7 @@ Feature: Use advanced features of Salt formulas
      And I follow first "Testform" in the content area
      And I click on "Save Formula"
      Then I should see a "Formula saved" text
+     When I refresh the pillar data
      Then the pillar data for "testing:str" should be "text1" on "sle_minion"
      And the pillar data for "testing:str_def" should be "defvalue" on "sle_minion"
      And the pillar data for "testing:str_or_null" should be "None" on "sle_minion"
@@ -182,7 +185,8 @@ Feature: Use advanced features of Salt formulas
      And I enter "min_pw3" as "testing#pw_opt"
      And I click on "Save Formula"
      Then I should see a "Formula saved" text
-     And the pillar data for "testing:str" should be "min_text1" on "sle_minion"
+     When I refresh the pillar data
+     Then the pillar data for "testing:str" should be "min_text1" on "sle_minion"
      And the pillar data for "testing:str_def" should be "min_text2" on "sle_minion"
      And the pillar data for "testing:str_or_null" should be "min_text3" on "sle_minion"
      And the pillar data for "testing:str_opt" should be "min_text4" on "sle_minion"
@@ -202,6 +206,7 @@ Feature: Use advanced features of Salt formulas
      And I click on "Clear values" and confirm
      And I click on "Save Formula"
      Then I should see a "Formula saved" text
+     When I refresh the pillar data
      Then the pillar data for "testing:str" should be "text1" on "sle_minion"
      And the pillar data for "testing:str_def" should be "defvalue" on "sle_minion"
      And the pillar data for "testing:str_or_null" should be "None" on "sle_minion"

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -547,6 +547,7 @@ Then(/^the pillar data for "([^"]*)" should (be|contain|not contain) "([^"]*)" o
   if verb == 'be' && value == ''
     raise "Output has more than one line: #{output}" unless output.split("\n").length == 1
   elsif verb == 'be'
+    raise "Output value not found : #{output}" unless output.split("\n") > 1
     raise "Output value is different than #{value}: #{output}" unless output.split("\n")[1].strip == value
   elsif verb == 'contain'
     raise "Output doesn't contain #{value}: #{output}" unless output.include? value


### PR DESCRIPTION
## What does this PR change?

This PR aimes to fix a testsuite issue retrieving pillar data, which is not up to date sometimes when we save the formula.
Also, prevents an error handling the output text from salt.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests 

- [x] **DONE**

## Links

Need ports

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
