### PR TITLE
Uyuni installer updates optional

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -1799,7 +1799,9 @@ public class ContentSyncManager {
 
              if (isAccessible) {
                  return Stream.concat(
-                     entries.stream(),
+                     entries.stream().filter(e ->
+                         e.isMandatory() || repoIdsWithAuth.contains(e.getRepository().getId())
+                     ),
                      SUSEProductFactory.findAllExtensionProductsForRootOf(product, root).stream()
                              .flatMap(nextProduct ->
                                      getAvailableRepositories(root, nextProduct, allEntries, repoIdsWithAuth))

--- a/java/code/src/com/redhat/rhn/manager/content/test/ContentSyncManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/content/test/ContentSyncManagerTest.java
@@ -1223,7 +1223,6 @@ public class ContentSyncManagerTest extends BaseTestCaseWithUser {
         List<MgrSyncChannelDto> channels = csm.listChannels();
         boolean foundPool = false;
         boolean foundDebugPool = false;
-        boolean foundInstallerUpdate = false;
         for (MgrSyncChannelDto c : channels) {
             if (c.getLabel().equals("sles12-pool-x86_64")) {
                 assertEquals("https://updates.suse.com/SUSE/Products/SLE-SERVER/12/x86_64/product/", c.getSourceUrl());
@@ -1236,8 +1235,7 @@ public class ContentSyncManagerTest extends BaseTestCaseWithUser {
                 foundDebugPool = true;
             }
             else if (c.getLabel().equals("sles12-installer-updates-x86_64")) {
-                assertEquals("https://updates.suse.com/SUSE/Updates/SLE-SERVER-INSTALLER/12/x86_64/update/", c.getSourceUrl());
-                foundInstallerUpdate = true;
+                assertTrue("Unexpected Installer Update channel found", false);
             }
             else if (c.getLabel().startsWith("suse-enterprise-storage")) {
                 assertTrue("Storage Channels should not be listed", false);
@@ -1245,7 +1243,6 @@ public class ContentSyncManagerTest extends BaseTestCaseWithUser {
         }
         assertTrue("Pool channel not found", foundPool);
         assertTrue("Debuginfo Pool channel not found", foundDebugPool);
-        assertFalse("Unexpected Installer Update channel found", foundInstallerUpdate);
         Map<MgrSyncStatus, List<MgrSyncChannelDto>> collect = channels.stream().collect(Collectors.groupingBy(c -> c.getStatus()));
         assertEquals(2, collect.get(MgrSyncStatus.INSTALLED).size());
         assertEquals(62, collect.get(MgrSyncStatus.AVAILABLE).size());

--- a/java/code/src/com/redhat/rhn/manager/content/test/ContentSyncManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/content/test/ContentSyncManagerTest.java
@@ -80,7 +80,6 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.apache.commons.io.FileUtils;
 
 /**
  * Tests for {@link ContentSyncManager}.
@@ -786,6 +785,8 @@ public class ContentSyncManagerTest extends BaseTestCaseWithUser {
         assertContains(avChanLanbels, "sles12-ltss-updates-x86_64");
         assertContains(avChanLanbels, "sle-ha-geo12-debuginfo-pool-x86_64");
         assertContains(avChanLanbels, "sle-we12-updates-x86_64");
+        // Installer Updates is optional and not in repositories.json
+        assertFalse("unexpected optional channel found", avChanLanbels.contains("sles12-installer-updates-x86_64"));
         // Storage 2 is not in repositories.json to emulate no subscription
         assertFalse("Storage should not be avaliable", avChanLanbels.contains("suse-enterprise-storage-2-updates-x86_64"));
     }
@@ -1222,6 +1223,7 @@ public class ContentSyncManagerTest extends BaseTestCaseWithUser {
         List<MgrSyncChannelDto> channels = csm.listChannels();
         boolean foundPool = false;
         boolean foundDebugPool = false;
+        boolean foundInstallerUpdate = false;
         for (MgrSyncChannelDto c : channels) {
             if (c.getLabel().equals("sles12-pool-x86_64")) {
                 assertEquals("https://updates.suse.com/SUSE/Products/SLE-SERVER/12/x86_64/product/", c.getSourceUrl());
@@ -1233,12 +1235,17 @@ public class ContentSyncManagerTest extends BaseTestCaseWithUser {
                 assertEquals(MgrSyncStatus.AVAILABLE, c.getStatus());
                 foundDebugPool = true;
             }
+            else if (c.getLabel().equals("sles12-installer-updates-x86_64")) {
+                assertEquals("https://updates.suse.com/SUSE/Updates/SLE-SERVER-INSTALLER/12/x86_64/update/", c.getSourceUrl());
+                foundInstallerUpdate = true;
+            }
             else if (c.getLabel().startsWith("suse-enterprise-storage")) {
                 assertTrue("Storage Channels should not be listed", false);
             }
         }
         assertTrue("Pool channel not found", foundPool);
         assertTrue("Debuginfo Pool channel not found", foundDebugPool);
+        assertFalse("Unexpected Installer Update channel found", foundInstallerUpdate);
         Map<MgrSyncStatus, List<MgrSyncChannelDto>> collect = channels.stream().collect(Collectors.groupingBy(c -> c.getStatus()));
         assertEquals(2, collect.get(MgrSyncStatus.INSTALLED).size());
         assertEquals(62, collect.get(MgrSyncStatus.AVAILABLE).size());
@@ -1267,6 +1274,8 @@ public class ContentSyncManagerTest extends BaseTestCaseWithUser {
         for (MgrSyncProductDto product : products) {
             if (product.getFriendlyName().equals("SUSE Linux Enterprise Server 12 x86_64")) {
                 assertEquals(MgrSyncStatus.INSTALLED, product.getStatus());
+                assertFalse("Unexpected Installer Update Channel found",
+                        product.getChannels().stream().anyMatch(c -> c.getLabel().equals("sles12-installer-updates-x86_64")));
                 foundSLES = true;
 
                 for (MgrSyncProductDto ext : product.getExtensions()) {
@@ -1313,7 +1322,7 @@ public class ContentSyncManagerTest extends BaseTestCaseWithUser {
 
         // if mgr-sync never ran, return true
         WriteMode clear = ModeFactory.getWriteMode("test_queries","delete_last_mgr_sync_refresh");
-        clear.executeUpdate(new HashMap());
+        clear.executeUpdate(new HashMap<>());
         assertTrue(csm.isRefreshNeeded(null));
     }
 

--- a/java/code/src/com/redhat/rhn/manager/content/test/smallBase/product_tree.json
+++ b/java/code/src/com/redhat/rhn/manager/content/test/smallBase/product_tree.json
@@ -8340,6 +8340,21 @@
         "channel_name": "SLES12-Debuginfo-Pool for x86_64"
     },
     {
+        "channel_label": "sles12-installer-updates-x86_64",
+        "parent_channel_label": "sles12-pool-x86_64",
+        "product_id": 1117,
+        "repository_id": 999999,
+        "parent_product_id": null,
+        "root_product_id": 1117,
+        "update_tag": "SLE-SERVER-INSTALLER",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-SERVER-INSTALLER/12/x86_64/update/",
+        "release_stage": "released",
+        "mandatory": false,
+        "signed": true,
+        "recommended": false,
+        "channel_name": "SLES12-Installer-Updates for x86_64"
+    },
+    {
         "channel_label": "sle-manager-tools12-updates-x86_64",
         "parent_channel_label": "sles12-pool-x86_64",
         "product_id": 1117,

--- a/java/code/src/com/redhat/rhn/manager/content/test/smallBase/productsUnscoped.json
+++ b/java/code/src/com/redhat/rhn/manager/content/test/smallBase/productsUnscoped.json
@@ -1190,6 +1190,16 @@
         "enabled": false,
         "autorefresh": true,
         "installer_updates": false
+      },
+      {
+        "autorefresh": true,
+        "description": "SLES12-Installer-Updates for sle-12-x86_64",
+        "distro_target": "sle-12-x86_64",
+        "enabled": false,
+        "id": 999999,
+        "installer_updates": true,
+        "name": "SLES12-Installer-Updates",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-SERVER-INSTALLER/12/x86_64/update/"
       }
     ]
   },

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,4 +1,6 @@
+- filter not available optional channels out
 - Fix: handle version comparison corner cases in Ubuntu packages
+
 -------------------------------------------------------------------
 Mon Sep 21 12:04:31 CEST 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Installer Update channels are optional, but they are added by default when a product gets synced.
This cause exceptions when the channel is not available (e.g. when fromdir is used).

The existing method getAvailableRepositories() were only checking mandatory channels. As soon as
all mandatory channels are available, the whole products with its optional channels where marked as available too.

This change add a filter and remove all optional channels which are not available from the output.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/12445

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
