### PR TITLE
Fix link to documentation in Admin -> Manager Configuration -> Monitoring (bsc#1176172)

### DIFF
--- a/web/html/src/manager/admin/config/monitoring-admin.js
+++ b/web/html/src/manager/admin/config/monitoring-admin.js
@@ -109,7 +109,7 @@ const HelpPanel = (props) => {
         {t("The server uses ")}<a href="https://prometheus.io" target="_blank" rel="noopener noreferrer">{t("Prometheus")}</a>{t(" exporters to expose metrics about your environment.")}
       </p>
       <p>
-        {t("Refer to the ")}<a href="/docs/administration/pages/prometheus.html" target="_blank">{t("documentation")}</a>{t(" to learn how to to consume these metrics.")}
+        {t("Refer to the ")}<a href="/docs/suse-manager/administration/monitoring.html" target="_blank">{t("documentation")}</a>{t(" to learn how to to consume these metrics.")}
       </p>
   </div>);
 }
@@ -216,7 +216,7 @@ const MonitoringAdmin = (props) => {
         <h1>
           <i className="fa fa-info-circle"></i>
           {t("SUSE Manager Configuration - Monitoring")}
-          <HelpLink url="/docs/administration/pages/prometheus.html"/>
+          <HelpLink url="/docs/suse-manager/administration/monitoring.html"/>
         </h1>
       </div>
       <div className="page-summary">

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Fix link to documentation in Admin -> Manager Configuration -> Monitoring (bsc#1176172)
 - Notify about missing libvirt or hypervisor on virtual host
 - Redesign maintenance schedule systems table to use paginated data from server
 


### PR DESCRIPTION
## What does this PR change?

https://bugzilla.suse.com/show_bug.cgi?id=1176172
Link to documentation in Admin -> Manager Configuration -> Monitoring was wrong.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: small bugfix

- [x] **DONE**

## Test coverage
- No tests: cosmetic issue

- [x] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/12447

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
