### PR TITLE
Testsuite: Fix rubocop version for PR checks

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -17,7 +17,7 @@ jobs:
         ruby-version: '2.5'
 
     - name: Install RuboCop
-      run: gem install rubocop -v 0.84.0
+      run: gem install rubocop -v 0.83.0
 
     - name: Run RuboCop
       run: |


### PR DESCRIPTION
## What does this PR change?
Fix broken Ruby style checks at uyuni PRs.

Use Rubocop v0.83.0, i.e., the version useed to generate .rubocop_todo.yml.
See https://github.com/SUSE/spacewalk/issues/12456


## Links
### Ports
No ports: only for Uyuni.


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)
