### PR TITLE
Exclude salt-netapi-client from action cache

### DIFF
--- a/.github/workflows/java-checkstyle.yml
+++ b/.github/workflows/java-checkstyle.yml
@@ -17,13 +17,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Cache dependencies
-      id: cache-dependencies
-      uses: actions/cache@v2
-      with:
-        path: java/lib
-        key: ${{ runner.os }}-jars-${{ hashFiles('java/buildconf/ivy/*.*') }}
-
     - name: Resolve dependencies
       if: steps.cache-dependencies.outputs.cache-hit != 'true'
       run: |


### PR DESCRIPTION
## What does this PR change?

Try to pull fresh salt-netapi-client in github actions

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: test fix
- [X] **DONE**

## Test coverage
- No tests: test fix

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle" (Test skipped, there are no changes to test)
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
