### PR TITLE
Fix cobbler testsuite failure

### DIFF
--- a/susemanager-utils/testing/docker/master/uyuni-master-cobbler/add_packages.sh
+++ b/susemanager-utils/testing/docker/master/uyuni-master-cobbler/add_packages.sh
@@ -4,4 +4,5 @@ set -e
 # Packages required to run the cobbler unit tests
 zypper -n in  --no-recommends apache2 \
                               koan \
-                              virt-install
+                              virt-install \
+                              hardlink

--- a/susemanager-utils/testing/docker/master/uyuni-master-root/add_packages.sh
+++ b/susemanager-utils/testing/docker/master/uyuni-master-root/add_packages.sh
@@ -16,5 +16,4 @@ zypper in -y  make \
               curl
 
 zypper -n in vim \
-             less \
-             hardlink
+             less


### PR DESCRIPTION
## What does this PR change?
This PR fixes the cobbler cli test (`cobbler_cli_direct_test.py` in `manager-Head-Cobbler-Tests`). The `hardlink` package is needed by the cli test and was missing. 
Furthermore it reverts #2607. @brejoc and I found out that the `hardlink` package should be added in a different place.

## GUI diff

No difference.

## Documentation
No documentation needed: Just a bugfix

## Test coverage
No tests: Just a bugfix


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
