### PR TITLE
Make rubocop happy

### DIFF
--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -544,11 +544,13 @@ Then(/^the pillar data for "([^"]*)" should (be|contain|not contain) "([^"]*)" o
   end
   output, _code = $server.run("#{cmd} '#{system_name}' pillar.get '#{key}' #{extra_cmd}")
   STDOUT.puts "#{cmd} '#{system_name}' pillar.get '#{key}' #{extra_cmd} => #{output}"
-  if verb == 'be' && value == ''
-    raise "Output has more than one line: #{output}" unless output.split("\n").length == 1
-  elsif verb == 'be'
-    raise "Output value not found : #{output}" unless output.split("\n").length() > 1
-    raise "Output value is different than #{value}: #{output}" unless output.split("\n")[1].strip == value
+  if verb == 'be'
+    if value == ''
+      raise "Output has more than one line: #{output}" unless output.split("\n").length == 1
+    else
+      raise "Output value wasn't found: #{output}" unless output.split("\n").length > 1
+      raise "Output value is different than #{value}: #{output}" unless output.split("\n")[1].strip == value
+    end
   elsif verb == 'contain'
     raise "Output doesn't contain #{value}: #{output}" unless output.include? value
   elsif verb == 'not contain'


### PR DESCRIPTION
## What does this PR change?

Make rubocop happy by:
* not using parentheses when calling length with no arguments
* having shorter blocks

## Links

Ports:
* 3.2: SUSE/spacewalk#12467
* 4.0: SUSE/spacewalk#12463
* 4.1: SUSE/spacewalk#12462

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
