### PR TITLE
Enable different languages for Uyuni and SUSE Manager

### DIFF
--- a/java/conf/rhn_java.conf
+++ b/java/conf/rhn_java.conf
@@ -35,6 +35,7 @@ java.l10n_debug_marker=$$$
 java.l10n_missingmessage_exceptions=false
 
 # List of supported locales
+# NOTE: for the RPMs this is defined at the SPEC!
 java.supported_locales=bn_IN,ca,de,en_US,es,fr,gu,hi,it,ja,ko,pa,pt,pt_BR,ru,ta,zh_CN,zh_TW
 
 # List of countries to exclude for new user creation

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -60,6 +60,12 @@
 %define java_version    1:11
 %endif
 
+%if 0%{?is_opensuse}
+%define supported_locales bn_IN,ca,de,en_US,es,fr,gu,hi,it,ja,ko,pa,pt,pt_BR,ru,ta,zh_CN,zh_TW
+%else
+%define supported_locales en_US,zh_CN
+%endif
+
 Name:           spacewalk-java
 Summary:        Java web application files for Spacewalk
 License:        GPL-2.0-only
@@ -524,6 +530,9 @@ sed -i -e 's/^java.product_tree_tag =.*$/java.product_tree_tag = Uyuni/' $RPM_BU
 %else
 sed -i -e 's/^java.product_tree_tag =.*$/java.product_tree_tag = Beta/' $RPM_BUILD_ROOT%{_prefix}/share/rhn/config-defaults/rhn_java.conf
 %endif
+# Adjust languages
+sed -i -e '/# NOTE: for the RPMs this is defined at the SPEC!/d' $RPM_BUILD_ROOT%{_prefix}/share/rhn/config-defaults/rhn_java.conf
+sed -i -e 's/^java.supported_locales=.*$/java.supported_locales=%{supported_locales}/' $RPM_BUILD_ROOT%{_prefix}/share/rhn/config-defaults/rhn_java.conf
 install -m 644 conf/logrotate/rhn_web_api $RPM_BUILD_ROOT%{_sysconfdir}/logrotate.d/rhn_web_api
 install -m 644 conf/logrotate/gatherer $RPM_BUILD_ROOT%{_sysconfdir}/logrotate.d/gatherer
 # LOGROTATE >= 3.8 requires extra permission config


### PR DESCRIPTION
## What does this PR change?

Define a different set of languages for Uyuni and SUSE Manager. For SUSE Manager only `en_EN` and `cn_CZ` will be supported initially.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: This is just automating something that was going to be done manually before the next SUSE Manager major release.

Packages to verify the result:
https://build.opensuse.org/project/show/home:juliogonzalezgil:branches:systemsmanagement:Uyuni:Master
https://build.suse.de/project/show/home:juliogonzalezgil:branches:Devel:Galaxy:Manager:Head (I could not build for SLE15SP2 at OBS as some packages from SLE15SP2 that are only build dependencies were missing)

- [x] **DONE**

## Test coverage
- No tests: Cucumber testsuite should probably check this.

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/12284

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
