### PR TITLE
Warn user about missing hypervisor or libvirt binding

### DIFF
--- a/java/code/src/com/suse/manager/virtualization/VirtManagerSalt.java
+++ b/java/code/src/com/suse/manager/virtualization/VirtManagerSalt.java
@@ -190,4 +190,14 @@ public class VirtManagerSalt implements VirtManager {
         saltApi.refreshPillar(new MinionList(minion.getMinionId()));
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    public Optional<String> getHypervisor(String minionId) {
+        LocalCall<String> call =
+                new LocalCall<>("virt.get_hypervisor", Optional.empty(), Optional.empty(),
+                        new TypeToken<String>() { });
+
+        return saltApi.callSync(call, minionId);
+    }
 }

--- a/java/code/src/com/suse/manager/virtualization/test/TestVirtManager.java
+++ b/java/code/src/com/suse/manager/virtualization/test/TestVirtManager.java
@@ -14,13 +14,15 @@
  */
 package com.suse.manager.virtualization.test;
 
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
 import com.redhat.rhn.domain.server.MinionServer;
+
 import com.suse.manager.virtualization.GuestDefinition;
 import com.suse.manager.virtualization.PoolCapabilitiesJson;
 import com.suse.manager.virtualization.PoolDefinition;
 import com.suse.manager.webui.services.iface.VirtManager;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 
 import java.util.Map;
 import java.util.Optional;
@@ -64,6 +66,11 @@ public class TestVirtManager implements VirtManager {
 
     @Override
     public void updateLibvirtEngine(MinionServer minion) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<String> getHypervisor(String minionId) {
         throw new UnsupportedOperationException();
     }
 }

--- a/java/code/src/com/suse/manager/webui/controllers/virtualization/VirtualGuestsController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/virtualization/VirtualGuestsController.java
@@ -144,6 +144,9 @@ public class VirtualGuestsController extends AbstractVirtualizationController {
         data.put("salt_entitled", server.hasEntitlement(EntitlementManager.SALT));
         data.put("foreign_entitled", server.hasEntitlement(EntitlementManager.FOREIGN));
         data.put("is_admin", user.hasRole(RoleFactory.ORG_ADMIN));
+        data.put("hypervisor", server.hasVirtualizationEntitlement() ?
+                virtManager.getHypervisor(server.getMinionId()).orElse("") :
+                "");
 
         return renderPage(request, response, user, "show", () -> data);
     }

--- a/java/code/src/com/suse/manager/webui/controllers/virtualization/VirtualNetsController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/virtualization/VirtualNetsController.java
@@ -35,6 +35,7 @@ import com.suse.manager.webui.services.iface.VirtManager;
 
 import com.google.gson.JsonObject;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -86,7 +87,14 @@ public class VirtualNetsController extends AbstractVirtualizationController {
      * @return the ModelAndView object to render the page
      */
     public ModelAndView show(Request request, Response response, User user) {
-        return renderPage(request, response, user, "show", null);
+        Server host = getServer(request, user);
+        return renderPage(request, response, user, "show", () -> {
+            Map<String, Object> extra = new HashMap<>();
+            extra.put("hypervisor", host.hasVirtualizationEntitlement() ?
+                    virtManager.getHypervisor(host.getMinionId()).orElse("") :
+                    "");
+            return extra;
+        });
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/controllers/virtualization/VirtualPoolsController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/virtualization/VirtualPoolsController.java
@@ -120,7 +120,14 @@ public class VirtualPoolsController extends AbstractVirtualizationController {
      * @return the ModelAndView object to render the page
      */
     public ModelAndView show(Request request, Response response, User user) {
-        return renderPage(request, response, user, "show", null);
+        Server host = getServer(request, user);
+        return renderPage(request, response, user, "show", () -> {
+            Map<String, Object> extra = new HashMap<>();
+            extra.put("hypervisor", host.hasVirtualizationEntitlement() ?
+                    virtManager.getHypervisor(host.getMinionId()).orElse("") :
+                    "");
+            return extra;
+        });
     }
 
 

--- a/java/code/src/com/suse/manager/webui/controllers/virtualization/test/VirtualGuestsControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/virtualization/test/VirtualGuestsControllerTest.java
@@ -42,9 +42,8 @@ import com.suse.manager.virtualization.VmInfoJson;
 import com.suse.manager.virtualization.test.TestVirtManager;
 import com.suse.manager.webui.controllers.test.BaseControllerTestCase;
 import com.suse.manager.webui.controllers.virtualization.VirtualGuestsController;
-import com.suse.manager.webui.services.test.TestSaltApi;
-import com.suse.manager.webui.services.test.TestSystemQuery;
 import com.suse.manager.webui.services.iface.VirtManager;
+import com.suse.manager.webui.services.test.TestSaltApi;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;

--- a/java/code/src/com/suse/manager/webui/services/iface/VirtManager.java
+++ b/java/code/src/com/suse/manager/webui/services/iface/VirtManager.java
@@ -14,12 +14,14 @@
  */
 package com.suse.manager.webui.services.iface;
 
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
 import com.redhat.rhn.domain.server.MinionServer;
+
 import com.suse.manager.virtualization.GuestDefinition;
 import com.suse.manager.virtualization.PoolCapabilitiesJson;
 import com.suse.manager.virtualization.PoolDefinition;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 
 import java.util.Map;
 import java.util.Optional;
@@ -93,4 +95,12 @@ public interface VirtManager {
      */
     void updateLibvirtEngine(MinionServer minion);
 
+    /**
+     * Get the name of the running hypervisor on a minion.
+     *
+     * @param minionId the minion to ask about
+     *
+     * @return either "kvm" or "xen"
+     */
+    Optional<String> getHypervisor(String minionId);
 }

--- a/java/code/src/com/suse/manager/webui/services/pillar/test/MinionVirtualizationPillarGeneratorTest.java
+++ b/java/code/src/com/suse/manager/webui/services/pillar/test/MinionVirtualizationPillarGeneratorTest.java
@@ -30,11 +30,10 @@ import com.redhat.rhn.testing.BaseTestCaseWithUser;
 import com.suse.manager.virtualization.GuestDefinition;
 import com.suse.manager.virtualization.PoolCapabilitiesJson;
 import com.suse.manager.virtualization.PoolDefinition;
-import com.suse.manager.webui.services.test.TestSaltApi;
-import com.suse.manager.webui.services.test.TestSystemQuery;
 import com.suse.manager.webui.services.iface.VirtManager;
 import com.suse.manager.webui.services.pillar.MinionPillarFileManager;
 import com.suse.manager.webui.services.pillar.MinionVirtualizationPillarGenerator;
+import com.suse.manager.webui.services.test.TestSaltApi;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -100,6 +99,11 @@ public class MinionVirtualizationPillarGeneratorTest extends BaseTestCaseWithUse
 
             @Override
             public void updateLibvirtEngine(MinionServer minion) {
+            }
+
+            @Override
+            public Optional<String> getHypervisor(String minionId) {
+                return Optional.empty();
             }
         };
 

--- a/java/code/src/com/suse/manager/webui/templates/virtualization/guests/show.jade
+++ b/java/code/src/com/suse/manager/webui/templates/virtualization/guests/show.jade
@@ -17,7 +17,8 @@ script(type='text/javascript').
                   pageSize: "#{pageSize}",
                   saltEntitled: #{salt_entitled},
                   foreignEntitled: #{foreign_entitled},
-                  isAdmin: #{is_admin}
+                  isAdmin: #{is_admin},
+                  hypervisor: "#{hypervisor}"
               }
             )
         });

--- a/java/code/src/com/suse/manager/webui/templates/virtualization/nets/show.jade
+++ b/java/code/src/com/suse/manager/webui/templates/virtualization/nets/show.jade
@@ -15,6 +15,7 @@ script(type='text/javascript').
               {
                   serverId: "#{server.id}",
                   pageSize: "#{pageSize}",
+                  hypervisor: "#{hypervisor}"
               }
             )
         });

--- a/java/code/src/com/suse/manager/webui/templates/virtualization/pools/show.jade
+++ b/java/code/src/com/suse/manager/webui/templates/virtualization/pools/show.jade
@@ -14,6 +14,7 @@ script(type='text/javascript').
               {
                   serverId: "#{server.id}",
                   pageSize: "#{pageSize}",
+                  hypervisor: "#{hypervisor}"
               }
             )
         });

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Notify about missing libvirt or hypervisor on virtual host
 - Redesign maintenance schedule systems table to use paginated data from server
 - Fix SP migration after dry run for cloned channels (bsc#1176307)
 - filter not available optional channels out

--- a/web/html/src/manager/virtualization/HypervisorCheck.js
+++ b/web/html/src/manager/virtualization/HypervisorCheck.js
@@ -1,0 +1,32 @@
+// @flow
+import * as React from 'react';
+
+import { Messages } from 'components/messages';
+import { Utils as MessagesUtils } from 'components/messages';
+
+type Props = {
+    hypervisor: string,
+    foreignEntitled: boolean,
+};
+
+export function HypervisorCheck(props: Props) {
+    if (props.foreignEntitled) {
+        return null;
+    }
+
+    const virtMissing = props.hypervisor.includes("'virt' __virtual__ returned False");
+    if (virtMissing) {
+        return <Messages items={MessagesUtils.error(t("Please install libvirt python module."))}/>;
+    }
+
+    const error = props.hypervisor === "" ?
+        MessagesUtils.error(t("Neither KVM nor Xen is running. Ensure they are installed and the kernel modules are loaded.")) :
+        [];
+    return (
+        <Messages items={error}/>
+    );
+};
+
+HypervisorCheck.defaultProps = {
+    foreignEntitled: false,
+};

--- a/web/html/src/manager/virtualization/guests/list/guests-list.js
+++ b/web/html/src/manager/virtualization/guests/list/guests-list.js
@@ -7,6 +7,7 @@ import { LinkButton, AsyncButton } from 'components/buttons';
 import * as Systems from 'components/systems';
 import { Utils as ListUtils } from '../../list.utils';
 import { ListTab } from '../../ListTab';
+import { HypervisorCheck } from '../../HypervisorCheck';
 
 type Props = {
   serverId: string,
@@ -14,6 +15,7 @@ type Props = {
   saltEntitled: boolean,
   foreignEntitled: boolean,
   isAdmin: boolean,
+  hypervisor: string,
 };
 
 export function GuestsList(props: Props) {
@@ -36,134 +38,134 @@ export function GuestsList(props: Props) {
   ];
 
   return (
-    <ListTab
-      serverId={props.serverId}
-      saltEntitled={props.saltEntitled}
-      pageSize={props.pageSize}
-      type="guest"
-      title={t('Hosted Virtual Systems')}
-      description={t('This is a list of virtual guests which are configured to run on this host.')}
-      modalsData={modalsData}
-      isActionVisible={(action) => !props.foreignEntitled && (action.type !== 'delete' || props.saltEntitled)}
-      getCreateActionsKeys={(actions) => {
-        return Object.keys(actions).filter(key => key.startsWith("new-") && actions[key].type === "virt.create")
-      }}
-      idName="uuid"
-    >
-    {
-      (createModalButton, onAction) => {
-          const columns = [
-            <Column
-              columnKey="name"
-              comparator={Utils.sortByText}
-              header={t('Guest')}
-              cell={row => row.name}
-            />,
-            <Column
-              columnKey="serverName"
-              comparator={Utils.sortByText}
-              header={t('System')}
-              cell={(row) => {
-                if (row.virtualSystemId == null) {
-                  return t('Unregistered System');
-                }
+    <>
+      <HypervisorCheck foreignEntitled={props.foreignEntitled} hypervisor={props.hypervisor}/>
+      <ListTab
+        serverId={props.serverId}
+        saltEntitled={props.saltEntitled}
+        pageSize={props.pageSize}
+        type="guest"
+        title={t('Hosted Virtual Systems')}
+        description={t('This is a list of virtual guests which are configured to run on this host.')}
+        modalsData={modalsData}
+        isActionVisible={(action) => !props.foreignEntitled && (action.type !== 'delete' || props.saltEntitled)}
+        getCreateActionsKeys={(actions) => {
+          return Object.keys(actions).filter(key => key.startsWith("new-") && actions[key].type === "virt.create")
+        }}
+        idName="uuid"
+      >
+      {
+        (createModalButton, onAction) => {
+            const columns = [
+              <Column
+                columnKey="name"
+                comparator={Utils.sortByText}
+                header={t('Guest')}
+                cell={row => row.name}
+              />,
+              <Column
+                columnKey="serverName"
+                comparator={Utils.sortByText}
+                header={t('System')}
+                cell={(row) => {
+                  if (row.virtualSystemId == null) {
+                    return t('Unregistered System');
+                  }
 
-                if (row.accessible) {
-                  return <a href={`/rhn/systems/details/Overview.do?sid=${row.virtualSystemId}`}>{row.serverName}</a>;
-                }
-                return row.serverName;
-              }}
-            />,
-            <Column
-              columnKey="statusType"
-              comparator={ListUtils.sortByUpdate}
-              header={t('Updates')}
-              cell={(row) => {
-                if (row.statusType == null) {
-                  return '-';
-                }
-                return Systems.statusDisplay(row, props.isAdmin);
-              }}
-            />,
-            <Column
-              columnKey="stateLabel"
-              header={t('State')}
-              comparator={ListUtils.sortByState}
-              cell={row => row.stateName}
-            />,
-            <Column
-              columnKey="memory"
-              comparator={Utils.sortByNumber}
-              header={t('Current Memory')}
-              cell={row => `${row.memory / 1024} MiB`}
-            />,
-            <Column
-              columnKey="vcpus"
-              comparator={Utils.sortByNumber}
-              header={t('vCPUs')}
-              cell={row => row.vcpus}
-            />,
-            <Column
-              columnKey="channelLabels"
-              comparator={Utils.sortByText}
-              header={t('Base Software Channel')}
-              cell={(row) => {
-                if (row.channelId == null) {
-                  return t('(none)');
-                }
-                if (row.subscribable) {
-                  return <a href={`/rhn/channels/ChannelDetail.do?cid=${row.channelId}`}>{row.channelLabels}</a>;
-                }
-                return row.channelLabels;
-              }}
-            />
-          ];
+                  if (row.accessible) {
+                    return <a href={`/rhn/systems/details/Overview.do?sid=${row.virtualSystemId}`}>{row.serverName}</a>;
+                  }
+                  return row.serverName;
+                }}
+              />,
+              <Column
+                columnKey="statusType"
+                comparator={ListUtils.sortByUpdate}
+                header={t('Updates')}
+                cell={(row) => {
+                  if (row.statusType == null) {
+                    return '-';
+                  }
+                  return Systems.statusDisplay(row, props.isAdmin);
+                }}
+              />,
+              <Column
+                columnKey="stateLabel"
+                header={t('State')}
+                comparator={ListUtils.sortByState}
+                cell={row => row.stateName}
+              />,
+              <Column
+                columnKey="memory"
+                comparator={Utils.sortByNumber}
+                header={t('Current Memory')}
+                cell={row => `${row.memory / 1024} MiB`}
+              />,
+              <Column
+                columnKey="vcpus"
+                comparator={Utils.sortByNumber}
+                header={t('vCPUs')}
+                cell={row => row.vcpus}
+              />,
+              <Column
+                columnKey="channelLabels"
+                comparator={Utils.sortByText}
+                header={t('Base Software Channel')}
+                cell={(row) => {
+                  if (row.channelId == null) {
+                    return t('(none)');
+                  }
+                  if (row.subscribable) {
+                    return <a href={`/rhn/channels/ChannelDetail.do?cid=${row.channelId}`}>{row.channelLabels}</a>;
+                  }
+                  return row.channelLabels;
+                }}
+              />
+            ];
 
-          const actionsProvider =
-            (row) => {
-              if (props.foreignEntitled) {
-                return [];
-              }
-              const state = row.stateLabel;
-              return (
-                <div className="btn-group">
-                  {state !== 'running' && row.name !== 'Domain-0'
-                   && (
-                     <AsyncButton
-                       defaultType="btn-default btn-sm"
-                       title={t(state === 'paused' ? 'Resume' : 'Start')}
-                       icon="fa-play"
-                       action={() => onAction('start', [row.uuid], {})}
-                     />) }
-                  {state === 'running' && row.name !== 'Domain-0'
-                   && createModalButton('suspend', modalsData, row) }
-                  {state !== 'stopped' && row.name !== 'Domain-0'
-                   && createModalButton('shutdown', modalsData, row) }
-                  {(state === 'paused' || state === 'running') && createModalButton('restart', modalsData, row) }
-                  {props.saltEntitled && state === 'running' && (
+            const actionsProvider =
+              (row) => {
+                if (props.foreignEntitled) {
+                  return [];
+                }
+                const state = row.stateLabel;
+                return (
+                  <div className="btn-group">
+                    {state !== 'running' && row.name !== 'Domain-0'
+                     && (
+                       <AsyncButton
+                         defaultType="btn-default btn-sm"
+                         title={t(state === 'paused' ? 'Resume' : 'Start')}
+                         icon="fa-play"
+                         action={() => onAction('start', [row.uuid], {})}
+                       />) }
+                    {state === 'running' && row.name !== 'Domain-0' && createModalButton('suspend', modalsData, row)}
+                    {state !== 'stopped' && row.name !== 'Domain-0' && createModalButton('shutdown', modalsData, row)}
+                    {(state === 'paused' || state === 'running') && createModalButton('restart', modalsData, row)}
+                    {props.saltEntitled && state === 'running' && (
+                      <LinkButton
+                        title={t('Graphical Console')}
+                        className="btn-default btn-sm"
+                        icon="fa-desktop"
+                        href={`/rhn/manager/systems/details/virtualization/guests/${props.serverId}/console/${row.uuid}`}
+                        target="_blank"
+                      />
+                    )}
                     <LinkButton
-                      title={t('Graphical Console')}
+                      title={t('Edit')}
                       className="btn-default btn-sm"
-                      icon="fa-desktop"
-                      href={`/rhn/manager/systems/details/virtualization/guests/${props.serverId}/console/${row.uuid}`}
-                      target="_blank"
+                      icon="fa-edit"
+                      href={`/rhn/manager/systems/details/virtualization/guests/${props.serverId}/edit/${row.uuid}`}
                     />
-                  )}
-                  <LinkButton
-                    title={t('Edit')}
-                    className="btn-default btn-sm"
-                    icon="fa-edit"
-                    href={`/rhn/manager/systems/details/virtualization/guests/${props.serverId}/edit/${row.uuid}`}
-                  />
-                  { props.saltEntitled && row.name !== 'Domain-0'
-                    && createModalButton('delete', modalsData, row) }
-                </div>
-              );
-            }
+                    {props.saltEntitled && row.name !== 'Domain-0' && createModalButton('delete', modalsData, row)}
+                  </div>
+                );
+              }
 
-          return { columns, actionsProvider };
-        }
-    }
-    </ListTab>
+            return { columns, actionsProvider };
+          }
+      }
+      </ListTab>
+    </>
   );
 }

--- a/web/html/src/manager/virtualization/guests/list/guests-list.renderer.js
+++ b/web/html/src/manager/virtualization/guests/list/guests-list.renderer.js
@@ -2,7 +2,7 @@ const SpaRenderer  = require("core/spa/spa-renderer").default;
 const React = require('react');
 const { GuestsList } = require('./guests-list');
 
-export const renderer = (id, { serverId, pageSize, saltEntitled, foreignEntitled, isAdmin }) => {
+export const renderer = (id, { serverId, pageSize, saltEntitled, foreignEntitled, isAdmin, hypervisor }) => {
   SpaRenderer.renderNavigationReact(
     <GuestsList
       serverId={serverId}
@@ -10,6 +10,7 @@ export const renderer = (id, { serverId, pageSize, saltEntitled, foreignEntitled
       saltEntitled={saltEntitled}
       foreignEntitled={foreignEntitled}
       isAdmin={isAdmin}
+      hypervisor={hypervisor}
     />,
     document.getElementById(id),
   );

--- a/web/html/src/manager/virtualization/nets/list/nets-list.js
+++ b/web/html/src/manager/virtualization/nets/list/nets-list.js
@@ -6,11 +6,13 @@ import { Utils } from 'utils/functions';
 import { AsyncButton } from 'components/buttons';
 import { Utils as ListUtils } from '../../list.utils';
 import { ListTab } from '../../ListTab';
+import { HypervisorCheck } from '../../HypervisorCheck';
 
 
 type Props = {
   serverId: string,
   pageSize: number,
+  hypervisor: string,
 };
 
 export function NetsList(props: Props) {
@@ -26,76 +28,79 @@ export function NetsList(props: Props) {
     },
   ];
   return (
-    <ListTab
-      serverId={props.serverId}
-      pageSize={props.pageSize}
-      type="network"
-      urlType="nets"
-      title={t('Virtual Networks')}
-      description={t('This is a list of virtual networks which are configured to run on this host.')}
-      modalsData={modalsData}
-      idName="name"
-      canCreate={false}
-    >
-      {
-        (createModalButton, onAction) => {
-          const columns = [
-            <Column
-              columnKey="name"
-              comparator={Utils.sortByText}
-              header={t('Name')}
-              cell={row => row.name}
-            />,
-            <Column
-              columnKey="state"
-              header={t('State')}
-              comparator={ListUtils.sortByState}
-              cell={row => row.active ? 'running' : 'stopped'}
-            />,
-            <Column
-              columnKey="autostart"
-              header={t('Autostart')}
-              cell={
-                row => row.autostart &&
-                  <i className="fa fa-check-square fa-1-5x" title={t(`${row.name} is started automatically`)}/>
-              }
-            />,
-            <Column
-              columnKey="persistent"
-              header={t('Persistent')}
-              cell={
-                row => row.persistent &&
-                  <i className="fa fa-check-square fa-1-5x" title={t(`${row.name} is persistent`)}/>
-              }
-            />,
-            <Column
-              columnKey="bridge"
-              comparator={Utils.sortByText}
-              header={t('Bridge')}
-              cell={row => row.bridge}
-            />,
-          ];
-          const actionsProvider = (row) => {
-            return (
-              <div className="btn-group">
-              {
-                !row.active && (
-                  <AsyncButton
-                    defaultType="btn-default btn-sm"
-                    title={t('Start')}
-                    icon="fa-play"
-                    action={() => onAction('start', [row.name], {})}
-                  />
-                )
-              }
-              { row.active && createModalButton('stop', modalsData, row) }
-              { createModalButton('delete', modalsData, row) }
-              </div>
-            );
-          };
-          return {columns, actionsProvider};
+    <>
+      <HypervisorCheck hypervisor={props.hypervisor} />
+      <ListTab
+        serverId={props.serverId}
+        pageSize={props.pageSize}
+        type="network"
+        urlType="nets"
+        title={t('Virtual Networks')}
+        description={t('This is a list of virtual networks which are configured to run on this host.')}
+        modalsData={modalsData}
+        idName="name"
+        canCreate={false}
+      >
+        {
+          (createModalButton, onAction) => {
+            const columns = [
+              <Column
+                columnKey="name"
+                comparator={Utils.sortByText}
+                header={t('Name')}
+                cell={row => row.name}
+              />,
+              <Column
+                columnKey="state"
+                header={t('State')}
+                comparator={ListUtils.sortByState}
+                cell={row => row.active ? 'running' : 'stopped'}
+              />,
+              <Column
+                columnKey="autostart"
+                header={t('Autostart')}
+                cell={
+                  row => row.autostart &&
+                    <i className="fa fa-check-square fa-1-5x" title={t(`${row.name} is started automatically`)}/>
+                }
+              />,
+              <Column
+                columnKey="persistent"
+                header={t('Persistent')}
+                cell={
+                  row => row.persistent &&
+                    <i className="fa fa-check-square fa-1-5x" title={t(`${row.name} is persistent`)}/>
+                }
+              />,
+              <Column
+                columnKey="bridge"
+                comparator={Utils.sortByText}
+                header={t('Bridge')}
+                cell={row => row.bridge}
+              />,
+            ];
+            const actionsProvider = (row) => {
+              return (
+                <div className="btn-group">
+                {
+                  !row.active && (
+                    <AsyncButton
+                      defaultType="btn-default btn-sm"
+                      title={t('Start')}
+                      icon="fa-play"
+                      action={() => onAction('start', [row.name], {})}
+                    />
+                  )
+                }
+                { row.active && createModalButton('stop', modalsData, row) }
+                { createModalButton('delete', modalsData, row) }
+                </div>
+              );
+            };
+            return {columns, actionsProvider};
+          }
         }
-      }
-    </ListTab>
+      </ListTab>
+    </>
   );
 }

--- a/web/html/src/manager/virtualization/nets/list/nets-list.renderer.js
+++ b/web/html/src/manager/virtualization/nets/list/nets-list.renderer.js
@@ -2,11 +2,12 @@ import * as React from 'react';
 import { NetsList } from './nets-list';
 import SpaRenderer from "core/spa/spa-renderer";
 
-export const renderer = (id, { serverId, pageSize }) => {
+export const renderer = (id, { serverId, pageSize, hypervisor }) => {
   SpaRenderer.renderNavigationReact(
     <NetsList
       serverId={serverId}
       pageSize={pageSize}
+      hypervisor={hypervisor}
     />,
     document.getElementById(id),
   );

--- a/web/html/src/manager/virtualization/pools/list/pools-list.js
+++ b/web/html/src/manager/virtualization/pools/list/pools-list.js
@@ -16,6 +16,7 @@ import { ActionConfirm } from 'components/dialog/ActionConfirm';
 import { VirtualizationPoolsListRefreshApi } from '../virtualization-pools-list-refresh-api';
 import { VirtualizationPoolsActionApi } from '../virtualization-pools-action-api';
 import { useVirtNotification } from '../../useVirtNotification.js';
+import { HypervisorCheck } from '../../HypervisorCheck';
 
 import type {MessageType} from 'components/messages';
 
@@ -23,6 +24,7 @@ type Props = {
   serverId: string,
   refreshInterval: number,
   pageSize: number,
+  hypervisor: string,
 };
 
 function poolsInfoToTree(pools: Object) {
@@ -341,6 +343,7 @@ export function PoolsList(props: Props) {
 
               return (
                 <>
+                  <HypervisorCheck hypervisor={props.hypervisor} />
                   <div className="pull-right btn-group">
                     <LinkButton
                       text={t('Create Pool')}

--- a/web/html/src/manager/virtualization/pools/list/pools-list.renderer.js
+++ b/web/html/src/manager/virtualization/pools/list/pools-list.renderer.js
@@ -2,12 +2,13 @@ import * as React from 'react';
 import { PoolsList } from './pools-list';
 import SpaRenderer from "core/spa/spa-renderer";
 
-export const renderer = (id, { serverId, pageSize }) => {
+export const renderer = (id, { serverId, pageSize, hypervisor }) => {
   SpaRenderer.renderNavigationReact(
     <PoolsList
       refreshInterval={5 * 1000}
       pageSize={pageSize}
       serverId={serverId}
+      hypervisor={hypervisor}
     />,
     document.getElementById(id),
   );

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Notify about missing libvirt or hypervisor on virtual host
 - Redesign maintenance schedule systems table to use paginated data from server
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

The user could add the virtualization entitlement and have none or part
of the dependencies set up on the virtualization host. A message will
indicate that the libvirt python binding (and thus the salt virt module)
is missing.

Also warn the user if the KVM or Xen modules are not loaded. This could
mean that they have been installed but the system still needs a reboot.

## GUI diff

Screenshot if there is no libvirt python binding:
![no-libvirt](https://user-images.githubusercontent.com/397931/93337438-6e885f00-f829-11ea-9a85-81f228bab04d.png)

Screenshot if no running hypervisor can be found:
![no-hypervisor](https://user-images.githubusercontent.com/397931/93337521-8829a680-f829-11ea-9920-c1c7a53355bf.png)

- [X] **DONE**

## Documentation
- No documentation needed: only error display

- [X] **DONE**

## Test coverage
- No tests:  costly to cover automatically. These warning may also help debugging some of the testsuite issues related to nested KVM.

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/11997

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
