### PR TITLE
Search daemon: default to reasonable max heap size

### DIFF
--- a/search-server/spacewalk-search/spacewalk-search.changes
+++ b/search-server/spacewalk-search/spacewalk-search.changes
@@ -1,3 +1,5 @@
+- change default maximum memory to 512 MB, preventing OutOfMemoryError
+
 -------------------------------------------------------------------
 Fri Sep 18 11:43:02 CEST 2020 - jgonzalez@suse.com
 

--- a/search-server/spacewalk-search/src/config/search/rhn_search_daemon.conf
+++ b/search-server/spacewalk-search/src/config/search/rhn_search_daemon.conf
@@ -8,4 +8,4 @@ SEARCH_RHN_CLASSPATH="/usr/share/rhn/classes:/usr/share/nutch-core:/usr/share/nu
 SEARCH_RHN_JARS="/usr/share/rhn/lib/spacewalk-asm.jar:/usr/share/rhn/lib/rhn.jar:/usr/share/rhn/lib/java-branding.jar"
 SEARCH_JARS="/usr/share/rhn/search/lib/*"
 SEARCH_INIT_MEMORY=32
-SEARCH_MAX_MEMORY=96
+SEARCH_MAX_MEMORY=512


### PR DESCRIPTION
## What does this PR change?

Addresses #2436. Documentation was correct but code was not.

https://www.uyuni-project.org/uyuni-docs/uyuni/large-deployments/tuning.html#rhn-search-java-maxmemory reported 512 MB

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **documentation was correct, aligning implementation to it**

- [x] **DONE**

## Test coverage
- No tests: **covered, tuning**

- [x] **DONE**

## Links

Fixes #2436
Supersedes #2513
Tracks https://github.com/SUSE/spacewalk/pull/12531

- [ ] **DONE**

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
