### PR TITLE
Fix the links for downloading the binaries in the package details UI (bsc#1176603)

### DIFF
--- a/java/code/webapp/WEB-INF/pages/rhnpackage/packagedetail.jsp
+++ b/java/code/webapp/WEB-INF/pages/rhnpackage/packagedetail.jsp
@@ -216,7 +216,7 @@
                             <div class="input-group">
                                 <div class="form-control">${pack.file}</div>
                                 <span class="input-group-btn">
-                                    <a class="btn btn-info" href="${url}">Download ${pack.packageSizeString}</a>
+                                    <a class="btn btn-info" href="${url}" data-senna-off="true">Download ${pack.packageSizeString}</a>
                                 </span>
                             </div>
                         </c:if>
@@ -240,7 +240,7 @@
                             <div class="input-group">
                                 <div class="form-control">${srpm_path}</div>
                                 <span class="input-group-btn">
-                                    <a class="btn btn-info" href="${srpm_url}">Download</a>
+                                    <a class="btn btn-info" href="${srpm_url}" data-senna-off="true">Download</a>
                                 </span>
                             </div>
                         </c:if>
@@ -263,7 +263,7 @@
                             </label>
                             <div class="col-lg-6">
                             <c:if test="${debugInfoUrl != null}">
-                                <a class="btn btn-info" href="${debugInfoUrl}"><bean:message key="package.jsp.download"/></a>
+                                <a class="btn btn-info" href="${debugInfoUrl}" data-senna-off="true"><bean:message key="package.jsp.download"/></a>
                                 <c:if test="${debugInfoFtp}" >
                                     <span class="help-block">
                                         <bean:message key="debuginfo.external" />
@@ -284,7 +284,7 @@
                             </label>
                             <div class="col-lg-6">
                             <c:if test="${debugSourceUrl != null}">
-                                <a class="btn btn-info" href="${debugSourceUrl}"><bean:message key="package.jsp.download"/></a>
+                                <a class="btn btn-info" href="${debugSourceUrl}" data-senna-off="true"><bean:message key="package.jsp.download"/></a>
                             </c:if>
                             <c:if test="${debugSourceUrl == null}">
                                 <bean:message key="package.jsp.unavailable" />

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix the links for downloading the binaries in the package details UI (bsc#1176603)
 - Notify about missing libvirt or hypervisor on virtual host
 - Redesign maintenance schedule systems table to use paginated data from server
 - Fix SP migration after dry run for cloned channels (bsc#1176307)


### PR DESCRIPTION
## What does this PR change?

https://bugzilla.suse.com/show_bug.cgi?id=1176603

On a package page on the dashboard, clicking on the Download button doesn't download the package: it will reload the page with another URL - the one with the package location - but it won't download it. 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bugfix

- [x] **DONE**

## Test coverage
- No tests: **add explanation**

- [ ] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/12459

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
