### PR TITLE
add message about schema upgrade running

### DIFF
--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,4 +1,6 @@
+- show info message when applying schema upgrade
 - Fix: handle version comparison corner cases in Ubuntu packages
+
 -------------------------------------------------------------------
 Mon Sep 21 18:42:16 CEST 2020 - jgonzalez@suse.com
 

--- a/schema/spacewalk/susemanager-schema.spec
+++ b/schema/spacewalk/susemanager-schema.spec
@@ -104,6 +104,10 @@ fi
 %endif
 
 %posttrans
+systemctl is-active --quiet uyuni-check-database.service && {
+  echo "  Running DB schema upgrade. This may take a while."
+  echo "  Call the following command to see progress: journalctl -f -u uyuni-check-database.service"
+} ||:
 systemctl try-restart uyuni-check-database.service ||:
 
 %files

--- a/spacewalk/admin/spacewalk-admin.changes
+++ b/spacewalk/admin/spacewalk-admin.changes
@@ -1,3 +1,5 @@
+- show info message when applying schema upgrade
+
 -------------------------------------------------------------------
 Fri Sep 18 12:33:58 CEST 2020 - jgonzalez@suse.com
 

--- a/spacewalk/admin/spacewalk-service.systemd
+++ b/spacewalk/admin/spacewalk-service.systemd
@@ -67,6 +67,8 @@ start() {
     else
         touch $DISABLE_FILE
     fi
+    echo "  Running DB schema upgrade. This may take a while."
+    echo "  Call the following command to see progress: journalctl -f -u uyuni-check-database.service"
     MSG1=$(systemctl start spacewalk.target 2>&1) || {
         MSG2=$(systemctl status uyuni-check-database.service)
         if [ $? -ne 0 ]; then


### PR DESCRIPTION
## What does this PR change?

Print info messages about doing a database schema upgrade to inform the admin that it might take longer.

I did not find a better way as systemd does not let you print on the console. Showing progress is not possible.
Other ideas as showing a webpage is not possible either as apache is stopped.
Starting a different webserver just for this sounds a bit like overkill to me.

More ideas are welcome.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **we just print additional info on the terminal**

- [x] **DONE**

## Test coverage
- No tests: **just an info message added**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/11923
Tracks https://github.com/SUSE/spacewalk/pull/12555

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
