### PR TITLE
ActivationKeyHandler: refresh API docs

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/activationkey/ActivationKeyHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/activationkey/ActivationKeyHandler.java
@@ -132,9 +132,12 @@ public class ActivationKeyHandler extends BaseHandler {
      * default.")
      * @xmlrpc.param #param_desc("int", "usageLimit", "If unlimited usage is desired,
      * use the create API that does not include the parameter.")
-     * @xmlrpc.param #array_desc("string", "Add-on entitlement label to associate with the
+     * @xmlrpc.param #array_desc("string", "Add-on system type labels to associate with the
      * key.")
      *   #options()
+     *     #item("container_build_host")
+     *     #item("monitoring_entitled")
+     *     #item("osimage_build_host")
      *     #item("virtualization_host")
      *   #options_end()
      * #array_desc_end()
@@ -522,12 +525,15 @@ public class ActivationKeyHandler extends BaseHandler {
      * @param entitlements List of string entitlement labels to be added.
      * @return 1 on success, exception thrown otherwise.
      *
-     * @xmlrpc.doc Add entitlements to an activation key. Currently only
-     * virtualization_host add-on entitlement is permitted.
+     * @xmlrpc.doc Add add-on System Types to an activation key.
      * @xmlrpc.param #param("string", "sessionKey")
      * @xmlrpc.param #param("string", "key")
-     * @xmlrpc.param #array_desc("string", "entitlement label")
+     * @xmlrpc.param #array_desc("string", "Add-on system type labels to associate with the
+     * key.")
      *   #options()
+     *     #item("container_build_host")
+     *     #item("monitoring_entitled")
+     *     #item("osimage_build_host")
      *     #item("virtualization_host")
      *   #options_end()
      * #array_desc_end()


### PR DESCRIPTION
## What does this PR change?

This PR refreshes API docs for the `activationkey` namespace, in particular in regard of add-on system types which changed in the UI but changes are not reflected in the API yet.

## GUI diff

No difference.
- [x] **DONE**

## Documentation
- No documentation needed: **this is a documentation change itself**

- [x] **DONE**

## Test coverage
- No tests: **we do not test docs**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
