### PR TITLE
Fix the jQuery selector in SP Migration page

### DIFF
--- a/web/html/javascript/susemanager-sp-migration.js
+++ b/web/html/javascript/susemanager-sp-migration.js
@@ -7,7 +7,7 @@ jQuery(function() {
 
   // Create hidden inputs to submit channel IDs
   function prepareSubmitChannels() {
-    jQuery('#migrationForm input[type="hidden", name="childChannels"]').remove();
+    jQuery('#migrationForm input[type="hidden"][name="childChannels"]').remove();
     // Submit all checked child channel's IDs
     jQuery('.channels-tree:visible input:checked').each(function() {
       jQuery('#migrationForm').append(

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Fix the jQuery selector in SP Migration page (bsc#1176500)
 - Fix JavaScript error caused by SPA navigation event with empty event field (bsc#1176503)
 - Force disable SPA for non-navigation links (bsc#1175512)
 - Add translation support for react t() function


### PR DESCRIPTION
## What does this PR change?

see the commit msg.

We likely have many other occurences of this problem in the codebase, but that's for later.

## GUI diff



- [x] **DONE**

## Documentation
- No documentation needed: bug

- [x] **DONE**

## Test coverage
- No tests: legacy JS - no tests

- [x] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/12427

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
