### PR TITLE
Fix for spacewalk-koan test

### DIFF
--- a/client/tools/spacewalk-koan/test/test_merge_rd.py
+++ b/client/tools/spacewalk-koan/test/test_merge_rd.py
@@ -74,6 +74,7 @@ class MergeRdTest(unittest.TestCase):
             self.fail("Command failed for a different reason: {0}".format(errors))
 
     def test_should_fail_when_the_initrd_is_not_a_valid_file(self):
+        (status, stdout, stderr) = my_popen(["touch", "/etc/fstab"])
         (status, stdout, stderr) = my_popen([
             "/bin/sh",
             MERGE_RD_CMD,


### PR DESCRIPTION
## What does this PR change?
This PR fixes the spacewalk-koan test. The test needs `/etc/fstab` which does not exist in the docker container.
See https://ci.suse.de/view/Manager/view/Manager-4.1/job/manager-4.1-spacewalk-koan/105/console

## GUI diff

No difference.

## Documentation
- No documentation needed: No customer changing change.

## Test coverage
- No tests: Change to tests.

## Links

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
