### PR TITLE
Log exception trace on fatal Taskomatic startup error

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/core/TaskomaticDaemon.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/core/TaskomaticDaemon.java
@@ -163,7 +163,7 @@ public class TaskomaticDaemon {
             t.start();
         }
         catch (Throwable t) {
-            LOG.fatal(t.getMessage());
+            LOG.fatal("Fatal error starting Taskomatic", t);
             System.exit(-1);
         }
         return retval;

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Log exception trace on fatal Taskomatic startup error
+
 -------------------------------------------------------------------
 Fri Sep 18 12:34:25 CEST 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Improves logging in case of a fatal Taskomatic startup error

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: small enhancement

- [x] **DONE**

## Test coverage
- No tests: **add explanation**

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
