### PR TITLE
Fixing Rubopcop warning about ConditionalAssignment style

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -674,29 +674,29 @@ end
 # Repositories and packages management
 When(/^I (enable|disable) (the repositories|repository) "([^"]*)" on this "([^"]*)"((?: without error control)?)$/) do |action, _optional, repos, host, error_control|
   node = get_target(host)
-  os_version, os_family = get_os_version(node)
-  if os_family =~ /^opensuse/ || os_family =~ /^sles/
-    cmd = "zypper mr --#{action} #{repos}"
-  else
-    if action == 'enable'
-      cmd = repos.split(' ').map do |repo|
-        if os_family =~ /^centos/
-          "sed -i 's/enabled=.*/enabled=1/g' /etc/yum.repos.d/#{repo}.repo; "
-        elsif os_family =~ /^ubuntu/
-          "sed -i '/^#\\s*deb.*/ s/^#\\s*deb /deb /' /etc/apt/sources.list.d/#{repo}.list; "
+  _os_version, os_family = get_os_version(node)
+  cmd = if os_family =~ /^opensuse/ || os_family =~ /^sles/
+          "zypper mr --#{action} #{repos}"
+        else
+          cmd_list = if action == 'enable'
+                       repos.split(' ').map do |repo|
+                         if os_family =~ /^centos/
+                           "sed -i 's/enabled=.*/enabled=1/g' /etc/yum.repos.d/#{repo}.repo; "
+                         elsif os_family =~ /^ubuntu/
+                           "sed -i '/^#\\s*deb.*/ s/^#\\s*deb /deb /' /etc/apt/sources.list.d/#{repo}.list; "
+                         end
+                       end
+                     else
+                       repos.split(' ').map do |repo|
+                         if os_family =~ /^centos/
+                           "sed -i 's/enabled=.*/enabled=0/g' /etc/yum.repos.d/#{repo}.repo; "
+                         elsif os_family =~ /^ubuntu/
+                           "sed -i '/^deb.*/ s/^deb /# deb /' /etc/apt/sources.list.d/#{repo}.list; "
+                         end
+                       end
+                     end
+          cmd_list.reduce(:+)
         end
-      end
-    else
-      cmd = repos.split(' ').map do |repo|
-        if os_family =~ /^centos/
-          "sed -i 's/enabled=.*/enabled=0/g' /etc/yum.repos.d/#{repo}.repo; "
-        elsif os_family =~ /^ubuntu/
-          "sed -i '/^deb.*/ s/^deb /# deb /' /etc/apt/sources.list.d/#{repo}.list; "
-        end
-      end
-    end
-    cmd = cmd.reduce(:+)
-  end
   node.run(cmd, error_control.empty?)
 end
 


### PR DESCRIPTION
## What does this PR change?

Refactoring a step definition to fix a rubocop warning.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

That needs port, in 4.0 and 4.1, it will go altogether with a previous refactor.

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
