### PR TITLE
Fix usercreation 

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/user/CreateUserAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/user/CreateUserAction.java
@@ -64,6 +64,17 @@ public class CreateUserAction extends RhnAction {
             command.setUsePamAuthentication(false);
         }
 
+        // Check passwords
+        String passwd = (String)form.get(UserActionHelper.DESIRED_PASS);
+        String passwdConfirm = (String)form.get(UserActionHelper.DESIRED_PASS_CONFIRM);
+        if (passwd.equals(passwdConfirm)) {
+            command.setPassword(passwd);
+        }
+        else {
+            errors.add(ActionMessages.GLOBAL_MESSAGE,
+                    new ActionMessage("error.password_mismatch"));
+        }
+
         // Put any validationErrors into ActionErrors object
         ValidatorError[] validationErrors = command.validate();
         for (int i = 0; i < validationErrors.length; i++) {
@@ -76,17 +87,7 @@ public class CreateUserAction extends RhnAction {
         fillOutAddress(form, addr);
         command.setAddress(addr);
 
-        // Check passwords
-        String passwd = (String)form.get(UserActionHelper.DESIRED_PASS);
-        String passwdConfirm = (String)form.get(UserActionHelper.DESIRED_PASS_CONFIRM);
 
-        if (passwd.equals(passwdConfirm)) {
-            command.setPassword(passwd);
-        }
-        else {
-            errors.add(ActionMessages.GLOBAL_MESSAGE,
-                       new ActionMessage("error.password_mismatch"));
-        }
 
         return errors;
     }

--- a/java/code/src/com/redhat/rhn/manager/user/CreateUserCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/user/CreateUserCommand.java
@@ -286,7 +286,7 @@ public class CreateUserCommand {
 
         else if (passwordIn.length() > UserDefaults.get().getMaxPasswordLength()) {
             passwordErrors.add(new ValidatorError("error.maxpassword",
-                                                  user.getPassword()));
+                    UserDefaults.get().getMaxPasswordLength()));
         }
     }
 

--- a/java/code/webapp/WEB-INF/pages/user/create/usercreate.jsp
+++ b/java/code/webapp/WEB-INF/pages/user/create/usercreate.jsp
@@ -32,7 +32,7 @@
                       class="required-form-field">*</span>:</label>
                 <div class="col-sm-6">
                   <div id="desiredpassword-input-group" class="input-group">
-                      <html:password property="desiredpassword" styleClass="form-control" size="15" maxlength="${passwordLength}"/>
+                      <html:password property="desiredpassword" styleClass="form-control" size="15"/>
                       <span class="input-group-addon">
                           <i class="fa fa-times-circle text-danger fa-1-5x" id="desiredtick"></i>
                       </span>
@@ -44,7 +44,7 @@
                       class="required-form-field">*</span>:</label>
                 <div class="col-sm-6">
                   <div class="input-group">
-                      <html:password styleClass="form-control" property="desiredpasswordConfirm" onkeyup="updateTickIcon()" size="15" maxlength="${passwordLength}" styleId="confirmpass"/>
+                      <html:password styleClass="form-control" property="desiredpasswordConfirm" onkeyup="updateTickIcon()" size="15" styleId="confirmpass"/>
                       <span class="input-group-addon">
                           <i class="fa fa-times-circle text-danger fa-1-5x" id="confirmtick"></i>
                       </span>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- fix max password length check at user creation (bsc#1176765)
 - Fix the links for downloading the binaries in the package details UI (bsc#1176603)
 - Notify about missing libvirt or hypervisor on virtual host
 - Redesign maintenance schedule systems table to use paginated data from server


### PR DESCRIPTION
## What does this PR change?

This fixes 2 issues one where any password validation during user creation with the web ui was ignored (this should only happen on browsers that don't support the input field maxlength attribute. And second the error message when trying to create a with a password exceeding the max length.

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/12509

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
