### PR TITLE
Feat: add support for i18n of user-facing strings

### DIFF
--- a/spacecmd/po/Makefile
+++ b/spacecmd/po/Makefile
@@ -1,0 +1,176 @@
+# Makefile for program source directory in GNU NLS utilities package.
+# Copyright (C) 1995-1997, 2000, 2001 by Ulrich Drepper <drepper@gnu.ai.mit.edu>
+#
+# This file file be copied and used freely without restrictions.  It can
+# be used in projects which are not available under the GNU Public License
+# but which still want to provide support for the GNU gettext functionality.
+# Please note that the actual code is *not* freely available.
+#
+#  Modified by Yukihiro Nakai <ynakai@redhat.com> to use pygettext.py
+#  Modified by Yukihiro Nakai <ynakai@redhat.com> to use libglade-xgettext
+#
+
+PACKAGE = spacecmd
+VERSION = $(shell awk '/Version:/ { print $$2 }' ../spacecmd.spec)
+
+# These two variables depend on the location of this directory.
+subdir = po
+top_builddir = ..
+
+SHELL = /bin/sh
+
+
+srcdir = .
+top_srcdir = ..
+
+PREFIX ?=
+prefix = /usr
+exec_prefix = $(PREFIX)${prefix}
+datadir = $(PREFIX)${prefix}/share
+localedir = $(datadir)/locale
+gettextsrcdir = $(datadir)/gettext/po
+
+INSTALL = /usr/bin/install -c
+INSTALL_DATA = ${INSTALL} -m 644
+
+GMSGFMT = /usr/bin/msgfmt
+MSGFMT = /usr/bin/msgfmt
+MSGMERGE = /usr/bin/intltool-update -x --gettext-package=$(PACKAGE) --dist
+
+INCLUDES = -I.. -I$(top_srcdir)/intl
+
+POFILES = $(shell ls *.po)
+GMOFILES = $(patsubst %.po,%.gmo,$(POFILES))
+DISTFILES = POTFILES.in $(PACKAGE).pot $(POFILES) $(GMOFILES)
+
+POTFILES = \
+	$(shell find ../src/ -iname \*.py | sort) \
+	$(shell find ../src/bin -name spacecmd | sort)
+
+CATALOGS = $(GMOFILES)
+
+.SUFFIXES:
+.SUFFIXES: .po .pox .gmo .mo
+
+.po.pox:
+	$(MAKE) $(PACKAGE).pot
+	$(MSGMERGE) $< $(srcdir)/$(PACKAGE).pot -o $*.pox
+
+.po.mo:
+	$(MSGFMT) -o $@ $<
+
+.po.gmo:
+	file=$(srcdir)/`echo $* | sed 's,.*/,,'`.gmo \
+	  && rm -f $$file && $(GMSGFMT) --statistics -o $$file $<
+
+
+all: all-yes
+
+all-yes: $(CATALOGS)
+all-no:
+
+# Note: Target 'all' must not depend on target '$(srcdir)/$(PACKAGE).pot',
+# otherwise packages like GCC can not be built if only parts of the source
+# have been downloaded.
+
+POTFILES.in:
+	echo "[encoding: UTF-8]" > $@
+	for file in $(POTFILES); do \
+	  echo "$${file#../}" ; \
+	done >> $@
+
+$(srcdir)/$(PACKAGE).pot: $(POTFILES) POTFILES.in
+	/usr/bin/intltool-update --gettext-package=$(PACKAGE) --pot
+	rm -f POTFILES.in
+
+install: install-exec install-data
+install-exec:
+install-data: install-data-yes
+install-data-no: all
+install-data-yes: all
+	mkdir -p $(DESTDIR)$(datadir)
+	@catalogs='$(CATALOGS)'; \
+	for cat in $$catalogs; do \
+	  cat=`basename $$cat`; \
+	  lang=`echo $$cat | sed 's/\.gmo$$//'`; \
+	  dir=$(localedir)/$$lang/LC_MESSAGES; \
+	  mkdir -p $(DESTDIR)$$dir; \
+	  if test -r $$cat; then \
+	    $(INSTALL_DATA) $$cat $(DESTDIR)$$dir/$(PACKAGE).mo; \
+	    echo "installing $$cat as $(DESTDIR)$$dir/$(PACKAGE).mo"; \
+	  else \
+	    $(INSTALL_DATA) $(srcdir)/$$cat $(DESTDIR)$$dir/$(PACKAGE).mo; \
+	    echo "installing $(srcdir)/$$cat as" \
+		 "$(DESTDIR)$$dir/$(PACKAGE).mo"; \
+	  fi; \
+	done
+
+# Define this as empty until I found a useful application.
+installcheck:
+
+uninstall:
+	catalogs='$(CATALOGS)'; \
+	for cat in $$catalogs; do \
+	  cat=`basename $$cat`; \
+	  lang=`echo $$cat | sed 's/\.gmo$$//'`; \
+	  rm -f $(DESTDIR)$(localedir)/$$lang/LC_MESSAGES/$(PACKAGE).mo; \
+	done
+
+check: all
+
+dvi info tags TAGS ID:
+
+mostlyclean:
+	rm -f core core.* *.pox $(PACKAGE).po *.new.po POTFILES.in
+	rm -fr *.o
+
+clean: mostlyclean
+	rm -f *.gmo
+
+distclean: clean
+	rm -f POTFILES *.mo
+
+maintainer-clean: distclean
+	@echo "This command is intended for maintainers to use;"
+	@echo "it deletes files that may require special tools to rebuild."
+	rm -f $(GMOFILES)
+
+distdir = $(top_builddir)/$(PACKAGE)-$(VERSION)/$(subdir)
+dist distdir:
+	$(MAKE) update-po
+	@$(MAKE) dist2
+# This is a separate target because 'update-po' must be executed before.
+dist2: $(DISTFILES)
+	dists="$(DISTFILES)"; \
+	for file in $$dists; do \
+	  if test -f $$file; then dir=.; else dir=$(srcdir); fi; \
+	  cp -p $$dir/$$file $(distdir); \
+	done
+
+update-po: Makefile POTFILES.in $(PACKAGE).pot
+	$(MAKE) $(PACKAGE).pot
+	if test "$(PACKAGE)" = "gettext"; then PATH=`pwd`/../src:$$PATH; fi; \
+	cd $(srcdir); \
+	catalogs='$(GMOFILES)'; \
+	for cat in $$catalogs; do \
+	  cat=`basename $$cat`; \
+	  lang=`echo $$cat | sed 's/\.gmo$$//'`; \
+	  echo "$$lang:"; \
+	  cp $$lang.po $$lang.old.po; \
+	  if $(MSGMERGE) $$lang; then \
+	    rm -f $$lang.old.po ; \
+	  else \
+	    echo "msgmerge for $$cat failed!"; \
+	    mv $$lang.old.po $$lang.po ; \
+	  fi; \
+	done
+	$(MAKE) update-gmo
+
+update-gmo: Makefile $(GMOFILES)
+	@:
+
+Makefile:
+
+# Tell versions [3.59,3.63) of GNU make not to export all variables.
+# Otherwise a system limit (for SysV at least) may be exceeded.
+.NOEXPORT:

--- a/spacecmd/po/Makevars
+++ b/spacecmd/po/Makevars
@@ -1,0 +1,1 @@
+XGETTEXT_OPTIONS = --keyword=_

--- a/spacecmd/po/de.po
+++ b/spacecmd/po/de.po
@@ -1,0 +1,7456 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#: ../src/bin/spacecmd:59
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-09-24 17:29+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../src/spacecmd/activationkey.py:49
+msgid "activationkey_addpackages: Add packages to an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:50
+msgid "usage: activationkey_addpackages KEY <PACKAGE ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:83
+msgid "activationkey_removepackages: Remove packages from an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:85
+msgid "usage: activationkey_removepackages KEY <PACKAGE ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:121
+msgid "activationkey_addgroups: Add groups to an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:122
+msgid "usage: activationkey_addgroups KEY <GROUP ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:160
+msgid "activationkey_removegroups: Remove groups from an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:161
+msgid "usage: activationkey_removegroups KEY <GROUP ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:208
+msgid "activationkey_addentitlements: Add entitlements to an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:210
+msgid "usage: activationkey_addentitlements KEY <ENTITLEMENT ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:245
+msgid ""
+"activationkey_removeentitlements: Remove entitlements from an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:247
+msgid "usage: activationkey_removeentitlements KEY <ENTITLEMENT ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:285
+msgid "activationkey_addchildchannels: Add child channels to an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:287
+msgid "usage: activationkey_addchildchannels KEY <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:337
+msgid ""
+"activationkey_removechildchannels: Remove child channels from an activation "
+"key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:339
+msgid "usage: activationkey_removechildchannels KEY <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:376
+msgid ""
+"activationkey_listchildchannels: List the child channels for an activation "
+"key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:378
+msgid "usage: activationkey_listchildchannels KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:407
+msgid ""
+"activationkey_listbasechannel: List the base channels for an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:409
+msgid "usage: activationkey_listbasechannel KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:437
+msgid "activationkey_listgroups: List the groups for an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:439
+msgid "usage: activationkey_listgroups KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:470
+msgid ""
+"activationkey_listentitlements: List the entitlements for an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:472
+msgid "usage: activationkey_listentitlements KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:501
+msgid "activationkey_listpackages: List the packages for an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:503
+msgid "usage: activationkey_listpackages KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:535
+msgid ""
+"activationkey_listconfigchannels: List the configuration channels for an "
+"activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:537
+msgid "usage: activationkey_listconfigchannels KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:570
+msgid ""
+"activationkey_addconfigchannels: Add config channels to an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:572
+msgid ""
+"usage: activationkey_addconfigchannels KEY <CHANNEL ...> [options])\n"
+"\n"
+"options:\n"
+"  -t add channels to the top of the list\n"
+"  -b add channels to the bottom of the list"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:625
+msgid ""
+"activationkey_removeconfigchannels: Remove config channels from an "
+"activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:627
+msgid "usage: activationkey_removeconfigchannels KEY <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:666
+msgid ""
+"activationkey_setconfigchannelorder: Set the ranked order of configuration "
+"channels"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:668
+msgid "usage: activationkey_setconfigchannelorder KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:698
+msgid "New Configuration Channels:"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:712
+msgid "activationkey_create: Create an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:713
+msgid ""
+"usage: activationkey_create [options])\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -d DESCRIPTION\n"
+"  -b BASE_CHANNEL\n"
+"  -u set key as universal default\n"
+"  -e [enterprise_entitled,virtualization_host]"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:734
+msgid "Name (blank to autogenerate):"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:735
+msgid "Description [None]:"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:738 ../src/spacecmd/distribution.py:78
+#: ../src/spacecmd/softwarechannel.py:927
+msgid "Base Channels"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:743
+msgid "Base Channel (blank for default):"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:751
+#, python-format
+msgid "%s Entitlement [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:755
+msgid "Universal Default [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:782
+#, python-format
+msgid "Created activation key %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:790
+msgid "activationkey_delete: Delete an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:791
+msgid "usage: activationkey_delete KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:813 ../src/spacecmd/cryptokey.py:139
+#: ../src/spacecmd/cryptokey.py:197
+#, python-format
+msgid "No keys matched argument %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:819
+msgid "Delete activation key(s) [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:832
+msgid "activationkey_list: List all activation keys"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:833
+msgid "usage: activationkey_list"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:857
+msgid "activationkey_listsystems: List systems registered with a key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:858
+msgid "usage: activationkey_listsystems KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:881 ../src/spacecmd/activationkey.py:930
+#, python-format
+msgid "%s is not a valid activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:895
+msgid "activationkey_details: Show the details of an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:896
+msgid "usage: activationkey_details KEY ..."
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:943
+#, python-format
+msgid "Key:                    %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:944
+#, python-format
+msgid "Description:            %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:945
+#, python-format
+msgid "Universal Default:      %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:946
+#, python-format
+msgid "Usage Limit:            %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:947
+#, python-format
+msgid "Deploy Config Channels: %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:949
+#, python-format
+msgid "Contact Method:         %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:952 ../src/spacecmd/kickstart.py:425
+#: ../src/spacecmd/system.py:3048
+msgid "Software Channels"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:960 ../src/spacecmd/configchannel.py:765
+#: ../src/spacecmd/configchannel.py:870 ../src/spacecmd/system.py:3057
+msgid "Configuration Channels"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:966 ../src/spacecmd/system.py:3062
+msgid "Entitlements"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:971 ../src/spacecmd/system.py:3068
+msgid "System Groups"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:976 ../src/spacecmd/package.py:206
+#: ../src/spacecmd/package.py:263 ../src/spacecmd/softwarechannel.py:1392
+#: ../src/spacecmd/softwarechannel.py:1494
+#: ../src/spacecmd/softwarechannel.py:1576
+#: ../src/spacecmd/softwarechannel.py:1822
+msgid "Packages"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:991
+msgid "activationkey_enableconfigdeployment: Enable config channel deployment"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:993
+msgid "usage: activationkey_enableconfigdeployment KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1020
+msgid ""
+"activationkey_disableconfigdeployment: Disable config channel deployment"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1022
+msgid "usage: activationkey_disableconfigdeployment KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1049
+msgid "activationkey_setbasechannel: Set the base channel of an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1051
+msgid "usage: activationkey_setbasechannel KEY CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1098
+msgid ""
+"activationkey_setusagelimit: Set the usage limit of an activation key, can "
+"be a number or \"unlimited\""
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1100
+msgid "usage: activationkey_setusagelimit KEY <usage limit>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1101
+msgid "usage: activationkey_setusagelimit KEY unlimited "
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1131
+#, python-format
+msgid "Couldn't convert argument %s to an integer"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1153
+msgid ""
+"activationkey_setuniversaldefault: Set this key as the universal default"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1155
+msgid "usage: activationkey_setuniversaldefault KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1196
+msgid "activationkey_export: Export activation key(s) to JSON format file"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1197
+msgid ""
+"usage: activationkey_export [options] [<KEY> ...])\n"
+"\n"
+"options:\n"
+"    -f outfile.json : specify an output filename, defaults to <KEY>.json\n"
+"                      if exporting a single key, akeys.json for multiple "
+"keys,\n"
+"                      or akey_all.json if no KEY specified (export ALL)\n"
+"\n"
+"Note : KEY list is optional, default is to export ALL keys "
+msgstr ""
+
+#. Get the key details
+#: ../src/spacecmd/activationkey.py:1213
+#, python-format
+msgid "Getting activation key details for %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1267
+#, python-format
+msgid "Exporting ALL activation keys to %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1276
+msgid "Invalid activation key passed"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1291
+#, python-format
+msgid "Exporting key %s to %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1300
+#, python-format
+msgid "File %s exists, confirm overwrite file? (y/n)"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1305
+msgid "Failed to save exported keys to file: {}"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1314
+msgid "activationkey_import: import activation key(s) from JSON file(s)"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1315
+msgid "usage: activationkey_import <JSONFILE ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1324
+msgid "No filename passed"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1333
+#, python-format
+msgid "Could not read json data from %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1338 ../src/spacecmd/activationkey.py:1382
+#, python-format
+msgid "Failed to import key %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1352
+#, python-format
+msgid "%s already exists! Skipping!"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1407
+#, python-format
+msgid "System group %s doesn't exist, creating"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1428
+msgid "activationkey_clone: Clone an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1429
+msgid ""
+"usage examples:\n"
+"                 activationkey_clone foo_key -c bar_key\n"
+"                 activationkey_clone foo_key1 foo_key2 -c prefix\n"
+"                 activationkey_clone foo_key -x \"s/foo/bar\"\n"
+"                 activationkey_clone foo_key1 foo_key2 -x \"s/foo/bar\"\n"
+"\n"
+"options:\n"
+"  -c CLONE_NAME  : Name of the resulting key, treated as a prefix for "
+"multiple\n"
+"                   keys\n"
+"  -x \"s/foo/bar\" : Optional regex replacement, replaces foo with bar in "
+"the\n"
+"                   clone description, base-channel label, child-channel\n"
+"                   labels, config-channel names "
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1457 ../src/spacecmd/kickstart.py:460
+#: ../src/spacecmd/system.py:3043
+msgid "Activation Keys"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1463
+#, python-format
+msgid "Key to clone: %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1467
+msgid "Original Key:"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1469
+msgid "Cloned Key:"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1472 ../src/spacecmd/configchannel.py:1376
+msgid "Error - must specify either -c or -x options!"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1477
+#, python-format
+msgid "Key %s already exists"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1481
+msgid "Error no activationkey to clone passed!"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1535
+#, python-format
+msgid "Found child channel %s key %s, %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1537
+msgid " does not exist, skipping!"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1544
+#, python-format
+msgid "Regex-replacement results in new base-channel %s which does not exist!"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1560
+#, python-format
+msgid "Found config channel %s for key %s, %s "
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1562
+msgid "does not exist, skipping!"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1584 ../src/spacecmd/configchannel.py:1428
+#, python-format
+msgid "Failed to clone %s to %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1602
+msgid "no activationkey label given"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1605
+msgid "invalid activationkey label "
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1622
+msgid "activationkey_diff: Diff activation keys"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1624
+msgid "usage: activationkey_diff SOURCE_KEY TARGET_KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1673
+msgid "activationkey_disable: Disable an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1675
+msgid "usage: activationkey_disable KEY [KEY ...]"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1707
+msgid "activationkey_enable: Enable an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1709
+msgid "usage: activationkey_enable KEY [KEY ...]"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1741
+msgid "activationkey_setdescription: Set the activation key description"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1743
+msgid "usage: activationkey_setdescription KEY DESCRIPTION"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1775
+msgid ""
+"activationkey_setcontactmethod: Set the contact method to use for systems "
+"registered with this key."
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1777 ../src/spacecmd/system.py:4132
+msgid "Available contact methods: "
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1778
+msgid "usage: activationkey_setcontactmethod KEY CONTACT_METHOD"
+msgstr ""
+
+#: ../src/spacecmd/api.py:44
+msgid "api: call RHN API with arguments directly"
+msgstr ""
+
+#: ../src/spacecmd/api.py:45
+#, python-format
+msgid ""
+"usage: api [options] API_STRING)\n"
+"\n"
+"options:\n"
+"  -A, --args  Arguments for the API other than session id in comma "
+"separated\n"
+"              strings or JSON expression\n"
+"  -F, --format   Output format\n"
+"  -o, --output   Output file\n"
+"\n"
+"examples:\n"
+"  api api.getApiCallList\n"
+"  api --args \"sysgroup_A\" systemgroup.listSystems\n"
+"  api -A \"rhel-i386-server-5,2011-04-01,2011-05-01\" -F \"%(name)s\" \\\n"
+"      channel.software.listAllPackages\n"
+msgstr ""
+
+#: ../src/spacecmd/api.py:81
+msgid "Could not open to write: "
+msgstr ""
+
+#: ../src/spacecmd/api.py:82
+msgid "Fallback output to stdout"
+msgstr ""
+
+#: ../src/spacecmd/api.py:91
+msgid "No such API: "
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:50
+msgid "configchannel_list: List all configuration channels"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:51
+msgid "usage: configchannel_list"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:68
+msgid "configchannel_listsystems: List the systems subscribed to a"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:69
+msgid "                           configuration channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:70
+msgid "usage: configchannel_listsystems CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:79
+msgid "This version of the API doesn't support this method"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:103
+msgid "configchannel_listfiles: List the files in a config channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:104
+msgid "usage: configchannel_listfiles CHANNEL ..."
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:133
+msgid "configchannel_forcedeploy: Forces a redeployment"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:134
+msgid "                           of files within this channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:135
+msgid "                           on all subscribed systems"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:136
+msgid "usage: configchannel_forcedeploy CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:158
+msgid "No files within selected configchannel."
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:164
+msgid "Channel has no subscribed Systems"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:167
+msgid "Force deployment of the following configfiles:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:170
+msgid ""
+"\n"
+"On these systems:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:173
+msgid "Really force deployment [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:182
+msgid "configchannel_filedetails: Show the details of a file"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:183
+msgid "in a configuration channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:184
+msgid "usage: configchannel_filedetails CHANNEL FILE [REVISION]"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:216
+#, python-format
+msgid "Invalid revision: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:222
+#, python-format
+msgid "%s is not in this configuration channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:240
+#, python-format
+msgid "Path:     %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:241
+#, python-format
+msgid "Type:     %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:242
+#, python-format
+msgid "Revision: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:243
+#, python-format
+msgid "Created:  %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:244
+#, python-format
+msgid "Modified: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:248 ../src/spacecmd/configchannel.py:650
+#, python-format
+msgid "Target Path:     %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:251 ../src/spacecmd/configchannel.py:680
+#, python-format
+msgid "Owner:           %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:252 ../src/spacecmd/configchannel.py:681
+#, python-format
+msgid "Group:           %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:253 ../src/spacecmd/configchannel.py:682
+#, python-format
+msgid "Mode:            %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:255 ../src/spacecmd/configchannel.py:651
+#: ../src/spacecmd/configchannel.py:684
+#, python-format
+msgid "SELinux Context: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:258
+#, python-format
+msgid "SHA256:          %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:259 ../src/spacecmd/configchannel.py:683
+#, python-format
+msgid "Binary:          %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:263 ../src/spacecmd/configchannel.py:696
+#: ../src/spacecmd/configchannel.py:933 ../src/spacecmd/kickstart.py:1903
+#: ../src/spacecmd/snippet.py:161
+msgid "Contents"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:273
+msgid "configchannel_backup: backup a config channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:274
+msgid ""
+"usage: configchannel_backup CHANNEL [OUTDIR])\n"
+"\n"
+"OUTDIR defaults to $HOME/spacecmd-backup/configchannel/YYYY-MM-DD/CHANNEL\n"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:313 ../src/spacecmd/group.py:266
+#, python-format
+msgid "Could not create output directory: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:326
+#, python-format
+msgid "Could not create \"%s\" file: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:332
+#, python-format
+msgid "Output Path:   %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:371
+msgid "configchannel_details: Show the details of a config channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:372
+msgid "usage: configchannel_details CHANNEL ..."
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:402 ../src/spacecmd/kickstart.py:414
+#, python-format
+msgid "Label:       %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:403 ../src/spacecmd/kickstart.py:413
+#, python-format
+msgid "Name:        %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:404 ../src/spacecmd/cryptokey.py:214
+#: ../src/spacecmd/system.py:678
+#, python-format
+msgid "Description: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:405 ../src/spacecmd/cryptokey.py:215
+#: ../src/spacecmd/kickstart.py:500 ../src/spacecmd/kickstart.py:1899
+#, python-format
+msgid "Type:        %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:408
+msgid "Files"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:418
+msgid "configchannel_create: Create a configuration channel of specific type"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:419
+msgid ""
+"usage: configchannel_create [options])\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -l LABEL\n"
+"  -d DESCRIPTION\n"
+"  -t TYPE('normal,'state')"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:438 ../src/spacecmd/custominfo.py:54
+#: ../src/spacecmd/custominfo.py:198 ../src/spacecmd/distribution.py:71
+#: ../src/spacecmd/filepreservation.py:70 ../src/spacecmd/group.py:177
+#: ../src/spacecmd/repo.py:349 ../src/spacecmd/repo.py:461
+#: ../src/spacecmd/softwarechannel.py:800
+msgid "Name:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:439
+msgid "Label:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:440 ../src/spacecmd/cryptokey.py:66
+#: ../src/spacecmd/custominfo.py:59 ../src/spacecmd/custominfo.py:203
+#: ../src/spacecmd/group.py:182 ../src/spacecmd/softwarechannel.py:812
+#: ../src/spacecmd/system.py:3519
+msgid "Description:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:441
+msgid "Type [normal, state]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:448
+msgid "Only [normal/state] values are acceptable for type"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:452 ../src/spacecmd/distribution.py:109
+#: ../src/spacecmd/repo.py:357 ../src/spacecmd/repo.py:467
+msgid "A name is required"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:461
+msgid "Only [normal/state] values are acceptable for --type parameter"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:476
+msgid "configchannel_delete: Delete a configuration channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:477
+msgid "usage: configchannel_delete CHANNEL ..."
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:498
+#, python-format
+msgid "No channels matched argument(s): %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:504 ../src/spacecmd/softwarechannel.py:736
+msgid "Delete these channels [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:548
+msgid "Symlink [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:552
+msgid "Target Path:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:553
+msgid "SELinux Context [none]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:561
+msgid "Directory [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:570
+#, python-format
+msgid "Owner [%s]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:571
+#, python-format
+msgid "Group [%s]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:572
+#, python-format
+msgid "Mode [%s]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:574
+#, python-format
+msgid "SELinux Context [%s]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:575
+msgid "Revision [next]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:593
+msgid "The revision must be an integer"
+msgstr ""
+
+#. get the contents of the script
+#: ../src/spacecmd/configchannel.py:596 ../src/spacecmd/configchannel.py:896
+#: ../src/spacecmd/cryptokey.py:68 ../src/spacecmd/kickstart.py:1954
+#: ../src/spacecmd/snippet.py:141
+msgid "Read an existing file [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:598 ../src/spacecmd/kickstart.py:1956
+msgid "File:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:616
+msgid "The path is required"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:630 ../src/spacecmd/configchannel.py:913
+msgid "You must provide the file contents"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:634
+msgid "You must provide the target path for a symlink"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:649 ../src/spacecmd/configchannel.py:678
+#, python-format
+msgid "Path:            %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:679
+#, python-format
+msgid "Directory:       %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:689
+#, python-format
+msgid "Revision:        %i"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:694
+msgid "Contents not displayed (base64 encoded)"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:707
+msgid ""
+"configchannel_addfile/configchannel_updatefile: Create a configuration file"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:708
+msgid ""
+"usage: configchannel_addfile/configchannel_updatefile -c CHANNEL - p PATH -f "
+"LOCAL_FILE_PATH [OPTIONS])\n"
+"\n"
+"options:\n"
+"  -c CHANNEL\n"
+"  -p PATH\n"
+"  -r REVISION\n"
+"  -o OWNER [default: root]\n"
+"  -g GROUP [default: root]\n"
+"  -m MODE [defualt: 0644]\n"
+"  -x SELINUX_CONTEXT\n"
+"  -d path is a directory\n"
+"  -s path is a symlink\n"
+"  -b path is a binary (or other file which needs base64 encoding)\n"
+"  -t SYMLINK_TARGET\n"
+"  -f local path to file contents\n"
+"  -y automatically proceed with file contents\n"
+"\n"
+"  Note re binary/base64: Some text files, notably those containing trailing\n"
+"  newlines, those containing ASCII escape characters (or other charaters "
+"not\n"
+"  allowed in XML) need to be sent as binary (-b).  Some effort is made to "
+"auto-\n"
+"  detect files which require this, but you may need to explicitly specify.\n"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:770 ../src/spacecmd/softwarechannel.py:819
+#: ../src/spacecmd/softwarechannel.py:940
+#: ../src/spacecmd/softwarechannel.py:947
+msgid "Select:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:778 ../src/spacecmd/softwarechannel.py:1374
+#, python-format
+msgid "%s is not a valid channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:783
+msgid "Unable to obtain a valid channel. Aborting."
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:789 ../src/spacecmd/scap.py:160
+msgid "Path:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:805 ../src/spacecmd/configchannel.py:924
+msgid "No config channel specified!"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:810 ../src/spacecmd/configchannel.py:929
+msgid "Error obtaining file info"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:845
+msgid "configchannel_updateinitsls: Update init.sls file"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:846
+msgid ""
+"usage: configchannel_updateinitsls -c CHANNEL -f LOCAL_FILE_PATH [OPTIONS])\n"
+"\n"
+"options:\n"
+"  -c CHANNEL\n"
+"  -f local path to file contents\n"
+"  -y automatically proceed with file contents\n"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:892
+#, python-format
+msgid "No existing file information found for %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:932
+#, python-format
+msgid "contents_enc64:           %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:959
+msgid "configchannel_removefiles: Remove configuration files"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:960
+msgid "usage: configchannel_removefiles CHANNEL <FILE ...>"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:997
+msgid "configchannel_verifyfile: Verify a configuration file"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:998
+msgid "usage: configchannel_verifyfile CHANNEL FILE <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1037
+msgid "No valid system selected"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1045 ../src/spacecmd/system.py:509
+#: ../src/spacecmd/system.py:529 ../src/spacecmd/system.py:959
+#, python-format
+msgid "Action ID: %i"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1053
+msgid "configchannel_export: export config channel(s) to json format file"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1054
+msgid ""
+"usage: configchannel_export <CHANNEL>... [options])\n"
+"options:\n"
+"    -f outfile.json : specify an output filename, defaults to <CHANNEL>."
+"json\n"
+"                      if exporting a single channel, ccs.json for multiple\n"
+"                      channels, or cc_all.json if no CHANNEL specified\n"
+"                      e.g (export ALL)\n"
+"\n"
+"Note : CHANNEL list is optional, default is to export ALL"
+msgstr ""
+
+#. Get the cc details
+#: ../src/spacecmd/configchannel.py:1070
+#, python-format
+msgid "Getting config channel details for %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1090
+#, python-format
+msgid "Failed to get details for file %s from %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1136
+#, python-format
+msgid "File %s could not be exported "
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1137
+msgid "with this API version(needs base64 encoding)"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1139
+#, python-format
+msgid "File %s could not be exported as"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1140
+msgid " text...getting base64 encoded version"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1163
+#, python-format
+msgid "Passed filename '%s' to do_configchannel_export command."
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1171
+#, python-format
+msgid "Exporting ALL config channels to %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1178
+msgid ""
+"Error, no valid config channel passed, check name is  correct with spacecmd "
+"configchannel_list"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1193
+#, python-format
+msgid "Exporting cc %s to %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1200
+msgid "File '{}' exists, confirm overwrite file? (y/n)"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1203
+#, python-format
+msgid "Error saving exported config channels to file: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1212
+msgid "configchannel_import: import config channel(s) from json file"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1213
+msgid "usage: configchannel_import <JSONFILES...>"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1222 ../src/spacecmd/kickstart.py:2330
+msgid "Error, no filename passed"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1230 ../src/spacecmd/kickstart.py:2338
+#, python-format
+msgid "Error, could not read json data from %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1234
+#, python-format
+msgid "Error importing configchannel %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1246
+#, python-format
+msgid "Config channel %s already exists! Skipping!"
+msgstr ""
+
+#. create the cc, we need to drop the org prefix from the cc name
+#: ../src/spacecmd/configchannel.py:1251
+#, python-format
+msgid "Importing config channel  %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1294
+#, python-format
+msgid "Failed trying to import file %s (empty content)"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1296
+msgid "Older APIs can't export encoded files"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1319
+#, python-format
+msgid "Error adding file %s to %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1329
+msgid "configchannel_clone: Clone config channel(s)"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1330
+msgid ""
+"usage examples:\n"
+"                 configchannel_clone foo_label -c bar_label\n"
+"                 configchannel_clone foo_label1 foo_label2 -c prefix\n"
+"                 configchannel_clone foo_label -x \"s/foo/bar\"\n"
+"                 configchannel_clone foo_label1 foo_label2 -x \"s/foo/bar\"\n"
+"\n"
+"options:\n"
+"  -c CLONE_LABEL : name/label of the resulting cc (note does not update\n"
+"                   description, see -x option), treated as a prefix if\n"
+"                   multiple keys are passed\n"
+"  -x \"s/foo/bar\" : Optional regex replacement, replaces foo with bar in "
+"the\n"
+"                   clone name, label and description\n"
+"  Note : If no -c or -x option is specified, interactive is assumed"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1359
+msgid "No config channels found"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1362
+msgid "Config Channels"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1368
+#, python-format
+msgid "Channel to clone: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1372
+msgid "Channel to clone:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1373
+msgid "Clone label:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1382
+msgid "Error no channel label passed!"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1391
+msgid "No suitable channels to clone has been found."
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1444
+msgid "no configchannel given"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1447
+msgid "invalid configchannel label "
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1473
+msgid "configchannel_diff: diff between config channels"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1475
+msgid "usage: configchannel_diff SOURCE_CHANNEL TARGET_CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1524
+msgid "configchannel_sync:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1525
+msgid "sync config files between two config channels"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1527
+msgid "usage: configchannel_sync SOURCE_CHANNEL TARGET_CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1565
+msgid "syncing files from configchannel "
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1572
+msgid "files common in both channels:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1578
+msgid "files only in source "
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1584
+msgid "files only in target "
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1589
+msgid ""
+"files that are in both channels will be overwritten in the target channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1591
+msgid "files only in the source channel will be added to the target channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1593
+msgid "files only in the target channel will be deleted"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1596
+msgid "nothing to do"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1600
+msgid "perform synchronisation [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1652
+msgid "unknown file type "
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:43
+msgid "cryptokey_create: Create a cryptographic key"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:44
+msgid ""
+"usage: cryptokey_create [options])\n"
+"\n"
+"options:\n"
+"  -t GPG or SSL\n"
+"  -d DESCRIPTION\n"
+"  -f KEY_FILE"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:62
+msgid "GPG or SSL [G/S]:"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:75
+msgid "The key type is required"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:79
+msgid "A description is required"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:83
+msgid "A file containing the key is required"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:91
+msgid "No contents of the file"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:100
+msgid "Invalid key type"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:114
+msgid "cryptokey_delete: Delete a cryptographic key"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:115
+msgid "usage: cryptokey_delete NAME"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:145
+msgid "Delete key(s) [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:156
+msgid "cryptokey_list: List all cryptographic keys (SSL, GPG)"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:157
+msgid "usage: cryptokey_list"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:174
+msgid "cryptokey_details: Show the contents of a cryptographic key"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:175
+msgid "usage: cryptokey_details KEY ..."
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:207
+#, python-format
+msgid "%s is not a valid crypto key"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:39
+msgid "custominfo_createkey: Create a custom key"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:40
+msgid "usage: custominfo_createkey [NAME] [DESCRIPTION]"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:73
+msgid "custominfo_deletekey: Delete a custom key"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:74
+msgid "usage: custominfo_deletekey KEY ..."
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:114
+msgid "custominfo_listkeys: List all custom keys"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:115
+msgid "usage: custominfo_listkeys"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:132
+msgid "custominfo_details: Show the details of a custom key"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:133
+msgid "usage: custominfo_details KEY ..."
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:155
+msgid "No keys matched argument '{}'."
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:172
+#, python-format
+msgid "Label:        %s"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:173
+#, python-format
+msgid "Description:  %s"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:174
+#, python-format
+msgid "Modified:     %s"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:175
+#, python-format
+msgid "System Count: %i"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:183
+msgid "custominfo_updatekey: Update a custom key"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:184
+msgid "usage: custominfo_updatekey [NAME] [DESCRIPTION]"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:42
+msgid "distribution_create: Create a Kickstart tree"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:43
+msgid ""
+"usage: distribution_create [options]\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -p path to tree\n"
+"  -b base channel to associate with\n"
+"  -t install type [fedora|rhel_4/5/6|generic_rpm]"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:66
+msgid "The name of the distribution is required"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:73
+msgid "Path to Kickstart Tree:"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:83
+msgid "Base Channel:"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:86
+msgid "Invalid channel label"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:97
+msgid "Install Types"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:102
+msgid "Install Type:"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:105
+msgid "Invalid install type"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:113
+msgid "A path is required"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:117 ../src/spacecmd/system.py:2556
+msgid "A base channel is required"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:121
+msgid "An install type is required"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:143
+msgid "distribution_list: List the available autoinstall trees"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:144
+msgid "usage: distribution_list"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:168
+msgid "distribution_delete: Delete a Kickstart tree"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:169
+msgid "usage: distribution_delete LABEL"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:193 ../src/spacecmd/distribution.py:232
+#, python-format
+msgid "No distributions matched argument %s"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:199
+msgid "Delete distribution tree(s) [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:209
+msgid "distribution_details: Show the details of a Kickstart tree"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:210
+msgid "usage: distribution_details LABEL"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:248 ../src/spacecmd/package.py:93
+#, python-format
+msgid "Name:    %s"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:249 ../src/spacecmd/package.py:100
+#, python-format
+msgid "Path:    %s"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:250
+#, python-format
+msgid "Channel: %s"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:258
+msgid "distribution_rename: Rename a Kickstart tree"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:259
+msgid "usage: distribution_rename OLDNAME NEWNAME"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:288
+msgid "distribution_update: Update the path of a Kickstart tree"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:289
+msgid ""
+"usage: distribution_update NAME [options]\n"
+"\n"
+"options:\n"
+"  -p path to tree\n"
+"  -b base channel to associate with\n"
+"  -t install type [fedora|rhel_4/5/6|generic_rpm]"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:49
+msgid "errata_list: List all patches"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:50
+msgid "usage: errata_list"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:66
+msgid "errata_summary: Print a summary of all errata"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:67
+msgid "usage: errata_summary"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:82
+msgid "errata_apply: Apply an erratum to all affected systems"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:83
+msgid ""
+"usage: errata_apply [options] ERRATA|search:XXX ...)\n"
+"\n"
+"options:\n"
+"  -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:110 ../src/spacecmd/system.py:417
+#: ../src/spacecmd/system.py:725 ../src/spacecmd/system.py:880
+#: ../src/spacecmd/system.py:1015 ../src/spacecmd/system.py:1762
+#: ../src/spacecmd/system.py:3673 ../src/spacecmd/system.py:3983
+#: ../src/spacecmd/system.py:4045 ../src/spacecmd/system.py:4209
+msgid "Start Time [now]:"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:158
+msgid "No patches to apply"
+msgstr ""
+
+#. a summary of which errata we're going to apply
+#: ../src/spacecmd/errata.py:162
+msgid "Errata             Systems"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:166 ../src/spacecmd/system.py:230
+#: ../src/spacecmd/system.py:467 ../src/spacecmd/system.py:820
+#: ../src/spacecmd/system.py:942 ../src/spacecmd/system.py:1079
+#: ../src/spacecmd/system.py:1781 ../src/spacecmd/system.py:3685
+#: ../src/spacecmd/system.py:4228
+#, python-format
+msgid "Start Time: %s"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:168
+msgid "Apply these patches [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:218
+#, python-format
+msgid "No patches to schedule for %s"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:227
+#, python-format
+msgid "Scheduled %i patches for %s"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:236
+msgid "errata_listaffectedsystems: List of systems affected by an patch"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:237
+msgid "usage: errata_listaffectedsystems ERRATA|search:XXX ..."
+msgstr ""
+
+#: ../src/spacecmd/errata.py:275
+msgid "errata_listcves: List of CVEs addressed by an patch"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:276
+msgid "usage: errata_listcves ERRATA|search:XXX ..."
+msgstr ""
+
+#: ../src/spacecmd/errata.py:312
+msgid "No errata has been found"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:319
+msgid "errata_findbycve: List errata addressing a CVE"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:320
+msgid "usage: errata_findbycve CVE-YYYY-NNNN ..."
+msgstr ""
+
+#: ../src/spacecmd/errata.py:354
+msgid "errata_details: Show the details of an patch"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:355
+msgid "usage: errata_details ERRATA|search:XXX ..."
+msgstr ""
+
+#: ../src/spacecmd/errata.py:390
+#, python-format
+msgid "%s is not a valid erratum"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:397
+#, python-format
+msgid "Name:       %s"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:398
+msgid "Product:   s"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:399
+msgid "Type:      s"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:400
+msgid "Issue Date:s"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:402
+msgid "Topic"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:406 ../src/spacecmd/package.py:107
+#: ../src/spacecmd/softwarechannel.py:591
+msgid "Description"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:412
+msgid "Notes"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:417
+msgid "CVEs"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:421
+msgid "Solution"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:425
+msgid "References"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:429
+msgid "Affected Channels"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:433 ../src/spacecmd/org.py:278
+msgid "Affected Systems"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:437
+msgid "Affected Packages"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:447
+msgid "errata_delete: Delete an patch"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:448
+msgid "usage: errata_delete ERRATA|search:XXX ..."
+msgstr ""
+
+#: ../src/spacecmd/errata.py:468
+msgid "No patches to delete"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:471
+msgid "Erratum            Channels"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:479
+msgid "Delete these patches [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:485
+#, python-format
+msgid "Deleted %i patches"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:495
+msgid "errata_publish: Publish an patch to a channel"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:496
+msgid "usage: errata_publish ERRATA|search:XXX <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:523
+msgid "No patches to publish"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:528
+msgid "Publish these patches [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:540
+msgid "errata_search: List patches that meet the given criteria"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:541
+msgid "usage: errata_search CVE|RHSA|RHBA|RHEA|CLA ..."
+msgstr ""
+
+#: ../src/spacecmd/errata.py:543 ../src/spacecmd/scap.py:179
+msgid "Example:"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:42
+msgid "filepreservation_list: List all file preservations"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:43
+msgid "usage: filepreservation_list"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:58
+msgid "filepreservation_create: Create a file preservation list"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:59
+msgid "usage: filepreservation_create [NAME] [FILE ...]"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:78
+#: ../src/spacecmd/filepreservation.py:92
+msgid "File List"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:83
+msgid "File [blank to finish]:"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:109
+msgid "filepreservation_delete: Delete a file preservation list"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:110
+msgid "usage: filepreservation_delete NAME"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:128
+msgid "Delete this list [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:139
+msgid ""
+"filepreservation_details: Show the details of a file\n"
+"'preservation list"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:141
+msgid "usage: filepreservation_details NAME"
+msgstr ""
+
+#: ../src/spacecmd/group.py:50
+msgid "group_addsystems: Add systems to a group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:51
+msgid "usage: group_addsystems GROUP <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/group.py:52
+msgid "       group_addsystems GROUP <ssm>"
+msgstr ""
+
+#: ../src/spacecmd/group.py:103
+msgid "group_removesystems: Remove systems from a group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:104
+msgid "usage: group_removesystems GROUP <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/group.py:145 ../src/spacecmd/system.py:118
+#: ../src/spacecmd/system.py:232 ../src/spacecmd/system.py:475
+#: ../src/spacecmd/system.py:1475 ../src/spacecmd/system.py:1783
+#: ../src/spacecmd/system.py:4230
+msgid "Systems"
+msgstr ""
+
+#: ../src/spacecmd/group.py:149
+msgid "Remove these systems [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/group.py:158 ../src/spacecmd/schedule.py:385
+#: ../src/spacecmd/ssm.py:87 ../src/spacecmd/ssm.py:136
+#: ../src/spacecmd/ssm.py:186 ../src/spacecmd/system.py:4273
+#: ../src/spacecmd/system.py:4329
+msgid "No systems found"
+msgstr ""
+
+#: ../src/spacecmd/group.py:165
+msgid "group_create: Create a system group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:166
+msgid "usage: group_create [NAME] [DESCRIPTION]"
+msgstr ""
+
+#: ../src/spacecmd/group.py:192
+msgid "group_delete: Delete a system group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:193
+msgid "usage: group_delete NAME ..."
+msgstr ""
+
+#: ../src/spacecmd/group.py:212
+msgid "Delete these groups [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/group.py:224
+msgid "group_backup: backup a system group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:225
+msgid ""
+"usage: group_backup <NAME> [OUTDIR])\n"
+"                    group_backup ALL\n"
+"\n"
+"\"OUTDIR\" defaults to $HOME/spacecmd-backup/group/YYYY-MM-DD/NAME\n"
+"\"ALL\" is a keyword and collects all groups\n"
+msgstr ""
+
+#: ../src/spacecmd/group.py:270
+#, python-format
+msgid "Backup Group: %s"
+msgstr ""
+
+#: ../src/spacecmd/group.py:273
+#, python-format
+msgid "Output File: %s"
+msgstr ""
+
+#: ../src/spacecmd/group.py:284
+msgid "group_restore: restore a system group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:285
+msgid ""
+"\n"
+"usage: group_restore INPUTDIR [NAME] ...\n"
+"       group_restore INPUTDIR ALL\n"
+"       group_restore INPUTDIR\n"
+"       group_restore .\n"
+"\n"
+"Specifying only INPUTDIR will default to ALL groups.\n"
+"Setting dot (.) instead of full INPUTDIR will imply current directory.\n"
+"    "
+msgstr ""
+
+#: ../src/spacecmd/group.py:329
+#, python-format
+msgid "Restore dir %s does not exits or is not a directory"
+msgstr ""
+
+#: ../src/spacecmd/group.py:333
+#, python-format
+msgid "Restore dir %s has no restore items"
+msgstr ""
+
+#: ../src/spacecmd/group.py:340
+#, python-format
+msgid "Group %s was not found in backup"
+msgstr ""
+
+#: ../src/spacecmd/group.py:343
+#, python-format
+msgid "Found %s missing groups, terminating"
+msgstr ""
+
+#: ../src/spacecmd/group.py:358
+#, python-format
+msgid "Group %s already restored"
+msgstr ""
+
+#: ../src/spacecmd/group.py:365
+msgid "Changing description from:"
+msgstr ""
+
+#: ../src/spacecmd/group.py:367
+msgid "Continue [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/group.py:370 ../src/spacecmd/group.py:373
+#, python-format
+msgid "Updating description for group: %s"
+msgstr ""
+
+#: ../src/spacecmd/group.py:376
+#, python-format
+msgid "Creating new group %s"
+msgstr ""
+
+#: ../src/spacecmd/group.py:385
+msgid "group_list: List available system groups"
+msgstr ""
+
+#: ../src/spacecmd/group.py:386
+msgid "usage: group_list"
+msgstr ""
+
+#: ../src/spacecmd/group.py:403
+msgid "group_listsystems: List the members of a group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:404
+msgid "usage: group_listsystems GROUP"
+msgstr ""
+
+#: ../src/spacecmd/group.py:426
+#, python-format
+msgid "%s is not a valid group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:439
+msgid "group_details: Show the details of a system group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:440
+msgid "usage: group_details GROUP ..."
+msgstr ""
+
+#: ../src/spacecmd/group.py:463
+#, python-format
+msgid "The group \"%s\" is invalid"
+msgstr ""
+
+#: ../src/spacecmd/group.py:470
+#, python-format
+msgid "ID:                %i"
+msgstr ""
+
+#: ../src/spacecmd/group.py:471
+#, python-format
+msgid "Name:              %s"
+msgstr ""
+
+#: ../src/spacecmd/group.py:472
+#, python-format
+msgid "Description:       %s"
+msgstr ""
+
+#: ../src/spacecmd/group.py:473
+#, python-format
+msgid "Number of Systems: %i"
+msgstr ""
+
+#: ../src/spacecmd/group.py:477
+msgid "Members"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:72
+msgid "kickstart_list: List the available Kickstart profiles"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:73
+msgid "usage: kickstart_list"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:85 ../src/spacecmd/kickstart.py:2108
+msgid "No kickstart profiles available"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:91
+msgid "kickstart_create: Create a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:92
+msgid ""
+"usage: kickstart_create [options])\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -d DISTRIBUTION\n"
+"  -p ROOT_PASSWORD\n"
+"  -v VIRT_TYPE ['none', 'para_host', 'qemu', 'xenfv', 'xenpv']"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:113 ../src/spacecmd/kickstart.py:249
+msgid "Virtualization Types"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:118 ../src/spacecmd/kickstart.py:254
+msgid "Virtualization Type [none]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:126 ../src/spacecmd/kickstart.py:262
+msgid "Distributions"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:136
+msgid "Root Password: "
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:137 ../src/spacecmd/org.py:90
+#: ../src/spacecmd/user.py:85
+msgid "Repeat Password: "
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:142 ../src/spacecmd/org.py:95
+#: ../src/spacecmd/user.py:90
+msgid "Password must be at least 5 characters"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:144 ../src/spacecmd/org.py:97
+#: ../src/spacecmd/user.py:92
+msgid "Passwords don't match"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:147 ../src/spacecmd/kickstart.py:270
+#: ../src/spacecmd/kickstart.py:1980 ../src/spacecmd/kickstart.py:2122
+msgid "The Kickstart name is required"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:151 ../src/spacecmd/kickstart.py:274
+msgid "The distribution is required"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:158
+msgid "A root password is required"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:177
+msgid "kickstart_delete: Delete kickstart profile(s)"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:178
+msgid "usage: kickstart_delete PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:179
+msgid "usage: kickstart_delete PROFILE1 PROFILE2"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:180
+msgid "usage: kickstart_delete \"PROF*\""
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:203 ../src/spacecmd/kickstart.py:2597
+#: ../src/spacecmd/kickstart.py:2653 ../src/spacecmd/kickstart.py:2695
+msgid "No valid kickstart labels passed as arguments!"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:209
+msgid "The following kickstart labels are invalid:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:214
+#, python-format
+msgid "Delete profile %s [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:222
+msgid "kickstart_import: Import a Kickstart profile from a file"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:223
+msgid ""
+"usage: kickstart_import [options])\n"
+"\n"
+"options:\n"
+"  -f FILE\n"
+"  -n NAME\n"
+"  -d DISTRIBUTION\n"
+"  -v VIRT_TYPE ['none', 'para_host', 'qemu', 'xenfv', 'xenpv']"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:278 ../src/spacecmd/kickstart.py:1984
+msgid "A filename is required"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:308
+msgid ""
+"kickstart_import_raw: Import a raw Kickstart or autoyast profile from a file"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:309
+msgid ""
+"usage: kickstart_import_raw [options])\n"
+"\n"
+"options:\n"
+"  -f FILE\n"
+"  -n NAME\n"
+"  -d DISTRIBUTION\n"
+"  -v VIRT_TYPE ['none', 'para_host', 'qemu', 'xenfv', 'xenpv']"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:325
+msgid "kickstart_details: Show the details of a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:326
+msgid "usage: kickstart_details PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:353
+msgid "Invalid Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:415
+#, python-format
+msgid "Tree:        %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:416
+#, python-format
+msgid "Active:      %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:417
+#, python-format
+msgid "Advanced:    %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:418
+#, python-format
+msgid "Org Default: %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:421
+#, python-format
+msgid "Configuration Management: %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:422
+#, python-format
+msgid "Remote Commands:          %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:434
+msgid "Advanced Options"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:442
+msgid "Custom Options"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:449
+msgid "Partitioning"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:454
+msgid "Software"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:467
+msgid "Crypto Keys"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:474
+msgid "File Preservations"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:483
+msgid "Variables"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:490
+msgid "Scripts"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:501 ../src/spacecmd/kickstart.py:1900
+#, python-format
+msgid "Chroot:      %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:504 ../src/spacecmd/kickstart.py:1901
+#, python-format
+msgid "Interpreter: %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:530
+msgid "Could not retrieve the Kickstart file"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:536
+msgid "kickstart_getcontents: Show the contents of a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:537
+msgid "                   as they would be presented to a client"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:538
+msgid "usage: kickstart_getcontents LABEL"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:572
+msgid "kickstart_rename: Rename a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:573
+msgid "usage: kickstart_rename OLDNAME NEWNAME"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:601
+msgid ""
+"kickstart_listcryptokeys: List the crypto keys associated with a Kickstart "
+"profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:603
+msgid "usage: kickstart_listcryptokeys PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:632
+msgid "No crypto keys has been found"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:638
+msgid "kickstart_addcryptokeys: Add crypto keys to a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:639
+msgid "usage: kickstart_addcryptokeys PROFILE <KEY ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:665
+msgid "kickstart_removecryptokeys: Remove crypto keys from a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:667
+msgid "usage: kickstart_removecryptokeys PROFILE <KEY ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:707
+msgid ""
+"kickstart_listactivationkeys: List the activation keys associated with a "
+"Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:709
+msgid "usage: kickstart_listactivationkeys PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:739
+msgid "kickstart_addactivationkeys: Add activation keys to a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:741
+msgid "usage: kickstart_addactivationkeys PROFILE <KEY ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:770
+msgid ""
+"kickstart_removeactivationkeys: Remove activation keys from a Kickstart "
+"profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:772
+msgid "usage: kickstart_removeactivationkeys PROFILE <KEY ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:796
+msgid "Remove these keys [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:811
+msgid ""
+"kickstart_enableconfigmanagement: Enable configuration management on a "
+"Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:813
+msgid "usage: kickstart_enableconfigmanagement PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:844
+msgid ""
+"kickstart_disableconfigmanagement: Disable configuration management on a "
+"Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:846
+msgid "usage: kickstart_disableconfigmanagement PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:877
+msgid ""
+"kickstart_enableremotecommands: Enable remote commands on a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:879
+msgid "usage: kickstart_enableremotecommands PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:910
+msgid ""
+"kickstart_disableremotecommands: Disable remote commands on a Kickstart "
+"profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:912
+msgid "usage: kickstart_disableremotecommands PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:942
+msgid "kickstart_setlocale: Set the locale for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:943
+msgid "usage: kickstart_setlocale PROFILE LOCALE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:981
+msgid "kickstart_setselinux: Set the SELinux mode for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:983
+msgid "usage: kickstart_setselinux PROFILE MODE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1018
+msgid ""
+"kickstart_setpartitions: Set the partitioning scheme for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1020
+msgid "usage: kickstart_setpartitions PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1069
+msgid "kickstart_setdistribution: Set the distribution for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1071
+msgid "usage: kickstart_setdistribution PROFILE DISTRIBUTION"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1105
+msgid "kickstart_enablelogging: Enable logging for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1106
+msgid "usage: kickstart_enablelogging PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1138
+msgid "kickstart_addvariable: Add a variable to a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1139
+msgid "usage: kickstart_addvariable PROFILE KEY VALUE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1177
+msgid "kickstart_updatevariable: Update a variable in a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1179
+msgid "usage: kickstart_updatevariable PROFILE KEY VALUE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1214
+msgid "kickstart_removevariables: Remove variables from a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1216
+msgid "usage: kickstart_removevariables PROFILE <KEY ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1265
+msgid "kickstart_listvariables: List the variables of a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1267
+msgid "usage: kickstart_listvariables PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1300
+msgid "kickstart_addoption: Set an option for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1301
+msgid "usage: kickstart_addoption PROFILE KEY [VALUE]"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1348
+#, python-format
+msgid "%s needs to be set as a custom option"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1356
+msgid "kickstart_removeoptions: Remove options from a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1357
+msgid "usage: kickstart_removeoptions PROFILE <OPTION ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1409
+msgid "kickstart_listoptions: List the options of a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1411
+msgid "usage: kickstart_listoptions PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1445
+msgid ""
+"kickstart_listcustomoptions: List the custom options of a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1447
+msgid "usage: kickstart_listcustomoptions PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1481
+msgid "kickstart_setcustomoptions: Set custom options for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1483
+msgid "usage: kickstart_setcustomoptions PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1531
+msgid "kickstart_addchildchannels: Add a child channels to a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1533
+msgid "usage: kickstart_addchildchannels PROFILE <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1591
+msgid ""
+"kickstart_removechildchannels: Remove child channels from a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1593
+msgid "usage: kickstart_removechildchannels PROFILE <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1636
+msgid ""
+"kickstart_listchildchannels: List the child channels of a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1638
+msgid "usage: kickstart_listchildchannels PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1672
+msgid ""
+"kickstart_addfilepreservations: Add file preservations to a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1674
+msgid "usage: kickstart_addfilepreservations PROFILE <FILELIST ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1709
+msgid ""
+"kickstart_removefilepreservations: Remove file preservations from a "
+"Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1711
+msgid "usage: kickstart_removefilepreservations PROFILE <FILE ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1756
+msgid "kickstart_listpackages: List the packages for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1758
+msgid "usage: kickstart_listpackages PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1790
+msgid "kickstart_addpackages: Add packages to a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1791
+msgid "usage: kickstart_addpackages PROFILE <PACKAGE ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1824
+msgid "kickstart_removepackages: Remove packages from a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1826
+msgid "usage: kickstart_removepackages PROFILE <PACKAGE ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1869
+msgid "kickstart_listscripts: List the scripts for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1871
+msgid "usage: kickstart_listscripts PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1890
+#, python-format
+msgid "No scripts has been found for profile '%s'"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1898
+#, python-format
+msgid "ID:          %i"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1913
+msgid "kickstart_addscript: Add a script to a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1914
+msgid ""
+"usage: kickstart_addscript PROFILE [options])\n"
+"\n"
+"options:\n"
+"  -p PROFILE\n"
+"  -e EXECUTION_TIME ['pre', 'post']\n"
+"  -i INTERPRETER\n"
+"  -f FILE\n"
+"  -c execute in a chroot environment\n"
+"  -t ENABLING_TEMPLATING"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1947
+msgid "Profile Name:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1949
+msgid "Pre/Post Script [post]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1950
+msgid "Chrooted [Y/n]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1951
+msgid "Interpreter [/bin/bash]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1988
+msgid "The execution time is required"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2004
+#, python-format
+msgid "Profile Name:   %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2005
+#, python-format
+msgid "Execution Time: %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2006
+#, python-format
+msgid "Chroot:         %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2007
+#, python-format
+msgid "Template:       %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2008
+#, python-format
+msgid "Interpreter:    %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2009
+msgid "Contents:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2029
+msgid "kickstart_removescript: Remove a script from a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2030
+msgid "usage: kickstart_removescript PROFILE [ID]"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2058 ../src/spacecmd/kickstart.py:2071
+msgid "Invalid script ID"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2066
+msgid "Script ID:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2073
+msgid "Remove this script [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2086
+msgid "kickstart_clone: Clone a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2087
+msgid ""
+"usage: kickstart_clone [options])\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -c CLONE_NAME"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2112
+msgid "Kickstart Profiles"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2117
+msgid "Original Profile:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2118
+msgid "Cloned Profile:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2126
+msgid "The Kickstart clone name is required"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2131
+msgid "Kickstart profile you've entered was not found"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2144
+msgid "kickstart_export: export kickstart profile(s) to json format file"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2145
+msgid ""
+"usage: kickstart_export <KSPROFILE>... [options])\n"
+"options:\n"
+"    -f outfile.json : specify an output filename, defaults to <KSPROFILE>."
+"json\n"
+"                      if exporting a single kickstart, profiles.json for "
+"multiple\n"
+"                      kickstarts, or ks_all.json if no KSPROFILE specified\n"
+"                      e.g (export ALL)\n"
+"\n"
+"Note : KSPROFILE list is optional, default is to export ALL"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2271
+#, python-format
+msgid "Exporting ALL kickstart profiles to %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2279
+msgid ""
+"Error, no valid kickstart profile passed, check name is  correct with "
+"spacecmd kickstart_list"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2299
+#, python-format
+msgid "Exporting ks %s to %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2306
+#, python-format
+msgid "File %s exists, "
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2307
+msgid "confirm overwrite file? (y/n)"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2310
+msgid "Error saving exported kickstart profiles to file"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2320
+msgid "kickstart_import: import kickstart profile(s) from json file"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2321
+msgid "usage: kickstart_import <JSONFILES...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2342
+#, python-format
+msgid "Error importing kickstart %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2355
+#, python-format
+msgid "ERROR : kickstart profile %s already exists! Skipping!"
+msgstr ""
+
+#. create the ks, we need to drop the org prefix from the ks name
+#: ../src/spacecmd/kickstart.py:2359
+#, python-format
+msgid "Found ks %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2415
+#, python-format
+msgid "Error adding %s script"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2423
+#, python-format
+msgid "failed to add ip range %s-%s, continuing"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2437
+#, python-format
+msgid "failed to add file preservation %s, skipping"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2439
+#, python-format
+msgid "file preservation list %s doesn't exist, skipping"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2450
+#, python-format
+msgid "Actvationkey %s does not exist on the "
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2461
+#, python-format
+msgid "GPG/SSL key %s does not exist on the "
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2462
+msgid "satellite, skipping"
+msgstr ""
+
+#. There are some frustrating ommisions from the API which means we can't
+#. export/import some settings, so we post a warning that some manual
+#. fixup may be required
+#: ../src/spacecmd/kickstart.py:2471
+msgid ""
+"Due to API ommissions, there are some settings which cannot be imported, "
+"please check and fixup manually if necessary"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2473
+msgid " * Details->Preserve ks.cfg"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2474
+msgid " * Details->Comment"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2478
+msgid " * Details->Organization Default Profile"
+msgstr ""
+
+#. No way to set the kernel options
+#: ../src/spacecmd/kickstart.py:2480
+msgid " * Details->Kernel Options"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2484
+#, python-format
+msgid " * Details->Post Kernel Options : %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2500
+msgid "no kickstart label given"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2503
+msgid "invalid kickstart label "
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2520
+msgid "kickstart_diff: diff kickstart files"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2522
+msgid "usage: kickstart_diff SOURCE_CHANNEL TARGET_CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2571
+msgid "kickstart_getupdatetype: Get the update type for a kickstart profile(s)"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2572
+msgid "usage: kickstart_getupdatetype PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2573
+msgid "usage: kickstart_getupdatetype PROFILE1 PROFILE2"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2574
+msgid "usage: kickstart_getupdatetype \"PROF*\""
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2603 ../src/spacecmd/kickstart.py:2659
+#: ../src/spacecmd/kickstart.py:2701
+#, python-format
+msgid "kickstart label %s doesn't exist!"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2619
+msgid "kickstart_setupdatetype: Set the update type for a kickstart profile(s)"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2620
+msgid ""
+"usage: kickstart_setupdatetype [options] KS_LABEL)\n"
+"\n"
+"options:\n"
+"    -u UPDATE_TYPE ['red_hat', 'all', 'none']"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2634
+msgid "Update Types"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2639
+msgid "Update Type [none]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2670
+msgid "kickstart_getsoftwaredetails: Gets kickstart profile software details"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2671
+msgid "usage: kickstart_getsoftwaredetails KS_LABEL"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2672
+msgid "usage: kickstart_getsoftwaredetails KS_LABEL KS_LABEL2 ..."
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2707
+#, python-format
+msgid "noBase:        %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2708
+#, python-format
+msgid "ignoreMissing: %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2710
+#, python-format
+msgid "Kickstart Label: %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2711
+#, python-format
+msgid "noBase:          %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2712
+#, python-format
+msgid "ignoreMissing:   %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2721
+msgid "kickstart_setsoftwaredetails: Sets kickstart profile software details."
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2722
+msgid ""
+"usage: kickstart_setsoftwaredetails PROFILE KICKSTART_PACKAGES_INFO VALUE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2723
+msgid ""
+"usage: kickstart_setsoftwaredetails PROFILE KICKSTART_PACKAGES_INFO VALUE "
+"KICKSTART_PACKAGES_INFO VALUE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2757
+msgid "Selected profile does not exist"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2760 ../src/spacecmd/kickstart.py:2765
+msgid "Enter valid input"
+msgstr ""
+
+#. list of system selection options for the help output
+#: ../src/spacecmd/misc.py:57
+msgid ""
+"<SYSTEMS> can be any of the following:\n"
+"name\n"
+"ssm (see 'help ssm')\n"
+"search:QUERY (see 'help system_search')\n"
+"group:GROUP\n"
+"channel:CHANNEL\n"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:65
+msgid ""
+"Dates can be any of the following:\n"
+"Explicit Dates:\n"
+"Dates can be expressed as explicit date strings in the YYYYMMDD[HHMMSS]\n"
+"format.  The year, month and day are required, while the hours and\n"
+"minutes are not; the hours and minutes will default to 0000 if no\n"
+"values are provided.\n"
+"\n"
+"Deltas:\n"
+"Dates can be expressed as delta values.  For example, '2h' would\n"
+"mean 2 hours in the future.  You can also use negative values to\n"
+"express times in the past (e.g., -7d would be one week ago).\n"
+"\n"
+"Units:\n"
+"s -> seconds\n"
+"m -> minutes\n"
+"h -> hours\n"
+"d -> days\n"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:120
+msgid "clear: clear the screen"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:121
+msgid "usage: clear"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:132
+msgid "clear_caches: Clear the internal caches kept for systems and packages"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:133
+msgid "usage: clear_caches"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:146
+msgid "get_apiversion: Display the API version of the server"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:147
+msgid "usage: get_apiversion"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:158
+msgid "get_serverversion: Display the version of the server"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:159
+msgid "usage: get_serverversion"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:171
+msgid "list_proxies: List the proxies within the user's organization "
+msgstr ""
+
+#: ../src/spacecmd/misc.py:172
+msgid "usage: list_proxies"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:184
+msgid "get_session: Show the current session string"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:185
+msgid "usage: get_session"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:193
+msgid "No session found"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:200
+msgid "help: Show help for the given command"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:201
+msgid "usage: help COMMAND"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:207
+msgid "history: List your command history"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:208
+msgid "usage: history"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:220
+msgid "toggle_confirmations: Toggle confirmation messages on/off"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:221
+msgid "usage: toggle_confirmations"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:226
+msgid "Confirmation messages are"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:226
+msgid "enabled"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:233
+msgid "login: Connect to a Spacewalk server"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:234
+msgid "usage: login [USERNAME] [SERVER]"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:244
+msgid "You are already logged in"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:256
+msgid "No server specified"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:301
+#, python-format
+msgid "Failed to connect to %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:309
+#, python-format
+msgid "API (%s) is too old (>= %s required)"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:339 ../src/spacecmd/utils.py:249
+#: ../src/spacecmd/utils.py:560
+#, python-format
+msgid "Could not read %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:348
+msgid "Cached credentials are invalid"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:355
+#, python-format
+msgid "Spacewalk Username: %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:357
+msgid "Spacewalk Username:"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:368
+msgid "Spacewalk Password: "
+msgstr ""
+
+#: ../src/spacecmd/misc.py:374
+msgid "Invalid credentials"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:392
+#, python-format
+msgid "Could not write session file: %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:401
+#, python-format
+msgid "Connected to %s as %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:409
+msgid "logout: Disconnect from the server"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:410
+msgid "usage: logout"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:427
+msgid "whoami: Print the name of the currently logged in user"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:428
+msgid "usage: whoami"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:436
+msgid "You are not logged in"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:443
+msgid "whoamitalkingto: Print the name of the server"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:444
+msgid "usage: whoamitalkingto"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:452
+msgid "Yourself"
+msgstr ""
+
+#. tell the user what's going on
+#: ../src/spacecmd/misc.py:524
+msgid "** Generating errata cache **"
+msgstr ""
+
+#. tell the user what's going on
+#: ../src/spacecmd/misc.py:573
+msgid "** Generating package cache **"
+msgstr ""
+
+#. tell the user what's going on
+#: ../src/spacecmd/misc.py:680
+msgid "** Generating system cache **"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:715
+#, python-format
+msgid "Could not create directory %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:787
+#, python-format
+msgid "Can't find system ID for %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:792
+msgid "Duplicate system profile names found!"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:793
+msgid "Please reference systems by ID or resolve the"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:794
+msgid "underlying issue with 'system_delete' or 'system_rename'"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:860
+#, python-format
+msgid "No systems in group %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:874
+#, python-format
+msgid "No systems subscribed to %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:934
+msgid "Is this ok [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:47
+msgid "org_create: Create an organization"
+msgstr ""
+
+#: ../src/spacecmd/org.py:48
+#, python-format
+msgid ""
+"usage: org_create [options])\n"
+"\n"
+"options:\n"
+"  -n ORG_NAME\n"
+"  -u USERNAME\n"
+"  -P PREFIX (%s)\n"
+"  -f FIRST_NAME\n"
+"  -l LAST_NAME\n"
+"  -e EMAIL\n"
+"  -p PASSWORD\n"
+"  --pam enable PAM authentication"
+msgstr ""
+
+#: ../src/spacecmd/org.py:75
+msgid "Organization Name:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:76 ../src/spacecmd/user.py:73
+msgid "Username:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:77
+#, python-format
+msgid "Prefix (%s):"
+msgstr ""
+
+#: ../src/spacecmd/org.py:79 ../src/spacecmd/user.py:74
+msgid "First Name:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:80 ../src/spacecmd/user.py:75
+msgid "Last Name:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:81 ../src/spacecmd/user.py:76
+msgid "Email:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:82 ../src/spacecmd/user.py:77
+msgid "PAM Authentication [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:89 ../src/spacecmd/user.py:84
+msgid "Password: "
+msgstr ""
+
+#: ../src/spacecmd/org.py:100
+msgid "An organization name is required"
+msgstr ""
+
+#: ../src/spacecmd/org.py:104 ../src/spacecmd/user.py:95
+msgid "A username is required"
+msgstr ""
+
+#: ../src/spacecmd/org.py:108 ../src/spacecmd/user.py:99
+msgid "A first name is required"
+msgstr ""
+
+#: ../src/spacecmd/org.py:112 ../src/spacecmd/user.py:103
+msgid "A last name is required"
+msgstr ""
+
+#: ../src/spacecmd/org.py:116 ../src/spacecmd/user.py:107
+msgid "An email address is required"
+msgstr ""
+
+#: ../src/spacecmd/org.py:120 ../src/spacecmd/user.py:111
+msgid "A password is required"
+msgstr ""
+
+#: ../src/spacecmd/org.py:127
+msgid "Dr."
+msgstr ""
+
+#: ../src/spacecmd/org.py:129
+msgid "Miss"
+msgstr ""
+
+#: ../src/spacecmd/org.py:148
+msgid "org_delete: Delete an organization"
+msgstr ""
+
+#: ../src/spacecmd/org.py:149
+msgid "usage: org_delete NAME"
+msgstr ""
+
+#: ../src/spacecmd/org.py:168 ../src/spacecmd/org.py:199
+#: ../src/spacecmd/org.py:233 ../src/spacecmd/org.py:269
+#: ../src/spacecmd/org.py:377 ../src/spacecmd/org.py:413
+#, python-format
+msgid "No organisation found for the name %s"
+msgstr ""
+
+#: ../src/spacecmd/org.py:169 ../src/spacecmd/org.py:200
+#: ../src/spacecmd/org.py:234 ../src/spacecmd/org.py:270
+#: ../src/spacecmd/org.py:378 ../src/spacecmd/org.py:414
+msgid "Organisation '{}' was not found"
+msgstr ""
+
+#: ../src/spacecmd/org.py:171
+msgid "Delete this organization [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:179
+msgid "org_rename: Rename an organization"
+msgstr ""
+
+#: ../src/spacecmd/org.py:180
+msgid "usage: org_rename OLDNAME NEWNAME"
+msgstr ""
+
+#: ../src/spacecmd/org.py:211
+msgid "org_addtrust: Add a trust between two organizations"
+msgstr ""
+
+#: ../src/spacecmd/org.py:212
+msgid "usage: org_addtrust YOUR_ORG ORG_TO_TRUST"
+msgstr ""
+
+#: ../src/spacecmd/org.py:237 ../src/spacecmd/org.py:273
+#, python-format
+msgid "No trust organisation found for the name %s"
+msgstr ""
+
+#: ../src/spacecmd/org.py:238 ../src/spacecmd/org.py:274
+msgid "Organisation '{}' to trust for, was not found"
+msgstr ""
+
+#: ../src/spacecmd/org.py:248
+msgid "org_removetrust: Remove a trust between two organizations"
+msgstr ""
+
+#: ../src/spacecmd/org.py:249
+msgid "usage: org_removetrust YOUR_ORG TRUSTED_ORG"
+msgstr ""
+
+#: ../src/spacecmd/org.py:284
+msgid "None"
+msgstr ""
+
+#: ../src/spacecmd/org.py:286
+msgid "Remove this trust [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:292
+msgid "org_trustdetails: Show the details of an organizational trust"
+msgstr ""
+
+#: ../src/spacecmd/org.py:293
+msgid "usage: org_trustdetails TRUSTED_ORG"
+msgstr ""
+
+#: ../src/spacecmd/org.py:312
+#, python-format
+msgid "No trusted organisation found for the name %s"
+msgstr ""
+
+#: ../src/spacecmd/org.py:313
+msgid "Trusted organisation '{}' was not found"
+msgstr ""
+
+#: ../src/spacecmd/org.py:320
+#, python-format
+msgid "Trusted Organization:   %s"
+msgstr ""
+
+#: ../src/spacecmd/org.py:321
+#, python-format
+msgid "Trusted Since:          %s"
+msgstr ""
+
+#: ../src/spacecmd/org.py:322
+#, python-format
+msgid "Systems Migrated From:  %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:323
+#, python-format
+msgid "Systems Migrated To:    %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:325
+msgid "Channels Consumed"
+msgstr ""
+
+#: ../src/spacecmd/org.py:332
+msgid "Channels Provided"
+msgstr ""
+
+#: ../src/spacecmd/org.py:340
+msgid "org_list: List all organizations"
+msgstr ""
+
+#: ../src/spacecmd/org.py:341
+msgid "usage: org_list"
+msgstr ""
+
+#: ../src/spacecmd/org.py:358
+msgid "org_listtrusts: List an organization's trusts"
+msgstr ""
+
+#: ../src/spacecmd/org.py:359
+msgid "usage: org_listtrusts NAME"
+msgstr ""
+
+#: ../src/spacecmd/org.py:383 ../src/spacecmd/org.py:384
+msgid "No trust organisation has been found"
+msgstr ""
+
+#: ../src/spacecmd/org.py:394
+msgid "org_listusers: List an organization's users"
+msgstr ""
+
+#: ../src/spacecmd/org.py:395
+msgid "usage: org_listusers NAME"
+msgstr ""
+
+#: ../src/spacecmd/org.py:425
+msgid "org_details: Show the details of an organization"
+msgstr ""
+
+#: ../src/spacecmd/org.py:426
+msgid "usage: org_details NAME"
+msgstr ""
+
+#: ../src/spacecmd/org.py:446
+#, python-format
+msgid "Name:                   %s"
+msgstr ""
+
+#: ../src/spacecmd/org.py:447
+#, python-format
+msgid "Active Users:           %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:448
+#, python-format
+msgid "Systems:                %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:452 ../src/spacecmd/org.py:454
+#, python-format
+msgid "Trusts:                 %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:456
+#, python-format
+msgid "System Groups:          %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:457
+#, python-format
+msgid "Activation Keys:        %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:458
+#, python-format
+msgid "Kickstart Profiles:     %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:459
+#, python-format
+msgid "Configuration Channels: %i"
+msgstr ""
+
+#: ../src/spacecmd/package.py:68 ../src/spacecmd/package.py:302
+#: ../src/spacecmd/package.py:351 ../src/spacecmd/package.py:395
+msgid "No packages found"
+msgstr ""
+
+#: ../src/spacecmd/package.py:81 ../src/spacecmd/package.py:406
+#, python-format
+msgid "%s is not a valid package"
+msgstr ""
+
+#: ../src/spacecmd/package.py:94
+#, python-format
+msgid "Version: %s"
+msgstr ""
+
+#: ../src/spacecmd/package.py:95
+#, python-format
+msgid "Release: %s"
+msgstr ""
+
+#: ../src/spacecmd/package.py:96
+#, python-format
+msgid "Epoch:   %s"
+msgstr ""
+
+#: ../src/spacecmd/package.py:97
+#, python-format
+msgid "Arch:    %s"
+msgstr ""
+
+#: ../src/spacecmd/package.py:99
+#, python-format
+msgid "File:    %s"
+msgstr ""
+
+#: ../src/spacecmd/package.py:101
+#, python-format
+msgid "Size:    %s"
+msgstr ""
+
+#: ../src/spacecmd/package.py:105
+#, python-format
+msgid "Installed Systems: %i"
+msgstr ""
+
+#: ../src/spacecmd/package.py:111
+msgid "Available From Channels"
+msgstr ""
+
+#: ../src/spacecmd/package.py:122
+msgid "package_search: Find packages that meet the given criteria"
+msgstr ""
+
+#: ../src/spacecmd/package.py:123
+msgid "usage: package_search NAME|QUERY"
+msgstr ""
+
+#: ../src/spacecmd/package.py:125
+msgid "Example: package_search kernel"
+msgstr ""
+
+#: ../src/spacecmd/package.py:127
+msgid "Advanced Search:"
+msgstr ""
+
+#: ../src/spacecmd/package.py:128
+msgid ""
+"Available Fields: name, epoch, version, release, arch, description, summary"
+msgstr ""
+
+#: ../src/spacecmd/package.py:129
+msgid "Example: name:kernel AND version:2.6.18 AND -description:devel"
+msgstr ""
+
+#: ../src/spacecmd/package.py:178
+msgid "package_remove: Remove a package from Satellite"
+msgstr ""
+
+#: ../src/spacecmd/package.py:179
+msgid "usage: package_remove PACKAGE ..."
+msgstr ""
+
+#: ../src/spacecmd/package.py:199
+msgid "No packages found to remove"
+msgstr ""
+
+#: ../src/spacecmd/package.py:202 ../src/spacecmd/package.py:259
+#: ../src/spacecmd/softwarechannel.py:1580 ../src/spacecmd/system.py:944
+msgid "Remove these packages [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/package.py:203
+msgid "No packages has been removed"
+msgstr ""
+
+#: ../src/spacecmd/package.py:215 ../src/spacecmd/package.py:271
+#, python-format
+msgid "Failed to remove package ID %i"
+msgstr ""
+
+#: ../src/spacecmd/package.py:226
+msgid "package_listorphans: List packages that are not in a channel"
+msgstr ""
+
+#: ../src/spacecmd/package.py:227
+msgid "usage: package_listorphans"
+msgstr ""
+
+#: ../src/spacecmd/package.py:246
+msgid "package_removeorphans: Remove packages that are not in a channel"
+msgstr ""
+
+#: ../src/spacecmd/package.py:247
+msgid "usage: package_removeorphans"
+msgstr ""
+
+#: ../src/spacecmd/package.py:255
+msgid "No orphaned packages has been found"
+msgstr ""
+
+#: ../src/spacecmd/package.py:256
+msgid "No orphaned packages"
+msgstr ""
+
+#: ../src/spacecmd/package.py:260
+msgid "No packages were removed"
+msgstr ""
+
+#: ../src/spacecmd/package.py:280
+msgid "package_listinstalledsystems: List the systems with a package installed"
+msgstr ""
+
+#: ../src/spacecmd/package.py:281
+msgid "usage: package_listinstalledsystems PACKAGE ..."
+msgstr ""
+
+#: ../src/spacecmd/package.py:329
+msgid "package_listerrata: List the errata that provide this package"
+msgstr ""
+
+#: ../src/spacecmd/package.py:330
+msgid "usage: package_listerrata PACKAGE ..."
+msgstr ""
+
+#: ../src/spacecmd/package.py:377
+msgid "package_listdependencies: List the dependencies for a package"
+msgstr ""
+
+#: ../src/spacecmd/package.py:378
+msgid "usage: package_listdependencies PACKAGE"
+msgstr ""
+
+#: ../src/spacecmd/package.py:411
+#, python-format
+msgid "Package Name: %s"
+msgstr ""
+
+#: ../src/spacecmd/package.py:413
+#, python-format
+msgid "Dependency: %s Type: %s Modifier: %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:47
+msgid "repo_list: List all available user repos"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:48
+msgid "usage: repo_list"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:65
+msgid "repo_details: Show the details of a user repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:66
+msgid "usage: repo_details <repo ...>"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:94
+#, python-format
+msgid "Repository Label:                  %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:95
+#, python-format
+msgid "Repository URL:                    %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:96
+#, python-format
+msgid "Repository Type:                   %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:97
+#, python-format
+msgid "Repository SSL Ca Certificate:     %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:98
+#, python-format
+msgid "Repository SSL Client Certificate: %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:99
+#, python-format
+msgid "Repository SSL Client Key:         %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:101
+msgid "No repositories found for '{}' query"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:110
+msgid "repo_listfilters: Show the filters for a user repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:111
+msgid "usage: repo_listfilters repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:132
+msgid "No filters found"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:141
+msgid "repo_addfilters: Add filters for a user repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:142
+msgid "usage: repo_addfilters repo <filter ...>"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:166 ../src/spacecmd/repo.py:203
+#: ../src/spacecmd/repo.py:242
+msgid "Each filter must start with + or -"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:180
+msgid "repo_removefilters: Remove filters from a user repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:181
+msgid "usage: repo_removefilters repo <filter ...>"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:217
+msgid "repo_setfilters: Set the filters for a user repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:218
+msgid "usage: repo_setfilters repo <filter ...>"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:255
+msgid "repo_clearfilters: Clears the filters for a user repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:256
+msgid ""
+"usage: repo_clearfilters repo <options>\n"
+"\n"
+"options:\n"
+"  -y, --yes   Confirm without prompt\n"
+"\n"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:278
+msgid "Remove these filters [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:287
+msgid "repo_delete: Delete a user repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:288
+msgid "usage: repo_delete <repo ...>"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:307 ../src/spacecmd/softwarechannel.py:610
+msgid "Repos"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:311
+msgid "Delete these repos [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:316
+#, python-format
+msgid "Failed to remove repo %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:324
+msgid "repo_create: Create a user repository"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:325
+msgid ""
+"usage: repo_create <options>)\n"
+"\n"
+"options:\n"
+"  -n, --name   name of repository\n"
+"  -u, --url    url of repository\n"
+"  -t, --type   type of repository (defaults to yum)\n"
+"\n"
+"  --ca         SSL CA certificate (not required)\n"
+"  --cert       SSL Client certificate (not required)\n"
+"  --key        SSL Client key (not required)"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:350
+msgid "URL:"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:351
+msgid "Type:"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:352 ../src/spacecmd/repo.py:462
+msgid "SSL CA cert:"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:353 ../src/spacecmd/repo.py:463
+msgid "SSL Client cert:"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:354 ../src/spacecmd/repo.py:464
+msgid "SSL Client key:"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:361
+msgid "A URL is required"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:381
+msgid "repo_rename: Rename a user repository"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:382
+msgid "usage: repo_rename OLDNAME NEWNAME"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:404
+#, python-format
+msgid "Could not find repo %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:417
+msgid "repo_updateurl: Change the URL of a user repository"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:418
+msgid "usage: repo_updateurl <repo> <url>"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:443
+msgid "repo_updatessl: Change the SSL certificates of a user repository"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:444
+msgid ""
+"usage: repo_updatessl <options>)\n"
+"options:\n"
+"  --ca         SSL CA certificate (not required)\n"
+"  --cert       SSL Client certificate (not required)\n"
+"  --key        SSL Client key (not required)"
+msgstr ""
+
+#: ../src/spacecmd/report.py:43
+msgid "report_inactivesystems: List all inactive systems"
+msgstr ""
+
+#: ../src/spacecmd/report.py:44
+msgid "usage: report_inactivesystems [DAYS]"
+msgstr ""
+
+#: ../src/spacecmd/report.py:84
+msgid "report_outofdatesystems: List all out-of-date systems"
+msgstr ""
+
+#: ../src/spacecmd/report.py:85
+msgid "usage: report_outofdatesystems"
+msgstr ""
+
+#: ../src/spacecmd/report.py:112
+msgid "report_ungroupedsystems: List all ungrouped systems"
+msgstr ""
+
+#: ../src/spacecmd/report.py:113
+msgid "usage: report_ungroupedsystems"
+msgstr ""
+
+#: ../src/spacecmd/report.py:130
+msgid "report_errata: List all errata and how many systems they affect"
+msgstr ""
+
+#: ../src/spacecmd/report.py:131
+msgid "usage: report_errata [ERRATA|search:XXX ...]"
+msgstr ""
+
+#: ../src/spacecmd/report.py:143
+msgid "All errata requested - this may take a few minutes, please be patient!"
+msgstr ""
+
+#: ../src/spacecmd/report.py:166
+#, python-format
+msgid "%s  # Systems"
+msgstr ""
+
+#: ../src/spacecmd/report.py:173
+msgid "No errata found for '{}'"
+msgstr ""
+
+#: ../src/spacecmd/report.py:180
+msgid "report_ipaddresses: List the hostname and IP of each system"
+msgstr ""
+
+#: ../src/spacecmd/report.py:181
+msgid "usage: report_ipaddresses [<SYSTEMS>]"
+msgstr ""
+
+#: ../src/spacecmd/report.py:201 ../src/spacecmd/report.py:265
+#: ../src/spacecmd/scap.py:67 ../src/spacecmd/scap.py:207
+#: ../src/spacecmd/system.py:213 ../src/spacecmd/system.py:394
+#: ../src/spacecmd/system.py:579 ../src/spacecmd/system.py:743
+#: ../src/spacecmd/system.py:898 ../src/spacecmd/system.py:1033
+#: ../src/spacecmd/system.py:1134 ../src/spacecmd/system.py:1204
+#: ../src/spacecmd/system.py:1259 ../src/spacecmd/system.py:1358
+#: ../src/spacecmd/system.py:1591 ../src/spacecmd/system.py:1654
+#: ../src/spacecmd/system.py:1697 ../src/spacecmd/system.py:1777
+#: ../src/spacecmd/system.py:1919 ../src/spacecmd/system.py:1961
+#: ../src/spacecmd/system.py:2049 ../src/spacecmd/system.py:2116
+#: ../src/spacecmd/system.py:2198 ../src/spacecmd/system.py:2253
+#: ../src/spacecmd/system.py:2313 ../src/spacecmd/system.py:2372
+#: ../src/spacecmd/system.py:2430 ../src/spacecmd/system.py:2489
+#: ../src/spacecmd/system.py:2566 ../src/spacecmd/system.py:2647
+#: ../src/spacecmd/system.py:2702 ../src/spacecmd/system.py:2955
+#: ../src/spacecmd/system.py:3108 ../src/spacecmd/system.py:3177
+#: ../src/spacecmd/system.py:3223 ../src/spacecmd/system.py:3282
+#: ../src/spacecmd/system.py:3346 ../src/spacecmd/system.py:3402
+#: ../src/spacecmd/system.py:3577 ../src/spacecmd/system.py:3855
+#: ../src/spacecmd/system.py:3998 ../src/spacecmd/system.py:4060
+#: ../src/spacecmd/system.py:4108 ../src/spacecmd/system.py:4166
+#: ../src/spacecmd/system.py:4224
+msgid "No systems selected"
+msgstr ""
+
+#: ../src/spacecmd/report.py:244
+msgid "report_kernels: List the running kernel of each system"
+msgstr ""
+
+#: ../src/spacecmd/report.py:245
+msgid "usage: report_kernels [<SYSTEMS>]"
+msgstr ""
+
+#: ../src/spacecmd/report.py:282
+#, python-format
+msgid "%s  Kernel"
+msgstr ""
+
+#: ../src/spacecmd/report.py:282
+msgid "System"
+msgstr ""
+
+#: ../src/spacecmd/report.py:296
+msgid "report_duplicates: List duplicate system profiles"
+msgstr ""
+
+#: ../src/spacecmd/report.py:297
+msgid "usage: report_duplicates"
+msgstr ""
+
+#: ../src/spacecmd/report.py:319 ../src/spacecmd/report.py:341
+#: ../src/spacecmd/report.py:359 ../src/spacecmd/report.py:377
+msgid "System ID   Last Checkin"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:43
+msgid ""
+"scap_listxccdfscans: Return a list of finished OpenSCAP scans for given "
+"systems"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:44
+msgid "usage: scap_listxccdfscans <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:78 ../src/spacecmd/system.py:608
+#: ../src/spacecmd/system.py:1220 ../src/spacecmd/system.py:1371
+#: ../src/spacecmd/system.py:2060 ../src/spacecmd/system.py:2383
+#: ../src/spacecmd/system.py:2441 ../src/spacecmd/system.py:2660
+#: ../src/spacecmd/system.py:2715 ../src/spacecmd/system.py:3121
+#: ../src/spacecmd/system.py:3238 ../src/spacecmd/system.py:3295
+#, python-format
+msgid "System: %s"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:88
+#, python-format
+msgid "XID: %d Profile: %s Path: (%s) Completed: %s"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:96
+msgid ""
+"scap_getxccdfscanruleresults: Return a full list of RuleResults for given "
+"OpenSCAP XCCDF scan"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:97
+msgid "usage: scap_getxccdfscanruleresults <XID>"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:117
+#, python-format
+msgid "XID: %s"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:124
+#, python-format
+msgid "IDref: %s Result: %s Idents: (%s)"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:132
+msgid "scap_getxccdfscandetails: Get details of given OpenSCAP XCCDF scan"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:133
+msgid "usage: scap_getxccdfscandetails <XID>"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:159
+msgid "XID:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:159
+msgid "SID:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:159
+msgid "Action_ID:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:161
+msgid "OSCAP_Parameters:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:162
+msgid "Test_Result:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:162
+msgid "Benchmark:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:163
+msgid "Benchmark_Version:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:164
+msgid "Profile:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:165
+msgid "Profile_Title:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:165
+msgid "Start_Time:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:166
+msgid "End_Time:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:167
+msgid "Errors:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:175
+msgid "scap_schedulexccdfscan: Schedule Scap XCCDF scan"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:176
+msgid "usage: scap_schedulexccdfscan PATH_TO_XCCDF_FILE XCCDF_OPTIONS SYSTEMS"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:177
+msgid "       scap_schedulexccdfscan ssm PATH_TO_XCCDF_FILE XCCDF_OPTIONS"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:182
+msgid ""
+"\n"
+"To use systems in the ssm, pass the \"ssm\" keyword in front. Example:"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:88
+msgid "ID      Date                 C    F    P     Action"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:134
+msgid "schedule_cancel: Cancel scheduled actions"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:135
+msgid "usage: schedule_cancel ID|* ..."
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:157
+msgid "Cancel all pending actions [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:158
+msgid "All pending actions left untouched"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:173 ../src/spacecmd/schedule.py:234
+#, python-format
+msgid "\"%s\" is not a valid ID"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:179
+#, python-format
+msgid "Canceled action: %i"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:182
+#, python-format
+msgid "Failed action: %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:184
+#, python-format
+msgid "Canceled %i action(s)"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:192
+msgid "schedule_reschedule: Reschedule failed actions"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:193
+msgid "usage: schedule_reschedule ID|* ..."
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:220
+msgid "Reschedule all failed actions [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:232
+#, python-format
+msgid "\"%i\" is not a failed action"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:238
+msgid "No failed actions to reschedule"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:242
+#, python-format
+msgid "Rescheduled %i action(s)"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:250
+msgid "schedule_details: Show the details of a scheduled action"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:251
+msgid "usage: schedule_details ID"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:268
+#, python-format
+msgid "The ID \"%s\" is invalid"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:277
+#, python-format
+msgid "ID:        %i"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:278
+#, python-format
+msgid "Action:    %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:279
+#, python-format
+msgid "User:      %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:280
+#, python-format
+msgid "Date:      %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:282 ../src/spacecmd/schedule.py:379
+#: ../src/spacecmd/system.py:3245
+#, python-format
+msgid "Completed: %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:283
+#, python-format
+msgid "Failed:    %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:284
+#, python-format
+msgid "Pending:   %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:288
+msgid "Completed Systems"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:295
+msgid "Failed Systems"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:302
+msgid "Pending Systems"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:307
+#, python-format
+msgid "No action found with the ID \"%s\""
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:316
+msgid "schedule_getoutput: Show the output from an action"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:317
+msgid "usage: schedule_getoutput ID"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:332
+#, python-format
+msgid "\"%s\" is not a valid action ID"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:354
+#, python-format
+msgid "System:      %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:355
+#, python-format
+msgid "Start Time:  %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:356
+#, python-format
+msgid "Stop Time:   %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:357
+#, python-format
+msgid "Return Code: %i"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:359 ../src/spacecmd/schedule.py:381
+msgid "Output"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:378
+#, python-format
+msgid "System:    %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:394
+msgid "schedule_listpending: List pending actions"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:395
+msgid "usage: schedule_listpending [BEGINDATE] [ENDDATE]"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:407
+msgid "schedule_listcompleted: List completed actions"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:408
+msgid "usage: schedule_listcompleted [BEGINDATE] [ENDDATE]"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:420
+msgid "schedule_listfailed: List failed actions"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:421
+msgid "usage: schedule_listfailed [BEGINDATE] [ENDDATE]"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:433
+msgid "schedule_listarchived: List archived actions"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:434
+msgid "usage: schedule_listarchived [BEGINDATE] [ENDDATE]"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:446
+msgid "schedule_list: List all actions"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:447
+msgid "usage: schedule_list [BEGINDATE] [ENDDATE]"
+msgstr ""
+
+#: ../src/spacecmd/shell.py:120
+msgid "Could not read history file"
+msgstr ""
+
+#. pylint: disable=W0702
+#: ../src/spacecmd/shell.py:124
+msgid "Exception occurred: {}"
+msgstr ""
+
+#: ../src/spacecmd/shell.py:188 ../src/spacecmd/shell.py:227
+#, python-format
+msgid "%s: event not found"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:42
+msgid "snippet_list: List the available Kickstart snippets"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:43
+msgid "usage: snippet_list"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:60
+msgid "snippet_details: Show the contents of a snippet"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:61
+msgid "usage: snippet_details SNIPPET ..."
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:90
+#, python-format
+msgid "%s is not a valid snippet"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:97
+#, python-format
+msgid "Name:   %s"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:98
+#, python-format
+msgid "Macro:  %s"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:99
+#, python-format
+msgid "File:   %s"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:110
+msgid "snippet_create: Create a Kickstart snippet"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:111
+msgid ""
+"usage: snippet_create [options])\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -f FILE"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:149
+msgid "A name is required for the snippet"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:153
+msgid "A file is required"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:160
+#, python-format
+msgid "Snippet: %s"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:176
+msgid "snippet_update: Update a Kickstart snippet"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:177
+msgid "usage: snippet_update NAME"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:199
+msgid "snippet_delete: Delete a Kickstart snippet"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:200
+msgid "usage: snippet_delete NAME"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:218
+msgid "Remove this snippet [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:57
+msgid "softwarechannel_list: List all available software channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:58
+msgid ""
+"usage: softwarechannel_list [options]')\n"
+"options:\n"
+"  -v verbose (display label and summary)\n"
+"  -t tree view (pretty-print(child-channels))\n"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:106
+msgid "softwarechannel_listmanageablechannels: List all software channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:107
+msgid "                                        manageable by current user"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:108
+msgid ""
+"usage: softwarechannel_listmanageablechannels [options]\n"
+"options:\n"
+"  -v verbose (display label and summary)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:143
+msgid "softwarechannel_listbasechannels: List all base software channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:144
+msgid ""
+"usage: softwarechannel_listbasechannels [options])\n"
+"options:\n"
+"  -v verbose (display label and summary)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:172
+msgid "softwarechannel_listchildchannels: List child software channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:173
+#: ../src/spacecmd/softwarechannel.py:2735
+msgid "usage:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:174
+msgid "softwarechannel_listchildchannels [options]"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:175
+msgid "softwarechannel_listchildchannels : List all child channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:176
+msgid ""
+"softwarechannel_listchildchannels CHANNEL : List children for aspecific base "
+"channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:178
+msgid ""
+"options:\n"
+" -v verbose (display label and summary)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:206
+msgid "softwarechannel_listsystems: List all systems subscribed to"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:207
+msgid "                             a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:208
+msgid "usage: softwarechannel_listsystems CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:242
+msgid "softwarechannel_listpackages: List the most recent packages"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:243
+msgid "                              available from a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:244
+msgid "usage: softwarechannel_listpackages CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:281
+msgid "softwarechannel_listallpackages: List all packages in a channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:282
+msgid "usage: softwarechannel_listallpackages CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:340
+msgid ""
+"softwarechannel_listlatestpackages: List the newest version of all packages "
+"in a channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:341
+msgid "usage: softwarechannel_listlatestpackages CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:380
+msgid "softwarechannel_setdetails: Modify details of a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:381
+#, python-format
+msgid ""
+"usage: softwarechannel_setdetails [options] <CHANNEL ...>)\n"
+"\n"
+"options, at least one of which must be given:\n"
+"  -n NAME\n"
+"  -d DESCRIPTION\n"
+"  -s SUMMARY\n"
+"  -c CHECKSUM %s\n"
+"  -m MAINTAINER_NAME\n"
+"  -e MAINTAINER_EMAIL\n"
+"  -p MAINTAINER_PHONE\n"
+"  -u GPG_URL\n"
+"  -i GPG_ID\n"
+"  -f GPG_FINGERPRINT"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:443
+msgid "At least one attribute to set must be given"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:449
+msgid "No channels matching that label"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:461
+msgid "Setting same name for more than one channel will fail"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:469
+#, python-format
+msgid "Name \"%s\" already in use by channel %s"
+msgstr ""
+
+#. get confirmation
+#: ../src/spacecmd/softwarechannel.py:474
+msgid "Setting following attributes..."
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:477
+#, python-format
+msgid "Name:             %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:479
+#, python-format
+msgid "Summary:          %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:481
+#, python-format
+msgid "Description:      %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:483
+#, python-format
+msgid "Checksum:         %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:485
+#, python-format
+msgid "Maintainer name:  %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:487
+#, python-format
+msgid "Maintainer email: %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:489
+#, python-format
+msgid "Maintainer phone: %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:491
+#, python-format
+msgid "GPG Key:          %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:493
+#, python-format
+msgid "GPG Fingerprint:  %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:495
+#, python-format
+msgid "GPG URL:          %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:497
+msgid "... for the following channels:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:500
+msgid "Apply? [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:512
+#, python-format
+msgid "Could not get details for %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:524
+#, python-format
+msgid "Error while setting details for %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:527
+#, python-format
+msgid "Channels changed: %d"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:535
+msgid "softwarechannel_details: Show the details of a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:536
+msgid "usage: softwarechannel_details <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:576
+#, python-format
+msgid "Label:              %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:577
+#, python-format
+msgid "Name:               %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:578
+#, python-format
+msgid "Architecture:       %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:579
+#, python-format
+msgid "Parent:             %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:580
+#, python-format
+msgid "Systems Subscribed: %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:581
+#, python-format
+msgid "Number of Packages: %i"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:585
+msgid "Summary"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:596
+#, python-format
+msgid "GPG Key:            %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:597
+#, python-format
+msgid "GPG Fingerprint:    %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:598
+#, python-format
+msgid "GPG URL:            %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:599
+#, python-format
+msgid "GPG CHECK:          %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:603
+msgid "Kickstart Trees"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:621
+msgid "softwarechannel_listerrata: List the errata associated with a"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:622
+msgid "                            software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:623
+msgid ""
+"usage: softwarechannel_listerrata <CHANNEL ...> [from=yyyymmdd [to=yyyymmdd]]"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:681
+msgid "softwarechannel_listarches: lists the potential software"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:682
+msgid "                            channel architectures that can be created"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:683
+msgid "usage: softwarechannel_listarches"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:684 ../src/spacecmd/system.py:3826
+msgid "options:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:685
+msgid "    -v verbose (display label and name)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:706
+msgid "softwarechannel_delete: Delete a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:707
+msgid "usage: softwarechannel_delete <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:732
+msgid "Channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:760
+msgid "softwarechannel_update: Update a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:761
+#, python-format
+msgid ""
+"usage: softwarechannel_update LABEL(To identify the channel) [options]\n"
+"options:\n"
+"  -l LABEL(Required)\n"
+"  -n NAME\n"
+"  -s SUMMARY\n"
+"  -d DESCRIPTION\n"
+"  -c CHECKSUM %s\n"
+"  -u GPG-URL\n"
+"  -i GPG-ID\n"
+"  -f GPG-FINGERPRINT\n"
+"  -g DISABLE-GPG-CHECK"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:792
+#: ../src/spacecmd/softwarechannel.py:924
+#: ../src/spacecmd/softwarechannel.py:1094
+msgid "Channel Label:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:797
+msgid "New Name (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:803
+msgid "New Summary (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:806
+msgid "Summary:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:809
+msgid "New Description (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:815
+msgid "New Checksum type (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:822
+msgid "New GPG URL (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:825
+#: ../src/spacecmd/softwarechannel.py:953
+#: ../src/spacecmd/softwarechannel.py:1107
+#: ../src/spacecmd/softwarechannel.py:1196
+msgid "GPG URL:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:828
+msgid "New GPG ID (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:831
+#: ../src/spacecmd/softwarechannel.py:959
+#: ../src/spacecmd/softwarechannel.py:1108
+#: ../src/spacecmd/softwarechannel.py:1197
+msgid "GPG ID:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:834
+msgid "New GPG Fingerprint (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:837
+#: ../src/spacecmd/softwarechannel.py:965
+#: ../src/spacecmd/softwarechannel.py:1109
+#: ../src/spacecmd/softwarechannel.py:1198
+msgid "GPG Fingerprint:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:840
+msgid "Disable GPG CHECK (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:843
+#: ../src/spacecmd/softwarechannel.py:1110
+#: ../src/spacecmd/softwarechannel.py:1199
+msgid "Disable GPG Check [yes/no]? "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:846
+msgid "A channel label is required to identify the channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:849
+msgid "Only [yes/no] values are acceptable for --disable_gpg_check"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:889
+msgid "softwarechannel_create: Create a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:890
+#, python-format
+msgid ""
+"usage: softwarechannel_create [options])\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -l LABEL\n"
+"  -s SUMMARY\n"
+"  -p PARENT_CHANNEL\n"
+"  -a ARCHITECTURE\n"
+"  -c CHECKSUM %s\n"
+"  -u GPG_URL\n"
+"  -i GPG_ID\n"
+"  -f GPG_FINGERPRINT\n"
+"  -g DISABLE_GPG_CHECK"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:923
+#: ../src/spacecmd/softwarechannel.py:1093
+msgid "Channel Name:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:925
+msgid "Channel Summary:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:933
+#: ../src/spacecmd/softwarechannel.py:1101
+msgid "Select Parent [blank to create a base channel]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:936
+msgid "Architecture"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:943
+msgid "Checksum type"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:950
+msgid "GPG URL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:956
+msgid "GPG ID"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:962
+msgid "GPG Fingerprint"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:968
+msgid "GPG CHECK"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:971
+msgid "Disable GPG Check [y/N]? "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1023
+#: ../src/spacecmd/softwarechannel.py:1121
+msgid "A channel name is required"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1027
+#: ../src/spacecmd/softwarechannel.py:1125
+msgid "A channel label is required"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1040
+#, python-format
+msgid "Name %s already in use by channel %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1044
+#, python-format
+msgid "Label %s already in use by channel %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1052
+msgid "softwarechannel_clone: Clone a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1053
+msgid ""
+"usage: softwarechannel_clone [options])\n"
+"\n"
+"options:\n"
+"  -s SOURCE_CHANNEL\n"
+"  -n NAME\n"
+"  -l LABEL\n"
+"  -p PARENT_CHANNEL\n"
+"  --gpg-copy/-g (copy SOURCE_CHANNEL GPG details)\n"
+"  --gpg-url GPG_URL\n"
+"  --gpg-id GPG_ID\n"
+"  --gpg-fingerprint(GPG_FINGERPRINT)\n"
+"  --disable-gpg-check DISABLE_GPG_CHECK\n"
+"  -o do not clone any patches\n"
+"  --regex/-x \"s/foo/bar\" : Optional regex replacement,\n"
+"        replaces foo with bar in the clone name and label"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1088
+#: ../src/spacecmd/softwarechannel.py:1188
+msgid "Source Channels:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1092
+#: ../src/spacecmd/softwarechannel.py:1191
+msgid "Select source channel:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1096
+msgid "Base Channels:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1104
+#: ../src/spacecmd/softwarechannel.py:1194
+msgid "Copy source channel GPG details? [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1113
+#: ../src/spacecmd/softwarechannel.py:1202
+msgid "Original State (No Errata) [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1117
+#: ../src/spacecmd/softwarechannel.py:1205
+msgid "A source channel is required"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1138
+#: ../src/spacecmd/softwarechannel.py:1216
+msgid "Only [yes/no] values are acceptable for --disable-gpg-check"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1154
+msgid ""
+"softwarechannel_clonetree: Clone a software channel and its child channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1155
+msgid ""
+"usage: softwarechannel_clonetree [options])\n"
+"             e.g    softwarechannel_clonetree foobasechannel -p \"my_\"\n"
+"                    softwarechannel_clonetree foobasechannel -x \"s/foo/bar"
+"\"\n"
+"                    softwarechannel_clonetree foobasechannel -x \"s/^/my_\"\n"
+"\n"
+"options:\n"
+"  -s/--source-channel SOURCE_CHANNEL\n"
+"  -p/--prefix PREFIX (is prepended to the label and name of all channels)\n"
+"  --gpg-copy/-g (copy GPG details for correspondoing source channel))\n"
+"  --gpg-url GPG_URL (applied to all channels)\n"
+"  --gpg-id GPG_ID (applied to all channels)\n"
+"  --gpg-fingerprint(GPG_FINGERPRINT (applied to all channels))\n"
+"  --disable-gpg-check DISABLE_GPG_CHECK(applied to all channels)\n"
+"  -o do not clone any errata\n"
+"  --regex/-x \"s/foo/bar\" : Optional regex replacement,\n"
+"        replaces foo with bar in the clone name, label and description"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1192
+msgid "Prefix:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1209
+msgid "A prefix or regex is required"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1221
+#: ../src/spacecmd/softwarechannel.py:1994
+#: ../src/spacecmd/softwarechannel.py:2034
+msgid "Channel does not exist or is not a base channel!"
+msgstr ""
+
+#. Shouldn't ever get here due to earlier checks
+#: ../src/spacecmd/softwarechannel.py:1248
+msgid "called without prefix or regex option!"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1348
+msgid "softwarechannel_addpackages: Add packages to a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1349
+msgid "usage: softwarechannel_addpackages CHANNEL <PACKAGE ...>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1389
+msgid "No packages to add"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1396
+msgid "Add these packages [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1408
+msgid ""
+"softwarechannel_mergepackages: Merge packages from one software channel into "
+"another"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1409
+msgid "usage: softwarechannel_mergepackages SOURCE_CHANNEL TARGET_CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1433
+msgid "softwarechannel_removeerrata: Remove patches from a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1435
+msgid "usage: softwarechannel_removeerrata CHANNEL <ERRATA:search:XXX ...>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1488
+msgid "No patches to remove"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1499
+#: ../src/spacecmd/softwarechannel.py:1828
+#, python-format
+msgid "Total Errata:   %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1500
+#: ../src/spacecmd/softwarechannel.py:1831
+#, python-format
+msgid "Total Packages: %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1502
+msgid "Remove these patches [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1517
+msgid "softwarechannel_removepackages: Remove packages from a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1519
+msgid "usage: softwarechannel_removepackages CHANNEL <PACKAGE ...>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1573
+msgid "No packages to remove"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1593
+msgid ""
+"softwarechannel_adderratabydate: Add errata from one channel into another "
+"channel based on a date range"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1595
+msgid ""
+"usage: softwarechannel_adderratabydate [options] SOURCE DEST BEGINDATE "
+"ENDDATE"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1596
+#: ../src/spacecmd/softwarechannel.py:1671
+msgid "Date format : YYYYMMDD"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1597
+#: ../src/spacecmd/softwarechannel.py:1728
+#: ../src/spacecmd/softwarechannel.py:2620
+#: ../src/spacecmd/softwarechannel.py:2663
+#: ../src/spacecmd/softwarechannel.py:2879
+msgid "Options:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1598
+msgid "        -p/--publish : Publish errata to the channel (don't clone)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1625
+#: ../src/spacecmd/softwarechannel.py:1630
+#: ../src/spacecmd/softwarechannel.py:1696
+#: ../src/spacecmd/softwarechannel.py:1701
+#, python-format
+msgid "%s is an invalid date"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1643
+msgid "No patches found between the given dates"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1650
+#, python-format
+msgid "Publishing errata %s to %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1668
+msgid ""
+"softwarechannel_listerratabydate: list errata from channelbased on a date "
+"range"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1670
+msgid "usage: softwarechannel_listerratabydate CHANNEL BEGINDATE ENDDATE"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1714
+msgid "No errata found between the given dates"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1725
+msgid ""
+"softwarechannel_adderrata: Add patches from one channel into another channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1727
+msgid "usage: softwarechannel_adderrata SOURCE DEST <ERRATA|search:XXX ...>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1729
+msgid "    -q/--quick : Don't display list of packages (slightly faster)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1730
+msgid "    -s/--skip :  Skip errata which appear to exist already in DEST"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1756
+#, python-format
+msgid "source channel %s does not exist!"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1761
+#, python-format
+msgid "dest channel %s does not exist!"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1814
+msgid "No patch to add"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1833
+msgid "Add these patches [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1847
+msgid "Using the old errata.clone function"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1848
+msgid ""
+"If you have base channels for multiple OS versions, check no unexpected "
+"packages have been added"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1861
+msgid ""
+"softwarechannel_getorgaccess: Get the org-access for the software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1862
+msgid "usage: softwarechannel_getorgaccess [CHANNEL ...]"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1900
+msgid ""
+"softwarechannel_setorgaccess: Set the org-access for the software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1901
+msgid ""
+"usage : softwarechannel_setorgaccess <CHANNEL> [options])\n"
+"-d,--disable : disable org access (private, no org sharing)\n"
+"-e,--enable : enable org access (public access to all trusted orgs)\n"
+"-p,--protected ORG : protected org access for ORG only (multiple instances "
+"of -p ORG are allowed)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1941
+#, python-format
+msgid "Making org sharing public for channel : %s "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1946
+#, python-format
+msgid "Making org sharing private for channel : %s "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1951
+#, python-format
+msgid "Making org sharing protected for channel : %s "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1957
+#, python-format
+msgid "Enabling %s access for channel : %s "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1962
+#, python-format
+msgid "Disabling %s access for channel : %s "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1975
+msgid ""
+"softwarechannel_getorgaccesstree: Get the org-access for a software base "
+"channel and its children"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1976
+msgid "usage: softwarechannel_getorgaccesstree [CHANNEL]"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2009
+msgid ""
+"softwarechannel_setorgaccesstree: set the org-access for a software base "
+"channel and its children"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2010
+msgid ""
+"usage: softwarechannel_setorgaccesstree <CHANNEL> [options])\n"
+"-d,--disable : disable org access (private, no org sharing)\n"
+"-e,--enable : enable org access (public access to all trusted orgs)\n"
+"-p,--protected ORG : protected org access for ORG only (multiple instances "
+"of -p ORG are allowed)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2049
+msgid "softwarechannel_regenerateneededcache: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2050
+msgid "Regenerate the needed errata and package cache for all systems"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2052
+msgid "usage: softwarechannel_regenerateneededcache"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2066
+msgid "softwarechannel_regenerateyumcache: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2067
+msgid "Regenerate the YUM cache for a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2069
+msgid ""
+"usage: softwarechannel_regenerateyumcache [options] <CHANNEL ...>\n"
+"\n"
+"    options:\n"
+"      -f force cache regeneration\n"
+"    "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2113
+msgid "no softwarechannel label given"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2116
+msgid "invalid softwarechannel label "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2134
+msgid "softwarechannel_diff: diff softwarechannel files"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2136
+msgid "usage: softwarechannel_diff SOURCE_CHANNEL TARGET_CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2197
+msgid "softwarechannel_errata_diff: diff softwarechannel files"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2199
+msgid "usage: softwarechannel_errata_diff SOURCE_CHANNEL TARGET_CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2248
+msgid "softwarechannel_sync: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2249
+msgid "sync the packages of two software channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2251
+msgid ""
+"usage: softwarechannel_sync SOURCE_CHANNEL TARGET_CHANNEL [options])\n"
+"    -q,--quiet : quiet mode (omits the output of common packages in both "
+"channels)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2293
+#, python-format
+msgid "%s packages from softwarechannel %s to %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2312
+#: ../src/spacecmd/softwarechannel.py:2320
+#: ../src/spacecmd/softwarechannel.py:2434
+#: ../src/spacecmd/softwarechannel.py:2442
+#: ../src/spacecmd/softwarechannel.py:2574
+#: ../src/spacecmd/softwarechannel.py:2582
+msgid "failed to read key id"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2323
+msgid "packages common in both channels:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2328
+msgid "Omitting common packages in both specified channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2333
+msgid "packages to add to channel \""
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2341
+msgid "packages to remove from channel \""
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2347
+#: ../src/spacecmd/softwarechannel.py:2469
+#: ../src/spacecmd/softwarechannel.py:2599
+msgid "summary:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2348
+#: ../src/spacecmd/softwarechannel.py:2349
+msgid " packages"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2350
+msgid "    add    "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2351
+msgid " packages to   "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2354
+msgid "    remove "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2355
+msgid " packages from "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2357
+#: ../src/spacecmd/softwarechannel.py:2477
+msgid "Perform these changes to channel "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2378
+msgid "softwarechannel_errata_sync: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2379
+msgid "sync errata of two software channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2381
+msgid "usage: softwarechannel_errata_sync SOURCE_CHANNEL TARGET_CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2420
+msgid "syncing errata from softwarechannel "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2421
+#: ../src/spacecmd/softwarechannel.py:2553
+msgid " to "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2445
+msgid "errata common in both channels:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2454
+msgid "errata to add to channel \""
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2463
+msgid "errata to remove from channel \""
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2472
+#: ../src/spacecmd/softwarechannel.py:2602
+msgid "    add   "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2473
+msgid "errata to  "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2474
+msgid "    remove"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2475
+msgid "errata from"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2500
+msgid "softwarechannel_errata_merge: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2501
+msgid "merge errata of one software channel into another"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2503
+msgid ""
+"usage:   softwarechannel_errata_merge SOURCE_CHANNEL TARGET_CHANNEL "
+"[FROM_DATE] [TO_DATE]"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2504
+msgid ""
+"example: softwarechannel_errata_merge OldSoftChannel NewSoftChannel "
+"2018-01-01"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2505
+msgid ""
+"note:    Providing only FROM_DATE will merge all errata since that date."
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2506
+msgid "note:    When no date is provided, all errata will be merged."
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2536
+#: ../src/spacecmd/softwarechannel.py:2543
+msgid "wrong dateformat: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2536
+#: ../src/spacecmd/softwarechannel.py:2543
+msgid " please specify as: YYYY-MM-DD"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2552
+msgid "merging errata from softwarechannel "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2589
+msgid "{} contains no errata which is not already present in {}"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2594
+msgid "errata to add to channel {}: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2600
+#: ../src/spacecmd/softwarechannel.py:2601
+msgid " errata"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2603
+msgid " errata to  "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2605
+msgid "Perform these changes to channel {} [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2616
+msgid "softwarechannel_syncrepos: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2617
+msgid "Sync users repos for a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2619
+msgid "usage: softwarechannel_syncrepos <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2621
+#: ../src/spacecmd/softwarechannel.py:2664
+msgid "    -e/--no-errata : Do not sync errata"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2622
+#: ../src/spacecmd/softwarechannel.py:2665
+msgid "    -f/--fail : Terminate upon any error"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2623
+#: ../src/spacecmd/softwarechannel.py:2666
+msgid "    -k/--sync-kickstart : Create kickstartable tree"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2624
+#: ../src/spacecmd/softwarechannel.py:2667
+msgid "    -l/--latest : Only download latest package versions when repo syncs"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2659
+msgid "softwarechannel_setsyncschedule: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2660
+msgid "Sets the repo sync schedule for a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2662
+msgid "usage: softwarechannel_setsyncschedule <CHANNEL> <SCHEDULE>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2669
+msgid ""
+"The schedule is specified in Quartz CronTrigger format without enclosing "
+"quotes."
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2670
+msgid ""
+"For example, to set a schedule of every day at 1am, <SCHEDULE> would be 0 0 "
+"1 * * ?"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2671
+msgid "If <SCHEDULE> is left empty, it will be disabled."
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2734
+msgid ""
+"softwarechannel_listsyncschedule: List sync schedules for all software "
+"channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2736
+msgid "softwarechannel_listsyncschedule : List all channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2759
+msgid "key"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2759
+msgid "Channel Name"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2759
+msgid "Update Schedule"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2771
+msgid "softwarechannel_addrepo: Add a repo to a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2772
+msgid "usage: softwarechannel_addrepo CHANNEL REPO"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2805
+msgid "softwarechannel_removerepo: Remove a repo from a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2806
+msgid "usage: softwarechannel_removerepo CHANNEL REPO"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2846
+msgid "softwarechannel_listrepos: List the repos for a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2847
+msgid "usage: softwarechannel_listrepos CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2870
+msgid "No repos have been found for this channel."
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2877
+msgid "softwarechannel_mirrorpackages: Download packages of a given channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2878
+msgid "usage: softwarechannel_mirrorpackages CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2880
+msgid "    -l/--latest : Only mirror latest package version"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2911
+msgid "Skipping"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2913
+msgid "Fetching package"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2918
+#, python-format
+msgid "Received package %s from channel %s is broken. Content is too short"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2922
+#, python-format
+msgid "Could not fetch package %s from channel %s"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:42
+msgid "The System Set Manager (SSM) is a group of systems that you "
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:43
+msgid "can perform tasks on as a whole."
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:45
+msgid "Adding Systems:"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:51
+msgid "Intersections:"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:63
+msgid "ssm_add: Add systems to the SSM"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:64
+msgid "usage: ssm_add <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:66 ../src/spacecmd/ssm.py:115
+#: ../src/spacecmd/ssm.py:165 ../src/spacecmd/ssm.py:209
+msgid "see 'help ssm' for more details"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:92
+#, python-format
+msgid "%s is already in the list"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:110
+msgid "ssm_intersect: Replace the current SSM with the intersection"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:111
+msgid "               of the current list of systems and the list of"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:112
+msgid "               systems passed as arguments"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:113
+msgid "usage: ssm_intersect <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:162
+msgid "ssm_remove: Remove systems from the SSM"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:163
+msgid "usage: ssm_remove <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:206
+msgid "ssm_list: List the systems currently in the SSM"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:207
+msgid "usage: ssm_list"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:226
+msgid "ssm_clear: Remove all systems from the SSM"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:227
+msgid "usage: ssm_clear"
+msgstr ""
+
+#: ../src/spacecmd/system.py:49
+msgid "Same"
+msgstr ""
+
+#: ../src/spacecmd/system.py:50
+msgid "Only here"
+msgstr ""
+
+#: ../src/spacecmd/system.py:51
+msgid "Newer here"
+msgstr ""
+
+#: ../src/spacecmd/system.py:52
+msgid "Only there"
+msgstr ""
+
+#: ../src/spacecmd/system.py:53
+msgid "Newer there"
+msgstr ""
+
+#: ../src/spacecmd/system.py:73 ../src/spacecmd/system.py:3771
+msgid "Package"
+msgstr ""
+
+#: ../src/spacecmd/system.py:74
+msgid "This System"
+msgstr ""
+
+#: ../src/spacecmd/system.py:75
+msgid "Other System"
+msgstr ""
+
+#: ../src/spacecmd/system.py:76 ../src/spacecmd/system.py:3774
+msgid "Difference"
+msgstr ""
+
+#: ../src/spacecmd/system.py:124
+msgid "Removing Channels"
+msgstr ""
+
+#: ../src/spacecmd/system.py:127
+msgid "Adding Channels"
+msgstr ""
+
+#: ../src/spacecmd/system.py:163
+msgid "system_list: List all system profiles"
+msgstr ""
+
+#: ../src/spacecmd/system.py:164
+msgid "usage: system_list"
+msgstr ""
+
+#: ../src/spacecmd/system.py:180
+msgid "system_reboot: Reboot a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:181
+msgid ""
+"usage: system_reboot <SYSTEMS> [options])\n"
+"\n"
+"options:\n"
+"  -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:236
+msgid "Reboot these systems [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:252
+msgid "system_search: List systems that match the given criteria"
+msgstr ""
+
+#: ../src/spacecmd/system.py:253
+msgid "usage: system_search QUERY"
+msgstr ""
+
+#: ../src/spacecmd/system.py:255
+msgid "Available Fields:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:258
+msgid "Examples:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:259
+msgid "> system_search device:vmware"
+msgstr ""
+
+#: ../src/spacecmd/system.py:260
+msgid "> system_search ip:192.168.82"
+msgstr ""
+
+#: ../src/spacecmd/system.py:278 ../src/spacecmd/system.py:285
+msgid "Invalid query"
+msgstr ""
+
+#: ../src/spacecmd/system.py:321
+msgid "Invalid search field"
+msgstr ""
+
+#: ../src/spacecmd/system.py:351
+msgid "system_runscript: Schedule a script to run on the list of"
+msgstr ""
+
+#: ../src/spacecmd/system.py:352
+msgid "                  systems provided"
+msgstr ""
+
+#: ../src/spacecmd/system.py:353
+msgid ""
+"usage: system_runscript <SYSTEMS> [options])\n"
+"\n"
+"options:\n"
+"  -u USER\n"
+"  -g GROUP\n"
+"  -t TIMEOUT\n"
+"  -s START_TIME\n"
+"  -l LABEL\n"
+"  -f FILE"
+msgstr ""
+
+#: ../src/spacecmd/system.py:398
+msgid "User [root]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:399
+msgid "Group [root]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:408
+msgid "Timeout (in seconds) [600]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:414
+msgid "Invalid timeout"
+msgstr ""
+
+#: ../src/spacecmd/system.py:420
+msgid "Label/Short Description [default]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:424
+msgid "Script File [create]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:437
+msgid "No script provided"
+msgstr ""
+
+#: ../src/spacecmd/system.py:456
+msgid "A script file is required"
+msgstr ""
+
+#: ../src/spacecmd/system.py:464
+#, python-format
+msgid "User:       %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:465
+#, python-format
+msgid "Group:      %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:466
+#, python-format
+msgid "Timeout:    %i seconds"
+msgstr ""
+
+#: ../src/spacecmd/system.py:470
+#, python-format
+msgid "Label:      %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:471
+msgid "Script Contents"
+msgstr ""
+
+#: ../src/spacecmd/system.py:533 ../src/spacecmd/system.py:835
+#: ../src/spacecmd/system.py:962 ../src/spacecmd/system.py:1096
+#: ../src/spacecmd/system.py:4358
+#, python-format
+msgid "Failed to schedule %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:536
+#, python-format
+msgid "Scheduled: %i system(s)"
+msgstr ""
+
+#: ../src/spacecmd/system.py:543 ../src/spacecmd/utils.py:245
+#, python-format
+msgid "Could not remove %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:552
+msgid "system_listhardware: List the hardware details of a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:553
+msgid "usage: system_listhardware <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:612
+msgid "Network"
+msgstr ""
+
+#: ../src/spacecmd/system.py:621
+#, python-format
+msgid "Interface:   %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:622
+#, python-format
+msgid "MAC Address: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:623
+#, python-format
+msgid "IP Address:  %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:624
+#, python-format
+msgid "Netmask:     %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:625
+#, python-format
+msgid "Broadcast:   %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:626
+#, python-format
+msgid "Module:      %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:630
+msgid "CPU"
+msgstr ""
+
+#: ../src/spacecmd/system.py:632
+#, python-format
+msgid "Count:    %i"
+msgstr ""
+
+#: ../src/spacecmd/system.py:633
+#, python-format
+msgid "Arch:     %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:634
+#, python-format
+msgid "MHz:      %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:635
+#, python-format
+msgid "Cache:    %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:636
+#, python-format
+msgid "Vendor:   %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:637
+#, python-format
+msgid "Model:    %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:640
+msgid "Memory"
+msgstr ""
+
+#: ../src/spacecmd/system.py:642
+#, python-format
+msgid "RAM:  %i"
+msgstr ""
+
+#: ../src/spacecmd/system.py:643
+#, python-format
+msgid "Swap: %i"
+msgstr ""
+
+#: ../src/spacecmd/system.py:647
+msgid "DMI"
+msgstr ""
+
+#: ../src/spacecmd/system.py:648
+#, python-format
+msgid "Vendor:       %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:649
+#, python-format
+msgid "System:       %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:650
+#, python-format
+msgid "Product:      %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:651
+#, python-format
+msgid "Board:        %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:654
+msgid "Asset"
+msgstr ""
+
+#: ../src/spacecmd/system.py:660
+#, python-format
+msgid "BIOS Release: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:661
+#, python-format
+msgid "BIOS Vendor:  %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:662
+#, python-format
+msgid "BIOS Version: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:666
+msgid "Devices"
+msgstr ""
+
+#: ../src/spacecmd/system.py:676
+msgid "Description: None"
+msgstr ""
+
+#: ../src/spacecmd/system.py:680
+#, python-format
+msgid "Driver:      %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:681
+#, python-format
+msgid "Class:       %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:682
+#, python-format
+msgid "Bus:         %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:690
+msgid "system_installpackage: Install a package on a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:691
+msgid ""
+"usage: system_installpackage <SYSTEMS> <PACKAGE ...> [options])\n"
+"\n"
+"options:\n"
+"    -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:792
+msgid "No packages to install"
+msgstr ""
+
+#: ../src/spacecmd/system.py:816
+#, python-format
+msgid "%s does not have access to all requested packages"
+msgstr ""
+
+#: ../src/spacecmd/system.py:822
+msgid "Install these packages [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:837 ../src/spacecmd/system.py:964
+#: ../src/spacecmd/system.py:1098
+#, python-format
+msgid "Scheduled %i system(s)"
+msgstr ""
+
+#: ../src/spacecmd/system.py:845
+msgid "system_removepackage: Remove a package from a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:846
+msgid ""
+"usage: system_removepackage <SYSTEMS> <PACKAGE ...> [options])\n"
+"\n"
+"options:\n"
+"    -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:972
+msgid "system_upgradepackage: Upgrade a package on a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:973
+msgid ""
+"usage: system_upgradepackage <SYSTEMS> <PACKAGE ...>|* [options]')\n"
+"\n"
+"options:\n"
+"    -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1051 ../src/spacecmd/system.py:1147
+#, python-format
+msgid "No upgrades available for %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1074
+#, python-format
+msgid "Couldn't get name for package %i"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1081
+msgid "Upgrade these packages [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1106
+msgid "system_listupgrades: List the available upgrades for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1107
+msgid "usage: system_listupgrades <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1175
+msgid "system_listinstalledpackages: List the installed packages on a"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1176
+msgid "                              system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1177
+msgid "usage: system_listinstalledpackages <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1231
+msgid "system_listconfigchannels: List the config channels of a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1232
+msgid "usage: system_listconfigchannels <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1278 ../src/spacecmd/system.py:1381
+#, python-format
+msgid "%s does not support configuration channels"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1315
+msgid "system_listconfigfiles: List the managed config files of a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1316
+msgid ""
+"usage: system_listconfigfiles <SYSTEMS>')\n"
+"options:\n"
+"  -s/--sandbox : list only system-sandbox files\n"
+"  -l/--local   : list only locally managed files\n"
+"  -c/--central : list only centrally managed files\n"
+"  -q/--quiet   : quiet mode (omits the header)"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1416
+msgid "system_addconfigfile: Create a configuration file"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1417
+msgid "Note this is only for system sandbox or locally-managed files"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1418
+msgid "Centrally managed files should be created via configchannel_addfile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1419
+msgid ""
+"usage: system_addconfigfile [SYSTEM] [options]\n"
+"\n"
+"options:\n"
+"  -S/--sandbox : list only system-sandbox files\n"
+"  -L/--local   : list only locally managed files\n"
+"  -p PATH\n"
+"  -r REVISION\n"
+"  -o OWNER [default: root]\n"
+"  -g GROUP [default: root]\n"
+"  -m MODE [defualt: 0644]\n"
+"  -x SELINUX_CONTEXT\n"
+"  -d path is a directory\n"
+"  -s path is a symlink\n"
+"  -b path is a binary (or other file which needs base64 encoding)\n"
+"  -t SYMLINK_TARGET\n"
+"  -f local path to file contents\n"
+"\n"
+"  Note re binary/base64: Some text files, notably those containing trailing\n"
+"  newlines, those containing ASCII escape characters (or other charaters "
+"not\n"
+"  allowed in XML) need to be sent as binary (-b).  Some effort is made to "
+"auto-\n"
+"  detect files which require this, but you may need to explicitly specify.\n"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1487
+#, python-format
+msgid "%s is not a valid system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1497
+msgid "System-Sandbox or Locally-Managed? [S/L]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1513
+msgid "Must choose system-sandbox or locally-managed option"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1552
+msgid "system_addconfigchannels: Add config channels to a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1553
+msgid ""
+"usage: system_addconfigchannels <SYSTEMS> <CHANNEL ...> [options]\n"
+"\n"
+"options:\n"
+"  -t add channels to the top of the list\n"
+"  -b add channels to the bottom of the list"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1597
+msgid "Add to top or bottom? [T/b]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1621
+msgid "system_removeconfigchannels: Remove config channels from a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1622
+msgid "usage: system_removeconfigchannels <SYSTEMS> <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1671
+msgid ""
+"system_setconfigchannelorder: Set the ranked order of configuration channels"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1672
+msgid "usage: system_setconfigchannelorder <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1712
+msgid "New Configuration Channels"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1732
+msgid "system_deployconfigfiles: Deploy all configuration files for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1733
+msgid ""
+"usage: system_deployconfigfiles <SYSTEMS> [options]\n"
+"\n"
+"options:\n"
+"    -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1787
+msgid "Deploy ALL configuration files to these systems [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1797
+#, python-format
+msgid "Scheduled deployment for %i system(s)"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1805
+msgid "system_delete: Delete a system profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1806
+msgid ""
+"usage: system_delete [options] <SYSTEMS>\n"
+"\n"
+"    options:\n"
+"          -c TYPE - Possible values:\n"
+"             *  'FAIL_ON_CLEANUP_ERR' - fail in case of cleanup error,\n"
+"             *  'NO_CLEANUP' - do not cleanup, just delete,\n"
+"             *  'FORCE_DELETE' - Try cleanup first but delete server anyway "
+"in case of error\n"
+"    "
+msgstr ""
+
+#: ../src/spacecmd/system.py:1850
+msgid "No systems to delete"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1858
+#, python-format
+msgid "%s  System ID"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1858
+msgid "Profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1866
+msgid "Delete these systems [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1873
+#, python-format
+msgid "%i system(s) scheduled for removal"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1893
+msgid "system_lock: Lock a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1894
+msgid "usage: system_lock <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1935
+msgid "system_unlock: Unlock a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1936
+msgid "usage: system_unlock <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1977
+msgid "system_rename: Rename a system profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1978
+msgid "usage: system_rename OLDNAME NEWNAME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2023
+msgid "system_listcustomvalues: List the custom values for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2024
+msgid "usage: system_listcustomvalues <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2079
+msgid "system_addcustomvalue: Set a custom value for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2080
+msgid "usage: system_addcustomvalue KEY VALUE <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2134
+msgid "system_updatecustomvalue: Update a custom value for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2135
+msgid "usage: system_updatecustomvalue KEY VALUE <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2166
+msgid "system_removecustomvalues: Remove a custom value for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2167
+msgid "usage: system_removecustomvalues <SYSTEMS> <KEY ...>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2203
+msgid "Delete these values [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2221
+msgid "system_addnote: Set a note for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2222
+msgid ""
+"usage: system_addnote <SYSTEM> [options]\n"
+"\n"
+"options:\n"
+"  -s SUBJECT\n"
+"  -b BODY"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2257
+msgid "Subject of the Note:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2259
+msgid "Note Body (ctrl-D to finish):"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2263
+msgid "A subject is required"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2267
+msgid "A body is required"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2286
+msgid "system_deletenotes: Delete notes from a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2287
+msgid "usage: system_deletenotes <SYSTEM> <ID|*>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2319
+msgid "No notes to delete"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2346
+msgid "system_listnotes: List the available notes for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2347
+msgid "usage: system_listnotes <SYSTEM>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2405
+msgid "system_listfqdns: List the associated FQDNs for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2406
+msgid "usage: system_listfqdns <SYSTEM>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2458
+msgid "system_setbasechannel: Set a system's base software channel"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2459
+msgid "usage: system_setbasechannel <SYSTEMS> CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2506 ../src/spacecmd/system.py:2593
+#, python-format
+msgid "System:           %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2507 ../src/spacecmd/system.py:2594
+#, python-format
+msgid "Old Base Channel: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2508 ../src/spacecmd/system.py:2596
+#, python-format
+msgid "New Base Channel: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2527
+msgid ""
+"system_schedulechangechannels: Schedule changing a system's software channels"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2528
+msgid ""
+"usage: system_setbasechannel <SYSTEMS> [options]\n"
+"\n"
+"options:\n"
+"  -b BASE_CHANNEL base channel label\n"
+"  -c CHILD_CHANNEL child channel labels (allowed multiple times)\n"
+"  -s START_TIME time defaults to now"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2595
+#, python-format
+msgid "Old Child Channels: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2597
+#, python-format
+msgid "New Child channels %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2612 ../src/spacecmd/system.py:4243
+#, python-format
+msgid "Scheduled action id: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2619
+msgid "system_listbasechannel: List the base channel for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2620
+msgid "usage: system_listbasechannel <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2674
+msgid "system_listchildchannels: List the child channels for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2675
+msgid "usage: system_listchildchannels <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2729
+msgid "system_addchildchannels: Add child channels to a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2730
+msgid "usage: system_addchildchannels <SYSTEMS> <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2752
+msgid ""
+"system_listcrashedsystems: List all systems that have experienced a crash "
+"and reported by spacewalk-abrt"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2753
+msgid "usage: system_listcrashedsystems"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2759
+msgid "Count | System ID | Profile Name"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2773
+msgid "system_deletecrashes: Delete crashes reported by spacewalk-abrt."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2774
+msgid ""
+"usage: Delete all crashes for all systems    : system_deletecrashes [--"
+"verbose]"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2775
+msgid ""
+"usage: Delete all crashes for a single system: system_deletecrashes -i "
+"sys_id [--verbose]"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2776
+msgid ""
+"usage: Delete a single crash record          : system_deletecrashes -c "
+"crash_id [--verbose]"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2794
+#, python-format
+msgid "Deleting crash with id %s."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2801
+#, python-format
+msgid "Deleting all crashes from system with systemid %s [y/N]:"
+msgstr ""
+
+#. all systems
+#: ../src/spacecmd/system.py:2803
+msgid "Deleting all crashes from all systems [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2815
+#, python-format
+msgid "Deleting crash with id %s from system %s."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2824
+msgid "system_listcrashesbysystem: List all reported crashes for a system."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2825 ../src/spacecmd/system.py:2837
+msgid "usage: system_listcrashesbysystem -i sys_id"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2836
+msgid "# System id must be provided."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2842
+msgid "Crash ID | Crash Name"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2853
+msgid "system_getcrashfiles: Download all files for a crash record."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2854
+msgid "usage: system_getcrashfiles -c crash_id [--verbose]"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2855 ../src/spacecmd/system.py:2869
+msgid ""
+"usage: system_getcrashfiles -c crash_id [--dest_folder=/tmp/crash_files] [--"
+"verbose]"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2868
+msgid "# Crash id must be provided."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2895
+#, python-format
+msgid "# All files we downloaded to %s."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2904
+msgid "system_removechildchannels: Remove child channels from a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2905
+msgid "usage: system_removechildchannels <SYSTEMS> <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2927
+msgid "system_details: Show the details of a system profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2928
+msgid "usage: system_details <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2981
+#, python-format
+msgid "Name:          %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2982
+#, python-format
+msgid "System ID:     %i"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2985
+#, python-format
+msgid "UUID:          %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2987
+#, python-format
+msgid "Locked:        %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2988
+#, python-format
+msgid "Registered:    %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2989
+#, python-format
+msgid "Last Checkin:  %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2990
+#, python-format
+msgid "OSA Status:    %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2991
+#, python-format
+msgid "Last Boot:     %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2993
+#, python-format
+msgid "Contact Method:%s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3037
+#, python-format
+msgid "Hostname:      %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3038
+#, python-format
+msgid "IP Address:    %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3039
+#, python-format
+msgid "Kernel:        %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3080
+msgid "system_listerrata: List available errata for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3081
+msgid "usage: system_listerrata <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3135
+msgid "system_applyerrata: Apply errata to a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3136
+msgid ""
+"usage: system_applyerrata [options] <SYSTEMS>\n"
+"[ERRATA|search:XXX ...]\n"
+"\n"
+"options:\n"
+"  -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3197
+msgid "system_listevents: List the event history for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3198
+msgid "usage: system_listevents <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3244
+#, python-format
+msgid "Summary:   %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3246
+#, python-format
+msgid "Details:   %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3254
+msgid "system_listentitlements: List the entitlements for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3255
+msgid "usage: system_listentitlements <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3308
+msgid "system_addentitlements: Add entitlements to a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3309
+msgid "usage: system_addentitlements <SYSTEMS> ENTITLEMENT"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3364
+msgid "system_removeentitlement: Remove an entitlement from a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3365
+msgid "usage: system_removeentitlement <SYSTEMS> ENTITLEMENT"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3420
+msgid "system_listpackageprofiles: List all package profiles"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3421
+msgid "usage: system_listpackageprofiles"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3440
+msgid "system_deletepackageprofile: Delete a package profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3441
+msgid "usage: system_deletepackageprofile PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3465
+msgid "Delete this profile [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3476
+#, python-format
+msgid "%s is not a valid profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3487
+msgid "system_createpackageprofile: Create a package profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3488
+msgid ""
+"usage: system_createpackageprofile SYSTEM [options]\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -d DESCRIPTION"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3518
+msgid "Profile Label:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3522
+msgid "A profile name is required"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3526
+msgid "A profile description is required"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3534
+#, python-format
+msgid "Created package profile '%s'"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3542
+msgid ""
+"system_comparepackageprofile: Compare a system against a package profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3543
+msgid "usage: system_comparepackageprofile <SYSTEMS> PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3606
+msgid "system_comparepackages: Compare the packages between two systems"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3607
+msgid "usage: system_comparepackages SOME_SYSTEM ANOTHER_SYSTEM"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3638
+msgid "system_syncpackages: Sync packages between two systems"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3639
+msgid ""
+"usage: system_syncpackages SOURCE TARGET [options]\n"
+"\n"
+"options:\n"
+"    -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3687
+msgid "Sync packages [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3729
+#, python-format
+msgid "Failed to filter package list, package %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3730
+msgid "found with no arch or arch_label"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3772
+msgid "System Version"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3773
+msgid "Channel Version"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3795
+msgid "Channel_newer_than_system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3808
+msgid "System_newer_than_channel"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3817
+msgid "Missing_in_channel"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3821
+msgid "system_comparewithchannel: Compare the installed packages on a"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3822
+msgid "                           system with those in the channels it is"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3823
+msgid "                           registerd to, or optionally some other"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3824
+msgid "                           channel"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3825
+msgid "usage: system_comparewithchannel <SYSTEMS> [options]"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3827
+msgid "         -c/--channel : Specific channel to compare against,"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3828
+msgid "                        default is those subscribed to, including"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3829
+msgid "                        child channels"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3880
+msgid "Specified channel does not exist"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3891
+#, python-format
+msgid "system %s is not subscribed to any channel!"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3893
+msgid "Please subscribe to a channel, or specify achannel to compare with"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3927
+#, python-format
+msgid ""
+"\n"
+"System: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3953
+msgid ""
+"system_schedulehardwarerefresh: Schedule a hardware refresh for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3954
+msgid ""
+"usage: system_schedulehardwarerefresh <SYSTEMS> [options]\n"
+"\n"
+"options:\n"
+"  -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4016
+msgid ""
+"system_schedulepackagerefresh: Schedule a software package refresh for a "
+"system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4017
+msgid ""
+"usage: system_schedulepackagerefresh <SYSTEMS> [options])\n"
+"\n"
+"options:\n"
+"  -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4078
+msgid ""
+"system_show_packageversion: Shows version of installed package on given "
+"system(s)"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4079
+msgid "usage: system_show_packageversion <SYSTEM> <PACKAGE>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4111
+msgid "Package\tVersion\tRelease\tEpoch\tArch\tSystem"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4131
+msgid "system_setcontactmethod: Set the contact method for given system(s)."
+msgstr ""
+
+#: ../src/spacecmd/system.py:4133
+msgid "usage: system_setcontactmethod <SYSTEMS> <CONTACT_METHOD>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4182
+msgid ""
+"system_scheduleapplyconfigchannels: Schedule applying the assigned config "
+"channels to the System (Minion only)"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4183
+msgid ""
+"usage: scheduleapplyconfigchannels <SYSTEMS> [options]\n"
+"\n"
+"    options:\n"
+"        -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4234
+msgid "Schedule applying config channels to these systems [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4251
+msgid ""
+"system_listmigrationtargets: List possible migration targets for given "
+"systems."
+msgstr ""
+
+#: ../src/spacecmd/system.py:4252
+msgid "usage: system_listmigrationtargets <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4279
+msgid "WARN: Cannot find system "
+msgstr ""
+
+#: ../src/spacecmd/system.py:4286
+msgid "  No migration targets"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4289
+msgid "  Target #"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4290
+msgid "    IDs: "
+msgstr ""
+
+#: ../src/spacecmd/system.py:4291
+msgid "    Friendly names: "
+msgstr ""
+
+#: ../src/spacecmd/system.py:4297
+msgid ""
+"system_schedulespmigration: Schedule a Service Pack migration for systems."
+msgstr ""
+
+#: ../src/spacecmd/system.py:4298
+msgid ""
+"usage: system_schedulespmigration <SYSTEM> <BASE_CHANNEL_LABEL> "
+"<MIGRATION_TARGET> [options] \n"
+"    For MIGRATION_TARGET parameter see system_listmigrationtargets. \n"
+"    The MIGRATION_TARGET parameter must be passed in the following format: "
+"[3143,3146,3147,3145,3144,3148,3062]. \n"
+"    Options: \n"
+"        -s START_TIME \n"
+"        -d pass this flag, if you want to do a dry run \n"
+"        -c CHILD_CHANNELS (comma-separated child channels labels (with no "
+"spaces))"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4348
+msgid "Cannot find system "
+msgstr ""
+
+#: ../src/spacecmd/system.py:4348
+msgid ". Skipping it."
+msgstr ""
+
+#: ../src/spacecmd/system.py:4351
+msgid "Scheduling Service Pack migration for system "
+msgstr ""
+
+#: ../src/spacecmd/system.py:4356
+msgid "Scheduled action ID: "
+msgstr ""
+
+#: ../src/spacecmd/user.py:49
+msgid "user_create: Create an user"
+msgstr ""
+
+#: ../src/spacecmd/user.py:50
+msgid ""
+"usage: user_create [options])\n"
+"\n"
+"options:\n"
+"  -u USERNAME\n"
+"  -f FIRST_NAME\n"
+"  -l LAST_NAME\n"
+"  -e EMAIL\n"
+"  -p PASSWORD\n"
+"  --pam enable PAM authentication"
+msgstr ""
+
+#: ../src/spacecmd/user.py:119
+msgid "Note: password was ignored due to PAM mode"
+msgstr ""
+
+#: ../src/spacecmd/user.py:138
+msgid "user_delete: Delete an user"
+msgstr ""
+
+#: ../src/spacecmd/user.py:139
+msgid "usage: user_delete NAME"
+msgstr ""
+
+#: ../src/spacecmd/user.py:167
+msgid "user_disable: Disable an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:168
+msgid "usage: user_disable NAME"
+msgstr ""
+
+#: ../src/spacecmd/user.py:194
+msgid "user_enable: Enable an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:195
+msgid "usage: user_enable NAME"
+msgstr ""
+
+#: ../src/spacecmd/user.py:221
+msgid "user_list: List all users"
+msgstr ""
+
+#: ../src/spacecmd/user.py:222
+msgid "usage: user_list"
+msgstr ""
+
+#: ../src/spacecmd/user.py:239
+msgid "user_listavailableroles: List all available roles for users"
+msgstr ""
+
+#: ../src/spacecmd/user.py:240
+msgid "usage: user_listavailableroles"
+msgstr ""
+
+#: ../src/spacecmd/user.py:252
+msgid "No roles has been found"
+msgstr ""
+
+#: ../src/spacecmd/user.py:258
+msgid "user_addrole: Add a role to an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:259
+msgid "usage: user_addrole USER ROLE"
+msgstr ""
+
+#: ../src/spacecmd/user.py:292
+msgid "user_removerole: Remove a role from an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:293
+msgid "usage: user_removerole USER ROLE"
+msgstr ""
+
+#: ../src/spacecmd/user.py:327
+msgid "user_details: Show the details of an user"
+msgstr ""
+
+#: ../src/spacecmd/user.py:328
+msgid "usage: user_details USER ..."
+msgstr ""
+
+#: ../src/spacecmd/user.py:360
+#, python-format
+msgid "%s is not a valid user"
+msgstr ""
+
+#: ../src/spacecmd/user.py:361
+msgid "Error '{}' while getting data about user '{}': {}"
+msgstr ""
+
+#: ../src/spacecmd/user.py:371
+#, python-format
+msgid "Username:      %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:372
+#, python-format
+msgid "First Name:    %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:373
+#, python-format
+msgid "Last Name:     %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:374
+#, python-format
+msgid "Email Address: %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:375
+#, python-format
+msgid "Organisation:  %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:376
+#, python-format
+msgid "Last Login:    %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:377
+#, python-format
+msgid "Created:       %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:378
+#, python-format
+msgid "Enabled:       %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:382
+msgid "Roles"
+msgstr ""
+
+#: ../src/spacecmd/user.py:388
+msgid "Assigned Groups"
+msgstr ""
+
+#: ../src/spacecmd/user.py:394
+msgid "Default Groups"
+msgstr ""
+
+#: ../src/spacecmd/user.py:404
+msgid "user_addgroup: Add a group to an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:405
+msgid "usage: user_addgroup USER <GROUP ...>"
+msgstr ""
+
+#: ../src/spacecmd/user.py:442
+msgid "user_adddefaultgroup: Add a default group to an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:443
+msgid "usage: user_adddefaultgroup USER <GROUP ...>"
+msgstr ""
+
+#: ../src/spacecmd/user.py:479
+msgid "user_removegroup: Remove a group to an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:480
+msgid "usage: user_removegroup USER <GROUP ...>"
+msgstr ""
+
+#: ../src/spacecmd/user.py:520
+msgid "user_removedefaultgroup: Remove a default group from an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:522
+msgid "usage: user_removedefaultgroup USER <GROUP ...>"
+msgstr ""
+
+#: ../src/spacecmd/user.py:561
+msgid "user_setfirstname: Set an user accounts first name field"
+msgstr ""
+
+#: ../src/spacecmd/user.py:562
+msgid "usage: user_setfirstname USER FIRST_NAME"
+msgstr ""
+
+#: ../src/spacecmd/user.py:596
+msgid "user_setlastname: Set an user accounts last name field"
+msgstr ""
+
+#: ../src/spacecmd/user.py:597
+msgid "usage: user_setlastname USER LAST_NAME"
+msgstr ""
+
+#: ../src/spacecmd/user.py:631
+msgid "user_setemail: Set an user accounts email field"
+msgstr ""
+
+#: ../src/spacecmd/user.py:632
+msgid "usage: user_setemail USER EMAIL"
+msgstr ""
+
+#: ../src/spacecmd/user.py:666
+msgid "user_setprefix: Set an user accounts name prefix field"
+msgstr ""
+
+#: ../src/spacecmd/user.py:667
+msgid "usage: user_setprefix USER PREFIX"
+msgstr ""
+
+#: ../src/spacecmd/user.py:706
+msgid "user_setpassword: Set an user accounts name prefix field"
+msgstr ""
+
+#: ../src/spacecmd/user.py:707
+msgid "usage: user_setpassword USER PASSWORD"
+msgstr ""
+
+#. If cache generation is interrupted (e.g by ctrl-c) you can end up
+#. with an EOFError exception due to the partial picked file
+#. So we catch this error and remove the corrupt partial file
+#. If you don't do this then spacecmd will fail with an unhandled
+#. exception until the partial file is manually removed
+#: ../src/spacecmd/utils.py:133
+#, python-format
+msgid "Loading cache file %s failed"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:134
+#, python-format
+msgid "Cache generation was probably interrupted,removing corrupt %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:139
+#, python-format
+msgid "Couldn't load cache from %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:160
+#, python-format
+msgid "Couldn't write to %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:205
+msgid "Could not open the temporary file"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:225
+#, python-format
+msgid "Editor \"%s\" exited with code %i"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:227
+#, python-format
+msgid "General failure running editor: %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:230
+msgid "No editors found"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:367
+msgid "Invalid time provided"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:463
+msgid "Security Errata"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:472
+msgid "Bug Fix Errata"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:481
+msgid "Enhancement Errata"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:491
+msgid "Current Selections"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:501
+msgid "Available Configuration Channels"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:507 ../src/spacecmd/utils.py:527
+msgid "Channel:"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:510 ../src/spacecmd/utils.py:530
+msgid "Invalid channel"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:514
+msgid "New Rank:"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:521 ../src/spacecmd/utils.py:524
+msgid "Invalid rank"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:535
+msgid "Clearing current selections"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:690
+msgid "Could not generate json data object!"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:697
+#, python-format
+msgid "Could not open file %s for writing: %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:708
+#, python-format
+msgid "Could not open file %s for reading: %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:710
+#, python-format
+msgid "Could not parse JSON data from %s: %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:712
+#, python-format
+msgid "Error processing file %s: %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:740
+msgid "Skipping usage of common strings: both strings are equal"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:756
+msgid "Skipping usage of common strings: number of substrings differ"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:842
+msgid "Parameter {} not a string type, but {}."
+msgstr ""
+
+#: ../src/bin/spacecmd:74
+msgid "Unhandled exception occurred while getting FQDN:"
+msgstr ""

--- a/spacecmd/po/es.po
+++ b/spacecmd/po/es.po
@@ -1,0 +1,7456 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#: ../src/bin/spacecmd:59
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-09-24 17:29+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../src/spacecmd/activationkey.py:49
+msgid "activationkey_addpackages: Add packages to an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:50
+msgid "usage: activationkey_addpackages KEY <PACKAGE ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:83
+msgid "activationkey_removepackages: Remove packages from an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:85
+msgid "usage: activationkey_removepackages KEY <PACKAGE ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:121
+msgid "activationkey_addgroups: Add groups to an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:122
+msgid "usage: activationkey_addgroups KEY <GROUP ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:160
+msgid "activationkey_removegroups: Remove groups from an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:161
+msgid "usage: activationkey_removegroups KEY <GROUP ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:208
+msgid "activationkey_addentitlements: Add entitlements to an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:210
+msgid "usage: activationkey_addentitlements KEY <ENTITLEMENT ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:245
+msgid ""
+"activationkey_removeentitlements: Remove entitlements from an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:247
+msgid "usage: activationkey_removeentitlements KEY <ENTITLEMENT ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:285
+msgid "activationkey_addchildchannels: Add child channels to an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:287
+msgid "usage: activationkey_addchildchannels KEY <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:337
+msgid ""
+"activationkey_removechildchannels: Remove child channels from an activation "
+"key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:339
+msgid "usage: activationkey_removechildchannels KEY <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:376
+msgid ""
+"activationkey_listchildchannels: List the child channels for an activation "
+"key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:378
+msgid "usage: activationkey_listchildchannels KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:407
+msgid ""
+"activationkey_listbasechannel: List the base channels for an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:409
+msgid "usage: activationkey_listbasechannel KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:437
+msgid "activationkey_listgroups: List the groups for an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:439
+msgid "usage: activationkey_listgroups KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:470
+msgid ""
+"activationkey_listentitlements: List the entitlements for an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:472
+msgid "usage: activationkey_listentitlements KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:501
+msgid "activationkey_listpackages: List the packages for an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:503
+msgid "usage: activationkey_listpackages KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:535
+msgid ""
+"activationkey_listconfigchannels: List the configuration channels for an "
+"activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:537
+msgid "usage: activationkey_listconfigchannels KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:570
+msgid ""
+"activationkey_addconfigchannels: Add config channels to an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:572
+msgid ""
+"usage: activationkey_addconfigchannels KEY <CHANNEL ...> [options])\n"
+"\n"
+"options:\n"
+"  -t add channels to the top of the list\n"
+"  -b add channels to the bottom of the list"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:625
+msgid ""
+"activationkey_removeconfigchannels: Remove config channels from an "
+"activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:627
+msgid "usage: activationkey_removeconfigchannels KEY <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:666
+msgid ""
+"activationkey_setconfigchannelorder: Set the ranked order of configuration "
+"channels"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:668
+msgid "usage: activationkey_setconfigchannelorder KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:698
+msgid "New Configuration Channels:"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:712
+msgid "activationkey_create: Create an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:713
+msgid ""
+"usage: activationkey_create [options])\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -d DESCRIPTION\n"
+"  -b BASE_CHANNEL\n"
+"  -u set key as universal default\n"
+"  -e [enterprise_entitled,virtualization_host]"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:734
+msgid "Name (blank to autogenerate):"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:735
+msgid "Description [None]:"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:738 ../src/spacecmd/distribution.py:78
+#: ../src/spacecmd/softwarechannel.py:927
+msgid "Base Channels"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:743
+msgid "Base Channel (blank for default):"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:751
+#, python-format
+msgid "%s Entitlement [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:755
+msgid "Universal Default [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:782
+#, python-format
+msgid "Created activation key %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:790
+msgid "activationkey_delete: Delete an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:791
+msgid "usage: activationkey_delete KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:813 ../src/spacecmd/cryptokey.py:139
+#: ../src/spacecmd/cryptokey.py:197
+#, python-format
+msgid "No keys matched argument %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:819
+msgid "Delete activation key(s) [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:832
+msgid "activationkey_list: List all activation keys"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:833
+msgid "usage: activationkey_list"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:857
+msgid "activationkey_listsystems: List systems registered with a key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:858
+msgid "usage: activationkey_listsystems KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:881 ../src/spacecmd/activationkey.py:930
+#, python-format
+msgid "%s is not a valid activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:895
+msgid "activationkey_details: Show the details of an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:896
+msgid "usage: activationkey_details KEY ..."
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:943
+#, python-format
+msgid "Key:                    %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:944
+#, python-format
+msgid "Description:            %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:945
+#, python-format
+msgid "Universal Default:      %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:946
+#, python-format
+msgid "Usage Limit:            %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:947
+#, python-format
+msgid "Deploy Config Channels: %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:949
+#, python-format
+msgid "Contact Method:         %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:952 ../src/spacecmd/kickstart.py:425
+#: ../src/spacecmd/system.py:3048
+msgid "Software Channels"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:960 ../src/spacecmd/configchannel.py:765
+#: ../src/spacecmd/configchannel.py:870 ../src/spacecmd/system.py:3057
+msgid "Configuration Channels"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:966 ../src/spacecmd/system.py:3062
+msgid "Entitlements"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:971 ../src/spacecmd/system.py:3068
+msgid "System Groups"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:976 ../src/spacecmd/package.py:206
+#: ../src/spacecmd/package.py:263 ../src/spacecmd/softwarechannel.py:1392
+#: ../src/spacecmd/softwarechannel.py:1494
+#: ../src/spacecmd/softwarechannel.py:1576
+#: ../src/spacecmd/softwarechannel.py:1822
+msgid "Packages"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:991
+msgid "activationkey_enableconfigdeployment: Enable config channel deployment"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:993
+msgid "usage: activationkey_enableconfigdeployment KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1020
+msgid ""
+"activationkey_disableconfigdeployment: Disable config channel deployment"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1022
+msgid "usage: activationkey_disableconfigdeployment KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1049
+msgid "activationkey_setbasechannel: Set the base channel of an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1051
+msgid "usage: activationkey_setbasechannel KEY CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1098
+msgid ""
+"activationkey_setusagelimit: Set the usage limit of an activation key, can "
+"be a number or \"unlimited\""
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1100
+msgid "usage: activationkey_setusagelimit KEY <usage limit>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1101
+msgid "usage: activationkey_setusagelimit KEY unlimited "
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1131
+#, python-format
+msgid "Couldn't convert argument %s to an integer"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1153
+msgid ""
+"activationkey_setuniversaldefault: Set this key as the universal default"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1155
+msgid "usage: activationkey_setuniversaldefault KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1196
+msgid "activationkey_export: Export activation key(s) to JSON format file"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1197
+msgid ""
+"usage: activationkey_export [options] [<KEY> ...])\n"
+"\n"
+"options:\n"
+"    -f outfile.json : specify an output filename, defaults to <KEY>.json\n"
+"                      if exporting a single key, akeys.json for multiple "
+"keys,\n"
+"                      or akey_all.json if no KEY specified (export ALL)\n"
+"\n"
+"Note : KEY list is optional, default is to export ALL keys "
+msgstr ""
+
+#. Get the key details
+#: ../src/spacecmd/activationkey.py:1213
+#, python-format
+msgid "Getting activation key details for %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1267
+#, python-format
+msgid "Exporting ALL activation keys to %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1276
+msgid "Invalid activation key passed"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1291
+#, python-format
+msgid "Exporting key %s to %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1300
+#, python-format
+msgid "File %s exists, confirm overwrite file? (y/n)"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1305
+msgid "Failed to save exported keys to file: {}"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1314
+msgid "activationkey_import: import activation key(s) from JSON file(s)"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1315
+msgid "usage: activationkey_import <JSONFILE ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1324
+msgid "No filename passed"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1333
+#, python-format
+msgid "Could not read json data from %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1338 ../src/spacecmd/activationkey.py:1382
+#, python-format
+msgid "Failed to import key %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1352
+#, python-format
+msgid "%s already exists! Skipping!"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1407
+#, python-format
+msgid "System group %s doesn't exist, creating"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1428
+msgid "activationkey_clone: Clone an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1429
+msgid ""
+"usage examples:\n"
+"                 activationkey_clone foo_key -c bar_key\n"
+"                 activationkey_clone foo_key1 foo_key2 -c prefix\n"
+"                 activationkey_clone foo_key -x \"s/foo/bar\"\n"
+"                 activationkey_clone foo_key1 foo_key2 -x \"s/foo/bar\"\n"
+"\n"
+"options:\n"
+"  -c CLONE_NAME  : Name of the resulting key, treated as a prefix for "
+"multiple\n"
+"                   keys\n"
+"  -x \"s/foo/bar\" : Optional regex replacement, replaces foo with bar in "
+"the\n"
+"                   clone description, base-channel label, child-channel\n"
+"                   labels, config-channel names "
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1457 ../src/spacecmd/kickstart.py:460
+#: ../src/spacecmd/system.py:3043
+msgid "Activation Keys"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1463
+#, python-format
+msgid "Key to clone: %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1467
+msgid "Original Key:"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1469
+msgid "Cloned Key:"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1472 ../src/spacecmd/configchannel.py:1376
+msgid "Error - must specify either -c or -x options!"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1477
+#, python-format
+msgid "Key %s already exists"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1481
+msgid "Error no activationkey to clone passed!"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1535
+#, python-format
+msgid "Found child channel %s key %s, %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1537
+msgid " does not exist, skipping!"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1544
+#, python-format
+msgid "Regex-replacement results in new base-channel %s which does not exist!"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1560
+#, python-format
+msgid "Found config channel %s for key %s, %s "
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1562
+msgid "does not exist, skipping!"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1584 ../src/spacecmd/configchannel.py:1428
+#, python-format
+msgid "Failed to clone %s to %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1602
+msgid "no activationkey label given"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1605
+msgid "invalid activationkey label "
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1622
+msgid "activationkey_diff: Diff activation keys"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1624
+msgid "usage: activationkey_diff SOURCE_KEY TARGET_KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1673
+msgid "activationkey_disable: Disable an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1675
+msgid "usage: activationkey_disable KEY [KEY ...]"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1707
+msgid "activationkey_enable: Enable an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1709
+msgid "usage: activationkey_enable KEY [KEY ...]"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1741
+msgid "activationkey_setdescription: Set the activation key description"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1743
+msgid "usage: activationkey_setdescription KEY DESCRIPTION"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1775
+msgid ""
+"activationkey_setcontactmethod: Set the contact method to use for systems "
+"registered with this key."
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1777 ../src/spacecmd/system.py:4132
+msgid "Available contact methods: "
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1778
+msgid "usage: activationkey_setcontactmethod KEY CONTACT_METHOD"
+msgstr ""
+
+#: ../src/spacecmd/api.py:44
+msgid "api: call RHN API with arguments directly"
+msgstr ""
+
+#: ../src/spacecmd/api.py:45
+#, python-format
+msgid ""
+"usage: api [options] API_STRING)\n"
+"\n"
+"options:\n"
+"  -A, --args  Arguments for the API other than session id in comma "
+"separated\n"
+"              strings or JSON expression\n"
+"  -F, --format   Output format\n"
+"  -o, --output   Output file\n"
+"\n"
+"examples:\n"
+"  api api.getApiCallList\n"
+"  api --args \"sysgroup_A\" systemgroup.listSystems\n"
+"  api -A \"rhel-i386-server-5,2011-04-01,2011-05-01\" -F \"%(name)s\" \\\n"
+"      channel.software.listAllPackages\n"
+msgstr ""
+
+#: ../src/spacecmd/api.py:81
+msgid "Could not open to write: "
+msgstr ""
+
+#: ../src/spacecmd/api.py:82
+msgid "Fallback output to stdout"
+msgstr ""
+
+#: ../src/spacecmd/api.py:91
+msgid "No such API: "
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:50
+msgid "configchannel_list: List all configuration channels"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:51
+msgid "usage: configchannel_list"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:68
+msgid "configchannel_listsystems: List the systems subscribed to a"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:69
+msgid "                           configuration channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:70
+msgid "usage: configchannel_listsystems CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:79
+msgid "This version of the API doesn't support this method"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:103
+msgid "configchannel_listfiles: List the files in a config channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:104
+msgid "usage: configchannel_listfiles CHANNEL ..."
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:133
+msgid "configchannel_forcedeploy: Forces a redeployment"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:134
+msgid "                           of files within this channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:135
+msgid "                           on all subscribed systems"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:136
+msgid "usage: configchannel_forcedeploy CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:158
+msgid "No files within selected configchannel."
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:164
+msgid "Channel has no subscribed Systems"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:167
+msgid "Force deployment of the following configfiles:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:170
+msgid ""
+"\n"
+"On these systems:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:173
+msgid "Really force deployment [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:182
+msgid "configchannel_filedetails: Show the details of a file"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:183
+msgid "in a configuration channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:184
+msgid "usage: configchannel_filedetails CHANNEL FILE [REVISION]"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:216
+#, python-format
+msgid "Invalid revision: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:222
+#, python-format
+msgid "%s is not in this configuration channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:240
+#, python-format
+msgid "Path:     %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:241
+#, python-format
+msgid "Type:     %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:242
+#, python-format
+msgid "Revision: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:243
+#, python-format
+msgid "Created:  %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:244
+#, python-format
+msgid "Modified: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:248 ../src/spacecmd/configchannel.py:650
+#, python-format
+msgid "Target Path:     %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:251 ../src/spacecmd/configchannel.py:680
+#, python-format
+msgid "Owner:           %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:252 ../src/spacecmd/configchannel.py:681
+#, python-format
+msgid "Group:           %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:253 ../src/spacecmd/configchannel.py:682
+#, python-format
+msgid "Mode:            %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:255 ../src/spacecmd/configchannel.py:651
+#: ../src/spacecmd/configchannel.py:684
+#, python-format
+msgid "SELinux Context: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:258
+#, python-format
+msgid "SHA256:          %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:259 ../src/spacecmd/configchannel.py:683
+#, python-format
+msgid "Binary:          %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:263 ../src/spacecmd/configchannel.py:696
+#: ../src/spacecmd/configchannel.py:933 ../src/spacecmd/kickstart.py:1903
+#: ../src/spacecmd/snippet.py:161
+msgid "Contents"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:273
+msgid "configchannel_backup: backup a config channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:274
+msgid ""
+"usage: configchannel_backup CHANNEL [OUTDIR])\n"
+"\n"
+"OUTDIR defaults to $HOME/spacecmd-backup/configchannel/YYYY-MM-DD/CHANNEL\n"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:313 ../src/spacecmd/group.py:266
+#, python-format
+msgid "Could not create output directory: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:326
+#, python-format
+msgid "Could not create \"%s\" file: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:332
+#, python-format
+msgid "Output Path:   %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:371
+msgid "configchannel_details: Show the details of a config channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:372
+msgid "usage: configchannel_details CHANNEL ..."
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:402 ../src/spacecmd/kickstart.py:414
+#, python-format
+msgid "Label:       %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:403 ../src/spacecmd/kickstart.py:413
+#, python-format
+msgid "Name:        %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:404 ../src/spacecmd/cryptokey.py:214
+#: ../src/spacecmd/system.py:678
+#, python-format
+msgid "Description: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:405 ../src/spacecmd/cryptokey.py:215
+#: ../src/spacecmd/kickstart.py:500 ../src/spacecmd/kickstart.py:1899
+#, python-format
+msgid "Type:        %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:408
+msgid "Files"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:418
+msgid "configchannel_create: Create a configuration channel of specific type"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:419
+msgid ""
+"usage: configchannel_create [options])\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -l LABEL\n"
+"  -d DESCRIPTION\n"
+"  -t TYPE('normal,'state')"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:438 ../src/spacecmd/custominfo.py:54
+#: ../src/spacecmd/custominfo.py:198 ../src/spacecmd/distribution.py:71
+#: ../src/spacecmd/filepreservation.py:70 ../src/spacecmd/group.py:177
+#: ../src/spacecmd/repo.py:349 ../src/spacecmd/repo.py:461
+#: ../src/spacecmd/softwarechannel.py:800
+msgid "Name:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:439
+msgid "Label:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:440 ../src/spacecmd/cryptokey.py:66
+#: ../src/spacecmd/custominfo.py:59 ../src/spacecmd/custominfo.py:203
+#: ../src/spacecmd/group.py:182 ../src/spacecmd/softwarechannel.py:812
+#: ../src/spacecmd/system.py:3519
+msgid "Description:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:441
+msgid "Type [normal, state]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:448
+msgid "Only [normal/state] values are acceptable for type"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:452 ../src/spacecmd/distribution.py:109
+#: ../src/spacecmd/repo.py:357 ../src/spacecmd/repo.py:467
+msgid "A name is required"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:461
+msgid "Only [normal/state] values are acceptable for --type parameter"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:476
+msgid "configchannel_delete: Delete a configuration channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:477
+msgid "usage: configchannel_delete CHANNEL ..."
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:498
+#, python-format
+msgid "No channels matched argument(s): %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:504 ../src/spacecmd/softwarechannel.py:736
+msgid "Delete these channels [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:548
+msgid "Symlink [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:552
+msgid "Target Path:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:553
+msgid "SELinux Context [none]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:561
+msgid "Directory [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:570
+#, python-format
+msgid "Owner [%s]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:571
+#, python-format
+msgid "Group [%s]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:572
+#, python-format
+msgid "Mode [%s]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:574
+#, python-format
+msgid "SELinux Context [%s]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:575
+msgid "Revision [next]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:593
+msgid "The revision must be an integer"
+msgstr ""
+
+#. get the contents of the script
+#: ../src/spacecmd/configchannel.py:596 ../src/spacecmd/configchannel.py:896
+#: ../src/spacecmd/cryptokey.py:68 ../src/spacecmd/kickstart.py:1954
+#: ../src/spacecmd/snippet.py:141
+msgid "Read an existing file [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:598 ../src/spacecmd/kickstart.py:1956
+msgid "File:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:616
+msgid "The path is required"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:630 ../src/spacecmd/configchannel.py:913
+msgid "You must provide the file contents"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:634
+msgid "You must provide the target path for a symlink"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:649 ../src/spacecmd/configchannel.py:678
+#, python-format
+msgid "Path:            %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:679
+#, python-format
+msgid "Directory:       %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:689
+#, python-format
+msgid "Revision:        %i"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:694
+msgid "Contents not displayed (base64 encoded)"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:707
+msgid ""
+"configchannel_addfile/configchannel_updatefile: Create a configuration file"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:708
+msgid ""
+"usage: configchannel_addfile/configchannel_updatefile -c CHANNEL - p PATH -f "
+"LOCAL_FILE_PATH [OPTIONS])\n"
+"\n"
+"options:\n"
+"  -c CHANNEL\n"
+"  -p PATH\n"
+"  -r REVISION\n"
+"  -o OWNER [default: root]\n"
+"  -g GROUP [default: root]\n"
+"  -m MODE [defualt: 0644]\n"
+"  -x SELINUX_CONTEXT\n"
+"  -d path is a directory\n"
+"  -s path is a symlink\n"
+"  -b path is a binary (or other file which needs base64 encoding)\n"
+"  -t SYMLINK_TARGET\n"
+"  -f local path to file contents\n"
+"  -y automatically proceed with file contents\n"
+"\n"
+"  Note re binary/base64: Some text files, notably those containing trailing\n"
+"  newlines, those containing ASCII escape characters (or other charaters "
+"not\n"
+"  allowed in XML) need to be sent as binary (-b).  Some effort is made to "
+"auto-\n"
+"  detect files which require this, but you may need to explicitly specify.\n"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:770 ../src/spacecmd/softwarechannel.py:819
+#: ../src/spacecmd/softwarechannel.py:940
+#: ../src/spacecmd/softwarechannel.py:947
+msgid "Select:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:778 ../src/spacecmd/softwarechannel.py:1374
+#, python-format
+msgid "%s is not a valid channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:783
+msgid "Unable to obtain a valid channel. Aborting."
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:789 ../src/spacecmd/scap.py:160
+msgid "Path:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:805 ../src/spacecmd/configchannel.py:924
+msgid "No config channel specified!"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:810 ../src/spacecmd/configchannel.py:929
+msgid "Error obtaining file info"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:845
+msgid "configchannel_updateinitsls: Update init.sls file"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:846
+msgid ""
+"usage: configchannel_updateinitsls -c CHANNEL -f LOCAL_FILE_PATH [OPTIONS])\n"
+"\n"
+"options:\n"
+"  -c CHANNEL\n"
+"  -f local path to file contents\n"
+"  -y automatically proceed with file contents\n"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:892
+#, python-format
+msgid "No existing file information found for %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:932
+#, python-format
+msgid "contents_enc64:           %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:959
+msgid "configchannel_removefiles: Remove configuration files"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:960
+msgid "usage: configchannel_removefiles CHANNEL <FILE ...>"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:997
+msgid "configchannel_verifyfile: Verify a configuration file"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:998
+msgid "usage: configchannel_verifyfile CHANNEL FILE <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1037
+msgid "No valid system selected"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1045 ../src/spacecmd/system.py:509
+#: ../src/spacecmd/system.py:529 ../src/spacecmd/system.py:959
+#, python-format
+msgid "Action ID: %i"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1053
+msgid "configchannel_export: export config channel(s) to json format file"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1054
+msgid ""
+"usage: configchannel_export <CHANNEL>... [options])\n"
+"options:\n"
+"    -f outfile.json : specify an output filename, defaults to <CHANNEL>."
+"json\n"
+"                      if exporting a single channel, ccs.json for multiple\n"
+"                      channels, or cc_all.json if no CHANNEL specified\n"
+"                      e.g (export ALL)\n"
+"\n"
+"Note : CHANNEL list is optional, default is to export ALL"
+msgstr ""
+
+#. Get the cc details
+#: ../src/spacecmd/configchannel.py:1070
+#, python-format
+msgid "Getting config channel details for %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1090
+#, python-format
+msgid "Failed to get details for file %s from %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1136
+#, python-format
+msgid "File %s could not be exported "
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1137
+msgid "with this API version(needs base64 encoding)"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1139
+#, python-format
+msgid "File %s could not be exported as"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1140
+msgid " text...getting base64 encoded version"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1163
+#, python-format
+msgid "Passed filename '%s' to do_configchannel_export command."
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1171
+#, python-format
+msgid "Exporting ALL config channels to %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1178
+msgid ""
+"Error, no valid config channel passed, check name is  correct with spacecmd "
+"configchannel_list"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1193
+#, python-format
+msgid "Exporting cc %s to %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1200
+msgid "File '{}' exists, confirm overwrite file? (y/n)"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1203
+#, python-format
+msgid "Error saving exported config channels to file: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1212
+msgid "configchannel_import: import config channel(s) from json file"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1213
+msgid "usage: configchannel_import <JSONFILES...>"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1222 ../src/spacecmd/kickstart.py:2330
+msgid "Error, no filename passed"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1230 ../src/spacecmd/kickstart.py:2338
+#, python-format
+msgid "Error, could not read json data from %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1234
+#, python-format
+msgid "Error importing configchannel %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1246
+#, python-format
+msgid "Config channel %s already exists! Skipping!"
+msgstr ""
+
+#. create the cc, we need to drop the org prefix from the cc name
+#: ../src/spacecmd/configchannel.py:1251
+#, python-format
+msgid "Importing config channel  %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1294
+#, python-format
+msgid "Failed trying to import file %s (empty content)"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1296
+msgid "Older APIs can't export encoded files"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1319
+#, python-format
+msgid "Error adding file %s to %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1329
+msgid "configchannel_clone: Clone config channel(s)"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1330
+msgid ""
+"usage examples:\n"
+"                 configchannel_clone foo_label -c bar_label\n"
+"                 configchannel_clone foo_label1 foo_label2 -c prefix\n"
+"                 configchannel_clone foo_label -x \"s/foo/bar\"\n"
+"                 configchannel_clone foo_label1 foo_label2 -x \"s/foo/bar\"\n"
+"\n"
+"options:\n"
+"  -c CLONE_LABEL : name/label of the resulting cc (note does not update\n"
+"                   description, see -x option), treated as a prefix if\n"
+"                   multiple keys are passed\n"
+"  -x \"s/foo/bar\" : Optional regex replacement, replaces foo with bar in "
+"the\n"
+"                   clone name, label and description\n"
+"  Note : If no -c or -x option is specified, interactive is assumed"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1359
+msgid "No config channels found"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1362
+msgid "Config Channels"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1368
+#, python-format
+msgid "Channel to clone: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1372
+msgid "Channel to clone:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1373
+msgid "Clone label:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1382
+msgid "Error no channel label passed!"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1391
+msgid "No suitable channels to clone has been found."
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1444
+msgid "no configchannel given"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1447
+msgid "invalid configchannel label "
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1473
+msgid "configchannel_diff: diff between config channels"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1475
+msgid "usage: configchannel_diff SOURCE_CHANNEL TARGET_CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1524
+msgid "configchannel_sync:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1525
+msgid "sync config files between two config channels"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1527
+msgid "usage: configchannel_sync SOURCE_CHANNEL TARGET_CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1565
+msgid "syncing files from configchannel "
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1572
+msgid "files common in both channels:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1578
+msgid "files only in source "
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1584
+msgid "files only in target "
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1589
+msgid ""
+"files that are in both channels will be overwritten in the target channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1591
+msgid "files only in the source channel will be added to the target channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1593
+msgid "files only in the target channel will be deleted"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1596
+msgid "nothing to do"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1600
+msgid "perform synchronisation [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1652
+msgid "unknown file type "
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:43
+msgid "cryptokey_create: Create a cryptographic key"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:44
+msgid ""
+"usage: cryptokey_create [options])\n"
+"\n"
+"options:\n"
+"  -t GPG or SSL\n"
+"  -d DESCRIPTION\n"
+"  -f KEY_FILE"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:62
+msgid "GPG or SSL [G/S]:"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:75
+msgid "The key type is required"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:79
+msgid "A description is required"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:83
+msgid "A file containing the key is required"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:91
+msgid "No contents of the file"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:100
+msgid "Invalid key type"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:114
+msgid "cryptokey_delete: Delete a cryptographic key"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:115
+msgid "usage: cryptokey_delete NAME"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:145
+msgid "Delete key(s) [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:156
+msgid "cryptokey_list: List all cryptographic keys (SSL, GPG)"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:157
+msgid "usage: cryptokey_list"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:174
+msgid "cryptokey_details: Show the contents of a cryptographic key"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:175
+msgid "usage: cryptokey_details KEY ..."
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:207
+#, python-format
+msgid "%s is not a valid crypto key"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:39
+msgid "custominfo_createkey: Create a custom key"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:40
+msgid "usage: custominfo_createkey [NAME] [DESCRIPTION]"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:73
+msgid "custominfo_deletekey: Delete a custom key"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:74
+msgid "usage: custominfo_deletekey KEY ..."
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:114
+msgid "custominfo_listkeys: List all custom keys"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:115
+msgid "usage: custominfo_listkeys"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:132
+msgid "custominfo_details: Show the details of a custom key"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:133
+msgid "usage: custominfo_details KEY ..."
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:155
+msgid "No keys matched argument '{}'."
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:172
+#, python-format
+msgid "Label:        %s"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:173
+#, python-format
+msgid "Description:  %s"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:174
+#, python-format
+msgid "Modified:     %s"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:175
+#, python-format
+msgid "System Count: %i"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:183
+msgid "custominfo_updatekey: Update a custom key"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:184
+msgid "usage: custominfo_updatekey [NAME] [DESCRIPTION]"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:42
+msgid "distribution_create: Create a Kickstart tree"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:43
+msgid ""
+"usage: distribution_create [options]\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -p path to tree\n"
+"  -b base channel to associate with\n"
+"  -t install type [fedora|rhel_4/5/6|generic_rpm]"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:66
+msgid "The name of the distribution is required"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:73
+msgid "Path to Kickstart Tree:"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:83
+msgid "Base Channel:"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:86
+msgid "Invalid channel label"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:97
+msgid "Install Types"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:102
+msgid "Install Type:"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:105
+msgid "Invalid install type"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:113
+msgid "A path is required"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:117 ../src/spacecmd/system.py:2556
+msgid "A base channel is required"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:121
+msgid "An install type is required"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:143
+msgid "distribution_list: List the available autoinstall trees"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:144
+msgid "usage: distribution_list"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:168
+msgid "distribution_delete: Delete a Kickstart tree"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:169
+msgid "usage: distribution_delete LABEL"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:193 ../src/spacecmd/distribution.py:232
+#, python-format
+msgid "No distributions matched argument %s"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:199
+msgid "Delete distribution tree(s) [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:209
+msgid "distribution_details: Show the details of a Kickstart tree"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:210
+msgid "usage: distribution_details LABEL"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:248 ../src/spacecmd/package.py:93
+#, python-format
+msgid "Name:    %s"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:249 ../src/spacecmd/package.py:100
+#, python-format
+msgid "Path:    %s"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:250
+#, python-format
+msgid "Channel: %s"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:258
+msgid "distribution_rename: Rename a Kickstart tree"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:259
+msgid "usage: distribution_rename OLDNAME NEWNAME"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:288
+msgid "distribution_update: Update the path of a Kickstart tree"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:289
+msgid ""
+"usage: distribution_update NAME [options]\n"
+"\n"
+"options:\n"
+"  -p path to tree\n"
+"  -b base channel to associate with\n"
+"  -t install type [fedora|rhel_4/5/6|generic_rpm]"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:49
+msgid "errata_list: List all patches"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:50
+msgid "usage: errata_list"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:66
+msgid "errata_summary: Print a summary of all errata"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:67
+msgid "usage: errata_summary"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:82
+msgid "errata_apply: Apply an erratum to all affected systems"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:83
+msgid ""
+"usage: errata_apply [options] ERRATA|search:XXX ...)\n"
+"\n"
+"options:\n"
+"  -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:110 ../src/spacecmd/system.py:417
+#: ../src/spacecmd/system.py:725 ../src/spacecmd/system.py:880
+#: ../src/spacecmd/system.py:1015 ../src/spacecmd/system.py:1762
+#: ../src/spacecmd/system.py:3673 ../src/spacecmd/system.py:3983
+#: ../src/spacecmd/system.py:4045 ../src/spacecmd/system.py:4209
+msgid "Start Time [now]:"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:158
+msgid "No patches to apply"
+msgstr ""
+
+#. a summary of which errata we're going to apply
+#: ../src/spacecmd/errata.py:162
+msgid "Errata             Systems"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:166 ../src/spacecmd/system.py:230
+#: ../src/spacecmd/system.py:467 ../src/spacecmd/system.py:820
+#: ../src/spacecmd/system.py:942 ../src/spacecmd/system.py:1079
+#: ../src/spacecmd/system.py:1781 ../src/spacecmd/system.py:3685
+#: ../src/spacecmd/system.py:4228
+#, python-format
+msgid "Start Time: %s"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:168
+msgid "Apply these patches [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:218
+#, python-format
+msgid "No patches to schedule for %s"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:227
+#, python-format
+msgid "Scheduled %i patches for %s"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:236
+msgid "errata_listaffectedsystems: List of systems affected by an patch"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:237
+msgid "usage: errata_listaffectedsystems ERRATA|search:XXX ..."
+msgstr ""
+
+#: ../src/spacecmd/errata.py:275
+msgid "errata_listcves: List of CVEs addressed by an patch"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:276
+msgid "usage: errata_listcves ERRATA|search:XXX ..."
+msgstr ""
+
+#: ../src/spacecmd/errata.py:312
+msgid "No errata has been found"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:319
+msgid "errata_findbycve: List errata addressing a CVE"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:320
+msgid "usage: errata_findbycve CVE-YYYY-NNNN ..."
+msgstr ""
+
+#: ../src/spacecmd/errata.py:354
+msgid "errata_details: Show the details of an patch"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:355
+msgid "usage: errata_details ERRATA|search:XXX ..."
+msgstr ""
+
+#: ../src/spacecmd/errata.py:390
+#, python-format
+msgid "%s is not a valid erratum"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:397
+#, python-format
+msgid "Name:       %s"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:398
+msgid "Product:   s"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:399
+msgid "Type:      s"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:400
+msgid "Issue Date:s"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:402
+msgid "Topic"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:406 ../src/spacecmd/package.py:107
+#: ../src/spacecmd/softwarechannel.py:591
+msgid "Description"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:412
+msgid "Notes"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:417
+msgid "CVEs"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:421
+msgid "Solution"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:425
+msgid "References"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:429
+msgid "Affected Channels"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:433 ../src/spacecmd/org.py:278
+msgid "Affected Systems"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:437
+msgid "Affected Packages"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:447
+msgid "errata_delete: Delete an patch"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:448
+msgid "usage: errata_delete ERRATA|search:XXX ..."
+msgstr ""
+
+#: ../src/spacecmd/errata.py:468
+msgid "No patches to delete"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:471
+msgid "Erratum            Channels"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:479
+msgid "Delete these patches [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:485
+#, python-format
+msgid "Deleted %i patches"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:495
+msgid "errata_publish: Publish an patch to a channel"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:496
+msgid "usage: errata_publish ERRATA|search:XXX <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:523
+msgid "No patches to publish"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:528
+msgid "Publish these patches [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:540
+msgid "errata_search: List patches that meet the given criteria"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:541
+msgid "usage: errata_search CVE|RHSA|RHBA|RHEA|CLA ..."
+msgstr ""
+
+#: ../src/spacecmd/errata.py:543 ../src/spacecmd/scap.py:179
+msgid "Example:"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:42
+msgid "filepreservation_list: List all file preservations"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:43
+msgid "usage: filepreservation_list"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:58
+msgid "filepreservation_create: Create a file preservation list"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:59
+msgid "usage: filepreservation_create [NAME] [FILE ...]"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:78
+#: ../src/spacecmd/filepreservation.py:92
+msgid "File List"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:83
+msgid "File [blank to finish]:"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:109
+msgid "filepreservation_delete: Delete a file preservation list"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:110
+msgid "usage: filepreservation_delete NAME"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:128
+msgid "Delete this list [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:139
+msgid ""
+"filepreservation_details: Show the details of a file\n"
+"'preservation list"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:141
+msgid "usage: filepreservation_details NAME"
+msgstr ""
+
+#: ../src/spacecmd/group.py:50
+msgid "group_addsystems: Add systems to a group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:51
+msgid "usage: group_addsystems GROUP <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/group.py:52
+msgid "       group_addsystems GROUP <ssm>"
+msgstr ""
+
+#: ../src/spacecmd/group.py:103
+msgid "group_removesystems: Remove systems from a group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:104
+msgid "usage: group_removesystems GROUP <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/group.py:145 ../src/spacecmd/system.py:118
+#: ../src/spacecmd/system.py:232 ../src/spacecmd/system.py:475
+#: ../src/spacecmd/system.py:1475 ../src/spacecmd/system.py:1783
+#: ../src/spacecmd/system.py:4230
+msgid "Systems"
+msgstr ""
+
+#: ../src/spacecmd/group.py:149
+msgid "Remove these systems [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/group.py:158 ../src/spacecmd/schedule.py:385
+#: ../src/spacecmd/ssm.py:87 ../src/spacecmd/ssm.py:136
+#: ../src/spacecmd/ssm.py:186 ../src/spacecmd/system.py:4273
+#: ../src/spacecmd/system.py:4329
+msgid "No systems found"
+msgstr ""
+
+#: ../src/spacecmd/group.py:165
+msgid "group_create: Create a system group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:166
+msgid "usage: group_create [NAME] [DESCRIPTION]"
+msgstr ""
+
+#: ../src/spacecmd/group.py:192
+msgid "group_delete: Delete a system group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:193
+msgid "usage: group_delete NAME ..."
+msgstr ""
+
+#: ../src/spacecmd/group.py:212
+msgid "Delete these groups [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/group.py:224
+msgid "group_backup: backup a system group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:225
+msgid ""
+"usage: group_backup <NAME> [OUTDIR])\n"
+"                    group_backup ALL\n"
+"\n"
+"\"OUTDIR\" defaults to $HOME/spacecmd-backup/group/YYYY-MM-DD/NAME\n"
+"\"ALL\" is a keyword and collects all groups\n"
+msgstr ""
+
+#: ../src/spacecmd/group.py:270
+#, python-format
+msgid "Backup Group: %s"
+msgstr ""
+
+#: ../src/spacecmd/group.py:273
+#, python-format
+msgid "Output File: %s"
+msgstr ""
+
+#: ../src/spacecmd/group.py:284
+msgid "group_restore: restore a system group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:285
+msgid ""
+"\n"
+"usage: group_restore INPUTDIR [NAME] ...\n"
+"       group_restore INPUTDIR ALL\n"
+"       group_restore INPUTDIR\n"
+"       group_restore .\n"
+"\n"
+"Specifying only INPUTDIR will default to ALL groups.\n"
+"Setting dot (.) instead of full INPUTDIR will imply current directory.\n"
+"    "
+msgstr ""
+
+#: ../src/spacecmd/group.py:329
+#, python-format
+msgid "Restore dir %s does not exits or is not a directory"
+msgstr ""
+
+#: ../src/spacecmd/group.py:333
+#, python-format
+msgid "Restore dir %s has no restore items"
+msgstr ""
+
+#: ../src/spacecmd/group.py:340
+#, python-format
+msgid "Group %s was not found in backup"
+msgstr ""
+
+#: ../src/spacecmd/group.py:343
+#, python-format
+msgid "Found %s missing groups, terminating"
+msgstr ""
+
+#: ../src/spacecmd/group.py:358
+#, python-format
+msgid "Group %s already restored"
+msgstr ""
+
+#: ../src/spacecmd/group.py:365
+msgid "Changing description from:"
+msgstr ""
+
+#: ../src/spacecmd/group.py:367
+msgid "Continue [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/group.py:370 ../src/spacecmd/group.py:373
+#, python-format
+msgid "Updating description for group: %s"
+msgstr ""
+
+#: ../src/spacecmd/group.py:376
+#, python-format
+msgid "Creating new group %s"
+msgstr ""
+
+#: ../src/spacecmd/group.py:385
+msgid "group_list: List available system groups"
+msgstr ""
+
+#: ../src/spacecmd/group.py:386
+msgid "usage: group_list"
+msgstr ""
+
+#: ../src/spacecmd/group.py:403
+msgid "group_listsystems: List the members of a group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:404
+msgid "usage: group_listsystems GROUP"
+msgstr ""
+
+#: ../src/spacecmd/group.py:426
+#, python-format
+msgid "%s is not a valid group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:439
+msgid "group_details: Show the details of a system group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:440
+msgid "usage: group_details GROUP ..."
+msgstr ""
+
+#: ../src/spacecmd/group.py:463
+#, python-format
+msgid "The group \"%s\" is invalid"
+msgstr ""
+
+#: ../src/spacecmd/group.py:470
+#, python-format
+msgid "ID:                %i"
+msgstr ""
+
+#: ../src/spacecmd/group.py:471
+#, python-format
+msgid "Name:              %s"
+msgstr ""
+
+#: ../src/spacecmd/group.py:472
+#, python-format
+msgid "Description:       %s"
+msgstr ""
+
+#: ../src/spacecmd/group.py:473
+#, python-format
+msgid "Number of Systems: %i"
+msgstr ""
+
+#: ../src/spacecmd/group.py:477
+msgid "Members"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:72
+msgid "kickstart_list: List the available Kickstart profiles"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:73
+msgid "usage: kickstart_list"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:85 ../src/spacecmd/kickstart.py:2108
+msgid "No kickstart profiles available"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:91
+msgid "kickstart_create: Create a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:92
+msgid ""
+"usage: kickstart_create [options])\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -d DISTRIBUTION\n"
+"  -p ROOT_PASSWORD\n"
+"  -v VIRT_TYPE ['none', 'para_host', 'qemu', 'xenfv', 'xenpv']"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:113 ../src/spacecmd/kickstart.py:249
+msgid "Virtualization Types"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:118 ../src/spacecmd/kickstart.py:254
+msgid "Virtualization Type [none]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:126 ../src/spacecmd/kickstart.py:262
+msgid "Distributions"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:136
+msgid "Root Password: "
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:137 ../src/spacecmd/org.py:90
+#: ../src/spacecmd/user.py:85
+msgid "Repeat Password: "
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:142 ../src/spacecmd/org.py:95
+#: ../src/spacecmd/user.py:90
+msgid "Password must be at least 5 characters"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:144 ../src/spacecmd/org.py:97
+#: ../src/spacecmd/user.py:92
+msgid "Passwords don't match"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:147 ../src/spacecmd/kickstart.py:270
+#: ../src/spacecmd/kickstart.py:1980 ../src/spacecmd/kickstart.py:2122
+msgid "The Kickstart name is required"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:151 ../src/spacecmd/kickstart.py:274
+msgid "The distribution is required"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:158
+msgid "A root password is required"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:177
+msgid "kickstart_delete: Delete kickstart profile(s)"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:178
+msgid "usage: kickstart_delete PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:179
+msgid "usage: kickstart_delete PROFILE1 PROFILE2"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:180
+msgid "usage: kickstart_delete \"PROF*\""
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:203 ../src/spacecmd/kickstart.py:2597
+#: ../src/spacecmd/kickstart.py:2653 ../src/spacecmd/kickstart.py:2695
+msgid "No valid kickstart labels passed as arguments!"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:209
+msgid "The following kickstart labels are invalid:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:214
+#, python-format
+msgid "Delete profile %s [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:222
+msgid "kickstart_import: Import a Kickstart profile from a file"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:223
+msgid ""
+"usage: kickstart_import [options])\n"
+"\n"
+"options:\n"
+"  -f FILE\n"
+"  -n NAME\n"
+"  -d DISTRIBUTION\n"
+"  -v VIRT_TYPE ['none', 'para_host', 'qemu', 'xenfv', 'xenpv']"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:278 ../src/spacecmd/kickstart.py:1984
+msgid "A filename is required"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:308
+msgid ""
+"kickstart_import_raw: Import a raw Kickstart or autoyast profile from a file"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:309
+msgid ""
+"usage: kickstart_import_raw [options])\n"
+"\n"
+"options:\n"
+"  -f FILE\n"
+"  -n NAME\n"
+"  -d DISTRIBUTION\n"
+"  -v VIRT_TYPE ['none', 'para_host', 'qemu', 'xenfv', 'xenpv']"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:325
+msgid "kickstart_details: Show the details of a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:326
+msgid "usage: kickstart_details PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:353
+msgid "Invalid Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:415
+#, python-format
+msgid "Tree:        %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:416
+#, python-format
+msgid "Active:      %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:417
+#, python-format
+msgid "Advanced:    %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:418
+#, python-format
+msgid "Org Default: %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:421
+#, python-format
+msgid "Configuration Management: %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:422
+#, python-format
+msgid "Remote Commands:          %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:434
+msgid "Advanced Options"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:442
+msgid "Custom Options"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:449
+msgid "Partitioning"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:454
+msgid "Software"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:467
+msgid "Crypto Keys"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:474
+msgid "File Preservations"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:483
+msgid "Variables"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:490
+msgid "Scripts"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:501 ../src/spacecmd/kickstart.py:1900
+#, python-format
+msgid "Chroot:      %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:504 ../src/spacecmd/kickstart.py:1901
+#, python-format
+msgid "Interpreter: %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:530
+msgid "Could not retrieve the Kickstart file"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:536
+msgid "kickstart_getcontents: Show the contents of a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:537
+msgid "                   as they would be presented to a client"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:538
+msgid "usage: kickstart_getcontents LABEL"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:572
+msgid "kickstart_rename: Rename a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:573
+msgid "usage: kickstart_rename OLDNAME NEWNAME"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:601
+msgid ""
+"kickstart_listcryptokeys: List the crypto keys associated with a Kickstart "
+"profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:603
+msgid "usage: kickstart_listcryptokeys PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:632
+msgid "No crypto keys has been found"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:638
+msgid "kickstart_addcryptokeys: Add crypto keys to a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:639
+msgid "usage: kickstart_addcryptokeys PROFILE <KEY ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:665
+msgid "kickstart_removecryptokeys: Remove crypto keys from a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:667
+msgid "usage: kickstart_removecryptokeys PROFILE <KEY ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:707
+msgid ""
+"kickstart_listactivationkeys: List the activation keys associated with a "
+"Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:709
+msgid "usage: kickstart_listactivationkeys PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:739
+msgid "kickstart_addactivationkeys: Add activation keys to a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:741
+msgid "usage: kickstart_addactivationkeys PROFILE <KEY ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:770
+msgid ""
+"kickstart_removeactivationkeys: Remove activation keys from a Kickstart "
+"profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:772
+msgid "usage: kickstart_removeactivationkeys PROFILE <KEY ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:796
+msgid "Remove these keys [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:811
+msgid ""
+"kickstart_enableconfigmanagement: Enable configuration management on a "
+"Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:813
+msgid "usage: kickstart_enableconfigmanagement PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:844
+msgid ""
+"kickstart_disableconfigmanagement: Disable configuration management on a "
+"Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:846
+msgid "usage: kickstart_disableconfigmanagement PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:877
+msgid ""
+"kickstart_enableremotecommands: Enable remote commands on a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:879
+msgid "usage: kickstart_enableremotecommands PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:910
+msgid ""
+"kickstart_disableremotecommands: Disable remote commands on a Kickstart "
+"profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:912
+msgid "usage: kickstart_disableremotecommands PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:942
+msgid "kickstart_setlocale: Set the locale for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:943
+msgid "usage: kickstart_setlocale PROFILE LOCALE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:981
+msgid "kickstart_setselinux: Set the SELinux mode for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:983
+msgid "usage: kickstart_setselinux PROFILE MODE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1018
+msgid ""
+"kickstart_setpartitions: Set the partitioning scheme for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1020
+msgid "usage: kickstart_setpartitions PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1069
+msgid "kickstart_setdistribution: Set the distribution for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1071
+msgid "usage: kickstart_setdistribution PROFILE DISTRIBUTION"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1105
+msgid "kickstart_enablelogging: Enable logging for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1106
+msgid "usage: kickstart_enablelogging PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1138
+msgid "kickstart_addvariable: Add a variable to a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1139
+msgid "usage: kickstart_addvariable PROFILE KEY VALUE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1177
+msgid "kickstart_updatevariable: Update a variable in a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1179
+msgid "usage: kickstart_updatevariable PROFILE KEY VALUE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1214
+msgid "kickstart_removevariables: Remove variables from a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1216
+msgid "usage: kickstart_removevariables PROFILE <KEY ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1265
+msgid "kickstart_listvariables: List the variables of a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1267
+msgid "usage: kickstart_listvariables PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1300
+msgid "kickstart_addoption: Set an option for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1301
+msgid "usage: kickstart_addoption PROFILE KEY [VALUE]"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1348
+#, python-format
+msgid "%s needs to be set as a custom option"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1356
+msgid "kickstart_removeoptions: Remove options from a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1357
+msgid "usage: kickstart_removeoptions PROFILE <OPTION ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1409
+msgid "kickstart_listoptions: List the options of a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1411
+msgid "usage: kickstart_listoptions PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1445
+msgid ""
+"kickstart_listcustomoptions: List the custom options of a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1447
+msgid "usage: kickstart_listcustomoptions PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1481
+msgid "kickstart_setcustomoptions: Set custom options for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1483
+msgid "usage: kickstart_setcustomoptions PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1531
+msgid "kickstart_addchildchannels: Add a child channels to a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1533
+msgid "usage: kickstart_addchildchannels PROFILE <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1591
+msgid ""
+"kickstart_removechildchannels: Remove child channels from a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1593
+msgid "usage: kickstart_removechildchannels PROFILE <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1636
+msgid ""
+"kickstart_listchildchannels: List the child channels of a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1638
+msgid "usage: kickstart_listchildchannels PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1672
+msgid ""
+"kickstart_addfilepreservations: Add file preservations to a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1674
+msgid "usage: kickstart_addfilepreservations PROFILE <FILELIST ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1709
+msgid ""
+"kickstart_removefilepreservations: Remove file preservations from a "
+"Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1711
+msgid "usage: kickstart_removefilepreservations PROFILE <FILE ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1756
+msgid "kickstart_listpackages: List the packages for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1758
+msgid "usage: kickstart_listpackages PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1790
+msgid "kickstart_addpackages: Add packages to a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1791
+msgid "usage: kickstart_addpackages PROFILE <PACKAGE ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1824
+msgid "kickstart_removepackages: Remove packages from a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1826
+msgid "usage: kickstart_removepackages PROFILE <PACKAGE ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1869
+msgid "kickstart_listscripts: List the scripts for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1871
+msgid "usage: kickstart_listscripts PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1890
+#, python-format
+msgid "No scripts has been found for profile '%s'"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1898
+#, python-format
+msgid "ID:          %i"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1913
+msgid "kickstart_addscript: Add a script to a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1914
+msgid ""
+"usage: kickstart_addscript PROFILE [options])\n"
+"\n"
+"options:\n"
+"  -p PROFILE\n"
+"  -e EXECUTION_TIME ['pre', 'post']\n"
+"  -i INTERPRETER\n"
+"  -f FILE\n"
+"  -c execute in a chroot environment\n"
+"  -t ENABLING_TEMPLATING"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1947
+msgid "Profile Name:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1949
+msgid "Pre/Post Script [post]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1950
+msgid "Chrooted [Y/n]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1951
+msgid "Interpreter [/bin/bash]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1988
+msgid "The execution time is required"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2004
+#, python-format
+msgid "Profile Name:   %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2005
+#, python-format
+msgid "Execution Time: %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2006
+#, python-format
+msgid "Chroot:         %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2007
+#, python-format
+msgid "Template:       %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2008
+#, python-format
+msgid "Interpreter:    %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2009
+msgid "Contents:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2029
+msgid "kickstart_removescript: Remove a script from a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2030
+msgid "usage: kickstart_removescript PROFILE [ID]"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2058 ../src/spacecmd/kickstart.py:2071
+msgid "Invalid script ID"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2066
+msgid "Script ID:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2073
+msgid "Remove this script [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2086
+msgid "kickstart_clone: Clone a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2087
+msgid ""
+"usage: kickstart_clone [options])\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -c CLONE_NAME"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2112
+msgid "Kickstart Profiles"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2117
+msgid "Original Profile:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2118
+msgid "Cloned Profile:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2126
+msgid "The Kickstart clone name is required"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2131
+msgid "Kickstart profile you've entered was not found"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2144
+msgid "kickstart_export: export kickstart profile(s) to json format file"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2145
+msgid ""
+"usage: kickstart_export <KSPROFILE>... [options])\n"
+"options:\n"
+"    -f outfile.json : specify an output filename, defaults to <KSPROFILE>."
+"json\n"
+"                      if exporting a single kickstart, profiles.json for "
+"multiple\n"
+"                      kickstarts, or ks_all.json if no KSPROFILE specified\n"
+"                      e.g (export ALL)\n"
+"\n"
+"Note : KSPROFILE list is optional, default is to export ALL"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2271
+#, python-format
+msgid "Exporting ALL kickstart profiles to %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2279
+msgid ""
+"Error, no valid kickstart profile passed, check name is  correct with "
+"spacecmd kickstart_list"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2299
+#, python-format
+msgid "Exporting ks %s to %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2306
+#, python-format
+msgid "File %s exists, "
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2307
+msgid "confirm overwrite file? (y/n)"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2310
+msgid "Error saving exported kickstart profiles to file"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2320
+msgid "kickstart_import: import kickstart profile(s) from json file"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2321
+msgid "usage: kickstart_import <JSONFILES...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2342
+#, python-format
+msgid "Error importing kickstart %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2355
+#, python-format
+msgid "ERROR : kickstart profile %s already exists! Skipping!"
+msgstr ""
+
+#. create the ks, we need to drop the org prefix from the ks name
+#: ../src/spacecmd/kickstart.py:2359
+#, python-format
+msgid "Found ks %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2415
+#, python-format
+msgid "Error adding %s script"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2423
+#, python-format
+msgid "failed to add ip range %s-%s, continuing"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2437
+#, python-format
+msgid "failed to add file preservation %s, skipping"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2439
+#, python-format
+msgid "file preservation list %s doesn't exist, skipping"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2450
+#, python-format
+msgid "Actvationkey %s does not exist on the "
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2461
+#, python-format
+msgid "GPG/SSL key %s does not exist on the "
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2462
+msgid "satellite, skipping"
+msgstr ""
+
+#. There are some frustrating ommisions from the API which means we can't
+#. export/import some settings, so we post a warning that some manual
+#. fixup may be required
+#: ../src/spacecmd/kickstart.py:2471
+msgid ""
+"Due to API ommissions, there are some settings which cannot be imported, "
+"please check and fixup manually if necessary"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2473
+msgid " * Details->Preserve ks.cfg"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2474
+msgid " * Details->Comment"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2478
+msgid " * Details->Organization Default Profile"
+msgstr ""
+
+#. No way to set the kernel options
+#: ../src/spacecmd/kickstart.py:2480
+msgid " * Details->Kernel Options"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2484
+#, python-format
+msgid " * Details->Post Kernel Options : %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2500
+msgid "no kickstart label given"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2503
+msgid "invalid kickstart label "
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2520
+msgid "kickstart_diff: diff kickstart files"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2522
+msgid "usage: kickstart_diff SOURCE_CHANNEL TARGET_CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2571
+msgid "kickstart_getupdatetype: Get the update type for a kickstart profile(s)"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2572
+msgid "usage: kickstart_getupdatetype PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2573
+msgid "usage: kickstart_getupdatetype PROFILE1 PROFILE2"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2574
+msgid "usage: kickstart_getupdatetype \"PROF*\""
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2603 ../src/spacecmd/kickstart.py:2659
+#: ../src/spacecmd/kickstart.py:2701
+#, python-format
+msgid "kickstart label %s doesn't exist!"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2619
+msgid "kickstart_setupdatetype: Set the update type for a kickstart profile(s)"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2620
+msgid ""
+"usage: kickstart_setupdatetype [options] KS_LABEL)\n"
+"\n"
+"options:\n"
+"    -u UPDATE_TYPE ['red_hat', 'all', 'none']"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2634
+msgid "Update Types"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2639
+msgid "Update Type [none]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2670
+msgid "kickstart_getsoftwaredetails: Gets kickstart profile software details"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2671
+msgid "usage: kickstart_getsoftwaredetails KS_LABEL"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2672
+msgid "usage: kickstart_getsoftwaredetails KS_LABEL KS_LABEL2 ..."
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2707
+#, python-format
+msgid "noBase:        %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2708
+#, python-format
+msgid "ignoreMissing: %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2710
+#, python-format
+msgid "Kickstart Label: %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2711
+#, python-format
+msgid "noBase:          %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2712
+#, python-format
+msgid "ignoreMissing:   %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2721
+msgid "kickstart_setsoftwaredetails: Sets kickstart profile software details."
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2722
+msgid ""
+"usage: kickstart_setsoftwaredetails PROFILE KICKSTART_PACKAGES_INFO VALUE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2723
+msgid ""
+"usage: kickstart_setsoftwaredetails PROFILE KICKSTART_PACKAGES_INFO VALUE "
+"KICKSTART_PACKAGES_INFO VALUE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2757
+msgid "Selected profile does not exist"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2760 ../src/spacecmd/kickstart.py:2765
+msgid "Enter valid input"
+msgstr ""
+
+#. list of system selection options for the help output
+#: ../src/spacecmd/misc.py:57
+msgid ""
+"<SYSTEMS> can be any of the following:\n"
+"name\n"
+"ssm (see 'help ssm')\n"
+"search:QUERY (see 'help system_search')\n"
+"group:GROUP\n"
+"channel:CHANNEL\n"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:65
+msgid ""
+"Dates can be any of the following:\n"
+"Explicit Dates:\n"
+"Dates can be expressed as explicit date strings in the YYYYMMDD[HHMMSS]\n"
+"format.  The year, month and day are required, while the hours and\n"
+"minutes are not; the hours and minutes will default to 0000 if no\n"
+"values are provided.\n"
+"\n"
+"Deltas:\n"
+"Dates can be expressed as delta values.  For example, '2h' would\n"
+"mean 2 hours in the future.  You can also use negative values to\n"
+"express times in the past (e.g., -7d would be one week ago).\n"
+"\n"
+"Units:\n"
+"s -> seconds\n"
+"m -> minutes\n"
+"h -> hours\n"
+"d -> days\n"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:120
+msgid "clear: clear the screen"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:121
+msgid "usage: clear"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:132
+msgid "clear_caches: Clear the internal caches kept for systems and packages"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:133
+msgid "usage: clear_caches"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:146
+msgid "get_apiversion: Display the API version of the server"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:147
+msgid "usage: get_apiversion"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:158
+msgid "get_serverversion: Display the version of the server"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:159
+msgid "usage: get_serverversion"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:171
+msgid "list_proxies: List the proxies within the user's organization "
+msgstr ""
+
+#: ../src/spacecmd/misc.py:172
+msgid "usage: list_proxies"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:184
+msgid "get_session: Show the current session string"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:185
+msgid "usage: get_session"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:193
+msgid "No session found"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:200
+msgid "help: Show help for the given command"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:201
+msgid "usage: help COMMAND"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:207
+msgid "history: List your command history"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:208
+msgid "usage: history"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:220
+msgid "toggle_confirmations: Toggle confirmation messages on/off"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:221
+msgid "usage: toggle_confirmations"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:226
+msgid "Confirmation messages are"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:226
+msgid "enabled"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:233
+msgid "login: Connect to a Spacewalk server"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:234
+msgid "usage: login [USERNAME] [SERVER]"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:244
+msgid "You are already logged in"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:256
+msgid "No server specified"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:301
+#, python-format
+msgid "Failed to connect to %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:309
+#, python-format
+msgid "API (%s) is too old (>= %s required)"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:339 ../src/spacecmd/utils.py:249
+#: ../src/spacecmd/utils.py:560
+#, python-format
+msgid "Could not read %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:348
+msgid "Cached credentials are invalid"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:355
+#, python-format
+msgid "Spacewalk Username: %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:357
+msgid "Spacewalk Username:"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:368
+msgid "Spacewalk Password: "
+msgstr ""
+
+#: ../src/spacecmd/misc.py:374
+msgid "Invalid credentials"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:392
+#, python-format
+msgid "Could not write session file: %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:401
+#, python-format
+msgid "Connected to %s as %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:409
+msgid "logout: Disconnect from the server"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:410
+msgid "usage: logout"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:427
+msgid "whoami: Print the name of the currently logged in user"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:428
+msgid "usage: whoami"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:436
+msgid "You are not logged in"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:443
+msgid "whoamitalkingto: Print the name of the server"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:444
+msgid "usage: whoamitalkingto"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:452
+msgid "Yourself"
+msgstr ""
+
+#. tell the user what's going on
+#: ../src/spacecmd/misc.py:524
+msgid "** Generating errata cache **"
+msgstr ""
+
+#. tell the user what's going on
+#: ../src/spacecmd/misc.py:573
+msgid "** Generating package cache **"
+msgstr ""
+
+#. tell the user what's going on
+#: ../src/spacecmd/misc.py:680
+msgid "** Generating system cache **"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:715
+#, python-format
+msgid "Could not create directory %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:787
+#, python-format
+msgid "Can't find system ID for %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:792
+msgid "Duplicate system profile names found!"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:793
+msgid "Please reference systems by ID or resolve the"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:794
+msgid "underlying issue with 'system_delete' or 'system_rename'"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:860
+#, python-format
+msgid "No systems in group %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:874
+#, python-format
+msgid "No systems subscribed to %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:934
+msgid "Is this ok [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:47
+msgid "org_create: Create an organization"
+msgstr ""
+
+#: ../src/spacecmd/org.py:48
+#, python-format
+msgid ""
+"usage: org_create [options])\n"
+"\n"
+"options:\n"
+"  -n ORG_NAME\n"
+"  -u USERNAME\n"
+"  -P PREFIX (%s)\n"
+"  -f FIRST_NAME\n"
+"  -l LAST_NAME\n"
+"  -e EMAIL\n"
+"  -p PASSWORD\n"
+"  --pam enable PAM authentication"
+msgstr ""
+
+#: ../src/spacecmd/org.py:75
+msgid "Organization Name:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:76 ../src/spacecmd/user.py:73
+msgid "Username:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:77
+#, python-format
+msgid "Prefix (%s):"
+msgstr ""
+
+#: ../src/spacecmd/org.py:79 ../src/spacecmd/user.py:74
+msgid "First Name:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:80 ../src/spacecmd/user.py:75
+msgid "Last Name:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:81 ../src/spacecmd/user.py:76
+msgid "Email:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:82 ../src/spacecmd/user.py:77
+msgid "PAM Authentication [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:89 ../src/spacecmd/user.py:84
+msgid "Password: "
+msgstr ""
+
+#: ../src/spacecmd/org.py:100
+msgid "An organization name is required"
+msgstr ""
+
+#: ../src/spacecmd/org.py:104 ../src/spacecmd/user.py:95
+msgid "A username is required"
+msgstr ""
+
+#: ../src/spacecmd/org.py:108 ../src/spacecmd/user.py:99
+msgid "A first name is required"
+msgstr ""
+
+#: ../src/spacecmd/org.py:112 ../src/spacecmd/user.py:103
+msgid "A last name is required"
+msgstr ""
+
+#: ../src/spacecmd/org.py:116 ../src/spacecmd/user.py:107
+msgid "An email address is required"
+msgstr ""
+
+#: ../src/spacecmd/org.py:120 ../src/spacecmd/user.py:111
+msgid "A password is required"
+msgstr ""
+
+#: ../src/spacecmd/org.py:127
+msgid "Dr."
+msgstr ""
+
+#: ../src/spacecmd/org.py:129
+msgid "Miss"
+msgstr ""
+
+#: ../src/spacecmd/org.py:148
+msgid "org_delete: Delete an organization"
+msgstr ""
+
+#: ../src/spacecmd/org.py:149
+msgid "usage: org_delete NAME"
+msgstr ""
+
+#: ../src/spacecmd/org.py:168 ../src/spacecmd/org.py:199
+#: ../src/spacecmd/org.py:233 ../src/spacecmd/org.py:269
+#: ../src/spacecmd/org.py:377 ../src/spacecmd/org.py:413
+#, python-format
+msgid "No organisation found for the name %s"
+msgstr ""
+
+#: ../src/spacecmd/org.py:169 ../src/spacecmd/org.py:200
+#: ../src/spacecmd/org.py:234 ../src/spacecmd/org.py:270
+#: ../src/spacecmd/org.py:378 ../src/spacecmd/org.py:414
+msgid "Organisation '{}' was not found"
+msgstr ""
+
+#: ../src/spacecmd/org.py:171
+msgid "Delete this organization [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:179
+msgid "org_rename: Rename an organization"
+msgstr ""
+
+#: ../src/spacecmd/org.py:180
+msgid "usage: org_rename OLDNAME NEWNAME"
+msgstr ""
+
+#: ../src/spacecmd/org.py:211
+msgid "org_addtrust: Add a trust between two organizations"
+msgstr ""
+
+#: ../src/spacecmd/org.py:212
+msgid "usage: org_addtrust YOUR_ORG ORG_TO_TRUST"
+msgstr ""
+
+#: ../src/spacecmd/org.py:237 ../src/spacecmd/org.py:273
+#, python-format
+msgid "No trust organisation found for the name %s"
+msgstr ""
+
+#: ../src/spacecmd/org.py:238 ../src/spacecmd/org.py:274
+msgid "Organisation '{}' to trust for, was not found"
+msgstr ""
+
+#: ../src/spacecmd/org.py:248
+msgid "org_removetrust: Remove a trust between two organizations"
+msgstr ""
+
+#: ../src/spacecmd/org.py:249
+msgid "usage: org_removetrust YOUR_ORG TRUSTED_ORG"
+msgstr ""
+
+#: ../src/spacecmd/org.py:284
+msgid "None"
+msgstr ""
+
+#: ../src/spacecmd/org.py:286
+msgid "Remove this trust [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:292
+msgid "org_trustdetails: Show the details of an organizational trust"
+msgstr ""
+
+#: ../src/spacecmd/org.py:293
+msgid "usage: org_trustdetails TRUSTED_ORG"
+msgstr ""
+
+#: ../src/spacecmd/org.py:312
+#, python-format
+msgid "No trusted organisation found for the name %s"
+msgstr ""
+
+#: ../src/spacecmd/org.py:313
+msgid "Trusted organisation '{}' was not found"
+msgstr ""
+
+#: ../src/spacecmd/org.py:320
+#, python-format
+msgid "Trusted Organization:   %s"
+msgstr ""
+
+#: ../src/spacecmd/org.py:321
+#, python-format
+msgid "Trusted Since:          %s"
+msgstr ""
+
+#: ../src/spacecmd/org.py:322
+#, python-format
+msgid "Systems Migrated From:  %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:323
+#, python-format
+msgid "Systems Migrated To:    %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:325
+msgid "Channels Consumed"
+msgstr ""
+
+#: ../src/spacecmd/org.py:332
+msgid "Channels Provided"
+msgstr ""
+
+#: ../src/spacecmd/org.py:340
+msgid "org_list: List all organizations"
+msgstr ""
+
+#: ../src/spacecmd/org.py:341
+msgid "usage: org_list"
+msgstr ""
+
+#: ../src/spacecmd/org.py:358
+msgid "org_listtrusts: List an organization's trusts"
+msgstr ""
+
+#: ../src/spacecmd/org.py:359
+msgid "usage: org_listtrusts NAME"
+msgstr ""
+
+#: ../src/spacecmd/org.py:383 ../src/spacecmd/org.py:384
+msgid "No trust organisation has been found"
+msgstr ""
+
+#: ../src/spacecmd/org.py:394
+msgid "org_listusers: List an organization's users"
+msgstr ""
+
+#: ../src/spacecmd/org.py:395
+msgid "usage: org_listusers NAME"
+msgstr ""
+
+#: ../src/spacecmd/org.py:425
+msgid "org_details: Show the details of an organization"
+msgstr ""
+
+#: ../src/spacecmd/org.py:426
+msgid "usage: org_details NAME"
+msgstr ""
+
+#: ../src/spacecmd/org.py:446
+#, python-format
+msgid "Name:                   %s"
+msgstr ""
+
+#: ../src/spacecmd/org.py:447
+#, python-format
+msgid "Active Users:           %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:448
+#, python-format
+msgid "Systems:                %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:452 ../src/spacecmd/org.py:454
+#, python-format
+msgid "Trusts:                 %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:456
+#, python-format
+msgid "System Groups:          %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:457
+#, python-format
+msgid "Activation Keys:        %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:458
+#, python-format
+msgid "Kickstart Profiles:     %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:459
+#, python-format
+msgid "Configuration Channels: %i"
+msgstr ""
+
+#: ../src/spacecmd/package.py:68 ../src/spacecmd/package.py:302
+#: ../src/spacecmd/package.py:351 ../src/spacecmd/package.py:395
+msgid "No packages found"
+msgstr ""
+
+#: ../src/spacecmd/package.py:81 ../src/spacecmd/package.py:406
+#, python-format
+msgid "%s is not a valid package"
+msgstr ""
+
+#: ../src/spacecmd/package.py:94
+#, python-format
+msgid "Version: %s"
+msgstr ""
+
+#: ../src/spacecmd/package.py:95
+#, python-format
+msgid "Release: %s"
+msgstr ""
+
+#: ../src/spacecmd/package.py:96
+#, python-format
+msgid "Epoch:   %s"
+msgstr ""
+
+#: ../src/spacecmd/package.py:97
+#, python-format
+msgid "Arch:    %s"
+msgstr ""
+
+#: ../src/spacecmd/package.py:99
+#, python-format
+msgid "File:    %s"
+msgstr ""
+
+#: ../src/spacecmd/package.py:101
+#, python-format
+msgid "Size:    %s"
+msgstr ""
+
+#: ../src/spacecmd/package.py:105
+#, python-format
+msgid "Installed Systems: %i"
+msgstr ""
+
+#: ../src/spacecmd/package.py:111
+msgid "Available From Channels"
+msgstr ""
+
+#: ../src/spacecmd/package.py:122
+msgid "package_search: Find packages that meet the given criteria"
+msgstr ""
+
+#: ../src/spacecmd/package.py:123
+msgid "usage: package_search NAME|QUERY"
+msgstr ""
+
+#: ../src/spacecmd/package.py:125
+msgid "Example: package_search kernel"
+msgstr ""
+
+#: ../src/spacecmd/package.py:127
+msgid "Advanced Search:"
+msgstr ""
+
+#: ../src/spacecmd/package.py:128
+msgid ""
+"Available Fields: name, epoch, version, release, arch, description, summary"
+msgstr ""
+
+#: ../src/spacecmd/package.py:129
+msgid "Example: name:kernel AND version:2.6.18 AND -description:devel"
+msgstr ""
+
+#: ../src/spacecmd/package.py:178
+msgid "package_remove: Remove a package from Satellite"
+msgstr ""
+
+#: ../src/spacecmd/package.py:179
+msgid "usage: package_remove PACKAGE ..."
+msgstr ""
+
+#: ../src/spacecmd/package.py:199
+msgid "No packages found to remove"
+msgstr ""
+
+#: ../src/spacecmd/package.py:202 ../src/spacecmd/package.py:259
+#: ../src/spacecmd/softwarechannel.py:1580 ../src/spacecmd/system.py:944
+msgid "Remove these packages [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/package.py:203
+msgid "No packages has been removed"
+msgstr ""
+
+#: ../src/spacecmd/package.py:215 ../src/spacecmd/package.py:271
+#, python-format
+msgid "Failed to remove package ID %i"
+msgstr ""
+
+#: ../src/spacecmd/package.py:226
+msgid "package_listorphans: List packages that are not in a channel"
+msgstr ""
+
+#: ../src/spacecmd/package.py:227
+msgid "usage: package_listorphans"
+msgstr ""
+
+#: ../src/spacecmd/package.py:246
+msgid "package_removeorphans: Remove packages that are not in a channel"
+msgstr ""
+
+#: ../src/spacecmd/package.py:247
+msgid "usage: package_removeorphans"
+msgstr ""
+
+#: ../src/spacecmd/package.py:255
+msgid "No orphaned packages has been found"
+msgstr ""
+
+#: ../src/spacecmd/package.py:256
+msgid "No orphaned packages"
+msgstr ""
+
+#: ../src/spacecmd/package.py:260
+msgid "No packages were removed"
+msgstr ""
+
+#: ../src/spacecmd/package.py:280
+msgid "package_listinstalledsystems: List the systems with a package installed"
+msgstr ""
+
+#: ../src/spacecmd/package.py:281
+msgid "usage: package_listinstalledsystems PACKAGE ..."
+msgstr ""
+
+#: ../src/spacecmd/package.py:329
+msgid "package_listerrata: List the errata that provide this package"
+msgstr ""
+
+#: ../src/spacecmd/package.py:330
+msgid "usage: package_listerrata PACKAGE ..."
+msgstr ""
+
+#: ../src/spacecmd/package.py:377
+msgid "package_listdependencies: List the dependencies for a package"
+msgstr ""
+
+#: ../src/spacecmd/package.py:378
+msgid "usage: package_listdependencies PACKAGE"
+msgstr ""
+
+#: ../src/spacecmd/package.py:411
+#, python-format
+msgid "Package Name: %s"
+msgstr ""
+
+#: ../src/spacecmd/package.py:413
+#, python-format
+msgid "Dependency: %s Type: %s Modifier: %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:47
+msgid "repo_list: List all available user repos"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:48
+msgid "usage: repo_list"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:65
+msgid "repo_details: Show the details of a user repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:66
+msgid "usage: repo_details <repo ...>"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:94
+#, python-format
+msgid "Repository Label:                  %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:95
+#, python-format
+msgid "Repository URL:                    %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:96
+#, python-format
+msgid "Repository Type:                   %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:97
+#, python-format
+msgid "Repository SSL Ca Certificate:     %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:98
+#, python-format
+msgid "Repository SSL Client Certificate: %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:99
+#, python-format
+msgid "Repository SSL Client Key:         %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:101
+msgid "No repositories found for '{}' query"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:110
+msgid "repo_listfilters: Show the filters for a user repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:111
+msgid "usage: repo_listfilters repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:132
+msgid "No filters found"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:141
+msgid "repo_addfilters: Add filters for a user repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:142
+msgid "usage: repo_addfilters repo <filter ...>"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:166 ../src/spacecmd/repo.py:203
+#: ../src/spacecmd/repo.py:242
+msgid "Each filter must start with + or -"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:180
+msgid "repo_removefilters: Remove filters from a user repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:181
+msgid "usage: repo_removefilters repo <filter ...>"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:217
+msgid "repo_setfilters: Set the filters for a user repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:218
+msgid "usage: repo_setfilters repo <filter ...>"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:255
+msgid "repo_clearfilters: Clears the filters for a user repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:256
+msgid ""
+"usage: repo_clearfilters repo <options>\n"
+"\n"
+"options:\n"
+"  -y, --yes   Confirm without prompt\n"
+"\n"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:278
+msgid "Remove these filters [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:287
+msgid "repo_delete: Delete a user repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:288
+msgid "usage: repo_delete <repo ...>"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:307 ../src/spacecmd/softwarechannel.py:610
+msgid "Repos"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:311
+msgid "Delete these repos [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:316
+#, python-format
+msgid "Failed to remove repo %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:324
+msgid "repo_create: Create a user repository"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:325
+msgid ""
+"usage: repo_create <options>)\n"
+"\n"
+"options:\n"
+"  -n, --name   name of repository\n"
+"  -u, --url    url of repository\n"
+"  -t, --type   type of repository (defaults to yum)\n"
+"\n"
+"  --ca         SSL CA certificate (not required)\n"
+"  --cert       SSL Client certificate (not required)\n"
+"  --key        SSL Client key (not required)"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:350
+msgid "URL:"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:351
+msgid "Type:"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:352 ../src/spacecmd/repo.py:462
+msgid "SSL CA cert:"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:353 ../src/spacecmd/repo.py:463
+msgid "SSL Client cert:"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:354 ../src/spacecmd/repo.py:464
+msgid "SSL Client key:"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:361
+msgid "A URL is required"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:381
+msgid "repo_rename: Rename a user repository"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:382
+msgid "usage: repo_rename OLDNAME NEWNAME"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:404
+#, python-format
+msgid "Could not find repo %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:417
+msgid "repo_updateurl: Change the URL of a user repository"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:418
+msgid "usage: repo_updateurl <repo> <url>"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:443
+msgid "repo_updatessl: Change the SSL certificates of a user repository"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:444
+msgid ""
+"usage: repo_updatessl <options>)\n"
+"options:\n"
+"  --ca         SSL CA certificate (not required)\n"
+"  --cert       SSL Client certificate (not required)\n"
+"  --key        SSL Client key (not required)"
+msgstr ""
+
+#: ../src/spacecmd/report.py:43
+msgid "report_inactivesystems: List all inactive systems"
+msgstr ""
+
+#: ../src/spacecmd/report.py:44
+msgid "usage: report_inactivesystems [DAYS]"
+msgstr ""
+
+#: ../src/spacecmd/report.py:84
+msgid "report_outofdatesystems: List all out-of-date systems"
+msgstr ""
+
+#: ../src/spacecmd/report.py:85
+msgid "usage: report_outofdatesystems"
+msgstr ""
+
+#: ../src/spacecmd/report.py:112
+msgid "report_ungroupedsystems: List all ungrouped systems"
+msgstr ""
+
+#: ../src/spacecmd/report.py:113
+msgid "usage: report_ungroupedsystems"
+msgstr ""
+
+#: ../src/spacecmd/report.py:130
+msgid "report_errata: List all errata and how many systems they affect"
+msgstr ""
+
+#: ../src/spacecmd/report.py:131
+msgid "usage: report_errata [ERRATA|search:XXX ...]"
+msgstr ""
+
+#: ../src/spacecmd/report.py:143
+msgid "All errata requested - this may take a few minutes, please be patient!"
+msgstr ""
+
+#: ../src/spacecmd/report.py:166
+#, python-format
+msgid "%s  # Systems"
+msgstr ""
+
+#: ../src/spacecmd/report.py:173
+msgid "No errata found for '{}'"
+msgstr ""
+
+#: ../src/spacecmd/report.py:180
+msgid "report_ipaddresses: List the hostname and IP of each system"
+msgstr ""
+
+#: ../src/spacecmd/report.py:181
+msgid "usage: report_ipaddresses [<SYSTEMS>]"
+msgstr ""
+
+#: ../src/spacecmd/report.py:201 ../src/spacecmd/report.py:265
+#: ../src/spacecmd/scap.py:67 ../src/spacecmd/scap.py:207
+#: ../src/spacecmd/system.py:213 ../src/spacecmd/system.py:394
+#: ../src/spacecmd/system.py:579 ../src/spacecmd/system.py:743
+#: ../src/spacecmd/system.py:898 ../src/spacecmd/system.py:1033
+#: ../src/spacecmd/system.py:1134 ../src/spacecmd/system.py:1204
+#: ../src/spacecmd/system.py:1259 ../src/spacecmd/system.py:1358
+#: ../src/spacecmd/system.py:1591 ../src/spacecmd/system.py:1654
+#: ../src/spacecmd/system.py:1697 ../src/spacecmd/system.py:1777
+#: ../src/spacecmd/system.py:1919 ../src/spacecmd/system.py:1961
+#: ../src/spacecmd/system.py:2049 ../src/spacecmd/system.py:2116
+#: ../src/spacecmd/system.py:2198 ../src/spacecmd/system.py:2253
+#: ../src/spacecmd/system.py:2313 ../src/spacecmd/system.py:2372
+#: ../src/spacecmd/system.py:2430 ../src/spacecmd/system.py:2489
+#: ../src/spacecmd/system.py:2566 ../src/spacecmd/system.py:2647
+#: ../src/spacecmd/system.py:2702 ../src/spacecmd/system.py:2955
+#: ../src/spacecmd/system.py:3108 ../src/spacecmd/system.py:3177
+#: ../src/spacecmd/system.py:3223 ../src/spacecmd/system.py:3282
+#: ../src/spacecmd/system.py:3346 ../src/spacecmd/system.py:3402
+#: ../src/spacecmd/system.py:3577 ../src/spacecmd/system.py:3855
+#: ../src/spacecmd/system.py:3998 ../src/spacecmd/system.py:4060
+#: ../src/spacecmd/system.py:4108 ../src/spacecmd/system.py:4166
+#: ../src/spacecmd/system.py:4224
+msgid "No systems selected"
+msgstr ""
+
+#: ../src/spacecmd/report.py:244
+msgid "report_kernels: List the running kernel of each system"
+msgstr ""
+
+#: ../src/spacecmd/report.py:245
+msgid "usage: report_kernels [<SYSTEMS>]"
+msgstr ""
+
+#: ../src/spacecmd/report.py:282
+#, python-format
+msgid "%s  Kernel"
+msgstr ""
+
+#: ../src/spacecmd/report.py:282
+msgid "System"
+msgstr ""
+
+#: ../src/spacecmd/report.py:296
+msgid "report_duplicates: List duplicate system profiles"
+msgstr ""
+
+#: ../src/spacecmd/report.py:297
+msgid "usage: report_duplicates"
+msgstr ""
+
+#: ../src/spacecmd/report.py:319 ../src/spacecmd/report.py:341
+#: ../src/spacecmd/report.py:359 ../src/spacecmd/report.py:377
+msgid "System ID   Last Checkin"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:43
+msgid ""
+"scap_listxccdfscans: Return a list of finished OpenSCAP scans for given "
+"systems"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:44
+msgid "usage: scap_listxccdfscans <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:78 ../src/spacecmd/system.py:608
+#: ../src/spacecmd/system.py:1220 ../src/spacecmd/system.py:1371
+#: ../src/spacecmd/system.py:2060 ../src/spacecmd/system.py:2383
+#: ../src/spacecmd/system.py:2441 ../src/spacecmd/system.py:2660
+#: ../src/spacecmd/system.py:2715 ../src/spacecmd/system.py:3121
+#: ../src/spacecmd/system.py:3238 ../src/spacecmd/system.py:3295
+#, python-format
+msgid "System: %s"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:88
+#, python-format
+msgid "XID: %d Profile: %s Path: (%s) Completed: %s"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:96
+msgid ""
+"scap_getxccdfscanruleresults: Return a full list of RuleResults for given "
+"OpenSCAP XCCDF scan"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:97
+msgid "usage: scap_getxccdfscanruleresults <XID>"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:117
+#, python-format
+msgid "XID: %s"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:124
+#, python-format
+msgid "IDref: %s Result: %s Idents: (%s)"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:132
+msgid "scap_getxccdfscandetails: Get details of given OpenSCAP XCCDF scan"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:133
+msgid "usage: scap_getxccdfscandetails <XID>"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:159
+msgid "XID:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:159
+msgid "SID:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:159
+msgid "Action_ID:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:161
+msgid "OSCAP_Parameters:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:162
+msgid "Test_Result:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:162
+msgid "Benchmark:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:163
+msgid "Benchmark_Version:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:164
+msgid "Profile:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:165
+msgid "Profile_Title:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:165
+msgid "Start_Time:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:166
+msgid "End_Time:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:167
+msgid "Errors:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:175
+msgid "scap_schedulexccdfscan: Schedule Scap XCCDF scan"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:176
+msgid "usage: scap_schedulexccdfscan PATH_TO_XCCDF_FILE XCCDF_OPTIONS SYSTEMS"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:177
+msgid "       scap_schedulexccdfscan ssm PATH_TO_XCCDF_FILE XCCDF_OPTIONS"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:182
+msgid ""
+"\n"
+"To use systems in the ssm, pass the \"ssm\" keyword in front. Example:"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:88
+msgid "ID      Date                 C    F    P     Action"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:134
+msgid "schedule_cancel: Cancel scheduled actions"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:135
+msgid "usage: schedule_cancel ID|* ..."
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:157
+msgid "Cancel all pending actions [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:158
+msgid "All pending actions left untouched"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:173 ../src/spacecmd/schedule.py:234
+#, python-format
+msgid "\"%s\" is not a valid ID"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:179
+#, python-format
+msgid "Canceled action: %i"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:182
+#, python-format
+msgid "Failed action: %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:184
+#, python-format
+msgid "Canceled %i action(s)"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:192
+msgid "schedule_reschedule: Reschedule failed actions"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:193
+msgid "usage: schedule_reschedule ID|* ..."
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:220
+msgid "Reschedule all failed actions [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:232
+#, python-format
+msgid "\"%i\" is not a failed action"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:238
+msgid "No failed actions to reschedule"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:242
+#, python-format
+msgid "Rescheduled %i action(s)"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:250
+msgid "schedule_details: Show the details of a scheduled action"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:251
+msgid "usage: schedule_details ID"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:268
+#, python-format
+msgid "The ID \"%s\" is invalid"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:277
+#, python-format
+msgid "ID:        %i"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:278
+#, python-format
+msgid "Action:    %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:279
+#, python-format
+msgid "User:      %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:280
+#, python-format
+msgid "Date:      %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:282 ../src/spacecmd/schedule.py:379
+#: ../src/spacecmd/system.py:3245
+#, python-format
+msgid "Completed: %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:283
+#, python-format
+msgid "Failed:    %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:284
+#, python-format
+msgid "Pending:   %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:288
+msgid "Completed Systems"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:295
+msgid "Failed Systems"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:302
+msgid "Pending Systems"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:307
+#, python-format
+msgid "No action found with the ID \"%s\""
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:316
+msgid "schedule_getoutput: Show the output from an action"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:317
+msgid "usage: schedule_getoutput ID"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:332
+#, python-format
+msgid "\"%s\" is not a valid action ID"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:354
+#, python-format
+msgid "System:      %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:355
+#, python-format
+msgid "Start Time:  %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:356
+#, python-format
+msgid "Stop Time:   %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:357
+#, python-format
+msgid "Return Code: %i"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:359 ../src/spacecmd/schedule.py:381
+msgid "Output"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:378
+#, python-format
+msgid "System:    %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:394
+msgid "schedule_listpending: List pending actions"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:395
+msgid "usage: schedule_listpending [BEGINDATE] [ENDDATE]"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:407
+msgid "schedule_listcompleted: List completed actions"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:408
+msgid "usage: schedule_listcompleted [BEGINDATE] [ENDDATE]"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:420
+msgid "schedule_listfailed: List failed actions"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:421
+msgid "usage: schedule_listfailed [BEGINDATE] [ENDDATE]"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:433
+msgid "schedule_listarchived: List archived actions"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:434
+msgid "usage: schedule_listarchived [BEGINDATE] [ENDDATE]"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:446
+msgid "schedule_list: List all actions"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:447
+msgid "usage: schedule_list [BEGINDATE] [ENDDATE]"
+msgstr ""
+
+#: ../src/spacecmd/shell.py:120
+msgid "Could not read history file"
+msgstr ""
+
+#. pylint: disable=W0702
+#: ../src/spacecmd/shell.py:124
+msgid "Exception occurred: {}"
+msgstr ""
+
+#: ../src/spacecmd/shell.py:188 ../src/spacecmd/shell.py:227
+#, python-format
+msgid "%s: event not found"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:42
+msgid "snippet_list: List the available Kickstart snippets"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:43
+msgid "usage: snippet_list"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:60
+msgid "snippet_details: Show the contents of a snippet"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:61
+msgid "usage: snippet_details SNIPPET ..."
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:90
+#, python-format
+msgid "%s is not a valid snippet"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:97
+#, python-format
+msgid "Name:   %s"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:98
+#, python-format
+msgid "Macro:  %s"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:99
+#, python-format
+msgid "File:   %s"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:110
+msgid "snippet_create: Create a Kickstart snippet"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:111
+msgid ""
+"usage: snippet_create [options])\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -f FILE"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:149
+msgid "A name is required for the snippet"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:153
+msgid "A file is required"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:160
+#, python-format
+msgid "Snippet: %s"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:176
+msgid "snippet_update: Update a Kickstart snippet"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:177
+msgid "usage: snippet_update NAME"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:199
+msgid "snippet_delete: Delete a Kickstart snippet"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:200
+msgid "usage: snippet_delete NAME"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:218
+msgid "Remove this snippet [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:57
+msgid "softwarechannel_list: List all available software channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:58
+msgid ""
+"usage: softwarechannel_list [options]')\n"
+"options:\n"
+"  -v verbose (display label and summary)\n"
+"  -t tree view (pretty-print(child-channels))\n"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:106
+msgid "softwarechannel_listmanageablechannels: List all software channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:107
+msgid "                                        manageable by current user"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:108
+msgid ""
+"usage: softwarechannel_listmanageablechannels [options]\n"
+"options:\n"
+"  -v verbose (display label and summary)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:143
+msgid "softwarechannel_listbasechannels: List all base software channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:144
+msgid ""
+"usage: softwarechannel_listbasechannels [options])\n"
+"options:\n"
+"  -v verbose (display label and summary)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:172
+msgid "softwarechannel_listchildchannels: List child software channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:173
+#: ../src/spacecmd/softwarechannel.py:2735
+msgid "usage:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:174
+msgid "softwarechannel_listchildchannels [options]"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:175
+msgid "softwarechannel_listchildchannels : List all child channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:176
+msgid ""
+"softwarechannel_listchildchannels CHANNEL : List children for aspecific base "
+"channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:178
+msgid ""
+"options:\n"
+" -v verbose (display label and summary)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:206
+msgid "softwarechannel_listsystems: List all systems subscribed to"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:207
+msgid "                             a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:208
+msgid "usage: softwarechannel_listsystems CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:242
+msgid "softwarechannel_listpackages: List the most recent packages"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:243
+msgid "                              available from a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:244
+msgid "usage: softwarechannel_listpackages CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:281
+msgid "softwarechannel_listallpackages: List all packages in a channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:282
+msgid "usage: softwarechannel_listallpackages CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:340
+msgid ""
+"softwarechannel_listlatestpackages: List the newest version of all packages "
+"in a channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:341
+msgid "usage: softwarechannel_listlatestpackages CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:380
+msgid "softwarechannel_setdetails: Modify details of a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:381
+#, python-format
+msgid ""
+"usage: softwarechannel_setdetails [options] <CHANNEL ...>)\n"
+"\n"
+"options, at least one of which must be given:\n"
+"  -n NAME\n"
+"  -d DESCRIPTION\n"
+"  -s SUMMARY\n"
+"  -c CHECKSUM %s\n"
+"  -m MAINTAINER_NAME\n"
+"  -e MAINTAINER_EMAIL\n"
+"  -p MAINTAINER_PHONE\n"
+"  -u GPG_URL\n"
+"  -i GPG_ID\n"
+"  -f GPG_FINGERPRINT"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:443
+msgid "At least one attribute to set must be given"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:449
+msgid "No channels matching that label"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:461
+msgid "Setting same name for more than one channel will fail"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:469
+#, python-format
+msgid "Name \"%s\" already in use by channel %s"
+msgstr ""
+
+#. get confirmation
+#: ../src/spacecmd/softwarechannel.py:474
+msgid "Setting following attributes..."
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:477
+#, python-format
+msgid "Name:             %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:479
+#, python-format
+msgid "Summary:          %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:481
+#, python-format
+msgid "Description:      %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:483
+#, python-format
+msgid "Checksum:         %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:485
+#, python-format
+msgid "Maintainer name:  %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:487
+#, python-format
+msgid "Maintainer email: %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:489
+#, python-format
+msgid "Maintainer phone: %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:491
+#, python-format
+msgid "GPG Key:          %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:493
+#, python-format
+msgid "GPG Fingerprint:  %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:495
+#, python-format
+msgid "GPG URL:          %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:497
+msgid "... for the following channels:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:500
+msgid "Apply? [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:512
+#, python-format
+msgid "Could not get details for %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:524
+#, python-format
+msgid "Error while setting details for %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:527
+#, python-format
+msgid "Channels changed: %d"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:535
+msgid "softwarechannel_details: Show the details of a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:536
+msgid "usage: softwarechannel_details <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:576
+#, python-format
+msgid "Label:              %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:577
+#, python-format
+msgid "Name:               %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:578
+#, python-format
+msgid "Architecture:       %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:579
+#, python-format
+msgid "Parent:             %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:580
+#, python-format
+msgid "Systems Subscribed: %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:581
+#, python-format
+msgid "Number of Packages: %i"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:585
+msgid "Summary"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:596
+#, python-format
+msgid "GPG Key:            %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:597
+#, python-format
+msgid "GPG Fingerprint:    %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:598
+#, python-format
+msgid "GPG URL:            %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:599
+#, python-format
+msgid "GPG CHECK:          %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:603
+msgid "Kickstart Trees"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:621
+msgid "softwarechannel_listerrata: List the errata associated with a"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:622
+msgid "                            software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:623
+msgid ""
+"usage: softwarechannel_listerrata <CHANNEL ...> [from=yyyymmdd [to=yyyymmdd]]"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:681
+msgid "softwarechannel_listarches: lists the potential software"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:682
+msgid "                            channel architectures that can be created"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:683
+msgid "usage: softwarechannel_listarches"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:684 ../src/spacecmd/system.py:3826
+msgid "options:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:685
+msgid "    -v verbose (display label and name)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:706
+msgid "softwarechannel_delete: Delete a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:707
+msgid "usage: softwarechannel_delete <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:732
+msgid "Channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:760
+msgid "softwarechannel_update: Update a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:761
+#, python-format
+msgid ""
+"usage: softwarechannel_update LABEL(To identify the channel) [options]\n"
+"options:\n"
+"  -l LABEL(Required)\n"
+"  -n NAME\n"
+"  -s SUMMARY\n"
+"  -d DESCRIPTION\n"
+"  -c CHECKSUM %s\n"
+"  -u GPG-URL\n"
+"  -i GPG-ID\n"
+"  -f GPG-FINGERPRINT\n"
+"  -g DISABLE-GPG-CHECK"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:792
+#: ../src/spacecmd/softwarechannel.py:924
+#: ../src/spacecmd/softwarechannel.py:1094
+msgid "Channel Label:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:797
+msgid "New Name (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:803
+msgid "New Summary (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:806
+msgid "Summary:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:809
+msgid "New Description (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:815
+msgid "New Checksum type (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:822
+msgid "New GPG URL (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:825
+#: ../src/spacecmd/softwarechannel.py:953
+#: ../src/spacecmd/softwarechannel.py:1107
+#: ../src/spacecmd/softwarechannel.py:1196
+msgid "GPG URL:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:828
+msgid "New GPG ID (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:831
+#: ../src/spacecmd/softwarechannel.py:959
+#: ../src/spacecmd/softwarechannel.py:1108
+#: ../src/spacecmd/softwarechannel.py:1197
+msgid "GPG ID:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:834
+msgid "New GPG Fingerprint (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:837
+#: ../src/spacecmd/softwarechannel.py:965
+#: ../src/spacecmd/softwarechannel.py:1109
+#: ../src/spacecmd/softwarechannel.py:1198
+msgid "GPG Fingerprint:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:840
+msgid "Disable GPG CHECK (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:843
+#: ../src/spacecmd/softwarechannel.py:1110
+#: ../src/spacecmd/softwarechannel.py:1199
+msgid "Disable GPG Check [yes/no]? "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:846
+msgid "A channel label is required to identify the channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:849
+msgid "Only [yes/no] values are acceptable for --disable_gpg_check"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:889
+msgid "softwarechannel_create: Create a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:890
+#, python-format
+msgid ""
+"usage: softwarechannel_create [options])\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -l LABEL\n"
+"  -s SUMMARY\n"
+"  -p PARENT_CHANNEL\n"
+"  -a ARCHITECTURE\n"
+"  -c CHECKSUM %s\n"
+"  -u GPG_URL\n"
+"  -i GPG_ID\n"
+"  -f GPG_FINGERPRINT\n"
+"  -g DISABLE_GPG_CHECK"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:923
+#: ../src/spacecmd/softwarechannel.py:1093
+msgid "Channel Name:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:925
+msgid "Channel Summary:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:933
+#: ../src/spacecmd/softwarechannel.py:1101
+msgid "Select Parent [blank to create a base channel]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:936
+msgid "Architecture"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:943
+msgid "Checksum type"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:950
+msgid "GPG URL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:956
+msgid "GPG ID"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:962
+msgid "GPG Fingerprint"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:968
+msgid "GPG CHECK"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:971
+msgid "Disable GPG Check [y/N]? "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1023
+#: ../src/spacecmd/softwarechannel.py:1121
+msgid "A channel name is required"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1027
+#: ../src/spacecmd/softwarechannel.py:1125
+msgid "A channel label is required"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1040
+#, python-format
+msgid "Name %s already in use by channel %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1044
+#, python-format
+msgid "Label %s already in use by channel %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1052
+msgid "softwarechannel_clone: Clone a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1053
+msgid ""
+"usage: softwarechannel_clone [options])\n"
+"\n"
+"options:\n"
+"  -s SOURCE_CHANNEL\n"
+"  -n NAME\n"
+"  -l LABEL\n"
+"  -p PARENT_CHANNEL\n"
+"  --gpg-copy/-g (copy SOURCE_CHANNEL GPG details)\n"
+"  --gpg-url GPG_URL\n"
+"  --gpg-id GPG_ID\n"
+"  --gpg-fingerprint(GPG_FINGERPRINT)\n"
+"  --disable-gpg-check DISABLE_GPG_CHECK\n"
+"  -o do not clone any patches\n"
+"  --regex/-x \"s/foo/bar\" : Optional regex replacement,\n"
+"        replaces foo with bar in the clone name and label"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1088
+#: ../src/spacecmd/softwarechannel.py:1188
+msgid "Source Channels:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1092
+#: ../src/spacecmd/softwarechannel.py:1191
+msgid "Select source channel:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1096
+msgid "Base Channels:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1104
+#: ../src/spacecmd/softwarechannel.py:1194
+msgid "Copy source channel GPG details? [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1113
+#: ../src/spacecmd/softwarechannel.py:1202
+msgid "Original State (No Errata) [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1117
+#: ../src/spacecmd/softwarechannel.py:1205
+msgid "A source channel is required"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1138
+#: ../src/spacecmd/softwarechannel.py:1216
+msgid "Only [yes/no] values are acceptable for --disable-gpg-check"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1154
+msgid ""
+"softwarechannel_clonetree: Clone a software channel and its child channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1155
+msgid ""
+"usage: softwarechannel_clonetree [options])\n"
+"             e.g    softwarechannel_clonetree foobasechannel -p \"my_\"\n"
+"                    softwarechannel_clonetree foobasechannel -x \"s/foo/bar"
+"\"\n"
+"                    softwarechannel_clonetree foobasechannel -x \"s/^/my_\"\n"
+"\n"
+"options:\n"
+"  -s/--source-channel SOURCE_CHANNEL\n"
+"  -p/--prefix PREFIX (is prepended to the label and name of all channels)\n"
+"  --gpg-copy/-g (copy GPG details for correspondoing source channel))\n"
+"  --gpg-url GPG_URL (applied to all channels)\n"
+"  --gpg-id GPG_ID (applied to all channels)\n"
+"  --gpg-fingerprint(GPG_FINGERPRINT (applied to all channels))\n"
+"  --disable-gpg-check DISABLE_GPG_CHECK(applied to all channels)\n"
+"  -o do not clone any errata\n"
+"  --regex/-x \"s/foo/bar\" : Optional regex replacement,\n"
+"        replaces foo with bar in the clone name, label and description"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1192
+msgid "Prefix:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1209
+msgid "A prefix or regex is required"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1221
+#: ../src/spacecmd/softwarechannel.py:1994
+#: ../src/spacecmd/softwarechannel.py:2034
+msgid "Channel does not exist or is not a base channel!"
+msgstr ""
+
+#. Shouldn't ever get here due to earlier checks
+#: ../src/spacecmd/softwarechannel.py:1248
+msgid "called without prefix or regex option!"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1348
+msgid "softwarechannel_addpackages: Add packages to a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1349
+msgid "usage: softwarechannel_addpackages CHANNEL <PACKAGE ...>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1389
+msgid "No packages to add"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1396
+msgid "Add these packages [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1408
+msgid ""
+"softwarechannel_mergepackages: Merge packages from one software channel into "
+"another"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1409
+msgid "usage: softwarechannel_mergepackages SOURCE_CHANNEL TARGET_CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1433
+msgid "softwarechannel_removeerrata: Remove patches from a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1435
+msgid "usage: softwarechannel_removeerrata CHANNEL <ERRATA:search:XXX ...>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1488
+msgid "No patches to remove"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1499
+#: ../src/spacecmd/softwarechannel.py:1828
+#, python-format
+msgid "Total Errata:   %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1500
+#: ../src/spacecmd/softwarechannel.py:1831
+#, python-format
+msgid "Total Packages: %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1502
+msgid "Remove these patches [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1517
+msgid "softwarechannel_removepackages: Remove packages from a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1519
+msgid "usage: softwarechannel_removepackages CHANNEL <PACKAGE ...>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1573
+msgid "No packages to remove"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1593
+msgid ""
+"softwarechannel_adderratabydate: Add errata from one channel into another "
+"channel based on a date range"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1595
+msgid ""
+"usage: softwarechannel_adderratabydate [options] SOURCE DEST BEGINDATE "
+"ENDDATE"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1596
+#: ../src/spacecmd/softwarechannel.py:1671
+msgid "Date format : YYYYMMDD"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1597
+#: ../src/spacecmd/softwarechannel.py:1728
+#: ../src/spacecmd/softwarechannel.py:2620
+#: ../src/spacecmd/softwarechannel.py:2663
+#: ../src/spacecmd/softwarechannel.py:2879
+msgid "Options:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1598
+msgid "        -p/--publish : Publish errata to the channel (don't clone)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1625
+#: ../src/spacecmd/softwarechannel.py:1630
+#: ../src/spacecmd/softwarechannel.py:1696
+#: ../src/spacecmd/softwarechannel.py:1701
+#, python-format
+msgid "%s is an invalid date"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1643
+msgid "No patches found between the given dates"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1650
+#, python-format
+msgid "Publishing errata %s to %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1668
+msgid ""
+"softwarechannel_listerratabydate: list errata from channelbased on a date "
+"range"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1670
+msgid "usage: softwarechannel_listerratabydate CHANNEL BEGINDATE ENDDATE"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1714
+msgid "No errata found between the given dates"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1725
+msgid ""
+"softwarechannel_adderrata: Add patches from one channel into another channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1727
+msgid "usage: softwarechannel_adderrata SOURCE DEST <ERRATA|search:XXX ...>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1729
+msgid "    -q/--quick : Don't display list of packages (slightly faster)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1730
+msgid "    -s/--skip :  Skip errata which appear to exist already in DEST"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1756
+#, python-format
+msgid "source channel %s does not exist!"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1761
+#, python-format
+msgid "dest channel %s does not exist!"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1814
+msgid "No patch to add"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1833
+msgid "Add these patches [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1847
+msgid "Using the old errata.clone function"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1848
+msgid ""
+"If you have base channels for multiple OS versions, check no unexpected "
+"packages have been added"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1861
+msgid ""
+"softwarechannel_getorgaccess: Get the org-access for the software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1862
+msgid "usage: softwarechannel_getorgaccess [CHANNEL ...]"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1900
+msgid ""
+"softwarechannel_setorgaccess: Set the org-access for the software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1901
+msgid ""
+"usage : softwarechannel_setorgaccess <CHANNEL> [options])\n"
+"-d,--disable : disable org access (private, no org sharing)\n"
+"-e,--enable : enable org access (public access to all trusted orgs)\n"
+"-p,--protected ORG : protected org access for ORG only (multiple instances "
+"of -p ORG are allowed)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1941
+#, python-format
+msgid "Making org sharing public for channel : %s "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1946
+#, python-format
+msgid "Making org sharing private for channel : %s "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1951
+#, python-format
+msgid "Making org sharing protected for channel : %s "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1957
+#, python-format
+msgid "Enabling %s access for channel : %s "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1962
+#, python-format
+msgid "Disabling %s access for channel : %s "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1975
+msgid ""
+"softwarechannel_getorgaccesstree: Get the org-access for a software base "
+"channel and its children"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1976
+msgid "usage: softwarechannel_getorgaccesstree [CHANNEL]"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2009
+msgid ""
+"softwarechannel_setorgaccesstree: set the org-access for a software base "
+"channel and its children"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2010
+msgid ""
+"usage: softwarechannel_setorgaccesstree <CHANNEL> [options])\n"
+"-d,--disable : disable org access (private, no org sharing)\n"
+"-e,--enable : enable org access (public access to all trusted orgs)\n"
+"-p,--protected ORG : protected org access for ORG only (multiple instances "
+"of -p ORG are allowed)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2049
+msgid "softwarechannel_regenerateneededcache: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2050
+msgid "Regenerate the needed errata and package cache for all systems"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2052
+msgid "usage: softwarechannel_regenerateneededcache"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2066
+msgid "softwarechannel_regenerateyumcache: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2067
+msgid "Regenerate the YUM cache for a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2069
+msgid ""
+"usage: softwarechannel_regenerateyumcache [options] <CHANNEL ...>\n"
+"\n"
+"    options:\n"
+"      -f force cache regeneration\n"
+"    "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2113
+msgid "no softwarechannel label given"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2116
+msgid "invalid softwarechannel label "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2134
+msgid "softwarechannel_diff: diff softwarechannel files"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2136
+msgid "usage: softwarechannel_diff SOURCE_CHANNEL TARGET_CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2197
+msgid "softwarechannel_errata_diff: diff softwarechannel files"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2199
+msgid "usage: softwarechannel_errata_diff SOURCE_CHANNEL TARGET_CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2248
+msgid "softwarechannel_sync: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2249
+msgid "sync the packages of two software channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2251
+msgid ""
+"usage: softwarechannel_sync SOURCE_CHANNEL TARGET_CHANNEL [options])\n"
+"    -q,--quiet : quiet mode (omits the output of common packages in both "
+"channels)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2293
+#, python-format
+msgid "%s packages from softwarechannel %s to %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2312
+#: ../src/spacecmd/softwarechannel.py:2320
+#: ../src/spacecmd/softwarechannel.py:2434
+#: ../src/spacecmd/softwarechannel.py:2442
+#: ../src/spacecmd/softwarechannel.py:2574
+#: ../src/spacecmd/softwarechannel.py:2582
+msgid "failed to read key id"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2323
+msgid "packages common in both channels:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2328
+msgid "Omitting common packages in both specified channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2333
+msgid "packages to add to channel \""
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2341
+msgid "packages to remove from channel \""
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2347
+#: ../src/spacecmd/softwarechannel.py:2469
+#: ../src/spacecmd/softwarechannel.py:2599
+msgid "summary:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2348
+#: ../src/spacecmd/softwarechannel.py:2349
+msgid " packages"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2350
+msgid "    add    "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2351
+msgid " packages to   "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2354
+msgid "    remove "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2355
+msgid " packages from "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2357
+#: ../src/spacecmd/softwarechannel.py:2477
+msgid "Perform these changes to channel "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2378
+msgid "softwarechannel_errata_sync: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2379
+msgid "sync errata of two software channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2381
+msgid "usage: softwarechannel_errata_sync SOURCE_CHANNEL TARGET_CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2420
+msgid "syncing errata from softwarechannel "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2421
+#: ../src/spacecmd/softwarechannel.py:2553
+msgid " to "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2445
+msgid "errata common in both channels:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2454
+msgid "errata to add to channel \""
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2463
+msgid "errata to remove from channel \""
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2472
+#: ../src/spacecmd/softwarechannel.py:2602
+msgid "    add   "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2473
+msgid "errata to  "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2474
+msgid "    remove"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2475
+msgid "errata from"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2500
+msgid "softwarechannel_errata_merge: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2501
+msgid "merge errata of one software channel into another"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2503
+msgid ""
+"usage:   softwarechannel_errata_merge SOURCE_CHANNEL TARGET_CHANNEL "
+"[FROM_DATE] [TO_DATE]"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2504
+msgid ""
+"example: softwarechannel_errata_merge OldSoftChannel NewSoftChannel "
+"2018-01-01"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2505
+msgid ""
+"note:    Providing only FROM_DATE will merge all errata since that date."
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2506
+msgid "note:    When no date is provided, all errata will be merged."
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2536
+#: ../src/spacecmd/softwarechannel.py:2543
+msgid "wrong dateformat: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2536
+#: ../src/spacecmd/softwarechannel.py:2543
+msgid " please specify as: YYYY-MM-DD"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2552
+msgid "merging errata from softwarechannel "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2589
+msgid "{} contains no errata which is not already present in {}"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2594
+msgid "errata to add to channel {}: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2600
+#: ../src/spacecmd/softwarechannel.py:2601
+msgid " errata"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2603
+msgid " errata to  "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2605
+msgid "Perform these changes to channel {} [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2616
+msgid "softwarechannel_syncrepos: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2617
+msgid "Sync users repos for a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2619
+msgid "usage: softwarechannel_syncrepos <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2621
+#: ../src/spacecmd/softwarechannel.py:2664
+msgid "    -e/--no-errata : Do not sync errata"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2622
+#: ../src/spacecmd/softwarechannel.py:2665
+msgid "    -f/--fail : Terminate upon any error"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2623
+#: ../src/spacecmd/softwarechannel.py:2666
+msgid "    -k/--sync-kickstart : Create kickstartable tree"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2624
+#: ../src/spacecmd/softwarechannel.py:2667
+msgid "    -l/--latest : Only download latest package versions when repo syncs"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2659
+msgid "softwarechannel_setsyncschedule: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2660
+msgid "Sets the repo sync schedule for a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2662
+msgid "usage: softwarechannel_setsyncschedule <CHANNEL> <SCHEDULE>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2669
+msgid ""
+"The schedule is specified in Quartz CronTrigger format without enclosing "
+"quotes."
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2670
+msgid ""
+"For example, to set a schedule of every day at 1am, <SCHEDULE> would be 0 0 "
+"1 * * ?"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2671
+msgid "If <SCHEDULE> is left empty, it will be disabled."
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2734
+msgid ""
+"softwarechannel_listsyncschedule: List sync schedules for all software "
+"channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2736
+msgid "softwarechannel_listsyncschedule : List all channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2759
+msgid "key"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2759
+msgid "Channel Name"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2759
+msgid "Update Schedule"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2771
+msgid "softwarechannel_addrepo: Add a repo to a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2772
+msgid "usage: softwarechannel_addrepo CHANNEL REPO"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2805
+msgid "softwarechannel_removerepo: Remove a repo from a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2806
+msgid "usage: softwarechannel_removerepo CHANNEL REPO"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2846
+msgid "softwarechannel_listrepos: List the repos for a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2847
+msgid "usage: softwarechannel_listrepos CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2870
+msgid "No repos have been found for this channel."
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2877
+msgid "softwarechannel_mirrorpackages: Download packages of a given channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2878
+msgid "usage: softwarechannel_mirrorpackages CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2880
+msgid "    -l/--latest : Only mirror latest package version"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2911
+msgid "Skipping"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2913
+msgid "Fetching package"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2918
+#, python-format
+msgid "Received package %s from channel %s is broken. Content is too short"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2922
+#, python-format
+msgid "Could not fetch package %s from channel %s"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:42
+msgid "The System Set Manager (SSM) is a group of systems that you "
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:43
+msgid "can perform tasks on as a whole."
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:45
+msgid "Adding Systems:"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:51
+msgid "Intersections:"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:63
+msgid "ssm_add: Add systems to the SSM"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:64
+msgid "usage: ssm_add <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:66 ../src/spacecmd/ssm.py:115
+#: ../src/spacecmd/ssm.py:165 ../src/spacecmd/ssm.py:209
+msgid "see 'help ssm' for more details"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:92
+#, python-format
+msgid "%s is already in the list"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:110
+msgid "ssm_intersect: Replace the current SSM with the intersection"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:111
+msgid "               of the current list of systems and the list of"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:112
+msgid "               systems passed as arguments"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:113
+msgid "usage: ssm_intersect <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:162
+msgid "ssm_remove: Remove systems from the SSM"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:163
+msgid "usage: ssm_remove <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:206
+msgid "ssm_list: List the systems currently in the SSM"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:207
+msgid "usage: ssm_list"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:226
+msgid "ssm_clear: Remove all systems from the SSM"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:227
+msgid "usage: ssm_clear"
+msgstr ""
+
+#: ../src/spacecmd/system.py:49
+msgid "Same"
+msgstr ""
+
+#: ../src/spacecmd/system.py:50
+msgid "Only here"
+msgstr ""
+
+#: ../src/spacecmd/system.py:51
+msgid "Newer here"
+msgstr ""
+
+#: ../src/spacecmd/system.py:52
+msgid "Only there"
+msgstr ""
+
+#: ../src/spacecmd/system.py:53
+msgid "Newer there"
+msgstr ""
+
+#: ../src/spacecmd/system.py:73 ../src/spacecmd/system.py:3771
+msgid "Package"
+msgstr ""
+
+#: ../src/spacecmd/system.py:74
+msgid "This System"
+msgstr ""
+
+#: ../src/spacecmd/system.py:75
+msgid "Other System"
+msgstr ""
+
+#: ../src/spacecmd/system.py:76 ../src/spacecmd/system.py:3774
+msgid "Difference"
+msgstr ""
+
+#: ../src/spacecmd/system.py:124
+msgid "Removing Channels"
+msgstr ""
+
+#: ../src/spacecmd/system.py:127
+msgid "Adding Channels"
+msgstr ""
+
+#: ../src/spacecmd/system.py:163
+msgid "system_list: List all system profiles"
+msgstr ""
+
+#: ../src/spacecmd/system.py:164
+msgid "usage: system_list"
+msgstr ""
+
+#: ../src/spacecmd/system.py:180
+msgid "system_reboot: Reboot a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:181
+msgid ""
+"usage: system_reboot <SYSTEMS> [options])\n"
+"\n"
+"options:\n"
+"  -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:236
+msgid "Reboot these systems [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:252
+msgid "system_search: List systems that match the given criteria"
+msgstr ""
+
+#: ../src/spacecmd/system.py:253
+msgid "usage: system_search QUERY"
+msgstr ""
+
+#: ../src/spacecmd/system.py:255
+msgid "Available Fields:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:258
+msgid "Examples:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:259
+msgid "> system_search device:vmware"
+msgstr ""
+
+#: ../src/spacecmd/system.py:260
+msgid "> system_search ip:192.168.82"
+msgstr ""
+
+#: ../src/spacecmd/system.py:278 ../src/spacecmd/system.py:285
+msgid "Invalid query"
+msgstr ""
+
+#: ../src/spacecmd/system.py:321
+msgid "Invalid search field"
+msgstr ""
+
+#: ../src/spacecmd/system.py:351
+msgid "system_runscript: Schedule a script to run on the list of"
+msgstr ""
+
+#: ../src/spacecmd/system.py:352
+msgid "                  systems provided"
+msgstr ""
+
+#: ../src/spacecmd/system.py:353
+msgid ""
+"usage: system_runscript <SYSTEMS> [options])\n"
+"\n"
+"options:\n"
+"  -u USER\n"
+"  -g GROUP\n"
+"  -t TIMEOUT\n"
+"  -s START_TIME\n"
+"  -l LABEL\n"
+"  -f FILE"
+msgstr ""
+
+#: ../src/spacecmd/system.py:398
+msgid "User [root]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:399
+msgid "Group [root]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:408
+msgid "Timeout (in seconds) [600]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:414
+msgid "Invalid timeout"
+msgstr ""
+
+#: ../src/spacecmd/system.py:420
+msgid "Label/Short Description [default]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:424
+msgid "Script File [create]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:437
+msgid "No script provided"
+msgstr ""
+
+#: ../src/spacecmd/system.py:456
+msgid "A script file is required"
+msgstr ""
+
+#: ../src/spacecmd/system.py:464
+#, python-format
+msgid "User:       %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:465
+#, python-format
+msgid "Group:      %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:466
+#, python-format
+msgid "Timeout:    %i seconds"
+msgstr ""
+
+#: ../src/spacecmd/system.py:470
+#, python-format
+msgid "Label:      %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:471
+msgid "Script Contents"
+msgstr ""
+
+#: ../src/spacecmd/system.py:533 ../src/spacecmd/system.py:835
+#: ../src/spacecmd/system.py:962 ../src/spacecmd/system.py:1096
+#: ../src/spacecmd/system.py:4358
+#, python-format
+msgid "Failed to schedule %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:536
+#, python-format
+msgid "Scheduled: %i system(s)"
+msgstr ""
+
+#: ../src/spacecmd/system.py:543 ../src/spacecmd/utils.py:245
+#, python-format
+msgid "Could not remove %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:552
+msgid "system_listhardware: List the hardware details of a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:553
+msgid "usage: system_listhardware <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:612
+msgid "Network"
+msgstr ""
+
+#: ../src/spacecmd/system.py:621
+#, python-format
+msgid "Interface:   %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:622
+#, python-format
+msgid "MAC Address: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:623
+#, python-format
+msgid "IP Address:  %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:624
+#, python-format
+msgid "Netmask:     %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:625
+#, python-format
+msgid "Broadcast:   %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:626
+#, python-format
+msgid "Module:      %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:630
+msgid "CPU"
+msgstr ""
+
+#: ../src/spacecmd/system.py:632
+#, python-format
+msgid "Count:    %i"
+msgstr ""
+
+#: ../src/spacecmd/system.py:633
+#, python-format
+msgid "Arch:     %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:634
+#, python-format
+msgid "MHz:      %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:635
+#, python-format
+msgid "Cache:    %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:636
+#, python-format
+msgid "Vendor:   %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:637
+#, python-format
+msgid "Model:    %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:640
+msgid "Memory"
+msgstr ""
+
+#: ../src/spacecmd/system.py:642
+#, python-format
+msgid "RAM:  %i"
+msgstr ""
+
+#: ../src/spacecmd/system.py:643
+#, python-format
+msgid "Swap: %i"
+msgstr ""
+
+#: ../src/spacecmd/system.py:647
+msgid "DMI"
+msgstr ""
+
+#: ../src/spacecmd/system.py:648
+#, python-format
+msgid "Vendor:       %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:649
+#, python-format
+msgid "System:       %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:650
+#, python-format
+msgid "Product:      %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:651
+#, python-format
+msgid "Board:        %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:654
+msgid "Asset"
+msgstr ""
+
+#: ../src/spacecmd/system.py:660
+#, python-format
+msgid "BIOS Release: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:661
+#, python-format
+msgid "BIOS Vendor:  %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:662
+#, python-format
+msgid "BIOS Version: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:666
+msgid "Devices"
+msgstr ""
+
+#: ../src/spacecmd/system.py:676
+msgid "Description: None"
+msgstr ""
+
+#: ../src/spacecmd/system.py:680
+#, python-format
+msgid "Driver:      %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:681
+#, python-format
+msgid "Class:       %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:682
+#, python-format
+msgid "Bus:         %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:690
+msgid "system_installpackage: Install a package on a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:691
+msgid ""
+"usage: system_installpackage <SYSTEMS> <PACKAGE ...> [options])\n"
+"\n"
+"options:\n"
+"    -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:792
+msgid "No packages to install"
+msgstr ""
+
+#: ../src/spacecmd/system.py:816
+#, python-format
+msgid "%s does not have access to all requested packages"
+msgstr ""
+
+#: ../src/spacecmd/system.py:822
+msgid "Install these packages [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:837 ../src/spacecmd/system.py:964
+#: ../src/spacecmd/system.py:1098
+#, python-format
+msgid "Scheduled %i system(s)"
+msgstr ""
+
+#: ../src/spacecmd/system.py:845
+msgid "system_removepackage: Remove a package from a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:846
+msgid ""
+"usage: system_removepackage <SYSTEMS> <PACKAGE ...> [options])\n"
+"\n"
+"options:\n"
+"    -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:972
+msgid "system_upgradepackage: Upgrade a package on a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:973
+msgid ""
+"usage: system_upgradepackage <SYSTEMS> <PACKAGE ...>|* [options]')\n"
+"\n"
+"options:\n"
+"    -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1051 ../src/spacecmd/system.py:1147
+#, python-format
+msgid "No upgrades available for %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1074
+#, python-format
+msgid "Couldn't get name for package %i"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1081
+msgid "Upgrade these packages [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1106
+msgid "system_listupgrades: List the available upgrades for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1107
+msgid "usage: system_listupgrades <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1175
+msgid "system_listinstalledpackages: List the installed packages on a"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1176
+msgid "                              system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1177
+msgid "usage: system_listinstalledpackages <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1231
+msgid "system_listconfigchannels: List the config channels of a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1232
+msgid "usage: system_listconfigchannels <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1278 ../src/spacecmd/system.py:1381
+#, python-format
+msgid "%s does not support configuration channels"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1315
+msgid "system_listconfigfiles: List the managed config files of a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1316
+msgid ""
+"usage: system_listconfigfiles <SYSTEMS>')\n"
+"options:\n"
+"  -s/--sandbox : list only system-sandbox files\n"
+"  -l/--local   : list only locally managed files\n"
+"  -c/--central : list only centrally managed files\n"
+"  -q/--quiet   : quiet mode (omits the header)"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1416
+msgid "system_addconfigfile: Create a configuration file"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1417
+msgid "Note this is only for system sandbox or locally-managed files"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1418
+msgid "Centrally managed files should be created via configchannel_addfile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1419
+msgid ""
+"usage: system_addconfigfile [SYSTEM] [options]\n"
+"\n"
+"options:\n"
+"  -S/--sandbox : list only system-sandbox files\n"
+"  -L/--local   : list only locally managed files\n"
+"  -p PATH\n"
+"  -r REVISION\n"
+"  -o OWNER [default: root]\n"
+"  -g GROUP [default: root]\n"
+"  -m MODE [defualt: 0644]\n"
+"  -x SELINUX_CONTEXT\n"
+"  -d path is a directory\n"
+"  -s path is a symlink\n"
+"  -b path is a binary (or other file which needs base64 encoding)\n"
+"  -t SYMLINK_TARGET\n"
+"  -f local path to file contents\n"
+"\n"
+"  Note re binary/base64: Some text files, notably those containing trailing\n"
+"  newlines, those containing ASCII escape characters (or other charaters "
+"not\n"
+"  allowed in XML) need to be sent as binary (-b).  Some effort is made to "
+"auto-\n"
+"  detect files which require this, but you may need to explicitly specify.\n"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1487
+#, python-format
+msgid "%s is not a valid system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1497
+msgid "System-Sandbox or Locally-Managed? [S/L]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1513
+msgid "Must choose system-sandbox or locally-managed option"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1552
+msgid "system_addconfigchannels: Add config channels to a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1553
+msgid ""
+"usage: system_addconfigchannels <SYSTEMS> <CHANNEL ...> [options]\n"
+"\n"
+"options:\n"
+"  -t add channels to the top of the list\n"
+"  -b add channels to the bottom of the list"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1597
+msgid "Add to top or bottom? [T/b]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1621
+msgid "system_removeconfigchannels: Remove config channels from a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1622
+msgid "usage: system_removeconfigchannels <SYSTEMS> <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1671
+msgid ""
+"system_setconfigchannelorder: Set the ranked order of configuration channels"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1672
+msgid "usage: system_setconfigchannelorder <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1712
+msgid "New Configuration Channels"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1732
+msgid "system_deployconfigfiles: Deploy all configuration files for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1733
+msgid ""
+"usage: system_deployconfigfiles <SYSTEMS> [options]\n"
+"\n"
+"options:\n"
+"    -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1787
+msgid "Deploy ALL configuration files to these systems [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1797
+#, python-format
+msgid "Scheduled deployment for %i system(s)"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1805
+msgid "system_delete: Delete a system profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1806
+msgid ""
+"usage: system_delete [options] <SYSTEMS>\n"
+"\n"
+"    options:\n"
+"          -c TYPE - Possible values:\n"
+"             *  'FAIL_ON_CLEANUP_ERR' - fail in case of cleanup error,\n"
+"             *  'NO_CLEANUP' - do not cleanup, just delete,\n"
+"             *  'FORCE_DELETE' - Try cleanup first but delete server anyway "
+"in case of error\n"
+"    "
+msgstr ""
+
+#: ../src/spacecmd/system.py:1850
+msgid "No systems to delete"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1858
+#, python-format
+msgid "%s  System ID"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1858
+msgid "Profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1866
+msgid "Delete these systems [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1873
+#, python-format
+msgid "%i system(s) scheduled for removal"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1893
+msgid "system_lock: Lock a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1894
+msgid "usage: system_lock <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1935
+msgid "system_unlock: Unlock a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1936
+msgid "usage: system_unlock <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1977
+msgid "system_rename: Rename a system profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1978
+msgid "usage: system_rename OLDNAME NEWNAME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2023
+msgid "system_listcustomvalues: List the custom values for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2024
+msgid "usage: system_listcustomvalues <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2079
+msgid "system_addcustomvalue: Set a custom value for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2080
+msgid "usage: system_addcustomvalue KEY VALUE <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2134
+msgid "system_updatecustomvalue: Update a custom value for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2135
+msgid "usage: system_updatecustomvalue KEY VALUE <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2166
+msgid "system_removecustomvalues: Remove a custom value for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2167
+msgid "usage: system_removecustomvalues <SYSTEMS> <KEY ...>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2203
+msgid "Delete these values [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2221
+msgid "system_addnote: Set a note for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2222
+msgid ""
+"usage: system_addnote <SYSTEM> [options]\n"
+"\n"
+"options:\n"
+"  -s SUBJECT\n"
+"  -b BODY"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2257
+msgid "Subject of the Note:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2259
+msgid "Note Body (ctrl-D to finish):"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2263
+msgid "A subject is required"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2267
+msgid "A body is required"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2286
+msgid "system_deletenotes: Delete notes from a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2287
+msgid "usage: system_deletenotes <SYSTEM> <ID|*>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2319
+msgid "No notes to delete"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2346
+msgid "system_listnotes: List the available notes for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2347
+msgid "usage: system_listnotes <SYSTEM>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2405
+msgid "system_listfqdns: List the associated FQDNs for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2406
+msgid "usage: system_listfqdns <SYSTEM>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2458
+msgid "system_setbasechannel: Set a system's base software channel"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2459
+msgid "usage: system_setbasechannel <SYSTEMS> CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2506 ../src/spacecmd/system.py:2593
+#, python-format
+msgid "System:           %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2507 ../src/spacecmd/system.py:2594
+#, python-format
+msgid "Old Base Channel: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2508 ../src/spacecmd/system.py:2596
+#, python-format
+msgid "New Base Channel: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2527
+msgid ""
+"system_schedulechangechannels: Schedule changing a system's software channels"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2528
+msgid ""
+"usage: system_setbasechannel <SYSTEMS> [options]\n"
+"\n"
+"options:\n"
+"  -b BASE_CHANNEL base channel label\n"
+"  -c CHILD_CHANNEL child channel labels (allowed multiple times)\n"
+"  -s START_TIME time defaults to now"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2595
+#, python-format
+msgid "Old Child Channels: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2597
+#, python-format
+msgid "New Child channels %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2612 ../src/spacecmd/system.py:4243
+#, python-format
+msgid "Scheduled action id: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2619
+msgid "system_listbasechannel: List the base channel for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2620
+msgid "usage: system_listbasechannel <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2674
+msgid "system_listchildchannels: List the child channels for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2675
+msgid "usage: system_listchildchannels <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2729
+msgid "system_addchildchannels: Add child channels to a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2730
+msgid "usage: system_addchildchannels <SYSTEMS> <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2752
+msgid ""
+"system_listcrashedsystems: List all systems that have experienced a crash "
+"and reported by spacewalk-abrt"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2753
+msgid "usage: system_listcrashedsystems"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2759
+msgid "Count | System ID | Profile Name"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2773
+msgid "system_deletecrashes: Delete crashes reported by spacewalk-abrt."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2774
+msgid ""
+"usage: Delete all crashes for all systems    : system_deletecrashes [--"
+"verbose]"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2775
+msgid ""
+"usage: Delete all crashes for a single system: system_deletecrashes -i "
+"sys_id [--verbose]"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2776
+msgid ""
+"usage: Delete a single crash record          : system_deletecrashes -c "
+"crash_id [--verbose]"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2794
+#, python-format
+msgid "Deleting crash with id %s."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2801
+#, python-format
+msgid "Deleting all crashes from system with systemid %s [y/N]:"
+msgstr ""
+
+#. all systems
+#: ../src/spacecmd/system.py:2803
+msgid "Deleting all crashes from all systems [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2815
+#, python-format
+msgid "Deleting crash with id %s from system %s."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2824
+msgid "system_listcrashesbysystem: List all reported crashes for a system."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2825 ../src/spacecmd/system.py:2837
+msgid "usage: system_listcrashesbysystem -i sys_id"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2836
+msgid "# System id must be provided."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2842
+msgid "Crash ID | Crash Name"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2853
+msgid "system_getcrashfiles: Download all files for a crash record."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2854
+msgid "usage: system_getcrashfiles -c crash_id [--verbose]"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2855 ../src/spacecmd/system.py:2869
+msgid ""
+"usage: system_getcrashfiles -c crash_id [--dest_folder=/tmp/crash_files] [--"
+"verbose]"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2868
+msgid "# Crash id must be provided."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2895
+#, python-format
+msgid "# All files we downloaded to %s."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2904
+msgid "system_removechildchannels: Remove child channels from a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2905
+msgid "usage: system_removechildchannels <SYSTEMS> <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2927
+msgid "system_details: Show the details of a system profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2928
+msgid "usage: system_details <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2981
+#, python-format
+msgid "Name:          %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2982
+#, python-format
+msgid "System ID:     %i"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2985
+#, python-format
+msgid "UUID:          %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2987
+#, python-format
+msgid "Locked:        %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2988
+#, python-format
+msgid "Registered:    %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2989
+#, python-format
+msgid "Last Checkin:  %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2990
+#, python-format
+msgid "OSA Status:    %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2991
+#, python-format
+msgid "Last Boot:     %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2993
+#, python-format
+msgid "Contact Method:%s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3037
+#, python-format
+msgid "Hostname:      %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3038
+#, python-format
+msgid "IP Address:    %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3039
+#, python-format
+msgid "Kernel:        %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3080
+msgid "system_listerrata: List available errata for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3081
+msgid "usage: system_listerrata <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3135
+msgid "system_applyerrata: Apply errata to a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3136
+msgid ""
+"usage: system_applyerrata [options] <SYSTEMS>\n"
+"[ERRATA|search:XXX ...]\n"
+"\n"
+"options:\n"
+"  -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3197
+msgid "system_listevents: List the event history for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3198
+msgid "usage: system_listevents <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3244
+#, python-format
+msgid "Summary:   %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3246
+#, python-format
+msgid "Details:   %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3254
+msgid "system_listentitlements: List the entitlements for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3255
+msgid "usage: system_listentitlements <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3308
+msgid "system_addentitlements: Add entitlements to a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3309
+msgid "usage: system_addentitlements <SYSTEMS> ENTITLEMENT"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3364
+msgid "system_removeentitlement: Remove an entitlement from a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3365
+msgid "usage: system_removeentitlement <SYSTEMS> ENTITLEMENT"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3420
+msgid "system_listpackageprofiles: List all package profiles"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3421
+msgid "usage: system_listpackageprofiles"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3440
+msgid "system_deletepackageprofile: Delete a package profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3441
+msgid "usage: system_deletepackageprofile PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3465
+msgid "Delete this profile [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3476
+#, python-format
+msgid "%s is not a valid profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3487
+msgid "system_createpackageprofile: Create a package profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3488
+msgid ""
+"usage: system_createpackageprofile SYSTEM [options]\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -d DESCRIPTION"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3518
+msgid "Profile Label:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3522
+msgid "A profile name is required"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3526
+msgid "A profile description is required"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3534
+#, python-format
+msgid "Created package profile '%s'"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3542
+msgid ""
+"system_comparepackageprofile: Compare a system against a package profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3543
+msgid "usage: system_comparepackageprofile <SYSTEMS> PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3606
+msgid "system_comparepackages: Compare the packages between two systems"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3607
+msgid "usage: system_comparepackages SOME_SYSTEM ANOTHER_SYSTEM"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3638
+msgid "system_syncpackages: Sync packages between two systems"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3639
+msgid ""
+"usage: system_syncpackages SOURCE TARGET [options]\n"
+"\n"
+"options:\n"
+"    -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3687
+msgid "Sync packages [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3729
+#, python-format
+msgid "Failed to filter package list, package %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3730
+msgid "found with no arch or arch_label"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3772
+msgid "System Version"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3773
+msgid "Channel Version"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3795
+msgid "Channel_newer_than_system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3808
+msgid "System_newer_than_channel"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3817
+msgid "Missing_in_channel"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3821
+msgid "system_comparewithchannel: Compare the installed packages on a"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3822
+msgid "                           system with those in the channels it is"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3823
+msgid "                           registerd to, or optionally some other"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3824
+msgid "                           channel"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3825
+msgid "usage: system_comparewithchannel <SYSTEMS> [options]"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3827
+msgid "         -c/--channel : Specific channel to compare against,"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3828
+msgid "                        default is those subscribed to, including"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3829
+msgid "                        child channels"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3880
+msgid "Specified channel does not exist"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3891
+#, python-format
+msgid "system %s is not subscribed to any channel!"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3893
+msgid "Please subscribe to a channel, or specify achannel to compare with"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3927
+#, python-format
+msgid ""
+"\n"
+"System: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3953
+msgid ""
+"system_schedulehardwarerefresh: Schedule a hardware refresh for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3954
+msgid ""
+"usage: system_schedulehardwarerefresh <SYSTEMS> [options]\n"
+"\n"
+"options:\n"
+"  -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4016
+msgid ""
+"system_schedulepackagerefresh: Schedule a software package refresh for a "
+"system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4017
+msgid ""
+"usage: system_schedulepackagerefresh <SYSTEMS> [options])\n"
+"\n"
+"options:\n"
+"  -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4078
+msgid ""
+"system_show_packageversion: Shows version of installed package on given "
+"system(s)"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4079
+msgid "usage: system_show_packageversion <SYSTEM> <PACKAGE>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4111
+msgid "Package\tVersion\tRelease\tEpoch\tArch\tSystem"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4131
+msgid "system_setcontactmethod: Set the contact method for given system(s)."
+msgstr ""
+
+#: ../src/spacecmd/system.py:4133
+msgid "usage: system_setcontactmethod <SYSTEMS> <CONTACT_METHOD>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4182
+msgid ""
+"system_scheduleapplyconfigchannels: Schedule applying the assigned config "
+"channels to the System (Minion only)"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4183
+msgid ""
+"usage: scheduleapplyconfigchannels <SYSTEMS> [options]\n"
+"\n"
+"    options:\n"
+"        -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4234
+msgid "Schedule applying config channels to these systems [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4251
+msgid ""
+"system_listmigrationtargets: List possible migration targets for given "
+"systems."
+msgstr ""
+
+#: ../src/spacecmd/system.py:4252
+msgid "usage: system_listmigrationtargets <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4279
+msgid "WARN: Cannot find system "
+msgstr ""
+
+#: ../src/spacecmd/system.py:4286
+msgid "  No migration targets"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4289
+msgid "  Target #"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4290
+msgid "    IDs: "
+msgstr ""
+
+#: ../src/spacecmd/system.py:4291
+msgid "    Friendly names: "
+msgstr ""
+
+#: ../src/spacecmd/system.py:4297
+msgid ""
+"system_schedulespmigration: Schedule a Service Pack migration for systems."
+msgstr ""
+
+#: ../src/spacecmd/system.py:4298
+msgid ""
+"usage: system_schedulespmigration <SYSTEM> <BASE_CHANNEL_LABEL> "
+"<MIGRATION_TARGET> [options] \n"
+"    For MIGRATION_TARGET parameter see system_listmigrationtargets. \n"
+"    The MIGRATION_TARGET parameter must be passed in the following format: "
+"[3143,3146,3147,3145,3144,3148,3062]. \n"
+"    Options: \n"
+"        -s START_TIME \n"
+"        -d pass this flag, if you want to do a dry run \n"
+"        -c CHILD_CHANNELS (comma-separated child channels labels (with no "
+"spaces))"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4348
+msgid "Cannot find system "
+msgstr ""
+
+#: ../src/spacecmd/system.py:4348
+msgid ". Skipping it."
+msgstr ""
+
+#: ../src/spacecmd/system.py:4351
+msgid "Scheduling Service Pack migration for system "
+msgstr ""
+
+#: ../src/spacecmd/system.py:4356
+msgid "Scheduled action ID: "
+msgstr ""
+
+#: ../src/spacecmd/user.py:49
+msgid "user_create: Create an user"
+msgstr ""
+
+#: ../src/spacecmd/user.py:50
+msgid ""
+"usage: user_create [options])\n"
+"\n"
+"options:\n"
+"  -u USERNAME\n"
+"  -f FIRST_NAME\n"
+"  -l LAST_NAME\n"
+"  -e EMAIL\n"
+"  -p PASSWORD\n"
+"  --pam enable PAM authentication"
+msgstr ""
+
+#: ../src/spacecmd/user.py:119
+msgid "Note: password was ignored due to PAM mode"
+msgstr ""
+
+#: ../src/spacecmd/user.py:138
+msgid "user_delete: Delete an user"
+msgstr ""
+
+#: ../src/spacecmd/user.py:139
+msgid "usage: user_delete NAME"
+msgstr ""
+
+#: ../src/spacecmd/user.py:167
+msgid "user_disable: Disable an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:168
+msgid "usage: user_disable NAME"
+msgstr ""
+
+#: ../src/spacecmd/user.py:194
+msgid "user_enable: Enable an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:195
+msgid "usage: user_enable NAME"
+msgstr ""
+
+#: ../src/spacecmd/user.py:221
+msgid "user_list: List all users"
+msgstr ""
+
+#: ../src/spacecmd/user.py:222
+msgid "usage: user_list"
+msgstr ""
+
+#: ../src/spacecmd/user.py:239
+msgid "user_listavailableroles: List all available roles for users"
+msgstr ""
+
+#: ../src/spacecmd/user.py:240
+msgid "usage: user_listavailableroles"
+msgstr ""
+
+#: ../src/spacecmd/user.py:252
+msgid "No roles has been found"
+msgstr ""
+
+#: ../src/spacecmd/user.py:258
+msgid "user_addrole: Add a role to an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:259
+msgid "usage: user_addrole USER ROLE"
+msgstr ""
+
+#: ../src/spacecmd/user.py:292
+msgid "user_removerole: Remove a role from an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:293
+msgid "usage: user_removerole USER ROLE"
+msgstr ""
+
+#: ../src/spacecmd/user.py:327
+msgid "user_details: Show the details of an user"
+msgstr ""
+
+#: ../src/spacecmd/user.py:328
+msgid "usage: user_details USER ..."
+msgstr ""
+
+#: ../src/spacecmd/user.py:360
+#, python-format
+msgid "%s is not a valid user"
+msgstr ""
+
+#: ../src/spacecmd/user.py:361
+msgid "Error '{}' while getting data about user '{}': {}"
+msgstr ""
+
+#: ../src/spacecmd/user.py:371
+#, python-format
+msgid "Username:      %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:372
+#, python-format
+msgid "First Name:    %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:373
+#, python-format
+msgid "Last Name:     %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:374
+#, python-format
+msgid "Email Address: %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:375
+#, python-format
+msgid "Organisation:  %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:376
+#, python-format
+msgid "Last Login:    %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:377
+#, python-format
+msgid "Created:       %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:378
+#, python-format
+msgid "Enabled:       %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:382
+msgid "Roles"
+msgstr ""
+
+#: ../src/spacecmd/user.py:388
+msgid "Assigned Groups"
+msgstr ""
+
+#: ../src/spacecmd/user.py:394
+msgid "Default Groups"
+msgstr ""
+
+#: ../src/spacecmd/user.py:404
+msgid "user_addgroup: Add a group to an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:405
+msgid "usage: user_addgroup USER <GROUP ...>"
+msgstr ""
+
+#: ../src/spacecmd/user.py:442
+msgid "user_adddefaultgroup: Add a default group to an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:443
+msgid "usage: user_adddefaultgroup USER <GROUP ...>"
+msgstr ""
+
+#: ../src/spacecmd/user.py:479
+msgid "user_removegroup: Remove a group to an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:480
+msgid "usage: user_removegroup USER <GROUP ...>"
+msgstr ""
+
+#: ../src/spacecmd/user.py:520
+msgid "user_removedefaultgroup: Remove a default group from an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:522
+msgid "usage: user_removedefaultgroup USER <GROUP ...>"
+msgstr ""
+
+#: ../src/spacecmd/user.py:561
+msgid "user_setfirstname: Set an user accounts first name field"
+msgstr ""
+
+#: ../src/spacecmd/user.py:562
+msgid "usage: user_setfirstname USER FIRST_NAME"
+msgstr ""
+
+#: ../src/spacecmd/user.py:596
+msgid "user_setlastname: Set an user accounts last name field"
+msgstr ""
+
+#: ../src/spacecmd/user.py:597
+msgid "usage: user_setlastname USER LAST_NAME"
+msgstr ""
+
+#: ../src/spacecmd/user.py:631
+msgid "user_setemail: Set an user accounts email field"
+msgstr ""
+
+#: ../src/spacecmd/user.py:632
+msgid "usage: user_setemail USER EMAIL"
+msgstr ""
+
+#: ../src/spacecmd/user.py:666
+msgid "user_setprefix: Set an user accounts name prefix field"
+msgstr ""
+
+#: ../src/spacecmd/user.py:667
+msgid "usage: user_setprefix USER PREFIX"
+msgstr ""
+
+#: ../src/spacecmd/user.py:706
+msgid "user_setpassword: Set an user accounts name prefix field"
+msgstr ""
+
+#: ../src/spacecmd/user.py:707
+msgid "usage: user_setpassword USER PASSWORD"
+msgstr ""
+
+#. If cache generation is interrupted (e.g by ctrl-c) you can end up
+#. with an EOFError exception due to the partial picked file
+#. So we catch this error and remove the corrupt partial file
+#. If you don't do this then spacecmd will fail with an unhandled
+#. exception until the partial file is manually removed
+#: ../src/spacecmd/utils.py:133
+#, python-format
+msgid "Loading cache file %s failed"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:134
+#, python-format
+msgid "Cache generation was probably interrupted,removing corrupt %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:139
+#, python-format
+msgid "Couldn't load cache from %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:160
+#, python-format
+msgid "Couldn't write to %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:205
+msgid "Could not open the temporary file"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:225
+#, python-format
+msgid "Editor \"%s\" exited with code %i"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:227
+#, python-format
+msgid "General failure running editor: %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:230
+msgid "No editors found"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:367
+msgid "Invalid time provided"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:463
+msgid "Security Errata"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:472
+msgid "Bug Fix Errata"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:481
+msgid "Enhancement Errata"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:491
+msgid "Current Selections"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:501
+msgid "Available Configuration Channels"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:507 ../src/spacecmd/utils.py:527
+msgid "Channel:"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:510 ../src/spacecmd/utils.py:530
+msgid "Invalid channel"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:514
+msgid "New Rank:"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:521 ../src/spacecmd/utils.py:524
+msgid "Invalid rank"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:535
+msgid "Clearing current selections"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:690
+msgid "Could not generate json data object!"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:697
+#, python-format
+msgid "Could not open file %s for writing: %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:708
+#, python-format
+msgid "Could not open file %s for reading: %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:710
+#, python-format
+msgid "Could not parse JSON data from %s: %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:712
+#, python-format
+msgid "Error processing file %s: %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:740
+msgid "Skipping usage of common strings: both strings are equal"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:756
+msgid "Skipping usage of common strings: number of substrings differ"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:842
+msgid "Parameter {} not a string type, but {}."
+msgstr ""
+
+#: ../src/bin/spacecmd:74
+msgid "Unhandled exception occurred while getting FQDN:"
+msgstr ""

--- a/spacecmd/po/it.po
+++ b/spacecmd/po/it.po
@@ -1,0 +1,7456 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#: ../src/bin/spacecmd:59
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-09-24 17:29+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../src/spacecmd/activationkey.py:49
+msgid "activationkey_addpackages: Add packages to an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:50
+msgid "usage: activationkey_addpackages KEY <PACKAGE ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:83
+msgid "activationkey_removepackages: Remove packages from an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:85
+msgid "usage: activationkey_removepackages KEY <PACKAGE ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:121
+msgid "activationkey_addgroups: Add groups to an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:122
+msgid "usage: activationkey_addgroups KEY <GROUP ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:160
+msgid "activationkey_removegroups: Remove groups from an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:161
+msgid "usage: activationkey_removegroups KEY <GROUP ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:208
+msgid "activationkey_addentitlements: Add entitlements to an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:210
+msgid "usage: activationkey_addentitlements KEY <ENTITLEMENT ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:245
+msgid ""
+"activationkey_removeentitlements: Remove entitlements from an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:247
+msgid "usage: activationkey_removeentitlements KEY <ENTITLEMENT ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:285
+msgid "activationkey_addchildchannels: Add child channels to an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:287
+msgid "usage: activationkey_addchildchannels KEY <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:337
+msgid ""
+"activationkey_removechildchannels: Remove child channels from an activation "
+"key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:339
+msgid "usage: activationkey_removechildchannels KEY <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:376
+msgid ""
+"activationkey_listchildchannels: List the child channels for an activation "
+"key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:378
+msgid "usage: activationkey_listchildchannels KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:407
+msgid ""
+"activationkey_listbasechannel: List the base channels for an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:409
+msgid "usage: activationkey_listbasechannel KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:437
+msgid "activationkey_listgroups: List the groups for an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:439
+msgid "usage: activationkey_listgroups KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:470
+msgid ""
+"activationkey_listentitlements: List the entitlements for an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:472
+msgid "usage: activationkey_listentitlements KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:501
+msgid "activationkey_listpackages: List the packages for an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:503
+msgid "usage: activationkey_listpackages KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:535
+msgid ""
+"activationkey_listconfigchannels: List the configuration channels for an "
+"activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:537
+msgid "usage: activationkey_listconfigchannels KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:570
+msgid ""
+"activationkey_addconfigchannels: Add config channels to an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:572
+msgid ""
+"usage: activationkey_addconfigchannels KEY <CHANNEL ...> [options])\n"
+"\n"
+"options:\n"
+"  -t add channels to the top of the list\n"
+"  -b add channels to the bottom of the list"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:625
+msgid ""
+"activationkey_removeconfigchannels: Remove config channels from an "
+"activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:627
+msgid "usage: activationkey_removeconfigchannels KEY <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:666
+msgid ""
+"activationkey_setconfigchannelorder: Set the ranked order of configuration "
+"channels"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:668
+msgid "usage: activationkey_setconfigchannelorder KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:698
+msgid "New Configuration Channels:"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:712
+msgid "activationkey_create: Create an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:713
+msgid ""
+"usage: activationkey_create [options])\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -d DESCRIPTION\n"
+"  -b BASE_CHANNEL\n"
+"  -u set key as universal default\n"
+"  -e [enterprise_entitled,virtualization_host]"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:734
+msgid "Name (blank to autogenerate):"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:735
+msgid "Description [None]:"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:738 ../src/spacecmd/distribution.py:78
+#: ../src/spacecmd/softwarechannel.py:927
+msgid "Base Channels"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:743
+msgid "Base Channel (blank for default):"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:751
+#, python-format
+msgid "%s Entitlement [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:755
+msgid "Universal Default [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:782
+#, python-format
+msgid "Created activation key %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:790
+msgid "activationkey_delete: Delete an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:791
+msgid "usage: activationkey_delete KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:813 ../src/spacecmd/cryptokey.py:139
+#: ../src/spacecmd/cryptokey.py:197
+#, python-format
+msgid "No keys matched argument %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:819
+msgid "Delete activation key(s) [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:832
+msgid "activationkey_list: List all activation keys"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:833
+msgid "usage: activationkey_list"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:857
+msgid "activationkey_listsystems: List systems registered with a key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:858
+msgid "usage: activationkey_listsystems KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:881 ../src/spacecmd/activationkey.py:930
+#, python-format
+msgid "%s is not a valid activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:895
+msgid "activationkey_details: Show the details of an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:896
+msgid "usage: activationkey_details KEY ..."
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:943
+#, python-format
+msgid "Key:                    %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:944
+#, python-format
+msgid "Description:            %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:945
+#, python-format
+msgid "Universal Default:      %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:946
+#, python-format
+msgid "Usage Limit:            %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:947
+#, python-format
+msgid "Deploy Config Channels: %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:949
+#, python-format
+msgid "Contact Method:         %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:952 ../src/spacecmd/kickstart.py:425
+#: ../src/spacecmd/system.py:3048
+msgid "Software Channels"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:960 ../src/spacecmd/configchannel.py:765
+#: ../src/spacecmd/configchannel.py:870 ../src/spacecmd/system.py:3057
+msgid "Configuration Channels"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:966 ../src/spacecmd/system.py:3062
+msgid "Entitlements"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:971 ../src/spacecmd/system.py:3068
+msgid "System Groups"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:976 ../src/spacecmd/package.py:206
+#: ../src/spacecmd/package.py:263 ../src/spacecmd/softwarechannel.py:1392
+#: ../src/spacecmd/softwarechannel.py:1494
+#: ../src/spacecmd/softwarechannel.py:1576
+#: ../src/spacecmd/softwarechannel.py:1822
+msgid "Packages"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:991
+msgid "activationkey_enableconfigdeployment: Enable config channel deployment"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:993
+msgid "usage: activationkey_enableconfigdeployment KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1020
+msgid ""
+"activationkey_disableconfigdeployment: Disable config channel deployment"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1022
+msgid "usage: activationkey_disableconfigdeployment KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1049
+msgid "activationkey_setbasechannel: Set the base channel of an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1051
+msgid "usage: activationkey_setbasechannel KEY CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1098
+msgid ""
+"activationkey_setusagelimit: Set the usage limit of an activation key, can "
+"be a number or \"unlimited\""
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1100
+msgid "usage: activationkey_setusagelimit KEY <usage limit>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1101
+msgid "usage: activationkey_setusagelimit KEY unlimited "
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1131
+#, python-format
+msgid "Couldn't convert argument %s to an integer"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1153
+msgid ""
+"activationkey_setuniversaldefault: Set this key as the universal default"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1155
+msgid "usage: activationkey_setuniversaldefault KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1196
+msgid "activationkey_export: Export activation key(s) to JSON format file"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1197
+msgid ""
+"usage: activationkey_export [options] [<KEY> ...])\n"
+"\n"
+"options:\n"
+"    -f outfile.json : specify an output filename, defaults to <KEY>.json\n"
+"                      if exporting a single key, akeys.json for multiple "
+"keys,\n"
+"                      or akey_all.json if no KEY specified (export ALL)\n"
+"\n"
+"Note : KEY list is optional, default is to export ALL keys "
+msgstr ""
+
+#. Get the key details
+#: ../src/spacecmd/activationkey.py:1213
+#, python-format
+msgid "Getting activation key details for %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1267
+#, python-format
+msgid "Exporting ALL activation keys to %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1276
+msgid "Invalid activation key passed"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1291
+#, python-format
+msgid "Exporting key %s to %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1300
+#, python-format
+msgid "File %s exists, confirm overwrite file? (y/n)"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1305
+msgid "Failed to save exported keys to file: {}"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1314
+msgid "activationkey_import: import activation key(s) from JSON file(s)"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1315
+msgid "usage: activationkey_import <JSONFILE ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1324
+msgid "No filename passed"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1333
+#, python-format
+msgid "Could not read json data from %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1338 ../src/spacecmd/activationkey.py:1382
+#, python-format
+msgid "Failed to import key %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1352
+#, python-format
+msgid "%s already exists! Skipping!"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1407
+#, python-format
+msgid "System group %s doesn't exist, creating"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1428
+msgid "activationkey_clone: Clone an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1429
+msgid ""
+"usage examples:\n"
+"                 activationkey_clone foo_key -c bar_key\n"
+"                 activationkey_clone foo_key1 foo_key2 -c prefix\n"
+"                 activationkey_clone foo_key -x \"s/foo/bar\"\n"
+"                 activationkey_clone foo_key1 foo_key2 -x \"s/foo/bar\"\n"
+"\n"
+"options:\n"
+"  -c CLONE_NAME  : Name of the resulting key, treated as a prefix for "
+"multiple\n"
+"                   keys\n"
+"  -x \"s/foo/bar\" : Optional regex replacement, replaces foo with bar in "
+"the\n"
+"                   clone description, base-channel label, child-channel\n"
+"                   labels, config-channel names "
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1457 ../src/spacecmd/kickstart.py:460
+#: ../src/spacecmd/system.py:3043
+msgid "Activation Keys"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1463
+#, python-format
+msgid "Key to clone: %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1467
+msgid "Original Key:"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1469
+msgid "Cloned Key:"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1472 ../src/spacecmd/configchannel.py:1376
+msgid "Error - must specify either -c or -x options!"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1477
+#, python-format
+msgid "Key %s already exists"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1481
+msgid "Error no activationkey to clone passed!"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1535
+#, python-format
+msgid "Found child channel %s key %s, %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1537
+msgid " does not exist, skipping!"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1544
+#, python-format
+msgid "Regex-replacement results in new base-channel %s which does not exist!"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1560
+#, python-format
+msgid "Found config channel %s for key %s, %s "
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1562
+msgid "does not exist, skipping!"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1584 ../src/spacecmd/configchannel.py:1428
+#, python-format
+msgid "Failed to clone %s to %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1602
+msgid "no activationkey label given"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1605
+msgid "invalid activationkey label "
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1622
+msgid "activationkey_diff: Diff activation keys"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1624
+msgid "usage: activationkey_diff SOURCE_KEY TARGET_KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1673
+msgid "activationkey_disable: Disable an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1675
+msgid "usage: activationkey_disable KEY [KEY ...]"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1707
+msgid "activationkey_enable: Enable an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1709
+msgid "usage: activationkey_enable KEY [KEY ...]"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1741
+msgid "activationkey_setdescription: Set the activation key description"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1743
+msgid "usage: activationkey_setdescription KEY DESCRIPTION"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1775
+msgid ""
+"activationkey_setcontactmethod: Set the contact method to use for systems "
+"registered with this key."
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1777 ../src/spacecmd/system.py:4132
+msgid "Available contact methods: "
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1778
+msgid "usage: activationkey_setcontactmethod KEY CONTACT_METHOD"
+msgstr ""
+
+#: ../src/spacecmd/api.py:44
+msgid "api: call RHN API with arguments directly"
+msgstr ""
+
+#: ../src/spacecmd/api.py:45
+#, python-format
+msgid ""
+"usage: api [options] API_STRING)\n"
+"\n"
+"options:\n"
+"  -A, --args  Arguments for the API other than session id in comma "
+"separated\n"
+"              strings or JSON expression\n"
+"  -F, --format   Output format\n"
+"  -o, --output   Output file\n"
+"\n"
+"examples:\n"
+"  api api.getApiCallList\n"
+"  api --args \"sysgroup_A\" systemgroup.listSystems\n"
+"  api -A \"rhel-i386-server-5,2011-04-01,2011-05-01\" -F \"%(name)s\" \\\n"
+"      channel.software.listAllPackages\n"
+msgstr ""
+
+#: ../src/spacecmd/api.py:81
+msgid "Could not open to write: "
+msgstr ""
+
+#: ../src/spacecmd/api.py:82
+msgid "Fallback output to stdout"
+msgstr ""
+
+#: ../src/spacecmd/api.py:91
+msgid "No such API: "
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:50
+msgid "configchannel_list: List all configuration channels"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:51
+msgid "usage: configchannel_list"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:68
+msgid "configchannel_listsystems: List the systems subscribed to a"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:69
+msgid "                           configuration channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:70
+msgid "usage: configchannel_listsystems CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:79
+msgid "This version of the API doesn't support this method"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:103
+msgid "configchannel_listfiles: List the files in a config channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:104
+msgid "usage: configchannel_listfiles CHANNEL ..."
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:133
+msgid "configchannel_forcedeploy: Forces a redeployment"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:134
+msgid "                           of files within this channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:135
+msgid "                           on all subscribed systems"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:136
+msgid "usage: configchannel_forcedeploy CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:158
+msgid "No files within selected configchannel."
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:164
+msgid "Channel has no subscribed Systems"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:167
+msgid "Force deployment of the following configfiles:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:170
+msgid ""
+"\n"
+"On these systems:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:173
+msgid "Really force deployment [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:182
+msgid "configchannel_filedetails: Show the details of a file"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:183
+msgid "in a configuration channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:184
+msgid "usage: configchannel_filedetails CHANNEL FILE [REVISION]"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:216
+#, python-format
+msgid "Invalid revision: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:222
+#, python-format
+msgid "%s is not in this configuration channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:240
+#, python-format
+msgid "Path:     %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:241
+#, python-format
+msgid "Type:     %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:242
+#, python-format
+msgid "Revision: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:243
+#, python-format
+msgid "Created:  %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:244
+#, python-format
+msgid "Modified: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:248 ../src/spacecmd/configchannel.py:650
+#, python-format
+msgid "Target Path:     %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:251 ../src/spacecmd/configchannel.py:680
+#, python-format
+msgid "Owner:           %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:252 ../src/spacecmd/configchannel.py:681
+#, python-format
+msgid "Group:           %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:253 ../src/spacecmd/configchannel.py:682
+#, python-format
+msgid "Mode:            %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:255 ../src/spacecmd/configchannel.py:651
+#: ../src/spacecmd/configchannel.py:684
+#, python-format
+msgid "SELinux Context: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:258
+#, python-format
+msgid "SHA256:          %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:259 ../src/spacecmd/configchannel.py:683
+#, python-format
+msgid "Binary:          %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:263 ../src/spacecmd/configchannel.py:696
+#: ../src/spacecmd/configchannel.py:933 ../src/spacecmd/kickstart.py:1903
+#: ../src/spacecmd/snippet.py:161
+msgid "Contents"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:273
+msgid "configchannel_backup: backup a config channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:274
+msgid ""
+"usage: configchannel_backup CHANNEL [OUTDIR])\n"
+"\n"
+"OUTDIR defaults to $HOME/spacecmd-backup/configchannel/YYYY-MM-DD/CHANNEL\n"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:313 ../src/spacecmd/group.py:266
+#, python-format
+msgid "Could not create output directory: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:326
+#, python-format
+msgid "Could not create \"%s\" file: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:332
+#, python-format
+msgid "Output Path:   %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:371
+msgid "configchannel_details: Show the details of a config channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:372
+msgid "usage: configchannel_details CHANNEL ..."
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:402 ../src/spacecmd/kickstart.py:414
+#, python-format
+msgid "Label:       %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:403 ../src/spacecmd/kickstart.py:413
+#, python-format
+msgid "Name:        %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:404 ../src/spacecmd/cryptokey.py:214
+#: ../src/spacecmd/system.py:678
+#, python-format
+msgid "Description: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:405 ../src/spacecmd/cryptokey.py:215
+#: ../src/spacecmd/kickstart.py:500 ../src/spacecmd/kickstart.py:1899
+#, python-format
+msgid "Type:        %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:408
+msgid "Files"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:418
+msgid "configchannel_create: Create a configuration channel of specific type"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:419
+msgid ""
+"usage: configchannel_create [options])\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -l LABEL\n"
+"  -d DESCRIPTION\n"
+"  -t TYPE('normal,'state')"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:438 ../src/spacecmd/custominfo.py:54
+#: ../src/spacecmd/custominfo.py:198 ../src/spacecmd/distribution.py:71
+#: ../src/spacecmd/filepreservation.py:70 ../src/spacecmd/group.py:177
+#: ../src/spacecmd/repo.py:349 ../src/spacecmd/repo.py:461
+#: ../src/spacecmd/softwarechannel.py:800
+msgid "Name:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:439
+msgid "Label:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:440 ../src/spacecmd/cryptokey.py:66
+#: ../src/spacecmd/custominfo.py:59 ../src/spacecmd/custominfo.py:203
+#: ../src/spacecmd/group.py:182 ../src/spacecmd/softwarechannel.py:812
+#: ../src/spacecmd/system.py:3519
+msgid "Description:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:441
+msgid "Type [normal, state]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:448
+msgid "Only [normal/state] values are acceptable for type"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:452 ../src/spacecmd/distribution.py:109
+#: ../src/spacecmd/repo.py:357 ../src/spacecmd/repo.py:467
+msgid "A name is required"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:461
+msgid "Only [normal/state] values are acceptable for --type parameter"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:476
+msgid "configchannel_delete: Delete a configuration channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:477
+msgid "usage: configchannel_delete CHANNEL ..."
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:498
+#, python-format
+msgid "No channels matched argument(s): %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:504 ../src/spacecmd/softwarechannel.py:736
+msgid "Delete these channels [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:548
+msgid "Symlink [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:552
+msgid "Target Path:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:553
+msgid "SELinux Context [none]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:561
+msgid "Directory [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:570
+#, python-format
+msgid "Owner [%s]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:571
+#, python-format
+msgid "Group [%s]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:572
+#, python-format
+msgid "Mode [%s]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:574
+#, python-format
+msgid "SELinux Context [%s]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:575
+msgid "Revision [next]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:593
+msgid "The revision must be an integer"
+msgstr ""
+
+#. get the contents of the script
+#: ../src/spacecmd/configchannel.py:596 ../src/spacecmd/configchannel.py:896
+#: ../src/spacecmd/cryptokey.py:68 ../src/spacecmd/kickstart.py:1954
+#: ../src/spacecmd/snippet.py:141
+msgid "Read an existing file [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:598 ../src/spacecmd/kickstart.py:1956
+msgid "File:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:616
+msgid "The path is required"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:630 ../src/spacecmd/configchannel.py:913
+msgid "You must provide the file contents"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:634
+msgid "You must provide the target path for a symlink"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:649 ../src/spacecmd/configchannel.py:678
+#, python-format
+msgid "Path:            %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:679
+#, python-format
+msgid "Directory:       %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:689
+#, python-format
+msgid "Revision:        %i"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:694
+msgid "Contents not displayed (base64 encoded)"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:707
+msgid ""
+"configchannel_addfile/configchannel_updatefile: Create a configuration file"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:708
+msgid ""
+"usage: configchannel_addfile/configchannel_updatefile -c CHANNEL - p PATH -f "
+"LOCAL_FILE_PATH [OPTIONS])\n"
+"\n"
+"options:\n"
+"  -c CHANNEL\n"
+"  -p PATH\n"
+"  -r REVISION\n"
+"  -o OWNER [default: root]\n"
+"  -g GROUP [default: root]\n"
+"  -m MODE [defualt: 0644]\n"
+"  -x SELINUX_CONTEXT\n"
+"  -d path is a directory\n"
+"  -s path is a symlink\n"
+"  -b path is a binary (or other file which needs base64 encoding)\n"
+"  -t SYMLINK_TARGET\n"
+"  -f local path to file contents\n"
+"  -y automatically proceed with file contents\n"
+"\n"
+"  Note re binary/base64: Some text files, notably those containing trailing\n"
+"  newlines, those containing ASCII escape characters (or other charaters "
+"not\n"
+"  allowed in XML) need to be sent as binary (-b).  Some effort is made to "
+"auto-\n"
+"  detect files which require this, but you may need to explicitly specify.\n"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:770 ../src/spacecmd/softwarechannel.py:819
+#: ../src/spacecmd/softwarechannel.py:940
+#: ../src/spacecmd/softwarechannel.py:947
+msgid "Select:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:778 ../src/spacecmd/softwarechannel.py:1374
+#, python-format
+msgid "%s is not a valid channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:783
+msgid "Unable to obtain a valid channel. Aborting."
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:789 ../src/spacecmd/scap.py:160
+msgid "Path:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:805 ../src/spacecmd/configchannel.py:924
+msgid "No config channel specified!"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:810 ../src/spacecmd/configchannel.py:929
+msgid "Error obtaining file info"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:845
+msgid "configchannel_updateinitsls: Update init.sls file"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:846
+msgid ""
+"usage: configchannel_updateinitsls -c CHANNEL -f LOCAL_FILE_PATH [OPTIONS])\n"
+"\n"
+"options:\n"
+"  -c CHANNEL\n"
+"  -f local path to file contents\n"
+"  -y automatically proceed with file contents\n"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:892
+#, python-format
+msgid "No existing file information found for %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:932
+#, python-format
+msgid "contents_enc64:           %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:959
+msgid "configchannel_removefiles: Remove configuration files"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:960
+msgid "usage: configchannel_removefiles CHANNEL <FILE ...>"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:997
+msgid "configchannel_verifyfile: Verify a configuration file"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:998
+msgid "usage: configchannel_verifyfile CHANNEL FILE <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1037
+msgid "No valid system selected"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1045 ../src/spacecmd/system.py:509
+#: ../src/spacecmd/system.py:529 ../src/spacecmd/system.py:959
+#, python-format
+msgid "Action ID: %i"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1053
+msgid "configchannel_export: export config channel(s) to json format file"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1054
+msgid ""
+"usage: configchannel_export <CHANNEL>... [options])\n"
+"options:\n"
+"    -f outfile.json : specify an output filename, defaults to <CHANNEL>."
+"json\n"
+"                      if exporting a single channel, ccs.json for multiple\n"
+"                      channels, or cc_all.json if no CHANNEL specified\n"
+"                      e.g (export ALL)\n"
+"\n"
+"Note : CHANNEL list is optional, default is to export ALL"
+msgstr ""
+
+#. Get the cc details
+#: ../src/spacecmd/configchannel.py:1070
+#, python-format
+msgid "Getting config channel details for %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1090
+#, python-format
+msgid "Failed to get details for file %s from %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1136
+#, python-format
+msgid "File %s could not be exported "
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1137
+msgid "with this API version(needs base64 encoding)"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1139
+#, python-format
+msgid "File %s could not be exported as"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1140
+msgid " text...getting base64 encoded version"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1163
+#, python-format
+msgid "Passed filename '%s' to do_configchannel_export command."
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1171
+#, python-format
+msgid "Exporting ALL config channels to %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1178
+msgid ""
+"Error, no valid config channel passed, check name is  correct with spacecmd "
+"configchannel_list"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1193
+#, python-format
+msgid "Exporting cc %s to %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1200
+msgid "File '{}' exists, confirm overwrite file? (y/n)"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1203
+#, python-format
+msgid "Error saving exported config channels to file: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1212
+msgid "configchannel_import: import config channel(s) from json file"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1213
+msgid "usage: configchannel_import <JSONFILES...>"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1222 ../src/spacecmd/kickstart.py:2330
+msgid "Error, no filename passed"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1230 ../src/spacecmd/kickstart.py:2338
+#, python-format
+msgid "Error, could not read json data from %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1234
+#, python-format
+msgid "Error importing configchannel %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1246
+#, python-format
+msgid "Config channel %s already exists! Skipping!"
+msgstr ""
+
+#. create the cc, we need to drop the org prefix from the cc name
+#: ../src/spacecmd/configchannel.py:1251
+#, python-format
+msgid "Importing config channel  %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1294
+#, python-format
+msgid "Failed trying to import file %s (empty content)"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1296
+msgid "Older APIs can't export encoded files"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1319
+#, python-format
+msgid "Error adding file %s to %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1329
+msgid "configchannel_clone: Clone config channel(s)"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1330
+msgid ""
+"usage examples:\n"
+"                 configchannel_clone foo_label -c bar_label\n"
+"                 configchannel_clone foo_label1 foo_label2 -c prefix\n"
+"                 configchannel_clone foo_label -x \"s/foo/bar\"\n"
+"                 configchannel_clone foo_label1 foo_label2 -x \"s/foo/bar\"\n"
+"\n"
+"options:\n"
+"  -c CLONE_LABEL : name/label of the resulting cc (note does not update\n"
+"                   description, see -x option), treated as a prefix if\n"
+"                   multiple keys are passed\n"
+"  -x \"s/foo/bar\" : Optional regex replacement, replaces foo with bar in "
+"the\n"
+"                   clone name, label and description\n"
+"  Note : If no -c or -x option is specified, interactive is assumed"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1359
+msgid "No config channels found"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1362
+msgid "Config Channels"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1368
+#, python-format
+msgid "Channel to clone: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1372
+msgid "Channel to clone:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1373
+msgid "Clone label:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1382
+msgid "Error no channel label passed!"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1391
+msgid "No suitable channels to clone has been found."
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1444
+msgid "no configchannel given"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1447
+msgid "invalid configchannel label "
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1473
+msgid "configchannel_diff: diff between config channels"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1475
+msgid "usage: configchannel_diff SOURCE_CHANNEL TARGET_CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1524
+msgid "configchannel_sync:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1525
+msgid "sync config files between two config channels"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1527
+msgid "usage: configchannel_sync SOURCE_CHANNEL TARGET_CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1565
+msgid "syncing files from configchannel "
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1572
+msgid "files common in both channels:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1578
+msgid "files only in source "
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1584
+msgid "files only in target "
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1589
+msgid ""
+"files that are in both channels will be overwritten in the target channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1591
+msgid "files only in the source channel will be added to the target channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1593
+msgid "files only in the target channel will be deleted"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1596
+msgid "nothing to do"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1600
+msgid "perform synchronisation [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1652
+msgid "unknown file type "
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:43
+msgid "cryptokey_create: Create a cryptographic key"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:44
+msgid ""
+"usage: cryptokey_create [options])\n"
+"\n"
+"options:\n"
+"  -t GPG or SSL\n"
+"  -d DESCRIPTION\n"
+"  -f KEY_FILE"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:62
+msgid "GPG or SSL [G/S]:"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:75
+msgid "The key type is required"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:79
+msgid "A description is required"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:83
+msgid "A file containing the key is required"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:91
+msgid "No contents of the file"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:100
+msgid "Invalid key type"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:114
+msgid "cryptokey_delete: Delete a cryptographic key"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:115
+msgid "usage: cryptokey_delete NAME"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:145
+msgid "Delete key(s) [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:156
+msgid "cryptokey_list: List all cryptographic keys (SSL, GPG)"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:157
+msgid "usage: cryptokey_list"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:174
+msgid "cryptokey_details: Show the contents of a cryptographic key"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:175
+msgid "usage: cryptokey_details KEY ..."
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:207
+#, python-format
+msgid "%s is not a valid crypto key"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:39
+msgid "custominfo_createkey: Create a custom key"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:40
+msgid "usage: custominfo_createkey [NAME] [DESCRIPTION]"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:73
+msgid "custominfo_deletekey: Delete a custom key"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:74
+msgid "usage: custominfo_deletekey KEY ..."
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:114
+msgid "custominfo_listkeys: List all custom keys"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:115
+msgid "usage: custominfo_listkeys"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:132
+msgid "custominfo_details: Show the details of a custom key"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:133
+msgid "usage: custominfo_details KEY ..."
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:155
+msgid "No keys matched argument '{}'."
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:172
+#, python-format
+msgid "Label:        %s"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:173
+#, python-format
+msgid "Description:  %s"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:174
+#, python-format
+msgid "Modified:     %s"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:175
+#, python-format
+msgid "System Count: %i"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:183
+msgid "custominfo_updatekey: Update a custom key"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:184
+msgid "usage: custominfo_updatekey [NAME] [DESCRIPTION]"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:42
+msgid "distribution_create: Create a Kickstart tree"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:43
+msgid ""
+"usage: distribution_create [options]\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -p path to tree\n"
+"  -b base channel to associate with\n"
+"  -t install type [fedora|rhel_4/5/6|generic_rpm]"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:66
+msgid "The name of the distribution is required"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:73
+msgid "Path to Kickstart Tree:"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:83
+msgid "Base Channel:"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:86
+msgid "Invalid channel label"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:97
+msgid "Install Types"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:102
+msgid "Install Type:"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:105
+msgid "Invalid install type"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:113
+msgid "A path is required"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:117 ../src/spacecmd/system.py:2556
+msgid "A base channel is required"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:121
+msgid "An install type is required"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:143
+msgid "distribution_list: List the available autoinstall trees"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:144
+msgid "usage: distribution_list"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:168
+msgid "distribution_delete: Delete a Kickstart tree"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:169
+msgid "usage: distribution_delete LABEL"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:193 ../src/spacecmd/distribution.py:232
+#, python-format
+msgid "No distributions matched argument %s"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:199
+msgid "Delete distribution tree(s) [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:209
+msgid "distribution_details: Show the details of a Kickstart tree"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:210
+msgid "usage: distribution_details LABEL"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:248 ../src/spacecmd/package.py:93
+#, python-format
+msgid "Name:    %s"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:249 ../src/spacecmd/package.py:100
+#, python-format
+msgid "Path:    %s"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:250
+#, python-format
+msgid "Channel: %s"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:258
+msgid "distribution_rename: Rename a Kickstart tree"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:259
+msgid "usage: distribution_rename OLDNAME NEWNAME"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:288
+msgid "distribution_update: Update the path of a Kickstart tree"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:289
+msgid ""
+"usage: distribution_update NAME [options]\n"
+"\n"
+"options:\n"
+"  -p path to tree\n"
+"  -b base channel to associate with\n"
+"  -t install type [fedora|rhel_4/5/6|generic_rpm]"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:49
+msgid "errata_list: List all patches"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:50
+msgid "usage: errata_list"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:66
+msgid "errata_summary: Print a summary of all errata"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:67
+msgid "usage: errata_summary"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:82
+msgid "errata_apply: Apply an erratum to all affected systems"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:83
+msgid ""
+"usage: errata_apply [options] ERRATA|search:XXX ...)\n"
+"\n"
+"options:\n"
+"  -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:110 ../src/spacecmd/system.py:417
+#: ../src/spacecmd/system.py:725 ../src/spacecmd/system.py:880
+#: ../src/spacecmd/system.py:1015 ../src/spacecmd/system.py:1762
+#: ../src/spacecmd/system.py:3673 ../src/spacecmd/system.py:3983
+#: ../src/spacecmd/system.py:4045 ../src/spacecmd/system.py:4209
+msgid "Start Time [now]:"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:158
+msgid "No patches to apply"
+msgstr ""
+
+#. a summary of which errata we're going to apply
+#: ../src/spacecmd/errata.py:162
+msgid "Errata             Systems"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:166 ../src/spacecmd/system.py:230
+#: ../src/spacecmd/system.py:467 ../src/spacecmd/system.py:820
+#: ../src/spacecmd/system.py:942 ../src/spacecmd/system.py:1079
+#: ../src/spacecmd/system.py:1781 ../src/spacecmd/system.py:3685
+#: ../src/spacecmd/system.py:4228
+#, python-format
+msgid "Start Time: %s"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:168
+msgid "Apply these patches [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:218
+#, python-format
+msgid "No patches to schedule for %s"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:227
+#, python-format
+msgid "Scheduled %i patches for %s"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:236
+msgid "errata_listaffectedsystems: List of systems affected by an patch"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:237
+msgid "usage: errata_listaffectedsystems ERRATA|search:XXX ..."
+msgstr ""
+
+#: ../src/spacecmd/errata.py:275
+msgid "errata_listcves: List of CVEs addressed by an patch"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:276
+msgid "usage: errata_listcves ERRATA|search:XXX ..."
+msgstr ""
+
+#: ../src/spacecmd/errata.py:312
+msgid "No errata has been found"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:319
+msgid "errata_findbycve: List errata addressing a CVE"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:320
+msgid "usage: errata_findbycve CVE-YYYY-NNNN ..."
+msgstr ""
+
+#: ../src/spacecmd/errata.py:354
+msgid "errata_details: Show the details of an patch"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:355
+msgid "usage: errata_details ERRATA|search:XXX ..."
+msgstr ""
+
+#: ../src/spacecmd/errata.py:390
+#, python-format
+msgid "%s is not a valid erratum"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:397
+#, python-format
+msgid "Name:       %s"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:398
+msgid "Product:   s"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:399
+msgid "Type:      s"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:400
+msgid "Issue Date:s"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:402
+msgid "Topic"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:406 ../src/spacecmd/package.py:107
+#: ../src/spacecmd/softwarechannel.py:591
+msgid "Description"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:412
+msgid "Notes"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:417
+msgid "CVEs"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:421
+msgid "Solution"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:425
+msgid "References"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:429
+msgid "Affected Channels"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:433 ../src/spacecmd/org.py:278
+msgid "Affected Systems"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:437
+msgid "Affected Packages"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:447
+msgid "errata_delete: Delete an patch"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:448
+msgid "usage: errata_delete ERRATA|search:XXX ..."
+msgstr ""
+
+#: ../src/spacecmd/errata.py:468
+msgid "No patches to delete"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:471
+msgid "Erratum            Channels"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:479
+msgid "Delete these patches [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:485
+#, python-format
+msgid "Deleted %i patches"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:495
+msgid "errata_publish: Publish an patch to a channel"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:496
+msgid "usage: errata_publish ERRATA|search:XXX <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:523
+msgid "No patches to publish"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:528
+msgid "Publish these patches [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:540
+msgid "errata_search: List patches that meet the given criteria"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:541
+msgid "usage: errata_search CVE|RHSA|RHBA|RHEA|CLA ..."
+msgstr ""
+
+#: ../src/spacecmd/errata.py:543 ../src/spacecmd/scap.py:179
+msgid "Example:"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:42
+msgid "filepreservation_list: List all file preservations"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:43
+msgid "usage: filepreservation_list"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:58
+msgid "filepreservation_create: Create a file preservation list"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:59
+msgid "usage: filepreservation_create [NAME] [FILE ...]"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:78
+#: ../src/spacecmd/filepreservation.py:92
+msgid "File List"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:83
+msgid "File [blank to finish]:"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:109
+msgid "filepreservation_delete: Delete a file preservation list"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:110
+msgid "usage: filepreservation_delete NAME"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:128
+msgid "Delete this list [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:139
+msgid ""
+"filepreservation_details: Show the details of a file\n"
+"'preservation list"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:141
+msgid "usage: filepreservation_details NAME"
+msgstr ""
+
+#: ../src/spacecmd/group.py:50
+msgid "group_addsystems: Add systems to a group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:51
+msgid "usage: group_addsystems GROUP <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/group.py:52
+msgid "       group_addsystems GROUP <ssm>"
+msgstr ""
+
+#: ../src/spacecmd/group.py:103
+msgid "group_removesystems: Remove systems from a group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:104
+msgid "usage: group_removesystems GROUP <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/group.py:145 ../src/spacecmd/system.py:118
+#: ../src/spacecmd/system.py:232 ../src/spacecmd/system.py:475
+#: ../src/spacecmd/system.py:1475 ../src/spacecmd/system.py:1783
+#: ../src/spacecmd/system.py:4230
+msgid "Systems"
+msgstr ""
+
+#: ../src/spacecmd/group.py:149
+msgid "Remove these systems [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/group.py:158 ../src/spacecmd/schedule.py:385
+#: ../src/spacecmd/ssm.py:87 ../src/spacecmd/ssm.py:136
+#: ../src/spacecmd/ssm.py:186 ../src/spacecmd/system.py:4273
+#: ../src/spacecmd/system.py:4329
+msgid "No systems found"
+msgstr ""
+
+#: ../src/spacecmd/group.py:165
+msgid "group_create: Create a system group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:166
+msgid "usage: group_create [NAME] [DESCRIPTION]"
+msgstr ""
+
+#: ../src/spacecmd/group.py:192
+msgid "group_delete: Delete a system group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:193
+msgid "usage: group_delete NAME ..."
+msgstr ""
+
+#: ../src/spacecmd/group.py:212
+msgid "Delete these groups [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/group.py:224
+msgid "group_backup: backup a system group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:225
+msgid ""
+"usage: group_backup <NAME> [OUTDIR])\n"
+"                    group_backup ALL\n"
+"\n"
+"\"OUTDIR\" defaults to $HOME/spacecmd-backup/group/YYYY-MM-DD/NAME\n"
+"\"ALL\" is a keyword and collects all groups\n"
+msgstr ""
+
+#: ../src/spacecmd/group.py:270
+#, python-format
+msgid "Backup Group: %s"
+msgstr ""
+
+#: ../src/spacecmd/group.py:273
+#, python-format
+msgid "Output File: %s"
+msgstr ""
+
+#: ../src/spacecmd/group.py:284
+msgid "group_restore: restore a system group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:285
+msgid ""
+"\n"
+"usage: group_restore INPUTDIR [NAME] ...\n"
+"       group_restore INPUTDIR ALL\n"
+"       group_restore INPUTDIR\n"
+"       group_restore .\n"
+"\n"
+"Specifying only INPUTDIR will default to ALL groups.\n"
+"Setting dot (.) instead of full INPUTDIR will imply current directory.\n"
+"    "
+msgstr ""
+
+#: ../src/spacecmd/group.py:329
+#, python-format
+msgid "Restore dir %s does not exits or is not a directory"
+msgstr ""
+
+#: ../src/spacecmd/group.py:333
+#, python-format
+msgid "Restore dir %s has no restore items"
+msgstr ""
+
+#: ../src/spacecmd/group.py:340
+#, python-format
+msgid "Group %s was not found in backup"
+msgstr ""
+
+#: ../src/spacecmd/group.py:343
+#, python-format
+msgid "Found %s missing groups, terminating"
+msgstr ""
+
+#: ../src/spacecmd/group.py:358
+#, python-format
+msgid "Group %s already restored"
+msgstr ""
+
+#: ../src/spacecmd/group.py:365
+msgid "Changing description from:"
+msgstr ""
+
+#: ../src/spacecmd/group.py:367
+msgid "Continue [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/group.py:370 ../src/spacecmd/group.py:373
+#, python-format
+msgid "Updating description for group: %s"
+msgstr ""
+
+#: ../src/spacecmd/group.py:376
+#, python-format
+msgid "Creating new group %s"
+msgstr ""
+
+#: ../src/spacecmd/group.py:385
+msgid "group_list: List available system groups"
+msgstr ""
+
+#: ../src/spacecmd/group.py:386
+msgid "usage: group_list"
+msgstr ""
+
+#: ../src/spacecmd/group.py:403
+msgid "group_listsystems: List the members of a group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:404
+msgid "usage: group_listsystems GROUP"
+msgstr ""
+
+#: ../src/spacecmd/group.py:426
+#, python-format
+msgid "%s is not a valid group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:439
+msgid "group_details: Show the details of a system group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:440
+msgid "usage: group_details GROUP ..."
+msgstr ""
+
+#: ../src/spacecmd/group.py:463
+#, python-format
+msgid "The group \"%s\" is invalid"
+msgstr ""
+
+#: ../src/spacecmd/group.py:470
+#, python-format
+msgid "ID:                %i"
+msgstr ""
+
+#: ../src/spacecmd/group.py:471
+#, python-format
+msgid "Name:              %s"
+msgstr ""
+
+#: ../src/spacecmd/group.py:472
+#, python-format
+msgid "Description:       %s"
+msgstr ""
+
+#: ../src/spacecmd/group.py:473
+#, python-format
+msgid "Number of Systems: %i"
+msgstr ""
+
+#: ../src/spacecmd/group.py:477
+msgid "Members"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:72
+msgid "kickstart_list: List the available Kickstart profiles"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:73
+msgid "usage: kickstart_list"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:85 ../src/spacecmd/kickstart.py:2108
+msgid "No kickstart profiles available"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:91
+msgid "kickstart_create: Create a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:92
+msgid ""
+"usage: kickstart_create [options])\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -d DISTRIBUTION\n"
+"  -p ROOT_PASSWORD\n"
+"  -v VIRT_TYPE ['none', 'para_host', 'qemu', 'xenfv', 'xenpv']"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:113 ../src/spacecmd/kickstart.py:249
+msgid "Virtualization Types"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:118 ../src/spacecmd/kickstart.py:254
+msgid "Virtualization Type [none]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:126 ../src/spacecmd/kickstart.py:262
+msgid "Distributions"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:136
+msgid "Root Password: "
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:137 ../src/spacecmd/org.py:90
+#: ../src/spacecmd/user.py:85
+msgid "Repeat Password: "
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:142 ../src/spacecmd/org.py:95
+#: ../src/spacecmd/user.py:90
+msgid "Password must be at least 5 characters"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:144 ../src/spacecmd/org.py:97
+#: ../src/spacecmd/user.py:92
+msgid "Passwords don't match"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:147 ../src/spacecmd/kickstart.py:270
+#: ../src/spacecmd/kickstart.py:1980 ../src/spacecmd/kickstart.py:2122
+msgid "The Kickstart name is required"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:151 ../src/spacecmd/kickstart.py:274
+msgid "The distribution is required"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:158
+msgid "A root password is required"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:177
+msgid "kickstart_delete: Delete kickstart profile(s)"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:178
+msgid "usage: kickstart_delete PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:179
+msgid "usage: kickstart_delete PROFILE1 PROFILE2"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:180
+msgid "usage: kickstart_delete \"PROF*\""
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:203 ../src/spacecmd/kickstart.py:2597
+#: ../src/spacecmd/kickstart.py:2653 ../src/spacecmd/kickstart.py:2695
+msgid "No valid kickstart labels passed as arguments!"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:209
+msgid "The following kickstart labels are invalid:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:214
+#, python-format
+msgid "Delete profile %s [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:222
+msgid "kickstart_import: Import a Kickstart profile from a file"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:223
+msgid ""
+"usage: kickstart_import [options])\n"
+"\n"
+"options:\n"
+"  -f FILE\n"
+"  -n NAME\n"
+"  -d DISTRIBUTION\n"
+"  -v VIRT_TYPE ['none', 'para_host', 'qemu', 'xenfv', 'xenpv']"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:278 ../src/spacecmd/kickstart.py:1984
+msgid "A filename is required"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:308
+msgid ""
+"kickstart_import_raw: Import a raw Kickstart or autoyast profile from a file"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:309
+msgid ""
+"usage: kickstart_import_raw [options])\n"
+"\n"
+"options:\n"
+"  -f FILE\n"
+"  -n NAME\n"
+"  -d DISTRIBUTION\n"
+"  -v VIRT_TYPE ['none', 'para_host', 'qemu', 'xenfv', 'xenpv']"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:325
+msgid "kickstart_details: Show the details of a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:326
+msgid "usage: kickstart_details PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:353
+msgid "Invalid Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:415
+#, python-format
+msgid "Tree:        %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:416
+#, python-format
+msgid "Active:      %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:417
+#, python-format
+msgid "Advanced:    %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:418
+#, python-format
+msgid "Org Default: %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:421
+#, python-format
+msgid "Configuration Management: %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:422
+#, python-format
+msgid "Remote Commands:          %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:434
+msgid "Advanced Options"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:442
+msgid "Custom Options"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:449
+msgid "Partitioning"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:454
+msgid "Software"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:467
+msgid "Crypto Keys"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:474
+msgid "File Preservations"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:483
+msgid "Variables"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:490
+msgid "Scripts"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:501 ../src/spacecmd/kickstart.py:1900
+#, python-format
+msgid "Chroot:      %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:504 ../src/spacecmd/kickstart.py:1901
+#, python-format
+msgid "Interpreter: %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:530
+msgid "Could not retrieve the Kickstart file"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:536
+msgid "kickstart_getcontents: Show the contents of a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:537
+msgid "                   as they would be presented to a client"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:538
+msgid "usage: kickstart_getcontents LABEL"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:572
+msgid "kickstart_rename: Rename a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:573
+msgid "usage: kickstart_rename OLDNAME NEWNAME"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:601
+msgid ""
+"kickstart_listcryptokeys: List the crypto keys associated with a Kickstart "
+"profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:603
+msgid "usage: kickstart_listcryptokeys PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:632
+msgid "No crypto keys has been found"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:638
+msgid "kickstart_addcryptokeys: Add crypto keys to a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:639
+msgid "usage: kickstart_addcryptokeys PROFILE <KEY ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:665
+msgid "kickstart_removecryptokeys: Remove crypto keys from a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:667
+msgid "usage: kickstart_removecryptokeys PROFILE <KEY ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:707
+msgid ""
+"kickstart_listactivationkeys: List the activation keys associated with a "
+"Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:709
+msgid "usage: kickstart_listactivationkeys PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:739
+msgid "kickstart_addactivationkeys: Add activation keys to a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:741
+msgid "usage: kickstart_addactivationkeys PROFILE <KEY ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:770
+msgid ""
+"kickstart_removeactivationkeys: Remove activation keys from a Kickstart "
+"profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:772
+msgid "usage: kickstart_removeactivationkeys PROFILE <KEY ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:796
+msgid "Remove these keys [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:811
+msgid ""
+"kickstart_enableconfigmanagement: Enable configuration management on a "
+"Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:813
+msgid "usage: kickstart_enableconfigmanagement PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:844
+msgid ""
+"kickstart_disableconfigmanagement: Disable configuration management on a "
+"Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:846
+msgid "usage: kickstart_disableconfigmanagement PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:877
+msgid ""
+"kickstart_enableremotecommands: Enable remote commands on a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:879
+msgid "usage: kickstart_enableremotecommands PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:910
+msgid ""
+"kickstart_disableremotecommands: Disable remote commands on a Kickstart "
+"profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:912
+msgid "usage: kickstart_disableremotecommands PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:942
+msgid "kickstart_setlocale: Set the locale for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:943
+msgid "usage: kickstart_setlocale PROFILE LOCALE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:981
+msgid "kickstart_setselinux: Set the SELinux mode for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:983
+msgid "usage: kickstart_setselinux PROFILE MODE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1018
+msgid ""
+"kickstart_setpartitions: Set the partitioning scheme for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1020
+msgid "usage: kickstart_setpartitions PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1069
+msgid "kickstart_setdistribution: Set the distribution for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1071
+msgid "usage: kickstart_setdistribution PROFILE DISTRIBUTION"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1105
+msgid "kickstart_enablelogging: Enable logging for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1106
+msgid "usage: kickstart_enablelogging PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1138
+msgid "kickstart_addvariable: Add a variable to a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1139
+msgid "usage: kickstart_addvariable PROFILE KEY VALUE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1177
+msgid "kickstart_updatevariable: Update a variable in a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1179
+msgid "usage: kickstart_updatevariable PROFILE KEY VALUE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1214
+msgid "kickstart_removevariables: Remove variables from a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1216
+msgid "usage: kickstart_removevariables PROFILE <KEY ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1265
+msgid "kickstart_listvariables: List the variables of a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1267
+msgid "usage: kickstart_listvariables PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1300
+msgid "kickstart_addoption: Set an option for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1301
+msgid "usage: kickstart_addoption PROFILE KEY [VALUE]"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1348
+#, python-format
+msgid "%s needs to be set as a custom option"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1356
+msgid "kickstart_removeoptions: Remove options from a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1357
+msgid "usage: kickstart_removeoptions PROFILE <OPTION ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1409
+msgid "kickstart_listoptions: List the options of a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1411
+msgid "usage: kickstart_listoptions PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1445
+msgid ""
+"kickstart_listcustomoptions: List the custom options of a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1447
+msgid "usage: kickstart_listcustomoptions PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1481
+msgid "kickstart_setcustomoptions: Set custom options for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1483
+msgid "usage: kickstart_setcustomoptions PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1531
+msgid "kickstart_addchildchannels: Add a child channels to a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1533
+msgid "usage: kickstart_addchildchannels PROFILE <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1591
+msgid ""
+"kickstart_removechildchannels: Remove child channels from a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1593
+msgid "usage: kickstart_removechildchannels PROFILE <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1636
+msgid ""
+"kickstart_listchildchannels: List the child channels of a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1638
+msgid "usage: kickstart_listchildchannels PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1672
+msgid ""
+"kickstart_addfilepreservations: Add file preservations to a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1674
+msgid "usage: kickstart_addfilepreservations PROFILE <FILELIST ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1709
+msgid ""
+"kickstart_removefilepreservations: Remove file preservations from a "
+"Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1711
+msgid "usage: kickstart_removefilepreservations PROFILE <FILE ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1756
+msgid "kickstart_listpackages: List the packages for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1758
+msgid "usage: kickstart_listpackages PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1790
+msgid "kickstart_addpackages: Add packages to a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1791
+msgid "usage: kickstart_addpackages PROFILE <PACKAGE ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1824
+msgid "kickstart_removepackages: Remove packages from a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1826
+msgid "usage: kickstart_removepackages PROFILE <PACKAGE ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1869
+msgid "kickstart_listscripts: List the scripts for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1871
+msgid "usage: kickstart_listscripts PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1890
+#, python-format
+msgid "No scripts has been found for profile '%s'"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1898
+#, python-format
+msgid "ID:          %i"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1913
+msgid "kickstart_addscript: Add a script to a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1914
+msgid ""
+"usage: kickstart_addscript PROFILE [options])\n"
+"\n"
+"options:\n"
+"  -p PROFILE\n"
+"  -e EXECUTION_TIME ['pre', 'post']\n"
+"  -i INTERPRETER\n"
+"  -f FILE\n"
+"  -c execute in a chroot environment\n"
+"  -t ENABLING_TEMPLATING"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1947
+msgid "Profile Name:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1949
+msgid "Pre/Post Script [post]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1950
+msgid "Chrooted [Y/n]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1951
+msgid "Interpreter [/bin/bash]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1988
+msgid "The execution time is required"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2004
+#, python-format
+msgid "Profile Name:   %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2005
+#, python-format
+msgid "Execution Time: %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2006
+#, python-format
+msgid "Chroot:         %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2007
+#, python-format
+msgid "Template:       %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2008
+#, python-format
+msgid "Interpreter:    %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2009
+msgid "Contents:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2029
+msgid "kickstart_removescript: Remove a script from a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2030
+msgid "usage: kickstart_removescript PROFILE [ID]"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2058 ../src/spacecmd/kickstart.py:2071
+msgid "Invalid script ID"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2066
+msgid "Script ID:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2073
+msgid "Remove this script [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2086
+msgid "kickstart_clone: Clone a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2087
+msgid ""
+"usage: kickstart_clone [options])\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -c CLONE_NAME"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2112
+msgid "Kickstart Profiles"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2117
+msgid "Original Profile:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2118
+msgid "Cloned Profile:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2126
+msgid "The Kickstart clone name is required"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2131
+msgid "Kickstart profile you've entered was not found"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2144
+msgid "kickstart_export: export kickstart profile(s) to json format file"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2145
+msgid ""
+"usage: kickstart_export <KSPROFILE>... [options])\n"
+"options:\n"
+"    -f outfile.json : specify an output filename, defaults to <KSPROFILE>."
+"json\n"
+"                      if exporting a single kickstart, profiles.json for "
+"multiple\n"
+"                      kickstarts, or ks_all.json if no KSPROFILE specified\n"
+"                      e.g (export ALL)\n"
+"\n"
+"Note : KSPROFILE list is optional, default is to export ALL"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2271
+#, python-format
+msgid "Exporting ALL kickstart profiles to %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2279
+msgid ""
+"Error, no valid kickstart profile passed, check name is  correct with "
+"spacecmd kickstart_list"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2299
+#, python-format
+msgid "Exporting ks %s to %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2306
+#, python-format
+msgid "File %s exists, "
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2307
+msgid "confirm overwrite file? (y/n)"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2310
+msgid "Error saving exported kickstart profiles to file"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2320
+msgid "kickstart_import: import kickstart profile(s) from json file"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2321
+msgid "usage: kickstart_import <JSONFILES...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2342
+#, python-format
+msgid "Error importing kickstart %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2355
+#, python-format
+msgid "ERROR : kickstart profile %s already exists! Skipping!"
+msgstr ""
+
+#. create the ks, we need to drop the org prefix from the ks name
+#: ../src/spacecmd/kickstart.py:2359
+#, python-format
+msgid "Found ks %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2415
+#, python-format
+msgid "Error adding %s script"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2423
+#, python-format
+msgid "failed to add ip range %s-%s, continuing"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2437
+#, python-format
+msgid "failed to add file preservation %s, skipping"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2439
+#, python-format
+msgid "file preservation list %s doesn't exist, skipping"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2450
+#, python-format
+msgid "Actvationkey %s does not exist on the "
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2461
+#, python-format
+msgid "GPG/SSL key %s does not exist on the "
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2462
+msgid "satellite, skipping"
+msgstr ""
+
+#. There are some frustrating ommisions from the API which means we can't
+#. export/import some settings, so we post a warning that some manual
+#. fixup may be required
+#: ../src/spacecmd/kickstart.py:2471
+msgid ""
+"Due to API ommissions, there are some settings which cannot be imported, "
+"please check and fixup manually if necessary"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2473
+msgid " * Details->Preserve ks.cfg"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2474
+msgid " * Details->Comment"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2478
+msgid " * Details->Organization Default Profile"
+msgstr ""
+
+#. No way to set the kernel options
+#: ../src/spacecmd/kickstart.py:2480
+msgid " * Details->Kernel Options"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2484
+#, python-format
+msgid " * Details->Post Kernel Options : %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2500
+msgid "no kickstart label given"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2503
+msgid "invalid kickstart label "
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2520
+msgid "kickstart_diff: diff kickstart files"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2522
+msgid "usage: kickstart_diff SOURCE_CHANNEL TARGET_CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2571
+msgid "kickstart_getupdatetype: Get the update type for a kickstart profile(s)"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2572
+msgid "usage: kickstart_getupdatetype PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2573
+msgid "usage: kickstart_getupdatetype PROFILE1 PROFILE2"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2574
+msgid "usage: kickstart_getupdatetype \"PROF*\""
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2603 ../src/spacecmd/kickstart.py:2659
+#: ../src/spacecmd/kickstart.py:2701
+#, python-format
+msgid "kickstart label %s doesn't exist!"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2619
+msgid "kickstart_setupdatetype: Set the update type for a kickstart profile(s)"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2620
+msgid ""
+"usage: kickstart_setupdatetype [options] KS_LABEL)\n"
+"\n"
+"options:\n"
+"    -u UPDATE_TYPE ['red_hat', 'all', 'none']"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2634
+msgid "Update Types"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2639
+msgid "Update Type [none]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2670
+msgid "kickstart_getsoftwaredetails: Gets kickstart profile software details"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2671
+msgid "usage: kickstart_getsoftwaredetails KS_LABEL"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2672
+msgid "usage: kickstart_getsoftwaredetails KS_LABEL KS_LABEL2 ..."
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2707
+#, python-format
+msgid "noBase:        %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2708
+#, python-format
+msgid "ignoreMissing: %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2710
+#, python-format
+msgid "Kickstart Label: %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2711
+#, python-format
+msgid "noBase:          %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2712
+#, python-format
+msgid "ignoreMissing:   %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2721
+msgid "kickstart_setsoftwaredetails: Sets kickstart profile software details."
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2722
+msgid ""
+"usage: kickstart_setsoftwaredetails PROFILE KICKSTART_PACKAGES_INFO VALUE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2723
+msgid ""
+"usage: kickstart_setsoftwaredetails PROFILE KICKSTART_PACKAGES_INFO VALUE "
+"KICKSTART_PACKAGES_INFO VALUE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2757
+msgid "Selected profile does not exist"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2760 ../src/spacecmd/kickstart.py:2765
+msgid "Enter valid input"
+msgstr ""
+
+#. list of system selection options for the help output
+#: ../src/spacecmd/misc.py:57
+msgid ""
+"<SYSTEMS> can be any of the following:\n"
+"name\n"
+"ssm (see 'help ssm')\n"
+"search:QUERY (see 'help system_search')\n"
+"group:GROUP\n"
+"channel:CHANNEL\n"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:65
+msgid ""
+"Dates can be any of the following:\n"
+"Explicit Dates:\n"
+"Dates can be expressed as explicit date strings in the YYYYMMDD[HHMMSS]\n"
+"format.  The year, month and day are required, while the hours and\n"
+"minutes are not; the hours and minutes will default to 0000 if no\n"
+"values are provided.\n"
+"\n"
+"Deltas:\n"
+"Dates can be expressed as delta values.  For example, '2h' would\n"
+"mean 2 hours in the future.  You can also use negative values to\n"
+"express times in the past (e.g., -7d would be one week ago).\n"
+"\n"
+"Units:\n"
+"s -> seconds\n"
+"m -> minutes\n"
+"h -> hours\n"
+"d -> days\n"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:120
+msgid "clear: clear the screen"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:121
+msgid "usage: clear"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:132
+msgid "clear_caches: Clear the internal caches kept for systems and packages"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:133
+msgid "usage: clear_caches"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:146
+msgid "get_apiversion: Display the API version of the server"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:147
+msgid "usage: get_apiversion"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:158
+msgid "get_serverversion: Display the version of the server"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:159
+msgid "usage: get_serverversion"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:171
+msgid "list_proxies: List the proxies within the user's organization "
+msgstr ""
+
+#: ../src/spacecmd/misc.py:172
+msgid "usage: list_proxies"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:184
+msgid "get_session: Show the current session string"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:185
+msgid "usage: get_session"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:193
+msgid "No session found"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:200
+msgid "help: Show help for the given command"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:201
+msgid "usage: help COMMAND"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:207
+msgid "history: List your command history"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:208
+msgid "usage: history"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:220
+msgid "toggle_confirmations: Toggle confirmation messages on/off"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:221
+msgid "usage: toggle_confirmations"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:226
+msgid "Confirmation messages are"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:226
+msgid "enabled"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:233
+msgid "login: Connect to a Spacewalk server"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:234
+msgid "usage: login [USERNAME] [SERVER]"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:244
+msgid "You are already logged in"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:256
+msgid "No server specified"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:301
+#, python-format
+msgid "Failed to connect to %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:309
+#, python-format
+msgid "API (%s) is too old (>= %s required)"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:339 ../src/spacecmd/utils.py:249
+#: ../src/spacecmd/utils.py:560
+#, python-format
+msgid "Could not read %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:348
+msgid "Cached credentials are invalid"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:355
+#, python-format
+msgid "Spacewalk Username: %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:357
+msgid "Spacewalk Username:"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:368
+msgid "Spacewalk Password: "
+msgstr ""
+
+#: ../src/spacecmd/misc.py:374
+msgid "Invalid credentials"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:392
+#, python-format
+msgid "Could not write session file: %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:401
+#, python-format
+msgid "Connected to %s as %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:409
+msgid "logout: Disconnect from the server"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:410
+msgid "usage: logout"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:427
+msgid "whoami: Print the name of the currently logged in user"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:428
+msgid "usage: whoami"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:436
+msgid "You are not logged in"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:443
+msgid "whoamitalkingto: Print the name of the server"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:444
+msgid "usage: whoamitalkingto"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:452
+msgid "Yourself"
+msgstr ""
+
+#. tell the user what's going on
+#: ../src/spacecmd/misc.py:524
+msgid "** Generating errata cache **"
+msgstr ""
+
+#. tell the user what's going on
+#: ../src/spacecmd/misc.py:573
+msgid "** Generating package cache **"
+msgstr ""
+
+#. tell the user what's going on
+#: ../src/spacecmd/misc.py:680
+msgid "** Generating system cache **"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:715
+#, python-format
+msgid "Could not create directory %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:787
+#, python-format
+msgid "Can't find system ID for %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:792
+msgid "Duplicate system profile names found!"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:793
+msgid "Please reference systems by ID or resolve the"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:794
+msgid "underlying issue with 'system_delete' or 'system_rename'"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:860
+#, python-format
+msgid "No systems in group %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:874
+#, python-format
+msgid "No systems subscribed to %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:934
+msgid "Is this ok [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:47
+msgid "org_create: Create an organization"
+msgstr ""
+
+#: ../src/spacecmd/org.py:48
+#, python-format
+msgid ""
+"usage: org_create [options])\n"
+"\n"
+"options:\n"
+"  -n ORG_NAME\n"
+"  -u USERNAME\n"
+"  -P PREFIX (%s)\n"
+"  -f FIRST_NAME\n"
+"  -l LAST_NAME\n"
+"  -e EMAIL\n"
+"  -p PASSWORD\n"
+"  --pam enable PAM authentication"
+msgstr ""
+
+#: ../src/spacecmd/org.py:75
+msgid "Organization Name:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:76 ../src/spacecmd/user.py:73
+msgid "Username:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:77
+#, python-format
+msgid "Prefix (%s):"
+msgstr ""
+
+#: ../src/spacecmd/org.py:79 ../src/spacecmd/user.py:74
+msgid "First Name:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:80 ../src/spacecmd/user.py:75
+msgid "Last Name:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:81 ../src/spacecmd/user.py:76
+msgid "Email:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:82 ../src/spacecmd/user.py:77
+msgid "PAM Authentication [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:89 ../src/spacecmd/user.py:84
+msgid "Password: "
+msgstr ""
+
+#: ../src/spacecmd/org.py:100
+msgid "An organization name is required"
+msgstr ""
+
+#: ../src/spacecmd/org.py:104 ../src/spacecmd/user.py:95
+msgid "A username is required"
+msgstr ""
+
+#: ../src/spacecmd/org.py:108 ../src/spacecmd/user.py:99
+msgid "A first name is required"
+msgstr ""
+
+#: ../src/spacecmd/org.py:112 ../src/spacecmd/user.py:103
+msgid "A last name is required"
+msgstr ""
+
+#: ../src/spacecmd/org.py:116 ../src/spacecmd/user.py:107
+msgid "An email address is required"
+msgstr ""
+
+#: ../src/spacecmd/org.py:120 ../src/spacecmd/user.py:111
+msgid "A password is required"
+msgstr ""
+
+#: ../src/spacecmd/org.py:127
+msgid "Dr."
+msgstr ""
+
+#: ../src/spacecmd/org.py:129
+msgid "Miss"
+msgstr ""
+
+#: ../src/spacecmd/org.py:148
+msgid "org_delete: Delete an organization"
+msgstr ""
+
+#: ../src/spacecmd/org.py:149
+msgid "usage: org_delete NAME"
+msgstr ""
+
+#: ../src/spacecmd/org.py:168 ../src/spacecmd/org.py:199
+#: ../src/spacecmd/org.py:233 ../src/spacecmd/org.py:269
+#: ../src/spacecmd/org.py:377 ../src/spacecmd/org.py:413
+#, python-format
+msgid "No organisation found for the name %s"
+msgstr ""
+
+#: ../src/spacecmd/org.py:169 ../src/spacecmd/org.py:200
+#: ../src/spacecmd/org.py:234 ../src/spacecmd/org.py:270
+#: ../src/spacecmd/org.py:378 ../src/spacecmd/org.py:414
+msgid "Organisation '{}' was not found"
+msgstr ""
+
+#: ../src/spacecmd/org.py:171
+msgid "Delete this organization [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:179
+msgid "org_rename: Rename an organization"
+msgstr ""
+
+#: ../src/spacecmd/org.py:180
+msgid "usage: org_rename OLDNAME NEWNAME"
+msgstr ""
+
+#: ../src/spacecmd/org.py:211
+msgid "org_addtrust: Add a trust between two organizations"
+msgstr ""
+
+#: ../src/spacecmd/org.py:212
+msgid "usage: org_addtrust YOUR_ORG ORG_TO_TRUST"
+msgstr ""
+
+#: ../src/spacecmd/org.py:237 ../src/spacecmd/org.py:273
+#, python-format
+msgid "No trust organisation found for the name %s"
+msgstr ""
+
+#: ../src/spacecmd/org.py:238 ../src/spacecmd/org.py:274
+msgid "Organisation '{}' to trust for, was not found"
+msgstr ""
+
+#: ../src/spacecmd/org.py:248
+msgid "org_removetrust: Remove a trust between two organizations"
+msgstr ""
+
+#: ../src/spacecmd/org.py:249
+msgid "usage: org_removetrust YOUR_ORG TRUSTED_ORG"
+msgstr ""
+
+#: ../src/spacecmd/org.py:284
+msgid "None"
+msgstr ""
+
+#: ../src/spacecmd/org.py:286
+msgid "Remove this trust [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:292
+msgid "org_trustdetails: Show the details of an organizational trust"
+msgstr ""
+
+#: ../src/spacecmd/org.py:293
+msgid "usage: org_trustdetails TRUSTED_ORG"
+msgstr ""
+
+#: ../src/spacecmd/org.py:312
+#, python-format
+msgid "No trusted organisation found for the name %s"
+msgstr ""
+
+#: ../src/spacecmd/org.py:313
+msgid "Trusted organisation '{}' was not found"
+msgstr ""
+
+#: ../src/spacecmd/org.py:320
+#, python-format
+msgid "Trusted Organization:   %s"
+msgstr ""
+
+#: ../src/spacecmd/org.py:321
+#, python-format
+msgid "Trusted Since:          %s"
+msgstr ""
+
+#: ../src/spacecmd/org.py:322
+#, python-format
+msgid "Systems Migrated From:  %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:323
+#, python-format
+msgid "Systems Migrated To:    %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:325
+msgid "Channels Consumed"
+msgstr ""
+
+#: ../src/spacecmd/org.py:332
+msgid "Channels Provided"
+msgstr ""
+
+#: ../src/spacecmd/org.py:340
+msgid "org_list: List all organizations"
+msgstr ""
+
+#: ../src/spacecmd/org.py:341
+msgid "usage: org_list"
+msgstr ""
+
+#: ../src/spacecmd/org.py:358
+msgid "org_listtrusts: List an organization's trusts"
+msgstr ""
+
+#: ../src/spacecmd/org.py:359
+msgid "usage: org_listtrusts NAME"
+msgstr ""
+
+#: ../src/spacecmd/org.py:383 ../src/spacecmd/org.py:384
+msgid "No trust organisation has been found"
+msgstr ""
+
+#: ../src/spacecmd/org.py:394
+msgid "org_listusers: List an organization's users"
+msgstr ""
+
+#: ../src/spacecmd/org.py:395
+msgid "usage: org_listusers NAME"
+msgstr ""
+
+#: ../src/spacecmd/org.py:425
+msgid "org_details: Show the details of an organization"
+msgstr ""
+
+#: ../src/spacecmd/org.py:426
+msgid "usage: org_details NAME"
+msgstr ""
+
+#: ../src/spacecmd/org.py:446
+#, python-format
+msgid "Name:                   %s"
+msgstr ""
+
+#: ../src/spacecmd/org.py:447
+#, python-format
+msgid "Active Users:           %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:448
+#, python-format
+msgid "Systems:                %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:452 ../src/spacecmd/org.py:454
+#, python-format
+msgid "Trusts:                 %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:456
+#, python-format
+msgid "System Groups:          %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:457
+#, python-format
+msgid "Activation Keys:        %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:458
+#, python-format
+msgid "Kickstart Profiles:     %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:459
+#, python-format
+msgid "Configuration Channels: %i"
+msgstr ""
+
+#: ../src/spacecmd/package.py:68 ../src/spacecmd/package.py:302
+#: ../src/spacecmd/package.py:351 ../src/spacecmd/package.py:395
+msgid "No packages found"
+msgstr ""
+
+#: ../src/spacecmd/package.py:81 ../src/spacecmd/package.py:406
+#, python-format
+msgid "%s is not a valid package"
+msgstr ""
+
+#: ../src/spacecmd/package.py:94
+#, python-format
+msgid "Version: %s"
+msgstr ""
+
+#: ../src/spacecmd/package.py:95
+#, python-format
+msgid "Release: %s"
+msgstr ""
+
+#: ../src/spacecmd/package.py:96
+#, python-format
+msgid "Epoch:   %s"
+msgstr ""
+
+#: ../src/spacecmd/package.py:97
+#, python-format
+msgid "Arch:    %s"
+msgstr ""
+
+#: ../src/spacecmd/package.py:99
+#, python-format
+msgid "File:    %s"
+msgstr ""
+
+#: ../src/spacecmd/package.py:101
+#, python-format
+msgid "Size:    %s"
+msgstr ""
+
+#: ../src/spacecmd/package.py:105
+#, python-format
+msgid "Installed Systems: %i"
+msgstr ""
+
+#: ../src/spacecmd/package.py:111
+msgid "Available From Channels"
+msgstr ""
+
+#: ../src/spacecmd/package.py:122
+msgid "package_search: Find packages that meet the given criteria"
+msgstr ""
+
+#: ../src/spacecmd/package.py:123
+msgid "usage: package_search NAME|QUERY"
+msgstr ""
+
+#: ../src/spacecmd/package.py:125
+msgid "Example: package_search kernel"
+msgstr ""
+
+#: ../src/spacecmd/package.py:127
+msgid "Advanced Search:"
+msgstr ""
+
+#: ../src/spacecmd/package.py:128
+msgid ""
+"Available Fields: name, epoch, version, release, arch, description, summary"
+msgstr ""
+
+#: ../src/spacecmd/package.py:129
+msgid "Example: name:kernel AND version:2.6.18 AND -description:devel"
+msgstr ""
+
+#: ../src/spacecmd/package.py:178
+msgid "package_remove: Remove a package from Satellite"
+msgstr ""
+
+#: ../src/spacecmd/package.py:179
+msgid "usage: package_remove PACKAGE ..."
+msgstr ""
+
+#: ../src/spacecmd/package.py:199
+msgid "No packages found to remove"
+msgstr ""
+
+#: ../src/spacecmd/package.py:202 ../src/spacecmd/package.py:259
+#: ../src/spacecmd/softwarechannel.py:1580 ../src/spacecmd/system.py:944
+msgid "Remove these packages [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/package.py:203
+msgid "No packages has been removed"
+msgstr ""
+
+#: ../src/spacecmd/package.py:215 ../src/spacecmd/package.py:271
+#, python-format
+msgid "Failed to remove package ID %i"
+msgstr ""
+
+#: ../src/spacecmd/package.py:226
+msgid "package_listorphans: List packages that are not in a channel"
+msgstr ""
+
+#: ../src/spacecmd/package.py:227
+msgid "usage: package_listorphans"
+msgstr ""
+
+#: ../src/spacecmd/package.py:246
+msgid "package_removeorphans: Remove packages that are not in a channel"
+msgstr ""
+
+#: ../src/spacecmd/package.py:247
+msgid "usage: package_removeorphans"
+msgstr ""
+
+#: ../src/spacecmd/package.py:255
+msgid "No orphaned packages has been found"
+msgstr ""
+
+#: ../src/spacecmd/package.py:256
+msgid "No orphaned packages"
+msgstr ""
+
+#: ../src/spacecmd/package.py:260
+msgid "No packages were removed"
+msgstr ""
+
+#: ../src/spacecmd/package.py:280
+msgid "package_listinstalledsystems: List the systems with a package installed"
+msgstr ""
+
+#: ../src/spacecmd/package.py:281
+msgid "usage: package_listinstalledsystems PACKAGE ..."
+msgstr ""
+
+#: ../src/spacecmd/package.py:329
+msgid "package_listerrata: List the errata that provide this package"
+msgstr ""
+
+#: ../src/spacecmd/package.py:330
+msgid "usage: package_listerrata PACKAGE ..."
+msgstr ""
+
+#: ../src/spacecmd/package.py:377
+msgid "package_listdependencies: List the dependencies for a package"
+msgstr ""
+
+#: ../src/spacecmd/package.py:378
+msgid "usage: package_listdependencies PACKAGE"
+msgstr ""
+
+#: ../src/spacecmd/package.py:411
+#, python-format
+msgid "Package Name: %s"
+msgstr ""
+
+#: ../src/spacecmd/package.py:413
+#, python-format
+msgid "Dependency: %s Type: %s Modifier: %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:47
+msgid "repo_list: List all available user repos"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:48
+msgid "usage: repo_list"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:65
+msgid "repo_details: Show the details of a user repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:66
+msgid "usage: repo_details <repo ...>"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:94
+#, python-format
+msgid "Repository Label:                  %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:95
+#, python-format
+msgid "Repository URL:                    %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:96
+#, python-format
+msgid "Repository Type:                   %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:97
+#, python-format
+msgid "Repository SSL Ca Certificate:     %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:98
+#, python-format
+msgid "Repository SSL Client Certificate: %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:99
+#, python-format
+msgid "Repository SSL Client Key:         %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:101
+msgid "No repositories found for '{}' query"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:110
+msgid "repo_listfilters: Show the filters for a user repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:111
+msgid "usage: repo_listfilters repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:132
+msgid "No filters found"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:141
+msgid "repo_addfilters: Add filters for a user repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:142
+msgid "usage: repo_addfilters repo <filter ...>"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:166 ../src/spacecmd/repo.py:203
+#: ../src/spacecmd/repo.py:242
+msgid "Each filter must start with + or -"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:180
+msgid "repo_removefilters: Remove filters from a user repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:181
+msgid "usage: repo_removefilters repo <filter ...>"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:217
+msgid "repo_setfilters: Set the filters for a user repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:218
+msgid "usage: repo_setfilters repo <filter ...>"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:255
+msgid "repo_clearfilters: Clears the filters for a user repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:256
+msgid ""
+"usage: repo_clearfilters repo <options>\n"
+"\n"
+"options:\n"
+"  -y, --yes   Confirm without prompt\n"
+"\n"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:278
+msgid "Remove these filters [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:287
+msgid "repo_delete: Delete a user repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:288
+msgid "usage: repo_delete <repo ...>"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:307 ../src/spacecmd/softwarechannel.py:610
+msgid "Repos"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:311
+msgid "Delete these repos [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:316
+#, python-format
+msgid "Failed to remove repo %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:324
+msgid "repo_create: Create a user repository"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:325
+msgid ""
+"usage: repo_create <options>)\n"
+"\n"
+"options:\n"
+"  -n, --name   name of repository\n"
+"  -u, --url    url of repository\n"
+"  -t, --type   type of repository (defaults to yum)\n"
+"\n"
+"  --ca         SSL CA certificate (not required)\n"
+"  --cert       SSL Client certificate (not required)\n"
+"  --key        SSL Client key (not required)"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:350
+msgid "URL:"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:351
+msgid "Type:"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:352 ../src/spacecmd/repo.py:462
+msgid "SSL CA cert:"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:353 ../src/spacecmd/repo.py:463
+msgid "SSL Client cert:"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:354 ../src/spacecmd/repo.py:464
+msgid "SSL Client key:"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:361
+msgid "A URL is required"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:381
+msgid "repo_rename: Rename a user repository"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:382
+msgid "usage: repo_rename OLDNAME NEWNAME"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:404
+#, python-format
+msgid "Could not find repo %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:417
+msgid "repo_updateurl: Change the URL of a user repository"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:418
+msgid "usage: repo_updateurl <repo> <url>"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:443
+msgid "repo_updatessl: Change the SSL certificates of a user repository"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:444
+msgid ""
+"usage: repo_updatessl <options>)\n"
+"options:\n"
+"  --ca         SSL CA certificate (not required)\n"
+"  --cert       SSL Client certificate (not required)\n"
+"  --key        SSL Client key (not required)"
+msgstr ""
+
+#: ../src/spacecmd/report.py:43
+msgid "report_inactivesystems: List all inactive systems"
+msgstr ""
+
+#: ../src/spacecmd/report.py:44
+msgid "usage: report_inactivesystems [DAYS]"
+msgstr ""
+
+#: ../src/spacecmd/report.py:84
+msgid "report_outofdatesystems: List all out-of-date systems"
+msgstr ""
+
+#: ../src/spacecmd/report.py:85
+msgid "usage: report_outofdatesystems"
+msgstr ""
+
+#: ../src/spacecmd/report.py:112
+msgid "report_ungroupedsystems: List all ungrouped systems"
+msgstr ""
+
+#: ../src/spacecmd/report.py:113
+msgid "usage: report_ungroupedsystems"
+msgstr ""
+
+#: ../src/spacecmd/report.py:130
+msgid "report_errata: List all errata and how many systems they affect"
+msgstr ""
+
+#: ../src/spacecmd/report.py:131
+msgid "usage: report_errata [ERRATA|search:XXX ...]"
+msgstr ""
+
+#: ../src/spacecmd/report.py:143
+msgid "All errata requested - this may take a few minutes, please be patient!"
+msgstr ""
+
+#: ../src/spacecmd/report.py:166
+#, python-format
+msgid "%s  # Systems"
+msgstr ""
+
+#: ../src/spacecmd/report.py:173
+msgid "No errata found for '{}'"
+msgstr ""
+
+#: ../src/spacecmd/report.py:180
+msgid "report_ipaddresses: List the hostname and IP of each system"
+msgstr ""
+
+#: ../src/spacecmd/report.py:181
+msgid "usage: report_ipaddresses [<SYSTEMS>]"
+msgstr ""
+
+#: ../src/spacecmd/report.py:201 ../src/spacecmd/report.py:265
+#: ../src/spacecmd/scap.py:67 ../src/spacecmd/scap.py:207
+#: ../src/spacecmd/system.py:213 ../src/spacecmd/system.py:394
+#: ../src/spacecmd/system.py:579 ../src/spacecmd/system.py:743
+#: ../src/spacecmd/system.py:898 ../src/spacecmd/system.py:1033
+#: ../src/spacecmd/system.py:1134 ../src/spacecmd/system.py:1204
+#: ../src/spacecmd/system.py:1259 ../src/spacecmd/system.py:1358
+#: ../src/spacecmd/system.py:1591 ../src/spacecmd/system.py:1654
+#: ../src/spacecmd/system.py:1697 ../src/spacecmd/system.py:1777
+#: ../src/spacecmd/system.py:1919 ../src/spacecmd/system.py:1961
+#: ../src/spacecmd/system.py:2049 ../src/spacecmd/system.py:2116
+#: ../src/spacecmd/system.py:2198 ../src/spacecmd/system.py:2253
+#: ../src/spacecmd/system.py:2313 ../src/spacecmd/system.py:2372
+#: ../src/spacecmd/system.py:2430 ../src/spacecmd/system.py:2489
+#: ../src/spacecmd/system.py:2566 ../src/spacecmd/system.py:2647
+#: ../src/spacecmd/system.py:2702 ../src/spacecmd/system.py:2955
+#: ../src/spacecmd/system.py:3108 ../src/spacecmd/system.py:3177
+#: ../src/spacecmd/system.py:3223 ../src/spacecmd/system.py:3282
+#: ../src/spacecmd/system.py:3346 ../src/spacecmd/system.py:3402
+#: ../src/spacecmd/system.py:3577 ../src/spacecmd/system.py:3855
+#: ../src/spacecmd/system.py:3998 ../src/spacecmd/system.py:4060
+#: ../src/spacecmd/system.py:4108 ../src/spacecmd/system.py:4166
+#: ../src/spacecmd/system.py:4224
+msgid "No systems selected"
+msgstr ""
+
+#: ../src/spacecmd/report.py:244
+msgid "report_kernels: List the running kernel of each system"
+msgstr ""
+
+#: ../src/spacecmd/report.py:245
+msgid "usage: report_kernels [<SYSTEMS>]"
+msgstr ""
+
+#: ../src/spacecmd/report.py:282
+#, python-format
+msgid "%s  Kernel"
+msgstr ""
+
+#: ../src/spacecmd/report.py:282
+msgid "System"
+msgstr ""
+
+#: ../src/spacecmd/report.py:296
+msgid "report_duplicates: List duplicate system profiles"
+msgstr ""
+
+#: ../src/spacecmd/report.py:297
+msgid "usage: report_duplicates"
+msgstr ""
+
+#: ../src/spacecmd/report.py:319 ../src/spacecmd/report.py:341
+#: ../src/spacecmd/report.py:359 ../src/spacecmd/report.py:377
+msgid "System ID   Last Checkin"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:43
+msgid ""
+"scap_listxccdfscans: Return a list of finished OpenSCAP scans for given "
+"systems"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:44
+msgid "usage: scap_listxccdfscans <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:78 ../src/spacecmd/system.py:608
+#: ../src/spacecmd/system.py:1220 ../src/spacecmd/system.py:1371
+#: ../src/spacecmd/system.py:2060 ../src/spacecmd/system.py:2383
+#: ../src/spacecmd/system.py:2441 ../src/spacecmd/system.py:2660
+#: ../src/spacecmd/system.py:2715 ../src/spacecmd/system.py:3121
+#: ../src/spacecmd/system.py:3238 ../src/spacecmd/system.py:3295
+#, python-format
+msgid "System: %s"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:88
+#, python-format
+msgid "XID: %d Profile: %s Path: (%s) Completed: %s"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:96
+msgid ""
+"scap_getxccdfscanruleresults: Return a full list of RuleResults for given "
+"OpenSCAP XCCDF scan"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:97
+msgid "usage: scap_getxccdfscanruleresults <XID>"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:117
+#, python-format
+msgid "XID: %s"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:124
+#, python-format
+msgid "IDref: %s Result: %s Idents: (%s)"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:132
+msgid "scap_getxccdfscandetails: Get details of given OpenSCAP XCCDF scan"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:133
+msgid "usage: scap_getxccdfscandetails <XID>"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:159
+msgid "XID:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:159
+msgid "SID:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:159
+msgid "Action_ID:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:161
+msgid "OSCAP_Parameters:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:162
+msgid "Test_Result:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:162
+msgid "Benchmark:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:163
+msgid "Benchmark_Version:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:164
+msgid "Profile:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:165
+msgid "Profile_Title:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:165
+msgid "Start_Time:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:166
+msgid "End_Time:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:167
+msgid "Errors:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:175
+msgid "scap_schedulexccdfscan: Schedule Scap XCCDF scan"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:176
+msgid "usage: scap_schedulexccdfscan PATH_TO_XCCDF_FILE XCCDF_OPTIONS SYSTEMS"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:177
+msgid "       scap_schedulexccdfscan ssm PATH_TO_XCCDF_FILE XCCDF_OPTIONS"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:182
+msgid ""
+"\n"
+"To use systems in the ssm, pass the \"ssm\" keyword in front. Example:"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:88
+msgid "ID      Date                 C    F    P     Action"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:134
+msgid "schedule_cancel: Cancel scheduled actions"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:135
+msgid "usage: schedule_cancel ID|* ..."
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:157
+msgid "Cancel all pending actions [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:158
+msgid "All pending actions left untouched"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:173 ../src/spacecmd/schedule.py:234
+#, python-format
+msgid "\"%s\" is not a valid ID"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:179
+#, python-format
+msgid "Canceled action: %i"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:182
+#, python-format
+msgid "Failed action: %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:184
+#, python-format
+msgid "Canceled %i action(s)"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:192
+msgid "schedule_reschedule: Reschedule failed actions"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:193
+msgid "usage: schedule_reschedule ID|* ..."
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:220
+msgid "Reschedule all failed actions [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:232
+#, python-format
+msgid "\"%i\" is not a failed action"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:238
+msgid "No failed actions to reschedule"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:242
+#, python-format
+msgid "Rescheduled %i action(s)"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:250
+msgid "schedule_details: Show the details of a scheduled action"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:251
+msgid "usage: schedule_details ID"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:268
+#, python-format
+msgid "The ID \"%s\" is invalid"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:277
+#, python-format
+msgid "ID:        %i"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:278
+#, python-format
+msgid "Action:    %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:279
+#, python-format
+msgid "User:      %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:280
+#, python-format
+msgid "Date:      %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:282 ../src/spacecmd/schedule.py:379
+#: ../src/spacecmd/system.py:3245
+#, python-format
+msgid "Completed: %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:283
+#, python-format
+msgid "Failed:    %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:284
+#, python-format
+msgid "Pending:   %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:288
+msgid "Completed Systems"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:295
+msgid "Failed Systems"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:302
+msgid "Pending Systems"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:307
+#, python-format
+msgid "No action found with the ID \"%s\""
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:316
+msgid "schedule_getoutput: Show the output from an action"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:317
+msgid "usage: schedule_getoutput ID"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:332
+#, python-format
+msgid "\"%s\" is not a valid action ID"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:354
+#, python-format
+msgid "System:      %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:355
+#, python-format
+msgid "Start Time:  %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:356
+#, python-format
+msgid "Stop Time:   %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:357
+#, python-format
+msgid "Return Code: %i"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:359 ../src/spacecmd/schedule.py:381
+msgid "Output"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:378
+#, python-format
+msgid "System:    %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:394
+msgid "schedule_listpending: List pending actions"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:395
+msgid "usage: schedule_listpending [BEGINDATE] [ENDDATE]"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:407
+msgid "schedule_listcompleted: List completed actions"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:408
+msgid "usage: schedule_listcompleted [BEGINDATE] [ENDDATE]"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:420
+msgid "schedule_listfailed: List failed actions"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:421
+msgid "usage: schedule_listfailed [BEGINDATE] [ENDDATE]"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:433
+msgid "schedule_listarchived: List archived actions"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:434
+msgid "usage: schedule_listarchived [BEGINDATE] [ENDDATE]"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:446
+msgid "schedule_list: List all actions"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:447
+msgid "usage: schedule_list [BEGINDATE] [ENDDATE]"
+msgstr ""
+
+#: ../src/spacecmd/shell.py:120
+msgid "Could not read history file"
+msgstr ""
+
+#. pylint: disable=W0702
+#: ../src/spacecmd/shell.py:124
+msgid "Exception occurred: {}"
+msgstr ""
+
+#: ../src/spacecmd/shell.py:188 ../src/spacecmd/shell.py:227
+#, python-format
+msgid "%s: event not found"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:42
+msgid "snippet_list: List the available Kickstart snippets"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:43
+msgid "usage: snippet_list"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:60
+msgid "snippet_details: Show the contents of a snippet"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:61
+msgid "usage: snippet_details SNIPPET ..."
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:90
+#, python-format
+msgid "%s is not a valid snippet"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:97
+#, python-format
+msgid "Name:   %s"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:98
+#, python-format
+msgid "Macro:  %s"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:99
+#, python-format
+msgid "File:   %s"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:110
+msgid "snippet_create: Create a Kickstart snippet"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:111
+msgid ""
+"usage: snippet_create [options])\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -f FILE"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:149
+msgid "A name is required for the snippet"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:153
+msgid "A file is required"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:160
+#, python-format
+msgid "Snippet: %s"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:176
+msgid "snippet_update: Update a Kickstart snippet"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:177
+msgid "usage: snippet_update NAME"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:199
+msgid "snippet_delete: Delete a Kickstart snippet"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:200
+msgid "usage: snippet_delete NAME"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:218
+msgid "Remove this snippet [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:57
+msgid "softwarechannel_list: List all available software channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:58
+msgid ""
+"usage: softwarechannel_list [options]')\n"
+"options:\n"
+"  -v verbose (display label and summary)\n"
+"  -t tree view (pretty-print(child-channels))\n"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:106
+msgid "softwarechannel_listmanageablechannels: List all software channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:107
+msgid "                                        manageable by current user"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:108
+msgid ""
+"usage: softwarechannel_listmanageablechannels [options]\n"
+"options:\n"
+"  -v verbose (display label and summary)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:143
+msgid "softwarechannel_listbasechannels: List all base software channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:144
+msgid ""
+"usage: softwarechannel_listbasechannels [options])\n"
+"options:\n"
+"  -v verbose (display label and summary)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:172
+msgid "softwarechannel_listchildchannels: List child software channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:173
+#: ../src/spacecmd/softwarechannel.py:2735
+msgid "usage:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:174
+msgid "softwarechannel_listchildchannels [options]"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:175
+msgid "softwarechannel_listchildchannels : List all child channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:176
+msgid ""
+"softwarechannel_listchildchannels CHANNEL : List children for aspecific base "
+"channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:178
+msgid ""
+"options:\n"
+" -v verbose (display label and summary)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:206
+msgid "softwarechannel_listsystems: List all systems subscribed to"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:207
+msgid "                             a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:208
+msgid "usage: softwarechannel_listsystems CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:242
+msgid "softwarechannel_listpackages: List the most recent packages"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:243
+msgid "                              available from a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:244
+msgid "usage: softwarechannel_listpackages CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:281
+msgid "softwarechannel_listallpackages: List all packages in a channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:282
+msgid "usage: softwarechannel_listallpackages CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:340
+msgid ""
+"softwarechannel_listlatestpackages: List the newest version of all packages "
+"in a channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:341
+msgid "usage: softwarechannel_listlatestpackages CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:380
+msgid "softwarechannel_setdetails: Modify details of a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:381
+#, python-format
+msgid ""
+"usage: softwarechannel_setdetails [options] <CHANNEL ...>)\n"
+"\n"
+"options, at least one of which must be given:\n"
+"  -n NAME\n"
+"  -d DESCRIPTION\n"
+"  -s SUMMARY\n"
+"  -c CHECKSUM %s\n"
+"  -m MAINTAINER_NAME\n"
+"  -e MAINTAINER_EMAIL\n"
+"  -p MAINTAINER_PHONE\n"
+"  -u GPG_URL\n"
+"  -i GPG_ID\n"
+"  -f GPG_FINGERPRINT"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:443
+msgid "At least one attribute to set must be given"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:449
+msgid "No channels matching that label"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:461
+msgid "Setting same name for more than one channel will fail"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:469
+#, python-format
+msgid "Name \"%s\" already in use by channel %s"
+msgstr ""
+
+#. get confirmation
+#: ../src/spacecmd/softwarechannel.py:474
+msgid "Setting following attributes..."
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:477
+#, python-format
+msgid "Name:             %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:479
+#, python-format
+msgid "Summary:          %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:481
+#, python-format
+msgid "Description:      %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:483
+#, python-format
+msgid "Checksum:         %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:485
+#, python-format
+msgid "Maintainer name:  %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:487
+#, python-format
+msgid "Maintainer email: %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:489
+#, python-format
+msgid "Maintainer phone: %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:491
+#, python-format
+msgid "GPG Key:          %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:493
+#, python-format
+msgid "GPG Fingerprint:  %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:495
+#, python-format
+msgid "GPG URL:          %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:497
+msgid "... for the following channels:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:500
+msgid "Apply? [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:512
+#, python-format
+msgid "Could not get details for %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:524
+#, python-format
+msgid "Error while setting details for %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:527
+#, python-format
+msgid "Channels changed: %d"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:535
+msgid "softwarechannel_details: Show the details of a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:536
+msgid "usage: softwarechannel_details <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:576
+#, python-format
+msgid "Label:              %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:577
+#, python-format
+msgid "Name:               %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:578
+#, python-format
+msgid "Architecture:       %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:579
+#, python-format
+msgid "Parent:             %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:580
+#, python-format
+msgid "Systems Subscribed: %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:581
+#, python-format
+msgid "Number of Packages: %i"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:585
+msgid "Summary"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:596
+#, python-format
+msgid "GPG Key:            %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:597
+#, python-format
+msgid "GPG Fingerprint:    %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:598
+#, python-format
+msgid "GPG URL:            %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:599
+#, python-format
+msgid "GPG CHECK:          %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:603
+msgid "Kickstart Trees"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:621
+msgid "softwarechannel_listerrata: List the errata associated with a"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:622
+msgid "                            software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:623
+msgid ""
+"usage: softwarechannel_listerrata <CHANNEL ...> [from=yyyymmdd [to=yyyymmdd]]"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:681
+msgid "softwarechannel_listarches: lists the potential software"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:682
+msgid "                            channel architectures that can be created"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:683
+msgid "usage: softwarechannel_listarches"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:684 ../src/spacecmd/system.py:3826
+msgid "options:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:685
+msgid "    -v verbose (display label and name)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:706
+msgid "softwarechannel_delete: Delete a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:707
+msgid "usage: softwarechannel_delete <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:732
+msgid "Channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:760
+msgid "softwarechannel_update: Update a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:761
+#, python-format
+msgid ""
+"usage: softwarechannel_update LABEL(To identify the channel) [options]\n"
+"options:\n"
+"  -l LABEL(Required)\n"
+"  -n NAME\n"
+"  -s SUMMARY\n"
+"  -d DESCRIPTION\n"
+"  -c CHECKSUM %s\n"
+"  -u GPG-URL\n"
+"  -i GPG-ID\n"
+"  -f GPG-FINGERPRINT\n"
+"  -g DISABLE-GPG-CHECK"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:792
+#: ../src/spacecmd/softwarechannel.py:924
+#: ../src/spacecmd/softwarechannel.py:1094
+msgid "Channel Label:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:797
+msgid "New Name (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:803
+msgid "New Summary (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:806
+msgid "Summary:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:809
+msgid "New Description (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:815
+msgid "New Checksum type (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:822
+msgid "New GPG URL (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:825
+#: ../src/spacecmd/softwarechannel.py:953
+#: ../src/spacecmd/softwarechannel.py:1107
+#: ../src/spacecmd/softwarechannel.py:1196
+msgid "GPG URL:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:828
+msgid "New GPG ID (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:831
+#: ../src/spacecmd/softwarechannel.py:959
+#: ../src/spacecmd/softwarechannel.py:1108
+#: ../src/spacecmd/softwarechannel.py:1197
+msgid "GPG ID:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:834
+msgid "New GPG Fingerprint (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:837
+#: ../src/spacecmd/softwarechannel.py:965
+#: ../src/spacecmd/softwarechannel.py:1109
+#: ../src/spacecmd/softwarechannel.py:1198
+msgid "GPG Fingerprint:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:840
+msgid "Disable GPG CHECK (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:843
+#: ../src/spacecmd/softwarechannel.py:1110
+#: ../src/spacecmd/softwarechannel.py:1199
+msgid "Disable GPG Check [yes/no]? "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:846
+msgid "A channel label is required to identify the channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:849
+msgid "Only [yes/no] values are acceptable for --disable_gpg_check"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:889
+msgid "softwarechannel_create: Create a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:890
+#, python-format
+msgid ""
+"usage: softwarechannel_create [options])\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -l LABEL\n"
+"  -s SUMMARY\n"
+"  -p PARENT_CHANNEL\n"
+"  -a ARCHITECTURE\n"
+"  -c CHECKSUM %s\n"
+"  -u GPG_URL\n"
+"  -i GPG_ID\n"
+"  -f GPG_FINGERPRINT\n"
+"  -g DISABLE_GPG_CHECK"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:923
+#: ../src/spacecmd/softwarechannel.py:1093
+msgid "Channel Name:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:925
+msgid "Channel Summary:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:933
+#: ../src/spacecmd/softwarechannel.py:1101
+msgid "Select Parent [blank to create a base channel]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:936
+msgid "Architecture"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:943
+msgid "Checksum type"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:950
+msgid "GPG URL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:956
+msgid "GPG ID"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:962
+msgid "GPG Fingerprint"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:968
+msgid "GPG CHECK"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:971
+msgid "Disable GPG Check [y/N]? "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1023
+#: ../src/spacecmd/softwarechannel.py:1121
+msgid "A channel name is required"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1027
+#: ../src/spacecmd/softwarechannel.py:1125
+msgid "A channel label is required"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1040
+#, python-format
+msgid "Name %s already in use by channel %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1044
+#, python-format
+msgid "Label %s already in use by channel %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1052
+msgid "softwarechannel_clone: Clone a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1053
+msgid ""
+"usage: softwarechannel_clone [options])\n"
+"\n"
+"options:\n"
+"  -s SOURCE_CHANNEL\n"
+"  -n NAME\n"
+"  -l LABEL\n"
+"  -p PARENT_CHANNEL\n"
+"  --gpg-copy/-g (copy SOURCE_CHANNEL GPG details)\n"
+"  --gpg-url GPG_URL\n"
+"  --gpg-id GPG_ID\n"
+"  --gpg-fingerprint(GPG_FINGERPRINT)\n"
+"  --disable-gpg-check DISABLE_GPG_CHECK\n"
+"  -o do not clone any patches\n"
+"  --regex/-x \"s/foo/bar\" : Optional regex replacement,\n"
+"        replaces foo with bar in the clone name and label"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1088
+#: ../src/spacecmd/softwarechannel.py:1188
+msgid "Source Channels:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1092
+#: ../src/spacecmd/softwarechannel.py:1191
+msgid "Select source channel:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1096
+msgid "Base Channels:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1104
+#: ../src/spacecmd/softwarechannel.py:1194
+msgid "Copy source channel GPG details? [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1113
+#: ../src/spacecmd/softwarechannel.py:1202
+msgid "Original State (No Errata) [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1117
+#: ../src/spacecmd/softwarechannel.py:1205
+msgid "A source channel is required"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1138
+#: ../src/spacecmd/softwarechannel.py:1216
+msgid "Only [yes/no] values are acceptable for --disable-gpg-check"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1154
+msgid ""
+"softwarechannel_clonetree: Clone a software channel and its child channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1155
+msgid ""
+"usage: softwarechannel_clonetree [options])\n"
+"             e.g    softwarechannel_clonetree foobasechannel -p \"my_\"\n"
+"                    softwarechannel_clonetree foobasechannel -x \"s/foo/bar"
+"\"\n"
+"                    softwarechannel_clonetree foobasechannel -x \"s/^/my_\"\n"
+"\n"
+"options:\n"
+"  -s/--source-channel SOURCE_CHANNEL\n"
+"  -p/--prefix PREFIX (is prepended to the label and name of all channels)\n"
+"  --gpg-copy/-g (copy GPG details for correspondoing source channel))\n"
+"  --gpg-url GPG_URL (applied to all channels)\n"
+"  --gpg-id GPG_ID (applied to all channels)\n"
+"  --gpg-fingerprint(GPG_FINGERPRINT (applied to all channels))\n"
+"  --disable-gpg-check DISABLE_GPG_CHECK(applied to all channels)\n"
+"  -o do not clone any errata\n"
+"  --regex/-x \"s/foo/bar\" : Optional regex replacement,\n"
+"        replaces foo with bar in the clone name, label and description"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1192
+msgid "Prefix:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1209
+msgid "A prefix or regex is required"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1221
+#: ../src/spacecmd/softwarechannel.py:1994
+#: ../src/spacecmd/softwarechannel.py:2034
+msgid "Channel does not exist or is not a base channel!"
+msgstr ""
+
+#. Shouldn't ever get here due to earlier checks
+#: ../src/spacecmd/softwarechannel.py:1248
+msgid "called without prefix or regex option!"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1348
+msgid "softwarechannel_addpackages: Add packages to a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1349
+msgid "usage: softwarechannel_addpackages CHANNEL <PACKAGE ...>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1389
+msgid "No packages to add"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1396
+msgid "Add these packages [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1408
+msgid ""
+"softwarechannel_mergepackages: Merge packages from one software channel into "
+"another"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1409
+msgid "usage: softwarechannel_mergepackages SOURCE_CHANNEL TARGET_CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1433
+msgid "softwarechannel_removeerrata: Remove patches from a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1435
+msgid "usage: softwarechannel_removeerrata CHANNEL <ERRATA:search:XXX ...>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1488
+msgid "No patches to remove"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1499
+#: ../src/spacecmd/softwarechannel.py:1828
+#, python-format
+msgid "Total Errata:   %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1500
+#: ../src/spacecmd/softwarechannel.py:1831
+#, python-format
+msgid "Total Packages: %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1502
+msgid "Remove these patches [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1517
+msgid "softwarechannel_removepackages: Remove packages from a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1519
+msgid "usage: softwarechannel_removepackages CHANNEL <PACKAGE ...>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1573
+msgid "No packages to remove"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1593
+msgid ""
+"softwarechannel_adderratabydate: Add errata from one channel into another "
+"channel based on a date range"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1595
+msgid ""
+"usage: softwarechannel_adderratabydate [options] SOURCE DEST BEGINDATE "
+"ENDDATE"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1596
+#: ../src/spacecmd/softwarechannel.py:1671
+msgid "Date format : YYYYMMDD"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1597
+#: ../src/spacecmd/softwarechannel.py:1728
+#: ../src/spacecmd/softwarechannel.py:2620
+#: ../src/spacecmd/softwarechannel.py:2663
+#: ../src/spacecmd/softwarechannel.py:2879
+msgid "Options:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1598
+msgid "        -p/--publish : Publish errata to the channel (don't clone)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1625
+#: ../src/spacecmd/softwarechannel.py:1630
+#: ../src/spacecmd/softwarechannel.py:1696
+#: ../src/spacecmd/softwarechannel.py:1701
+#, python-format
+msgid "%s is an invalid date"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1643
+msgid "No patches found between the given dates"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1650
+#, python-format
+msgid "Publishing errata %s to %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1668
+msgid ""
+"softwarechannel_listerratabydate: list errata from channelbased on a date "
+"range"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1670
+msgid "usage: softwarechannel_listerratabydate CHANNEL BEGINDATE ENDDATE"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1714
+msgid "No errata found between the given dates"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1725
+msgid ""
+"softwarechannel_adderrata: Add patches from one channel into another channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1727
+msgid "usage: softwarechannel_adderrata SOURCE DEST <ERRATA|search:XXX ...>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1729
+msgid "    -q/--quick : Don't display list of packages (slightly faster)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1730
+msgid "    -s/--skip :  Skip errata which appear to exist already in DEST"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1756
+#, python-format
+msgid "source channel %s does not exist!"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1761
+#, python-format
+msgid "dest channel %s does not exist!"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1814
+msgid "No patch to add"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1833
+msgid "Add these patches [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1847
+msgid "Using the old errata.clone function"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1848
+msgid ""
+"If you have base channels for multiple OS versions, check no unexpected "
+"packages have been added"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1861
+msgid ""
+"softwarechannel_getorgaccess: Get the org-access for the software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1862
+msgid "usage: softwarechannel_getorgaccess [CHANNEL ...]"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1900
+msgid ""
+"softwarechannel_setorgaccess: Set the org-access for the software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1901
+msgid ""
+"usage : softwarechannel_setorgaccess <CHANNEL> [options])\n"
+"-d,--disable : disable org access (private, no org sharing)\n"
+"-e,--enable : enable org access (public access to all trusted orgs)\n"
+"-p,--protected ORG : protected org access for ORG only (multiple instances "
+"of -p ORG are allowed)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1941
+#, python-format
+msgid "Making org sharing public for channel : %s "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1946
+#, python-format
+msgid "Making org sharing private for channel : %s "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1951
+#, python-format
+msgid "Making org sharing protected for channel : %s "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1957
+#, python-format
+msgid "Enabling %s access for channel : %s "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1962
+#, python-format
+msgid "Disabling %s access for channel : %s "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1975
+msgid ""
+"softwarechannel_getorgaccesstree: Get the org-access for a software base "
+"channel and its children"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1976
+msgid "usage: softwarechannel_getorgaccesstree [CHANNEL]"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2009
+msgid ""
+"softwarechannel_setorgaccesstree: set the org-access for a software base "
+"channel and its children"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2010
+msgid ""
+"usage: softwarechannel_setorgaccesstree <CHANNEL> [options])\n"
+"-d,--disable : disable org access (private, no org sharing)\n"
+"-e,--enable : enable org access (public access to all trusted orgs)\n"
+"-p,--protected ORG : protected org access for ORG only (multiple instances "
+"of -p ORG are allowed)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2049
+msgid "softwarechannel_regenerateneededcache: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2050
+msgid "Regenerate the needed errata and package cache for all systems"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2052
+msgid "usage: softwarechannel_regenerateneededcache"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2066
+msgid "softwarechannel_regenerateyumcache: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2067
+msgid "Regenerate the YUM cache for a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2069
+msgid ""
+"usage: softwarechannel_regenerateyumcache [options] <CHANNEL ...>\n"
+"\n"
+"    options:\n"
+"      -f force cache regeneration\n"
+"    "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2113
+msgid "no softwarechannel label given"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2116
+msgid "invalid softwarechannel label "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2134
+msgid "softwarechannel_diff: diff softwarechannel files"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2136
+msgid "usage: softwarechannel_diff SOURCE_CHANNEL TARGET_CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2197
+msgid "softwarechannel_errata_diff: diff softwarechannel files"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2199
+msgid "usage: softwarechannel_errata_diff SOURCE_CHANNEL TARGET_CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2248
+msgid "softwarechannel_sync: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2249
+msgid "sync the packages of two software channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2251
+msgid ""
+"usage: softwarechannel_sync SOURCE_CHANNEL TARGET_CHANNEL [options])\n"
+"    -q,--quiet : quiet mode (omits the output of common packages in both "
+"channels)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2293
+#, python-format
+msgid "%s packages from softwarechannel %s to %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2312
+#: ../src/spacecmd/softwarechannel.py:2320
+#: ../src/spacecmd/softwarechannel.py:2434
+#: ../src/spacecmd/softwarechannel.py:2442
+#: ../src/spacecmd/softwarechannel.py:2574
+#: ../src/spacecmd/softwarechannel.py:2582
+msgid "failed to read key id"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2323
+msgid "packages common in both channels:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2328
+msgid "Omitting common packages in both specified channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2333
+msgid "packages to add to channel \""
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2341
+msgid "packages to remove from channel \""
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2347
+#: ../src/spacecmd/softwarechannel.py:2469
+#: ../src/spacecmd/softwarechannel.py:2599
+msgid "summary:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2348
+#: ../src/spacecmd/softwarechannel.py:2349
+msgid " packages"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2350
+msgid "    add    "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2351
+msgid " packages to   "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2354
+msgid "    remove "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2355
+msgid " packages from "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2357
+#: ../src/spacecmd/softwarechannel.py:2477
+msgid "Perform these changes to channel "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2378
+msgid "softwarechannel_errata_sync: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2379
+msgid "sync errata of two software channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2381
+msgid "usage: softwarechannel_errata_sync SOURCE_CHANNEL TARGET_CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2420
+msgid "syncing errata from softwarechannel "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2421
+#: ../src/spacecmd/softwarechannel.py:2553
+msgid " to "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2445
+msgid "errata common in both channels:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2454
+msgid "errata to add to channel \""
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2463
+msgid "errata to remove from channel \""
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2472
+#: ../src/spacecmd/softwarechannel.py:2602
+msgid "    add   "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2473
+msgid "errata to  "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2474
+msgid "    remove"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2475
+msgid "errata from"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2500
+msgid "softwarechannel_errata_merge: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2501
+msgid "merge errata of one software channel into another"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2503
+msgid ""
+"usage:   softwarechannel_errata_merge SOURCE_CHANNEL TARGET_CHANNEL "
+"[FROM_DATE] [TO_DATE]"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2504
+msgid ""
+"example: softwarechannel_errata_merge OldSoftChannel NewSoftChannel "
+"2018-01-01"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2505
+msgid ""
+"note:    Providing only FROM_DATE will merge all errata since that date."
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2506
+msgid "note:    When no date is provided, all errata will be merged."
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2536
+#: ../src/spacecmd/softwarechannel.py:2543
+msgid "wrong dateformat: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2536
+#: ../src/spacecmd/softwarechannel.py:2543
+msgid " please specify as: YYYY-MM-DD"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2552
+msgid "merging errata from softwarechannel "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2589
+msgid "{} contains no errata which is not already present in {}"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2594
+msgid "errata to add to channel {}: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2600
+#: ../src/spacecmd/softwarechannel.py:2601
+msgid " errata"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2603
+msgid " errata to  "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2605
+msgid "Perform these changes to channel {} [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2616
+msgid "softwarechannel_syncrepos: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2617
+msgid "Sync users repos for a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2619
+msgid "usage: softwarechannel_syncrepos <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2621
+#: ../src/spacecmd/softwarechannel.py:2664
+msgid "    -e/--no-errata : Do not sync errata"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2622
+#: ../src/spacecmd/softwarechannel.py:2665
+msgid "    -f/--fail : Terminate upon any error"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2623
+#: ../src/spacecmd/softwarechannel.py:2666
+msgid "    -k/--sync-kickstart : Create kickstartable tree"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2624
+#: ../src/spacecmd/softwarechannel.py:2667
+msgid "    -l/--latest : Only download latest package versions when repo syncs"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2659
+msgid "softwarechannel_setsyncschedule: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2660
+msgid "Sets the repo sync schedule for a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2662
+msgid "usage: softwarechannel_setsyncschedule <CHANNEL> <SCHEDULE>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2669
+msgid ""
+"The schedule is specified in Quartz CronTrigger format without enclosing "
+"quotes."
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2670
+msgid ""
+"For example, to set a schedule of every day at 1am, <SCHEDULE> would be 0 0 "
+"1 * * ?"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2671
+msgid "If <SCHEDULE> is left empty, it will be disabled."
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2734
+msgid ""
+"softwarechannel_listsyncschedule: List sync schedules for all software "
+"channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2736
+msgid "softwarechannel_listsyncschedule : List all channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2759
+msgid "key"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2759
+msgid "Channel Name"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2759
+msgid "Update Schedule"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2771
+msgid "softwarechannel_addrepo: Add a repo to a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2772
+msgid "usage: softwarechannel_addrepo CHANNEL REPO"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2805
+msgid "softwarechannel_removerepo: Remove a repo from a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2806
+msgid "usage: softwarechannel_removerepo CHANNEL REPO"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2846
+msgid "softwarechannel_listrepos: List the repos for a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2847
+msgid "usage: softwarechannel_listrepos CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2870
+msgid "No repos have been found for this channel."
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2877
+msgid "softwarechannel_mirrorpackages: Download packages of a given channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2878
+msgid "usage: softwarechannel_mirrorpackages CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2880
+msgid "    -l/--latest : Only mirror latest package version"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2911
+msgid "Skipping"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2913
+msgid "Fetching package"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2918
+#, python-format
+msgid "Received package %s from channel %s is broken. Content is too short"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2922
+#, python-format
+msgid "Could not fetch package %s from channel %s"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:42
+msgid "The System Set Manager (SSM) is a group of systems that you "
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:43
+msgid "can perform tasks on as a whole."
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:45
+msgid "Adding Systems:"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:51
+msgid "Intersections:"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:63
+msgid "ssm_add: Add systems to the SSM"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:64
+msgid "usage: ssm_add <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:66 ../src/spacecmd/ssm.py:115
+#: ../src/spacecmd/ssm.py:165 ../src/spacecmd/ssm.py:209
+msgid "see 'help ssm' for more details"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:92
+#, python-format
+msgid "%s is already in the list"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:110
+msgid "ssm_intersect: Replace the current SSM with the intersection"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:111
+msgid "               of the current list of systems and the list of"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:112
+msgid "               systems passed as arguments"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:113
+msgid "usage: ssm_intersect <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:162
+msgid "ssm_remove: Remove systems from the SSM"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:163
+msgid "usage: ssm_remove <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:206
+msgid "ssm_list: List the systems currently in the SSM"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:207
+msgid "usage: ssm_list"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:226
+msgid "ssm_clear: Remove all systems from the SSM"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:227
+msgid "usage: ssm_clear"
+msgstr ""
+
+#: ../src/spacecmd/system.py:49
+msgid "Same"
+msgstr ""
+
+#: ../src/spacecmd/system.py:50
+msgid "Only here"
+msgstr ""
+
+#: ../src/spacecmd/system.py:51
+msgid "Newer here"
+msgstr ""
+
+#: ../src/spacecmd/system.py:52
+msgid "Only there"
+msgstr ""
+
+#: ../src/spacecmd/system.py:53
+msgid "Newer there"
+msgstr ""
+
+#: ../src/spacecmd/system.py:73 ../src/spacecmd/system.py:3771
+msgid "Package"
+msgstr ""
+
+#: ../src/spacecmd/system.py:74
+msgid "This System"
+msgstr ""
+
+#: ../src/spacecmd/system.py:75
+msgid "Other System"
+msgstr ""
+
+#: ../src/spacecmd/system.py:76 ../src/spacecmd/system.py:3774
+msgid "Difference"
+msgstr ""
+
+#: ../src/spacecmd/system.py:124
+msgid "Removing Channels"
+msgstr ""
+
+#: ../src/spacecmd/system.py:127
+msgid "Adding Channels"
+msgstr ""
+
+#: ../src/spacecmd/system.py:163
+msgid "system_list: List all system profiles"
+msgstr ""
+
+#: ../src/spacecmd/system.py:164
+msgid "usage: system_list"
+msgstr ""
+
+#: ../src/spacecmd/system.py:180
+msgid "system_reboot: Reboot a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:181
+msgid ""
+"usage: system_reboot <SYSTEMS> [options])\n"
+"\n"
+"options:\n"
+"  -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:236
+msgid "Reboot these systems [y/N]:"
+msgstr "Riavviare questi sistemi [y/N]:"
+
+#: ../src/spacecmd/system.py:252
+msgid "system_search: List systems that match the given criteria"
+msgstr ""
+
+#: ../src/spacecmd/system.py:253
+msgid "usage: system_search QUERY"
+msgstr ""
+
+#: ../src/spacecmd/system.py:255
+msgid "Available Fields:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:258
+msgid "Examples:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:259
+msgid "> system_search device:vmware"
+msgstr ""
+
+#: ../src/spacecmd/system.py:260
+msgid "> system_search ip:192.168.82"
+msgstr ""
+
+#: ../src/spacecmd/system.py:278 ../src/spacecmd/system.py:285
+msgid "Invalid query"
+msgstr ""
+
+#: ../src/spacecmd/system.py:321
+msgid "Invalid search field"
+msgstr ""
+
+#: ../src/spacecmd/system.py:351
+msgid "system_runscript: Schedule a script to run on the list of"
+msgstr ""
+
+#: ../src/spacecmd/system.py:352
+msgid "                  systems provided"
+msgstr ""
+
+#: ../src/spacecmd/system.py:353
+msgid ""
+"usage: system_runscript <SYSTEMS> [options])\n"
+"\n"
+"options:\n"
+"  -u USER\n"
+"  -g GROUP\n"
+"  -t TIMEOUT\n"
+"  -s START_TIME\n"
+"  -l LABEL\n"
+"  -f FILE"
+msgstr ""
+
+#: ../src/spacecmd/system.py:398
+msgid "User [root]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:399
+msgid "Group [root]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:408
+msgid "Timeout (in seconds) [600]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:414
+msgid "Invalid timeout"
+msgstr ""
+
+#: ../src/spacecmd/system.py:420
+msgid "Label/Short Description [default]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:424
+msgid "Script File [create]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:437
+msgid "No script provided"
+msgstr "Nessuno script passato"
+
+#: ../src/spacecmd/system.py:456
+msgid "A script file is required"
+msgstr ""
+
+#: ../src/spacecmd/system.py:464
+#, python-format
+msgid "User:       %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:465
+#, python-format
+msgid "Group:      %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:466
+#, python-format
+msgid "Timeout:    %i seconds"
+msgstr ""
+
+#: ../src/spacecmd/system.py:470
+#, python-format
+msgid "Label:      %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:471
+msgid "Script Contents"
+msgstr ""
+
+#: ../src/spacecmd/system.py:533 ../src/spacecmd/system.py:835
+#: ../src/spacecmd/system.py:962 ../src/spacecmd/system.py:1096
+#: ../src/spacecmd/system.py:4358
+#, python-format
+msgid "Failed to schedule %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:536
+#, python-format
+msgid "Scheduled: %i system(s)"
+msgstr ""
+
+#: ../src/spacecmd/system.py:543 ../src/spacecmd/utils.py:245
+#, python-format
+msgid "Could not remove %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:552
+msgid "system_listhardware: List the hardware details of a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:553
+msgid "usage: system_listhardware <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:612
+msgid "Network"
+msgstr ""
+
+#: ../src/spacecmd/system.py:621
+#, python-format
+msgid "Interface:   %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:622
+#, python-format
+msgid "MAC Address: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:623
+#, python-format
+msgid "IP Address:  %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:624
+#, python-format
+msgid "Netmask:     %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:625
+#, python-format
+msgid "Broadcast:   %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:626
+#, python-format
+msgid "Module:      %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:630
+msgid "CPU"
+msgstr ""
+
+#: ../src/spacecmd/system.py:632
+#, python-format
+msgid "Count:    %i"
+msgstr ""
+
+#: ../src/spacecmd/system.py:633
+#, python-format
+msgid "Arch:     %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:634
+#, python-format
+msgid "MHz:      %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:635
+#, python-format
+msgid "Cache:    %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:636
+#, python-format
+msgid "Vendor:   %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:637
+#, python-format
+msgid "Model:    %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:640
+msgid "Memory"
+msgstr ""
+
+#: ../src/spacecmd/system.py:642
+#, python-format
+msgid "RAM:  %i"
+msgstr ""
+
+#: ../src/spacecmd/system.py:643
+#, python-format
+msgid "Swap: %i"
+msgstr ""
+
+#: ../src/spacecmd/system.py:647
+msgid "DMI"
+msgstr ""
+
+#: ../src/spacecmd/system.py:648
+#, python-format
+msgid "Vendor:       %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:649
+#, python-format
+msgid "System:       %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:650
+#, python-format
+msgid "Product:      %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:651
+#, python-format
+msgid "Board:        %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:654
+msgid "Asset"
+msgstr ""
+
+#: ../src/spacecmd/system.py:660
+#, python-format
+msgid "BIOS Release: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:661
+#, python-format
+msgid "BIOS Vendor:  %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:662
+#, python-format
+msgid "BIOS Version: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:666
+msgid "Devices"
+msgstr ""
+
+#: ../src/spacecmd/system.py:676
+msgid "Description: None"
+msgstr ""
+
+#: ../src/spacecmd/system.py:680
+#, python-format
+msgid "Driver:      %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:681
+#, python-format
+msgid "Class:       %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:682
+#, python-format
+msgid "Bus:         %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:690
+msgid "system_installpackage: Install a package on a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:691
+msgid ""
+"usage: system_installpackage <SYSTEMS> <PACKAGE ...> [options])\n"
+"\n"
+"options:\n"
+"    -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:792
+msgid "No packages to install"
+msgstr ""
+
+#: ../src/spacecmd/system.py:816
+#, python-format
+msgid "%s does not have access to all requested packages"
+msgstr ""
+
+#: ../src/spacecmd/system.py:822
+msgid "Install these packages [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:837 ../src/spacecmd/system.py:964
+#: ../src/spacecmd/system.py:1098
+#, python-format
+msgid "Scheduled %i system(s)"
+msgstr ""
+
+#: ../src/spacecmd/system.py:845
+msgid "system_removepackage: Remove a package from a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:846
+msgid ""
+"usage: system_removepackage <SYSTEMS> <PACKAGE ...> [options])\n"
+"\n"
+"options:\n"
+"    -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:972
+msgid "system_upgradepackage: Upgrade a package on a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:973
+msgid ""
+"usage: system_upgradepackage <SYSTEMS> <PACKAGE ...>|* [options]')\n"
+"\n"
+"options:\n"
+"    -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1051 ../src/spacecmd/system.py:1147
+#, python-format
+msgid "No upgrades available for %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1074
+#, python-format
+msgid "Couldn't get name for package %i"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1081
+msgid "Upgrade these packages [y/N]:"
+msgstr "Aggiorna questi pacchetti [y/N]:"
+
+#: ../src/spacecmd/system.py:1106
+msgid "system_listupgrades: List the available upgrades for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1107
+msgid "usage: system_listupgrades <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1175
+msgid "system_listinstalledpackages: List the installed packages on a"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1176
+msgid "                              system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1177
+msgid "usage: system_listinstalledpackages <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1231
+msgid "system_listconfigchannels: List the config channels of a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1232
+msgid "usage: system_listconfigchannels <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1278 ../src/spacecmd/system.py:1381
+#, python-format
+msgid "%s does not support configuration channels"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1315
+msgid "system_listconfigfiles: List the managed config files of a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1316
+msgid ""
+"usage: system_listconfigfiles <SYSTEMS>')\n"
+"options:\n"
+"  -s/--sandbox : list only system-sandbox files\n"
+"  -l/--local   : list only locally managed files\n"
+"  -c/--central : list only centrally managed files\n"
+"  -q/--quiet   : quiet mode (omits the header)"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1416
+msgid "system_addconfigfile: Create a configuration file"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1417
+msgid "Note this is only for system sandbox or locally-managed files"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1418
+msgid "Centrally managed files should be created via configchannel_addfile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1419
+msgid ""
+"usage: system_addconfigfile [SYSTEM] [options]\n"
+"\n"
+"options:\n"
+"  -S/--sandbox : list only system-sandbox files\n"
+"  -L/--local   : list only locally managed files\n"
+"  -p PATH\n"
+"  -r REVISION\n"
+"  -o OWNER [default: root]\n"
+"  -g GROUP [default: root]\n"
+"  -m MODE [defualt: 0644]\n"
+"  -x SELINUX_CONTEXT\n"
+"  -d path is a directory\n"
+"  -s path is a symlink\n"
+"  -b path is a binary (or other file which needs base64 encoding)\n"
+"  -t SYMLINK_TARGET\n"
+"  -f local path to file contents\n"
+"\n"
+"  Note re binary/base64: Some text files, notably those containing trailing\n"
+"  newlines, those containing ASCII escape characters (or other charaters "
+"not\n"
+"  allowed in XML) need to be sent as binary (-b).  Some effort is made to "
+"auto-\n"
+"  detect files which require this, but you may need to explicitly specify.\n"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1487
+#, python-format
+msgid "%s is not a valid system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1497
+msgid "System-Sandbox or Locally-Managed? [S/L]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1513
+msgid "Must choose system-sandbox or locally-managed option"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1552
+msgid "system_addconfigchannels: Add config channels to a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1553
+msgid ""
+"usage: system_addconfigchannels <SYSTEMS> <CHANNEL ...> [options]\n"
+"\n"
+"options:\n"
+"  -t add channels to the top of the list\n"
+"  -b add channels to the bottom of the list"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1597
+msgid "Add to top or bottom? [T/b]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1621
+msgid "system_removeconfigchannels: Remove config channels from a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1622
+msgid "usage: system_removeconfigchannels <SYSTEMS> <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1671
+msgid ""
+"system_setconfigchannelorder: Set the ranked order of configuration channels"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1672
+msgid "usage: system_setconfigchannelorder <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1712
+msgid "New Configuration Channels"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1732
+msgid "system_deployconfigfiles: Deploy all configuration files for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1733
+msgid ""
+"usage: system_deployconfigfiles <SYSTEMS> [options]\n"
+"\n"
+"options:\n"
+"    -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1787
+msgid "Deploy ALL configuration files to these systems [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1797
+#, python-format
+msgid "Scheduled deployment for %i system(s)"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1805
+msgid "system_delete: Delete a system profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1806
+msgid ""
+"usage: system_delete [options] <SYSTEMS>\n"
+"\n"
+"    options:\n"
+"          -c TYPE - Possible values:\n"
+"             *  'FAIL_ON_CLEANUP_ERR' - fail in case of cleanup error,\n"
+"             *  'NO_CLEANUP' - do not cleanup, just delete,\n"
+"             *  'FORCE_DELETE' - Try cleanup first but delete server anyway "
+"in case of error\n"
+"    "
+msgstr ""
+
+#: ../src/spacecmd/system.py:1850
+msgid "No systems to delete"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1858
+#, python-format
+msgid "%s  System ID"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1858
+msgid "Profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1866
+msgid "Delete these systems [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1873
+#, python-format
+msgid "%i system(s) scheduled for removal"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1893
+msgid "system_lock: Lock a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1894
+msgid "usage: system_lock <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1935
+msgid "system_unlock: Unlock a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1936
+msgid "usage: system_unlock <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1977
+msgid "system_rename: Rename a system profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1978
+msgid "usage: system_rename OLDNAME NEWNAME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2023
+msgid "system_listcustomvalues: List the custom values for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2024
+msgid "usage: system_listcustomvalues <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2079
+msgid "system_addcustomvalue: Set a custom value for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2080
+msgid "usage: system_addcustomvalue KEY VALUE <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2134
+msgid "system_updatecustomvalue: Update a custom value for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2135
+msgid "usage: system_updatecustomvalue KEY VALUE <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2166
+msgid "system_removecustomvalues: Remove a custom value for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2167
+msgid "usage: system_removecustomvalues <SYSTEMS> <KEY ...>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2203
+msgid "Delete these values [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2221
+msgid "system_addnote: Set a note for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2222
+msgid ""
+"usage: system_addnote <SYSTEM> [options]\n"
+"\n"
+"options:\n"
+"  -s SUBJECT\n"
+"  -b BODY"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2257
+msgid "Subject of the Note:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2259
+msgid "Note Body (ctrl-D to finish):"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2263
+msgid "A subject is required"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2267
+msgid "A body is required"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2286
+msgid "system_deletenotes: Delete notes from a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2287
+msgid "usage: system_deletenotes <SYSTEM> <ID|*>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2319
+msgid "No notes to delete"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2346
+msgid "system_listnotes: List the available notes for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2347
+msgid "usage: system_listnotes <SYSTEM>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2405
+msgid "system_listfqdns: List the associated FQDNs for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2406
+msgid "usage: system_listfqdns <SYSTEM>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2458
+msgid "system_setbasechannel: Set a system's base software channel"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2459
+msgid "usage: system_setbasechannel <SYSTEMS> CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2506 ../src/spacecmd/system.py:2593
+#, python-format
+msgid "System:           %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2507 ../src/spacecmd/system.py:2594
+#, python-format
+msgid "Old Base Channel: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2508 ../src/spacecmd/system.py:2596
+#, python-format
+msgid "New Base Channel: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2527
+msgid ""
+"system_schedulechangechannels: Schedule changing a system's software channels"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2528
+msgid ""
+"usage: system_setbasechannel <SYSTEMS> [options]\n"
+"\n"
+"options:\n"
+"  -b BASE_CHANNEL base channel label\n"
+"  -c CHILD_CHANNEL child channel labels (allowed multiple times)\n"
+"  -s START_TIME time defaults to now"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2595
+#, python-format
+msgid "Old Child Channels: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2597
+#, python-format
+msgid "New Child channels %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2612 ../src/spacecmd/system.py:4243
+#, python-format
+msgid "Scheduled action id: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2619
+msgid "system_listbasechannel: List the base channel for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2620
+msgid "usage: system_listbasechannel <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2674
+msgid "system_listchildchannels: List the child channels for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2675
+msgid "usage: system_listchildchannels <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2729
+msgid "system_addchildchannels: Add child channels to a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2730
+msgid "usage: system_addchildchannels <SYSTEMS> <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2752
+msgid ""
+"system_listcrashedsystems: List all systems that have experienced a crash "
+"and reported by spacewalk-abrt"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2753
+msgid "usage: system_listcrashedsystems"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2759
+msgid "Count | System ID | Profile Name"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2773
+msgid "system_deletecrashes: Delete crashes reported by spacewalk-abrt."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2774
+msgid ""
+"usage: Delete all crashes for all systems    : system_deletecrashes [--"
+"verbose]"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2775
+msgid ""
+"usage: Delete all crashes for a single system: system_deletecrashes -i "
+"sys_id [--verbose]"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2776
+msgid ""
+"usage: Delete a single crash record          : system_deletecrashes -c "
+"crash_id [--verbose]"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2794
+#, python-format
+msgid "Deleting crash with id %s."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2801
+#, python-format
+msgid "Deleting all crashes from system with systemid %s [y/N]:"
+msgstr ""
+
+#. all systems
+#: ../src/spacecmd/system.py:2803
+msgid "Deleting all crashes from all systems [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2815
+#, python-format
+msgid "Deleting crash with id %s from system %s."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2824
+msgid "system_listcrashesbysystem: List all reported crashes for a system."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2825 ../src/spacecmd/system.py:2837
+msgid "usage: system_listcrashesbysystem -i sys_id"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2836
+msgid "# System id must be provided."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2842
+msgid "Crash ID | Crash Name"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2853
+msgid "system_getcrashfiles: Download all files for a crash record."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2854
+msgid "usage: system_getcrashfiles -c crash_id [--verbose]"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2855 ../src/spacecmd/system.py:2869
+msgid ""
+"usage: system_getcrashfiles -c crash_id [--dest_folder=/tmp/crash_files] [--"
+"verbose]"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2868
+msgid "# Crash id must be provided."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2895
+#, python-format
+msgid "# All files we downloaded to %s."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2904
+msgid "system_removechildchannels: Remove child channels from a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2905
+msgid "usage: system_removechildchannels <SYSTEMS> <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2927
+msgid "system_details: Show the details of a system profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2928
+msgid "usage: system_details <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2981
+#, python-format
+msgid "Name:          %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2982
+#, python-format
+msgid "System ID:     %i"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2985
+#, python-format
+msgid "UUID:          %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2987
+#, python-format
+msgid "Locked:        %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2988
+#, python-format
+msgid "Registered:    %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2989
+#, python-format
+msgid "Last Checkin:  %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2990
+#, python-format
+msgid "OSA Status:    %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2991
+#, python-format
+msgid "Last Boot:     %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2993
+#, python-format
+msgid "Contact Method:%s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3037
+#, python-format
+msgid "Hostname:      %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3038
+#, python-format
+msgid "IP Address:    %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3039
+#, python-format
+msgid "Kernel:        %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3080
+msgid "system_listerrata: List available errata for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3081
+msgid "usage: system_listerrata <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3135
+msgid "system_applyerrata: Apply errata to a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3136
+msgid ""
+"usage: system_applyerrata [options] <SYSTEMS>\n"
+"[ERRATA|search:XXX ...]\n"
+"\n"
+"options:\n"
+"  -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3197
+msgid "system_listevents: List the event history for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3198
+msgid "usage: system_listevents <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3244
+#, python-format
+msgid "Summary:   %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3246
+#, python-format
+msgid "Details:   %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3254
+msgid "system_listentitlements: List the entitlements for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3255
+msgid "usage: system_listentitlements <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3308
+msgid "system_addentitlements: Add entitlements to a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3309
+msgid "usage: system_addentitlements <SYSTEMS> ENTITLEMENT"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3364
+msgid "system_removeentitlement: Remove an entitlement from a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3365
+msgid "usage: system_removeentitlement <SYSTEMS> ENTITLEMENT"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3420
+msgid "system_listpackageprofiles: List all package profiles"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3421
+msgid "usage: system_listpackageprofiles"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3440
+msgid "system_deletepackageprofile: Delete a package profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3441
+msgid "usage: system_deletepackageprofile PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3465
+msgid "Delete this profile [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3476
+#, python-format
+msgid "%s is not a valid profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3487
+msgid "system_createpackageprofile: Create a package profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3488
+msgid ""
+"usage: system_createpackageprofile SYSTEM [options]\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -d DESCRIPTION"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3518
+msgid "Profile Label:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3522
+msgid "A profile name is required"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3526
+msgid "A profile description is required"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3534
+#, python-format
+msgid "Created package profile '%s'"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3542
+msgid ""
+"system_comparepackageprofile: Compare a system against a package profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3543
+msgid "usage: system_comparepackageprofile <SYSTEMS> PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3606
+msgid "system_comparepackages: Compare the packages between two systems"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3607
+msgid "usage: system_comparepackages SOME_SYSTEM ANOTHER_SYSTEM"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3638
+msgid "system_syncpackages: Sync packages between two systems"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3639
+msgid ""
+"usage: system_syncpackages SOURCE TARGET [options]\n"
+"\n"
+"options:\n"
+"    -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3687
+msgid "Sync packages [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3729
+#, python-format
+msgid "Failed to filter package list, package %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3730
+msgid "found with no arch or arch_label"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3772
+msgid "System Version"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3773
+msgid "Channel Version"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3795
+msgid "Channel_newer_than_system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3808
+msgid "System_newer_than_channel"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3817
+msgid "Missing_in_channel"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3821
+msgid "system_comparewithchannel: Compare the installed packages on a"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3822
+msgid "                           system with those in the channels it is"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3823
+msgid "                           registerd to, or optionally some other"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3824
+msgid "                           channel"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3825
+msgid "usage: system_comparewithchannel <SYSTEMS> [options]"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3827
+msgid "         -c/--channel : Specific channel to compare against,"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3828
+msgid "                        default is those subscribed to, including"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3829
+msgid "                        child channels"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3880
+msgid "Specified channel does not exist"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3891
+#, python-format
+msgid "system %s is not subscribed to any channel!"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3893
+msgid "Please subscribe to a channel, or specify achannel to compare with"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3927
+#, python-format
+msgid ""
+"\n"
+"System: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3953
+msgid ""
+"system_schedulehardwarerefresh: Schedule a hardware refresh for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3954
+msgid ""
+"usage: system_schedulehardwarerefresh <SYSTEMS> [options]\n"
+"\n"
+"options:\n"
+"  -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4016
+msgid ""
+"system_schedulepackagerefresh: Schedule a software package refresh for a "
+"system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4017
+msgid ""
+"usage: system_schedulepackagerefresh <SYSTEMS> [options])\n"
+"\n"
+"options:\n"
+"  -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4078
+msgid ""
+"system_show_packageversion: Shows version of installed package on given "
+"system(s)"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4079
+msgid "usage: system_show_packageversion <SYSTEM> <PACKAGE>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4111
+msgid "Package\tVersion\tRelease\tEpoch\tArch\tSystem"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4131
+msgid "system_setcontactmethod: Set the contact method for given system(s)."
+msgstr ""
+
+#: ../src/spacecmd/system.py:4133
+msgid "usage: system_setcontactmethod <SYSTEMS> <CONTACT_METHOD>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4182
+msgid ""
+"system_scheduleapplyconfigchannels: Schedule applying the assigned config "
+"channels to the System (Minion only)"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4183
+msgid ""
+"usage: scheduleapplyconfigchannels <SYSTEMS> [options]\n"
+"\n"
+"    options:\n"
+"        -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4234
+msgid "Schedule applying config channels to these systems [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4251
+msgid ""
+"system_listmigrationtargets: List possible migration targets for given "
+"systems."
+msgstr ""
+
+#: ../src/spacecmd/system.py:4252
+msgid "usage: system_listmigrationtargets <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4279
+msgid "WARN: Cannot find system "
+msgstr ""
+
+#: ../src/spacecmd/system.py:4286
+msgid "  No migration targets"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4289
+msgid "  Target #"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4290
+msgid "    IDs: "
+msgstr ""
+
+#: ../src/spacecmd/system.py:4291
+msgid "    Friendly names: "
+msgstr ""
+
+#: ../src/spacecmd/system.py:4297
+msgid ""
+"system_schedulespmigration: Schedule a Service Pack migration for systems."
+msgstr ""
+
+#: ../src/spacecmd/system.py:4298
+msgid ""
+"usage: system_schedulespmigration <SYSTEM> <BASE_CHANNEL_LABEL> "
+"<MIGRATION_TARGET> [options] \n"
+"    For MIGRATION_TARGET parameter see system_listmigrationtargets. \n"
+"    The MIGRATION_TARGET parameter must be passed in the following format: "
+"[3143,3146,3147,3145,3144,3148,3062]. \n"
+"    Options: \n"
+"        -s START_TIME \n"
+"        -d pass this flag, if you want to do a dry run \n"
+"        -c CHILD_CHANNELS (comma-separated child channels labels (with no "
+"spaces))"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4348
+msgid "Cannot find system "
+msgstr ""
+
+#: ../src/spacecmd/system.py:4348
+msgid ". Skipping it."
+msgstr ""
+
+#: ../src/spacecmd/system.py:4351
+msgid "Scheduling Service Pack migration for system "
+msgstr ""
+
+#: ../src/spacecmd/system.py:4356
+msgid "Scheduled action ID: "
+msgstr ""
+
+#: ../src/spacecmd/user.py:49
+msgid "user_create: Create an user"
+msgstr ""
+
+#: ../src/spacecmd/user.py:50
+msgid ""
+"usage: user_create [options])\n"
+"\n"
+"options:\n"
+"  -u USERNAME\n"
+"  -f FIRST_NAME\n"
+"  -l LAST_NAME\n"
+"  -e EMAIL\n"
+"  -p PASSWORD\n"
+"  --pam enable PAM authentication"
+msgstr ""
+
+#: ../src/spacecmd/user.py:119
+msgid "Note: password was ignored due to PAM mode"
+msgstr ""
+
+#: ../src/spacecmd/user.py:138
+msgid "user_delete: Delete an user"
+msgstr ""
+
+#: ../src/spacecmd/user.py:139
+msgid "usage: user_delete NAME"
+msgstr ""
+
+#: ../src/spacecmd/user.py:167
+msgid "user_disable: Disable an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:168
+msgid "usage: user_disable NAME"
+msgstr ""
+
+#: ../src/spacecmd/user.py:194
+msgid "user_enable: Enable an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:195
+msgid "usage: user_enable NAME"
+msgstr ""
+
+#: ../src/spacecmd/user.py:221
+msgid "user_list: List all users"
+msgstr ""
+
+#: ../src/spacecmd/user.py:222
+msgid "usage: user_list"
+msgstr ""
+
+#: ../src/spacecmd/user.py:239
+msgid "user_listavailableroles: List all available roles for users"
+msgstr ""
+
+#: ../src/spacecmd/user.py:240
+msgid "usage: user_listavailableroles"
+msgstr ""
+
+#: ../src/spacecmd/user.py:252
+msgid "No roles has been found"
+msgstr ""
+
+#: ../src/spacecmd/user.py:258
+msgid "user_addrole: Add a role to an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:259
+msgid "usage: user_addrole USER ROLE"
+msgstr ""
+
+#: ../src/spacecmd/user.py:292
+msgid "user_removerole: Remove a role from an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:293
+msgid "usage: user_removerole USER ROLE"
+msgstr ""
+
+#: ../src/spacecmd/user.py:327
+msgid "user_details: Show the details of an user"
+msgstr ""
+
+#: ../src/spacecmd/user.py:328
+msgid "usage: user_details USER ..."
+msgstr ""
+
+#: ../src/spacecmd/user.py:360
+#, python-format
+msgid "%s is not a valid user"
+msgstr ""
+
+#: ../src/spacecmd/user.py:361
+msgid "Error '{}' while getting data about user '{}': {}"
+msgstr ""
+
+#: ../src/spacecmd/user.py:371
+#, python-format
+msgid "Username:      %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:372
+#, python-format
+msgid "First Name:    %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:373
+#, python-format
+msgid "Last Name:     %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:374
+#, python-format
+msgid "Email Address: %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:375
+#, python-format
+msgid "Organisation:  %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:376
+#, python-format
+msgid "Last Login:    %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:377
+#, python-format
+msgid "Created:       %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:378
+#, python-format
+msgid "Enabled:       %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:382
+msgid "Roles"
+msgstr ""
+
+#: ../src/spacecmd/user.py:388
+msgid "Assigned Groups"
+msgstr ""
+
+#: ../src/spacecmd/user.py:394
+msgid "Default Groups"
+msgstr ""
+
+#: ../src/spacecmd/user.py:404
+msgid "user_addgroup: Add a group to an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:405
+msgid "usage: user_addgroup USER <GROUP ...>"
+msgstr ""
+
+#: ../src/spacecmd/user.py:442
+msgid "user_adddefaultgroup: Add a default group to an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:443
+msgid "usage: user_adddefaultgroup USER <GROUP ...>"
+msgstr ""
+
+#: ../src/spacecmd/user.py:479
+msgid "user_removegroup: Remove a group to an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:480
+msgid "usage: user_removegroup USER <GROUP ...>"
+msgstr ""
+
+#: ../src/spacecmd/user.py:520
+msgid "user_removedefaultgroup: Remove a default group from an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:522
+msgid "usage: user_removedefaultgroup USER <GROUP ...>"
+msgstr ""
+
+#: ../src/spacecmd/user.py:561
+msgid "user_setfirstname: Set an user accounts first name field"
+msgstr ""
+
+#: ../src/spacecmd/user.py:562
+msgid "usage: user_setfirstname USER FIRST_NAME"
+msgstr ""
+
+#: ../src/spacecmd/user.py:596
+msgid "user_setlastname: Set an user accounts last name field"
+msgstr ""
+
+#: ../src/spacecmd/user.py:597
+msgid "usage: user_setlastname USER LAST_NAME"
+msgstr ""
+
+#: ../src/spacecmd/user.py:631
+msgid "user_setemail: Set an user accounts email field"
+msgstr ""
+
+#: ../src/spacecmd/user.py:632
+msgid "usage: user_setemail USER EMAIL"
+msgstr ""
+
+#: ../src/spacecmd/user.py:666
+msgid "user_setprefix: Set an user accounts name prefix field"
+msgstr ""
+
+#: ../src/spacecmd/user.py:667
+msgid "usage: user_setprefix USER PREFIX"
+msgstr ""
+
+#: ../src/spacecmd/user.py:706
+msgid "user_setpassword: Set an user accounts name prefix field"
+msgstr ""
+
+#: ../src/spacecmd/user.py:707
+msgid "usage: user_setpassword USER PASSWORD"
+msgstr ""
+
+#. If cache generation is interrupted (e.g by ctrl-c) you can end up
+#. with an EOFError exception due to the partial picked file
+#. So we catch this error and remove the corrupt partial file
+#. If you don't do this then spacecmd will fail with an unhandled
+#. exception until the partial file is manually removed
+#: ../src/spacecmd/utils.py:133
+#, python-format
+msgid "Loading cache file %s failed"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:134
+#, python-format
+msgid "Cache generation was probably interrupted,removing corrupt %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:139
+#, python-format
+msgid "Couldn't load cache from %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:160
+#, python-format
+msgid "Couldn't write to %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:205
+msgid "Could not open the temporary file"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:225
+#, python-format
+msgid "Editor \"%s\" exited with code %i"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:227
+#, python-format
+msgid "General failure running editor: %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:230
+msgid "No editors found"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:367
+msgid "Invalid time provided"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:463
+msgid "Security Errata"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:472
+msgid "Bug Fix Errata"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:481
+msgid "Enhancement Errata"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:491
+msgid "Current Selections"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:501
+msgid "Available Configuration Channels"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:507 ../src/spacecmd/utils.py:527
+msgid "Channel:"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:510 ../src/spacecmd/utils.py:530
+msgid "Invalid channel"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:514
+msgid "New Rank:"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:521 ../src/spacecmd/utils.py:524
+msgid "Invalid rank"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:535
+msgid "Clearing current selections"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:690
+msgid "Could not generate json data object!"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:697
+#, python-format
+msgid "Could not open file %s for writing: %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:708
+#, python-format
+msgid "Could not open file %s for reading: %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:710
+#, python-format
+msgid "Could not parse JSON data from %s: %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:712
+#, python-format
+msgid "Error processing file %s: %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:740
+msgid "Skipping usage of common strings: both strings are equal"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:756
+msgid "Skipping usage of common strings: number of substrings differ"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:842
+msgid "Parameter {} not a string type, but {}."
+msgstr ""
+
+#: ../src/bin/spacecmd:74
+msgid "Unhandled exception occurred while getting FQDN:"
+msgstr ""

--- a/spacecmd/po/ja.po
+++ b/spacecmd/po/ja.po
@@ -1,0 +1,7456 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#: ../src/bin/spacecmd:59
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-09-24 17:29+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../src/spacecmd/activationkey.py:49
+msgid "activationkey_addpackages: Add packages to an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:50
+msgid "usage: activationkey_addpackages KEY <PACKAGE ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:83
+msgid "activationkey_removepackages: Remove packages from an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:85
+msgid "usage: activationkey_removepackages KEY <PACKAGE ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:121
+msgid "activationkey_addgroups: Add groups to an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:122
+msgid "usage: activationkey_addgroups KEY <GROUP ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:160
+msgid "activationkey_removegroups: Remove groups from an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:161
+msgid "usage: activationkey_removegroups KEY <GROUP ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:208
+msgid "activationkey_addentitlements: Add entitlements to an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:210
+msgid "usage: activationkey_addentitlements KEY <ENTITLEMENT ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:245
+msgid ""
+"activationkey_removeentitlements: Remove entitlements from an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:247
+msgid "usage: activationkey_removeentitlements KEY <ENTITLEMENT ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:285
+msgid "activationkey_addchildchannels: Add child channels to an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:287
+msgid "usage: activationkey_addchildchannels KEY <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:337
+msgid ""
+"activationkey_removechildchannels: Remove child channels from an activation "
+"key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:339
+msgid "usage: activationkey_removechildchannels KEY <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:376
+msgid ""
+"activationkey_listchildchannels: List the child channels for an activation "
+"key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:378
+msgid "usage: activationkey_listchildchannels KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:407
+msgid ""
+"activationkey_listbasechannel: List the base channels for an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:409
+msgid "usage: activationkey_listbasechannel KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:437
+msgid "activationkey_listgroups: List the groups for an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:439
+msgid "usage: activationkey_listgroups KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:470
+msgid ""
+"activationkey_listentitlements: List the entitlements for an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:472
+msgid "usage: activationkey_listentitlements KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:501
+msgid "activationkey_listpackages: List the packages for an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:503
+msgid "usage: activationkey_listpackages KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:535
+msgid ""
+"activationkey_listconfigchannels: List the configuration channels for an "
+"activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:537
+msgid "usage: activationkey_listconfigchannels KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:570
+msgid ""
+"activationkey_addconfigchannels: Add config channels to an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:572
+msgid ""
+"usage: activationkey_addconfigchannels KEY <CHANNEL ...> [options])\n"
+"\n"
+"options:\n"
+"  -t add channels to the top of the list\n"
+"  -b add channels to the bottom of the list"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:625
+msgid ""
+"activationkey_removeconfigchannels: Remove config channels from an "
+"activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:627
+msgid "usage: activationkey_removeconfigchannels KEY <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:666
+msgid ""
+"activationkey_setconfigchannelorder: Set the ranked order of configuration "
+"channels"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:668
+msgid "usage: activationkey_setconfigchannelorder KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:698
+msgid "New Configuration Channels:"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:712
+msgid "activationkey_create: Create an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:713
+msgid ""
+"usage: activationkey_create [options])\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -d DESCRIPTION\n"
+"  -b BASE_CHANNEL\n"
+"  -u set key as universal default\n"
+"  -e [enterprise_entitled,virtualization_host]"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:734
+msgid "Name (blank to autogenerate):"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:735
+msgid "Description [None]:"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:738 ../src/spacecmd/distribution.py:78
+#: ../src/spacecmd/softwarechannel.py:927
+msgid "Base Channels"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:743
+msgid "Base Channel (blank for default):"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:751
+#, python-format
+msgid "%s Entitlement [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:755
+msgid "Universal Default [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:782
+#, python-format
+msgid "Created activation key %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:790
+msgid "activationkey_delete: Delete an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:791
+msgid "usage: activationkey_delete KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:813 ../src/spacecmd/cryptokey.py:139
+#: ../src/spacecmd/cryptokey.py:197
+#, python-format
+msgid "No keys matched argument %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:819
+msgid "Delete activation key(s) [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:832
+msgid "activationkey_list: List all activation keys"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:833
+msgid "usage: activationkey_list"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:857
+msgid "activationkey_listsystems: List systems registered with a key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:858
+msgid "usage: activationkey_listsystems KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:881 ../src/spacecmd/activationkey.py:930
+#, python-format
+msgid "%s is not a valid activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:895
+msgid "activationkey_details: Show the details of an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:896
+msgid "usage: activationkey_details KEY ..."
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:943
+#, python-format
+msgid "Key:                    %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:944
+#, python-format
+msgid "Description:            %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:945
+#, python-format
+msgid "Universal Default:      %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:946
+#, python-format
+msgid "Usage Limit:            %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:947
+#, python-format
+msgid "Deploy Config Channels: %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:949
+#, python-format
+msgid "Contact Method:         %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:952 ../src/spacecmd/kickstart.py:425
+#: ../src/spacecmd/system.py:3048
+msgid "Software Channels"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:960 ../src/spacecmd/configchannel.py:765
+#: ../src/spacecmd/configchannel.py:870 ../src/spacecmd/system.py:3057
+msgid "Configuration Channels"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:966 ../src/spacecmd/system.py:3062
+msgid "Entitlements"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:971 ../src/spacecmd/system.py:3068
+msgid "System Groups"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:976 ../src/spacecmd/package.py:206
+#: ../src/spacecmd/package.py:263 ../src/spacecmd/softwarechannel.py:1392
+#: ../src/spacecmd/softwarechannel.py:1494
+#: ../src/spacecmd/softwarechannel.py:1576
+#: ../src/spacecmd/softwarechannel.py:1822
+msgid "Packages"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:991
+msgid "activationkey_enableconfigdeployment: Enable config channel deployment"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:993
+msgid "usage: activationkey_enableconfigdeployment KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1020
+msgid ""
+"activationkey_disableconfigdeployment: Disable config channel deployment"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1022
+msgid "usage: activationkey_disableconfigdeployment KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1049
+msgid "activationkey_setbasechannel: Set the base channel of an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1051
+msgid "usage: activationkey_setbasechannel KEY CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1098
+msgid ""
+"activationkey_setusagelimit: Set the usage limit of an activation key, can "
+"be a number or \"unlimited\""
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1100
+msgid "usage: activationkey_setusagelimit KEY <usage limit>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1101
+msgid "usage: activationkey_setusagelimit KEY unlimited "
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1131
+#, python-format
+msgid "Couldn't convert argument %s to an integer"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1153
+msgid ""
+"activationkey_setuniversaldefault: Set this key as the universal default"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1155
+msgid "usage: activationkey_setuniversaldefault KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1196
+msgid "activationkey_export: Export activation key(s) to JSON format file"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1197
+msgid ""
+"usage: activationkey_export [options] [<KEY> ...])\n"
+"\n"
+"options:\n"
+"    -f outfile.json : specify an output filename, defaults to <KEY>.json\n"
+"                      if exporting a single key, akeys.json for multiple "
+"keys,\n"
+"                      or akey_all.json if no KEY specified (export ALL)\n"
+"\n"
+"Note : KEY list is optional, default is to export ALL keys "
+msgstr ""
+
+#. Get the key details
+#: ../src/spacecmd/activationkey.py:1213
+#, python-format
+msgid "Getting activation key details for %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1267
+#, python-format
+msgid "Exporting ALL activation keys to %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1276
+msgid "Invalid activation key passed"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1291
+#, python-format
+msgid "Exporting key %s to %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1300
+#, python-format
+msgid "File %s exists, confirm overwrite file? (y/n)"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1305
+msgid "Failed to save exported keys to file: {}"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1314
+msgid "activationkey_import: import activation key(s) from JSON file(s)"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1315
+msgid "usage: activationkey_import <JSONFILE ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1324
+msgid "No filename passed"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1333
+#, python-format
+msgid "Could not read json data from %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1338 ../src/spacecmd/activationkey.py:1382
+#, python-format
+msgid "Failed to import key %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1352
+#, python-format
+msgid "%s already exists! Skipping!"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1407
+#, python-format
+msgid "System group %s doesn't exist, creating"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1428
+msgid "activationkey_clone: Clone an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1429
+msgid ""
+"usage examples:\n"
+"                 activationkey_clone foo_key -c bar_key\n"
+"                 activationkey_clone foo_key1 foo_key2 -c prefix\n"
+"                 activationkey_clone foo_key -x \"s/foo/bar\"\n"
+"                 activationkey_clone foo_key1 foo_key2 -x \"s/foo/bar\"\n"
+"\n"
+"options:\n"
+"  -c CLONE_NAME  : Name of the resulting key, treated as a prefix for "
+"multiple\n"
+"                   keys\n"
+"  -x \"s/foo/bar\" : Optional regex replacement, replaces foo with bar in "
+"the\n"
+"                   clone description, base-channel label, child-channel\n"
+"                   labels, config-channel names "
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1457 ../src/spacecmd/kickstart.py:460
+#: ../src/spacecmd/system.py:3043
+msgid "Activation Keys"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1463
+#, python-format
+msgid "Key to clone: %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1467
+msgid "Original Key:"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1469
+msgid "Cloned Key:"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1472 ../src/spacecmd/configchannel.py:1376
+msgid "Error - must specify either -c or -x options!"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1477
+#, python-format
+msgid "Key %s already exists"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1481
+msgid "Error no activationkey to clone passed!"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1535
+#, python-format
+msgid "Found child channel %s key %s, %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1537
+msgid " does not exist, skipping!"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1544
+#, python-format
+msgid "Regex-replacement results in new base-channel %s which does not exist!"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1560
+#, python-format
+msgid "Found config channel %s for key %s, %s "
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1562
+msgid "does not exist, skipping!"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1584 ../src/spacecmd/configchannel.py:1428
+#, python-format
+msgid "Failed to clone %s to %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1602
+msgid "no activationkey label given"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1605
+msgid "invalid activationkey label "
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1622
+msgid "activationkey_diff: Diff activation keys"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1624
+msgid "usage: activationkey_diff SOURCE_KEY TARGET_KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1673
+msgid "activationkey_disable: Disable an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1675
+msgid "usage: activationkey_disable KEY [KEY ...]"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1707
+msgid "activationkey_enable: Enable an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1709
+msgid "usage: activationkey_enable KEY [KEY ...]"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1741
+msgid "activationkey_setdescription: Set the activation key description"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1743
+msgid "usage: activationkey_setdescription KEY DESCRIPTION"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1775
+msgid ""
+"activationkey_setcontactmethod: Set the contact method to use for systems "
+"registered with this key."
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1777 ../src/spacecmd/system.py:4132
+msgid "Available contact methods: "
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1778
+msgid "usage: activationkey_setcontactmethod KEY CONTACT_METHOD"
+msgstr ""
+
+#: ../src/spacecmd/api.py:44
+msgid "api: call RHN API with arguments directly"
+msgstr ""
+
+#: ../src/spacecmd/api.py:45
+#, python-format
+msgid ""
+"usage: api [options] API_STRING)\n"
+"\n"
+"options:\n"
+"  -A, --args  Arguments for the API other than session id in comma "
+"separated\n"
+"              strings or JSON expression\n"
+"  -F, --format   Output format\n"
+"  -o, --output   Output file\n"
+"\n"
+"examples:\n"
+"  api api.getApiCallList\n"
+"  api --args \"sysgroup_A\" systemgroup.listSystems\n"
+"  api -A \"rhel-i386-server-5,2011-04-01,2011-05-01\" -F \"%(name)s\" \\\n"
+"      channel.software.listAllPackages\n"
+msgstr ""
+
+#: ../src/spacecmd/api.py:81
+msgid "Could not open to write: "
+msgstr ""
+
+#: ../src/spacecmd/api.py:82
+msgid "Fallback output to stdout"
+msgstr ""
+
+#: ../src/spacecmd/api.py:91
+msgid "No such API: "
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:50
+msgid "configchannel_list: List all configuration channels"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:51
+msgid "usage: configchannel_list"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:68
+msgid "configchannel_listsystems: List the systems subscribed to a"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:69
+msgid "                           configuration channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:70
+msgid "usage: configchannel_listsystems CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:79
+msgid "This version of the API doesn't support this method"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:103
+msgid "configchannel_listfiles: List the files in a config channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:104
+msgid "usage: configchannel_listfiles CHANNEL ..."
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:133
+msgid "configchannel_forcedeploy: Forces a redeployment"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:134
+msgid "                           of files within this channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:135
+msgid "                           on all subscribed systems"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:136
+msgid "usage: configchannel_forcedeploy CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:158
+msgid "No files within selected configchannel."
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:164
+msgid "Channel has no subscribed Systems"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:167
+msgid "Force deployment of the following configfiles:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:170
+msgid ""
+"\n"
+"On these systems:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:173
+msgid "Really force deployment [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:182
+msgid "configchannel_filedetails: Show the details of a file"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:183
+msgid "in a configuration channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:184
+msgid "usage: configchannel_filedetails CHANNEL FILE [REVISION]"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:216
+#, python-format
+msgid "Invalid revision: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:222
+#, python-format
+msgid "%s is not in this configuration channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:240
+#, python-format
+msgid "Path:     %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:241
+#, python-format
+msgid "Type:     %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:242
+#, python-format
+msgid "Revision: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:243
+#, python-format
+msgid "Created:  %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:244
+#, python-format
+msgid "Modified: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:248 ../src/spacecmd/configchannel.py:650
+#, python-format
+msgid "Target Path:     %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:251 ../src/spacecmd/configchannel.py:680
+#, python-format
+msgid "Owner:           %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:252 ../src/spacecmd/configchannel.py:681
+#, python-format
+msgid "Group:           %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:253 ../src/spacecmd/configchannel.py:682
+#, python-format
+msgid "Mode:            %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:255 ../src/spacecmd/configchannel.py:651
+#: ../src/spacecmd/configchannel.py:684
+#, python-format
+msgid "SELinux Context: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:258
+#, python-format
+msgid "SHA256:          %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:259 ../src/spacecmd/configchannel.py:683
+#, python-format
+msgid "Binary:          %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:263 ../src/spacecmd/configchannel.py:696
+#: ../src/spacecmd/configchannel.py:933 ../src/spacecmd/kickstart.py:1903
+#: ../src/spacecmd/snippet.py:161
+msgid "Contents"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:273
+msgid "configchannel_backup: backup a config channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:274
+msgid ""
+"usage: configchannel_backup CHANNEL [OUTDIR])\n"
+"\n"
+"OUTDIR defaults to $HOME/spacecmd-backup/configchannel/YYYY-MM-DD/CHANNEL\n"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:313 ../src/spacecmd/group.py:266
+#, python-format
+msgid "Could not create output directory: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:326
+#, python-format
+msgid "Could not create \"%s\" file: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:332
+#, python-format
+msgid "Output Path:   %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:371
+msgid "configchannel_details: Show the details of a config channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:372
+msgid "usage: configchannel_details CHANNEL ..."
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:402 ../src/spacecmd/kickstart.py:414
+#, python-format
+msgid "Label:       %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:403 ../src/spacecmd/kickstart.py:413
+#, python-format
+msgid "Name:        %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:404 ../src/spacecmd/cryptokey.py:214
+#: ../src/spacecmd/system.py:678
+#, python-format
+msgid "Description: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:405 ../src/spacecmd/cryptokey.py:215
+#: ../src/spacecmd/kickstart.py:500 ../src/spacecmd/kickstart.py:1899
+#, python-format
+msgid "Type:        %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:408
+msgid "Files"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:418
+msgid "configchannel_create: Create a configuration channel of specific type"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:419
+msgid ""
+"usage: configchannel_create [options])\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -l LABEL\n"
+"  -d DESCRIPTION\n"
+"  -t TYPE('normal,'state')"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:438 ../src/spacecmd/custominfo.py:54
+#: ../src/spacecmd/custominfo.py:198 ../src/spacecmd/distribution.py:71
+#: ../src/spacecmd/filepreservation.py:70 ../src/spacecmd/group.py:177
+#: ../src/spacecmd/repo.py:349 ../src/spacecmd/repo.py:461
+#: ../src/spacecmd/softwarechannel.py:800
+msgid "Name:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:439
+msgid "Label:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:440 ../src/spacecmd/cryptokey.py:66
+#: ../src/spacecmd/custominfo.py:59 ../src/spacecmd/custominfo.py:203
+#: ../src/spacecmd/group.py:182 ../src/spacecmd/softwarechannel.py:812
+#: ../src/spacecmd/system.py:3519
+msgid "Description:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:441
+msgid "Type [normal, state]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:448
+msgid "Only [normal/state] values are acceptable for type"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:452 ../src/spacecmd/distribution.py:109
+#: ../src/spacecmd/repo.py:357 ../src/spacecmd/repo.py:467
+msgid "A name is required"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:461
+msgid "Only [normal/state] values are acceptable for --type parameter"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:476
+msgid "configchannel_delete: Delete a configuration channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:477
+msgid "usage: configchannel_delete CHANNEL ..."
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:498
+#, python-format
+msgid "No channels matched argument(s): %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:504 ../src/spacecmd/softwarechannel.py:736
+msgid "Delete these channels [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:548
+msgid "Symlink [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:552
+msgid "Target Path:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:553
+msgid "SELinux Context [none]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:561
+msgid "Directory [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:570
+#, python-format
+msgid "Owner [%s]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:571
+#, python-format
+msgid "Group [%s]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:572
+#, python-format
+msgid "Mode [%s]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:574
+#, python-format
+msgid "SELinux Context [%s]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:575
+msgid "Revision [next]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:593
+msgid "The revision must be an integer"
+msgstr ""
+
+#. get the contents of the script
+#: ../src/spacecmd/configchannel.py:596 ../src/spacecmd/configchannel.py:896
+#: ../src/spacecmd/cryptokey.py:68 ../src/spacecmd/kickstart.py:1954
+#: ../src/spacecmd/snippet.py:141
+msgid "Read an existing file [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:598 ../src/spacecmd/kickstart.py:1956
+msgid "File:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:616
+msgid "The path is required"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:630 ../src/spacecmd/configchannel.py:913
+msgid "You must provide the file contents"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:634
+msgid "You must provide the target path for a symlink"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:649 ../src/spacecmd/configchannel.py:678
+#, python-format
+msgid "Path:            %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:679
+#, python-format
+msgid "Directory:       %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:689
+#, python-format
+msgid "Revision:        %i"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:694
+msgid "Contents not displayed (base64 encoded)"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:707
+msgid ""
+"configchannel_addfile/configchannel_updatefile: Create a configuration file"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:708
+msgid ""
+"usage: configchannel_addfile/configchannel_updatefile -c CHANNEL - p PATH -f "
+"LOCAL_FILE_PATH [OPTIONS])\n"
+"\n"
+"options:\n"
+"  -c CHANNEL\n"
+"  -p PATH\n"
+"  -r REVISION\n"
+"  -o OWNER [default: root]\n"
+"  -g GROUP [default: root]\n"
+"  -m MODE [defualt: 0644]\n"
+"  -x SELINUX_CONTEXT\n"
+"  -d path is a directory\n"
+"  -s path is a symlink\n"
+"  -b path is a binary (or other file which needs base64 encoding)\n"
+"  -t SYMLINK_TARGET\n"
+"  -f local path to file contents\n"
+"  -y automatically proceed with file contents\n"
+"\n"
+"  Note re binary/base64: Some text files, notably those containing trailing\n"
+"  newlines, those containing ASCII escape characters (or other charaters "
+"not\n"
+"  allowed in XML) need to be sent as binary (-b).  Some effort is made to "
+"auto-\n"
+"  detect files which require this, but you may need to explicitly specify.\n"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:770 ../src/spacecmd/softwarechannel.py:819
+#: ../src/spacecmd/softwarechannel.py:940
+#: ../src/spacecmd/softwarechannel.py:947
+msgid "Select:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:778 ../src/spacecmd/softwarechannel.py:1374
+#, python-format
+msgid "%s is not a valid channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:783
+msgid "Unable to obtain a valid channel. Aborting."
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:789 ../src/spacecmd/scap.py:160
+msgid "Path:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:805 ../src/spacecmd/configchannel.py:924
+msgid "No config channel specified!"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:810 ../src/spacecmd/configchannel.py:929
+msgid "Error obtaining file info"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:845
+msgid "configchannel_updateinitsls: Update init.sls file"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:846
+msgid ""
+"usage: configchannel_updateinitsls -c CHANNEL -f LOCAL_FILE_PATH [OPTIONS])\n"
+"\n"
+"options:\n"
+"  -c CHANNEL\n"
+"  -f local path to file contents\n"
+"  -y automatically proceed with file contents\n"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:892
+#, python-format
+msgid "No existing file information found for %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:932
+#, python-format
+msgid "contents_enc64:           %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:959
+msgid "configchannel_removefiles: Remove configuration files"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:960
+msgid "usage: configchannel_removefiles CHANNEL <FILE ...>"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:997
+msgid "configchannel_verifyfile: Verify a configuration file"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:998
+msgid "usage: configchannel_verifyfile CHANNEL FILE <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1037
+msgid "No valid system selected"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1045 ../src/spacecmd/system.py:509
+#: ../src/spacecmd/system.py:529 ../src/spacecmd/system.py:959
+#, python-format
+msgid "Action ID: %i"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1053
+msgid "configchannel_export: export config channel(s) to json format file"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1054
+msgid ""
+"usage: configchannel_export <CHANNEL>... [options])\n"
+"options:\n"
+"    -f outfile.json : specify an output filename, defaults to <CHANNEL>."
+"json\n"
+"                      if exporting a single channel, ccs.json for multiple\n"
+"                      channels, or cc_all.json if no CHANNEL specified\n"
+"                      e.g (export ALL)\n"
+"\n"
+"Note : CHANNEL list is optional, default is to export ALL"
+msgstr ""
+
+#. Get the cc details
+#: ../src/spacecmd/configchannel.py:1070
+#, python-format
+msgid "Getting config channel details for %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1090
+#, python-format
+msgid "Failed to get details for file %s from %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1136
+#, python-format
+msgid "File %s could not be exported "
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1137
+msgid "with this API version(needs base64 encoding)"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1139
+#, python-format
+msgid "File %s could not be exported as"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1140
+msgid " text...getting base64 encoded version"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1163
+#, python-format
+msgid "Passed filename '%s' to do_configchannel_export command."
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1171
+#, python-format
+msgid "Exporting ALL config channels to %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1178
+msgid ""
+"Error, no valid config channel passed, check name is  correct with spacecmd "
+"configchannel_list"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1193
+#, python-format
+msgid "Exporting cc %s to %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1200
+msgid "File '{}' exists, confirm overwrite file? (y/n)"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1203
+#, python-format
+msgid "Error saving exported config channels to file: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1212
+msgid "configchannel_import: import config channel(s) from json file"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1213
+msgid "usage: configchannel_import <JSONFILES...>"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1222 ../src/spacecmd/kickstart.py:2330
+msgid "Error, no filename passed"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1230 ../src/spacecmd/kickstart.py:2338
+#, python-format
+msgid "Error, could not read json data from %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1234
+#, python-format
+msgid "Error importing configchannel %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1246
+#, python-format
+msgid "Config channel %s already exists! Skipping!"
+msgstr ""
+
+#. create the cc, we need to drop the org prefix from the cc name
+#: ../src/spacecmd/configchannel.py:1251
+#, python-format
+msgid "Importing config channel  %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1294
+#, python-format
+msgid "Failed trying to import file %s (empty content)"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1296
+msgid "Older APIs can't export encoded files"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1319
+#, python-format
+msgid "Error adding file %s to %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1329
+msgid "configchannel_clone: Clone config channel(s)"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1330
+msgid ""
+"usage examples:\n"
+"                 configchannel_clone foo_label -c bar_label\n"
+"                 configchannel_clone foo_label1 foo_label2 -c prefix\n"
+"                 configchannel_clone foo_label -x \"s/foo/bar\"\n"
+"                 configchannel_clone foo_label1 foo_label2 -x \"s/foo/bar\"\n"
+"\n"
+"options:\n"
+"  -c CLONE_LABEL : name/label of the resulting cc (note does not update\n"
+"                   description, see -x option), treated as a prefix if\n"
+"                   multiple keys are passed\n"
+"  -x \"s/foo/bar\" : Optional regex replacement, replaces foo with bar in "
+"the\n"
+"                   clone name, label and description\n"
+"  Note : If no -c or -x option is specified, interactive is assumed"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1359
+msgid "No config channels found"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1362
+msgid "Config Channels"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1368
+#, python-format
+msgid "Channel to clone: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1372
+msgid "Channel to clone:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1373
+msgid "Clone label:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1382
+msgid "Error no channel label passed!"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1391
+msgid "No suitable channels to clone has been found."
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1444
+msgid "no configchannel given"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1447
+msgid "invalid configchannel label "
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1473
+msgid "configchannel_diff: diff between config channels"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1475
+msgid "usage: configchannel_diff SOURCE_CHANNEL TARGET_CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1524
+msgid "configchannel_sync:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1525
+msgid "sync config files between two config channels"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1527
+msgid "usage: configchannel_sync SOURCE_CHANNEL TARGET_CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1565
+msgid "syncing files from configchannel "
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1572
+msgid "files common in both channels:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1578
+msgid "files only in source "
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1584
+msgid "files only in target "
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1589
+msgid ""
+"files that are in both channels will be overwritten in the target channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1591
+msgid "files only in the source channel will be added to the target channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1593
+msgid "files only in the target channel will be deleted"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1596
+msgid "nothing to do"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1600
+msgid "perform synchronisation [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1652
+msgid "unknown file type "
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:43
+msgid "cryptokey_create: Create a cryptographic key"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:44
+msgid ""
+"usage: cryptokey_create [options])\n"
+"\n"
+"options:\n"
+"  -t GPG or SSL\n"
+"  -d DESCRIPTION\n"
+"  -f KEY_FILE"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:62
+msgid "GPG or SSL [G/S]:"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:75
+msgid "The key type is required"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:79
+msgid "A description is required"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:83
+msgid "A file containing the key is required"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:91
+msgid "No contents of the file"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:100
+msgid "Invalid key type"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:114
+msgid "cryptokey_delete: Delete a cryptographic key"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:115
+msgid "usage: cryptokey_delete NAME"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:145
+msgid "Delete key(s) [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:156
+msgid "cryptokey_list: List all cryptographic keys (SSL, GPG)"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:157
+msgid "usage: cryptokey_list"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:174
+msgid "cryptokey_details: Show the contents of a cryptographic key"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:175
+msgid "usage: cryptokey_details KEY ..."
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:207
+#, python-format
+msgid "%s is not a valid crypto key"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:39
+msgid "custominfo_createkey: Create a custom key"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:40
+msgid "usage: custominfo_createkey [NAME] [DESCRIPTION]"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:73
+msgid "custominfo_deletekey: Delete a custom key"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:74
+msgid "usage: custominfo_deletekey KEY ..."
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:114
+msgid "custominfo_listkeys: List all custom keys"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:115
+msgid "usage: custominfo_listkeys"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:132
+msgid "custominfo_details: Show the details of a custom key"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:133
+msgid "usage: custominfo_details KEY ..."
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:155
+msgid "No keys matched argument '{}'."
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:172
+#, python-format
+msgid "Label:        %s"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:173
+#, python-format
+msgid "Description:  %s"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:174
+#, python-format
+msgid "Modified:     %s"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:175
+#, python-format
+msgid "System Count: %i"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:183
+msgid "custominfo_updatekey: Update a custom key"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:184
+msgid "usage: custominfo_updatekey [NAME] [DESCRIPTION]"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:42
+msgid "distribution_create: Create a Kickstart tree"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:43
+msgid ""
+"usage: distribution_create [options]\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -p path to tree\n"
+"  -b base channel to associate with\n"
+"  -t install type [fedora|rhel_4/5/6|generic_rpm]"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:66
+msgid "The name of the distribution is required"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:73
+msgid "Path to Kickstart Tree:"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:83
+msgid "Base Channel:"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:86
+msgid "Invalid channel label"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:97
+msgid "Install Types"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:102
+msgid "Install Type:"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:105
+msgid "Invalid install type"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:113
+msgid "A path is required"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:117 ../src/spacecmd/system.py:2556
+msgid "A base channel is required"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:121
+msgid "An install type is required"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:143
+msgid "distribution_list: List the available autoinstall trees"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:144
+msgid "usage: distribution_list"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:168
+msgid "distribution_delete: Delete a Kickstart tree"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:169
+msgid "usage: distribution_delete LABEL"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:193 ../src/spacecmd/distribution.py:232
+#, python-format
+msgid "No distributions matched argument %s"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:199
+msgid "Delete distribution tree(s) [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:209
+msgid "distribution_details: Show the details of a Kickstart tree"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:210
+msgid "usage: distribution_details LABEL"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:248 ../src/spacecmd/package.py:93
+#, python-format
+msgid "Name:    %s"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:249 ../src/spacecmd/package.py:100
+#, python-format
+msgid "Path:    %s"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:250
+#, python-format
+msgid "Channel: %s"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:258
+msgid "distribution_rename: Rename a Kickstart tree"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:259
+msgid "usage: distribution_rename OLDNAME NEWNAME"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:288
+msgid "distribution_update: Update the path of a Kickstart tree"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:289
+msgid ""
+"usage: distribution_update NAME [options]\n"
+"\n"
+"options:\n"
+"  -p path to tree\n"
+"  -b base channel to associate with\n"
+"  -t install type [fedora|rhel_4/5/6|generic_rpm]"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:49
+msgid "errata_list: List all patches"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:50
+msgid "usage: errata_list"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:66
+msgid "errata_summary: Print a summary of all errata"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:67
+msgid "usage: errata_summary"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:82
+msgid "errata_apply: Apply an erratum to all affected systems"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:83
+msgid ""
+"usage: errata_apply [options] ERRATA|search:XXX ...)\n"
+"\n"
+"options:\n"
+"  -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:110 ../src/spacecmd/system.py:417
+#: ../src/spacecmd/system.py:725 ../src/spacecmd/system.py:880
+#: ../src/spacecmd/system.py:1015 ../src/spacecmd/system.py:1762
+#: ../src/spacecmd/system.py:3673 ../src/spacecmd/system.py:3983
+#: ../src/spacecmd/system.py:4045 ../src/spacecmd/system.py:4209
+msgid "Start Time [now]:"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:158
+msgid "No patches to apply"
+msgstr ""
+
+#. a summary of which errata we're going to apply
+#: ../src/spacecmd/errata.py:162
+msgid "Errata             Systems"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:166 ../src/spacecmd/system.py:230
+#: ../src/spacecmd/system.py:467 ../src/spacecmd/system.py:820
+#: ../src/spacecmd/system.py:942 ../src/spacecmd/system.py:1079
+#: ../src/spacecmd/system.py:1781 ../src/spacecmd/system.py:3685
+#: ../src/spacecmd/system.py:4228
+#, python-format
+msgid "Start Time: %s"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:168
+msgid "Apply these patches [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:218
+#, python-format
+msgid "No patches to schedule for %s"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:227
+#, python-format
+msgid "Scheduled %i patches for %s"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:236
+msgid "errata_listaffectedsystems: List of systems affected by an patch"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:237
+msgid "usage: errata_listaffectedsystems ERRATA|search:XXX ..."
+msgstr ""
+
+#: ../src/spacecmd/errata.py:275
+msgid "errata_listcves: List of CVEs addressed by an patch"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:276
+msgid "usage: errata_listcves ERRATA|search:XXX ..."
+msgstr ""
+
+#: ../src/spacecmd/errata.py:312
+msgid "No errata has been found"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:319
+msgid "errata_findbycve: List errata addressing a CVE"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:320
+msgid "usage: errata_findbycve CVE-YYYY-NNNN ..."
+msgstr ""
+
+#: ../src/spacecmd/errata.py:354
+msgid "errata_details: Show the details of an patch"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:355
+msgid "usage: errata_details ERRATA|search:XXX ..."
+msgstr ""
+
+#: ../src/spacecmd/errata.py:390
+#, python-format
+msgid "%s is not a valid erratum"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:397
+#, python-format
+msgid "Name:       %s"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:398
+msgid "Product:   s"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:399
+msgid "Type:      s"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:400
+msgid "Issue Date:s"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:402
+msgid "Topic"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:406 ../src/spacecmd/package.py:107
+#: ../src/spacecmd/softwarechannel.py:591
+msgid "Description"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:412
+msgid "Notes"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:417
+msgid "CVEs"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:421
+msgid "Solution"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:425
+msgid "References"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:429
+msgid "Affected Channels"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:433 ../src/spacecmd/org.py:278
+msgid "Affected Systems"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:437
+msgid "Affected Packages"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:447
+msgid "errata_delete: Delete an patch"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:448
+msgid "usage: errata_delete ERRATA|search:XXX ..."
+msgstr ""
+
+#: ../src/spacecmd/errata.py:468
+msgid "No patches to delete"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:471
+msgid "Erratum            Channels"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:479
+msgid "Delete these patches [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:485
+#, python-format
+msgid "Deleted %i patches"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:495
+msgid "errata_publish: Publish an patch to a channel"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:496
+msgid "usage: errata_publish ERRATA|search:XXX <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:523
+msgid "No patches to publish"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:528
+msgid "Publish these patches [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:540
+msgid "errata_search: List patches that meet the given criteria"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:541
+msgid "usage: errata_search CVE|RHSA|RHBA|RHEA|CLA ..."
+msgstr ""
+
+#: ../src/spacecmd/errata.py:543 ../src/spacecmd/scap.py:179
+msgid "Example:"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:42
+msgid "filepreservation_list: List all file preservations"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:43
+msgid "usage: filepreservation_list"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:58
+msgid "filepreservation_create: Create a file preservation list"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:59
+msgid "usage: filepreservation_create [NAME] [FILE ...]"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:78
+#: ../src/spacecmd/filepreservation.py:92
+msgid "File List"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:83
+msgid "File [blank to finish]:"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:109
+msgid "filepreservation_delete: Delete a file preservation list"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:110
+msgid "usage: filepreservation_delete NAME"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:128
+msgid "Delete this list [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:139
+msgid ""
+"filepreservation_details: Show the details of a file\n"
+"'preservation list"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:141
+msgid "usage: filepreservation_details NAME"
+msgstr ""
+
+#: ../src/spacecmd/group.py:50
+msgid "group_addsystems: Add systems to a group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:51
+msgid "usage: group_addsystems GROUP <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/group.py:52
+msgid "       group_addsystems GROUP <ssm>"
+msgstr ""
+
+#: ../src/spacecmd/group.py:103
+msgid "group_removesystems: Remove systems from a group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:104
+msgid "usage: group_removesystems GROUP <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/group.py:145 ../src/spacecmd/system.py:118
+#: ../src/spacecmd/system.py:232 ../src/spacecmd/system.py:475
+#: ../src/spacecmd/system.py:1475 ../src/spacecmd/system.py:1783
+#: ../src/spacecmd/system.py:4230
+msgid "Systems"
+msgstr ""
+
+#: ../src/spacecmd/group.py:149
+msgid "Remove these systems [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/group.py:158 ../src/spacecmd/schedule.py:385
+#: ../src/spacecmd/ssm.py:87 ../src/spacecmd/ssm.py:136
+#: ../src/spacecmd/ssm.py:186 ../src/spacecmd/system.py:4273
+#: ../src/spacecmd/system.py:4329
+msgid "No systems found"
+msgstr ""
+
+#: ../src/spacecmd/group.py:165
+msgid "group_create: Create a system group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:166
+msgid "usage: group_create [NAME] [DESCRIPTION]"
+msgstr ""
+
+#: ../src/spacecmd/group.py:192
+msgid "group_delete: Delete a system group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:193
+msgid "usage: group_delete NAME ..."
+msgstr ""
+
+#: ../src/spacecmd/group.py:212
+msgid "Delete these groups [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/group.py:224
+msgid "group_backup: backup a system group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:225
+msgid ""
+"usage: group_backup <NAME> [OUTDIR])\n"
+"                    group_backup ALL\n"
+"\n"
+"\"OUTDIR\" defaults to $HOME/spacecmd-backup/group/YYYY-MM-DD/NAME\n"
+"\"ALL\" is a keyword and collects all groups\n"
+msgstr ""
+
+#: ../src/spacecmd/group.py:270
+#, python-format
+msgid "Backup Group: %s"
+msgstr ""
+
+#: ../src/spacecmd/group.py:273
+#, python-format
+msgid "Output File: %s"
+msgstr ""
+
+#: ../src/spacecmd/group.py:284
+msgid "group_restore: restore a system group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:285
+msgid ""
+"\n"
+"usage: group_restore INPUTDIR [NAME] ...\n"
+"       group_restore INPUTDIR ALL\n"
+"       group_restore INPUTDIR\n"
+"       group_restore .\n"
+"\n"
+"Specifying only INPUTDIR will default to ALL groups.\n"
+"Setting dot (.) instead of full INPUTDIR will imply current directory.\n"
+"    "
+msgstr ""
+
+#: ../src/spacecmd/group.py:329
+#, python-format
+msgid "Restore dir %s does not exits or is not a directory"
+msgstr ""
+
+#: ../src/spacecmd/group.py:333
+#, python-format
+msgid "Restore dir %s has no restore items"
+msgstr ""
+
+#: ../src/spacecmd/group.py:340
+#, python-format
+msgid "Group %s was not found in backup"
+msgstr ""
+
+#: ../src/spacecmd/group.py:343
+#, python-format
+msgid "Found %s missing groups, terminating"
+msgstr ""
+
+#: ../src/spacecmd/group.py:358
+#, python-format
+msgid "Group %s already restored"
+msgstr ""
+
+#: ../src/spacecmd/group.py:365
+msgid "Changing description from:"
+msgstr ""
+
+#: ../src/spacecmd/group.py:367
+msgid "Continue [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/group.py:370 ../src/spacecmd/group.py:373
+#, python-format
+msgid "Updating description for group: %s"
+msgstr ""
+
+#: ../src/spacecmd/group.py:376
+#, python-format
+msgid "Creating new group %s"
+msgstr ""
+
+#: ../src/spacecmd/group.py:385
+msgid "group_list: List available system groups"
+msgstr ""
+
+#: ../src/spacecmd/group.py:386
+msgid "usage: group_list"
+msgstr ""
+
+#: ../src/spacecmd/group.py:403
+msgid "group_listsystems: List the members of a group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:404
+msgid "usage: group_listsystems GROUP"
+msgstr ""
+
+#: ../src/spacecmd/group.py:426
+#, python-format
+msgid "%s is not a valid group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:439
+msgid "group_details: Show the details of a system group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:440
+msgid "usage: group_details GROUP ..."
+msgstr ""
+
+#: ../src/spacecmd/group.py:463
+#, python-format
+msgid "The group \"%s\" is invalid"
+msgstr ""
+
+#: ../src/spacecmd/group.py:470
+#, python-format
+msgid "ID:                %i"
+msgstr ""
+
+#: ../src/spacecmd/group.py:471
+#, python-format
+msgid "Name:              %s"
+msgstr ""
+
+#: ../src/spacecmd/group.py:472
+#, python-format
+msgid "Description:       %s"
+msgstr ""
+
+#: ../src/spacecmd/group.py:473
+#, python-format
+msgid "Number of Systems: %i"
+msgstr ""
+
+#: ../src/spacecmd/group.py:477
+msgid "Members"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:72
+msgid "kickstart_list: List the available Kickstart profiles"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:73
+msgid "usage: kickstart_list"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:85 ../src/spacecmd/kickstart.py:2108
+msgid "No kickstart profiles available"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:91
+msgid "kickstart_create: Create a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:92
+msgid ""
+"usage: kickstart_create [options])\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -d DISTRIBUTION\n"
+"  -p ROOT_PASSWORD\n"
+"  -v VIRT_TYPE ['none', 'para_host', 'qemu', 'xenfv', 'xenpv']"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:113 ../src/spacecmd/kickstart.py:249
+msgid "Virtualization Types"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:118 ../src/spacecmd/kickstart.py:254
+msgid "Virtualization Type [none]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:126 ../src/spacecmd/kickstart.py:262
+msgid "Distributions"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:136
+msgid "Root Password: "
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:137 ../src/spacecmd/org.py:90
+#: ../src/spacecmd/user.py:85
+msgid "Repeat Password: "
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:142 ../src/spacecmd/org.py:95
+#: ../src/spacecmd/user.py:90
+msgid "Password must be at least 5 characters"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:144 ../src/spacecmd/org.py:97
+#: ../src/spacecmd/user.py:92
+msgid "Passwords don't match"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:147 ../src/spacecmd/kickstart.py:270
+#: ../src/spacecmd/kickstart.py:1980 ../src/spacecmd/kickstart.py:2122
+msgid "The Kickstart name is required"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:151 ../src/spacecmd/kickstart.py:274
+msgid "The distribution is required"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:158
+msgid "A root password is required"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:177
+msgid "kickstart_delete: Delete kickstart profile(s)"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:178
+msgid "usage: kickstart_delete PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:179
+msgid "usage: kickstart_delete PROFILE1 PROFILE2"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:180
+msgid "usage: kickstart_delete \"PROF*\""
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:203 ../src/spacecmd/kickstart.py:2597
+#: ../src/spacecmd/kickstart.py:2653 ../src/spacecmd/kickstart.py:2695
+msgid "No valid kickstart labels passed as arguments!"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:209
+msgid "The following kickstart labels are invalid:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:214
+#, python-format
+msgid "Delete profile %s [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:222
+msgid "kickstart_import: Import a Kickstart profile from a file"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:223
+msgid ""
+"usage: kickstart_import [options])\n"
+"\n"
+"options:\n"
+"  -f FILE\n"
+"  -n NAME\n"
+"  -d DISTRIBUTION\n"
+"  -v VIRT_TYPE ['none', 'para_host', 'qemu', 'xenfv', 'xenpv']"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:278 ../src/spacecmd/kickstart.py:1984
+msgid "A filename is required"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:308
+msgid ""
+"kickstart_import_raw: Import a raw Kickstart or autoyast profile from a file"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:309
+msgid ""
+"usage: kickstart_import_raw [options])\n"
+"\n"
+"options:\n"
+"  -f FILE\n"
+"  -n NAME\n"
+"  -d DISTRIBUTION\n"
+"  -v VIRT_TYPE ['none', 'para_host', 'qemu', 'xenfv', 'xenpv']"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:325
+msgid "kickstart_details: Show the details of a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:326
+msgid "usage: kickstart_details PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:353
+msgid "Invalid Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:415
+#, python-format
+msgid "Tree:        %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:416
+#, python-format
+msgid "Active:      %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:417
+#, python-format
+msgid "Advanced:    %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:418
+#, python-format
+msgid "Org Default: %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:421
+#, python-format
+msgid "Configuration Management: %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:422
+#, python-format
+msgid "Remote Commands:          %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:434
+msgid "Advanced Options"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:442
+msgid "Custom Options"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:449
+msgid "Partitioning"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:454
+msgid "Software"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:467
+msgid "Crypto Keys"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:474
+msgid "File Preservations"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:483
+msgid "Variables"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:490
+msgid "Scripts"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:501 ../src/spacecmd/kickstart.py:1900
+#, python-format
+msgid "Chroot:      %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:504 ../src/spacecmd/kickstart.py:1901
+#, python-format
+msgid "Interpreter: %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:530
+msgid "Could not retrieve the Kickstart file"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:536
+msgid "kickstart_getcontents: Show the contents of a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:537
+msgid "                   as they would be presented to a client"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:538
+msgid "usage: kickstart_getcontents LABEL"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:572
+msgid "kickstart_rename: Rename a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:573
+msgid "usage: kickstart_rename OLDNAME NEWNAME"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:601
+msgid ""
+"kickstart_listcryptokeys: List the crypto keys associated with a Kickstart "
+"profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:603
+msgid "usage: kickstart_listcryptokeys PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:632
+msgid "No crypto keys has been found"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:638
+msgid "kickstart_addcryptokeys: Add crypto keys to a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:639
+msgid "usage: kickstart_addcryptokeys PROFILE <KEY ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:665
+msgid "kickstart_removecryptokeys: Remove crypto keys from a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:667
+msgid "usage: kickstart_removecryptokeys PROFILE <KEY ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:707
+msgid ""
+"kickstart_listactivationkeys: List the activation keys associated with a "
+"Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:709
+msgid "usage: kickstart_listactivationkeys PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:739
+msgid "kickstart_addactivationkeys: Add activation keys to a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:741
+msgid "usage: kickstart_addactivationkeys PROFILE <KEY ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:770
+msgid ""
+"kickstart_removeactivationkeys: Remove activation keys from a Kickstart "
+"profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:772
+msgid "usage: kickstart_removeactivationkeys PROFILE <KEY ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:796
+msgid "Remove these keys [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:811
+msgid ""
+"kickstart_enableconfigmanagement: Enable configuration management on a "
+"Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:813
+msgid "usage: kickstart_enableconfigmanagement PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:844
+msgid ""
+"kickstart_disableconfigmanagement: Disable configuration management on a "
+"Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:846
+msgid "usage: kickstart_disableconfigmanagement PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:877
+msgid ""
+"kickstart_enableremotecommands: Enable remote commands on a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:879
+msgid "usage: kickstart_enableremotecommands PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:910
+msgid ""
+"kickstart_disableremotecommands: Disable remote commands on a Kickstart "
+"profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:912
+msgid "usage: kickstart_disableremotecommands PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:942
+msgid "kickstart_setlocale: Set the locale for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:943
+msgid "usage: kickstart_setlocale PROFILE LOCALE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:981
+msgid "kickstart_setselinux: Set the SELinux mode for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:983
+msgid "usage: kickstart_setselinux PROFILE MODE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1018
+msgid ""
+"kickstart_setpartitions: Set the partitioning scheme for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1020
+msgid "usage: kickstart_setpartitions PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1069
+msgid "kickstart_setdistribution: Set the distribution for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1071
+msgid "usage: kickstart_setdistribution PROFILE DISTRIBUTION"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1105
+msgid "kickstart_enablelogging: Enable logging for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1106
+msgid "usage: kickstart_enablelogging PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1138
+msgid "kickstart_addvariable: Add a variable to a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1139
+msgid "usage: kickstart_addvariable PROFILE KEY VALUE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1177
+msgid "kickstart_updatevariable: Update a variable in a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1179
+msgid "usage: kickstart_updatevariable PROFILE KEY VALUE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1214
+msgid "kickstart_removevariables: Remove variables from a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1216
+msgid "usage: kickstart_removevariables PROFILE <KEY ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1265
+msgid "kickstart_listvariables: List the variables of a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1267
+msgid "usage: kickstart_listvariables PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1300
+msgid "kickstart_addoption: Set an option for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1301
+msgid "usage: kickstart_addoption PROFILE KEY [VALUE]"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1348
+#, python-format
+msgid "%s needs to be set as a custom option"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1356
+msgid "kickstart_removeoptions: Remove options from a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1357
+msgid "usage: kickstart_removeoptions PROFILE <OPTION ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1409
+msgid "kickstart_listoptions: List the options of a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1411
+msgid "usage: kickstart_listoptions PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1445
+msgid ""
+"kickstart_listcustomoptions: List the custom options of a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1447
+msgid "usage: kickstart_listcustomoptions PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1481
+msgid "kickstart_setcustomoptions: Set custom options for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1483
+msgid "usage: kickstart_setcustomoptions PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1531
+msgid "kickstart_addchildchannels: Add a child channels to a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1533
+msgid "usage: kickstart_addchildchannels PROFILE <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1591
+msgid ""
+"kickstart_removechildchannels: Remove child channels from a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1593
+msgid "usage: kickstart_removechildchannels PROFILE <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1636
+msgid ""
+"kickstart_listchildchannels: List the child channels of a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1638
+msgid "usage: kickstart_listchildchannels PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1672
+msgid ""
+"kickstart_addfilepreservations: Add file preservations to a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1674
+msgid "usage: kickstart_addfilepreservations PROFILE <FILELIST ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1709
+msgid ""
+"kickstart_removefilepreservations: Remove file preservations from a "
+"Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1711
+msgid "usage: kickstart_removefilepreservations PROFILE <FILE ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1756
+msgid "kickstart_listpackages: List the packages for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1758
+msgid "usage: kickstart_listpackages PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1790
+msgid "kickstart_addpackages: Add packages to a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1791
+msgid "usage: kickstart_addpackages PROFILE <PACKAGE ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1824
+msgid "kickstart_removepackages: Remove packages from a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1826
+msgid "usage: kickstart_removepackages PROFILE <PACKAGE ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1869
+msgid "kickstart_listscripts: List the scripts for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1871
+msgid "usage: kickstart_listscripts PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1890
+#, python-format
+msgid "No scripts has been found for profile '%s'"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1898
+#, python-format
+msgid "ID:          %i"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1913
+msgid "kickstart_addscript: Add a script to a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1914
+msgid ""
+"usage: kickstart_addscript PROFILE [options])\n"
+"\n"
+"options:\n"
+"  -p PROFILE\n"
+"  -e EXECUTION_TIME ['pre', 'post']\n"
+"  -i INTERPRETER\n"
+"  -f FILE\n"
+"  -c execute in a chroot environment\n"
+"  -t ENABLING_TEMPLATING"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1947
+msgid "Profile Name:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1949
+msgid "Pre/Post Script [post]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1950
+msgid "Chrooted [Y/n]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1951
+msgid "Interpreter [/bin/bash]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1988
+msgid "The execution time is required"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2004
+#, python-format
+msgid "Profile Name:   %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2005
+#, python-format
+msgid "Execution Time: %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2006
+#, python-format
+msgid "Chroot:         %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2007
+#, python-format
+msgid "Template:       %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2008
+#, python-format
+msgid "Interpreter:    %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2009
+msgid "Contents:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2029
+msgid "kickstart_removescript: Remove a script from a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2030
+msgid "usage: kickstart_removescript PROFILE [ID]"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2058 ../src/spacecmd/kickstart.py:2071
+msgid "Invalid script ID"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2066
+msgid "Script ID:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2073
+msgid "Remove this script [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2086
+msgid "kickstart_clone: Clone a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2087
+msgid ""
+"usage: kickstart_clone [options])\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -c CLONE_NAME"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2112
+msgid "Kickstart Profiles"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2117
+msgid "Original Profile:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2118
+msgid "Cloned Profile:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2126
+msgid "The Kickstart clone name is required"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2131
+msgid "Kickstart profile you've entered was not found"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2144
+msgid "kickstart_export: export kickstart profile(s) to json format file"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2145
+msgid ""
+"usage: kickstart_export <KSPROFILE>... [options])\n"
+"options:\n"
+"    -f outfile.json : specify an output filename, defaults to <KSPROFILE>."
+"json\n"
+"                      if exporting a single kickstart, profiles.json for "
+"multiple\n"
+"                      kickstarts, or ks_all.json if no KSPROFILE specified\n"
+"                      e.g (export ALL)\n"
+"\n"
+"Note : KSPROFILE list is optional, default is to export ALL"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2271
+#, python-format
+msgid "Exporting ALL kickstart profiles to %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2279
+msgid ""
+"Error, no valid kickstart profile passed, check name is  correct with "
+"spacecmd kickstart_list"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2299
+#, python-format
+msgid "Exporting ks %s to %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2306
+#, python-format
+msgid "File %s exists, "
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2307
+msgid "confirm overwrite file? (y/n)"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2310
+msgid "Error saving exported kickstart profiles to file"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2320
+msgid "kickstart_import: import kickstart profile(s) from json file"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2321
+msgid "usage: kickstart_import <JSONFILES...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2342
+#, python-format
+msgid "Error importing kickstart %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2355
+#, python-format
+msgid "ERROR : kickstart profile %s already exists! Skipping!"
+msgstr ""
+
+#. create the ks, we need to drop the org prefix from the ks name
+#: ../src/spacecmd/kickstart.py:2359
+#, python-format
+msgid "Found ks %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2415
+#, python-format
+msgid "Error adding %s script"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2423
+#, python-format
+msgid "failed to add ip range %s-%s, continuing"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2437
+#, python-format
+msgid "failed to add file preservation %s, skipping"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2439
+#, python-format
+msgid "file preservation list %s doesn't exist, skipping"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2450
+#, python-format
+msgid "Actvationkey %s does not exist on the "
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2461
+#, python-format
+msgid "GPG/SSL key %s does not exist on the "
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2462
+msgid "satellite, skipping"
+msgstr ""
+
+#. There are some frustrating ommisions from the API which means we can't
+#. export/import some settings, so we post a warning that some manual
+#. fixup may be required
+#: ../src/spacecmd/kickstart.py:2471
+msgid ""
+"Due to API ommissions, there are some settings which cannot be imported, "
+"please check and fixup manually if necessary"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2473
+msgid " * Details->Preserve ks.cfg"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2474
+msgid " * Details->Comment"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2478
+msgid " * Details->Organization Default Profile"
+msgstr ""
+
+#. No way to set the kernel options
+#: ../src/spacecmd/kickstart.py:2480
+msgid " * Details->Kernel Options"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2484
+#, python-format
+msgid " * Details->Post Kernel Options : %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2500
+msgid "no kickstart label given"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2503
+msgid "invalid kickstart label "
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2520
+msgid "kickstart_diff: diff kickstart files"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2522
+msgid "usage: kickstart_diff SOURCE_CHANNEL TARGET_CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2571
+msgid "kickstart_getupdatetype: Get the update type for a kickstart profile(s)"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2572
+msgid "usage: kickstart_getupdatetype PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2573
+msgid "usage: kickstart_getupdatetype PROFILE1 PROFILE2"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2574
+msgid "usage: kickstart_getupdatetype \"PROF*\""
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2603 ../src/spacecmd/kickstart.py:2659
+#: ../src/spacecmd/kickstart.py:2701
+#, python-format
+msgid "kickstart label %s doesn't exist!"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2619
+msgid "kickstart_setupdatetype: Set the update type for a kickstart profile(s)"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2620
+msgid ""
+"usage: kickstart_setupdatetype [options] KS_LABEL)\n"
+"\n"
+"options:\n"
+"    -u UPDATE_TYPE ['red_hat', 'all', 'none']"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2634
+msgid "Update Types"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2639
+msgid "Update Type [none]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2670
+msgid "kickstart_getsoftwaredetails: Gets kickstart profile software details"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2671
+msgid "usage: kickstart_getsoftwaredetails KS_LABEL"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2672
+msgid "usage: kickstart_getsoftwaredetails KS_LABEL KS_LABEL2 ..."
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2707
+#, python-format
+msgid "noBase:        %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2708
+#, python-format
+msgid "ignoreMissing: %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2710
+#, python-format
+msgid "Kickstart Label: %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2711
+#, python-format
+msgid "noBase:          %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2712
+#, python-format
+msgid "ignoreMissing:   %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2721
+msgid "kickstart_setsoftwaredetails: Sets kickstart profile software details."
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2722
+msgid ""
+"usage: kickstart_setsoftwaredetails PROFILE KICKSTART_PACKAGES_INFO VALUE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2723
+msgid ""
+"usage: kickstart_setsoftwaredetails PROFILE KICKSTART_PACKAGES_INFO VALUE "
+"KICKSTART_PACKAGES_INFO VALUE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2757
+msgid "Selected profile does not exist"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2760 ../src/spacecmd/kickstart.py:2765
+msgid "Enter valid input"
+msgstr ""
+
+#. list of system selection options for the help output
+#: ../src/spacecmd/misc.py:57
+msgid ""
+"<SYSTEMS> can be any of the following:\n"
+"name\n"
+"ssm (see 'help ssm')\n"
+"search:QUERY (see 'help system_search')\n"
+"group:GROUP\n"
+"channel:CHANNEL\n"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:65
+msgid ""
+"Dates can be any of the following:\n"
+"Explicit Dates:\n"
+"Dates can be expressed as explicit date strings in the YYYYMMDD[HHMMSS]\n"
+"format.  The year, month and day are required, while the hours and\n"
+"minutes are not; the hours and minutes will default to 0000 if no\n"
+"values are provided.\n"
+"\n"
+"Deltas:\n"
+"Dates can be expressed as delta values.  For example, '2h' would\n"
+"mean 2 hours in the future.  You can also use negative values to\n"
+"express times in the past (e.g., -7d would be one week ago).\n"
+"\n"
+"Units:\n"
+"s -> seconds\n"
+"m -> minutes\n"
+"h -> hours\n"
+"d -> days\n"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:120
+msgid "clear: clear the screen"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:121
+msgid "usage: clear"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:132
+msgid "clear_caches: Clear the internal caches kept for systems and packages"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:133
+msgid "usage: clear_caches"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:146
+msgid "get_apiversion: Display the API version of the server"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:147
+msgid "usage: get_apiversion"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:158
+msgid "get_serverversion: Display the version of the server"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:159
+msgid "usage: get_serverversion"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:171
+msgid "list_proxies: List the proxies within the user's organization "
+msgstr ""
+
+#: ../src/spacecmd/misc.py:172
+msgid "usage: list_proxies"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:184
+msgid "get_session: Show the current session string"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:185
+msgid "usage: get_session"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:193
+msgid "No session found"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:200
+msgid "help: Show help for the given command"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:201
+msgid "usage: help COMMAND"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:207
+msgid "history: List your command history"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:208
+msgid "usage: history"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:220
+msgid "toggle_confirmations: Toggle confirmation messages on/off"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:221
+msgid "usage: toggle_confirmations"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:226
+msgid "Confirmation messages are"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:226
+msgid "enabled"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:233
+msgid "login: Connect to a Spacewalk server"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:234
+msgid "usage: login [USERNAME] [SERVER]"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:244
+msgid "You are already logged in"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:256
+msgid "No server specified"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:301
+#, python-format
+msgid "Failed to connect to %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:309
+#, python-format
+msgid "API (%s) is too old (>= %s required)"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:339 ../src/spacecmd/utils.py:249
+#: ../src/spacecmd/utils.py:560
+#, python-format
+msgid "Could not read %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:348
+msgid "Cached credentials are invalid"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:355
+#, python-format
+msgid "Spacewalk Username: %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:357
+msgid "Spacewalk Username:"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:368
+msgid "Spacewalk Password: "
+msgstr ""
+
+#: ../src/spacecmd/misc.py:374
+msgid "Invalid credentials"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:392
+#, python-format
+msgid "Could not write session file: %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:401
+#, python-format
+msgid "Connected to %s as %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:409
+msgid "logout: Disconnect from the server"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:410
+msgid "usage: logout"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:427
+msgid "whoami: Print the name of the currently logged in user"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:428
+msgid "usage: whoami"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:436
+msgid "You are not logged in"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:443
+msgid "whoamitalkingto: Print the name of the server"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:444
+msgid "usage: whoamitalkingto"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:452
+msgid "Yourself"
+msgstr ""
+
+#. tell the user what's going on
+#: ../src/spacecmd/misc.py:524
+msgid "** Generating errata cache **"
+msgstr ""
+
+#. tell the user what's going on
+#: ../src/spacecmd/misc.py:573
+msgid "** Generating package cache **"
+msgstr ""
+
+#. tell the user what's going on
+#: ../src/spacecmd/misc.py:680
+msgid "** Generating system cache **"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:715
+#, python-format
+msgid "Could not create directory %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:787
+#, python-format
+msgid "Can't find system ID for %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:792
+msgid "Duplicate system profile names found!"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:793
+msgid "Please reference systems by ID or resolve the"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:794
+msgid "underlying issue with 'system_delete' or 'system_rename'"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:860
+#, python-format
+msgid "No systems in group %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:874
+#, python-format
+msgid "No systems subscribed to %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:934
+msgid "Is this ok [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:47
+msgid "org_create: Create an organization"
+msgstr ""
+
+#: ../src/spacecmd/org.py:48
+#, python-format
+msgid ""
+"usage: org_create [options])\n"
+"\n"
+"options:\n"
+"  -n ORG_NAME\n"
+"  -u USERNAME\n"
+"  -P PREFIX (%s)\n"
+"  -f FIRST_NAME\n"
+"  -l LAST_NAME\n"
+"  -e EMAIL\n"
+"  -p PASSWORD\n"
+"  --pam enable PAM authentication"
+msgstr ""
+
+#: ../src/spacecmd/org.py:75
+msgid "Organization Name:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:76 ../src/spacecmd/user.py:73
+msgid "Username:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:77
+#, python-format
+msgid "Prefix (%s):"
+msgstr ""
+
+#: ../src/spacecmd/org.py:79 ../src/spacecmd/user.py:74
+msgid "First Name:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:80 ../src/spacecmd/user.py:75
+msgid "Last Name:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:81 ../src/spacecmd/user.py:76
+msgid "Email:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:82 ../src/spacecmd/user.py:77
+msgid "PAM Authentication [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:89 ../src/spacecmd/user.py:84
+msgid "Password: "
+msgstr ""
+
+#: ../src/spacecmd/org.py:100
+msgid "An organization name is required"
+msgstr ""
+
+#: ../src/spacecmd/org.py:104 ../src/spacecmd/user.py:95
+msgid "A username is required"
+msgstr ""
+
+#: ../src/spacecmd/org.py:108 ../src/spacecmd/user.py:99
+msgid "A first name is required"
+msgstr ""
+
+#: ../src/spacecmd/org.py:112 ../src/spacecmd/user.py:103
+msgid "A last name is required"
+msgstr ""
+
+#: ../src/spacecmd/org.py:116 ../src/spacecmd/user.py:107
+msgid "An email address is required"
+msgstr ""
+
+#: ../src/spacecmd/org.py:120 ../src/spacecmd/user.py:111
+msgid "A password is required"
+msgstr ""
+
+#: ../src/spacecmd/org.py:127
+msgid "Dr."
+msgstr ""
+
+#: ../src/spacecmd/org.py:129
+msgid "Miss"
+msgstr ""
+
+#: ../src/spacecmd/org.py:148
+msgid "org_delete: Delete an organization"
+msgstr ""
+
+#: ../src/spacecmd/org.py:149
+msgid "usage: org_delete NAME"
+msgstr ""
+
+#: ../src/spacecmd/org.py:168 ../src/spacecmd/org.py:199
+#: ../src/spacecmd/org.py:233 ../src/spacecmd/org.py:269
+#: ../src/spacecmd/org.py:377 ../src/spacecmd/org.py:413
+#, python-format
+msgid "No organisation found for the name %s"
+msgstr ""
+
+#: ../src/spacecmd/org.py:169 ../src/spacecmd/org.py:200
+#: ../src/spacecmd/org.py:234 ../src/spacecmd/org.py:270
+#: ../src/spacecmd/org.py:378 ../src/spacecmd/org.py:414
+msgid "Organisation '{}' was not found"
+msgstr ""
+
+#: ../src/spacecmd/org.py:171
+msgid "Delete this organization [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:179
+msgid "org_rename: Rename an organization"
+msgstr ""
+
+#: ../src/spacecmd/org.py:180
+msgid "usage: org_rename OLDNAME NEWNAME"
+msgstr ""
+
+#: ../src/spacecmd/org.py:211
+msgid "org_addtrust: Add a trust between two organizations"
+msgstr ""
+
+#: ../src/spacecmd/org.py:212
+msgid "usage: org_addtrust YOUR_ORG ORG_TO_TRUST"
+msgstr ""
+
+#: ../src/spacecmd/org.py:237 ../src/spacecmd/org.py:273
+#, python-format
+msgid "No trust organisation found for the name %s"
+msgstr ""
+
+#: ../src/spacecmd/org.py:238 ../src/spacecmd/org.py:274
+msgid "Organisation '{}' to trust for, was not found"
+msgstr ""
+
+#: ../src/spacecmd/org.py:248
+msgid "org_removetrust: Remove a trust between two organizations"
+msgstr ""
+
+#: ../src/spacecmd/org.py:249
+msgid "usage: org_removetrust YOUR_ORG TRUSTED_ORG"
+msgstr ""
+
+#: ../src/spacecmd/org.py:284
+msgid "None"
+msgstr ""
+
+#: ../src/spacecmd/org.py:286
+msgid "Remove this trust [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:292
+msgid "org_trustdetails: Show the details of an organizational trust"
+msgstr ""
+
+#: ../src/spacecmd/org.py:293
+msgid "usage: org_trustdetails TRUSTED_ORG"
+msgstr ""
+
+#: ../src/spacecmd/org.py:312
+#, python-format
+msgid "No trusted organisation found for the name %s"
+msgstr ""
+
+#: ../src/spacecmd/org.py:313
+msgid "Trusted organisation '{}' was not found"
+msgstr ""
+
+#: ../src/spacecmd/org.py:320
+#, python-format
+msgid "Trusted Organization:   %s"
+msgstr ""
+
+#: ../src/spacecmd/org.py:321
+#, python-format
+msgid "Trusted Since:          %s"
+msgstr ""
+
+#: ../src/spacecmd/org.py:322
+#, python-format
+msgid "Systems Migrated From:  %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:323
+#, python-format
+msgid "Systems Migrated To:    %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:325
+msgid "Channels Consumed"
+msgstr ""
+
+#: ../src/spacecmd/org.py:332
+msgid "Channels Provided"
+msgstr ""
+
+#: ../src/spacecmd/org.py:340
+msgid "org_list: List all organizations"
+msgstr ""
+
+#: ../src/spacecmd/org.py:341
+msgid "usage: org_list"
+msgstr ""
+
+#: ../src/spacecmd/org.py:358
+msgid "org_listtrusts: List an organization's trusts"
+msgstr ""
+
+#: ../src/spacecmd/org.py:359
+msgid "usage: org_listtrusts NAME"
+msgstr ""
+
+#: ../src/spacecmd/org.py:383 ../src/spacecmd/org.py:384
+msgid "No trust organisation has been found"
+msgstr ""
+
+#: ../src/spacecmd/org.py:394
+msgid "org_listusers: List an organization's users"
+msgstr ""
+
+#: ../src/spacecmd/org.py:395
+msgid "usage: org_listusers NAME"
+msgstr ""
+
+#: ../src/spacecmd/org.py:425
+msgid "org_details: Show the details of an organization"
+msgstr ""
+
+#: ../src/spacecmd/org.py:426
+msgid "usage: org_details NAME"
+msgstr ""
+
+#: ../src/spacecmd/org.py:446
+#, python-format
+msgid "Name:                   %s"
+msgstr ""
+
+#: ../src/spacecmd/org.py:447
+#, python-format
+msgid "Active Users:           %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:448
+#, python-format
+msgid "Systems:                %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:452 ../src/spacecmd/org.py:454
+#, python-format
+msgid "Trusts:                 %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:456
+#, python-format
+msgid "System Groups:          %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:457
+#, python-format
+msgid "Activation Keys:        %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:458
+#, python-format
+msgid "Kickstart Profiles:     %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:459
+#, python-format
+msgid "Configuration Channels: %i"
+msgstr ""
+
+#: ../src/spacecmd/package.py:68 ../src/spacecmd/package.py:302
+#: ../src/spacecmd/package.py:351 ../src/spacecmd/package.py:395
+msgid "No packages found"
+msgstr ""
+
+#: ../src/spacecmd/package.py:81 ../src/spacecmd/package.py:406
+#, python-format
+msgid "%s is not a valid package"
+msgstr ""
+
+#: ../src/spacecmd/package.py:94
+#, python-format
+msgid "Version: %s"
+msgstr ""
+
+#: ../src/spacecmd/package.py:95
+#, python-format
+msgid "Release: %s"
+msgstr ""
+
+#: ../src/spacecmd/package.py:96
+#, python-format
+msgid "Epoch:   %s"
+msgstr ""
+
+#: ../src/spacecmd/package.py:97
+#, python-format
+msgid "Arch:    %s"
+msgstr ""
+
+#: ../src/spacecmd/package.py:99
+#, python-format
+msgid "File:    %s"
+msgstr ""
+
+#: ../src/spacecmd/package.py:101
+#, python-format
+msgid "Size:    %s"
+msgstr ""
+
+#: ../src/spacecmd/package.py:105
+#, python-format
+msgid "Installed Systems: %i"
+msgstr ""
+
+#: ../src/spacecmd/package.py:111
+msgid "Available From Channels"
+msgstr ""
+
+#: ../src/spacecmd/package.py:122
+msgid "package_search: Find packages that meet the given criteria"
+msgstr ""
+
+#: ../src/spacecmd/package.py:123
+msgid "usage: package_search NAME|QUERY"
+msgstr ""
+
+#: ../src/spacecmd/package.py:125
+msgid "Example: package_search kernel"
+msgstr ""
+
+#: ../src/spacecmd/package.py:127
+msgid "Advanced Search:"
+msgstr ""
+
+#: ../src/spacecmd/package.py:128
+msgid ""
+"Available Fields: name, epoch, version, release, arch, description, summary"
+msgstr ""
+
+#: ../src/spacecmd/package.py:129
+msgid "Example: name:kernel AND version:2.6.18 AND -description:devel"
+msgstr ""
+
+#: ../src/spacecmd/package.py:178
+msgid "package_remove: Remove a package from Satellite"
+msgstr ""
+
+#: ../src/spacecmd/package.py:179
+msgid "usage: package_remove PACKAGE ..."
+msgstr ""
+
+#: ../src/spacecmd/package.py:199
+msgid "No packages found to remove"
+msgstr ""
+
+#: ../src/spacecmd/package.py:202 ../src/spacecmd/package.py:259
+#: ../src/spacecmd/softwarechannel.py:1580 ../src/spacecmd/system.py:944
+msgid "Remove these packages [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/package.py:203
+msgid "No packages has been removed"
+msgstr ""
+
+#: ../src/spacecmd/package.py:215 ../src/spacecmd/package.py:271
+#, python-format
+msgid "Failed to remove package ID %i"
+msgstr ""
+
+#: ../src/spacecmd/package.py:226
+msgid "package_listorphans: List packages that are not in a channel"
+msgstr ""
+
+#: ../src/spacecmd/package.py:227
+msgid "usage: package_listorphans"
+msgstr ""
+
+#: ../src/spacecmd/package.py:246
+msgid "package_removeorphans: Remove packages that are not in a channel"
+msgstr ""
+
+#: ../src/spacecmd/package.py:247
+msgid "usage: package_removeorphans"
+msgstr ""
+
+#: ../src/spacecmd/package.py:255
+msgid "No orphaned packages has been found"
+msgstr ""
+
+#: ../src/spacecmd/package.py:256
+msgid "No orphaned packages"
+msgstr ""
+
+#: ../src/spacecmd/package.py:260
+msgid "No packages were removed"
+msgstr ""
+
+#: ../src/spacecmd/package.py:280
+msgid "package_listinstalledsystems: List the systems with a package installed"
+msgstr ""
+
+#: ../src/spacecmd/package.py:281
+msgid "usage: package_listinstalledsystems PACKAGE ..."
+msgstr ""
+
+#: ../src/spacecmd/package.py:329
+msgid "package_listerrata: List the errata that provide this package"
+msgstr ""
+
+#: ../src/spacecmd/package.py:330
+msgid "usage: package_listerrata PACKAGE ..."
+msgstr ""
+
+#: ../src/spacecmd/package.py:377
+msgid "package_listdependencies: List the dependencies for a package"
+msgstr ""
+
+#: ../src/spacecmd/package.py:378
+msgid "usage: package_listdependencies PACKAGE"
+msgstr ""
+
+#: ../src/spacecmd/package.py:411
+#, python-format
+msgid "Package Name: %s"
+msgstr ""
+
+#: ../src/spacecmd/package.py:413
+#, python-format
+msgid "Dependency: %s Type: %s Modifier: %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:47
+msgid "repo_list: List all available user repos"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:48
+msgid "usage: repo_list"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:65
+msgid "repo_details: Show the details of a user repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:66
+msgid "usage: repo_details <repo ...>"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:94
+#, python-format
+msgid "Repository Label:                  %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:95
+#, python-format
+msgid "Repository URL:                    %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:96
+#, python-format
+msgid "Repository Type:                   %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:97
+#, python-format
+msgid "Repository SSL Ca Certificate:     %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:98
+#, python-format
+msgid "Repository SSL Client Certificate: %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:99
+#, python-format
+msgid "Repository SSL Client Key:         %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:101
+msgid "No repositories found for '{}' query"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:110
+msgid "repo_listfilters: Show the filters for a user repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:111
+msgid "usage: repo_listfilters repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:132
+msgid "No filters found"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:141
+msgid "repo_addfilters: Add filters for a user repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:142
+msgid "usage: repo_addfilters repo <filter ...>"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:166 ../src/spacecmd/repo.py:203
+#: ../src/spacecmd/repo.py:242
+msgid "Each filter must start with + or -"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:180
+msgid "repo_removefilters: Remove filters from a user repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:181
+msgid "usage: repo_removefilters repo <filter ...>"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:217
+msgid "repo_setfilters: Set the filters for a user repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:218
+msgid "usage: repo_setfilters repo <filter ...>"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:255
+msgid "repo_clearfilters: Clears the filters for a user repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:256
+msgid ""
+"usage: repo_clearfilters repo <options>\n"
+"\n"
+"options:\n"
+"  -y, --yes   Confirm without prompt\n"
+"\n"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:278
+msgid "Remove these filters [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:287
+msgid "repo_delete: Delete a user repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:288
+msgid "usage: repo_delete <repo ...>"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:307 ../src/spacecmd/softwarechannel.py:610
+msgid "Repos"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:311
+msgid "Delete these repos [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:316
+#, python-format
+msgid "Failed to remove repo %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:324
+msgid "repo_create: Create a user repository"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:325
+msgid ""
+"usage: repo_create <options>)\n"
+"\n"
+"options:\n"
+"  -n, --name   name of repository\n"
+"  -u, --url    url of repository\n"
+"  -t, --type   type of repository (defaults to yum)\n"
+"\n"
+"  --ca         SSL CA certificate (not required)\n"
+"  --cert       SSL Client certificate (not required)\n"
+"  --key        SSL Client key (not required)"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:350
+msgid "URL:"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:351
+msgid "Type:"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:352 ../src/spacecmd/repo.py:462
+msgid "SSL CA cert:"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:353 ../src/spacecmd/repo.py:463
+msgid "SSL Client cert:"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:354 ../src/spacecmd/repo.py:464
+msgid "SSL Client key:"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:361
+msgid "A URL is required"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:381
+msgid "repo_rename: Rename a user repository"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:382
+msgid "usage: repo_rename OLDNAME NEWNAME"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:404
+#, python-format
+msgid "Could not find repo %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:417
+msgid "repo_updateurl: Change the URL of a user repository"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:418
+msgid "usage: repo_updateurl <repo> <url>"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:443
+msgid "repo_updatessl: Change the SSL certificates of a user repository"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:444
+msgid ""
+"usage: repo_updatessl <options>)\n"
+"options:\n"
+"  --ca         SSL CA certificate (not required)\n"
+"  --cert       SSL Client certificate (not required)\n"
+"  --key        SSL Client key (not required)"
+msgstr ""
+
+#: ../src/spacecmd/report.py:43
+msgid "report_inactivesystems: List all inactive systems"
+msgstr ""
+
+#: ../src/spacecmd/report.py:44
+msgid "usage: report_inactivesystems [DAYS]"
+msgstr ""
+
+#: ../src/spacecmd/report.py:84
+msgid "report_outofdatesystems: List all out-of-date systems"
+msgstr ""
+
+#: ../src/spacecmd/report.py:85
+msgid "usage: report_outofdatesystems"
+msgstr ""
+
+#: ../src/spacecmd/report.py:112
+msgid "report_ungroupedsystems: List all ungrouped systems"
+msgstr ""
+
+#: ../src/spacecmd/report.py:113
+msgid "usage: report_ungroupedsystems"
+msgstr ""
+
+#: ../src/spacecmd/report.py:130
+msgid "report_errata: List all errata and how many systems they affect"
+msgstr ""
+
+#: ../src/spacecmd/report.py:131
+msgid "usage: report_errata [ERRATA|search:XXX ...]"
+msgstr ""
+
+#: ../src/spacecmd/report.py:143
+msgid "All errata requested - this may take a few minutes, please be patient!"
+msgstr ""
+
+#: ../src/spacecmd/report.py:166
+#, python-format
+msgid "%s  # Systems"
+msgstr ""
+
+#: ../src/spacecmd/report.py:173
+msgid "No errata found for '{}'"
+msgstr ""
+
+#: ../src/spacecmd/report.py:180
+msgid "report_ipaddresses: List the hostname and IP of each system"
+msgstr ""
+
+#: ../src/spacecmd/report.py:181
+msgid "usage: report_ipaddresses [<SYSTEMS>]"
+msgstr ""
+
+#: ../src/spacecmd/report.py:201 ../src/spacecmd/report.py:265
+#: ../src/spacecmd/scap.py:67 ../src/spacecmd/scap.py:207
+#: ../src/spacecmd/system.py:213 ../src/spacecmd/system.py:394
+#: ../src/spacecmd/system.py:579 ../src/spacecmd/system.py:743
+#: ../src/spacecmd/system.py:898 ../src/spacecmd/system.py:1033
+#: ../src/spacecmd/system.py:1134 ../src/spacecmd/system.py:1204
+#: ../src/spacecmd/system.py:1259 ../src/spacecmd/system.py:1358
+#: ../src/spacecmd/system.py:1591 ../src/spacecmd/system.py:1654
+#: ../src/spacecmd/system.py:1697 ../src/spacecmd/system.py:1777
+#: ../src/spacecmd/system.py:1919 ../src/spacecmd/system.py:1961
+#: ../src/spacecmd/system.py:2049 ../src/spacecmd/system.py:2116
+#: ../src/spacecmd/system.py:2198 ../src/spacecmd/system.py:2253
+#: ../src/spacecmd/system.py:2313 ../src/spacecmd/system.py:2372
+#: ../src/spacecmd/system.py:2430 ../src/spacecmd/system.py:2489
+#: ../src/spacecmd/system.py:2566 ../src/spacecmd/system.py:2647
+#: ../src/spacecmd/system.py:2702 ../src/spacecmd/system.py:2955
+#: ../src/spacecmd/system.py:3108 ../src/spacecmd/system.py:3177
+#: ../src/spacecmd/system.py:3223 ../src/spacecmd/system.py:3282
+#: ../src/spacecmd/system.py:3346 ../src/spacecmd/system.py:3402
+#: ../src/spacecmd/system.py:3577 ../src/spacecmd/system.py:3855
+#: ../src/spacecmd/system.py:3998 ../src/spacecmd/system.py:4060
+#: ../src/spacecmd/system.py:4108 ../src/spacecmd/system.py:4166
+#: ../src/spacecmd/system.py:4224
+msgid "No systems selected"
+msgstr ""
+
+#: ../src/spacecmd/report.py:244
+msgid "report_kernels: List the running kernel of each system"
+msgstr ""
+
+#: ../src/spacecmd/report.py:245
+msgid "usage: report_kernels [<SYSTEMS>]"
+msgstr ""
+
+#: ../src/spacecmd/report.py:282
+#, python-format
+msgid "%s  Kernel"
+msgstr ""
+
+#: ../src/spacecmd/report.py:282
+msgid "System"
+msgstr ""
+
+#: ../src/spacecmd/report.py:296
+msgid "report_duplicates: List duplicate system profiles"
+msgstr ""
+
+#: ../src/spacecmd/report.py:297
+msgid "usage: report_duplicates"
+msgstr ""
+
+#: ../src/spacecmd/report.py:319 ../src/spacecmd/report.py:341
+#: ../src/spacecmd/report.py:359 ../src/spacecmd/report.py:377
+msgid "System ID   Last Checkin"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:43
+msgid ""
+"scap_listxccdfscans: Return a list of finished OpenSCAP scans for given "
+"systems"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:44
+msgid "usage: scap_listxccdfscans <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:78 ../src/spacecmd/system.py:608
+#: ../src/spacecmd/system.py:1220 ../src/spacecmd/system.py:1371
+#: ../src/spacecmd/system.py:2060 ../src/spacecmd/system.py:2383
+#: ../src/spacecmd/system.py:2441 ../src/spacecmd/system.py:2660
+#: ../src/spacecmd/system.py:2715 ../src/spacecmd/system.py:3121
+#: ../src/spacecmd/system.py:3238 ../src/spacecmd/system.py:3295
+#, python-format
+msgid "System: %s"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:88
+#, python-format
+msgid "XID: %d Profile: %s Path: (%s) Completed: %s"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:96
+msgid ""
+"scap_getxccdfscanruleresults: Return a full list of RuleResults for given "
+"OpenSCAP XCCDF scan"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:97
+msgid "usage: scap_getxccdfscanruleresults <XID>"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:117
+#, python-format
+msgid "XID: %s"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:124
+#, python-format
+msgid "IDref: %s Result: %s Idents: (%s)"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:132
+msgid "scap_getxccdfscandetails: Get details of given OpenSCAP XCCDF scan"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:133
+msgid "usage: scap_getxccdfscandetails <XID>"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:159
+msgid "XID:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:159
+msgid "SID:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:159
+msgid "Action_ID:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:161
+msgid "OSCAP_Parameters:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:162
+msgid "Test_Result:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:162
+msgid "Benchmark:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:163
+msgid "Benchmark_Version:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:164
+msgid "Profile:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:165
+msgid "Profile_Title:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:165
+msgid "Start_Time:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:166
+msgid "End_Time:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:167
+msgid "Errors:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:175
+msgid "scap_schedulexccdfscan: Schedule Scap XCCDF scan"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:176
+msgid "usage: scap_schedulexccdfscan PATH_TO_XCCDF_FILE XCCDF_OPTIONS SYSTEMS"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:177
+msgid "       scap_schedulexccdfscan ssm PATH_TO_XCCDF_FILE XCCDF_OPTIONS"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:182
+msgid ""
+"\n"
+"To use systems in the ssm, pass the \"ssm\" keyword in front. Example:"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:88
+msgid "ID      Date                 C    F    P     Action"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:134
+msgid "schedule_cancel: Cancel scheduled actions"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:135
+msgid "usage: schedule_cancel ID|* ..."
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:157
+msgid "Cancel all pending actions [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:158
+msgid "All pending actions left untouched"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:173 ../src/spacecmd/schedule.py:234
+#, python-format
+msgid "\"%s\" is not a valid ID"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:179
+#, python-format
+msgid "Canceled action: %i"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:182
+#, python-format
+msgid "Failed action: %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:184
+#, python-format
+msgid "Canceled %i action(s)"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:192
+msgid "schedule_reschedule: Reschedule failed actions"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:193
+msgid "usage: schedule_reschedule ID|* ..."
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:220
+msgid "Reschedule all failed actions [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:232
+#, python-format
+msgid "\"%i\" is not a failed action"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:238
+msgid "No failed actions to reschedule"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:242
+#, python-format
+msgid "Rescheduled %i action(s)"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:250
+msgid "schedule_details: Show the details of a scheduled action"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:251
+msgid "usage: schedule_details ID"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:268
+#, python-format
+msgid "The ID \"%s\" is invalid"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:277
+#, python-format
+msgid "ID:        %i"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:278
+#, python-format
+msgid "Action:    %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:279
+#, python-format
+msgid "User:      %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:280
+#, python-format
+msgid "Date:      %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:282 ../src/spacecmd/schedule.py:379
+#: ../src/spacecmd/system.py:3245
+#, python-format
+msgid "Completed: %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:283
+#, python-format
+msgid "Failed:    %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:284
+#, python-format
+msgid "Pending:   %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:288
+msgid "Completed Systems"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:295
+msgid "Failed Systems"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:302
+msgid "Pending Systems"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:307
+#, python-format
+msgid "No action found with the ID \"%s\""
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:316
+msgid "schedule_getoutput: Show the output from an action"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:317
+msgid "usage: schedule_getoutput ID"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:332
+#, python-format
+msgid "\"%s\" is not a valid action ID"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:354
+#, python-format
+msgid "System:      %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:355
+#, python-format
+msgid "Start Time:  %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:356
+#, python-format
+msgid "Stop Time:   %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:357
+#, python-format
+msgid "Return Code: %i"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:359 ../src/spacecmd/schedule.py:381
+msgid "Output"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:378
+#, python-format
+msgid "System:    %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:394
+msgid "schedule_listpending: List pending actions"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:395
+msgid "usage: schedule_listpending [BEGINDATE] [ENDDATE]"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:407
+msgid "schedule_listcompleted: List completed actions"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:408
+msgid "usage: schedule_listcompleted [BEGINDATE] [ENDDATE]"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:420
+msgid "schedule_listfailed: List failed actions"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:421
+msgid "usage: schedule_listfailed [BEGINDATE] [ENDDATE]"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:433
+msgid "schedule_listarchived: List archived actions"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:434
+msgid "usage: schedule_listarchived [BEGINDATE] [ENDDATE]"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:446
+msgid "schedule_list: List all actions"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:447
+msgid "usage: schedule_list [BEGINDATE] [ENDDATE]"
+msgstr ""
+
+#: ../src/spacecmd/shell.py:120
+msgid "Could not read history file"
+msgstr ""
+
+#. pylint: disable=W0702
+#: ../src/spacecmd/shell.py:124
+msgid "Exception occurred: {}"
+msgstr ""
+
+#: ../src/spacecmd/shell.py:188 ../src/spacecmd/shell.py:227
+#, python-format
+msgid "%s: event not found"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:42
+msgid "snippet_list: List the available Kickstart snippets"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:43
+msgid "usage: snippet_list"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:60
+msgid "snippet_details: Show the contents of a snippet"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:61
+msgid "usage: snippet_details SNIPPET ..."
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:90
+#, python-format
+msgid "%s is not a valid snippet"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:97
+#, python-format
+msgid "Name:   %s"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:98
+#, python-format
+msgid "Macro:  %s"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:99
+#, python-format
+msgid "File:   %s"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:110
+msgid "snippet_create: Create a Kickstart snippet"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:111
+msgid ""
+"usage: snippet_create [options])\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -f FILE"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:149
+msgid "A name is required for the snippet"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:153
+msgid "A file is required"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:160
+#, python-format
+msgid "Snippet: %s"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:176
+msgid "snippet_update: Update a Kickstart snippet"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:177
+msgid "usage: snippet_update NAME"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:199
+msgid "snippet_delete: Delete a Kickstart snippet"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:200
+msgid "usage: snippet_delete NAME"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:218
+msgid "Remove this snippet [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:57
+msgid "softwarechannel_list: List all available software channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:58
+msgid ""
+"usage: softwarechannel_list [options]')\n"
+"options:\n"
+"  -v verbose (display label and summary)\n"
+"  -t tree view (pretty-print(child-channels))\n"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:106
+msgid "softwarechannel_listmanageablechannels: List all software channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:107
+msgid "                                        manageable by current user"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:108
+msgid ""
+"usage: softwarechannel_listmanageablechannels [options]\n"
+"options:\n"
+"  -v verbose (display label and summary)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:143
+msgid "softwarechannel_listbasechannels: List all base software channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:144
+msgid ""
+"usage: softwarechannel_listbasechannels [options])\n"
+"options:\n"
+"  -v verbose (display label and summary)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:172
+msgid "softwarechannel_listchildchannels: List child software channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:173
+#: ../src/spacecmd/softwarechannel.py:2735
+msgid "usage:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:174
+msgid "softwarechannel_listchildchannels [options]"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:175
+msgid "softwarechannel_listchildchannels : List all child channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:176
+msgid ""
+"softwarechannel_listchildchannels CHANNEL : List children for aspecific base "
+"channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:178
+msgid ""
+"options:\n"
+" -v verbose (display label and summary)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:206
+msgid "softwarechannel_listsystems: List all systems subscribed to"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:207
+msgid "                             a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:208
+msgid "usage: softwarechannel_listsystems CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:242
+msgid "softwarechannel_listpackages: List the most recent packages"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:243
+msgid "                              available from a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:244
+msgid "usage: softwarechannel_listpackages CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:281
+msgid "softwarechannel_listallpackages: List all packages in a channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:282
+msgid "usage: softwarechannel_listallpackages CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:340
+msgid ""
+"softwarechannel_listlatestpackages: List the newest version of all packages "
+"in a channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:341
+msgid "usage: softwarechannel_listlatestpackages CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:380
+msgid "softwarechannel_setdetails: Modify details of a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:381
+#, python-format
+msgid ""
+"usage: softwarechannel_setdetails [options] <CHANNEL ...>)\n"
+"\n"
+"options, at least one of which must be given:\n"
+"  -n NAME\n"
+"  -d DESCRIPTION\n"
+"  -s SUMMARY\n"
+"  -c CHECKSUM %s\n"
+"  -m MAINTAINER_NAME\n"
+"  -e MAINTAINER_EMAIL\n"
+"  -p MAINTAINER_PHONE\n"
+"  -u GPG_URL\n"
+"  -i GPG_ID\n"
+"  -f GPG_FINGERPRINT"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:443
+msgid "At least one attribute to set must be given"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:449
+msgid "No channels matching that label"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:461
+msgid "Setting same name for more than one channel will fail"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:469
+#, python-format
+msgid "Name \"%s\" already in use by channel %s"
+msgstr ""
+
+#. get confirmation
+#: ../src/spacecmd/softwarechannel.py:474
+msgid "Setting following attributes..."
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:477
+#, python-format
+msgid "Name:             %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:479
+#, python-format
+msgid "Summary:          %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:481
+#, python-format
+msgid "Description:      %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:483
+#, python-format
+msgid "Checksum:         %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:485
+#, python-format
+msgid "Maintainer name:  %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:487
+#, python-format
+msgid "Maintainer email: %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:489
+#, python-format
+msgid "Maintainer phone: %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:491
+#, python-format
+msgid "GPG Key:          %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:493
+#, python-format
+msgid "GPG Fingerprint:  %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:495
+#, python-format
+msgid "GPG URL:          %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:497
+msgid "... for the following channels:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:500
+msgid "Apply? [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:512
+#, python-format
+msgid "Could not get details for %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:524
+#, python-format
+msgid "Error while setting details for %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:527
+#, python-format
+msgid "Channels changed: %d"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:535
+msgid "softwarechannel_details: Show the details of a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:536
+msgid "usage: softwarechannel_details <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:576
+#, python-format
+msgid "Label:              %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:577
+#, python-format
+msgid "Name:               %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:578
+#, python-format
+msgid "Architecture:       %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:579
+#, python-format
+msgid "Parent:             %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:580
+#, python-format
+msgid "Systems Subscribed: %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:581
+#, python-format
+msgid "Number of Packages: %i"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:585
+msgid "Summary"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:596
+#, python-format
+msgid "GPG Key:            %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:597
+#, python-format
+msgid "GPG Fingerprint:    %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:598
+#, python-format
+msgid "GPG URL:            %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:599
+#, python-format
+msgid "GPG CHECK:          %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:603
+msgid "Kickstart Trees"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:621
+msgid "softwarechannel_listerrata: List the errata associated with a"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:622
+msgid "                            software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:623
+msgid ""
+"usage: softwarechannel_listerrata <CHANNEL ...> [from=yyyymmdd [to=yyyymmdd]]"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:681
+msgid "softwarechannel_listarches: lists the potential software"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:682
+msgid "                            channel architectures that can be created"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:683
+msgid "usage: softwarechannel_listarches"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:684 ../src/spacecmd/system.py:3826
+msgid "options:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:685
+msgid "    -v verbose (display label and name)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:706
+msgid "softwarechannel_delete: Delete a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:707
+msgid "usage: softwarechannel_delete <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:732
+msgid "Channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:760
+msgid "softwarechannel_update: Update a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:761
+#, python-format
+msgid ""
+"usage: softwarechannel_update LABEL(To identify the channel) [options]\n"
+"options:\n"
+"  -l LABEL(Required)\n"
+"  -n NAME\n"
+"  -s SUMMARY\n"
+"  -d DESCRIPTION\n"
+"  -c CHECKSUM %s\n"
+"  -u GPG-URL\n"
+"  -i GPG-ID\n"
+"  -f GPG-FINGERPRINT\n"
+"  -g DISABLE-GPG-CHECK"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:792
+#: ../src/spacecmd/softwarechannel.py:924
+#: ../src/spacecmd/softwarechannel.py:1094
+msgid "Channel Label:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:797
+msgid "New Name (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:803
+msgid "New Summary (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:806
+msgid "Summary:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:809
+msgid "New Description (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:815
+msgid "New Checksum type (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:822
+msgid "New GPG URL (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:825
+#: ../src/spacecmd/softwarechannel.py:953
+#: ../src/spacecmd/softwarechannel.py:1107
+#: ../src/spacecmd/softwarechannel.py:1196
+msgid "GPG URL:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:828
+msgid "New GPG ID (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:831
+#: ../src/spacecmd/softwarechannel.py:959
+#: ../src/spacecmd/softwarechannel.py:1108
+#: ../src/spacecmd/softwarechannel.py:1197
+msgid "GPG ID:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:834
+msgid "New GPG Fingerprint (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:837
+#: ../src/spacecmd/softwarechannel.py:965
+#: ../src/spacecmd/softwarechannel.py:1109
+#: ../src/spacecmd/softwarechannel.py:1198
+msgid "GPG Fingerprint:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:840
+msgid "Disable GPG CHECK (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:843
+#: ../src/spacecmd/softwarechannel.py:1110
+#: ../src/spacecmd/softwarechannel.py:1199
+msgid "Disable GPG Check [yes/no]? "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:846
+msgid "A channel label is required to identify the channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:849
+msgid "Only [yes/no] values are acceptable for --disable_gpg_check"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:889
+msgid "softwarechannel_create: Create a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:890
+#, python-format
+msgid ""
+"usage: softwarechannel_create [options])\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -l LABEL\n"
+"  -s SUMMARY\n"
+"  -p PARENT_CHANNEL\n"
+"  -a ARCHITECTURE\n"
+"  -c CHECKSUM %s\n"
+"  -u GPG_URL\n"
+"  -i GPG_ID\n"
+"  -f GPG_FINGERPRINT\n"
+"  -g DISABLE_GPG_CHECK"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:923
+#: ../src/spacecmd/softwarechannel.py:1093
+msgid "Channel Name:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:925
+msgid "Channel Summary:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:933
+#: ../src/spacecmd/softwarechannel.py:1101
+msgid "Select Parent [blank to create a base channel]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:936
+msgid "Architecture"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:943
+msgid "Checksum type"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:950
+msgid "GPG URL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:956
+msgid "GPG ID"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:962
+msgid "GPG Fingerprint"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:968
+msgid "GPG CHECK"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:971
+msgid "Disable GPG Check [y/N]? "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1023
+#: ../src/spacecmd/softwarechannel.py:1121
+msgid "A channel name is required"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1027
+#: ../src/spacecmd/softwarechannel.py:1125
+msgid "A channel label is required"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1040
+#, python-format
+msgid "Name %s already in use by channel %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1044
+#, python-format
+msgid "Label %s already in use by channel %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1052
+msgid "softwarechannel_clone: Clone a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1053
+msgid ""
+"usage: softwarechannel_clone [options])\n"
+"\n"
+"options:\n"
+"  -s SOURCE_CHANNEL\n"
+"  -n NAME\n"
+"  -l LABEL\n"
+"  -p PARENT_CHANNEL\n"
+"  --gpg-copy/-g (copy SOURCE_CHANNEL GPG details)\n"
+"  --gpg-url GPG_URL\n"
+"  --gpg-id GPG_ID\n"
+"  --gpg-fingerprint(GPG_FINGERPRINT)\n"
+"  --disable-gpg-check DISABLE_GPG_CHECK\n"
+"  -o do not clone any patches\n"
+"  --regex/-x \"s/foo/bar\" : Optional regex replacement,\n"
+"        replaces foo with bar in the clone name and label"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1088
+#: ../src/spacecmd/softwarechannel.py:1188
+msgid "Source Channels:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1092
+#: ../src/spacecmd/softwarechannel.py:1191
+msgid "Select source channel:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1096
+msgid "Base Channels:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1104
+#: ../src/spacecmd/softwarechannel.py:1194
+msgid "Copy source channel GPG details? [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1113
+#: ../src/spacecmd/softwarechannel.py:1202
+msgid "Original State (No Errata) [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1117
+#: ../src/spacecmd/softwarechannel.py:1205
+msgid "A source channel is required"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1138
+#: ../src/spacecmd/softwarechannel.py:1216
+msgid "Only [yes/no] values are acceptable for --disable-gpg-check"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1154
+msgid ""
+"softwarechannel_clonetree: Clone a software channel and its child channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1155
+msgid ""
+"usage: softwarechannel_clonetree [options])\n"
+"             e.g    softwarechannel_clonetree foobasechannel -p \"my_\"\n"
+"                    softwarechannel_clonetree foobasechannel -x \"s/foo/bar"
+"\"\n"
+"                    softwarechannel_clonetree foobasechannel -x \"s/^/my_\"\n"
+"\n"
+"options:\n"
+"  -s/--source-channel SOURCE_CHANNEL\n"
+"  -p/--prefix PREFIX (is prepended to the label and name of all channels)\n"
+"  --gpg-copy/-g (copy GPG details for correspondoing source channel))\n"
+"  --gpg-url GPG_URL (applied to all channels)\n"
+"  --gpg-id GPG_ID (applied to all channels)\n"
+"  --gpg-fingerprint(GPG_FINGERPRINT (applied to all channels))\n"
+"  --disable-gpg-check DISABLE_GPG_CHECK(applied to all channels)\n"
+"  -o do not clone any errata\n"
+"  --regex/-x \"s/foo/bar\" : Optional regex replacement,\n"
+"        replaces foo with bar in the clone name, label and description"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1192
+msgid "Prefix:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1209
+msgid "A prefix or regex is required"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1221
+#: ../src/spacecmd/softwarechannel.py:1994
+#: ../src/spacecmd/softwarechannel.py:2034
+msgid "Channel does not exist or is not a base channel!"
+msgstr ""
+
+#. Shouldn't ever get here due to earlier checks
+#: ../src/spacecmd/softwarechannel.py:1248
+msgid "called without prefix or regex option!"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1348
+msgid "softwarechannel_addpackages: Add packages to a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1349
+msgid "usage: softwarechannel_addpackages CHANNEL <PACKAGE ...>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1389
+msgid "No packages to add"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1396
+msgid "Add these packages [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1408
+msgid ""
+"softwarechannel_mergepackages: Merge packages from one software channel into "
+"another"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1409
+msgid "usage: softwarechannel_mergepackages SOURCE_CHANNEL TARGET_CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1433
+msgid "softwarechannel_removeerrata: Remove patches from a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1435
+msgid "usage: softwarechannel_removeerrata CHANNEL <ERRATA:search:XXX ...>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1488
+msgid "No patches to remove"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1499
+#: ../src/spacecmd/softwarechannel.py:1828
+#, python-format
+msgid "Total Errata:   %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1500
+#: ../src/spacecmd/softwarechannel.py:1831
+#, python-format
+msgid "Total Packages: %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1502
+msgid "Remove these patches [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1517
+msgid "softwarechannel_removepackages: Remove packages from a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1519
+msgid "usage: softwarechannel_removepackages CHANNEL <PACKAGE ...>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1573
+msgid "No packages to remove"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1593
+msgid ""
+"softwarechannel_adderratabydate: Add errata from one channel into another "
+"channel based on a date range"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1595
+msgid ""
+"usage: softwarechannel_adderratabydate [options] SOURCE DEST BEGINDATE "
+"ENDDATE"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1596
+#: ../src/spacecmd/softwarechannel.py:1671
+msgid "Date format : YYYYMMDD"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1597
+#: ../src/spacecmd/softwarechannel.py:1728
+#: ../src/spacecmd/softwarechannel.py:2620
+#: ../src/spacecmd/softwarechannel.py:2663
+#: ../src/spacecmd/softwarechannel.py:2879
+msgid "Options:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1598
+msgid "        -p/--publish : Publish errata to the channel (don't clone)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1625
+#: ../src/spacecmd/softwarechannel.py:1630
+#: ../src/spacecmd/softwarechannel.py:1696
+#: ../src/spacecmd/softwarechannel.py:1701
+#, python-format
+msgid "%s is an invalid date"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1643
+msgid "No patches found between the given dates"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1650
+#, python-format
+msgid "Publishing errata %s to %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1668
+msgid ""
+"softwarechannel_listerratabydate: list errata from channelbased on a date "
+"range"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1670
+msgid "usage: softwarechannel_listerratabydate CHANNEL BEGINDATE ENDDATE"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1714
+msgid "No errata found between the given dates"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1725
+msgid ""
+"softwarechannel_adderrata: Add patches from one channel into another channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1727
+msgid "usage: softwarechannel_adderrata SOURCE DEST <ERRATA|search:XXX ...>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1729
+msgid "    -q/--quick : Don't display list of packages (slightly faster)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1730
+msgid "    -s/--skip :  Skip errata which appear to exist already in DEST"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1756
+#, python-format
+msgid "source channel %s does not exist!"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1761
+#, python-format
+msgid "dest channel %s does not exist!"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1814
+msgid "No patch to add"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1833
+msgid "Add these patches [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1847
+msgid "Using the old errata.clone function"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1848
+msgid ""
+"If you have base channels for multiple OS versions, check no unexpected "
+"packages have been added"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1861
+msgid ""
+"softwarechannel_getorgaccess: Get the org-access for the software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1862
+msgid "usage: softwarechannel_getorgaccess [CHANNEL ...]"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1900
+msgid ""
+"softwarechannel_setorgaccess: Set the org-access for the software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1901
+msgid ""
+"usage : softwarechannel_setorgaccess <CHANNEL> [options])\n"
+"-d,--disable : disable org access (private, no org sharing)\n"
+"-e,--enable : enable org access (public access to all trusted orgs)\n"
+"-p,--protected ORG : protected org access for ORG only (multiple instances "
+"of -p ORG are allowed)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1941
+#, python-format
+msgid "Making org sharing public for channel : %s "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1946
+#, python-format
+msgid "Making org sharing private for channel : %s "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1951
+#, python-format
+msgid "Making org sharing protected for channel : %s "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1957
+#, python-format
+msgid "Enabling %s access for channel : %s "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1962
+#, python-format
+msgid "Disabling %s access for channel : %s "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1975
+msgid ""
+"softwarechannel_getorgaccesstree: Get the org-access for a software base "
+"channel and its children"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1976
+msgid "usage: softwarechannel_getorgaccesstree [CHANNEL]"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2009
+msgid ""
+"softwarechannel_setorgaccesstree: set the org-access for a software base "
+"channel and its children"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2010
+msgid ""
+"usage: softwarechannel_setorgaccesstree <CHANNEL> [options])\n"
+"-d,--disable : disable org access (private, no org sharing)\n"
+"-e,--enable : enable org access (public access to all trusted orgs)\n"
+"-p,--protected ORG : protected org access for ORG only (multiple instances "
+"of -p ORG are allowed)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2049
+msgid "softwarechannel_regenerateneededcache: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2050
+msgid "Regenerate the needed errata and package cache for all systems"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2052
+msgid "usage: softwarechannel_regenerateneededcache"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2066
+msgid "softwarechannel_regenerateyumcache: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2067
+msgid "Regenerate the YUM cache for a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2069
+msgid ""
+"usage: softwarechannel_regenerateyumcache [options] <CHANNEL ...>\n"
+"\n"
+"    options:\n"
+"      -f force cache regeneration\n"
+"    "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2113
+msgid "no softwarechannel label given"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2116
+msgid "invalid softwarechannel label "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2134
+msgid "softwarechannel_diff: diff softwarechannel files"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2136
+msgid "usage: softwarechannel_diff SOURCE_CHANNEL TARGET_CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2197
+msgid "softwarechannel_errata_diff: diff softwarechannel files"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2199
+msgid "usage: softwarechannel_errata_diff SOURCE_CHANNEL TARGET_CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2248
+msgid "softwarechannel_sync: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2249
+msgid "sync the packages of two software channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2251
+msgid ""
+"usage: softwarechannel_sync SOURCE_CHANNEL TARGET_CHANNEL [options])\n"
+"    -q,--quiet : quiet mode (omits the output of common packages in both "
+"channels)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2293
+#, python-format
+msgid "%s packages from softwarechannel %s to %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2312
+#: ../src/spacecmd/softwarechannel.py:2320
+#: ../src/spacecmd/softwarechannel.py:2434
+#: ../src/spacecmd/softwarechannel.py:2442
+#: ../src/spacecmd/softwarechannel.py:2574
+#: ../src/spacecmd/softwarechannel.py:2582
+msgid "failed to read key id"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2323
+msgid "packages common in both channels:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2328
+msgid "Omitting common packages in both specified channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2333
+msgid "packages to add to channel \""
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2341
+msgid "packages to remove from channel \""
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2347
+#: ../src/spacecmd/softwarechannel.py:2469
+#: ../src/spacecmd/softwarechannel.py:2599
+msgid "summary:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2348
+#: ../src/spacecmd/softwarechannel.py:2349
+msgid " packages"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2350
+msgid "    add    "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2351
+msgid " packages to   "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2354
+msgid "    remove "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2355
+msgid " packages from "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2357
+#: ../src/spacecmd/softwarechannel.py:2477
+msgid "Perform these changes to channel "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2378
+msgid "softwarechannel_errata_sync: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2379
+msgid "sync errata of two software channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2381
+msgid "usage: softwarechannel_errata_sync SOURCE_CHANNEL TARGET_CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2420
+msgid "syncing errata from softwarechannel "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2421
+#: ../src/spacecmd/softwarechannel.py:2553
+msgid " to "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2445
+msgid "errata common in both channels:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2454
+msgid "errata to add to channel \""
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2463
+msgid "errata to remove from channel \""
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2472
+#: ../src/spacecmd/softwarechannel.py:2602
+msgid "    add   "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2473
+msgid "errata to  "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2474
+msgid "    remove"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2475
+msgid "errata from"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2500
+msgid "softwarechannel_errata_merge: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2501
+msgid "merge errata of one software channel into another"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2503
+msgid ""
+"usage:   softwarechannel_errata_merge SOURCE_CHANNEL TARGET_CHANNEL "
+"[FROM_DATE] [TO_DATE]"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2504
+msgid ""
+"example: softwarechannel_errata_merge OldSoftChannel NewSoftChannel "
+"2018-01-01"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2505
+msgid ""
+"note:    Providing only FROM_DATE will merge all errata since that date."
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2506
+msgid "note:    When no date is provided, all errata will be merged."
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2536
+#: ../src/spacecmd/softwarechannel.py:2543
+msgid "wrong dateformat: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2536
+#: ../src/spacecmd/softwarechannel.py:2543
+msgid " please specify as: YYYY-MM-DD"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2552
+msgid "merging errata from softwarechannel "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2589
+msgid "{} contains no errata which is not already present in {}"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2594
+msgid "errata to add to channel {}: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2600
+#: ../src/spacecmd/softwarechannel.py:2601
+msgid " errata"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2603
+msgid " errata to  "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2605
+msgid "Perform these changes to channel {} [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2616
+msgid "softwarechannel_syncrepos: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2617
+msgid "Sync users repos for a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2619
+msgid "usage: softwarechannel_syncrepos <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2621
+#: ../src/spacecmd/softwarechannel.py:2664
+msgid "    -e/--no-errata : Do not sync errata"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2622
+#: ../src/spacecmd/softwarechannel.py:2665
+msgid "    -f/--fail : Terminate upon any error"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2623
+#: ../src/spacecmd/softwarechannel.py:2666
+msgid "    -k/--sync-kickstart : Create kickstartable tree"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2624
+#: ../src/spacecmd/softwarechannel.py:2667
+msgid "    -l/--latest : Only download latest package versions when repo syncs"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2659
+msgid "softwarechannel_setsyncschedule: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2660
+msgid "Sets the repo sync schedule for a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2662
+msgid "usage: softwarechannel_setsyncschedule <CHANNEL> <SCHEDULE>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2669
+msgid ""
+"The schedule is specified in Quartz CronTrigger format without enclosing "
+"quotes."
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2670
+msgid ""
+"For example, to set a schedule of every day at 1am, <SCHEDULE> would be 0 0 "
+"1 * * ?"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2671
+msgid "If <SCHEDULE> is left empty, it will be disabled."
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2734
+msgid ""
+"softwarechannel_listsyncschedule: List sync schedules for all software "
+"channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2736
+msgid "softwarechannel_listsyncschedule : List all channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2759
+msgid "key"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2759
+msgid "Channel Name"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2759
+msgid "Update Schedule"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2771
+msgid "softwarechannel_addrepo: Add a repo to a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2772
+msgid "usage: softwarechannel_addrepo CHANNEL REPO"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2805
+msgid "softwarechannel_removerepo: Remove a repo from a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2806
+msgid "usage: softwarechannel_removerepo CHANNEL REPO"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2846
+msgid "softwarechannel_listrepos: List the repos for a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2847
+msgid "usage: softwarechannel_listrepos CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2870
+msgid "No repos have been found for this channel."
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2877
+msgid "softwarechannel_mirrorpackages: Download packages of a given channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2878
+msgid "usage: softwarechannel_mirrorpackages CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2880
+msgid "    -l/--latest : Only mirror latest package version"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2911
+msgid "Skipping"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2913
+msgid "Fetching package"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2918
+#, python-format
+msgid "Received package %s from channel %s is broken. Content is too short"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2922
+#, python-format
+msgid "Could not fetch package %s from channel %s"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:42
+msgid "The System Set Manager (SSM) is a group of systems that you "
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:43
+msgid "can perform tasks on as a whole."
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:45
+msgid "Adding Systems:"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:51
+msgid "Intersections:"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:63
+msgid "ssm_add: Add systems to the SSM"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:64
+msgid "usage: ssm_add <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:66 ../src/spacecmd/ssm.py:115
+#: ../src/spacecmd/ssm.py:165 ../src/spacecmd/ssm.py:209
+msgid "see 'help ssm' for more details"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:92
+#, python-format
+msgid "%s is already in the list"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:110
+msgid "ssm_intersect: Replace the current SSM with the intersection"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:111
+msgid "               of the current list of systems and the list of"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:112
+msgid "               systems passed as arguments"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:113
+msgid "usage: ssm_intersect <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:162
+msgid "ssm_remove: Remove systems from the SSM"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:163
+msgid "usage: ssm_remove <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:206
+msgid "ssm_list: List the systems currently in the SSM"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:207
+msgid "usage: ssm_list"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:226
+msgid "ssm_clear: Remove all systems from the SSM"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:227
+msgid "usage: ssm_clear"
+msgstr ""
+
+#: ../src/spacecmd/system.py:49
+msgid "Same"
+msgstr ""
+
+#: ../src/spacecmd/system.py:50
+msgid "Only here"
+msgstr ""
+
+#: ../src/spacecmd/system.py:51
+msgid "Newer here"
+msgstr ""
+
+#: ../src/spacecmd/system.py:52
+msgid "Only there"
+msgstr ""
+
+#: ../src/spacecmd/system.py:53
+msgid "Newer there"
+msgstr ""
+
+#: ../src/spacecmd/system.py:73 ../src/spacecmd/system.py:3771
+msgid "Package"
+msgstr ""
+
+#: ../src/spacecmd/system.py:74
+msgid "This System"
+msgstr ""
+
+#: ../src/spacecmd/system.py:75
+msgid "Other System"
+msgstr ""
+
+#: ../src/spacecmd/system.py:76 ../src/spacecmd/system.py:3774
+msgid "Difference"
+msgstr ""
+
+#: ../src/spacecmd/system.py:124
+msgid "Removing Channels"
+msgstr ""
+
+#: ../src/spacecmd/system.py:127
+msgid "Adding Channels"
+msgstr ""
+
+#: ../src/spacecmd/system.py:163
+msgid "system_list: List all system profiles"
+msgstr ""
+
+#: ../src/spacecmd/system.py:164
+msgid "usage: system_list"
+msgstr ""
+
+#: ../src/spacecmd/system.py:180
+msgid "system_reboot: Reboot a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:181
+msgid ""
+"usage: system_reboot <SYSTEMS> [options])\n"
+"\n"
+"options:\n"
+"  -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:236
+msgid "Reboot these systems [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:252
+msgid "system_search: List systems that match the given criteria"
+msgstr ""
+
+#: ../src/spacecmd/system.py:253
+msgid "usage: system_search QUERY"
+msgstr ""
+
+#: ../src/spacecmd/system.py:255
+msgid "Available Fields:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:258
+msgid "Examples:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:259
+msgid "> system_search device:vmware"
+msgstr ""
+
+#: ../src/spacecmd/system.py:260
+msgid "> system_search ip:192.168.82"
+msgstr ""
+
+#: ../src/spacecmd/system.py:278 ../src/spacecmd/system.py:285
+msgid "Invalid query"
+msgstr ""
+
+#: ../src/spacecmd/system.py:321
+msgid "Invalid search field"
+msgstr ""
+
+#: ../src/spacecmd/system.py:351
+msgid "system_runscript: Schedule a script to run on the list of"
+msgstr ""
+
+#: ../src/spacecmd/system.py:352
+msgid "                  systems provided"
+msgstr ""
+
+#: ../src/spacecmd/system.py:353
+msgid ""
+"usage: system_runscript <SYSTEMS> [options])\n"
+"\n"
+"options:\n"
+"  -u USER\n"
+"  -g GROUP\n"
+"  -t TIMEOUT\n"
+"  -s START_TIME\n"
+"  -l LABEL\n"
+"  -f FILE"
+msgstr ""
+
+#: ../src/spacecmd/system.py:398
+msgid "User [root]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:399
+msgid "Group [root]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:408
+msgid "Timeout (in seconds) [600]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:414
+msgid "Invalid timeout"
+msgstr ""
+
+#: ../src/spacecmd/system.py:420
+msgid "Label/Short Description [default]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:424
+msgid "Script File [create]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:437
+msgid "No script provided"
+msgstr ""
+
+#: ../src/spacecmd/system.py:456
+msgid "A script file is required"
+msgstr ""
+
+#: ../src/spacecmd/system.py:464
+#, python-format
+msgid "User:       %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:465
+#, python-format
+msgid "Group:      %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:466
+#, python-format
+msgid "Timeout:    %i seconds"
+msgstr ""
+
+#: ../src/spacecmd/system.py:470
+#, python-format
+msgid "Label:      %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:471
+msgid "Script Contents"
+msgstr ""
+
+#: ../src/spacecmd/system.py:533 ../src/spacecmd/system.py:835
+#: ../src/spacecmd/system.py:962 ../src/spacecmd/system.py:1096
+#: ../src/spacecmd/system.py:4358
+#, python-format
+msgid "Failed to schedule %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:536
+#, python-format
+msgid "Scheduled: %i system(s)"
+msgstr ""
+
+#: ../src/spacecmd/system.py:543 ../src/spacecmd/utils.py:245
+#, python-format
+msgid "Could not remove %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:552
+msgid "system_listhardware: List the hardware details of a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:553
+msgid "usage: system_listhardware <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:612
+msgid "Network"
+msgstr ""
+
+#: ../src/spacecmd/system.py:621
+#, python-format
+msgid "Interface:   %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:622
+#, python-format
+msgid "MAC Address: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:623
+#, python-format
+msgid "IP Address:  %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:624
+#, python-format
+msgid "Netmask:     %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:625
+#, python-format
+msgid "Broadcast:   %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:626
+#, python-format
+msgid "Module:      %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:630
+msgid "CPU"
+msgstr ""
+
+#: ../src/spacecmd/system.py:632
+#, python-format
+msgid "Count:    %i"
+msgstr ""
+
+#: ../src/spacecmd/system.py:633
+#, python-format
+msgid "Arch:     %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:634
+#, python-format
+msgid "MHz:      %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:635
+#, python-format
+msgid "Cache:    %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:636
+#, python-format
+msgid "Vendor:   %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:637
+#, python-format
+msgid "Model:    %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:640
+msgid "Memory"
+msgstr ""
+
+#: ../src/spacecmd/system.py:642
+#, python-format
+msgid "RAM:  %i"
+msgstr ""
+
+#: ../src/spacecmd/system.py:643
+#, python-format
+msgid "Swap: %i"
+msgstr ""
+
+#: ../src/spacecmd/system.py:647
+msgid "DMI"
+msgstr ""
+
+#: ../src/spacecmd/system.py:648
+#, python-format
+msgid "Vendor:       %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:649
+#, python-format
+msgid "System:       %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:650
+#, python-format
+msgid "Product:      %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:651
+#, python-format
+msgid "Board:        %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:654
+msgid "Asset"
+msgstr ""
+
+#: ../src/spacecmd/system.py:660
+#, python-format
+msgid "BIOS Release: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:661
+#, python-format
+msgid "BIOS Vendor:  %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:662
+#, python-format
+msgid "BIOS Version: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:666
+msgid "Devices"
+msgstr ""
+
+#: ../src/spacecmd/system.py:676
+msgid "Description: None"
+msgstr ""
+
+#: ../src/spacecmd/system.py:680
+#, python-format
+msgid "Driver:      %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:681
+#, python-format
+msgid "Class:       %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:682
+#, python-format
+msgid "Bus:         %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:690
+msgid "system_installpackage: Install a package on a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:691
+msgid ""
+"usage: system_installpackage <SYSTEMS> <PACKAGE ...> [options])\n"
+"\n"
+"options:\n"
+"    -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:792
+msgid "No packages to install"
+msgstr ""
+
+#: ../src/spacecmd/system.py:816
+#, python-format
+msgid "%s does not have access to all requested packages"
+msgstr ""
+
+#: ../src/spacecmd/system.py:822
+msgid "Install these packages [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:837 ../src/spacecmd/system.py:964
+#: ../src/spacecmd/system.py:1098
+#, python-format
+msgid "Scheduled %i system(s)"
+msgstr ""
+
+#: ../src/spacecmd/system.py:845
+msgid "system_removepackage: Remove a package from a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:846
+msgid ""
+"usage: system_removepackage <SYSTEMS> <PACKAGE ...> [options])\n"
+"\n"
+"options:\n"
+"    -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:972
+msgid "system_upgradepackage: Upgrade a package on a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:973
+msgid ""
+"usage: system_upgradepackage <SYSTEMS> <PACKAGE ...>|* [options]')\n"
+"\n"
+"options:\n"
+"    -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1051 ../src/spacecmd/system.py:1147
+#, python-format
+msgid "No upgrades available for %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1074
+#, python-format
+msgid "Couldn't get name for package %i"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1081
+msgid "Upgrade these packages [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1106
+msgid "system_listupgrades: List the available upgrades for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1107
+msgid "usage: system_listupgrades <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1175
+msgid "system_listinstalledpackages: List the installed packages on a"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1176
+msgid "                              system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1177
+msgid "usage: system_listinstalledpackages <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1231
+msgid "system_listconfigchannels: List the config channels of a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1232
+msgid "usage: system_listconfigchannels <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1278 ../src/spacecmd/system.py:1381
+#, python-format
+msgid "%s does not support configuration channels"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1315
+msgid "system_listconfigfiles: List the managed config files of a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1316
+msgid ""
+"usage: system_listconfigfiles <SYSTEMS>')\n"
+"options:\n"
+"  -s/--sandbox : list only system-sandbox files\n"
+"  -l/--local   : list only locally managed files\n"
+"  -c/--central : list only centrally managed files\n"
+"  -q/--quiet   : quiet mode (omits the header)"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1416
+msgid "system_addconfigfile: Create a configuration file"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1417
+msgid "Note this is only for system sandbox or locally-managed files"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1418
+msgid "Centrally managed files should be created via configchannel_addfile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1419
+msgid ""
+"usage: system_addconfigfile [SYSTEM] [options]\n"
+"\n"
+"options:\n"
+"  -S/--sandbox : list only system-sandbox files\n"
+"  -L/--local   : list only locally managed files\n"
+"  -p PATH\n"
+"  -r REVISION\n"
+"  -o OWNER [default: root]\n"
+"  -g GROUP [default: root]\n"
+"  -m MODE [defualt: 0644]\n"
+"  -x SELINUX_CONTEXT\n"
+"  -d path is a directory\n"
+"  -s path is a symlink\n"
+"  -b path is a binary (or other file which needs base64 encoding)\n"
+"  -t SYMLINK_TARGET\n"
+"  -f local path to file contents\n"
+"\n"
+"  Note re binary/base64: Some text files, notably those containing trailing\n"
+"  newlines, those containing ASCII escape characters (or other charaters "
+"not\n"
+"  allowed in XML) need to be sent as binary (-b).  Some effort is made to "
+"auto-\n"
+"  detect files which require this, but you may need to explicitly specify.\n"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1487
+#, python-format
+msgid "%s is not a valid system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1497
+msgid "System-Sandbox or Locally-Managed? [S/L]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1513
+msgid "Must choose system-sandbox or locally-managed option"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1552
+msgid "system_addconfigchannels: Add config channels to a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1553
+msgid ""
+"usage: system_addconfigchannels <SYSTEMS> <CHANNEL ...> [options]\n"
+"\n"
+"options:\n"
+"  -t add channels to the top of the list\n"
+"  -b add channels to the bottom of the list"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1597
+msgid "Add to top or bottom? [T/b]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1621
+msgid "system_removeconfigchannels: Remove config channels from a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1622
+msgid "usage: system_removeconfigchannels <SYSTEMS> <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1671
+msgid ""
+"system_setconfigchannelorder: Set the ranked order of configuration channels"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1672
+msgid "usage: system_setconfigchannelorder <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1712
+msgid "New Configuration Channels"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1732
+msgid "system_deployconfigfiles: Deploy all configuration files for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1733
+msgid ""
+"usage: system_deployconfigfiles <SYSTEMS> [options]\n"
+"\n"
+"options:\n"
+"    -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1787
+msgid "Deploy ALL configuration files to these systems [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1797
+#, python-format
+msgid "Scheduled deployment for %i system(s)"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1805
+msgid "system_delete: Delete a system profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1806
+msgid ""
+"usage: system_delete [options] <SYSTEMS>\n"
+"\n"
+"    options:\n"
+"          -c TYPE - Possible values:\n"
+"             *  'FAIL_ON_CLEANUP_ERR' - fail in case of cleanup error,\n"
+"             *  'NO_CLEANUP' - do not cleanup, just delete,\n"
+"             *  'FORCE_DELETE' - Try cleanup first but delete server anyway "
+"in case of error\n"
+"    "
+msgstr ""
+
+#: ../src/spacecmd/system.py:1850
+msgid "No systems to delete"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1858
+#, python-format
+msgid "%s  System ID"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1858
+msgid "Profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1866
+msgid "Delete these systems [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1873
+#, python-format
+msgid "%i system(s) scheduled for removal"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1893
+msgid "system_lock: Lock a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1894
+msgid "usage: system_lock <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1935
+msgid "system_unlock: Unlock a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1936
+msgid "usage: system_unlock <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1977
+msgid "system_rename: Rename a system profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1978
+msgid "usage: system_rename OLDNAME NEWNAME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2023
+msgid "system_listcustomvalues: List the custom values for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2024
+msgid "usage: system_listcustomvalues <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2079
+msgid "system_addcustomvalue: Set a custom value for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2080
+msgid "usage: system_addcustomvalue KEY VALUE <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2134
+msgid "system_updatecustomvalue: Update a custom value for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2135
+msgid "usage: system_updatecustomvalue KEY VALUE <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2166
+msgid "system_removecustomvalues: Remove a custom value for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2167
+msgid "usage: system_removecustomvalues <SYSTEMS> <KEY ...>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2203
+msgid "Delete these values [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2221
+msgid "system_addnote: Set a note for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2222
+msgid ""
+"usage: system_addnote <SYSTEM> [options]\n"
+"\n"
+"options:\n"
+"  -s SUBJECT\n"
+"  -b BODY"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2257
+msgid "Subject of the Note:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2259
+msgid "Note Body (ctrl-D to finish):"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2263
+msgid "A subject is required"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2267
+msgid "A body is required"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2286
+msgid "system_deletenotes: Delete notes from a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2287
+msgid "usage: system_deletenotes <SYSTEM> <ID|*>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2319
+msgid "No notes to delete"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2346
+msgid "system_listnotes: List the available notes for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2347
+msgid "usage: system_listnotes <SYSTEM>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2405
+msgid "system_listfqdns: List the associated FQDNs for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2406
+msgid "usage: system_listfqdns <SYSTEM>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2458
+msgid "system_setbasechannel: Set a system's base software channel"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2459
+msgid "usage: system_setbasechannel <SYSTEMS> CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2506 ../src/spacecmd/system.py:2593
+#, python-format
+msgid "System:           %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2507 ../src/spacecmd/system.py:2594
+#, python-format
+msgid "Old Base Channel: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2508 ../src/spacecmd/system.py:2596
+#, python-format
+msgid "New Base Channel: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2527
+msgid ""
+"system_schedulechangechannels: Schedule changing a system's software channels"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2528
+msgid ""
+"usage: system_setbasechannel <SYSTEMS> [options]\n"
+"\n"
+"options:\n"
+"  -b BASE_CHANNEL base channel label\n"
+"  -c CHILD_CHANNEL child channel labels (allowed multiple times)\n"
+"  -s START_TIME time defaults to now"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2595
+#, python-format
+msgid "Old Child Channels: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2597
+#, python-format
+msgid "New Child channels %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2612 ../src/spacecmd/system.py:4243
+#, python-format
+msgid "Scheduled action id: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2619
+msgid "system_listbasechannel: List the base channel for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2620
+msgid "usage: system_listbasechannel <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2674
+msgid "system_listchildchannels: List the child channels for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2675
+msgid "usage: system_listchildchannels <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2729
+msgid "system_addchildchannels: Add child channels to a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2730
+msgid "usage: system_addchildchannels <SYSTEMS> <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2752
+msgid ""
+"system_listcrashedsystems: List all systems that have experienced a crash "
+"and reported by spacewalk-abrt"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2753
+msgid "usage: system_listcrashedsystems"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2759
+msgid "Count | System ID | Profile Name"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2773
+msgid "system_deletecrashes: Delete crashes reported by spacewalk-abrt."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2774
+msgid ""
+"usage: Delete all crashes for all systems    : system_deletecrashes [--"
+"verbose]"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2775
+msgid ""
+"usage: Delete all crashes for a single system: system_deletecrashes -i "
+"sys_id [--verbose]"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2776
+msgid ""
+"usage: Delete a single crash record          : system_deletecrashes -c "
+"crash_id [--verbose]"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2794
+#, python-format
+msgid "Deleting crash with id %s."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2801
+#, python-format
+msgid "Deleting all crashes from system with systemid %s [y/N]:"
+msgstr ""
+
+#. all systems
+#: ../src/spacecmd/system.py:2803
+msgid "Deleting all crashes from all systems [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2815
+#, python-format
+msgid "Deleting crash with id %s from system %s."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2824
+msgid "system_listcrashesbysystem: List all reported crashes for a system."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2825 ../src/spacecmd/system.py:2837
+msgid "usage: system_listcrashesbysystem -i sys_id"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2836
+msgid "# System id must be provided."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2842
+msgid "Crash ID | Crash Name"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2853
+msgid "system_getcrashfiles: Download all files for a crash record."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2854
+msgid "usage: system_getcrashfiles -c crash_id [--verbose]"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2855 ../src/spacecmd/system.py:2869
+msgid ""
+"usage: system_getcrashfiles -c crash_id [--dest_folder=/tmp/crash_files] [--"
+"verbose]"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2868
+msgid "# Crash id must be provided."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2895
+#, python-format
+msgid "# All files we downloaded to %s."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2904
+msgid "system_removechildchannels: Remove child channels from a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2905
+msgid "usage: system_removechildchannels <SYSTEMS> <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2927
+msgid "system_details: Show the details of a system profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2928
+msgid "usage: system_details <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2981
+#, python-format
+msgid "Name:          %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2982
+#, python-format
+msgid "System ID:     %i"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2985
+#, python-format
+msgid "UUID:          %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2987
+#, python-format
+msgid "Locked:        %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2988
+#, python-format
+msgid "Registered:    %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2989
+#, python-format
+msgid "Last Checkin:  %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2990
+#, python-format
+msgid "OSA Status:    %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2991
+#, python-format
+msgid "Last Boot:     %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2993
+#, python-format
+msgid "Contact Method:%s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3037
+#, python-format
+msgid "Hostname:      %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3038
+#, python-format
+msgid "IP Address:    %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3039
+#, python-format
+msgid "Kernel:        %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3080
+msgid "system_listerrata: List available errata for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3081
+msgid "usage: system_listerrata <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3135
+msgid "system_applyerrata: Apply errata to a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3136
+msgid ""
+"usage: system_applyerrata [options] <SYSTEMS>\n"
+"[ERRATA|search:XXX ...]\n"
+"\n"
+"options:\n"
+"  -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3197
+msgid "system_listevents: List the event history for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3198
+msgid "usage: system_listevents <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3244
+#, python-format
+msgid "Summary:   %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3246
+#, python-format
+msgid "Details:   %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3254
+msgid "system_listentitlements: List the entitlements for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3255
+msgid "usage: system_listentitlements <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3308
+msgid "system_addentitlements: Add entitlements to a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3309
+msgid "usage: system_addentitlements <SYSTEMS> ENTITLEMENT"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3364
+msgid "system_removeentitlement: Remove an entitlement from a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3365
+msgid "usage: system_removeentitlement <SYSTEMS> ENTITLEMENT"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3420
+msgid "system_listpackageprofiles: List all package profiles"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3421
+msgid "usage: system_listpackageprofiles"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3440
+msgid "system_deletepackageprofile: Delete a package profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3441
+msgid "usage: system_deletepackageprofile PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3465
+msgid "Delete this profile [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3476
+#, python-format
+msgid "%s is not a valid profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3487
+msgid "system_createpackageprofile: Create a package profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3488
+msgid ""
+"usage: system_createpackageprofile SYSTEM [options]\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -d DESCRIPTION"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3518
+msgid "Profile Label:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3522
+msgid "A profile name is required"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3526
+msgid "A profile description is required"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3534
+#, python-format
+msgid "Created package profile '%s'"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3542
+msgid ""
+"system_comparepackageprofile: Compare a system against a package profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3543
+msgid "usage: system_comparepackageprofile <SYSTEMS> PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3606
+msgid "system_comparepackages: Compare the packages between two systems"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3607
+msgid "usage: system_comparepackages SOME_SYSTEM ANOTHER_SYSTEM"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3638
+msgid "system_syncpackages: Sync packages between two systems"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3639
+msgid ""
+"usage: system_syncpackages SOURCE TARGET [options]\n"
+"\n"
+"options:\n"
+"    -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3687
+msgid "Sync packages [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3729
+#, python-format
+msgid "Failed to filter package list, package %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3730
+msgid "found with no arch or arch_label"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3772
+msgid "System Version"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3773
+msgid "Channel Version"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3795
+msgid "Channel_newer_than_system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3808
+msgid "System_newer_than_channel"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3817
+msgid "Missing_in_channel"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3821
+msgid "system_comparewithchannel: Compare the installed packages on a"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3822
+msgid "                           system with those in the channels it is"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3823
+msgid "                           registerd to, or optionally some other"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3824
+msgid "                           channel"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3825
+msgid "usage: system_comparewithchannel <SYSTEMS> [options]"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3827
+msgid "         -c/--channel : Specific channel to compare against,"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3828
+msgid "                        default is those subscribed to, including"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3829
+msgid "                        child channels"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3880
+msgid "Specified channel does not exist"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3891
+#, python-format
+msgid "system %s is not subscribed to any channel!"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3893
+msgid "Please subscribe to a channel, or specify achannel to compare with"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3927
+#, python-format
+msgid ""
+"\n"
+"System: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3953
+msgid ""
+"system_schedulehardwarerefresh: Schedule a hardware refresh for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3954
+msgid ""
+"usage: system_schedulehardwarerefresh <SYSTEMS> [options]\n"
+"\n"
+"options:\n"
+"  -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4016
+msgid ""
+"system_schedulepackagerefresh: Schedule a software package refresh for a "
+"system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4017
+msgid ""
+"usage: system_schedulepackagerefresh <SYSTEMS> [options])\n"
+"\n"
+"options:\n"
+"  -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4078
+msgid ""
+"system_show_packageversion: Shows version of installed package on given "
+"system(s)"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4079
+msgid "usage: system_show_packageversion <SYSTEM> <PACKAGE>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4111
+msgid "Package\tVersion\tRelease\tEpoch\tArch\tSystem"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4131
+msgid "system_setcontactmethod: Set the contact method for given system(s)."
+msgstr ""
+
+#: ../src/spacecmd/system.py:4133
+msgid "usage: system_setcontactmethod <SYSTEMS> <CONTACT_METHOD>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4182
+msgid ""
+"system_scheduleapplyconfigchannels: Schedule applying the assigned config "
+"channels to the System (Minion only)"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4183
+msgid ""
+"usage: scheduleapplyconfigchannels <SYSTEMS> [options]\n"
+"\n"
+"    options:\n"
+"        -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4234
+msgid "Schedule applying config channels to these systems [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4251
+msgid ""
+"system_listmigrationtargets: List possible migration targets for given "
+"systems."
+msgstr ""
+
+#: ../src/spacecmd/system.py:4252
+msgid "usage: system_listmigrationtargets <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4279
+msgid "WARN: Cannot find system "
+msgstr ""
+
+#: ../src/spacecmd/system.py:4286
+msgid "  No migration targets"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4289
+msgid "  Target #"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4290
+msgid "    IDs: "
+msgstr ""
+
+#: ../src/spacecmd/system.py:4291
+msgid "    Friendly names: "
+msgstr ""
+
+#: ../src/spacecmd/system.py:4297
+msgid ""
+"system_schedulespmigration: Schedule a Service Pack migration for systems."
+msgstr ""
+
+#: ../src/spacecmd/system.py:4298
+msgid ""
+"usage: system_schedulespmigration <SYSTEM> <BASE_CHANNEL_LABEL> "
+"<MIGRATION_TARGET> [options] \n"
+"    For MIGRATION_TARGET parameter see system_listmigrationtargets. \n"
+"    The MIGRATION_TARGET parameter must be passed in the following format: "
+"[3143,3146,3147,3145,3144,3148,3062]. \n"
+"    Options: \n"
+"        -s START_TIME \n"
+"        -d pass this flag, if you want to do a dry run \n"
+"        -c CHILD_CHANNELS (comma-separated child channels labels (with no "
+"spaces))"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4348
+msgid "Cannot find system "
+msgstr ""
+
+#: ../src/spacecmd/system.py:4348
+msgid ". Skipping it."
+msgstr ""
+
+#: ../src/spacecmd/system.py:4351
+msgid "Scheduling Service Pack migration for system "
+msgstr ""
+
+#: ../src/spacecmd/system.py:4356
+msgid "Scheduled action ID: "
+msgstr ""
+
+#: ../src/spacecmd/user.py:49
+msgid "user_create: Create an user"
+msgstr ""
+
+#: ../src/spacecmd/user.py:50
+msgid ""
+"usage: user_create [options])\n"
+"\n"
+"options:\n"
+"  -u USERNAME\n"
+"  -f FIRST_NAME\n"
+"  -l LAST_NAME\n"
+"  -e EMAIL\n"
+"  -p PASSWORD\n"
+"  --pam enable PAM authentication"
+msgstr ""
+
+#: ../src/spacecmd/user.py:119
+msgid "Note: password was ignored due to PAM mode"
+msgstr ""
+
+#: ../src/spacecmd/user.py:138
+msgid "user_delete: Delete an user"
+msgstr ""
+
+#: ../src/spacecmd/user.py:139
+msgid "usage: user_delete NAME"
+msgstr ""
+
+#: ../src/spacecmd/user.py:167
+msgid "user_disable: Disable an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:168
+msgid "usage: user_disable NAME"
+msgstr ""
+
+#: ../src/spacecmd/user.py:194
+msgid "user_enable: Enable an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:195
+msgid "usage: user_enable NAME"
+msgstr ""
+
+#: ../src/spacecmd/user.py:221
+msgid "user_list: List all users"
+msgstr ""
+
+#: ../src/spacecmd/user.py:222
+msgid "usage: user_list"
+msgstr ""
+
+#: ../src/spacecmd/user.py:239
+msgid "user_listavailableroles: List all available roles for users"
+msgstr ""
+
+#: ../src/spacecmd/user.py:240
+msgid "usage: user_listavailableroles"
+msgstr ""
+
+#: ../src/spacecmd/user.py:252
+msgid "No roles has been found"
+msgstr ""
+
+#: ../src/spacecmd/user.py:258
+msgid "user_addrole: Add a role to an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:259
+msgid "usage: user_addrole USER ROLE"
+msgstr ""
+
+#: ../src/spacecmd/user.py:292
+msgid "user_removerole: Remove a role from an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:293
+msgid "usage: user_removerole USER ROLE"
+msgstr ""
+
+#: ../src/spacecmd/user.py:327
+msgid "user_details: Show the details of an user"
+msgstr ""
+
+#: ../src/spacecmd/user.py:328
+msgid "usage: user_details USER ..."
+msgstr ""
+
+#: ../src/spacecmd/user.py:360
+#, python-format
+msgid "%s is not a valid user"
+msgstr ""
+
+#: ../src/spacecmd/user.py:361
+msgid "Error '{}' while getting data about user '{}': {}"
+msgstr ""
+
+#: ../src/spacecmd/user.py:371
+#, python-format
+msgid "Username:      %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:372
+#, python-format
+msgid "First Name:    %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:373
+#, python-format
+msgid "Last Name:     %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:374
+#, python-format
+msgid "Email Address: %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:375
+#, python-format
+msgid "Organisation:  %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:376
+#, python-format
+msgid "Last Login:    %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:377
+#, python-format
+msgid "Created:       %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:378
+#, python-format
+msgid "Enabled:       %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:382
+msgid "Roles"
+msgstr ""
+
+#: ../src/spacecmd/user.py:388
+msgid "Assigned Groups"
+msgstr ""
+
+#: ../src/spacecmd/user.py:394
+msgid "Default Groups"
+msgstr ""
+
+#: ../src/spacecmd/user.py:404
+msgid "user_addgroup: Add a group to an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:405
+msgid "usage: user_addgroup USER <GROUP ...>"
+msgstr ""
+
+#: ../src/spacecmd/user.py:442
+msgid "user_adddefaultgroup: Add a default group to an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:443
+msgid "usage: user_adddefaultgroup USER <GROUP ...>"
+msgstr ""
+
+#: ../src/spacecmd/user.py:479
+msgid "user_removegroup: Remove a group to an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:480
+msgid "usage: user_removegroup USER <GROUP ...>"
+msgstr ""
+
+#: ../src/spacecmd/user.py:520
+msgid "user_removedefaultgroup: Remove a default group from an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:522
+msgid "usage: user_removedefaultgroup USER <GROUP ...>"
+msgstr ""
+
+#: ../src/spacecmd/user.py:561
+msgid "user_setfirstname: Set an user accounts first name field"
+msgstr ""
+
+#: ../src/spacecmd/user.py:562
+msgid "usage: user_setfirstname USER FIRST_NAME"
+msgstr ""
+
+#: ../src/spacecmd/user.py:596
+msgid "user_setlastname: Set an user accounts last name field"
+msgstr ""
+
+#: ../src/spacecmd/user.py:597
+msgid "usage: user_setlastname USER LAST_NAME"
+msgstr ""
+
+#: ../src/spacecmd/user.py:631
+msgid "user_setemail: Set an user accounts email field"
+msgstr ""
+
+#: ../src/spacecmd/user.py:632
+msgid "usage: user_setemail USER EMAIL"
+msgstr ""
+
+#: ../src/spacecmd/user.py:666
+msgid "user_setprefix: Set an user accounts name prefix field"
+msgstr ""
+
+#: ../src/spacecmd/user.py:667
+msgid "usage: user_setprefix USER PREFIX"
+msgstr ""
+
+#: ../src/spacecmd/user.py:706
+msgid "user_setpassword: Set an user accounts name prefix field"
+msgstr ""
+
+#: ../src/spacecmd/user.py:707
+msgid "usage: user_setpassword USER PASSWORD"
+msgstr ""
+
+#. If cache generation is interrupted (e.g by ctrl-c) you can end up
+#. with an EOFError exception due to the partial picked file
+#. So we catch this error and remove the corrupt partial file
+#. If you don't do this then spacecmd will fail with an unhandled
+#. exception until the partial file is manually removed
+#: ../src/spacecmd/utils.py:133
+#, python-format
+msgid "Loading cache file %s failed"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:134
+#, python-format
+msgid "Cache generation was probably interrupted,removing corrupt %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:139
+#, python-format
+msgid "Couldn't load cache from %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:160
+#, python-format
+msgid "Couldn't write to %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:205
+msgid "Could not open the temporary file"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:225
+#, python-format
+msgid "Editor \"%s\" exited with code %i"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:227
+#, python-format
+msgid "General failure running editor: %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:230
+msgid "No editors found"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:367
+msgid "Invalid time provided"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:463
+msgid "Security Errata"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:472
+msgid "Bug Fix Errata"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:481
+msgid "Enhancement Errata"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:491
+msgid "Current Selections"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:501
+msgid "Available Configuration Channels"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:507 ../src/spacecmd/utils.py:527
+msgid "Channel:"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:510 ../src/spacecmd/utils.py:530
+msgid "Invalid channel"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:514
+msgid "New Rank:"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:521 ../src/spacecmd/utils.py:524
+msgid "Invalid rank"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:535
+msgid "Clearing current selections"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:690
+msgid "Could not generate json data object!"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:697
+#, python-format
+msgid "Could not open file %s for writing: %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:708
+#, python-format
+msgid "Could not open file %s for reading: %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:710
+#, python-format
+msgid "Could not parse JSON data from %s: %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:712
+#, python-format
+msgid "Error processing file %s: %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:740
+msgid "Skipping usage of common strings: both strings are equal"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:756
+msgid "Skipping usage of common strings: number of substrings differ"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:842
+msgid "Parameter {} not a string type, but {}."
+msgstr ""
+
+#: ../src/bin/spacecmd:74
+msgid "Unhandled exception occurred while getting FQDN:"
+msgstr ""

--- a/spacecmd/po/sk.po
+++ b/spacecmd/po/sk.po
@@ -1,0 +1,7456 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#: ../src/bin/spacecmd:59
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-09-24 17:29+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../src/spacecmd/activationkey.py:49
+msgid "activationkey_addpackages: Add packages to an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:50
+msgid "usage: activationkey_addpackages KEY <PACKAGE ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:83
+msgid "activationkey_removepackages: Remove packages from an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:85
+msgid "usage: activationkey_removepackages KEY <PACKAGE ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:121
+msgid "activationkey_addgroups: Add groups to an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:122
+msgid "usage: activationkey_addgroups KEY <GROUP ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:160
+msgid "activationkey_removegroups: Remove groups from an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:161
+msgid "usage: activationkey_removegroups KEY <GROUP ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:208
+msgid "activationkey_addentitlements: Add entitlements to an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:210
+msgid "usage: activationkey_addentitlements KEY <ENTITLEMENT ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:245
+msgid ""
+"activationkey_removeentitlements: Remove entitlements from an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:247
+msgid "usage: activationkey_removeentitlements KEY <ENTITLEMENT ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:285
+msgid "activationkey_addchildchannels: Add child channels to an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:287
+msgid "usage: activationkey_addchildchannels KEY <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:337
+msgid ""
+"activationkey_removechildchannels: Remove child channels from an activation "
+"key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:339
+msgid "usage: activationkey_removechildchannels KEY <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:376
+msgid ""
+"activationkey_listchildchannels: List the child channels for an activation "
+"key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:378
+msgid "usage: activationkey_listchildchannels KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:407
+msgid ""
+"activationkey_listbasechannel: List the base channels for an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:409
+msgid "usage: activationkey_listbasechannel KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:437
+msgid "activationkey_listgroups: List the groups for an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:439
+msgid "usage: activationkey_listgroups KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:470
+msgid ""
+"activationkey_listentitlements: List the entitlements for an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:472
+msgid "usage: activationkey_listentitlements KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:501
+msgid "activationkey_listpackages: List the packages for an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:503
+msgid "usage: activationkey_listpackages KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:535
+msgid ""
+"activationkey_listconfigchannels: List the configuration channels for an "
+"activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:537
+msgid "usage: activationkey_listconfigchannels KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:570
+msgid ""
+"activationkey_addconfigchannels: Add config channels to an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:572
+msgid ""
+"usage: activationkey_addconfigchannels KEY <CHANNEL ...> [options])\n"
+"\n"
+"options:\n"
+"  -t add channels to the top of the list\n"
+"  -b add channels to the bottom of the list"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:625
+msgid ""
+"activationkey_removeconfigchannels: Remove config channels from an "
+"activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:627
+msgid "usage: activationkey_removeconfigchannels KEY <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:666
+msgid ""
+"activationkey_setconfigchannelorder: Set the ranked order of configuration "
+"channels"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:668
+msgid "usage: activationkey_setconfigchannelorder KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:698
+msgid "New Configuration Channels:"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:712
+msgid "activationkey_create: Create an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:713
+msgid ""
+"usage: activationkey_create [options])\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -d DESCRIPTION\n"
+"  -b BASE_CHANNEL\n"
+"  -u set key as universal default\n"
+"  -e [enterprise_entitled,virtualization_host]"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:734
+msgid "Name (blank to autogenerate):"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:735
+msgid "Description [None]:"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:738 ../src/spacecmd/distribution.py:78
+#: ../src/spacecmd/softwarechannel.py:927
+msgid "Base Channels"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:743
+msgid "Base Channel (blank for default):"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:751
+#, python-format
+msgid "%s Entitlement [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:755
+msgid "Universal Default [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:782
+#, python-format
+msgid "Created activation key %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:790
+msgid "activationkey_delete: Delete an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:791
+msgid "usage: activationkey_delete KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:813 ../src/spacecmd/cryptokey.py:139
+#: ../src/spacecmd/cryptokey.py:197
+#, python-format
+msgid "No keys matched argument %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:819
+msgid "Delete activation key(s) [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:832
+msgid "activationkey_list: List all activation keys"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:833
+msgid "usage: activationkey_list"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:857
+msgid "activationkey_listsystems: List systems registered with a key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:858
+msgid "usage: activationkey_listsystems KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:881 ../src/spacecmd/activationkey.py:930
+#, python-format
+msgid "%s is not a valid activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:895
+msgid "activationkey_details: Show the details of an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:896
+msgid "usage: activationkey_details KEY ..."
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:943
+#, python-format
+msgid "Key:                    %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:944
+#, python-format
+msgid "Description:            %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:945
+#, python-format
+msgid "Universal Default:      %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:946
+#, python-format
+msgid "Usage Limit:            %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:947
+#, python-format
+msgid "Deploy Config Channels: %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:949
+#, python-format
+msgid "Contact Method:         %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:952 ../src/spacecmd/kickstart.py:425
+#: ../src/spacecmd/system.py:3048
+msgid "Software Channels"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:960 ../src/spacecmd/configchannel.py:765
+#: ../src/spacecmd/configchannel.py:870 ../src/spacecmd/system.py:3057
+msgid "Configuration Channels"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:966 ../src/spacecmd/system.py:3062
+msgid "Entitlements"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:971 ../src/spacecmd/system.py:3068
+msgid "System Groups"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:976 ../src/spacecmd/package.py:206
+#: ../src/spacecmd/package.py:263 ../src/spacecmd/softwarechannel.py:1392
+#: ../src/spacecmd/softwarechannel.py:1494
+#: ../src/spacecmd/softwarechannel.py:1576
+#: ../src/spacecmd/softwarechannel.py:1822
+msgid "Packages"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:991
+msgid "activationkey_enableconfigdeployment: Enable config channel deployment"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:993
+msgid "usage: activationkey_enableconfigdeployment KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1020
+msgid ""
+"activationkey_disableconfigdeployment: Disable config channel deployment"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1022
+msgid "usage: activationkey_disableconfigdeployment KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1049
+msgid "activationkey_setbasechannel: Set the base channel of an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1051
+msgid "usage: activationkey_setbasechannel KEY CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1098
+msgid ""
+"activationkey_setusagelimit: Set the usage limit of an activation key, can "
+"be a number or \"unlimited\""
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1100
+msgid "usage: activationkey_setusagelimit KEY <usage limit>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1101
+msgid "usage: activationkey_setusagelimit KEY unlimited "
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1131
+#, python-format
+msgid "Couldn't convert argument %s to an integer"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1153
+msgid ""
+"activationkey_setuniversaldefault: Set this key as the universal default"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1155
+msgid "usage: activationkey_setuniversaldefault KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1196
+msgid "activationkey_export: Export activation key(s) to JSON format file"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1197
+msgid ""
+"usage: activationkey_export [options] [<KEY> ...])\n"
+"\n"
+"options:\n"
+"    -f outfile.json : specify an output filename, defaults to <KEY>.json\n"
+"                      if exporting a single key, akeys.json for multiple "
+"keys,\n"
+"                      or akey_all.json if no KEY specified (export ALL)\n"
+"\n"
+"Note : KEY list is optional, default is to export ALL keys "
+msgstr ""
+
+#. Get the key details
+#: ../src/spacecmd/activationkey.py:1213
+#, python-format
+msgid "Getting activation key details for %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1267
+#, python-format
+msgid "Exporting ALL activation keys to %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1276
+msgid "Invalid activation key passed"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1291
+#, python-format
+msgid "Exporting key %s to %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1300
+#, python-format
+msgid "File %s exists, confirm overwrite file? (y/n)"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1305
+msgid "Failed to save exported keys to file: {}"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1314
+msgid "activationkey_import: import activation key(s) from JSON file(s)"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1315
+msgid "usage: activationkey_import <JSONFILE ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1324
+msgid "No filename passed"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1333
+#, python-format
+msgid "Could not read json data from %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1338 ../src/spacecmd/activationkey.py:1382
+#, python-format
+msgid "Failed to import key %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1352
+#, python-format
+msgid "%s already exists! Skipping!"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1407
+#, python-format
+msgid "System group %s doesn't exist, creating"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1428
+msgid "activationkey_clone: Clone an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1429
+msgid ""
+"usage examples:\n"
+"                 activationkey_clone foo_key -c bar_key\n"
+"                 activationkey_clone foo_key1 foo_key2 -c prefix\n"
+"                 activationkey_clone foo_key -x \"s/foo/bar\"\n"
+"                 activationkey_clone foo_key1 foo_key2 -x \"s/foo/bar\"\n"
+"\n"
+"options:\n"
+"  -c CLONE_NAME  : Name of the resulting key, treated as a prefix for "
+"multiple\n"
+"                   keys\n"
+"  -x \"s/foo/bar\" : Optional regex replacement, replaces foo with bar in "
+"the\n"
+"                   clone description, base-channel label, child-channel\n"
+"                   labels, config-channel names "
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1457 ../src/spacecmd/kickstart.py:460
+#: ../src/spacecmd/system.py:3043
+msgid "Activation Keys"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1463
+#, python-format
+msgid "Key to clone: %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1467
+msgid "Original Key:"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1469
+msgid "Cloned Key:"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1472 ../src/spacecmd/configchannel.py:1376
+msgid "Error - must specify either -c or -x options!"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1477
+#, python-format
+msgid "Key %s already exists"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1481
+msgid "Error no activationkey to clone passed!"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1535
+#, python-format
+msgid "Found child channel %s key %s, %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1537
+msgid " does not exist, skipping!"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1544
+#, python-format
+msgid "Regex-replacement results in new base-channel %s which does not exist!"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1560
+#, python-format
+msgid "Found config channel %s for key %s, %s "
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1562
+msgid "does not exist, skipping!"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1584 ../src/spacecmd/configchannel.py:1428
+#, python-format
+msgid "Failed to clone %s to %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1602
+msgid "no activationkey label given"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1605
+msgid "invalid activationkey label "
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1622
+msgid "activationkey_diff: Diff activation keys"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1624
+msgid "usage: activationkey_diff SOURCE_KEY TARGET_KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1673
+msgid "activationkey_disable: Disable an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1675
+msgid "usage: activationkey_disable KEY [KEY ...]"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1707
+msgid "activationkey_enable: Enable an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1709
+msgid "usage: activationkey_enable KEY [KEY ...]"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1741
+msgid "activationkey_setdescription: Set the activation key description"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1743
+msgid "usage: activationkey_setdescription KEY DESCRIPTION"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1775
+msgid ""
+"activationkey_setcontactmethod: Set the contact method to use for systems "
+"registered with this key."
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1777 ../src/spacecmd/system.py:4132
+msgid "Available contact methods: "
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1778
+msgid "usage: activationkey_setcontactmethod KEY CONTACT_METHOD"
+msgstr ""
+
+#: ../src/spacecmd/api.py:44
+msgid "api: call RHN API with arguments directly"
+msgstr ""
+
+#: ../src/spacecmd/api.py:45
+#, python-format
+msgid ""
+"usage: api [options] API_STRING)\n"
+"\n"
+"options:\n"
+"  -A, --args  Arguments for the API other than session id in comma "
+"separated\n"
+"              strings or JSON expression\n"
+"  -F, --format   Output format\n"
+"  -o, --output   Output file\n"
+"\n"
+"examples:\n"
+"  api api.getApiCallList\n"
+"  api --args \"sysgroup_A\" systemgroup.listSystems\n"
+"  api -A \"rhel-i386-server-5,2011-04-01,2011-05-01\" -F \"%(name)s\" \\\n"
+"      channel.software.listAllPackages\n"
+msgstr ""
+
+#: ../src/spacecmd/api.py:81
+msgid "Could not open to write: "
+msgstr ""
+
+#: ../src/spacecmd/api.py:82
+msgid "Fallback output to stdout"
+msgstr ""
+
+#: ../src/spacecmd/api.py:91
+msgid "No such API: "
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:50
+msgid "configchannel_list: List all configuration channels"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:51
+msgid "usage: configchannel_list"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:68
+msgid "configchannel_listsystems: List the systems subscribed to a"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:69
+msgid "                           configuration channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:70
+msgid "usage: configchannel_listsystems CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:79
+msgid "This version of the API doesn't support this method"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:103
+msgid "configchannel_listfiles: List the files in a config channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:104
+msgid "usage: configchannel_listfiles CHANNEL ..."
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:133
+msgid "configchannel_forcedeploy: Forces a redeployment"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:134
+msgid "                           of files within this channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:135
+msgid "                           on all subscribed systems"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:136
+msgid "usage: configchannel_forcedeploy CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:158
+msgid "No files within selected configchannel."
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:164
+msgid "Channel has no subscribed Systems"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:167
+msgid "Force deployment of the following configfiles:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:170
+msgid ""
+"\n"
+"On these systems:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:173
+msgid "Really force deployment [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:182
+msgid "configchannel_filedetails: Show the details of a file"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:183
+msgid "in a configuration channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:184
+msgid "usage: configchannel_filedetails CHANNEL FILE [REVISION]"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:216
+#, python-format
+msgid "Invalid revision: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:222
+#, python-format
+msgid "%s is not in this configuration channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:240
+#, python-format
+msgid "Path:     %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:241
+#, python-format
+msgid "Type:     %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:242
+#, python-format
+msgid "Revision: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:243
+#, python-format
+msgid "Created:  %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:244
+#, python-format
+msgid "Modified: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:248 ../src/spacecmd/configchannel.py:650
+#, python-format
+msgid "Target Path:     %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:251 ../src/spacecmd/configchannel.py:680
+#, python-format
+msgid "Owner:           %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:252 ../src/spacecmd/configchannel.py:681
+#, python-format
+msgid "Group:           %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:253 ../src/spacecmd/configchannel.py:682
+#, python-format
+msgid "Mode:            %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:255 ../src/spacecmd/configchannel.py:651
+#: ../src/spacecmd/configchannel.py:684
+#, python-format
+msgid "SELinux Context: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:258
+#, python-format
+msgid "SHA256:          %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:259 ../src/spacecmd/configchannel.py:683
+#, python-format
+msgid "Binary:          %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:263 ../src/spacecmd/configchannel.py:696
+#: ../src/spacecmd/configchannel.py:933 ../src/spacecmd/kickstart.py:1903
+#: ../src/spacecmd/snippet.py:161
+msgid "Contents"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:273
+msgid "configchannel_backup: backup a config channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:274
+msgid ""
+"usage: configchannel_backup CHANNEL [OUTDIR])\n"
+"\n"
+"OUTDIR defaults to $HOME/spacecmd-backup/configchannel/YYYY-MM-DD/CHANNEL\n"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:313 ../src/spacecmd/group.py:266
+#, python-format
+msgid "Could not create output directory: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:326
+#, python-format
+msgid "Could not create \"%s\" file: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:332
+#, python-format
+msgid "Output Path:   %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:371
+msgid "configchannel_details: Show the details of a config channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:372
+msgid "usage: configchannel_details CHANNEL ..."
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:402 ../src/spacecmd/kickstart.py:414
+#, python-format
+msgid "Label:       %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:403 ../src/spacecmd/kickstart.py:413
+#, python-format
+msgid "Name:        %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:404 ../src/spacecmd/cryptokey.py:214
+#: ../src/spacecmd/system.py:678
+#, python-format
+msgid "Description: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:405 ../src/spacecmd/cryptokey.py:215
+#: ../src/spacecmd/kickstart.py:500 ../src/spacecmd/kickstart.py:1899
+#, python-format
+msgid "Type:        %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:408
+msgid "Files"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:418
+msgid "configchannel_create: Create a configuration channel of specific type"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:419
+msgid ""
+"usage: configchannel_create [options])\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -l LABEL\n"
+"  -d DESCRIPTION\n"
+"  -t TYPE('normal,'state')"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:438 ../src/spacecmd/custominfo.py:54
+#: ../src/spacecmd/custominfo.py:198 ../src/spacecmd/distribution.py:71
+#: ../src/spacecmd/filepreservation.py:70 ../src/spacecmd/group.py:177
+#: ../src/spacecmd/repo.py:349 ../src/spacecmd/repo.py:461
+#: ../src/spacecmd/softwarechannel.py:800
+msgid "Name:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:439
+msgid "Label:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:440 ../src/spacecmd/cryptokey.py:66
+#: ../src/spacecmd/custominfo.py:59 ../src/spacecmd/custominfo.py:203
+#: ../src/spacecmd/group.py:182 ../src/spacecmd/softwarechannel.py:812
+#: ../src/spacecmd/system.py:3519
+msgid "Description:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:441
+msgid "Type [normal, state]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:448
+msgid "Only [normal/state] values are acceptable for type"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:452 ../src/spacecmd/distribution.py:109
+#: ../src/spacecmd/repo.py:357 ../src/spacecmd/repo.py:467
+msgid "A name is required"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:461
+msgid "Only [normal/state] values are acceptable for --type parameter"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:476
+msgid "configchannel_delete: Delete a configuration channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:477
+msgid "usage: configchannel_delete CHANNEL ..."
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:498
+#, python-format
+msgid "No channels matched argument(s): %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:504 ../src/spacecmd/softwarechannel.py:736
+msgid "Delete these channels [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:548
+msgid "Symlink [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:552
+msgid "Target Path:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:553
+msgid "SELinux Context [none]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:561
+msgid "Directory [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:570
+#, python-format
+msgid "Owner [%s]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:571
+#, python-format
+msgid "Group [%s]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:572
+#, python-format
+msgid "Mode [%s]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:574
+#, python-format
+msgid "SELinux Context [%s]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:575
+msgid "Revision [next]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:593
+msgid "The revision must be an integer"
+msgstr ""
+
+#. get the contents of the script
+#: ../src/spacecmd/configchannel.py:596 ../src/spacecmd/configchannel.py:896
+#: ../src/spacecmd/cryptokey.py:68 ../src/spacecmd/kickstart.py:1954
+#: ../src/spacecmd/snippet.py:141
+msgid "Read an existing file [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:598 ../src/spacecmd/kickstart.py:1956
+msgid "File:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:616
+msgid "The path is required"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:630 ../src/spacecmd/configchannel.py:913
+msgid "You must provide the file contents"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:634
+msgid "You must provide the target path for a symlink"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:649 ../src/spacecmd/configchannel.py:678
+#, python-format
+msgid "Path:            %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:679
+#, python-format
+msgid "Directory:       %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:689
+#, python-format
+msgid "Revision:        %i"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:694
+msgid "Contents not displayed (base64 encoded)"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:707
+msgid ""
+"configchannel_addfile/configchannel_updatefile: Create a configuration file"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:708
+msgid ""
+"usage: configchannel_addfile/configchannel_updatefile -c CHANNEL - p PATH -f "
+"LOCAL_FILE_PATH [OPTIONS])\n"
+"\n"
+"options:\n"
+"  -c CHANNEL\n"
+"  -p PATH\n"
+"  -r REVISION\n"
+"  -o OWNER [default: root]\n"
+"  -g GROUP [default: root]\n"
+"  -m MODE [defualt: 0644]\n"
+"  -x SELINUX_CONTEXT\n"
+"  -d path is a directory\n"
+"  -s path is a symlink\n"
+"  -b path is a binary (or other file which needs base64 encoding)\n"
+"  -t SYMLINK_TARGET\n"
+"  -f local path to file contents\n"
+"  -y automatically proceed with file contents\n"
+"\n"
+"  Note re binary/base64: Some text files, notably those containing trailing\n"
+"  newlines, those containing ASCII escape characters (or other charaters "
+"not\n"
+"  allowed in XML) need to be sent as binary (-b).  Some effort is made to "
+"auto-\n"
+"  detect files which require this, but you may need to explicitly specify.\n"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:770 ../src/spacecmd/softwarechannel.py:819
+#: ../src/spacecmd/softwarechannel.py:940
+#: ../src/spacecmd/softwarechannel.py:947
+msgid "Select:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:778 ../src/spacecmd/softwarechannel.py:1374
+#, python-format
+msgid "%s is not a valid channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:783
+msgid "Unable to obtain a valid channel. Aborting."
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:789 ../src/spacecmd/scap.py:160
+msgid "Path:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:805 ../src/spacecmd/configchannel.py:924
+msgid "No config channel specified!"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:810 ../src/spacecmd/configchannel.py:929
+msgid "Error obtaining file info"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:845
+msgid "configchannel_updateinitsls: Update init.sls file"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:846
+msgid ""
+"usage: configchannel_updateinitsls -c CHANNEL -f LOCAL_FILE_PATH [OPTIONS])\n"
+"\n"
+"options:\n"
+"  -c CHANNEL\n"
+"  -f local path to file contents\n"
+"  -y automatically proceed with file contents\n"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:892
+#, python-format
+msgid "No existing file information found for %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:932
+#, python-format
+msgid "contents_enc64:           %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:959
+msgid "configchannel_removefiles: Remove configuration files"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:960
+msgid "usage: configchannel_removefiles CHANNEL <FILE ...>"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:997
+msgid "configchannel_verifyfile: Verify a configuration file"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:998
+msgid "usage: configchannel_verifyfile CHANNEL FILE <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1037
+msgid "No valid system selected"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1045 ../src/spacecmd/system.py:509
+#: ../src/spacecmd/system.py:529 ../src/spacecmd/system.py:959
+#, python-format
+msgid "Action ID: %i"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1053
+msgid "configchannel_export: export config channel(s) to json format file"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1054
+msgid ""
+"usage: configchannel_export <CHANNEL>... [options])\n"
+"options:\n"
+"    -f outfile.json : specify an output filename, defaults to <CHANNEL>."
+"json\n"
+"                      if exporting a single channel, ccs.json for multiple\n"
+"                      channels, or cc_all.json if no CHANNEL specified\n"
+"                      e.g (export ALL)\n"
+"\n"
+"Note : CHANNEL list is optional, default is to export ALL"
+msgstr ""
+
+#. Get the cc details
+#: ../src/spacecmd/configchannel.py:1070
+#, python-format
+msgid "Getting config channel details for %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1090
+#, python-format
+msgid "Failed to get details for file %s from %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1136
+#, python-format
+msgid "File %s could not be exported "
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1137
+msgid "with this API version(needs base64 encoding)"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1139
+#, python-format
+msgid "File %s could not be exported as"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1140
+msgid " text...getting base64 encoded version"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1163
+#, python-format
+msgid "Passed filename '%s' to do_configchannel_export command."
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1171
+#, python-format
+msgid "Exporting ALL config channels to %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1178
+msgid ""
+"Error, no valid config channel passed, check name is  correct with spacecmd "
+"configchannel_list"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1193
+#, python-format
+msgid "Exporting cc %s to %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1200
+msgid "File '{}' exists, confirm overwrite file? (y/n)"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1203
+#, python-format
+msgid "Error saving exported config channels to file: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1212
+msgid "configchannel_import: import config channel(s) from json file"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1213
+msgid "usage: configchannel_import <JSONFILES...>"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1222 ../src/spacecmd/kickstart.py:2330
+msgid "Error, no filename passed"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1230 ../src/spacecmd/kickstart.py:2338
+#, python-format
+msgid "Error, could not read json data from %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1234
+#, python-format
+msgid "Error importing configchannel %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1246
+#, python-format
+msgid "Config channel %s already exists! Skipping!"
+msgstr ""
+
+#. create the cc, we need to drop the org prefix from the cc name
+#: ../src/spacecmd/configchannel.py:1251
+#, python-format
+msgid "Importing config channel  %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1294
+#, python-format
+msgid "Failed trying to import file %s (empty content)"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1296
+msgid "Older APIs can't export encoded files"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1319
+#, python-format
+msgid "Error adding file %s to %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1329
+msgid "configchannel_clone: Clone config channel(s)"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1330
+msgid ""
+"usage examples:\n"
+"                 configchannel_clone foo_label -c bar_label\n"
+"                 configchannel_clone foo_label1 foo_label2 -c prefix\n"
+"                 configchannel_clone foo_label -x \"s/foo/bar\"\n"
+"                 configchannel_clone foo_label1 foo_label2 -x \"s/foo/bar\"\n"
+"\n"
+"options:\n"
+"  -c CLONE_LABEL : name/label of the resulting cc (note does not update\n"
+"                   description, see -x option), treated as a prefix if\n"
+"                   multiple keys are passed\n"
+"  -x \"s/foo/bar\" : Optional regex replacement, replaces foo with bar in "
+"the\n"
+"                   clone name, label and description\n"
+"  Note : If no -c or -x option is specified, interactive is assumed"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1359
+msgid "No config channels found"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1362
+msgid "Config Channels"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1368
+#, python-format
+msgid "Channel to clone: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1372
+msgid "Channel to clone:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1373
+msgid "Clone label:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1382
+msgid "Error no channel label passed!"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1391
+msgid "No suitable channels to clone has been found."
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1444
+msgid "no configchannel given"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1447
+msgid "invalid configchannel label "
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1473
+msgid "configchannel_diff: diff between config channels"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1475
+msgid "usage: configchannel_diff SOURCE_CHANNEL TARGET_CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1524
+msgid "configchannel_sync:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1525
+msgid "sync config files between two config channels"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1527
+msgid "usage: configchannel_sync SOURCE_CHANNEL TARGET_CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1565
+msgid "syncing files from configchannel "
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1572
+msgid "files common in both channels:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1578
+msgid "files only in source "
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1584
+msgid "files only in target "
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1589
+msgid ""
+"files that are in both channels will be overwritten in the target channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1591
+msgid "files only in the source channel will be added to the target channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1593
+msgid "files only in the target channel will be deleted"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1596
+msgid "nothing to do"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1600
+msgid "perform synchronisation [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1652
+msgid "unknown file type "
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:43
+msgid "cryptokey_create: Create a cryptographic key"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:44
+msgid ""
+"usage: cryptokey_create [options])\n"
+"\n"
+"options:\n"
+"  -t GPG or SSL\n"
+"  -d DESCRIPTION\n"
+"  -f KEY_FILE"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:62
+msgid "GPG or SSL [G/S]:"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:75
+msgid "The key type is required"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:79
+msgid "A description is required"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:83
+msgid "A file containing the key is required"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:91
+msgid "No contents of the file"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:100
+msgid "Invalid key type"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:114
+msgid "cryptokey_delete: Delete a cryptographic key"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:115
+msgid "usage: cryptokey_delete NAME"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:145
+msgid "Delete key(s) [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:156
+msgid "cryptokey_list: List all cryptographic keys (SSL, GPG)"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:157
+msgid "usage: cryptokey_list"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:174
+msgid "cryptokey_details: Show the contents of a cryptographic key"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:175
+msgid "usage: cryptokey_details KEY ..."
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:207
+#, python-format
+msgid "%s is not a valid crypto key"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:39
+msgid "custominfo_createkey: Create a custom key"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:40
+msgid "usage: custominfo_createkey [NAME] [DESCRIPTION]"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:73
+msgid "custominfo_deletekey: Delete a custom key"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:74
+msgid "usage: custominfo_deletekey KEY ..."
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:114
+msgid "custominfo_listkeys: List all custom keys"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:115
+msgid "usage: custominfo_listkeys"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:132
+msgid "custominfo_details: Show the details of a custom key"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:133
+msgid "usage: custominfo_details KEY ..."
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:155
+msgid "No keys matched argument '{}'."
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:172
+#, python-format
+msgid "Label:        %s"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:173
+#, python-format
+msgid "Description:  %s"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:174
+#, python-format
+msgid "Modified:     %s"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:175
+#, python-format
+msgid "System Count: %i"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:183
+msgid "custominfo_updatekey: Update a custom key"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:184
+msgid "usage: custominfo_updatekey [NAME] [DESCRIPTION]"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:42
+msgid "distribution_create: Create a Kickstart tree"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:43
+msgid ""
+"usage: distribution_create [options]\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -p path to tree\n"
+"  -b base channel to associate with\n"
+"  -t install type [fedora|rhel_4/5/6|generic_rpm]"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:66
+msgid "The name of the distribution is required"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:73
+msgid "Path to Kickstart Tree:"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:83
+msgid "Base Channel:"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:86
+msgid "Invalid channel label"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:97
+msgid "Install Types"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:102
+msgid "Install Type:"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:105
+msgid "Invalid install type"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:113
+msgid "A path is required"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:117 ../src/spacecmd/system.py:2556
+msgid "A base channel is required"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:121
+msgid "An install type is required"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:143
+msgid "distribution_list: List the available autoinstall trees"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:144
+msgid "usage: distribution_list"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:168
+msgid "distribution_delete: Delete a Kickstart tree"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:169
+msgid "usage: distribution_delete LABEL"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:193 ../src/spacecmd/distribution.py:232
+#, python-format
+msgid "No distributions matched argument %s"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:199
+msgid "Delete distribution tree(s) [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:209
+msgid "distribution_details: Show the details of a Kickstart tree"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:210
+msgid "usage: distribution_details LABEL"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:248 ../src/spacecmd/package.py:93
+#, python-format
+msgid "Name:    %s"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:249 ../src/spacecmd/package.py:100
+#, python-format
+msgid "Path:    %s"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:250
+#, python-format
+msgid "Channel: %s"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:258
+msgid "distribution_rename: Rename a Kickstart tree"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:259
+msgid "usage: distribution_rename OLDNAME NEWNAME"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:288
+msgid "distribution_update: Update the path of a Kickstart tree"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:289
+msgid ""
+"usage: distribution_update NAME [options]\n"
+"\n"
+"options:\n"
+"  -p path to tree\n"
+"  -b base channel to associate with\n"
+"  -t install type [fedora|rhel_4/5/6|generic_rpm]"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:49
+msgid "errata_list: List all patches"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:50
+msgid "usage: errata_list"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:66
+msgid "errata_summary: Print a summary of all errata"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:67
+msgid "usage: errata_summary"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:82
+msgid "errata_apply: Apply an erratum to all affected systems"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:83
+msgid ""
+"usage: errata_apply [options] ERRATA|search:XXX ...)\n"
+"\n"
+"options:\n"
+"  -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:110 ../src/spacecmd/system.py:417
+#: ../src/spacecmd/system.py:725 ../src/spacecmd/system.py:880
+#: ../src/spacecmd/system.py:1015 ../src/spacecmd/system.py:1762
+#: ../src/spacecmd/system.py:3673 ../src/spacecmd/system.py:3983
+#: ../src/spacecmd/system.py:4045 ../src/spacecmd/system.py:4209
+msgid "Start Time [now]:"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:158
+msgid "No patches to apply"
+msgstr ""
+
+#. a summary of which errata we're going to apply
+#: ../src/spacecmd/errata.py:162
+msgid "Errata             Systems"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:166 ../src/spacecmd/system.py:230
+#: ../src/spacecmd/system.py:467 ../src/spacecmd/system.py:820
+#: ../src/spacecmd/system.py:942 ../src/spacecmd/system.py:1079
+#: ../src/spacecmd/system.py:1781 ../src/spacecmd/system.py:3685
+#: ../src/spacecmd/system.py:4228
+#, python-format
+msgid "Start Time: %s"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:168
+msgid "Apply these patches [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:218
+#, python-format
+msgid "No patches to schedule for %s"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:227
+#, python-format
+msgid "Scheduled %i patches for %s"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:236
+msgid "errata_listaffectedsystems: List of systems affected by an patch"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:237
+msgid "usage: errata_listaffectedsystems ERRATA|search:XXX ..."
+msgstr ""
+
+#: ../src/spacecmd/errata.py:275
+msgid "errata_listcves: List of CVEs addressed by an patch"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:276
+msgid "usage: errata_listcves ERRATA|search:XXX ..."
+msgstr ""
+
+#: ../src/spacecmd/errata.py:312
+msgid "No errata has been found"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:319
+msgid "errata_findbycve: List errata addressing a CVE"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:320
+msgid "usage: errata_findbycve CVE-YYYY-NNNN ..."
+msgstr ""
+
+#: ../src/spacecmd/errata.py:354
+msgid "errata_details: Show the details of an patch"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:355
+msgid "usage: errata_details ERRATA|search:XXX ..."
+msgstr ""
+
+#: ../src/spacecmd/errata.py:390
+#, python-format
+msgid "%s is not a valid erratum"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:397
+#, python-format
+msgid "Name:       %s"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:398
+msgid "Product:   s"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:399
+msgid "Type:      s"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:400
+msgid "Issue Date:s"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:402
+msgid "Topic"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:406 ../src/spacecmd/package.py:107
+#: ../src/spacecmd/softwarechannel.py:591
+msgid "Description"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:412
+msgid "Notes"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:417
+msgid "CVEs"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:421
+msgid "Solution"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:425
+msgid "References"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:429
+msgid "Affected Channels"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:433 ../src/spacecmd/org.py:278
+msgid "Affected Systems"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:437
+msgid "Affected Packages"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:447
+msgid "errata_delete: Delete an patch"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:448
+msgid "usage: errata_delete ERRATA|search:XXX ..."
+msgstr ""
+
+#: ../src/spacecmd/errata.py:468
+msgid "No patches to delete"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:471
+msgid "Erratum            Channels"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:479
+msgid "Delete these patches [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:485
+#, python-format
+msgid "Deleted %i patches"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:495
+msgid "errata_publish: Publish an patch to a channel"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:496
+msgid "usage: errata_publish ERRATA|search:XXX <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:523
+msgid "No patches to publish"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:528
+msgid "Publish these patches [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:540
+msgid "errata_search: List patches that meet the given criteria"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:541
+msgid "usage: errata_search CVE|RHSA|RHBA|RHEA|CLA ..."
+msgstr ""
+
+#: ../src/spacecmd/errata.py:543 ../src/spacecmd/scap.py:179
+msgid "Example:"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:42
+msgid "filepreservation_list: List all file preservations"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:43
+msgid "usage: filepreservation_list"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:58
+msgid "filepreservation_create: Create a file preservation list"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:59
+msgid "usage: filepreservation_create [NAME] [FILE ...]"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:78
+#: ../src/spacecmd/filepreservation.py:92
+msgid "File List"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:83
+msgid "File [blank to finish]:"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:109
+msgid "filepreservation_delete: Delete a file preservation list"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:110
+msgid "usage: filepreservation_delete NAME"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:128
+msgid "Delete this list [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:139
+msgid ""
+"filepreservation_details: Show the details of a file\n"
+"'preservation list"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:141
+msgid "usage: filepreservation_details NAME"
+msgstr ""
+
+#: ../src/spacecmd/group.py:50
+msgid "group_addsystems: Add systems to a group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:51
+msgid "usage: group_addsystems GROUP <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/group.py:52
+msgid "       group_addsystems GROUP <ssm>"
+msgstr ""
+
+#: ../src/spacecmd/group.py:103
+msgid "group_removesystems: Remove systems from a group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:104
+msgid "usage: group_removesystems GROUP <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/group.py:145 ../src/spacecmd/system.py:118
+#: ../src/spacecmd/system.py:232 ../src/spacecmd/system.py:475
+#: ../src/spacecmd/system.py:1475 ../src/spacecmd/system.py:1783
+#: ../src/spacecmd/system.py:4230
+msgid "Systems"
+msgstr ""
+
+#: ../src/spacecmd/group.py:149
+msgid "Remove these systems [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/group.py:158 ../src/spacecmd/schedule.py:385
+#: ../src/spacecmd/ssm.py:87 ../src/spacecmd/ssm.py:136
+#: ../src/spacecmd/ssm.py:186 ../src/spacecmd/system.py:4273
+#: ../src/spacecmd/system.py:4329
+msgid "No systems found"
+msgstr ""
+
+#: ../src/spacecmd/group.py:165
+msgid "group_create: Create a system group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:166
+msgid "usage: group_create [NAME] [DESCRIPTION]"
+msgstr ""
+
+#: ../src/spacecmd/group.py:192
+msgid "group_delete: Delete a system group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:193
+msgid "usage: group_delete NAME ..."
+msgstr ""
+
+#: ../src/spacecmd/group.py:212
+msgid "Delete these groups [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/group.py:224
+msgid "group_backup: backup a system group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:225
+msgid ""
+"usage: group_backup <NAME> [OUTDIR])\n"
+"                    group_backup ALL\n"
+"\n"
+"\"OUTDIR\" defaults to $HOME/spacecmd-backup/group/YYYY-MM-DD/NAME\n"
+"\"ALL\" is a keyword and collects all groups\n"
+msgstr ""
+
+#: ../src/spacecmd/group.py:270
+#, python-format
+msgid "Backup Group: %s"
+msgstr ""
+
+#: ../src/spacecmd/group.py:273
+#, python-format
+msgid "Output File: %s"
+msgstr ""
+
+#: ../src/spacecmd/group.py:284
+msgid "group_restore: restore a system group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:285
+msgid ""
+"\n"
+"usage: group_restore INPUTDIR [NAME] ...\n"
+"       group_restore INPUTDIR ALL\n"
+"       group_restore INPUTDIR\n"
+"       group_restore .\n"
+"\n"
+"Specifying only INPUTDIR will default to ALL groups.\n"
+"Setting dot (.) instead of full INPUTDIR will imply current directory.\n"
+"    "
+msgstr ""
+
+#: ../src/spacecmd/group.py:329
+#, python-format
+msgid "Restore dir %s does not exits or is not a directory"
+msgstr ""
+
+#: ../src/spacecmd/group.py:333
+#, python-format
+msgid "Restore dir %s has no restore items"
+msgstr ""
+
+#: ../src/spacecmd/group.py:340
+#, python-format
+msgid "Group %s was not found in backup"
+msgstr ""
+
+#: ../src/spacecmd/group.py:343
+#, python-format
+msgid "Found %s missing groups, terminating"
+msgstr ""
+
+#: ../src/spacecmd/group.py:358
+#, python-format
+msgid "Group %s already restored"
+msgstr ""
+
+#: ../src/spacecmd/group.py:365
+msgid "Changing description from:"
+msgstr ""
+
+#: ../src/spacecmd/group.py:367
+msgid "Continue [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/group.py:370 ../src/spacecmd/group.py:373
+#, python-format
+msgid "Updating description for group: %s"
+msgstr ""
+
+#: ../src/spacecmd/group.py:376
+#, python-format
+msgid "Creating new group %s"
+msgstr ""
+
+#: ../src/spacecmd/group.py:385
+msgid "group_list: List available system groups"
+msgstr ""
+
+#: ../src/spacecmd/group.py:386
+msgid "usage: group_list"
+msgstr ""
+
+#: ../src/spacecmd/group.py:403
+msgid "group_listsystems: List the members of a group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:404
+msgid "usage: group_listsystems GROUP"
+msgstr ""
+
+#: ../src/spacecmd/group.py:426
+#, python-format
+msgid "%s is not a valid group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:439
+msgid "group_details: Show the details of a system group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:440
+msgid "usage: group_details GROUP ..."
+msgstr ""
+
+#: ../src/spacecmd/group.py:463
+#, python-format
+msgid "The group \"%s\" is invalid"
+msgstr ""
+
+#: ../src/spacecmd/group.py:470
+#, python-format
+msgid "ID:                %i"
+msgstr ""
+
+#: ../src/spacecmd/group.py:471
+#, python-format
+msgid "Name:              %s"
+msgstr ""
+
+#: ../src/spacecmd/group.py:472
+#, python-format
+msgid "Description:       %s"
+msgstr ""
+
+#: ../src/spacecmd/group.py:473
+#, python-format
+msgid "Number of Systems: %i"
+msgstr ""
+
+#: ../src/spacecmd/group.py:477
+msgid "Members"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:72
+msgid "kickstart_list: List the available Kickstart profiles"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:73
+msgid "usage: kickstart_list"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:85 ../src/spacecmd/kickstart.py:2108
+msgid "No kickstart profiles available"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:91
+msgid "kickstart_create: Create a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:92
+msgid ""
+"usage: kickstart_create [options])\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -d DISTRIBUTION\n"
+"  -p ROOT_PASSWORD\n"
+"  -v VIRT_TYPE ['none', 'para_host', 'qemu', 'xenfv', 'xenpv']"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:113 ../src/spacecmd/kickstart.py:249
+msgid "Virtualization Types"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:118 ../src/spacecmd/kickstart.py:254
+msgid "Virtualization Type [none]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:126 ../src/spacecmd/kickstart.py:262
+msgid "Distributions"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:136
+msgid "Root Password: "
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:137 ../src/spacecmd/org.py:90
+#: ../src/spacecmd/user.py:85
+msgid "Repeat Password: "
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:142 ../src/spacecmd/org.py:95
+#: ../src/spacecmd/user.py:90
+msgid "Password must be at least 5 characters"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:144 ../src/spacecmd/org.py:97
+#: ../src/spacecmd/user.py:92
+msgid "Passwords don't match"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:147 ../src/spacecmd/kickstart.py:270
+#: ../src/spacecmd/kickstart.py:1980 ../src/spacecmd/kickstart.py:2122
+msgid "The Kickstart name is required"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:151 ../src/spacecmd/kickstart.py:274
+msgid "The distribution is required"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:158
+msgid "A root password is required"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:177
+msgid "kickstart_delete: Delete kickstart profile(s)"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:178
+msgid "usage: kickstart_delete PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:179
+msgid "usage: kickstart_delete PROFILE1 PROFILE2"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:180
+msgid "usage: kickstart_delete \"PROF*\""
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:203 ../src/spacecmd/kickstart.py:2597
+#: ../src/spacecmd/kickstart.py:2653 ../src/spacecmd/kickstart.py:2695
+msgid "No valid kickstart labels passed as arguments!"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:209
+msgid "The following kickstart labels are invalid:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:214
+#, python-format
+msgid "Delete profile %s [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:222
+msgid "kickstart_import: Import a Kickstart profile from a file"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:223
+msgid ""
+"usage: kickstart_import [options])\n"
+"\n"
+"options:\n"
+"  -f FILE\n"
+"  -n NAME\n"
+"  -d DISTRIBUTION\n"
+"  -v VIRT_TYPE ['none', 'para_host', 'qemu', 'xenfv', 'xenpv']"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:278 ../src/spacecmd/kickstart.py:1984
+msgid "A filename is required"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:308
+msgid ""
+"kickstart_import_raw: Import a raw Kickstart or autoyast profile from a file"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:309
+msgid ""
+"usage: kickstart_import_raw [options])\n"
+"\n"
+"options:\n"
+"  -f FILE\n"
+"  -n NAME\n"
+"  -d DISTRIBUTION\n"
+"  -v VIRT_TYPE ['none', 'para_host', 'qemu', 'xenfv', 'xenpv']"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:325
+msgid "kickstart_details: Show the details of a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:326
+msgid "usage: kickstart_details PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:353
+msgid "Invalid Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:415
+#, python-format
+msgid "Tree:        %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:416
+#, python-format
+msgid "Active:      %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:417
+#, python-format
+msgid "Advanced:    %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:418
+#, python-format
+msgid "Org Default: %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:421
+#, python-format
+msgid "Configuration Management: %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:422
+#, python-format
+msgid "Remote Commands:          %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:434
+msgid "Advanced Options"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:442
+msgid "Custom Options"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:449
+msgid "Partitioning"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:454
+msgid "Software"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:467
+msgid "Crypto Keys"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:474
+msgid "File Preservations"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:483
+msgid "Variables"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:490
+msgid "Scripts"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:501 ../src/spacecmd/kickstart.py:1900
+#, python-format
+msgid "Chroot:      %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:504 ../src/spacecmd/kickstart.py:1901
+#, python-format
+msgid "Interpreter: %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:530
+msgid "Could not retrieve the Kickstart file"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:536
+msgid "kickstart_getcontents: Show the contents of a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:537
+msgid "                   as they would be presented to a client"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:538
+msgid "usage: kickstart_getcontents LABEL"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:572
+msgid "kickstart_rename: Rename a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:573
+msgid "usage: kickstart_rename OLDNAME NEWNAME"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:601
+msgid ""
+"kickstart_listcryptokeys: List the crypto keys associated with a Kickstart "
+"profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:603
+msgid "usage: kickstart_listcryptokeys PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:632
+msgid "No crypto keys has been found"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:638
+msgid "kickstart_addcryptokeys: Add crypto keys to a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:639
+msgid "usage: kickstart_addcryptokeys PROFILE <KEY ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:665
+msgid "kickstart_removecryptokeys: Remove crypto keys from a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:667
+msgid "usage: kickstart_removecryptokeys PROFILE <KEY ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:707
+msgid ""
+"kickstart_listactivationkeys: List the activation keys associated with a "
+"Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:709
+msgid "usage: kickstart_listactivationkeys PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:739
+msgid "kickstart_addactivationkeys: Add activation keys to a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:741
+msgid "usage: kickstart_addactivationkeys PROFILE <KEY ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:770
+msgid ""
+"kickstart_removeactivationkeys: Remove activation keys from a Kickstart "
+"profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:772
+msgid "usage: kickstart_removeactivationkeys PROFILE <KEY ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:796
+msgid "Remove these keys [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:811
+msgid ""
+"kickstart_enableconfigmanagement: Enable configuration management on a "
+"Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:813
+msgid "usage: kickstart_enableconfigmanagement PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:844
+msgid ""
+"kickstart_disableconfigmanagement: Disable configuration management on a "
+"Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:846
+msgid "usage: kickstart_disableconfigmanagement PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:877
+msgid ""
+"kickstart_enableremotecommands: Enable remote commands on a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:879
+msgid "usage: kickstart_enableremotecommands PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:910
+msgid ""
+"kickstart_disableremotecommands: Disable remote commands on a Kickstart "
+"profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:912
+msgid "usage: kickstart_disableremotecommands PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:942
+msgid "kickstart_setlocale: Set the locale for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:943
+msgid "usage: kickstart_setlocale PROFILE LOCALE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:981
+msgid "kickstart_setselinux: Set the SELinux mode for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:983
+msgid "usage: kickstart_setselinux PROFILE MODE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1018
+msgid ""
+"kickstart_setpartitions: Set the partitioning scheme for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1020
+msgid "usage: kickstart_setpartitions PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1069
+msgid "kickstart_setdistribution: Set the distribution for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1071
+msgid "usage: kickstart_setdistribution PROFILE DISTRIBUTION"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1105
+msgid "kickstart_enablelogging: Enable logging for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1106
+msgid "usage: kickstart_enablelogging PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1138
+msgid "kickstart_addvariable: Add a variable to a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1139
+msgid "usage: kickstart_addvariable PROFILE KEY VALUE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1177
+msgid "kickstart_updatevariable: Update a variable in a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1179
+msgid "usage: kickstart_updatevariable PROFILE KEY VALUE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1214
+msgid "kickstart_removevariables: Remove variables from a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1216
+msgid "usage: kickstart_removevariables PROFILE <KEY ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1265
+msgid "kickstart_listvariables: List the variables of a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1267
+msgid "usage: kickstart_listvariables PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1300
+msgid "kickstart_addoption: Set an option for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1301
+msgid "usage: kickstart_addoption PROFILE KEY [VALUE]"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1348
+#, python-format
+msgid "%s needs to be set as a custom option"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1356
+msgid "kickstart_removeoptions: Remove options from a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1357
+msgid "usage: kickstart_removeoptions PROFILE <OPTION ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1409
+msgid "kickstart_listoptions: List the options of a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1411
+msgid "usage: kickstart_listoptions PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1445
+msgid ""
+"kickstart_listcustomoptions: List the custom options of a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1447
+msgid "usage: kickstart_listcustomoptions PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1481
+msgid "kickstart_setcustomoptions: Set custom options for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1483
+msgid "usage: kickstart_setcustomoptions PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1531
+msgid "kickstart_addchildchannels: Add a child channels to a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1533
+msgid "usage: kickstart_addchildchannels PROFILE <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1591
+msgid ""
+"kickstart_removechildchannels: Remove child channels from a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1593
+msgid "usage: kickstart_removechildchannels PROFILE <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1636
+msgid ""
+"kickstart_listchildchannels: List the child channels of a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1638
+msgid "usage: kickstart_listchildchannels PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1672
+msgid ""
+"kickstart_addfilepreservations: Add file preservations to a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1674
+msgid "usage: kickstart_addfilepreservations PROFILE <FILELIST ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1709
+msgid ""
+"kickstart_removefilepreservations: Remove file preservations from a "
+"Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1711
+msgid "usage: kickstart_removefilepreservations PROFILE <FILE ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1756
+msgid "kickstart_listpackages: List the packages for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1758
+msgid "usage: kickstart_listpackages PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1790
+msgid "kickstart_addpackages: Add packages to a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1791
+msgid "usage: kickstart_addpackages PROFILE <PACKAGE ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1824
+msgid "kickstart_removepackages: Remove packages from a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1826
+msgid "usage: kickstart_removepackages PROFILE <PACKAGE ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1869
+msgid "kickstart_listscripts: List the scripts for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1871
+msgid "usage: kickstart_listscripts PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1890
+#, python-format
+msgid "No scripts has been found for profile '%s'"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1898
+#, python-format
+msgid "ID:          %i"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1913
+msgid "kickstart_addscript: Add a script to a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1914
+msgid ""
+"usage: kickstart_addscript PROFILE [options])\n"
+"\n"
+"options:\n"
+"  -p PROFILE\n"
+"  -e EXECUTION_TIME ['pre', 'post']\n"
+"  -i INTERPRETER\n"
+"  -f FILE\n"
+"  -c execute in a chroot environment\n"
+"  -t ENABLING_TEMPLATING"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1947
+msgid "Profile Name:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1949
+msgid "Pre/Post Script [post]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1950
+msgid "Chrooted [Y/n]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1951
+msgid "Interpreter [/bin/bash]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1988
+msgid "The execution time is required"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2004
+#, python-format
+msgid "Profile Name:   %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2005
+#, python-format
+msgid "Execution Time: %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2006
+#, python-format
+msgid "Chroot:         %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2007
+#, python-format
+msgid "Template:       %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2008
+#, python-format
+msgid "Interpreter:    %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2009
+msgid "Contents:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2029
+msgid "kickstart_removescript: Remove a script from a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2030
+msgid "usage: kickstart_removescript PROFILE [ID]"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2058 ../src/spacecmd/kickstart.py:2071
+msgid "Invalid script ID"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2066
+msgid "Script ID:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2073
+msgid "Remove this script [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2086
+msgid "kickstart_clone: Clone a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2087
+msgid ""
+"usage: kickstart_clone [options])\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -c CLONE_NAME"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2112
+msgid "Kickstart Profiles"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2117
+msgid "Original Profile:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2118
+msgid "Cloned Profile:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2126
+msgid "The Kickstart clone name is required"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2131
+msgid "Kickstart profile you've entered was not found"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2144
+msgid "kickstart_export: export kickstart profile(s) to json format file"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2145
+msgid ""
+"usage: kickstart_export <KSPROFILE>... [options])\n"
+"options:\n"
+"    -f outfile.json : specify an output filename, defaults to <KSPROFILE>."
+"json\n"
+"                      if exporting a single kickstart, profiles.json for "
+"multiple\n"
+"                      kickstarts, or ks_all.json if no KSPROFILE specified\n"
+"                      e.g (export ALL)\n"
+"\n"
+"Note : KSPROFILE list is optional, default is to export ALL"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2271
+#, python-format
+msgid "Exporting ALL kickstart profiles to %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2279
+msgid ""
+"Error, no valid kickstart profile passed, check name is  correct with "
+"spacecmd kickstart_list"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2299
+#, python-format
+msgid "Exporting ks %s to %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2306
+#, python-format
+msgid "File %s exists, "
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2307
+msgid "confirm overwrite file? (y/n)"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2310
+msgid "Error saving exported kickstart profiles to file"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2320
+msgid "kickstart_import: import kickstart profile(s) from json file"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2321
+msgid "usage: kickstart_import <JSONFILES...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2342
+#, python-format
+msgid "Error importing kickstart %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2355
+#, python-format
+msgid "ERROR : kickstart profile %s already exists! Skipping!"
+msgstr ""
+
+#. create the ks, we need to drop the org prefix from the ks name
+#: ../src/spacecmd/kickstart.py:2359
+#, python-format
+msgid "Found ks %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2415
+#, python-format
+msgid "Error adding %s script"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2423
+#, python-format
+msgid "failed to add ip range %s-%s, continuing"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2437
+#, python-format
+msgid "failed to add file preservation %s, skipping"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2439
+#, python-format
+msgid "file preservation list %s doesn't exist, skipping"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2450
+#, python-format
+msgid "Actvationkey %s does not exist on the "
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2461
+#, python-format
+msgid "GPG/SSL key %s does not exist on the "
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2462
+msgid "satellite, skipping"
+msgstr ""
+
+#. There are some frustrating ommisions from the API which means we can't
+#. export/import some settings, so we post a warning that some manual
+#. fixup may be required
+#: ../src/spacecmd/kickstart.py:2471
+msgid ""
+"Due to API ommissions, there are some settings which cannot be imported, "
+"please check and fixup manually if necessary"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2473
+msgid " * Details->Preserve ks.cfg"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2474
+msgid " * Details->Comment"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2478
+msgid " * Details->Organization Default Profile"
+msgstr ""
+
+#. No way to set the kernel options
+#: ../src/spacecmd/kickstart.py:2480
+msgid " * Details->Kernel Options"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2484
+#, python-format
+msgid " * Details->Post Kernel Options : %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2500
+msgid "no kickstart label given"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2503
+msgid "invalid kickstart label "
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2520
+msgid "kickstart_diff: diff kickstart files"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2522
+msgid "usage: kickstart_diff SOURCE_CHANNEL TARGET_CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2571
+msgid "kickstart_getupdatetype: Get the update type for a kickstart profile(s)"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2572
+msgid "usage: kickstart_getupdatetype PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2573
+msgid "usage: kickstart_getupdatetype PROFILE1 PROFILE2"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2574
+msgid "usage: kickstart_getupdatetype \"PROF*\""
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2603 ../src/spacecmd/kickstart.py:2659
+#: ../src/spacecmd/kickstart.py:2701
+#, python-format
+msgid "kickstart label %s doesn't exist!"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2619
+msgid "kickstart_setupdatetype: Set the update type for a kickstart profile(s)"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2620
+msgid ""
+"usage: kickstart_setupdatetype [options] KS_LABEL)\n"
+"\n"
+"options:\n"
+"    -u UPDATE_TYPE ['red_hat', 'all', 'none']"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2634
+msgid "Update Types"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2639
+msgid "Update Type [none]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2670
+msgid "kickstart_getsoftwaredetails: Gets kickstart profile software details"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2671
+msgid "usage: kickstart_getsoftwaredetails KS_LABEL"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2672
+msgid "usage: kickstart_getsoftwaredetails KS_LABEL KS_LABEL2 ..."
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2707
+#, python-format
+msgid "noBase:        %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2708
+#, python-format
+msgid "ignoreMissing: %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2710
+#, python-format
+msgid "Kickstart Label: %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2711
+#, python-format
+msgid "noBase:          %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2712
+#, python-format
+msgid "ignoreMissing:   %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2721
+msgid "kickstart_setsoftwaredetails: Sets kickstart profile software details."
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2722
+msgid ""
+"usage: kickstart_setsoftwaredetails PROFILE KICKSTART_PACKAGES_INFO VALUE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2723
+msgid ""
+"usage: kickstart_setsoftwaredetails PROFILE KICKSTART_PACKAGES_INFO VALUE "
+"KICKSTART_PACKAGES_INFO VALUE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2757
+msgid "Selected profile does not exist"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2760 ../src/spacecmd/kickstart.py:2765
+msgid "Enter valid input"
+msgstr ""
+
+#. list of system selection options for the help output
+#: ../src/spacecmd/misc.py:57
+msgid ""
+"<SYSTEMS> can be any of the following:\n"
+"name\n"
+"ssm (see 'help ssm')\n"
+"search:QUERY (see 'help system_search')\n"
+"group:GROUP\n"
+"channel:CHANNEL\n"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:65
+msgid ""
+"Dates can be any of the following:\n"
+"Explicit Dates:\n"
+"Dates can be expressed as explicit date strings in the YYYYMMDD[HHMMSS]\n"
+"format.  The year, month and day are required, while the hours and\n"
+"minutes are not; the hours and minutes will default to 0000 if no\n"
+"values are provided.\n"
+"\n"
+"Deltas:\n"
+"Dates can be expressed as delta values.  For example, '2h' would\n"
+"mean 2 hours in the future.  You can also use negative values to\n"
+"express times in the past (e.g., -7d would be one week ago).\n"
+"\n"
+"Units:\n"
+"s -> seconds\n"
+"m -> minutes\n"
+"h -> hours\n"
+"d -> days\n"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:120
+msgid "clear: clear the screen"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:121
+msgid "usage: clear"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:132
+msgid "clear_caches: Clear the internal caches kept for systems and packages"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:133
+msgid "usage: clear_caches"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:146
+msgid "get_apiversion: Display the API version of the server"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:147
+msgid "usage: get_apiversion"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:158
+msgid "get_serverversion: Display the version of the server"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:159
+msgid "usage: get_serverversion"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:171
+msgid "list_proxies: List the proxies within the user's organization "
+msgstr ""
+
+#: ../src/spacecmd/misc.py:172
+msgid "usage: list_proxies"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:184
+msgid "get_session: Show the current session string"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:185
+msgid "usage: get_session"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:193
+msgid "No session found"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:200
+msgid "help: Show help for the given command"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:201
+msgid "usage: help COMMAND"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:207
+msgid "history: List your command history"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:208
+msgid "usage: history"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:220
+msgid "toggle_confirmations: Toggle confirmation messages on/off"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:221
+msgid "usage: toggle_confirmations"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:226
+msgid "Confirmation messages are"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:226
+msgid "enabled"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:233
+msgid "login: Connect to a Spacewalk server"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:234
+msgid "usage: login [USERNAME] [SERVER]"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:244
+msgid "You are already logged in"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:256
+msgid "No server specified"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:301
+#, python-format
+msgid "Failed to connect to %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:309
+#, python-format
+msgid "API (%s) is too old (>= %s required)"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:339 ../src/spacecmd/utils.py:249
+#: ../src/spacecmd/utils.py:560
+#, python-format
+msgid "Could not read %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:348
+msgid "Cached credentials are invalid"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:355
+#, python-format
+msgid "Spacewalk Username: %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:357
+msgid "Spacewalk Username:"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:368
+msgid "Spacewalk Password: "
+msgstr ""
+
+#: ../src/spacecmd/misc.py:374
+msgid "Invalid credentials"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:392
+#, python-format
+msgid "Could not write session file: %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:401
+#, python-format
+msgid "Connected to %s as %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:409
+msgid "logout: Disconnect from the server"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:410
+msgid "usage: logout"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:427
+msgid "whoami: Print the name of the currently logged in user"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:428
+msgid "usage: whoami"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:436
+msgid "You are not logged in"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:443
+msgid "whoamitalkingto: Print the name of the server"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:444
+msgid "usage: whoamitalkingto"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:452
+msgid "Yourself"
+msgstr ""
+
+#. tell the user what's going on
+#: ../src/spacecmd/misc.py:524
+msgid "** Generating errata cache **"
+msgstr ""
+
+#. tell the user what's going on
+#: ../src/spacecmd/misc.py:573
+msgid "** Generating package cache **"
+msgstr ""
+
+#. tell the user what's going on
+#: ../src/spacecmd/misc.py:680
+msgid "** Generating system cache **"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:715
+#, python-format
+msgid "Could not create directory %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:787
+#, python-format
+msgid "Can't find system ID for %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:792
+msgid "Duplicate system profile names found!"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:793
+msgid "Please reference systems by ID or resolve the"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:794
+msgid "underlying issue with 'system_delete' or 'system_rename'"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:860
+#, python-format
+msgid "No systems in group %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:874
+#, python-format
+msgid "No systems subscribed to %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:934
+msgid "Is this ok [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:47
+msgid "org_create: Create an organization"
+msgstr ""
+
+#: ../src/spacecmd/org.py:48
+#, python-format
+msgid ""
+"usage: org_create [options])\n"
+"\n"
+"options:\n"
+"  -n ORG_NAME\n"
+"  -u USERNAME\n"
+"  -P PREFIX (%s)\n"
+"  -f FIRST_NAME\n"
+"  -l LAST_NAME\n"
+"  -e EMAIL\n"
+"  -p PASSWORD\n"
+"  --pam enable PAM authentication"
+msgstr ""
+
+#: ../src/spacecmd/org.py:75
+msgid "Organization Name:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:76 ../src/spacecmd/user.py:73
+msgid "Username:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:77
+#, python-format
+msgid "Prefix (%s):"
+msgstr ""
+
+#: ../src/spacecmd/org.py:79 ../src/spacecmd/user.py:74
+msgid "First Name:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:80 ../src/spacecmd/user.py:75
+msgid "Last Name:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:81 ../src/spacecmd/user.py:76
+msgid "Email:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:82 ../src/spacecmd/user.py:77
+msgid "PAM Authentication [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:89 ../src/spacecmd/user.py:84
+msgid "Password: "
+msgstr ""
+
+#: ../src/spacecmd/org.py:100
+msgid "An organization name is required"
+msgstr ""
+
+#: ../src/spacecmd/org.py:104 ../src/spacecmd/user.py:95
+msgid "A username is required"
+msgstr ""
+
+#: ../src/spacecmd/org.py:108 ../src/spacecmd/user.py:99
+msgid "A first name is required"
+msgstr ""
+
+#: ../src/spacecmd/org.py:112 ../src/spacecmd/user.py:103
+msgid "A last name is required"
+msgstr ""
+
+#: ../src/spacecmd/org.py:116 ../src/spacecmd/user.py:107
+msgid "An email address is required"
+msgstr ""
+
+#: ../src/spacecmd/org.py:120 ../src/spacecmd/user.py:111
+msgid "A password is required"
+msgstr ""
+
+#: ../src/spacecmd/org.py:127
+msgid "Dr."
+msgstr ""
+
+#: ../src/spacecmd/org.py:129
+msgid "Miss"
+msgstr ""
+
+#: ../src/spacecmd/org.py:148
+msgid "org_delete: Delete an organization"
+msgstr ""
+
+#: ../src/spacecmd/org.py:149
+msgid "usage: org_delete NAME"
+msgstr ""
+
+#: ../src/spacecmd/org.py:168 ../src/spacecmd/org.py:199
+#: ../src/spacecmd/org.py:233 ../src/spacecmd/org.py:269
+#: ../src/spacecmd/org.py:377 ../src/spacecmd/org.py:413
+#, python-format
+msgid "No organisation found for the name %s"
+msgstr ""
+
+#: ../src/spacecmd/org.py:169 ../src/spacecmd/org.py:200
+#: ../src/spacecmd/org.py:234 ../src/spacecmd/org.py:270
+#: ../src/spacecmd/org.py:378 ../src/spacecmd/org.py:414
+msgid "Organisation '{}' was not found"
+msgstr ""
+
+#: ../src/spacecmd/org.py:171
+msgid "Delete this organization [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:179
+msgid "org_rename: Rename an organization"
+msgstr ""
+
+#: ../src/spacecmd/org.py:180
+msgid "usage: org_rename OLDNAME NEWNAME"
+msgstr ""
+
+#: ../src/spacecmd/org.py:211
+msgid "org_addtrust: Add a trust between two organizations"
+msgstr ""
+
+#: ../src/spacecmd/org.py:212
+msgid "usage: org_addtrust YOUR_ORG ORG_TO_TRUST"
+msgstr ""
+
+#: ../src/spacecmd/org.py:237 ../src/spacecmd/org.py:273
+#, python-format
+msgid "No trust organisation found for the name %s"
+msgstr ""
+
+#: ../src/spacecmd/org.py:238 ../src/spacecmd/org.py:274
+msgid "Organisation '{}' to trust for, was not found"
+msgstr ""
+
+#: ../src/spacecmd/org.py:248
+msgid "org_removetrust: Remove a trust between two organizations"
+msgstr ""
+
+#: ../src/spacecmd/org.py:249
+msgid "usage: org_removetrust YOUR_ORG TRUSTED_ORG"
+msgstr ""
+
+#: ../src/spacecmd/org.py:284
+msgid "None"
+msgstr ""
+
+#: ../src/spacecmd/org.py:286
+msgid "Remove this trust [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:292
+msgid "org_trustdetails: Show the details of an organizational trust"
+msgstr ""
+
+#: ../src/spacecmd/org.py:293
+msgid "usage: org_trustdetails TRUSTED_ORG"
+msgstr ""
+
+#: ../src/spacecmd/org.py:312
+#, python-format
+msgid "No trusted organisation found for the name %s"
+msgstr ""
+
+#: ../src/spacecmd/org.py:313
+msgid "Trusted organisation '{}' was not found"
+msgstr ""
+
+#: ../src/spacecmd/org.py:320
+#, python-format
+msgid "Trusted Organization:   %s"
+msgstr ""
+
+#: ../src/spacecmd/org.py:321
+#, python-format
+msgid "Trusted Since:          %s"
+msgstr ""
+
+#: ../src/spacecmd/org.py:322
+#, python-format
+msgid "Systems Migrated From:  %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:323
+#, python-format
+msgid "Systems Migrated To:    %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:325
+msgid "Channels Consumed"
+msgstr ""
+
+#: ../src/spacecmd/org.py:332
+msgid "Channels Provided"
+msgstr ""
+
+#: ../src/spacecmd/org.py:340
+msgid "org_list: List all organizations"
+msgstr ""
+
+#: ../src/spacecmd/org.py:341
+msgid "usage: org_list"
+msgstr ""
+
+#: ../src/spacecmd/org.py:358
+msgid "org_listtrusts: List an organization's trusts"
+msgstr ""
+
+#: ../src/spacecmd/org.py:359
+msgid "usage: org_listtrusts NAME"
+msgstr ""
+
+#: ../src/spacecmd/org.py:383 ../src/spacecmd/org.py:384
+msgid "No trust organisation has been found"
+msgstr ""
+
+#: ../src/spacecmd/org.py:394
+msgid "org_listusers: List an organization's users"
+msgstr ""
+
+#: ../src/spacecmd/org.py:395
+msgid "usage: org_listusers NAME"
+msgstr ""
+
+#: ../src/spacecmd/org.py:425
+msgid "org_details: Show the details of an organization"
+msgstr ""
+
+#: ../src/spacecmd/org.py:426
+msgid "usage: org_details NAME"
+msgstr ""
+
+#: ../src/spacecmd/org.py:446
+#, python-format
+msgid "Name:                   %s"
+msgstr ""
+
+#: ../src/spacecmd/org.py:447
+#, python-format
+msgid "Active Users:           %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:448
+#, python-format
+msgid "Systems:                %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:452 ../src/spacecmd/org.py:454
+#, python-format
+msgid "Trusts:                 %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:456
+#, python-format
+msgid "System Groups:          %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:457
+#, python-format
+msgid "Activation Keys:        %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:458
+#, python-format
+msgid "Kickstart Profiles:     %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:459
+#, python-format
+msgid "Configuration Channels: %i"
+msgstr ""
+
+#: ../src/spacecmd/package.py:68 ../src/spacecmd/package.py:302
+#: ../src/spacecmd/package.py:351 ../src/spacecmd/package.py:395
+msgid "No packages found"
+msgstr ""
+
+#: ../src/spacecmd/package.py:81 ../src/spacecmd/package.py:406
+#, python-format
+msgid "%s is not a valid package"
+msgstr ""
+
+#: ../src/spacecmd/package.py:94
+#, python-format
+msgid "Version: %s"
+msgstr ""
+
+#: ../src/spacecmd/package.py:95
+#, python-format
+msgid "Release: %s"
+msgstr ""
+
+#: ../src/spacecmd/package.py:96
+#, python-format
+msgid "Epoch:   %s"
+msgstr ""
+
+#: ../src/spacecmd/package.py:97
+#, python-format
+msgid "Arch:    %s"
+msgstr ""
+
+#: ../src/spacecmd/package.py:99
+#, python-format
+msgid "File:    %s"
+msgstr ""
+
+#: ../src/spacecmd/package.py:101
+#, python-format
+msgid "Size:    %s"
+msgstr ""
+
+#: ../src/spacecmd/package.py:105
+#, python-format
+msgid "Installed Systems: %i"
+msgstr ""
+
+#: ../src/spacecmd/package.py:111
+msgid "Available From Channels"
+msgstr ""
+
+#: ../src/spacecmd/package.py:122
+msgid "package_search: Find packages that meet the given criteria"
+msgstr ""
+
+#: ../src/spacecmd/package.py:123
+msgid "usage: package_search NAME|QUERY"
+msgstr ""
+
+#: ../src/spacecmd/package.py:125
+msgid "Example: package_search kernel"
+msgstr ""
+
+#: ../src/spacecmd/package.py:127
+msgid "Advanced Search:"
+msgstr ""
+
+#: ../src/spacecmd/package.py:128
+msgid ""
+"Available Fields: name, epoch, version, release, arch, description, summary"
+msgstr ""
+
+#: ../src/spacecmd/package.py:129
+msgid "Example: name:kernel AND version:2.6.18 AND -description:devel"
+msgstr ""
+
+#: ../src/spacecmd/package.py:178
+msgid "package_remove: Remove a package from Satellite"
+msgstr ""
+
+#: ../src/spacecmd/package.py:179
+msgid "usage: package_remove PACKAGE ..."
+msgstr ""
+
+#: ../src/spacecmd/package.py:199
+msgid "No packages found to remove"
+msgstr ""
+
+#: ../src/spacecmd/package.py:202 ../src/spacecmd/package.py:259
+#: ../src/spacecmd/softwarechannel.py:1580 ../src/spacecmd/system.py:944
+msgid "Remove these packages [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/package.py:203
+msgid "No packages has been removed"
+msgstr ""
+
+#: ../src/spacecmd/package.py:215 ../src/spacecmd/package.py:271
+#, python-format
+msgid "Failed to remove package ID %i"
+msgstr ""
+
+#: ../src/spacecmd/package.py:226
+msgid "package_listorphans: List packages that are not in a channel"
+msgstr ""
+
+#: ../src/spacecmd/package.py:227
+msgid "usage: package_listorphans"
+msgstr ""
+
+#: ../src/spacecmd/package.py:246
+msgid "package_removeorphans: Remove packages that are not in a channel"
+msgstr ""
+
+#: ../src/spacecmd/package.py:247
+msgid "usage: package_removeorphans"
+msgstr ""
+
+#: ../src/spacecmd/package.py:255
+msgid "No orphaned packages has been found"
+msgstr ""
+
+#: ../src/spacecmd/package.py:256
+msgid "No orphaned packages"
+msgstr ""
+
+#: ../src/spacecmd/package.py:260
+msgid "No packages were removed"
+msgstr ""
+
+#: ../src/spacecmd/package.py:280
+msgid "package_listinstalledsystems: List the systems with a package installed"
+msgstr ""
+
+#: ../src/spacecmd/package.py:281
+msgid "usage: package_listinstalledsystems PACKAGE ..."
+msgstr ""
+
+#: ../src/spacecmd/package.py:329
+msgid "package_listerrata: List the errata that provide this package"
+msgstr ""
+
+#: ../src/spacecmd/package.py:330
+msgid "usage: package_listerrata PACKAGE ..."
+msgstr ""
+
+#: ../src/spacecmd/package.py:377
+msgid "package_listdependencies: List the dependencies for a package"
+msgstr ""
+
+#: ../src/spacecmd/package.py:378
+msgid "usage: package_listdependencies PACKAGE"
+msgstr ""
+
+#: ../src/spacecmd/package.py:411
+#, python-format
+msgid "Package Name: %s"
+msgstr ""
+
+#: ../src/spacecmd/package.py:413
+#, python-format
+msgid "Dependency: %s Type: %s Modifier: %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:47
+msgid "repo_list: List all available user repos"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:48
+msgid "usage: repo_list"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:65
+msgid "repo_details: Show the details of a user repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:66
+msgid "usage: repo_details <repo ...>"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:94
+#, python-format
+msgid "Repository Label:                  %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:95
+#, python-format
+msgid "Repository URL:                    %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:96
+#, python-format
+msgid "Repository Type:                   %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:97
+#, python-format
+msgid "Repository SSL Ca Certificate:     %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:98
+#, python-format
+msgid "Repository SSL Client Certificate: %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:99
+#, python-format
+msgid "Repository SSL Client Key:         %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:101
+msgid "No repositories found for '{}' query"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:110
+msgid "repo_listfilters: Show the filters for a user repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:111
+msgid "usage: repo_listfilters repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:132
+msgid "No filters found"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:141
+msgid "repo_addfilters: Add filters for a user repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:142
+msgid "usage: repo_addfilters repo <filter ...>"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:166 ../src/spacecmd/repo.py:203
+#: ../src/spacecmd/repo.py:242
+msgid "Each filter must start with + or -"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:180
+msgid "repo_removefilters: Remove filters from a user repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:181
+msgid "usage: repo_removefilters repo <filter ...>"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:217
+msgid "repo_setfilters: Set the filters for a user repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:218
+msgid "usage: repo_setfilters repo <filter ...>"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:255
+msgid "repo_clearfilters: Clears the filters for a user repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:256
+msgid ""
+"usage: repo_clearfilters repo <options>\n"
+"\n"
+"options:\n"
+"  -y, --yes   Confirm without prompt\n"
+"\n"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:278
+msgid "Remove these filters [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:287
+msgid "repo_delete: Delete a user repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:288
+msgid "usage: repo_delete <repo ...>"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:307 ../src/spacecmd/softwarechannel.py:610
+msgid "Repos"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:311
+msgid "Delete these repos [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:316
+#, python-format
+msgid "Failed to remove repo %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:324
+msgid "repo_create: Create a user repository"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:325
+msgid ""
+"usage: repo_create <options>)\n"
+"\n"
+"options:\n"
+"  -n, --name   name of repository\n"
+"  -u, --url    url of repository\n"
+"  -t, --type   type of repository (defaults to yum)\n"
+"\n"
+"  --ca         SSL CA certificate (not required)\n"
+"  --cert       SSL Client certificate (not required)\n"
+"  --key        SSL Client key (not required)"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:350
+msgid "URL:"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:351
+msgid "Type:"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:352 ../src/spacecmd/repo.py:462
+msgid "SSL CA cert:"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:353 ../src/spacecmd/repo.py:463
+msgid "SSL Client cert:"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:354 ../src/spacecmd/repo.py:464
+msgid "SSL Client key:"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:361
+msgid "A URL is required"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:381
+msgid "repo_rename: Rename a user repository"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:382
+msgid "usage: repo_rename OLDNAME NEWNAME"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:404
+#, python-format
+msgid "Could not find repo %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:417
+msgid "repo_updateurl: Change the URL of a user repository"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:418
+msgid "usage: repo_updateurl <repo> <url>"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:443
+msgid "repo_updatessl: Change the SSL certificates of a user repository"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:444
+msgid ""
+"usage: repo_updatessl <options>)\n"
+"options:\n"
+"  --ca         SSL CA certificate (not required)\n"
+"  --cert       SSL Client certificate (not required)\n"
+"  --key        SSL Client key (not required)"
+msgstr ""
+
+#: ../src/spacecmd/report.py:43
+msgid "report_inactivesystems: List all inactive systems"
+msgstr ""
+
+#: ../src/spacecmd/report.py:44
+msgid "usage: report_inactivesystems [DAYS]"
+msgstr ""
+
+#: ../src/spacecmd/report.py:84
+msgid "report_outofdatesystems: List all out-of-date systems"
+msgstr ""
+
+#: ../src/spacecmd/report.py:85
+msgid "usage: report_outofdatesystems"
+msgstr ""
+
+#: ../src/spacecmd/report.py:112
+msgid "report_ungroupedsystems: List all ungrouped systems"
+msgstr ""
+
+#: ../src/spacecmd/report.py:113
+msgid "usage: report_ungroupedsystems"
+msgstr ""
+
+#: ../src/spacecmd/report.py:130
+msgid "report_errata: List all errata and how many systems they affect"
+msgstr ""
+
+#: ../src/spacecmd/report.py:131
+msgid "usage: report_errata [ERRATA|search:XXX ...]"
+msgstr ""
+
+#: ../src/spacecmd/report.py:143
+msgid "All errata requested - this may take a few minutes, please be patient!"
+msgstr ""
+
+#: ../src/spacecmd/report.py:166
+#, python-format
+msgid "%s  # Systems"
+msgstr ""
+
+#: ../src/spacecmd/report.py:173
+msgid "No errata found for '{}'"
+msgstr ""
+
+#: ../src/spacecmd/report.py:180
+msgid "report_ipaddresses: List the hostname and IP of each system"
+msgstr ""
+
+#: ../src/spacecmd/report.py:181
+msgid "usage: report_ipaddresses [<SYSTEMS>]"
+msgstr ""
+
+#: ../src/spacecmd/report.py:201 ../src/spacecmd/report.py:265
+#: ../src/spacecmd/scap.py:67 ../src/spacecmd/scap.py:207
+#: ../src/spacecmd/system.py:213 ../src/spacecmd/system.py:394
+#: ../src/spacecmd/system.py:579 ../src/spacecmd/system.py:743
+#: ../src/spacecmd/system.py:898 ../src/spacecmd/system.py:1033
+#: ../src/spacecmd/system.py:1134 ../src/spacecmd/system.py:1204
+#: ../src/spacecmd/system.py:1259 ../src/spacecmd/system.py:1358
+#: ../src/spacecmd/system.py:1591 ../src/spacecmd/system.py:1654
+#: ../src/spacecmd/system.py:1697 ../src/spacecmd/system.py:1777
+#: ../src/spacecmd/system.py:1919 ../src/spacecmd/system.py:1961
+#: ../src/spacecmd/system.py:2049 ../src/spacecmd/system.py:2116
+#: ../src/spacecmd/system.py:2198 ../src/spacecmd/system.py:2253
+#: ../src/spacecmd/system.py:2313 ../src/spacecmd/system.py:2372
+#: ../src/spacecmd/system.py:2430 ../src/spacecmd/system.py:2489
+#: ../src/spacecmd/system.py:2566 ../src/spacecmd/system.py:2647
+#: ../src/spacecmd/system.py:2702 ../src/spacecmd/system.py:2955
+#: ../src/spacecmd/system.py:3108 ../src/spacecmd/system.py:3177
+#: ../src/spacecmd/system.py:3223 ../src/spacecmd/system.py:3282
+#: ../src/spacecmd/system.py:3346 ../src/spacecmd/system.py:3402
+#: ../src/spacecmd/system.py:3577 ../src/spacecmd/system.py:3855
+#: ../src/spacecmd/system.py:3998 ../src/spacecmd/system.py:4060
+#: ../src/spacecmd/system.py:4108 ../src/spacecmd/system.py:4166
+#: ../src/spacecmd/system.py:4224
+msgid "No systems selected"
+msgstr ""
+
+#: ../src/spacecmd/report.py:244
+msgid "report_kernels: List the running kernel of each system"
+msgstr ""
+
+#: ../src/spacecmd/report.py:245
+msgid "usage: report_kernels [<SYSTEMS>]"
+msgstr ""
+
+#: ../src/spacecmd/report.py:282
+#, python-format
+msgid "%s  Kernel"
+msgstr ""
+
+#: ../src/spacecmd/report.py:282
+msgid "System"
+msgstr ""
+
+#: ../src/spacecmd/report.py:296
+msgid "report_duplicates: List duplicate system profiles"
+msgstr ""
+
+#: ../src/spacecmd/report.py:297
+msgid "usage: report_duplicates"
+msgstr ""
+
+#: ../src/spacecmd/report.py:319 ../src/spacecmd/report.py:341
+#: ../src/spacecmd/report.py:359 ../src/spacecmd/report.py:377
+msgid "System ID   Last Checkin"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:43
+msgid ""
+"scap_listxccdfscans: Return a list of finished OpenSCAP scans for given "
+"systems"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:44
+msgid "usage: scap_listxccdfscans <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:78 ../src/spacecmd/system.py:608
+#: ../src/spacecmd/system.py:1220 ../src/spacecmd/system.py:1371
+#: ../src/spacecmd/system.py:2060 ../src/spacecmd/system.py:2383
+#: ../src/spacecmd/system.py:2441 ../src/spacecmd/system.py:2660
+#: ../src/spacecmd/system.py:2715 ../src/spacecmd/system.py:3121
+#: ../src/spacecmd/system.py:3238 ../src/spacecmd/system.py:3295
+#, python-format
+msgid "System: %s"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:88
+#, python-format
+msgid "XID: %d Profile: %s Path: (%s) Completed: %s"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:96
+msgid ""
+"scap_getxccdfscanruleresults: Return a full list of RuleResults for given "
+"OpenSCAP XCCDF scan"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:97
+msgid "usage: scap_getxccdfscanruleresults <XID>"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:117
+#, python-format
+msgid "XID: %s"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:124
+#, python-format
+msgid "IDref: %s Result: %s Idents: (%s)"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:132
+msgid "scap_getxccdfscandetails: Get details of given OpenSCAP XCCDF scan"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:133
+msgid "usage: scap_getxccdfscandetails <XID>"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:159
+msgid "XID:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:159
+msgid "SID:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:159
+msgid "Action_ID:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:161
+msgid "OSCAP_Parameters:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:162
+msgid "Test_Result:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:162
+msgid "Benchmark:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:163
+msgid "Benchmark_Version:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:164
+msgid "Profile:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:165
+msgid "Profile_Title:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:165
+msgid "Start_Time:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:166
+msgid "End_Time:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:167
+msgid "Errors:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:175
+msgid "scap_schedulexccdfscan: Schedule Scap XCCDF scan"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:176
+msgid "usage: scap_schedulexccdfscan PATH_TO_XCCDF_FILE XCCDF_OPTIONS SYSTEMS"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:177
+msgid "       scap_schedulexccdfscan ssm PATH_TO_XCCDF_FILE XCCDF_OPTIONS"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:182
+msgid ""
+"\n"
+"To use systems in the ssm, pass the \"ssm\" keyword in front. Example:"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:88
+msgid "ID      Date                 C    F    P     Action"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:134
+msgid "schedule_cancel: Cancel scheduled actions"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:135
+msgid "usage: schedule_cancel ID|* ..."
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:157
+msgid "Cancel all pending actions [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:158
+msgid "All pending actions left untouched"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:173 ../src/spacecmd/schedule.py:234
+#, python-format
+msgid "\"%s\" is not a valid ID"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:179
+#, python-format
+msgid "Canceled action: %i"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:182
+#, python-format
+msgid "Failed action: %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:184
+#, python-format
+msgid "Canceled %i action(s)"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:192
+msgid "schedule_reschedule: Reschedule failed actions"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:193
+msgid "usage: schedule_reschedule ID|* ..."
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:220
+msgid "Reschedule all failed actions [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:232
+#, python-format
+msgid "\"%i\" is not a failed action"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:238
+msgid "No failed actions to reschedule"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:242
+#, python-format
+msgid "Rescheduled %i action(s)"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:250
+msgid "schedule_details: Show the details of a scheduled action"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:251
+msgid "usage: schedule_details ID"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:268
+#, python-format
+msgid "The ID \"%s\" is invalid"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:277
+#, python-format
+msgid "ID:        %i"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:278
+#, python-format
+msgid "Action:    %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:279
+#, python-format
+msgid "User:      %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:280
+#, python-format
+msgid "Date:      %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:282 ../src/spacecmd/schedule.py:379
+#: ../src/spacecmd/system.py:3245
+#, python-format
+msgid "Completed: %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:283
+#, python-format
+msgid "Failed:    %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:284
+#, python-format
+msgid "Pending:   %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:288
+msgid "Completed Systems"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:295
+msgid "Failed Systems"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:302
+msgid "Pending Systems"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:307
+#, python-format
+msgid "No action found with the ID \"%s\""
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:316
+msgid "schedule_getoutput: Show the output from an action"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:317
+msgid "usage: schedule_getoutput ID"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:332
+#, python-format
+msgid "\"%s\" is not a valid action ID"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:354
+#, python-format
+msgid "System:      %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:355
+#, python-format
+msgid "Start Time:  %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:356
+#, python-format
+msgid "Stop Time:   %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:357
+#, python-format
+msgid "Return Code: %i"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:359 ../src/spacecmd/schedule.py:381
+msgid "Output"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:378
+#, python-format
+msgid "System:    %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:394
+msgid "schedule_listpending: List pending actions"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:395
+msgid "usage: schedule_listpending [BEGINDATE] [ENDDATE]"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:407
+msgid "schedule_listcompleted: List completed actions"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:408
+msgid "usage: schedule_listcompleted [BEGINDATE] [ENDDATE]"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:420
+msgid "schedule_listfailed: List failed actions"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:421
+msgid "usage: schedule_listfailed [BEGINDATE] [ENDDATE]"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:433
+msgid "schedule_listarchived: List archived actions"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:434
+msgid "usage: schedule_listarchived [BEGINDATE] [ENDDATE]"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:446
+msgid "schedule_list: List all actions"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:447
+msgid "usage: schedule_list [BEGINDATE] [ENDDATE]"
+msgstr ""
+
+#: ../src/spacecmd/shell.py:120
+msgid "Could not read history file"
+msgstr ""
+
+#. pylint: disable=W0702
+#: ../src/spacecmd/shell.py:124
+msgid "Exception occurred: {}"
+msgstr ""
+
+#: ../src/spacecmd/shell.py:188 ../src/spacecmd/shell.py:227
+#, python-format
+msgid "%s: event not found"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:42
+msgid "snippet_list: List the available Kickstart snippets"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:43
+msgid "usage: snippet_list"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:60
+msgid "snippet_details: Show the contents of a snippet"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:61
+msgid "usage: snippet_details SNIPPET ..."
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:90
+#, python-format
+msgid "%s is not a valid snippet"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:97
+#, python-format
+msgid "Name:   %s"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:98
+#, python-format
+msgid "Macro:  %s"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:99
+#, python-format
+msgid "File:   %s"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:110
+msgid "snippet_create: Create a Kickstart snippet"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:111
+msgid ""
+"usage: snippet_create [options])\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -f FILE"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:149
+msgid "A name is required for the snippet"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:153
+msgid "A file is required"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:160
+#, python-format
+msgid "Snippet: %s"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:176
+msgid "snippet_update: Update a Kickstart snippet"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:177
+msgid "usage: snippet_update NAME"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:199
+msgid "snippet_delete: Delete a Kickstart snippet"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:200
+msgid "usage: snippet_delete NAME"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:218
+msgid "Remove this snippet [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:57
+msgid "softwarechannel_list: List all available software channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:58
+msgid ""
+"usage: softwarechannel_list [options]')\n"
+"options:\n"
+"  -v verbose (display label and summary)\n"
+"  -t tree view (pretty-print(child-channels))\n"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:106
+msgid "softwarechannel_listmanageablechannels: List all software channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:107
+msgid "                                        manageable by current user"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:108
+msgid ""
+"usage: softwarechannel_listmanageablechannels [options]\n"
+"options:\n"
+"  -v verbose (display label and summary)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:143
+msgid "softwarechannel_listbasechannels: List all base software channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:144
+msgid ""
+"usage: softwarechannel_listbasechannels [options])\n"
+"options:\n"
+"  -v verbose (display label and summary)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:172
+msgid "softwarechannel_listchildchannels: List child software channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:173
+#: ../src/spacecmd/softwarechannel.py:2735
+msgid "usage:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:174
+msgid "softwarechannel_listchildchannels [options]"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:175
+msgid "softwarechannel_listchildchannels : List all child channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:176
+msgid ""
+"softwarechannel_listchildchannels CHANNEL : List children for aspecific base "
+"channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:178
+msgid ""
+"options:\n"
+" -v verbose (display label and summary)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:206
+msgid "softwarechannel_listsystems: List all systems subscribed to"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:207
+msgid "                             a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:208
+msgid "usage: softwarechannel_listsystems CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:242
+msgid "softwarechannel_listpackages: List the most recent packages"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:243
+msgid "                              available from a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:244
+msgid "usage: softwarechannel_listpackages CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:281
+msgid "softwarechannel_listallpackages: List all packages in a channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:282
+msgid "usage: softwarechannel_listallpackages CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:340
+msgid ""
+"softwarechannel_listlatestpackages: List the newest version of all packages "
+"in a channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:341
+msgid "usage: softwarechannel_listlatestpackages CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:380
+msgid "softwarechannel_setdetails: Modify details of a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:381
+#, python-format
+msgid ""
+"usage: softwarechannel_setdetails [options] <CHANNEL ...>)\n"
+"\n"
+"options, at least one of which must be given:\n"
+"  -n NAME\n"
+"  -d DESCRIPTION\n"
+"  -s SUMMARY\n"
+"  -c CHECKSUM %s\n"
+"  -m MAINTAINER_NAME\n"
+"  -e MAINTAINER_EMAIL\n"
+"  -p MAINTAINER_PHONE\n"
+"  -u GPG_URL\n"
+"  -i GPG_ID\n"
+"  -f GPG_FINGERPRINT"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:443
+msgid "At least one attribute to set must be given"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:449
+msgid "No channels matching that label"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:461
+msgid "Setting same name for more than one channel will fail"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:469
+#, python-format
+msgid "Name \"%s\" already in use by channel %s"
+msgstr ""
+
+#. get confirmation
+#: ../src/spacecmd/softwarechannel.py:474
+msgid "Setting following attributes..."
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:477
+#, python-format
+msgid "Name:             %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:479
+#, python-format
+msgid "Summary:          %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:481
+#, python-format
+msgid "Description:      %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:483
+#, python-format
+msgid "Checksum:         %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:485
+#, python-format
+msgid "Maintainer name:  %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:487
+#, python-format
+msgid "Maintainer email: %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:489
+#, python-format
+msgid "Maintainer phone: %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:491
+#, python-format
+msgid "GPG Key:          %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:493
+#, python-format
+msgid "GPG Fingerprint:  %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:495
+#, python-format
+msgid "GPG URL:          %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:497
+msgid "... for the following channels:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:500
+msgid "Apply? [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:512
+#, python-format
+msgid "Could not get details for %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:524
+#, python-format
+msgid "Error while setting details for %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:527
+#, python-format
+msgid "Channels changed: %d"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:535
+msgid "softwarechannel_details: Show the details of a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:536
+msgid "usage: softwarechannel_details <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:576
+#, python-format
+msgid "Label:              %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:577
+#, python-format
+msgid "Name:               %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:578
+#, python-format
+msgid "Architecture:       %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:579
+#, python-format
+msgid "Parent:             %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:580
+#, python-format
+msgid "Systems Subscribed: %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:581
+#, python-format
+msgid "Number of Packages: %i"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:585
+msgid "Summary"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:596
+#, python-format
+msgid "GPG Key:            %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:597
+#, python-format
+msgid "GPG Fingerprint:    %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:598
+#, python-format
+msgid "GPG URL:            %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:599
+#, python-format
+msgid "GPG CHECK:          %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:603
+msgid "Kickstart Trees"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:621
+msgid "softwarechannel_listerrata: List the errata associated with a"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:622
+msgid "                            software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:623
+msgid ""
+"usage: softwarechannel_listerrata <CHANNEL ...> [from=yyyymmdd [to=yyyymmdd]]"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:681
+msgid "softwarechannel_listarches: lists the potential software"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:682
+msgid "                            channel architectures that can be created"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:683
+msgid "usage: softwarechannel_listarches"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:684 ../src/spacecmd/system.py:3826
+msgid "options:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:685
+msgid "    -v verbose (display label and name)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:706
+msgid "softwarechannel_delete: Delete a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:707
+msgid "usage: softwarechannel_delete <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:732
+msgid "Channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:760
+msgid "softwarechannel_update: Update a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:761
+#, python-format
+msgid ""
+"usage: softwarechannel_update LABEL(To identify the channel) [options]\n"
+"options:\n"
+"  -l LABEL(Required)\n"
+"  -n NAME\n"
+"  -s SUMMARY\n"
+"  -d DESCRIPTION\n"
+"  -c CHECKSUM %s\n"
+"  -u GPG-URL\n"
+"  -i GPG-ID\n"
+"  -f GPG-FINGERPRINT\n"
+"  -g DISABLE-GPG-CHECK"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:792
+#: ../src/spacecmd/softwarechannel.py:924
+#: ../src/spacecmd/softwarechannel.py:1094
+msgid "Channel Label:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:797
+msgid "New Name (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:803
+msgid "New Summary (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:806
+msgid "Summary:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:809
+msgid "New Description (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:815
+msgid "New Checksum type (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:822
+msgid "New GPG URL (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:825
+#: ../src/spacecmd/softwarechannel.py:953
+#: ../src/spacecmd/softwarechannel.py:1107
+#: ../src/spacecmd/softwarechannel.py:1196
+msgid "GPG URL:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:828
+msgid "New GPG ID (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:831
+#: ../src/spacecmd/softwarechannel.py:959
+#: ../src/spacecmd/softwarechannel.py:1108
+#: ../src/spacecmd/softwarechannel.py:1197
+msgid "GPG ID:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:834
+msgid "New GPG Fingerprint (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:837
+#: ../src/spacecmd/softwarechannel.py:965
+#: ../src/spacecmd/softwarechannel.py:1109
+#: ../src/spacecmd/softwarechannel.py:1198
+msgid "GPG Fingerprint:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:840
+msgid "Disable GPG CHECK (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:843
+#: ../src/spacecmd/softwarechannel.py:1110
+#: ../src/spacecmd/softwarechannel.py:1199
+msgid "Disable GPG Check [yes/no]? "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:846
+msgid "A channel label is required to identify the channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:849
+msgid "Only [yes/no] values are acceptable for --disable_gpg_check"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:889
+msgid "softwarechannel_create: Create a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:890
+#, python-format
+msgid ""
+"usage: softwarechannel_create [options])\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -l LABEL\n"
+"  -s SUMMARY\n"
+"  -p PARENT_CHANNEL\n"
+"  -a ARCHITECTURE\n"
+"  -c CHECKSUM %s\n"
+"  -u GPG_URL\n"
+"  -i GPG_ID\n"
+"  -f GPG_FINGERPRINT\n"
+"  -g DISABLE_GPG_CHECK"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:923
+#: ../src/spacecmd/softwarechannel.py:1093
+msgid "Channel Name:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:925
+msgid "Channel Summary:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:933
+#: ../src/spacecmd/softwarechannel.py:1101
+msgid "Select Parent [blank to create a base channel]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:936
+msgid "Architecture"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:943
+msgid "Checksum type"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:950
+msgid "GPG URL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:956
+msgid "GPG ID"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:962
+msgid "GPG Fingerprint"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:968
+msgid "GPG CHECK"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:971
+msgid "Disable GPG Check [y/N]? "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1023
+#: ../src/spacecmd/softwarechannel.py:1121
+msgid "A channel name is required"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1027
+#: ../src/spacecmd/softwarechannel.py:1125
+msgid "A channel label is required"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1040
+#, python-format
+msgid "Name %s already in use by channel %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1044
+#, python-format
+msgid "Label %s already in use by channel %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1052
+msgid "softwarechannel_clone: Clone a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1053
+msgid ""
+"usage: softwarechannel_clone [options])\n"
+"\n"
+"options:\n"
+"  -s SOURCE_CHANNEL\n"
+"  -n NAME\n"
+"  -l LABEL\n"
+"  -p PARENT_CHANNEL\n"
+"  --gpg-copy/-g (copy SOURCE_CHANNEL GPG details)\n"
+"  --gpg-url GPG_URL\n"
+"  --gpg-id GPG_ID\n"
+"  --gpg-fingerprint(GPG_FINGERPRINT)\n"
+"  --disable-gpg-check DISABLE_GPG_CHECK\n"
+"  -o do not clone any patches\n"
+"  --regex/-x \"s/foo/bar\" : Optional regex replacement,\n"
+"        replaces foo with bar in the clone name and label"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1088
+#: ../src/spacecmd/softwarechannel.py:1188
+msgid "Source Channels:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1092
+#: ../src/spacecmd/softwarechannel.py:1191
+msgid "Select source channel:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1096
+msgid "Base Channels:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1104
+#: ../src/spacecmd/softwarechannel.py:1194
+msgid "Copy source channel GPG details? [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1113
+#: ../src/spacecmd/softwarechannel.py:1202
+msgid "Original State (No Errata) [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1117
+#: ../src/spacecmd/softwarechannel.py:1205
+msgid "A source channel is required"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1138
+#: ../src/spacecmd/softwarechannel.py:1216
+msgid "Only [yes/no] values are acceptable for --disable-gpg-check"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1154
+msgid ""
+"softwarechannel_clonetree: Clone a software channel and its child channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1155
+msgid ""
+"usage: softwarechannel_clonetree [options])\n"
+"             e.g    softwarechannel_clonetree foobasechannel -p \"my_\"\n"
+"                    softwarechannel_clonetree foobasechannel -x \"s/foo/bar"
+"\"\n"
+"                    softwarechannel_clonetree foobasechannel -x \"s/^/my_\"\n"
+"\n"
+"options:\n"
+"  -s/--source-channel SOURCE_CHANNEL\n"
+"  -p/--prefix PREFIX (is prepended to the label and name of all channels)\n"
+"  --gpg-copy/-g (copy GPG details for correspondoing source channel))\n"
+"  --gpg-url GPG_URL (applied to all channels)\n"
+"  --gpg-id GPG_ID (applied to all channels)\n"
+"  --gpg-fingerprint(GPG_FINGERPRINT (applied to all channels))\n"
+"  --disable-gpg-check DISABLE_GPG_CHECK(applied to all channels)\n"
+"  -o do not clone any errata\n"
+"  --regex/-x \"s/foo/bar\" : Optional regex replacement,\n"
+"        replaces foo with bar in the clone name, label and description"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1192
+msgid "Prefix:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1209
+msgid "A prefix or regex is required"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1221
+#: ../src/spacecmd/softwarechannel.py:1994
+#: ../src/spacecmd/softwarechannel.py:2034
+msgid "Channel does not exist or is not a base channel!"
+msgstr ""
+
+#. Shouldn't ever get here due to earlier checks
+#: ../src/spacecmd/softwarechannel.py:1248
+msgid "called without prefix or regex option!"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1348
+msgid "softwarechannel_addpackages: Add packages to a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1349
+msgid "usage: softwarechannel_addpackages CHANNEL <PACKAGE ...>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1389
+msgid "No packages to add"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1396
+msgid "Add these packages [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1408
+msgid ""
+"softwarechannel_mergepackages: Merge packages from one software channel into "
+"another"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1409
+msgid "usage: softwarechannel_mergepackages SOURCE_CHANNEL TARGET_CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1433
+msgid "softwarechannel_removeerrata: Remove patches from a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1435
+msgid "usage: softwarechannel_removeerrata CHANNEL <ERRATA:search:XXX ...>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1488
+msgid "No patches to remove"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1499
+#: ../src/spacecmd/softwarechannel.py:1828
+#, python-format
+msgid "Total Errata:   %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1500
+#: ../src/spacecmd/softwarechannel.py:1831
+#, python-format
+msgid "Total Packages: %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1502
+msgid "Remove these patches [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1517
+msgid "softwarechannel_removepackages: Remove packages from a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1519
+msgid "usage: softwarechannel_removepackages CHANNEL <PACKAGE ...>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1573
+msgid "No packages to remove"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1593
+msgid ""
+"softwarechannel_adderratabydate: Add errata from one channel into another "
+"channel based on a date range"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1595
+msgid ""
+"usage: softwarechannel_adderratabydate [options] SOURCE DEST BEGINDATE "
+"ENDDATE"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1596
+#: ../src/spacecmd/softwarechannel.py:1671
+msgid "Date format : YYYYMMDD"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1597
+#: ../src/spacecmd/softwarechannel.py:1728
+#: ../src/spacecmd/softwarechannel.py:2620
+#: ../src/spacecmd/softwarechannel.py:2663
+#: ../src/spacecmd/softwarechannel.py:2879
+msgid "Options:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1598
+msgid "        -p/--publish : Publish errata to the channel (don't clone)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1625
+#: ../src/spacecmd/softwarechannel.py:1630
+#: ../src/spacecmd/softwarechannel.py:1696
+#: ../src/spacecmd/softwarechannel.py:1701
+#, python-format
+msgid "%s is an invalid date"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1643
+msgid "No patches found between the given dates"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1650
+#, python-format
+msgid "Publishing errata %s to %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1668
+msgid ""
+"softwarechannel_listerratabydate: list errata from channelbased on a date "
+"range"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1670
+msgid "usage: softwarechannel_listerratabydate CHANNEL BEGINDATE ENDDATE"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1714
+msgid "No errata found between the given dates"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1725
+msgid ""
+"softwarechannel_adderrata: Add patches from one channel into another channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1727
+msgid "usage: softwarechannel_adderrata SOURCE DEST <ERRATA|search:XXX ...>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1729
+msgid "    -q/--quick : Don't display list of packages (slightly faster)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1730
+msgid "    -s/--skip :  Skip errata which appear to exist already in DEST"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1756
+#, python-format
+msgid "source channel %s does not exist!"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1761
+#, python-format
+msgid "dest channel %s does not exist!"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1814
+msgid "No patch to add"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1833
+msgid "Add these patches [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1847
+msgid "Using the old errata.clone function"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1848
+msgid ""
+"If you have base channels for multiple OS versions, check no unexpected "
+"packages have been added"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1861
+msgid ""
+"softwarechannel_getorgaccess: Get the org-access for the software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1862
+msgid "usage: softwarechannel_getorgaccess [CHANNEL ...]"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1900
+msgid ""
+"softwarechannel_setorgaccess: Set the org-access for the software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1901
+msgid ""
+"usage : softwarechannel_setorgaccess <CHANNEL> [options])\n"
+"-d,--disable : disable org access (private, no org sharing)\n"
+"-e,--enable : enable org access (public access to all trusted orgs)\n"
+"-p,--protected ORG : protected org access for ORG only (multiple instances "
+"of -p ORG are allowed)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1941
+#, python-format
+msgid "Making org sharing public for channel : %s "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1946
+#, python-format
+msgid "Making org sharing private for channel : %s "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1951
+#, python-format
+msgid "Making org sharing protected for channel : %s "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1957
+#, python-format
+msgid "Enabling %s access for channel : %s "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1962
+#, python-format
+msgid "Disabling %s access for channel : %s "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1975
+msgid ""
+"softwarechannel_getorgaccesstree: Get the org-access for a software base "
+"channel and its children"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1976
+msgid "usage: softwarechannel_getorgaccesstree [CHANNEL]"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2009
+msgid ""
+"softwarechannel_setorgaccesstree: set the org-access for a software base "
+"channel and its children"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2010
+msgid ""
+"usage: softwarechannel_setorgaccesstree <CHANNEL> [options])\n"
+"-d,--disable : disable org access (private, no org sharing)\n"
+"-e,--enable : enable org access (public access to all trusted orgs)\n"
+"-p,--protected ORG : protected org access for ORG only (multiple instances "
+"of -p ORG are allowed)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2049
+msgid "softwarechannel_regenerateneededcache: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2050
+msgid "Regenerate the needed errata and package cache for all systems"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2052
+msgid "usage: softwarechannel_regenerateneededcache"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2066
+msgid "softwarechannel_regenerateyumcache: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2067
+msgid "Regenerate the YUM cache for a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2069
+msgid ""
+"usage: softwarechannel_regenerateyumcache [options] <CHANNEL ...>\n"
+"\n"
+"    options:\n"
+"      -f force cache regeneration\n"
+"    "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2113
+msgid "no softwarechannel label given"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2116
+msgid "invalid softwarechannel label "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2134
+msgid "softwarechannel_diff: diff softwarechannel files"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2136
+msgid "usage: softwarechannel_diff SOURCE_CHANNEL TARGET_CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2197
+msgid "softwarechannel_errata_diff: diff softwarechannel files"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2199
+msgid "usage: softwarechannel_errata_diff SOURCE_CHANNEL TARGET_CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2248
+msgid "softwarechannel_sync: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2249
+msgid "sync the packages of two software channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2251
+msgid ""
+"usage: softwarechannel_sync SOURCE_CHANNEL TARGET_CHANNEL [options])\n"
+"    -q,--quiet : quiet mode (omits the output of common packages in both "
+"channels)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2293
+#, python-format
+msgid "%s packages from softwarechannel %s to %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2312
+#: ../src/spacecmd/softwarechannel.py:2320
+#: ../src/spacecmd/softwarechannel.py:2434
+#: ../src/spacecmd/softwarechannel.py:2442
+#: ../src/spacecmd/softwarechannel.py:2574
+#: ../src/spacecmd/softwarechannel.py:2582
+msgid "failed to read key id"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2323
+msgid "packages common in both channels:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2328
+msgid "Omitting common packages in both specified channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2333
+msgid "packages to add to channel \""
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2341
+msgid "packages to remove from channel \""
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2347
+#: ../src/spacecmd/softwarechannel.py:2469
+#: ../src/spacecmd/softwarechannel.py:2599
+msgid "summary:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2348
+#: ../src/spacecmd/softwarechannel.py:2349
+msgid " packages"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2350
+msgid "    add    "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2351
+msgid " packages to   "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2354
+msgid "    remove "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2355
+msgid " packages from "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2357
+#: ../src/spacecmd/softwarechannel.py:2477
+msgid "Perform these changes to channel "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2378
+msgid "softwarechannel_errata_sync: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2379
+msgid "sync errata of two software channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2381
+msgid "usage: softwarechannel_errata_sync SOURCE_CHANNEL TARGET_CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2420
+msgid "syncing errata from softwarechannel "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2421
+#: ../src/spacecmd/softwarechannel.py:2553
+msgid " to "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2445
+msgid "errata common in both channels:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2454
+msgid "errata to add to channel \""
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2463
+msgid "errata to remove from channel \""
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2472
+#: ../src/spacecmd/softwarechannel.py:2602
+msgid "    add   "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2473
+msgid "errata to  "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2474
+msgid "    remove"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2475
+msgid "errata from"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2500
+msgid "softwarechannel_errata_merge: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2501
+msgid "merge errata of one software channel into another"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2503
+msgid ""
+"usage:   softwarechannel_errata_merge SOURCE_CHANNEL TARGET_CHANNEL "
+"[FROM_DATE] [TO_DATE]"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2504
+msgid ""
+"example: softwarechannel_errata_merge OldSoftChannel NewSoftChannel "
+"2018-01-01"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2505
+msgid ""
+"note:    Providing only FROM_DATE will merge all errata since that date."
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2506
+msgid "note:    When no date is provided, all errata will be merged."
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2536
+#: ../src/spacecmd/softwarechannel.py:2543
+msgid "wrong dateformat: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2536
+#: ../src/spacecmd/softwarechannel.py:2543
+msgid " please specify as: YYYY-MM-DD"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2552
+msgid "merging errata from softwarechannel "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2589
+msgid "{} contains no errata which is not already present in {}"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2594
+msgid "errata to add to channel {}: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2600
+#: ../src/spacecmd/softwarechannel.py:2601
+msgid " errata"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2603
+msgid " errata to  "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2605
+msgid "Perform these changes to channel {} [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2616
+msgid "softwarechannel_syncrepos: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2617
+msgid "Sync users repos for a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2619
+msgid "usage: softwarechannel_syncrepos <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2621
+#: ../src/spacecmd/softwarechannel.py:2664
+msgid "    -e/--no-errata : Do not sync errata"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2622
+#: ../src/spacecmd/softwarechannel.py:2665
+msgid "    -f/--fail : Terminate upon any error"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2623
+#: ../src/spacecmd/softwarechannel.py:2666
+msgid "    -k/--sync-kickstart : Create kickstartable tree"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2624
+#: ../src/spacecmd/softwarechannel.py:2667
+msgid "    -l/--latest : Only download latest package versions when repo syncs"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2659
+msgid "softwarechannel_setsyncschedule: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2660
+msgid "Sets the repo sync schedule for a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2662
+msgid "usage: softwarechannel_setsyncschedule <CHANNEL> <SCHEDULE>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2669
+msgid ""
+"The schedule is specified in Quartz CronTrigger format without enclosing "
+"quotes."
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2670
+msgid ""
+"For example, to set a schedule of every day at 1am, <SCHEDULE> would be 0 0 "
+"1 * * ?"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2671
+msgid "If <SCHEDULE> is left empty, it will be disabled."
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2734
+msgid ""
+"softwarechannel_listsyncschedule: List sync schedules for all software "
+"channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2736
+msgid "softwarechannel_listsyncschedule : List all channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2759
+msgid "key"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2759
+msgid "Channel Name"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2759
+msgid "Update Schedule"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2771
+msgid "softwarechannel_addrepo: Add a repo to a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2772
+msgid "usage: softwarechannel_addrepo CHANNEL REPO"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2805
+msgid "softwarechannel_removerepo: Remove a repo from a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2806
+msgid "usage: softwarechannel_removerepo CHANNEL REPO"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2846
+msgid "softwarechannel_listrepos: List the repos for a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2847
+msgid "usage: softwarechannel_listrepos CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2870
+msgid "No repos have been found for this channel."
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2877
+msgid "softwarechannel_mirrorpackages: Download packages of a given channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2878
+msgid "usage: softwarechannel_mirrorpackages CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2880
+msgid "    -l/--latest : Only mirror latest package version"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2911
+msgid "Skipping"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2913
+msgid "Fetching package"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2918
+#, python-format
+msgid "Received package %s from channel %s is broken. Content is too short"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2922
+#, python-format
+msgid "Could not fetch package %s from channel %s"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:42
+msgid "The System Set Manager (SSM) is a group of systems that you "
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:43
+msgid "can perform tasks on as a whole."
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:45
+msgid "Adding Systems:"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:51
+msgid "Intersections:"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:63
+msgid "ssm_add: Add systems to the SSM"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:64
+msgid "usage: ssm_add <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:66 ../src/spacecmd/ssm.py:115
+#: ../src/spacecmd/ssm.py:165 ../src/spacecmd/ssm.py:209
+msgid "see 'help ssm' for more details"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:92
+#, python-format
+msgid "%s is already in the list"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:110
+msgid "ssm_intersect: Replace the current SSM with the intersection"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:111
+msgid "               of the current list of systems and the list of"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:112
+msgid "               systems passed as arguments"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:113
+msgid "usage: ssm_intersect <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:162
+msgid "ssm_remove: Remove systems from the SSM"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:163
+msgid "usage: ssm_remove <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:206
+msgid "ssm_list: List the systems currently in the SSM"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:207
+msgid "usage: ssm_list"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:226
+msgid "ssm_clear: Remove all systems from the SSM"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:227
+msgid "usage: ssm_clear"
+msgstr ""
+
+#: ../src/spacecmd/system.py:49
+msgid "Same"
+msgstr ""
+
+#: ../src/spacecmd/system.py:50
+msgid "Only here"
+msgstr ""
+
+#: ../src/spacecmd/system.py:51
+msgid "Newer here"
+msgstr ""
+
+#: ../src/spacecmd/system.py:52
+msgid "Only there"
+msgstr ""
+
+#: ../src/spacecmd/system.py:53
+msgid "Newer there"
+msgstr ""
+
+#: ../src/spacecmd/system.py:73 ../src/spacecmd/system.py:3771
+msgid "Package"
+msgstr ""
+
+#: ../src/spacecmd/system.py:74
+msgid "This System"
+msgstr ""
+
+#: ../src/spacecmd/system.py:75
+msgid "Other System"
+msgstr ""
+
+#: ../src/spacecmd/system.py:76 ../src/spacecmd/system.py:3774
+msgid "Difference"
+msgstr ""
+
+#: ../src/spacecmd/system.py:124
+msgid "Removing Channels"
+msgstr ""
+
+#: ../src/spacecmd/system.py:127
+msgid "Adding Channels"
+msgstr ""
+
+#: ../src/spacecmd/system.py:163
+msgid "system_list: List all system profiles"
+msgstr ""
+
+#: ../src/spacecmd/system.py:164
+msgid "usage: system_list"
+msgstr ""
+
+#: ../src/spacecmd/system.py:180
+msgid "system_reboot: Reboot a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:181
+msgid ""
+"usage: system_reboot <SYSTEMS> [options])\n"
+"\n"
+"options:\n"
+"  -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:236
+msgid "Reboot these systems [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:252
+msgid "system_search: List systems that match the given criteria"
+msgstr ""
+
+#: ../src/spacecmd/system.py:253
+msgid "usage: system_search QUERY"
+msgstr ""
+
+#: ../src/spacecmd/system.py:255
+msgid "Available Fields:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:258
+msgid "Examples:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:259
+msgid "> system_search device:vmware"
+msgstr ""
+
+#: ../src/spacecmd/system.py:260
+msgid "> system_search ip:192.168.82"
+msgstr ""
+
+#: ../src/spacecmd/system.py:278 ../src/spacecmd/system.py:285
+msgid "Invalid query"
+msgstr ""
+
+#: ../src/spacecmd/system.py:321
+msgid "Invalid search field"
+msgstr ""
+
+#: ../src/spacecmd/system.py:351
+msgid "system_runscript: Schedule a script to run on the list of"
+msgstr ""
+
+#: ../src/spacecmd/system.py:352
+msgid "                  systems provided"
+msgstr ""
+
+#: ../src/spacecmd/system.py:353
+msgid ""
+"usage: system_runscript <SYSTEMS> [options])\n"
+"\n"
+"options:\n"
+"  -u USER\n"
+"  -g GROUP\n"
+"  -t TIMEOUT\n"
+"  -s START_TIME\n"
+"  -l LABEL\n"
+"  -f FILE"
+msgstr ""
+
+#: ../src/spacecmd/system.py:398
+msgid "User [root]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:399
+msgid "Group [root]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:408
+msgid "Timeout (in seconds) [600]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:414
+msgid "Invalid timeout"
+msgstr ""
+
+#: ../src/spacecmd/system.py:420
+msgid "Label/Short Description [default]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:424
+msgid "Script File [create]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:437
+msgid "No script provided"
+msgstr ""
+
+#: ../src/spacecmd/system.py:456
+msgid "A script file is required"
+msgstr ""
+
+#: ../src/spacecmd/system.py:464
+#, python-format
+msgid "User:       %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:465
+#, python-format
+msgid "Group:      %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:466
+#, python-format
+msgid "Timeout:    %i seconds"
+msgstr ""
+
+#: ../src/spacecmd/system.py:470
+#, python-format
+msgid "Label:      %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:471
+msgid "Script Contents"
+msgstr ""
+
+#: ../src/spacecmd/system.py:533 ../src/spacecmd/system.py:835
+#: ../src/spacecmd/system.py:962 ../src/spacecmd/system.py:1096
+#: ../src/spacecmd/system.py:4358
+#, python-format
+msgid "Failed to schedule %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:536
+#, python-format
+msgid "Scheduled: %i system(s)"
+msgstr ""
+
+#: ../src/spacecmd/system.py:543 ../src/spacecmd/utils.py:245
+#, python-format
+msgid "Could not remove %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:552
+msgid "system_listhardware: List the hardware details of a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:553
+msgid "usage: system_listhardware <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:612
+msgid "Network"
+msgstr ""
+
+#: ../src/spacecmd/system.py:621
+#, python-format
+msgid "Interface:   %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:622
+#, python-format
+msgid "MAC Address: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:623
+#, python-format
+msgid "IP Address:  %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:624
+#, python-format
+msgid "Netmask:     %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:625
+#, python-format
+msgid "Broadcast:   %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:626
+#, python-format
+msgid "Module:      %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:630
+msgid "CPU"
+msgstr ""
+
+#: ../src/spacecmd/system.py:632
+#, python-format
+msgid "Count:    %i"
+msgstr ""
+
+#: ../src/spacecmd/system.py:633
+#, python-format
+msgid "Arch:     %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:634
+#, python-format
+msgid "MHz:      %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:635
+#, python-format
+msgid "Cache:    %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:636
+#, python-format
+msgid "Vendor:   %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:637
+#, python-format
+msgid "Model:    %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:640
+msgid "Memory"
+msgstr ""
+
+#: ../src/spacecmd/system.py:642
+#, python-format
+msgid "RAM:  %i"
+msgstr ""
+
+#: ../src/spacecmd/system.py:643
+#, python-format
+msgid "Swap: %i"
+msgstr ""
+
+#: ../src/spacecmd/system.py:647
+msgid "DMI"
+msgstr ""
+
+#: ../src/spacecmd/system.py:648
+#, python-format
+msgid "Vendor:       %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:649
+#, python-format
+msgid "System:       %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:650
+#, python-format
+msgid "Product:      %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:651
+#, python-format
+msgid "Board:        %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:654
+msgid "Asset"
+msgstr ""
+
+#: ../src/spacecmd/system.py:660
+#, python-format
+msgid "BIOS Release: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:661
+#, python-format
+msgid "BIOS Vendor:  %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:662
+#, python-format
+msgid "BIOS Version: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:666
+msgid "Devices"
+msgstr ""
+
+#: ../src/spacecmd/system.py:676
+msgid "Description: None"
+msgstr ""
+
+#: ../src/spacecmd/system.py:680
+#, python-format
+msgid "Driver:      %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:681
+#, python-format
+msgid "Class:       %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:682
+#, python-format
+msgid "Bus:         %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:690
+msgid "system_installpackage: Install a package on a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:691
+msgid ""
+"usage: system_installpackage <SYSTEMS> <PACKAGE ...> [options])\n"
+"\n"
+"options:\n"
+"    -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:792
+msgid "No packages to install"
+msgstr ""
+
+#: ../src/spacecmd/system.py:816
+#, python-format
+msgid "%s does not have access to all requested packages"
+msgstr ""
+
+#: ../src/spacecmd/system.py:822
+msgid "Install these packages [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:837 ../src/spacecmd/system.py:964
+#: ../src/spacecmd/system.py:1098
+#, python-format
+msgid "Scheduled %i system(s)"
+msgstr ""
+
+#: ../src/spacecmd/system.py:845
+msgid "system_removepackage: Remove a package from a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:846
+msgid ""
+"usage: system_removepackage <SYSTEMS> <PACKAGE ...> [options])\n"
+"\n"
+"options:\n"
+"    -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:972
+msgid "system_upgradepackage: Upgrade a package on a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:973
+msgid ""
+"usage: system_upgradepackage <SYSTEMS> <PACKAGE ...>|* [options]')\n"
+"\n"
+"options:\n"
+"    -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1051 ../src/spacecmd/system.py:1147
+#, python-format
+msgid "No upgrades available for %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1074
+#, python-format
+msgid "Couldn't get name for package %i"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1081
+msgid "Upgrade these packages [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1106
+msgid "system_listupgrades: List the available upgrades for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1107
+msgid "usage: system_listupgrades <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1175
+msgid "system_listinstalledpackages: List the installed packages on a"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1176
+msgid "                              system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1177
+msgid "usage: system_listinstalledpackages <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1231
+msgid "system_listconfigchannels: List the config channels of a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1232
+msgid "usage: system_listconfigchannels <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1278 ../src/spacecmd/system.py:1381
+#, python-format
+msgid "%s does not support configuration channels"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1315
+msgid "system_listconfigfiles: List the managed config files of a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1316
+msgid ""
+"usage: system_listconfigfiles <SYSTEMS>')\n"
+"options:\n"
+"  -s/--sandbox : list only system-sandbox files\n"
+"  -l/--local   : list only locally managed files\n"
+"  -c/--central : list only centrally managed files\n"
+"  -q/--quiet   : quiet mode (omits the header)"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1416
+msgid "system_addconfigfile: Create a configuration file"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1417
+msgid "Note this is only for system sandbox or locally-managed files"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1418
+msgid "Centrally managed files should be created via configchannel_addfile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1419
+msgid ""
+"usage: system_addconfigfile [SYSTEM] [options]\n"
+"\n"
+"options:\n"
+"  -S/--sandbox : list only system-sandbox files\n"
+"  -L/--local   : list only locally managed files\n"
+"  -p PATH\n"
+"  -r REVISION\n"
+"  -o OWNER [default: root]\n"
+"  -g GROUP [default: root]\n"
+"  -m MODE [defualt: 0644]\n"
+"  -x SELINUX_CONTEXT\n"
+"  -d path is a directory\n"
+"  -s path is a symlink\n"
+"  -b path is a binary (or other file which needs base64 encoding)\n"
+"  -t SYMLINK_TARGET\n"
+"  -f local path to file contents\n"
+"\n"
+"  Note re binary/base64: Some text files, notably those containing trailing\n"
+"  newlines, those containing ASCII escape characters (or other charaters "
+"not\n"
+"  allowed in XML) need to be sent as binary (-b).  Some effort is made to "
+"auto-\n"
+"  detect files which require this, but you may need to explicitly specify.\n"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1487
+#, python-format
+msgid "%s is not a valid system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1497
+msgid "System-Sandbox or Locally-Managed? [S/L]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1513
+msgid "Must choose system-sandbox or locally-managed option"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1552
+msgid "system_addconfigchannels: Add config channels to a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1553
+msgid ""
+"usage: system_addconfigchannels <SYSTEMS> <CHANNEL ...> [options]\n"
+"\n"
+"options:\n"
+"  -t add channels to the top of the list\n"
+"  -b add channels to the bottom of the list"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1597
+msgid "Add to top or bottom? [T/b]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1621
+msgid "system_removeconfigchannels: Remove config channels from a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1622
+msgid "usage: system_removeconfigchannels <SYSTEMS> <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1671
+msgid ""
+"system_setconfigchannelorder: Set the ranked order of configuration channels"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1672
+msgid "usage: system_setconfigchannelorder <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1712
+msgid "New Configuration Channels"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1732
+msgid "system_deployconfigfiles: Deploy all configuration files for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1733
+msgid ""
+"usage: system_deployconfigfiles <SYSTEMS> [options]\n"
+"\n"
+"options:\n"
+"    -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1787
+msgid "Deploy ALL configuration files to these systems [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1797
+#, python-format
+msgid "Scheduled deployment for %i system(s)"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1805
+msgid "system_delete: Delete a system profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1806
+msgid ""
+"usage: system_delete [options] <SYSTEMS>\n"
+"\n"
+"    options:\n"
+"          -c TYPE - Possible values:\n"
+"             *  'FAIL_ON_CLEANUP_ERR' - fail in case of cleanup error,\n"
+"             *  'NO_CLEANUP' - do not cleanup, just delete,\n"
+"             *  'FORCE_DELETE' - Try cleanup first but delete server anyway "
+"in case of error\n"
+"    "
+msgstr ""
+
+#: ../src/spacecmd/system.py:1850
+msgid "No systems to delete"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1858
+#, python-format
+msgid "%s  System ID"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1858
+msgid "Profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1866
+msgid "Delete these systems [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1873
+#, python-format
+msgid "%i system(s) scheduled for removal"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1893
+msgid "system_lock: Lock a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1894
+msgid "usage: system_lock <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1935
+msgid "system_unlock: Unlock a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1936
+msgid "usage: system_unlock <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1977
+msgid "system_rename: Rename a system profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1978
+msgid "usage: system_rename OLDNAME NEWNAME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2023
+msgid "system_listcustomvalues: List the custom values for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2024
+msgid "usage: system_listcustomvalues <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2079
+msgid "system_addcustomvalue: Set a custom value for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2080
+msgid "usage: system_addcustomvalue KEY VALUE <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2134
+msgid "system_updatecustomvalue: Update a custom value for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2135
+msgid "usage: system_updatecustomvalue KEY VALUE <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2166
+msgid "system_removecustomvalues: Remove a custom value for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2167
+msgid "usage: system_removecustomvalues <SYSTEMS> <KEY ...>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2203
+msgid "Delete these values [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2221
+msgid "system_addnote: Set a note for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2222
+msgid ""
+"usage: system_addnote <SYSTEM> [options]\n"
+"\n"
+"options:\n"
+"  -s SUBJECT\n"
+"  -b BODY"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2257
+msgid "Subject of the Note:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2259
+msgid "Note Body (ctrl-D to finish):"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2263
+msgid "A subject is required"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2267
+msgid "A body is required"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2286
+msgid "system_deletenotes: Delete notes from a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2287
+msgid "usage: system_deletenotes <SYSTEM> <ID|*>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2319
+msgid "No notes to delete"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2346
+msgid "system_listnotes: List the available notes for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2347
+msgid "usage: system_listnotes <SYSTEM>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2405
+msgid "system_listfqdns: List the associated FQDNs for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2406
+msgid "usage: system_listfqdns <SYSTEM>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2458
+msgid "system_setbasechannel: Set a system's base software channel"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2459
+msgid "usage: system_setbasechannel <SYSTEMS> CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2506 ../src/spacecmd/system.py:2593
+#, python-format
+msgid "System:           %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2507 ../src/spacecmd/system.py:2594
+#, python-format
+msgid "Old Base Channel: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2508 ../src/spacecmd/system.py:2596
+#, python-format
+msgid "New Base Channel: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2527
+msgid ""
+"system_schedulechangechannels: Schedule changing a system's software channels"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2528
+msgid ""
+"usage: system_setbasechannel <SYSTEMS> [options]\n"
+"\n"
+"options:\n"
+"  -b BASE_CHANNEL base channel label\n"
+"  -c CHILD_CHANNEL child channel labels (allowed multiple times)\n"
+"  -s START_TIME time defaults to now"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2595
+#, python-format
+msgid "Old Child Channels: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2597
+#, python-format
+msgid "New Child channels %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2612 ../src/spacecmd/system.py:4243
+#, python-format
+msgid "Scheduled action id: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2619
+msgid "system_listbasechannel: List the base channel for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2620
+msgid "usage: system_listbasechannel <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2674
+msgid "system_listchildchannels: List the child channels for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2675
+msgid "usage: system_listchildchannels <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2729
+msgid "system_addchildchannels: Add child channels to a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2730
+msgid "usage: system_addchildchannels <SYSTEMS> <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2752
+msgid ""
+"system_listcrashedsystems: List all systems that have experienced a crash "
+"and reported by spacewalk-abrt"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2753
+msgid "usage: system_listcrashedsystems"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2759
+msgid "Count | System ID | Profile Name"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2773
+msgid "system_deletecrashes: Delete crashes reported by spacewalk-abrt."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2774
+msgid ""
+"usage: Delete all crashes for all systems    : system_deletecrashes [--"
+"verbose]"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2775
+msgid ""
+"usage: Delete all crashes for a single system: system_deletecrashes -i "
+"sys_id [--verbose]"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2776
+msgid ""
+"usage: Delete a single crash record          : system_deletecrashes -c "
+"crash_id [--verbose]"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2794
+#, python-format
+msgid "Deleting crash with id %s."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2801
+#, python-format
+msgid "Deleting all crashes from system with systemid %s [y/N]:"
+msgstr ""
+
+#. all systems
+#: ../src/spacecmd/system.py:2803
+msgid "Deleting all crashes from all systems [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2815
+#, python-format
+msgid "Deleting crash with id %s from system %s."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2824
+msgid "system_listcrashesbysystem: List all reported crashes for a system."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2825 ../src/spacecmd/system.py:2837
+msgid "usage: system_listcrashesbysystem -i sys_id"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2836
+msgid "# System id must be provided."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2842
+msgid "Crash ID | Crash Name"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2853
+msgid "system_getcrashfiles: Download all files for a crash record."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2854
+msgid "usage: system_getcrashfiles -c crash_id [--verbose]"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2855 ../src/spacecmd/system.py:2869
+msgid ""
+"usage: system_getcrashfiles -c crash_id [--dest_folder=/tmp/crash_files] [--"
+"verbose]"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2868
+msgid "# Crash id must be provided."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2895
+#, python-format
+msgid "# All files we downloaded to %s."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2904
+msgid "system_removechildchannels: Remove child channels from a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2905
+msgid "usage: system_removechildchannels <SYSTEMS> <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2927
+msgid "system_details: Show the details of a system profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2928
+msgid "usage: system_details <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2981
+#, python-format
+msgid "Name:          %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2982
+#, python-format
+msgid "System ID:     %i"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2985
+#, python-format
+msgid "UUID:          %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2987
+#, python-format
+msgid "Locked:        %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2988
+#, python-format
+msgid "Registered:    %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2989
+#, python-format
+msgid "Last Checkin:  %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2990
+#, python-format
+msgid "OSA Status:    %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2991
+#, python-format
+msgid "Last Boot:     %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2993
+#, python-format
+msgid "Contact Method:%s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3037
+#, python-format
+msgid "Hostname:      %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3038
+#, python-format
+msgid "IP Address:    %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3039
+#, python-format
+msgid "Kernel:        %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3080
+msgid "system_listerrata: List available errata for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3081
+msgid "usage: system_listerrata <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3135
+msgid "system_applyerrata: Apply errata to a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3136
+msgid ""
+"usage: system_applyerrata [options] <SYSTEMS>\n"
+"[ERRATA|search:XXX ...]\n"
+"\n"
+"options:\n"
+"  -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3197
+msgid "system_listevents: List the event history for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3198
+msgid "usage: system_listevents <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3244
+#, python-format
+msgid "Summary:   %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3246
+#, python-format
+msgid "Details:   %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3254
+msgid "system_listentitlements: List the entitlements for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3255
+msgid "usage: system_listentitlements <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3308
+msgid "system_addentitlements: Add entitlements to a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3309
+msgid "usage: system_addentitlements <SYSTEMS> ENTITLEMENT"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3364
+msgid "system_removeentitlement: Remove an entitlement from a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3365
+msgid "usage: system_removeentitlement <SYSTEMS> ENTITLEMENT"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3420
+msgid "system_listpackageprofiles: List all package profiles"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3421
+msgid "usage: system_listpackageprofiles"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3440
+msgid "system_deletepackageprofile: Delete a package profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3441
+msgid "usage: system_deletepackageprofile PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3465
+msgid "Delete this profile [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3476
+#, python-format
+msgid "%s is not a valid profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3487
+msgid "system_createpackageprofile: Create a package profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3488
+msgid ""
+"usage: system_createpackageprofile SYSTEM [options]\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -d DESCRIPTION"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3518
+msgid "Profile Label:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3522
+msgid "A profile name is required"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3526
+msgid "A profile description is required"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3534
+#, python-format
+msgid "Created package profile '%s'"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3542
+msgid ""
+"system_comparepackageprofile: Compare a system against a package profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3543
+msgid "usage: system_comparepackageprofile <SYSTEMS> PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3606
+msgid "system_comparepackages: Compare the packages between two systems"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3607
+msgid "usage: system_comparepackages SOME_SYSTEM ANOTHER_SYSTEM"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3638
+msgid "system_syncpackages: Sync packages between two systems"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3639
+msgid ""
+"usage: system_syncpackages SOURCE TARGET [options]\n"
+"\n"
+"options:\n"
+"    -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3687
+msgid "Sync packages [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3729
+#, python-format
+msgid "Failed to filter package list, package %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3730
+msgid "found with no arch or arch_label"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3772
+msgid "System Version"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3773
+msgid "Channel Version"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3795
+msgid "Channel_newer_than_system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3808
+msgid "System_newer_than_channel"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3817
+msgid "Missing_in_channel"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3821
+msgid "system_comparewithchannel: Compare the installed packages on a"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3822
+msgid "                           system with those in the channels it is"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3823
+msgid "                           registerd to, or optionally some other"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3824
+msgid "                           channel"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3825
+msgid "usage: system_comparewithchannel <SYSTEMS> [options]"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3827
+msgid "         -c/--channel : Specific channel to compare against,"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3828
+msgid "                        default is those subscribed to, including"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3829
+msgid "                        child channels"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3880
+msgid "Specified channel does not exist"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3891
+#, python-format
+msgid "system %s is not subscribed to any channel!"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3893
+msgid "Please subscribe to a channel, or specify achannel to compare with"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3927
+#, python-format
+msgid ""
+"\n"
+"System: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3953
+msgid ""
+"system_schedulehardwarerefresh: Schedule a hardware refresh for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3954
+msgid ""
+"usage: system_schedulehardwarerefresh <SYSTEMS> [options]\n"
+"\n"
+"options:\n"
+"  -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4016
+msgid ""
+"system_schedulepackagerefresh: Schedule a software package refresh for a "
+"system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4017
+msgid ""
+"usage: system_schedulepackagerefresh <SYSTEMS> [options])\n"
+"\n"
+"options:\n"
+"  -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4078
+msgid ""
+"system_show_packageversion: Shows version of installed package on given "
+"system(s)"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4079
+msgid "usage: system_show_packageversion <SYSTEM> <PACKAGE>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4111
+msgid "Package\tVersion\tRelease\tEpoch\tArch\tSystem"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4131
+msgid "system_setcontactmethod: Set the contact method for given system(s)."
+msgstr ""
+
+#: ../src/spacecmd/system.py:4133
+msgid "usage: system_setcontactmethod <SYSTEMS> <CONTACT_METHOD>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4182
+msgid ""
+"system_scheduleapplyconfigchannels: Schedule applying the assigned config "
+"channels to the System (Minion only)"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4183
+msgid ""
+"usage: scheduleapplyconfigchannels <SYSTEMS> [options]\n"
+"\n"
+"    options:\n"
+"        -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4234
+msgid "Schedule applying config channels to these systems [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4251
+msgid ""
+"system_listmigrationtargets: List possible migration targets for given "
+"systems."
+msgstr ""
+
+#: ../src/spacecmd/system.py:4252
+msgid "usage: system_listmigrationtargets <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4279
+msgid "WARN: Cannot find system "
+msgstr ""
+
+#: ../src/spacecmd/system.py:4286
+msgid "  No migration targets"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4289
+msgid "  Target #"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4290
+msgid "    IDs: "
+msgstr ""
+
+#: ../src/spacecmd/system.py:4291
+msgid "    Friendly names: "
+msgstr ""
+
+#: ../src/spacecmd/system.py:4297
+msgid ""
+"system_schedulespmigration: Schedule a Service Pack migration for systems."
+msgstr ""
+
+#: ../src/spacecmd/system.py:4298
+msgid ""
+"usage: system_schedulespmigration <SYSTEM> <BASE_CHANNEL_LABEL> "
+"<MIGRATION_TARGET> [options] \n"
+"    For MIGRATION_TARGET parameter see system_listmigrationtargets. \n"
+"    The MIGRATION_TARGET parameter must be passed in the following format: "
+"[3143,3146,3147,3145,3144,3148,3062]. \n"
+"    Options: \n"
+"        -s START_TIME \n"
+"        -d pass this flag, if you want to do a dry run \n"
+"        -c CHILD_CHANNELS (comma-separated child channels labels (with no "
+"spaces))"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4348
+msgid "Cannot find system "
+msgstr ""
+
+#: ../src/spacecmd/system.py:4348
+msgid ". Skipping it."
+msgstr ""
+
+#: ../src/spacecmd/system.py:4351
+msgid "Scheduling Service Pack migration for system "
+msgstr ""
+
+#: ../src/spacecmd/system.py:4356
+msgid "Scheduled action ID: "
+msgstr ""
+
+#: ../src/spacecmd/user.py:49
+msgid "user_create: Create an user"
+msgstr ""
+
+#: ../src/spacecmd/user.py:50
+msgid ""
+"usage: user_create [options])\n"
+"\n"
+"options:\n"
+"  -u USERNAME\n"
+"  -f FIRST_NAME\n"
+"  -l LAST_NAME\n"
+"  -e EMAIL\n"
+"  -p PASSWORD\n"
+"  --pam enable PAM authentication"
+msgstr ""
+
+#: ../src/spacecmd/user.py:119
+msgid "Note: password was ignored due to PAM mode"
+msgstr ""
+
+#: ../src/spacecmd/user.py:138
+msgid "user_delete: Delete an user"
+msgstr ""
+
+#: ../src/spacecmd/user.py:139
+msgid "usage: user_delete NAME"
+msgstr ""
+
+#: ../src/spacecmd/user.py:167
+msgid "user_disable: Disable an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:168
+msgid "usage: user_disable NAME"
+msgstr ""
+
+#: ../src/spacecmd/user.py:194
+msgid "user_enable: Enable an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:195
+msgid "usage: user_enable NAME"
+msgstr ""
+
+#: ../src/spacecmd/user.py:221
+msgid "user_list: List all users"
+msgstr ""
+
+#: ../src/spacecmd/user.py:222
+msgid "usage: user_list"
+msgstr ""
+
+#: ../src/spacecmd/user.py:239
+msgid "user_listavailableroles: List all available roles for users"
+msgstr ""
+
+#: ../src/spacecmd/user.py:240
+msgid "usage: user_listavailableroles"
+msgstr ""
+
+#: ../src/spacecmd/user.py:252
+msgid "No roles has been found"
+msgstr ""
+
+#: ../src/spacecmd/user.py:258
+msgid "user_addrole: Add a role to an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:259
+msgid "usage: user_addrole USER ROLE"
+msgstr ""
+
+#: ../src/spacecmd/user.py:292
+msgid "user_removerole: Remove a role from an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:293
+msgid "usage: user_removerole USER ROLE"
+msgstr ""
+
+#: ../src/spacecmd/user.py:327
+msgid "user_details: Show the details of an user"
+msgstr ""
+
+#: ../src/spacecmd/user.py:328
+msgid "usage: user_details USER ..."
+msgstr ""
+
+#: ../src/spacecmd/user.py:360
+#, python-format
+msgid "%s is not a valid user"
+msgstr ""
+
+#: ../src/spacecmd/user.py:361
+msgid "Error '{}' while getting data about user '{}': {}"
+msgstr ""
+
+#: ../src/spacecmd/user.py:371
+#, python-format
+msgid "Username:      %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:372
+#, python-format
+msgid "First Name:    %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:373
+#, python-format
+msgid "Last Name:     %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:374
+#, python-format
+msgid "Email Address: %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:375
+#, python-format
+msgid "Organisation:  %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:376
+#, python-format
+msgid "Last Login:    %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:377
+#, python-format
+msgid "Created:       %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:378
+#, python-format
+msgid "Enabled:       %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:382
+msgid "Roles"
+msgstr ""
+
+#: ../src/spacecmd/user.py:388
+msgid "Assigned Groups"
+msgstr ""
+
+#: ../src/spacecmd/user.py:394
+msgid "Default Groups"
+msgstr ""
+
+#: ../src/spacecmd/user.py:404
+msgid "user_addgroup: Add a group to an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:405
+msgid "usage: user_addgroup USER <GROUP ...>"
+msgstr ""
+
+#: ../src/spacecmd/user.py:442
+msgid "user_adddefaultgroup: Add a default group to an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:443
+msgid "usage: user_adddefaultgroup USER <GROUP ...>"
+msgstr ""
+
+#: ../src/spacecmd/user.py:479
+msgid "user_removegroup: Remove a group to an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:480
+msgid "usage: user_removegroup USER <GROUP ...>"
+msgstr ""
+
+#: ../src/spacecmd/user.py:520
+msgid "user_removedefaultgroup: Remove a default group from an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:522
+msgid "usage: user_removedefaultgroup USER <GROUP ...>"
+msgstr ""
+
+#: ../src/spacecmd/user.py:561
+msgid "user_setfirstname: Set an user accounts first name field"
+msgstr ""
+
+#: ../src/spacecmd/user.py:562
+msgid "usage: user_setfirstname USER FIRST_NAME"
+msgstr ""
+
+#: ../src/spacecmd/user.py:596
+msgid "user_setlastname: Set an user accounts last name field"
+msgstr ""
+
+#: ../src/spacecmd/user.py:597
+msgid "usage: user_setlastname USER LAST_NAME"
+msgstr ""
+
+#: ../src/spacecmd/user.py:631
+msgid "user_setemail: Set an user accounts email field"
+msgstr ""
+
+#: ../src/spacecmd/user.py:632
+msgid "usage: user_setemail USER EMAIL"
+msgstr ""
+
+#: ../src/spacecmd/user.py:666
+msgid "user_setprefix: Set an user accounts name prefix field"
+msgstr ""
+
+#: ../src/spacecmd/user.py:667
+msgid "usage: user_setprefix USER PREFIX"
+msgstr ""
+
+#: ../src/spacecmd/user.py:706
+msgid "user_setpassword: Set an user accounts name prefix field"
+msgstr ""
+
+#: ../src/spacecmd/user.py:707
+msgid "usage: user_setpassword USER PASSWORD"
+msgstr ""
+
+#. If cache generation is interrupted (e.g by ctrl-c) you can end up
+#. with an EOFError exception due to the partial picked file
+#. So we catch this error and remove the corrupt partial file
+#. If you don't do this then spacecmd will fail with an unhandled
+#. exception until the partial file is manually removed
+#: ../src/spacecmd/utils.py:133
+#, python-format
+msgid "Loading cache file %s failed"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:134
+#, python-format
+msgid "Cache generation was probably interrupted,removing corrupt %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:139
+#, python-format
+msgid "Couldn't load cache from %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:160
+#, python-format
+msgid "Couldn't write to %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:205
+msgid "Could not open the temporary file"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:225
+#, python-format
+msgid "Editor \"%s\" exited with code %i"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:227
+#, python-format
+msgid "General failure running editor: %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:230
+msgid "No editors found"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:367
+msgid "Invalid time provided"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:463
+msgid "Security Errata"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:472
+msgid "Bug Fix Errata"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:481
+msgid "Enhancement Errata"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:491
+msgid "Current Selections"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:501
+msgid "Available Configuration Channels"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:507 ../src/spacecmd/utils.py:527
+msgid "Channel:"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:510 ../src/spacecmd/utils.py:530
+msgid "Invalid channel"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:514
+msgid "New Rank:"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:521 ../src/spacecmd/utils.py:524
+msgid "Invalid rank"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:535
+msgid "Clearing current selections"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:690
+msgid "Could not generate json data object!"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:697
+#, python-format
+msgid "Could not open file %s for writing: %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:708
+#, python-format
+msgid "Could not open file %s for reading: %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:710
+#, python-format
+msgid "Could not parse JSON data from %s: %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:712
+#, python-format
+msgid "Error processing file %s: %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:740
+msgid "Skipping usage of common strings: both strings are equal"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:756
+msgid "Skipping usage of common strings: number of substrings differ"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:842
+msgid "Parameter {} not a string type, but {}."
+msgstr ""
+
+#: ../src/bin/spacecmd:74
+msgid "Unhandled exception occurred while getting FQDN:"
+msgstr ""

--- a/spacecmd/po/spacecmd.pot
+++ b/spacecmd/po/spacecmd.pot
@@ -1,0 +1,7456 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#: ../src/bin/spacecmd:59
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-09-24 17:29+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../src/spacecmd/activationkey.py:49
+msgid "activationkey_addpackages: Add packages to an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:50
+msgid "usage: activationkey_addpackages KEY <PACKAGE ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:83
+msgid "activationkey_removepackages: Remove packages from an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:85
+msgid "usage: activationkey_removepackages KEY <PACKAGE ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:121
+msgid "activationkey_addgroups: Add groups to an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:122
+msgid "usage: activationkey_addgroups KEY <GROUP ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:160
+msgid "activationkey_removegroups: Remove groups from an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:161
+msgid "usage: activationkey_removegroups KEY <GROUP ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:208
+msgid "activationkey_addentitlements: Add entitlements to an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:210
+msgid "usage: activationkey_addentitlements KEY <ENTITLEMENT ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:245
+msgid ""
+"activationkey_removeentitlements: Remove entitlements from an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:247
+msgid "usage: activationkey_removeentitlements KEY <ENTITLEMENT ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:285
+msgid "activationkey_addchildchannels: Add child channels to an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:287
+msgid "usage: activationkey_addchildchannels KEY <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:337
+msgid ""
+"activationkey_removechildchannels: Remove child channels from an activation "
+"key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:339
+msgid "usage: activationkey_removechildchannels KEY <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:376
+msgid ""
+"activationkey_listchildchannels: List the child channels for an activation "
+"key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:378
+msgid "usage: activationkey_listchildchannels KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:407
+msgid ""
+"activationkey_listbasechannel: List the base channels for an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:409
+msgid "usage: activationkey_listbasechannel KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:437
+msgid "activationkey_listgroups: List the groups for an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:439
+msgid "usage: activationkey_listgroups KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:470
+msgid ""
+"activationkey_listentitlements: List the entitlements for an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:472
+msgid "usage: activationkey_listentitlements KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:501
+msgid "activationkey_listpackages: List the packages for an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:503
+msgid "usage: activationkey_listpackages KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:535
+msgid ""
+"activationkey_listconfigchannels: List the configuration channels for an "
+"activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:537
+msgid "usage: activationkey_listconfigchannels KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:570
+msgid ""
+"activationkey_addconfigchannels: Add config channels to an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:572
+msgid ""
+"usage: activationkey_addconfigchannels KEY <CHANNEL ...> [options])\n"
+"\n"
+"options:\n"
+"  -t add channels to the top of the list\n"
+"  -b add channels to the bottom of the list"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:625
+msgid ""
+"activationkey_removeconfigchannels: Remove config channels from an "
+"activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:627
+msgid "usage: activationkey_removeconfigchannels KEY <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:666
+msgid ""
+"activationkey_setconfigchannelorder: Set the ranked order of configuration "
+"channels"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:668
+msgid "usage: activationkey_setconfigchannelorder KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:698
+msgid "New Configuration Channels:"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:712
+msgid "activationkey_create: Create an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:713
+msgid ""
+"usage: activationkey_create [options])\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -d DESCRIPTION\n"
+"  -b BASE_CHANNEL\n"
+"  -u set key as universal default\n"
+"  -e [enterprise_entitled,virtualization_host]"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:734
+msgid "Name (blank to autogenerate):"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:735
+msgid "Description [None]:"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:738 ../src/spacecmd/distribution.py:78
+#: ../src/spacecmd/softwarechannel.py:927
+msgid "Base Channels"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:743
+msgid "Base Channel (blank for default):"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:751
+#, python-format
+msgid "%s Entitlement [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:755
+msgid "Universal Default [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:782
+#, python-format
+msgid "Created activation key %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:790
+msgid "activationkey_delete: Delete an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:791
+msgid "usage: activationkey_delete KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:813 ../src/spacecmd/cryptokey.py:139
+#: ../src/spacecmd/cryptokey.py:197
+#, python-format
+msgid "No keys matched argument %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:819
+msgid "Delete activation key(s) [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:832
+msgid "activationkey_list: List all activation keys"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:833
+msgid "usage: activationkey_list"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:857
+msgid "activationkey_listsystems: List systems registered with a key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:858
+msgid "usage: activationkey_listsystems KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:881 ../src/spacecmd/activationkey.py:930
+#, python-format
+msgid "%s is not a valid activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:895
+msgid "activationkey_details: Show the details of an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:896
+msgid "usage: activationkey_details KEY ..."
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:943
+#, python-format
+msgid "Key:                    %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:944
+#, python-format
+msgid "Description:            %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:945
+#, python-format
+msgid "Universal Default:      %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:946
+#, python-format
+msgid "Usage Limit:            %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:947
+#, python-format
+msgid "Deploy Config Channels: %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:949
+#, python-format
+msgid "Contact Method:         %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:952 ../src/spacecmd/kickstart.py:425
+#: ../src/spacecmd/system.py:3048
+msgid "Software Channels"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:960 ../src/spacecmd/configchannel.py:765
+#: ../src/spacecmd/configchannel.py:870 ../src/spacecmd/system.py:3057
+msgid "Configuration Channels"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:966 ../src/spacecmd/system.py:3062
+msgid "Entitlements"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:971 ../src/spacecmd/system.py:3068
+msgid "System Groups"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:976 ../src/spacecmd/package.py:206
+#: ../src/spacecmd/package.py:263 ../src/spacecmd/softwarechannel.py:1392
+#: ../src/spacecmd/softwarechannel.py:1494
+#: ../src/spacecmd/softwarechannel.py:1576
+#: ../src/spacecmd/softwarechannel.py:1822
+msgid "Packages"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:991
+msgid "activationkey_enableconfigdeployment: Enable config channel deployment"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:993
+msgid "usage: activationkey_enableconfigdeployment KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1020
+msgid ""
+"activationkey_disableconfigdeployment: Disable config channel deployment"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1022
+msgid "usage: activationkey_disableconfigdeployment KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1049
+msgid "activationkey_setbasechannel: Set the base channel of an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1051
+msgid "usage: activationkey_setbasechannel KEY CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1098
+msgid ""
+"activationkey_setusagelimit: Set the usage limit of an activation key, can "
+"be a number or \"unlimited\""
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1100
+msgid "usage: activationkey_setusagelimit KEY <usage limit>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1101
+msgid "usage: activationkey_setusagelimit KEY unlimited "
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1131
+#, python-format
+msgid "Couldn't convert argument %s to an integer"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1153
+msgid ""
+"activationkey_setuniversaldefault: Set this key as the universal default"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1155
+msgid "usage: activationkey_setuniversaldefault KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1196
+msgid "activationkey_export: Export activation key(s) to JSON format file"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1197
+msgid ""
+"usage: activationkey_export [options] [<KEY> ...])\n"
+"\n"
+"options:\n"
+"    -f outfile.json : specify an output filename, defaults to <KEY>.json\n"
+"                      if exporting a single key, akeys.json for multiple "
+"keys,\n"
+"                      or akey_all.json if no KEY specified (export ALL)\n"
+"\n"
+"Note : KEY list is optional, default is to export ALL keys "
+msgstr ""
+
+#. Get the key details
+#: ../src/spacecmd/activationkey.py:1213
+#, python-format
+msgid "Getting activation key details for %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1267
+#, python-format
+msgid "Exporting ALL activation keys to %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1276
+msgid "Invalid activation key passed"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1291
+#, python-format
+msgid "Exporting key %s to %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1300
+#, python-format
+msgid "File %s exists, confirm overwrite file? (y/n)"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1305
+msgid "Failed to save exported keys to file: {}"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1314
+msgid "activationkey_import: import activation key(s) from JSON file(s)"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1315
+msgid "usage: activationkey_import <JSONFILE ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1324
+msgid "No filename passed"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1333
+#, python-format
+msgid "Could not read json data from %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1338 ../src/spacecmd/activationkey.py:1382
+#, python-format
+msgid "Failed to import key %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1352
+#, python-format
+msgid "%s already exists! Skipping!"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1407
+#, python-format
+msgid "System group %s doesn't exist, creating"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1428
+msgid "activationkey_clone: Clone an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1429
+msgid ""
+"usage examples:\n"
+"                 activationkey_clone foo_key -c bar_key\n"
+"                 activationkey_clone foo_key1 foo_key2 -c prefix\n"
+"                 activationkey_clone foo_key -x \"s/foo/bar\"\n"
+"                 activationkey_clone foo_key1 foo_key2 -x \"s/foo/bar\"\n"
+"\n"
+"options:\n"
+"  -c CLONE_NAME  : Name of the resulting key, treated as a prefix for "
+"multiple\n"
+"                   keys\n"
+"  -x \"s/foo/bar\" : Optional regex replacement, replaces foo with bar in "
+"the\n"
+"                   clone description, base-channel label, child-channel\n"
+"                   labels, config-channel names "
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1457 ../src/spacecmd/kickstart.py:460
+#: ../src/spacecmd/system.py:3043
+msgid "Activation Keys"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1463
+#, python-format
+msgid "Key to clone: %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1467
+msgid "Original Key:"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1469
+msgid "Cloned Key:"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1472 ../src/spacecmd/configchannel.py:1376
+msgid "Error - must specify either -c or -x options!"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1477
+#, python-format
+msgid "Key %s already exists"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1481
+msgid "Error no activationkey to clone passed!"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1535
+#, python-format
+msgid "Found child channel %s key %s, %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1537
+msgid " does not exist, skipping!"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1544
+#, python-format
+msgid "Regex-replacement results in new base-channel %s which does not exist!"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1560
+#, python-format
+msgid "Found config channel %s for key %s, %s "
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1562
+msgid "does not exist, skipping!"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1584 ../src/spacecmd/configchannel.py:1428
+#, python-format
+msgid "Failed to clone %s to %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1602
+msgid "no activationkey label given"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1605
+msgid "invalid activationkey label "
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1622
+msgid "activationkey_diff: Diff activation keys"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1624
+msgid "usage: activationkey_diff SOURCE_KEY TARGET_KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1673
+msgid "activationkey_disable: Disable an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1675
+msgid "usage: activationkey_disable KEY [KEY ...]"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1707
+msgid "activationkey_enable: Enable an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1709
+msgid "usage: activationkey_enable KEY [KEY ...]"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1741
+msgid "activationkey_setdescription: Set the activation key description"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1743
+msgid "usage: activationkey_setdescription KEY DESCRIPTION"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1775
+msgid ""
+"activationkey_setcontactmethod: Set the contact method to use for systems "
+"registered with this key."
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1777 ../src/spacecmd/system.py:4132
+msgid "Available contact methods: "
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1778
+msgid "usage: activationkey_setcontactmethod KEY CONTACT_METHOD"
+msgstr ""
+
+#: ../src/spacecmd/api.py:44
+msgid "api: call RHN API with arguments directly"
+msgstr ""
+
+#: ../src/spacecmd/api.py:45
+#, python-format
+msgid ""
+"usage: api [options] API_STRING)\n"
+"\n"
+"options:\n"
+"  -A, --args  Arguments for the API other than session id in comma "
+"separated\n"
+"              strings or JSON expression\n"
+"  -F, --format   Output format\n"
+"  -o, --output   Output file\n"
+"\n"
+"examples:\n"
+"  api api.getApiCallList\n"
+"  api --args \"sysgroup_A\" systemgroup.listSystems\n"
+"  api -A \"rhel-i386-server-5,2011-04-01,2011-05-01\" -F \"%(name)s\" \\\n"
+"      channel.software.listAllPackages\n"
+msgstr ""
+
+#: ../src/spacecmd/api.py:81
+msgid "Could not open to write: "
+msgstr ""
+
+#: ../src/spacecmd/api.py:82
+msgid "Fallback output to stdout"
+msgstr ""
+
+#: ../src/spacecmd/api.py:91
+msgid "No such API: "
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:50
+msgid "configchannel_list: List all configuration channels"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:51
+msgid "usage: configchannel_list"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:68
+msgid "configchannel_listsystems: List the systems subscribed to a"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:69
+msgid "                           configuration channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:70
+msgid "usage: configchannel_listsystems CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:79
+msgid "This version of the API doesn't support this method"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:103
+msgid "configchannel_listfiles: List the files in a config channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:104
+msgid "usage: configchannel_listfiles CHANNEL ..."
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:133
+msgid "configchannel_forcedeploy: Forces a redeployment"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:134
+msgid "                           of files within this channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:135
+msgid "                           on all subscribed systems"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:136
+msgid "usage: configchannel_forcedeploy CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:158
+msgid "No files within selected configchannel."
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:164
+msgid "Channel has no subscribed Systems"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:167
+msgid "Force deployment of the following configfiles:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:170
+msgid ""
+"\n"
+"On these systems:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:173
+msgid "Really force deployment [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:182
+msgid "configchannel_filedetails: Show the details of a file"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:183
+msgid "in a configuration channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:184
+msgid "usage: configchannel_filedetails CHANNEL FILE [REVISION]"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:216
+#, python-format
+msgid "Invalid revision: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:222
+#, python-format
+msgid "%s is not in this configuration channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:240
+#, python-format
+msgid "Path:     %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:241
+#, python-format
+msgid "Type:     %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:242
+#, python-format
+msgid "Revision: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:243
+#, python-format
+msgid "Created:  %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:244
+#, python-format
+msgid "Modified: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:248 ../src/spacecmd/configchannel.py:650
+#, python-format
+msgid "Target Path:     %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:251 ../src/spacecmd/configchannel.py:680
+#, python-format
+msgid "Owner:           %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:252 ../src/spacecmd/configchannel.py:681
+#, python-format
+msgid "Group:           %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:253 ../src/spacecmd/configchannel.py:682
+#, python-format
+msgid "Mode:            %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:255 ../src/spacecmd/configchannel.py:651
+#: ../src/spacecmd/configchannel.py:684
+#, python-format
+msgid "SELinux Context: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:258
+#, python-format
+msgid "SHA256:          %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:259 ../src/spacecmd/configchannel.py:683
+#, python-format
+msgid "Binary:          %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:263 ../src/spacecmd/configchannel.py:696
+#: ../src/spacecmd/configchannel.py:933 ../src/spacecmd/kickstart.py:1903
+#: ../src/spacecmd/snippet.py:161
+msgid "Contents"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:273
+msgid "configchannel_backup: backup a config channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:274
+msgid ""
+"usage: configchannel_backup CHANNEL [OUTDIR])\n"
+"\n"
+"OUTDIR defaults to $HOME/spacecmd-backup/configchannel/YYYY-MM-DD/CHANNEL\n"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:313 ../src/spacecmd/group.py:266
+#, python-format
+msgid "Could not create output directory: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:326
+#, python-format
+msgid "Could not create \"%s\" file: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:332
+#, python-format
+msgid "Output Path:   %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:371
+msgid "configchannel_details: Show the details of a config channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:372
+msgid "usage: configchannel_details CHANNEL ..."
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:402 ../src/spacecmd/kickstart.py:414
+#, python-format
+msgid "Label:       %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:403 ../src/spacecmd/kickstart.py:413
+#, python-format
+msgid "Name:        %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:404 ../src/spacecmd/cryptokey.py:214
+#: ../src/spacecmd/system.py:678
+#, python-format
+msgid "Description: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:405 ../src/spacecmd/cryptokey.py:215
+#: ../src/spacecmd/kickstart.py:500 ../src/spacecmd/kickstart.py:1899
+#, python-format
+msgid "Type:        %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:408
+msgid "Files"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:418
+msgid "configchannel_create: Create a configuration channel of specific type"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:419
+msgid ""
+"usage: configchannel_create [options])\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -l LABEL\n"
+"  -d DESCRIPTION\n"
+"  -t TYPE('normal,'state')"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:438 ../src/spacecmd/custominfo.py:54
+#: ../src/spacecmd/custominfo.py:198 ../src/spacecmd/distribution.py:71
+#: ../src/spacecmd/filepreservation.py:70 ../src/spacecmd/group.py:177
+#: ../src/spacecmd/repo.py:349 ../src/spacecmd/repo.py:461
+#: ../src/spacecmd/softwarechannel.py:800
+msgid "Name:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:439
+msgid "Label:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:440 ../src/spacecmd/cryptokey.py:66
+#: ../src/spacecmd/custominfo.py:59 ../src/spacecmd/custominfo.py:203
+#: ../src/spacecmd/group.py:182 ../src/spacecmd/softwarechannel.py:812
+#: ../src/spacecmd/system.py:3519
+msgid "Description:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:441
+msgid "Type [normal, state]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:448
+msgid "Only [normal/state] values are acceptable for type"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:452 ../src/spacecmd/distribution.py:109
+#: ../src/spacecmd/repo.py:357 ../src/spacecmd/repo.py:467
+msgid "A name is required"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:461
+msgid "Only [normal/state] values are acceptable for --type parameter"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:476
+msgid "configchannel_delete: Delete a configuration channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:477
+msgid "usage: configchannel_delete CHANNEL ..."
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:498
+#, python-format
+msgid "No channels matched argument(s): %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:504 ../src/spacecmd/softwarechannel.py:736
+msgid "Delete these channels [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:548
+msgid "Symlink [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:552
+msgid "Target Path:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:553
+msgid "SELinux Context [none]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:561
+msgid "Directory [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:570
+#, python-format
+msgid "Owner [%s]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:571
+#, python-format
+msgid "Group [%s]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:572
+#, python-format
+msgid "Mode [%s]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:574
+#, python-format
+msgid "SELinux Context [%s]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:575
+msgid "Revision [next]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:593
+msgid "The revision must be an integer"
+msgstr ""
+
+#. get the contents of the script
+#: ../src/spacecmd/configchannel.py:596 ../src/spacecmd/configchannel.py:896
+#: ../src/spacecmd/cryptokey.py:68 ../src/spacecmd/kickstart.py:1954
+#: ../src/spacecmd/snippet.py:141
+msgid "Read an existing file [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:598 ../src/spacecmd/kickstart.py:1956
+msgid "File:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:616
+msgid "The path is required"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:630 ../src/spacecmd/configchannel.py:913
+msgid "You must provide the file contents"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:634
+msgid "You must provide the target path for a symlink"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:649 ../src/spacecmd/configchannel.py:678
+#, python-format
+msgid "Path:            %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:679
+#, python-format
+msgid "Directory:       %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:689
+#, python-format
+msgid "Revision:        %i"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:694
+msgid "Contents not displayed (base64 encoded)"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:707
+msgid ""
+"configchannel_addfile/configchannel_updatefile: Create a configuration file"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:708
+msgid ""
+"usage: configchannel_addfile/configchannel_updatefile -c CHANNEL - p PATH -f "
+"LOCAL_FILE_PATH [OPTIONS])\n"
+"\n"
+"options:\n"
+"  -c CHANNEL\n"
+"  -p PATH\n"
+"  -r REVISION\n"
+"  -o OWNER [default: root]\n"
+"  -g GROUP [default: root]\n"
+"  -m MODE [defualt: 0644]\n"
+"  -x SELINUX_CONTEXT\n"
+"  -d path is a directory\n"
+"  -s path is a symlink\n"
+"  -b path is a binary (or other file which needs base64 encoding)\n"
+"  -t SYMLINK_TARGET\n"
+"  -f local path to file contents\n"
+"  -y automatically proceed with file contents\n"
+"\n"
+"  Note re binary/base64: Some text files, notably those containing trailing\n"
+"  newlines, those containing ASCII escape characters (or other charaters "
+"not\n"
+"  allowed in XML) need to be sent as binary (-b).  Some effort is made to "
+"auto-\n"
+"  detect files which require this, but you may need to explicitly specify.\n"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:770 ../src/spacecmd/softwarechannel.py:819
+#: ../src/spacecmd/softwarechannel.py:940
+#: ../src/spacecmd/softwarechannel.py:947
+msgid "Select:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:778 ../src/spacecmd/softwarechannel.py:1374
+#, python-format
+msgid "%s is not a valid channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:783
+msgid "Unable to obtain a valid channel. Aborting."
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:789 ../src/spacecmd/scap.py:160
+msgid "Path:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:805 ../src/spacecmd/configchannel.py:924
+msgid "No config channel specified!"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:810 ../src/spacecmd/configchannel.py:929
+msgid "Error obtaining file info"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:845
+msgid "configchannel_updateinitsls: Update init.sls file"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:846
+msgid ""
+"usage: configchannel_updateinitsls -c CHANNEL -f LOCAL_FILE_PATH [OPTIONS])\n"
+"\n"
+"options:\n"
+"  -c CHANNEL\n"
+"  -f local path to file contents\n"
+"  -y automatically proceed with file contents\n"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:892
+#, python-format
+msgid "No existing file information found for %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:932
+#, python-format
+msgid "contents_enc64:           %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:959
+msgid "configchannel_removefiles: Remove configuration files"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:960
+msgid "usage: configchannel_removefiles CHANNEL <FILE ...>"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:997
+msgid "configchannel_verifyfile: Verify a configuration file"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:998
+msgid "usage: configchannel_verifyfile CHANNEL FILE <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1037
+msgid "No valid system selected"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1045 ../src/spacecmd/system.py:509
+#: ../src/spacecmd/system.py:529 ../src/spacecmd/system.py:959
+#, python-format
+msgid "Action ID: %i"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1053
+msgid "configchannel_export: export config channel(s) to json format file"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1054
+msgid ""
+"usage: configchannel_export <CHANNEL>... [options])\n"
+"options:\n"
+"    -f outfile.json : specify an output filename, defaults to <CHANNEL>."
+"json\n"
+"                      if exporting a single channel, ccs.json for multiple\n"
+"                      channels, or cc_all.json if no CHANNEL specified\n"
+"                      e.g (export ALL)\n"
+"\n"
+"Note : CHANNEL list is optional, default is to export ALL"
+msgstr ""
+
+#. Get the cc details
+#: ../src/spacecmd/configchannel.py:1070
+#, python-format
+msgid "Getting config channel details for %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1090
+#, python-format
+msgid "Failed to get details for file %s from %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1136
+#, python-format
+msgid "File %s could not be exported "
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1137
+msgid "with this API version(needs base64 encoding)"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1139
+#, python-format
+msgid "File %s could not be exported as"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1140
+msgid " text...getting base64 encoded version"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1163
+#, python-format
+msgid "Passed filename '%s' to do_configchannel_export command."
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1171
+#, python-format
+msgid "Exporting ALL config channels to %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1178
+msgid ""
+"Error, no valid config channel passed, check name is  correct with spacecmd "
+"configchannel_list"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1193
+#, python-format
+msgid "Exporting cc %s to %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1200
+msgid "File '{}' exists, confirm overwrite file? (y/n)"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1203
+#, python-format
+msgid "Error saving exported config channels to file: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1212
+msgid "configchannel_import: import config channel(s) from json file"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1213
+msgid "usage: configchannel_import <JSONFILES...>"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1222 ../src/spacecmd/kickstart.py:2330
+msgid "Error, no filename passed"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1230 ../src/spacecmd/kickstart.py:2338
+#, python-format
+msgid "Error, could not read json data from %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1234
+#, python-format
+msgid "Error importing configchannel %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1246
+#, python-format
+msgid "Config channel %s already exists! Skipping!"
+msgstr ""
+
+#. create the cc, we need to drop the org prefix from the cc name
+#: ../src/spacecmd/configchannel.py:1251
+#, python-format
+msgid "Importing config channel  %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1294
+#, python-format
+msgid "Failed trying to import file %s (empty content)"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1296
+msgid "Older APIs can't export encoded files"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1319
+#, python-format
+msgid "Error adding file %s to %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1329
+msgid "configchannel_clone: Clone config channel(s)"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1330
+msgid ""
+"usage examples:\n"
+"                 configchannel_clone foo_label -c bar_label\n"
+"                 configchannel_clone foo_label1 foo_label2 -c prefix\n"
+"                 configchannel_clone foo_label -x \"s/foo/bar\"\n"
+"                 configchannel_clone foo_label1 foo_label2 -x \"s/foo/bar\"\n"
+"\n"
+"options:\n"
+"  -c CLONE_LABEL : name/label of the resulting cc (note does not update\n"
+"                   description, see -x option), treated as a prefix if\n"
+"                   multiple keys are passed\n"
+"  -x \"s/foo/bar\" : Optional regex replacement, replaces foo with bar in "
+"the\n"
+"                   clone name, label and description\n"
+"  Note : If no -c or -x option is specified, interactive is assumed"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1359
+msgid "No config channels found"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1362
+msgid "Config Channels"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1368
+#, python-format
+msgid "Channel to clone: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1372
+msgid "Channel to clone:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1373
+msgid "Clone label:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1382
+msgid "Error no channel label passed!"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1391
+msgid "No suitable channels to clone has been found."
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1444
+msgid "no configchannel given"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1447
+msgid "invalid configchannel label "
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1473
+msgid "configchannel_diff: diff between config channels"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1475
+msgid "usage: configchannel_diff SOURCE_CHANNEL TARGET_CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1524
+msgid "configchannel_sync:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1525
+msgid "sync config files between two config channels"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1527
+msgid "usage: configchannel_sync SOURCE_CHANNEL TARGET_CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1565
+msgid "syncing files from configchannel "
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1572
+msgid "files common in both channels:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1578
+msgid "files only in source "
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1584
+msgid "files only in target "
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1589
+msgid ""
+"files that are in both channels will be overwritten in the target channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1591
+msgid "files only in the source channel will be added to the target channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1593
+msgid "files only in the target channel will be deleted"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1596
+msgid "nothing to do"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1600
+msgid "perform synchronisation [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1652
+msgid "unknown file type "
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:43
+msgid "cryptokey_create: Create a cryptographic key"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:44
+msgid ""
+"usage: cryptokey_create [options])\n"
+"\n"
+"options:\n"
+"  -t GPG or SSL\n"
+"  -d DESCRIPTION\n"
+"  -f KEY_FILE"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:62
+msgid "GPG or SSL [G/S]:"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:75
+msgid "The key type is required"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:79
+msgid "A description is required"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:83
+msgid "A file containing the key is required"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:91
+msgid "No contents of the file"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:100
+msgid "Invalid key type"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:114
+msgid "cryptokey_delete: Delete a cryptographic key"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:115
+msgid "usage: cryptokey_delete NAME"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:145
+msgid "Delete key(s) [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:156
+msgid "cryptokey_list: List all cryptographic keys (SSL, GPG)"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:157
+msgid "usage: cryptokey_list"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:174
+msgid "cryptokey_details: Show the contents of a cryptographic key"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:175
+msgid "usage: cryptokey_details KEY ..."
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:207
+#, python-format
+msgid "%s is not a valid crypto key"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:39
+msgid "custominfo_createkey: Create a custom key"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:40
+msgid "usage: custominfo_createkey [NAME] [DESCRIPTION]"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:73
+msgid "custominfo_deletekey: Delete a custom key"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:74
+msgid "usage: custominfo_deletekey KEY ..."
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:114
+msgid "custominfo_listkeys: List all custom keys"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:115
+msgid "usage: custominfo_listkeys"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:132
+msgid "custominfo_details: Show the details of a custom key"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:133
+msgid "usage: custominfo_details KEY ..."
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:155
+msgid "No keys matched argument '{}'."
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:172
+#, python-format
+msgid "Label:        %s"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:173
+#, python-format
+msgid "Description:  %s"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:174
+#, python-format
+msgid "Modified:     %s"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:175
+#, python-format
+msgid "System Count: %i"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:183
+msgid "custominfo_updatekey: Update a custom key"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:184
+msgid "usage: custominfo_updatekey [NAME] [DESCRIPTION]"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:42
+msgid "distribution_create: Create a Kickstart tree"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:43
+msgid ""
+"usage: distribution_create [options]\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -p path to tree\n"
+"  -b base channel to associate with\n"
+"  -t install type [fedora|rhel_4/5/6|generic_rpm]"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:66
+msgid "The name of the distribution is required"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:73
+msgid "Path to Kickstart Tree:"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:83
+msgid "Base Channel:"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:86
+msgid "Invalid channel label"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:97
+msgid "Install Types"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:102
+msgid "Install Type:"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:105
+msgid "Invalid install type"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:113
+msgid "A path is required"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:117 ../src/spacecmd/system.py:2556
+msgid "A base channel is required"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:121
+msgid "An install type is required"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:143
+msgid "distribution_list: List the available autoinstall trees"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:144
+msgid "usage: distribution_list"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:168
+msgid "distribution_delete: Delete a Kickstart tree"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:169
+msgid "usage: distribution_delete LABEL"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:193 ../src/spacecmd/distribution.py:232
+#, python-format
+msgid "No distributions matched argument %s"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:199
+msgid "Delete distribution tree(s) [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:209
+msgid "distribution_details: Show the details of a Kickstart tree"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:210
+msgid "usage: distribution_details LABEL"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:248 ../src/spacecmd/package.py:93
+#, python-format
+msgid "Name:    %s"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:249 ../src/spacecmd/package.py:100
+#, python-format
+msgid "Path:    %s"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:250
+#, python-format
+msgid "Channel: %s"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:258
+msgid "distribution_rename: Rename a Kickstart tree"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:259
+msgid "usage: distribution_rename OLDNAME NEWNAME"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:288
+msgid "distribution_update: Update the path of a Kickstart tree"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:289
+msgid ""
+"usage: distribution_update NAME [options]\n"
+"\n"
+"options:\n"
+"  -p path to tree\n"
+"  -b base channel to associate with\n"
+"  -t install type [fedora|rhel_4/5/6|generic_rpm]"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:49
+msgid "errata_list: List all patches"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:50
+msgid "usage: errata_list"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:66
+msgid "errata_summary: Print a summary of all errata"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:67
+msgid "usage: errata_summary"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:82
+msgid "errata_apply: Apply an erratum to all affected systems"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:83
+msgid ""
+"usage: errata_apply [options] ERRATA|search:XXX ...)\n"
+"\n"
+"options:\n"
+"  -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:110 ../src/spacecmd/system.py:417
+#: ../src/spacecmd/system.py:725 ../src/spacecmd/system.py:880
+#: ../src/spacecmd/system.py:1015 ../src/spacecmd/system.py:1762
+#: ../src/spacecmd/system.py:3673 ../src/spacecmd/system.py:3983
+#: ../src/spacecmd/system.py:4045 ../src/spacecmd/system.py:4209
+msgid "Start Time [now]:"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:158
+msgid "No patches to apply"
+msgstr ""
+
+#. a summary of which errata we're going to apply
+#: ../src/spacecmd/errata.py:162
+msgid "Errata             Systems"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:166 ../src/spacecmd/system.py:230
+#: ../src/spacecmd/system.py:467 ../src/spacecmd/system.py:820
+#: ../src/spacecmd/system.py:942 ../src/spacecmd/system.py:1079
+#: ../src/spacecmd/system.py:1781 ../src/spacecmd/system.py:3685
+#: ../src/spacecmd/system.py:4228
+#, python-format
+msgid "Start Time: %s"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:168
+msgid "Apply these patches [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:218
+#, python-format
+msgid "No patches to schedule for %s"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:227
+#, python-format
+msgid "Scheduled %i patches for %s"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:236
+msgid "errata_listaffectedsystems: List of systems affected by an patch"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:237
+msgid "usage: errata_listaffectedsystems ERRATA|search:XXX ..."
+msgstr ""
+
+#: ../src/spacecmd/errata.py:275
+msgid "errata_listcves: List of CVEs addressed by an patch"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:276
+msgid "usage: errata_listcves ERRATA|search:XXX ..."
+msgstr ""
+
+#: ../src/spacecmd/errata.py:312
+msgid "No errata has been found"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:319
+msgid "errata_findbycve: List errata addressing a CVE"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:320
+msgid "usage: errata_findbycve CVE-YYYY-NNNN ..."
+msgstr ""
+
+#: ../src/spacecmd/errata.py:354
+msgid "errata_details: Show the details of an patch"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:355
+msgid "usage: errata_details ERRATA|search:XXX ..."
+msgstr ""
+
+#: ../src/spacecmd/errata.py:390
+#, python-format
+msgid "%s is not a valid erratum"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:397
+#, python-format
+msgid "Name:       %s"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:398
+msgid "Product:   s"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:399
+msgid "Type:      s"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:400
+msgid "Issue Date:s"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:402
+msgid "Topic"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:406 ../src/spacecmd/package.py:107
+#: ../src/spacecmd/softwarechannel.py:591
+msgid "Description"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:412
+msgid "Notes"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:417
+msgid "CVEs"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:421
+msgid "Solution"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:425
+msgid "References"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:429
+msgid "Affected Channels"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:433 ../src/spacecmd/org.py:278
+msgid "Affected Systems"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:437
+msgid "Affected Packages"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:447
+msgid "errata_delete: Delete an patch"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:448
+msgid "usage: errata_delete ERRATA|search:XXX ..."
+msgstr ""
+
+#: ../src/spacecmd/errata.py:468
+msgid "No patches to delete"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:471
+msgid "Erratum            Channels"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:479
+msgid "Delete these patches [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:485
+#, python-format
+msgid "Deleted %i patches"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:495
+msgid "errata_publish: Publish an patch to a channel"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:496
+msgid "usage: errata_publish ERRATA|search:XXX <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:523
+msgid "No patches to publish"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:528
+msgid "Publish these patches [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:540
+msgid "errata_search: List patches that meet the given criteria"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:541
+msgid "usage: errata_search CVE|RHSA|RHBA|RHEA|CLA ..."
+msgstr ""
+
+#: ../src/spacecmd/errata.py:543 ../src/spacecmd/scap.py:179
+msgid "Example:"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:42
+msgid "filepreservation_list: List all file preservations"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:43
+msgid "usage: filepreservation_list"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:58
+msgid "filepreservation_create: Create a file preservation list"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:59
+msgid "usage: filepreservation_create [NAME] [FILE ...]"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:78
+#: ../src/spacecmd/filepreservation.py:92
+msgid "File List"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:83
+msgid "File [blank to finish]:"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:109
+msgid "filepreservation_delete: Delete a file preservation list"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:110
+msgid "usage: filepreservation_delete NAME"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:128
+msgid "Delete this list [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:139
+msgid ""
+"filepreservation_details: Show the details of a file\n"
+"'preservation list"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:141
+msgid "usage: filepreservation_details NAME"
+msgstr ""
+
+#: ../src/spacecmd/group.py:50
+msgid "group_addsystems: Add systems to a group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:51
+msgid "usage: group_addsystems GROUP <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/group.py:52
+msgid "       group_addsystems GROUP <ssm>"
+msgstr ""
+
+#: ../src/spacecmd/group.py:103
+msgid "group_removesystems: Remove systems from a group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:104
+msgid "usage: group_removesystems GROUP <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/group.py:145 ../src/spacecmd/system.py:118
+#: ../src/spacecmd/system.py:232 ../src/spacecmd/system.py:475
+#: ../src/spacecmd/system.py:1475 ../src/spacecmd/system.py:1783
+#: ../src/spacecmd/system.py:4230
+msgid "Systems"
+msgstr ""
+
+#: ../src/spacecmd/group.py:149
+msgid "Remove these systems [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/group.py:158 ../src/spacecmd/schedule.py:385
+#: ../src/spacecmd/ssm.py:87 ../src/spacecmd/ssm.py:136
+#: ../src/spacecmd/ssm.py:186 ../src/spacecmd/system.py:4273
+#: ../src/spacecmd/system.py:4329
+msgid "No systems found"
+msgstr ""
+
+#: ../src/spacecmd/group.py:165
+msgid "group_create: Create a system group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:166
+msgid "usage: group_create [NAME] [DESCRIPTION]"
+msgstr ""
+
+#: ../src/spacecmd/group.py:192
+msgid "group_delete: Delete a system group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:193
+msgid "usage: group_delete NAME ..."
+msgstr ""
+
+#: ../src/spacecmd/group.py:212
+msgid "Delete these groups [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/group.py:224
+msgid "group_backup: backup a system group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:225
+msgid ""
+"usage: group_backup <NAME> [OUTDIR])\n"
+"                    group_backup ALL\n"
+"\n"
+"\"OUTDIR\" defaults to $HOME/spacecmd-backup/group/YYYY-MM-DD/NAME\n"
+"\"ALL\" is a keyword and collects all groups\n"
+msgstr ""
+
+#: ../src/spacecmd/group.py:270
+#, python-format
+msgid "Backup Group: %s"
+msgstr ""
+
+#: ../src/spacecmd/group.py:273
+#, python-format
+msgid "Output File: %s"
+msgstr ""
+
+#: ../src/spacecmd/group.py:284
+msgid "group_restore: restore a system group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:285
+msgid ""
+"\n"
+"usage: group_restore INPUTDIR [NAME] ...\n"
+"       group_restore INPUTDIR ALL\n"
+"       group_restore INPUTDIR\n"
+"       group_restore .\n"
+"\n"
+"Specifying only INPUTDIR will default to ALL groups.\n"
+"Setting dot (.) instead of full INPUTDIR will imply current directory.\n"
+"    "
+msgstr ""
+
+#: ../src/spacecmd/group.py:329
+#, python-format
+msgid "Restore dir %s does not exits or is not a directory"
+msgstr ""
+
+#: ../src/spacecmd/group.py:333
+#, python-format
+msgid "Restore dir %s has no restore items"
+msgstr ""
+
+#: ../src/spacecmd/group.py:340
+#, python-format
+msgid "Group %s was not found in backup"
+msgstr ""
+
+#: ../src/spacecmd/group.py:343
+#, python-format
+msgid "Found %s missing groups, terminating"
+msgstr ""
+
+#: ../src/spacecmd/group.py:358
+#, python-format
+msgid "Group %s already restored"
+msgstr ""
+
+#: ../src/spacecmd/group.py:365
+msgid "Changing description from:"
+msgstr ""
+
+#: ../src/spacecmd/group.py:367
+msgid "Continue [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/group.py:370 ../src/spacecmd/group.py:373
+#, python-format
+msgid "Updating description for group: %s"
+msgstr ""
+
+#: ../src/spacecmd/group.py:376
+#, python-format
+msgid "Creating new group %s"
+msgstr ""
+
+#: ../src/spacecmd/group.py:385
+msgid "group_list: List available system groups"
+msgstr ""
+
+#: ../src/spacecmd/group.py:386
+msgid "usage: group_list"
+msgstr ""
+
+#: ../src/spacecmd/group.py:403
+msgid "group_listsystems: List the members of a group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:404
+msgid "usage: group_listsystems GROUP"
+msgstr ""
+
+#: ../src/spacecmd/group.py:426
+#, python-format
+msgid "%s is not a valid group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:439
+msgid "group_details: Show the details of a system group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:440
+msgid "usage: group_details GROUP ..."
+msgstr ""
+
+#: ../src/spacecmd/group.py:463
+#, python-format
+msgid "The group \"%s\" is invalid"
+msgstr ""
+
+#: ../src/spacecmd/group.py:470
+#, python-format
+msgid "ID:                %i"
+msgstr ""
+
+#: ../src/spacecmd/group.py:471
+#, python-format
+msgid "Name:              %s"
+msgstr ""
+
+#: ../src/spacecmd/group.py:472
+#, python-format
+msgid "Description:       %s"
+msgstr ""
+
+#: ../src/spacecmd/group.py:473
+#, python-format
+msgid "Number of Systems: %i"
+msgstr ""
+
+#: ../src/spacecmd/group.py:477
+msgid "Members"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:72
+msgid "kickstart_list: List the available Kickstart profiles"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:73
+msgid "usage: kickstart_list"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:85 ../src/spacecmd/kickstart.py:2108
+msgid "No kickstart profiles available"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:91
+msgid "kickstart_create: Create a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:92
+msgid ""
+"usage: kickstart_create [options])\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -d DISTRIBUTION\n"
+"  -p ROOT_PASSWORD\n"
+"  -v VIRT_TYPE ['none', 'para_host', 'qemu', 'xenfv', 'xenpv']"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:113 ../src/spacecmd/kickstart.py:249
+msgid "Virtualization Types"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:118 ../src/spacecmd/kickstart.py:254
+msgid "Virtualization Type [none]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:126 ../src/spacecmd/kickstart.py:262
+msgid "Distributions"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:136
+msgid "Root Password: "
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:137 ../src/spacecmd/org.py:90
+#: ../src/spacecmd/user.py:85
+msgid "Repeat Password: "
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:142 ../src/spacecmd/org.py:95
+#: ../src/spacecmd/user.py:90
+msgid "Password must be at least 5 characters"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:144 ../src/spacecmd/org.py:97
+#: ../src/spacecmd/user.py:92
+msgid "Passwords don't match"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:147 ../src/spacecmd/kickstart.py:270
+#: ../src/spacecmd/kickstart.py:1980 ../src/spacecmd/kickstart.py:2122
+msgid "The Kickstart name is required"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:151 ../src/spacecmd/kickstart.py:274
+msgid "The distribution is required"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:158
+msgid "A root password is required"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:177
+msgid "kickstart_delete: Delete kickstart profile(s)"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:178
+msgid "usage: kickstart_delete PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:179
+msgid "usage: kickstart_delete PROFILE1 PROFILE2"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:180
+msgid "usage: kickstart_delete \"PROF*\""
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:203 ../src/spacecmd/kickstart.py:2597
+#: ../src/spacecmd/kickstart.py:2653 ../src/spacecmd/kickstart.py:2695
+msgid "No valid kickstart labels passed as arguments!"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:209
+msgid "The following kickstart labels are invalid:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:214
+#, python-format
+msgid "Delete profile %s [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:222
+msgid "kickstart_import: Import a Kickstart profile from a file"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:223
+msgid ""
+"usage: kickstart_import [options])\n"
+"\n"
+"options:\n"
+"  -f FILE\n"
+"  -n NAME\n"
+"  -d DISTRIBUTION\n"
+"  -v VIRT_TYPE ['none', 'para_host', 'qemu', 'xenfv', 'xenpv']"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:278 ../src/spacecmd/kickstart.py:1984
+msgid "A filename is required"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:308
+msgid ""
+"kickstart_import_raw: Import a raw Kickstart or autoyast profile from a file"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:309
+msgid ""
+"usage: kickstart_import_raw [options])\n"
+"\n"
+"options:\n"
+"  -f FILE\n"
+"  -n NAME\n"
+"  -d DISTRIBUTION\n"
+"  -v VIRT_TYPE ['none', 'para_host', 'qemu', 'xenfv', 'xenpv']"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:325
+msgid "kickstart_details: Show the details of a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:326
+msgid "usage: kickstart_details PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:353
+msgid "Invalid Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:415
+#, python-format
+msgid "Tree:        %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:416
+#, python-format
+msgid "Active:      %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:417
+#, python-format
+msgid "Advanced:    %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:418
+#, python-format
+msgid "Org Default: %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:421
+#, python-format
+msgid "Configuration Management: %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:422
+#, python-format
+msgid "Remote Commands:          %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:434
+msgid "Advanced Options"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:442
+msgid "Custom Options"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:449
+msgid "Partitioning"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:454
+msgid "Software"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:467
+msgid "Crypto Keys"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:474
+msgid "File Preservations"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:483
+msgid "Variables"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:490
+msgid "Scripts"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:501 ../src/spacecmd/kickstart.py:1900
+#, python-format
+msgid "Chroot:      %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:504 ../src/spacecmd/kickstart.py:1901
+#, python-format
+msgid "Interpreter: %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:530
+msgid "Could not retrieve the Kickstart file"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:536
+msgid "kickstart_getcontents: Show the contents of a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:537
+msgid "                   as they would be presented to a client"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:538
+msgid "usage: kickstart_getcontents LABEL"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:572
+msgid "kickstart_rename: Rename a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:573
+msgid "usage: kickstart_rename OLDNAME NEWNAME"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:601
+msgid ""
+"kickstart_listcryptokeys: List the crypto keys associated with a Kickstart "
+"profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:603
+msgid "usage: kickstart_listcryptokeys PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:632
+msgid "No crypto keys has been found"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:638
+msgid "kickstart_addcryptokeys: Add crypto keys to a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:639
+msgid "usage: kickstart_addcryptokeys PROFILE <KEY ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:665
+msgid "kickstart_removecryptokeys: Remove crypto keys from a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:667
+msgid "usage: kickstart_removecryptokeys PROFILE <KEY ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:707
+msgid ""
+"kickstart_listactivationkeys: List the activation keys associated with a "
+"Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:709
+msgid "usage: kickstart_listactivationkeys PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:739
+msgid "kickstart_addactivationkeys: Add activation keys to a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:741
+msgid "usage: kickstart_addactivationkeys PROFILE <KEY ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:770
+msgid ""
+"kickstart_removeactivationkeys: Remove activation keys from a Kickstart "
+"profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:772
+msgid "usage: kickstart_removeactivationkeys PROFILE <KEY ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:796
+msgid "Remove these keys [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:811
+msgid ""
+"kickstart_enableconfigmanagement: Enable configuration management on a "
+"Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:813
+msgid "usage: kickstart_enableconfigmanagement PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:844
+msgid ""
+"kickstart_disableconfigmanagement: Disable configuration management on a "
+"Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:846
+msgid "usage: kickstart_disableconfigmanagement PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:877
+msgid ""
+"kickstart_enableremotecommands: Enable remote commands on a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:879
+msgid "usage: kickstart_enableremotecommands PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:910
+msgid ""
+"kickstart_disableremotecommands: Disable remote commands on a Kickstart "
+"profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:912
+msgid "usage: kickstart_disableremotecommands PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:942
+msgid "kickstart_setlocale: Set the locale for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:943
+msgid "usage: kickstart_setlocale PROFILE LOCALE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:981
+msgid "kickstart_setselinux: Set the SELinux mode for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:983
+msgid "usage: kickstart_setselinux PROFILE MODE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1018
+msgid ""
+"kickstart_setpartitions: Set the partitioning scheme for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1020
+msgid "usage: kickstart_setpartitions PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1069
+msgid "kickstart_setdistribution: Set the distribution for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1071
+msgid "usage: kickstart_setdistribution PROFILE DISTRIBUTION"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1105
+msgid "kickstart_enablelogging: Enable logging for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1106
+msgid "usage: kickstart_enablelogging PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1138
+msgid "kickstart_addvariable: Add a variable to a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1139
+msgid "usage: kickstart_addvariable PROFILE KEY VALUE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1177
+msgid "kickstart_updatevariable: Update a variable in a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1179
+msgid "usage: kickstart_updatevariable PROFILE KEY VALUE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1214
+msgid "kickstart_removevariables: Remove variables from a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1216
+msgid "usage: kickstart_removevariables PROFILE <KEY ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1265
+msgid "kickstart_listvariables: List the variables of a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1267
+msgid "usage: kickstart_listvariables PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1300
+msgid "kickstart_addoption: Set an option for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1301
+msgid "usage: kickstart_addoption PROFILE KEY [VALUE]"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1348
+#, python-format
+msgid "%s needs to be set as a custom option"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1356
+msgid "kickstart_removeoptions: Remove options from a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1357
+msgid "usage: kickstart_removeoptions PROFILE <OPTION ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1409
+msgid "kickstart_listoptions: List the options of a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1411
+msgid "usage: kickstart_listoptions PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1445
+msgid ""
+"kickstart_listcustomoptions: List the custom options of a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1447
+msgid "usage: kickstart_listcustomoptions PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1481
+msgid "kickstart_setcustomoptions: Set custom options for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1483
+msgid "usage: kickstart_setcustomoptions PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1531
+msgid "kickstart_addchildchannels: Add a child channels to a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1533
+msgid "usage: kickstart_addchildchannels PROFILE <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1591
+msgid ""
+"kickstart_removechildchannels: Remove child channels from a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1593
+msgid "usage: kickstart_removechildchannels PROFILE <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1636
+msgid ""
+"kickstart_listchildchannels: List the child channels of a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1638
+msgid "usage: kickstart_listchildchannels PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1672
+msgid ""
+"kickstart_addfilepreservations: Add file preservations to a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1674
+msgid "usage: kickstart_addfilepreservations PROFILE <FILELIST ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1709
+msgid ""
+"kickstart_removefilepreservations: Remove file preservations from a "
+"Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1711
+msgid "usage: kickstart_removefilepreservations PROFILE <FILE ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1756
+msgid "kickstart_listpackages: List the packages for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1758
+msgid "usage: kickstart_listpackages PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1790
+msgid "kickstart_addpackages: Add packages to a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1791
+msgid "usage: kickstart_addpackages PROFILE <PACKAGE ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1824
+msgid "kickstart_removepackages: Remove packages from a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1826
+msgid "usage: kickstart_removepackages PROFILE <PACKAGE ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1869
+msgid "kickstart_listscripts: List the scripts for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1871
+msgid "usage: kickstart_listscripts PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1890
+#, python-format
+msgid "No scripts has been found for profile '%s'"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1898
+#, python-format
+msgid "ID:          %i"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1913
+msgid "kickstart_addscript: Add a script to a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1914
+msgid ""
+"usage: kickstart_addscript PROFILE [options])\n"
+"\n"
+"options:\n"
+"  -p PROFILE\n"
+"  -e EXECUTION_TIME ['pre', 'post']\n"
+"  -i INTERPRETER\n"
+"  -f FILE\n"
+"  -c execute in a chroot environment\n"
+"  -t ENABLING_TEMPLATING"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1947
+msgid "Profile Name:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1949
+msgid "Pre/Post Script [post]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1950
+msgid "Chrooted [Y/n]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1951
+msgid "Interpreter [/bin/bash]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1988
+msgid "The execution time is required"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2004
+#, python-format
+msgid "Profile Name:   %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2005
+#, python-format
+msgid "Execution Time: %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2006
+#, python-format
+msgid "Chroot:         %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2007
+#, python-format
+msgid "Template:       %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2008
+#, python-format
+msgid "Interpreter:    %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2009
+msgid "Contents:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2029
+msgid "kickstart_removescript: Remove a script from a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2030
+msgid "usage: kickstart_removescript PROFILE [ID]"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2058 ../src/spacecmd/kickstart.py:2071
+msgid "Invalid script ID"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2066
+msgid "Script ID:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2073
+msgid "Remove this script [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2086
+msgid "kickstart_clone: Clone a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2087
+msgid ""
+"usage: kickstart_clone [options])\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -c CLONE_NAME"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2112
+msgid "Kickstart Profiles"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2117
+msgid "Original Profile:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2118
+msgid "Cloned Profile:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2126
+msgid "The Kickstart clone name is required"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2131
+msgid "Kickstart profile you've entered was not found"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2144
+msgid "kickstart_export: export kickstart profile(s) to json format file"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2145
+msgid ""
+"usage: kickstart_export <KSPROFILE>... [options])\n"
+"options:\n"
+"    -f outfile.json : specify an output filename, defaults to <KSPROFILE>."
+"json\n"
+"                      if exporting a single kickstart, profiles.json for "
+"multiple\n"
+"                      kickstarts, or ks_all.json if no KSPROFILE specified\n"
+"                      e.g (export ALL)\n"
+"\n"
+"Note : KSPROFILE list is optional, default is to export ALL"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2271
+#, python-format
+msgid "Exporting ALL kickstart profiles to %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2279
+msgid ""
+"Error, no valid kickstart profile passed, check name is  correct with "
+"spacecmd kickstart_list"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2299
+#, python-format
+msgid "Exporting ks %s to %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2306
+#, python-format
+msgid "File %s exists, "
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2307
+msgid "confirm overwrite file? (y/n)"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2310
+msgid "Error saving exported kickstart profiles to file"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2320
+msgid "kickstart_import: import kickstart profile(s) from json file"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2321
+msgid "usage: kickstart_import <JSONFILES...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2342
+#, python-format
+msgid "Error importing kickstart %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2355
+#, python-format
+msgid "ERROR : kickstart profile %s already exists! Skipping!"
+msgstr ""
+
+#. create the ks, we need to drop the org prefix from the ks name
+#: ../src/spacecmd/kickstart.py:2359
+#, python-format
+msgid "Found ks %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2415
+#, python-format
+msgid "Error adding %s script"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2423
+#, python-format
+msgid "failed to add ip range %s-%s, continuing"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2437
+#, python-format
+msgid "failed to add file preservation %s, skipping"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2439
+#, python-format
+msgid "file preservation list %s doesn't exist, skipping"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2450
+#, python-format
+msgid "Actvationkey %s does not exist on the "
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2461
+#, python-format
+msgid "GPG/SSL key %s does not exist on the "
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2462
+msgid "satellite, skipping"
+msgstr ""
+
+#. There are some frustrating ommisions from the API which means we can't
+#. export/import some settings, so we post a warning that some manual
+#. fixup may be required
+#: ../src/spacecmd/kickstart.py:2471
+msgid ""
+"Due to API ommissions, there are some settings which cannot be imported, "
+"please check and fixup manually if necessary"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2473
+msgid " * Details->Preserve ks.cfg"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2474
+msgid " * Details->Comment"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2478
+msgid " * Details->Organization Default Profile"
+msgstr ""
+
+#. No way to set the kernel options
+#: ../src/spacecmd/kickstart.py:2480
+msgid " * Details->Kernel Options"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2484
+#, python-format
+msgid " * Details->Post Kernel Options : %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2500
+msgid "no kickstart label given"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2503
+msgid "invalid kickstart label "
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2520
+msgid "kickstart_diff: diff kickstart files"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2522
+msgid "usage: kickstart_diff SOURCE_CHANNEL TARGET_CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2571
+msgid "kickstart_getupdatetype: Get the update type for a kickstart profile(s)"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2572
+msgid "usage: kickstart_getupdatetype PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2573
+msgid "usage: kickstart_getupdatetype PROFILE1 PROFILE2"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2574
+msgid "usage: kickstart_getupdatetype \"PROF*\""
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2603 ../src/spacecmd/kickstart.py:2659
+#: ../src/spacecmd/kickstart.py:2701
+#, python-format
+msgid "kickstart label %s doesn't exist!"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2619
+msgid "kickstart_setupdatetype: Set the update type for a kickstart profile(s)"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2620
+msgid ""
+"usage: kickstart_setupdatetype [options] KS_LABEL)\n"
+"\n"
+"options:\n"
+"    -u UPDATE_TYPE ['red_hat', 'all', 'none']"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2634
+msgid "Update Types"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2639
+msgid "Update Type [none]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2670
+msgid "kickstart_getsoftwaredetails: Gets kickstart profile software details"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2671
+msgid "usage: kickstart_getsoftwaredetails KS_LABEL"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2672
+msgid "usage: kickstart_getsoftwaredetails KS_LABEL KS_LABEL2 ..."
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2707
+#, python-format
+msgid "noBase:        %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2708
+#, python-format
+msgid "ignoreMissing: %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2710
+#, python-format
+msgid "Kickstart Label: %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2711
+#, python-format
+msgid "noBase:          %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2712
+#, python-format
+msgid "ignoreMissing:   %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2721
+msgid "kickstart_setsoftwaredetails: Sets kickstart profile software details."
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2722
+msgid ""
+"usage: kickstart_setsoftwaredetails PROFILE KICKSTART_PACKAGES_INFO VALUE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2723
+msgid ""
+"usage: kickstart_setsoftwaredetails PROFILE KICKSTART_PACKAGES_INFO VALUE "
+"KICKSTART_PACKAGES_INFO VALUE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2757
+msgid "Selected profile does not exist"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2760 ../src/spacecmd/kickstart.py:2765
+msgid "Enter valid input"
+msgstr ""
+
+#. list of system selection options for the help output
+#: ../src/spacecmd/misc.py:57
+msgid ""
+"<SYSTEMS> can be any of the following:\n"
+"name\n"
+"ssm (see 'help ssm')\n"
+"search:QUERY (see 'help system_search')\n"
+"group:GROUP\n"
+"channel:CHANNEL\n"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:65
+msgid ""
+"Dates can be any of the following:\n"
+"Explicit Dates:\n"
+"Dates can be expressed as explicit date strings in the YYYYMMDD[HHMMSS]\n"
+"format.  The year, month and day are required, while the hours and\n"
+"minutes are not; the hours and minutes will default to 0000 if no\n"
+"values are provided.\n"
+"\n"
+"Deltas:\n"
+"Dates can be expressed as delta values.  For example, '2h' would\n"
+"mean 2 hours in the future.  You can also use negative values to\n"
+"express times in the past (e.g., -7d would be one week ago).\n"
+"\n"
+"Units:\n"
+"s -> seconds\n"
+"m -> minutes\n"
+"h -> hours\n"
+"d -> days\n"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:120
+msgid "clear: clear the screen"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:121
+msgid "usage: clear"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:132
+msgid "clear_caches: Clear the internal caches kept for systems and packages"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:133
+msgid "usage: clear_caches"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:146
+msgid "get_apiversion: Display the API version of the server"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:147
+msgid "usage: get_apiversion"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:158
+msgid "get_serverversion: Display the version of the server"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:159
+msgid "usage: get_serverversion"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:171
+msgid "list_proxies: List the proxies within the user's organization "
+msgstr ""
+
+#: ../src/spacecmd/misc.py:172
+msgid "usage: list_proxies"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:184
+msgid "get_session: Show the current session string"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:185
+msgid "usage: get_session"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:193
+msgid "No session found"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:200
+msgid "help: Show help for the given command"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:201
+msgid "usage: help COMMAND"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:207
+msgid "history: List your command history"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:208
+msgid "usage: history"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:220
+msgid "toggle_confirmations: Toggle confirmation messages on/off"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:221
+msgid "usage: toggle_confirmations"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:226
+msgid "Confirmation messages are"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:226
+msgid "enabled"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:233
+msgid "login: Connect to a Spacewalk server"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:234
+msgid "usage: login [USERNAME] [SERVER]"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:244
+msgid "You are already logged in"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:256
+msgid "No server specified"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:301
+#, python-format
+msgid "Failed to connect to %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:309
+#, python-format
+msgid "API (%s) is too old (>= %s required)"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:339 ../src/spacecmd/utils.py:249
+#: ../src/spacecmd/utils.py:560
+#, python-format
+msgid "Could not read %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:348
+msgid "Cached credentials are invalid"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:355
+#, python-format
+msgid "Spacewalk Username: %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:357
+msgid "Spacewalk Username:"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:368
+msgid "Spacewalk Password: "
+msgstr ""
+
+#: ../src/spacecmd/misc.py:374
+msgid "Invalid credentials"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:392
+#, python-format
+msgid "Could not write session file: %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:401
+#, python-format
+msgid "Connected to %s as %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:409
+msgid "logout: Disconnect from the server"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:410
+msgid "usage: logout"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:427
+msgid "whoami: Print the name of the currently logged in user"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:428
+msgid "usage: whoami"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:436
+msgid "You are not logged in"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:443
+msgid "whoamitalkingto: Print the name of the server"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:444
+msgid "usage: whoamitalkingto"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:452
+msgid "Yourself"
+msgstr ""
+
+#. tell the user what's going on
+#: ../src/spacecmd/misc.py:524
+msgid "** Generating errata cache **"
+msgstr ""
+
+#. tell the user what's going on
+#: ../src/spacecmd/misc.py:573
+msgid "** Generating package cache **"
+msgstr ""
+
+#. tell the user what's going on
+#: ../src/spacecmd/misc.py:680
+msgid "** Generating system cache **"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:715
+#, python-format
+msgid "Could not create directory %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:787
+#, python-format
+msgid "Can't find system ID for %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:792
+msgid "Duplicate system profile names found!"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:793
+msgid "Please reference systems by ID or resolve the"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:794
+msgid "underlying issue with 'system_delete' or 'system_rename'"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:860
+#, python-format
+msgid "No systems in group %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:874
+#, python-format
+msgid "No systems subscribed to %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:934
+msgid "Is this ok [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:47
+msgid "org_create: Create an organization"
+msgstr ""
+
+#: ../src/spacecmd/org.py:48
+#, python-format
+msgid ""
+"usage: org_create [options])\n"
+"\n"
+"options:\n"
+"  -n ORG_NAME\n"
+"  -u USERNAME\n"
+"  -P PREFIX (%s)\n"
+"  -f FIRST_NAME\n"
+"  -l LAST_NAME\n"
+"  -e EMAIL\n"
+"  -p PASSWORD\n"
+"  --pam enable PAM authentication"
+msgstr ""
+
+#: ../src/spacecmd/org.py:75
+msgid "Organization Name:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:76 ../src/spacecmd/user.py:73
+msgid "Username:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:77
+#, python-format
+msgid "Prefix (%s):"
+msgstr ""
+
+#: ../src/spacecmd/org.py:79 ../src/spacecmd/user.py:74
+msgid "First Name:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:80 ../src/spacecmd/user.py:75
+msgid "Last Name:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:81 ../src/spacecmd/user.py:76
+msgid "Email:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:82 ../src/spacecmd/user.py:77
+msgid "PAM Authentication [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:89 ../src/spacecmd/user.py:84
+msgid "Password: "
+msgstr ""
+
+#: ../src/spacecmd/org.py:100
+msgid "An organization name is required"
+msgstr ""
+
+#: ../src/spacecmd/org.py:104 ../src/spacecmd/user.py:95
+msgid "A username is required"
+msgstr ""
+
+#: ../src/spacecmd/org.py:108 ../src/spacecmd/user.py:99
+msgid "A first name is required"
+msgstr ""
+
+#: ../src/spacecmd/org.py:112 ../src/spacecmd/user.py:103
+msgid "A last name is required"
+msgstr ""
+
+#: ../src/spacecmd/org.py:116 ../src/spacecmd/user.py:107
+msgid "An email address is required"
+msgstr ""
+
+#: ../src/spacecmd/org.py:120 ../src/spacecmd/user.py:111
+msgid "A password is required"
+msgstr ""
+
+#: ../src/spacecmd/org.py:127
+msgid "Dr."
+msgstr ""
+
+#: ../src/spacecmd/org.py:129
+msgid "Miss"
+msgstr ""
+
+#: ../src/spacecmd/org.py:148
+msgid "org_delete: Delete an organization"
+msgstr ""
+
+#: ../src/spacecmd/org.py:149
+msgid "usage: org_delete NAME"
+msgstr ""
+
+#: ../src/spacecmd/org.py:168 ../src/spacecmd/org.py:199
+#: ../src/spacecmd/org.py:233 ../src/spacecmd/org.py:269
+#: ../src/spacecmd/org.py:377 ../src/spacecmd/org.py:413
+#, python-format
+msgid "No organisation found for the name %s"
+msgstr ""
+
+#: ../src/spacecmd/org.py:169 ../src/spacecmd/org.py:200
+#: ../src/spacecmd/org.py:234 ../src/spacecmd/org.py:270
+#: ../src/spacecmd/org.py:378 ../src/spacecmd/org.py:414
+msgid "Organisation '{}' was not found"
+msgstr ""
+
+#: ../src/spacecmd/org.py:171
+msgid "Delete this organization [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:179
+msgid "org_rename: Rename an organization"
+msgstr ""
+
+#: ../src/spacecmd/org.py:180
+msgid "usage: org_rename OLDNAME NEWNAME"
+msgstr ""
+
+#: ../src/spacecmd/org.py:211
+msgid "org_addtrust: Add a trust between two organizations"
+msgstr ""
+
+#: ../src/spacecmd/org.py:212
+msgid "usage: org_addtrust YOUR_ORG ORG_TO_TRUST"
+msgstr ""
+
+#: ../src/spacecmd/org.py:237 ../src/spacecmd/org.py:273
+#, python-format
+msgid "No trust organisation found for the name %s"
+msgstr ""
+
+#: ../src/spacecmd/org.py:238 ../src/spacecmd/org.py:274
+msgid "Organisation '{}' to trust for, was not found"
+msgstr ""
+
+#: ../src/spacecmd/org.py:248
+msgid "org_removetrust: Remove a trust between two organizations"
+msgstr ""
+
+#: ../src/spacecmd/org.py:249
+msgid "usage: org_removetrust YOUR_ORG TRUSTED_ORG"
+msgstr ""
+
+#: ../src/spacecmd/org.py:284
+msgid "None"
+msgstr ""
+
+#: ../src/spacecmd/org.py:286
+msgid "Remove this trust [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:292
+msgid "org_trustdetails: Show the details of an organizational trust"
+msgstr ""
+
+#: ../src/spacecmd/org.py:293
+msgid "usage: org_trustdetails TRUSTED_ORG"
+msgstr ""
+
+#: ../src/spacecmd/org.py:312
+#, python-format
+msgid "No trusted organisation found for the name %s"
+msgstr ""
+
+#: ../src/spacecmd/org.py:313
+msgid "Trusted organisation '{}' was not found"
+msgstr ""
+
+#: ../src/spacecmd/org.py:320
+#, python-format
+msgid "Trusted Organization:   %s"
+msgstr ""
+
+#: ../src/spacecmd/org.py:321
+#, python-format
+msgid "Trusted Since:          %s"
+msgstr ""
+
+#: ../src/spacecmd/org.py:322
+#, python-format
+msgid "Systems Migrated From:  %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:323
+#, python-format
+msgid "Systems Migrated To:    %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:325
+msgid "Channels Consumed"
+msgstr ""
+
+#: ../src/spacecmd/org.py:332
+msgid "Channels Provided"
+msgstr ""
+
+#: ../src/spacecmd/org.py:340
+msgid "org_list: List all organizations"
+msgstr ""
+
+#: ../src/spacecmd/org.py:341
+msgid "usage: org_list"
+msgstr ""
+
+#: ../src/spacecmd/org.py:358
+msgid "org_listtrusts: List an organization's trusts"
+msgstr ""
+
+#: ../src/spacecmd/org.py:359
+msgid "usage: org_listtrusts NAME"
+msgstr ""
+
+#: ../src/spacecmd/org.py:383 ../src/spacecmd/org.py:384
+msgid "No trust organisation has been found"
+msgstr ""
+
+#: ../src/spacecmd/org.py:394
+msgid "org_listusers: List an organization's users"
+msgstr ""
+
+#: ../src/spacecmd/org.py:395
+msgid "usage: org_listusers NAME"
+msgstr ""
+
+#: ../src/spacecmd/org.py:425
+msgid "org_details: Show the details of an organization"
+msgstr ""
+
+#: ../src/spacecmd/org.py:426
+msgid "usage: org_details NAME"
+msgstr ""
+
+#: ../src/spacecmd/org.py:446
+#, python-format
+msgid "Name:                   %s"
+msgstr ""
+
+#: ../src/spacecmd/org.py:447
+#, python-format
+msgid "Active Users:           %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:448
+#, python-format
+msgid "Systems:                %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:452 ../src/spacecmd/org.py:454
+#, python-format
+msgid "Trusts:                 %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:456
+#, python-format
+msgid "System Groups:          %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:457
+#, python-format
+msgid "Activation Keys:        %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:458
+#, python-format
+msgid "Kickstart Profiles:     %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:459
+#, python-format
+msgid "Configuration Channels: %i"
+msgstr ""
+
+#: ../src/spacecmd/package.py:68 ../src/spacecmd/package.py:302
+#: ../src/spacecmd/package.py:351 ../src/spacecmd/package.py:395
+msgid "No packages found"
+msgstr ""
+
+#: ../src/spacecmd/package.py:81 ../src/spacecmd/package.py:406
+#, python-format
+msgid "%s is not a valid package"
+msgstr ""
+
+#: ../src/spacecmd/package.py:94
+#, python-format
+msgid "Version: %s"
+msgstr ""
+
+#: ../src/spacecmd/package.py:95
+#, python-format
+msgid "Release: %s"
+msgstr ""
+
+#: ../src/spacecmd/package.py:96
+#, python-format
+msgid "Epoch:   %s"
+msgstr ""
+
+#: ../src/spacecmd/package.py:97
+#, python-format
+msgid "Arch:    %s"
+msgstr ""
+
+#: ../src/spacecmd/package.py:99
+#, python-format
+msgid "File:    %s"
+msgstr ""
+
+#: ../src/spacecmd/package.py:101
+#, python-format
+msgid "Size:    %s"
+msgstr ""
+
+#: ../src/spacecmd/package.py:105
+#, python-format
+msgid "Installed Systems: %i"
+msgstr ""
+
+#: ../src/spacecmd/package.py:111
+msgid "Available From Channels"
+msgstr ""
+
+#: ../src/spacecmd/package.py:122
+msgid "package_search: Find packages that meet the given criteria"
+msgstr ""
+
+#: ../src/spacecmd/package.py:123
+msgid "usage: package_search NAME|QUERY"
+msgstr ""
+
+#: ../src/spacecmd/package.py:125
+msgid "Example: package_search kernel"
+msgstr ""
+
+#: ../src/spacecmd/package.py:127
+msgid "Advanced Search:"
+msgstr ""
+
+#: ../src/spacecmd/package.py:128
+msgid ""
+"Available Fields: name, epoch, version, release, arch, description, summary"
+msgstr ""
+
+#: ../src/spacecmd/package.py:129
+msgid "Example: name:kernel AND version:2.6.18 AND -description:devel"
+msgstr ""
+
+#: ../src/spacecmd/package.py:178
+msgid "package_remove: Remove a package from Satellite"
+msgstr ""
+
+#: ../src/spacecmd/package.py:179
+msgid "usage: package_remove PACKAGE ..."
+msgstr ""
+
+#: ../src/spacecmd/package.py:199
+msgid "No packages found to remove"
+msgstr ""
+
+#: ../src/spacecmd/package.py:202 ../src/spacecmd/package.py:259
+#: ../src/spacecmd/softwarechannel.py:1580 ../src/spacecmd/system.py:944
+msgid "Remove these packages [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/package.py:203
+msgid "No packages has been removed"
+msgstr ""
+
+#: ../src/spacecmd/package.py:215 ../src/spacecmd/package.py:271
+#, python-format
+msgid "Failed to remove package ID %i"
+msgstr ""
+
+#: ../src/spacecmd/package.py:226
+msgid "package_listorphans: List packages that are not in a channel"
+msgstr ""
+
+#: ../src/spacecmd/package.py:227
+msgid "usage: package_listorphans"
+msgstr ""
+
+#: ../src/spacecmd/package.py:246
+msgid "package_removeorphans: Remove packages that are not in a channel"
+msgstr ""
+
+#: ../src/spacecmd/package.py:247
+msgid "usage: package_removeorphans"
+msgstr ""
+
+#: ../src/spacecmd/package.py:255
+msgid "No orphaned packages has been found"
+msgstr ""
+
+#: ../src/spacecmd/package.py:256
+msgid "No orphaned packages"
+msgstr ""
+
+#: ../src/spacecmd/package.py:260
+msgid "No packages were removed"
+msgstr ""
+
+#: ../src/spacecmd/package.py:280
+msgid "package_listinstalledsystems: List the systems with a package installed"
+msgstr ""
+
+#: ../src/spacecmd/package.py:281
+msgid "usage: package_listinstalledsystems PACKAGE ..."
+msgstr ""
+
+#: ../src/spacecmd/package.py:329
+msgid "package_listerrata: List the errata that provide this package"
+msgstr ""
+
+#: ../src/spacecmd/package.py:330
+msgid "usage: package_listerrata PACKAGE ..."
+msgstr ""
+
+#: ../src/spacecmd/package.py:377
+msgid "package_listdependencies: List the dependencies for a package"
+msgstr ""
+
+#: ../src/spacecmd/package.py:378
+msgid "usage: package_listdependencies PACKAGE"
+msgstr ""
+
+#: ../src/spacecmd/package.py:411
+#, python-format
+msgid "Package Name: %s"
+msgstr ""
+
+#: ../src/spacecmd/package.py:413
+#, python-format
+msgid "Dependency: %s Type: %s Modifier: %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:47
+msgid "repo_list: List all available user repos"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:48
+msgid "usage: repo_list"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:65
+msgid "repo_details: Show the details of a user repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:66
+msgid "usage: repo_details <repo ...>"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:94
+#, python-format
+msgid "Repository Label:                  %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:95
+#, python-format
+msgid "Repository URL:                    %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:96
+#, python-format
+msgid "Repository Type:                   %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:97
+#, python-format
+msgid "Repository SSL Ca Certificate:     %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:98
+#, python-format
+msgid "Repository SSL Client Certificate: %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:99
+#, python-format
+msgid "Repository SSL Client Key:         %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:101
+msgid "No repositories found for '{}' query"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:110
+msgid "repo_listfilters: Show the filters for a user repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:111
+msgid "usage: repo_listfilters repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:132
+msgid "No filters found"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:141
+msgid "repo_addfilters: Add filters for a user repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:142
+msgid "usage: repo_addfilters repo <filter ...>"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:166 ../src/spacecmd/repo.py:203
+#: ../src/spacecmd/repo.py:242
+msgid "Each filter must start with + or -"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:180
+msgid "repo_removefilters: Remove filters from a user repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:181
+msgid "usage: repo_removefilters repo <filter ...>"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:217
+msgid "repo_setfilters: Set the filters for a user repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:218
+msgid "usage: repo_setfilters repo <filter ...>"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:255
+msgid "repo_clearfilters: Clears the filters for a user repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:256
+msgid ""
+"usage: repo_clearfilters repo <options>\n"
+"\n"
+"options:\n"
+"  -y, --yes   Confirm without prompt\n"
+"\n"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:278
+msgid "Remove these filters [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:287
+msgid "repo_delete: Delete a user repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:288
+msgid "usage: repo_delete <repo ...>"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:307 ../src/spacecmd/softwarechannel.py:610
+msgid "Repos"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:311
+msgid "Delete these repos [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:316
+#, python-format
+msgid "Failed to remove repo %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:324
+msgid "repo_create: Create a user repository"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:325
+msgid ""
+"usage: repo_create <options>)\n"
+"\n"
+"options:\n"
+"  -n, --name   name of repository\n"
+"  -u, --url    url of repository\n"
+"  -t, --type   type of repository (defaults to yum)\n"
+"\n"
+"  --ca         SSL CA certificate (not required)\n"
+"  --cert       SSL Client certificate (not required)\n"
+"  --key        SSL Client key (not required)"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:350
+msgid "URL:"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:351
+msgid "Type:"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:352 ../src/spacecmd/repo.py:462
+msgid "SSL CA cert:"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:353 ../src/spacecmd/repo.py:463
+msgid "SSL Client cert:"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:354 ../src/spacecmd/repo.py:464
+msgid "SSL Client key:"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:361
+msgid "A URL is required"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:381
+msgid "repo_rename: Rename a user repository"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:382
+msgid "usage: repo_rename OLDNAME NEWNAME"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:404
+#, python-format
+msgid "Could not find repo %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:417
+msgid "repo_updateurl: Change the URL of a user repository"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:418
+msgid "usage: repo_updateurl <repo> <url>"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:443
+msgid "repo_updatessl: Change the SSL certificates of a user repository"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:444
+msgid ""
+"usage: repo_updatessl <options>)\n"
+"options:\n"
+"  --ca         SSL CA certificate (not required)\n"
+"  --cert       SSL Client certificate (not required)\n"
+"  --key        SSL Client key (not required)"
+msgstr ""
+
+#: ../src/spacecmd/report.py:43
+msgid "report_inactivesystems: List all inactive systems"
+msgstr ""
+
+#: ../src/spacecmd/report.py:44
+msgid "usage: report_inactivesystems [DAYS]"
+msgstr ""
+
+#: ../src/spacecmd/report.py:84
+msgid "report_outofdatesystems: List all out-of-date systems"
+msgstr ""
+
+#: ../src/spacecmd/report.py:85
+msgid "usage: report_outofdatesystems"
+msgstr ""
+
+#: ../src/spacecmd/report.py:112
+msgid "report_ungroupedsystems: List all ungrouped systems"
+msgstr ""
+
+#: ../src/spacecmd/report.py:113
+msgid "usage: report_ungroupedsystems"
+msgstr ""
+
+#: ../src/spacecmd/report.py:130
+msgid "report_errata: List all errata and how many systems they affect"
+msgstr ""
+
+#: ../src/spacecmd/report.py:131
+msgid "usage: report_errata [ERRATA|search:XXX ...]"
+msgstr ""
+
+#: ../src/spacecmd/report.py:143
+msgid "All errata requested - this may take a few minutes, please be patient!"
+msgstr ""
+
+#: ../src/spacecmd/report.py:166
+#, python-format
+msgid "%s  # Systems"
+msgstr ""
+
+#: ../src/spacecmd/report.py:173
+msgid "No errata found for '{}'"
+msgstr ""
+
+#: ../src/spacecmd/report.py:180
+msgid "report_ipaddresses: List the hostname and IP of each system"
+msgstr ""
+
+#: ../src/spacecmd/report.py:181
+msgid "usage: report_ipaddresses [<SYSTEMS>]"
+msgstr ""
+
+#: ../src/spacecmd/report.py:201 ../src/spacecmd/report.py:265
+#: ../src/spacecmd/scap.py:67 ../src/spacecmd/scap.py:207
+#: ../src/spacecmd/system.py:213 ../src/spacecmd/system.py:394
+#: ../src/spacecmd/system.py:579 ../src/spacecmd/system.py:743
+#: ../src/spacecmd/system.py:898 ../src/spacecmd/system.py:1033
+#: ../src/spacecmd/system.py:1134 ../src/spacecmd/system.py:1204
+#: ../src/spacecmd/system.py:1259 ../src/spacecmd/system.py:1358
+#: ../src/spacecmd/system.py:1591 ../src/spacecmd/system.py:1654
+#: ../src/spacecmd/system.py:1697 ../src/spacecmd/system.py:1777
+#: ../src/spacecmd/system.py:1919 ../src/spacecmd/system.py:1961
+#: ../src/spacecmd/system.py:2049 ../src/spacecmd/system.py:2116
+#: ../src/spacecmd/system.py:2198 ../src/spacecmd/system.py:2253
+#: ../src/spacecmd/system.py:2313 ../src/spacecmd/system.py:2372
+#: ../src/spacecmd/system.py:2430 ../src/spacecmd/system.py:2489
+#: ../src/spacecmd/system.py:2566 ../src/spacecmd/system.py:2647
+#: ../src/spacecmd/system.py:2702 ../src/spacecmd/system.py:2955
+#: ../src/spacecmd/system.py:3108 ../src/spacecmd/system.py:3177
+#: ../src/spacecmd/system.py:3223 ../src/spacecmd/system.py:3282
+#: ../src/spacecmd/system.py:3346 ../src/spacecmd/system.py:3402
+#: ../src/spacecmd/system.py:3577 ../src/spacecmd/system.py:3855
+#: ../src/spacecmd/system.py:3998 ../src/spacecmd/system.py:4060
+#: ../src/spacecmd/system.py:4108 ../src/spacecmd/system.py:4166
+#: ../src/spacecmd/system.py:4224
+msgid "No systems selected"
+msgstr ""
+
+#: ../src/spacecmd/report.py:244
+msgid "report_kernels: List the running kernel of each system"
+msgstr ""
+
+#: ../src/spacecmd/report.py:245
+msgid "usage: report_kernels [<SYSTEMS>]"
+msgstr ""
+
+#: ../src/spacecmd/report.py:282
+#, python-format
+msgid "%s  Kernel"
+msgstr ""
+
+#: ../src/spacecmd/report.py:282
+msgid "System"
+msgstr ""
+
+#: ../src/spacecmd/report.py:296
+msgid "report_duplicates: List duplicate system profiles"
+msgstr ""
+
+#: ../src/spacecmd/report.py:297
+msgid "usage: report_duplicates"
+msgstr ""
+
+#: ../src/spacecmd/report.py:319 ../src/spacecmd/report.py:341
+#: ../src/spacecmd/report.py:359 ../src/spacecmd/report.py:377
+msgid "System ID   Last Checkin"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:43
+msgid ""
+"scap_listxccdfscans: Return a list of finished OpenSCAP scans for given "
+"systems"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:44
+msgid "usage: scap_listxccdfscans <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:78 ../src/spacecmd/system.py:608
+#: ../src/spacecmd/system.py:1220 ../src/spacecmd/system.py:1371
+#: ../src/spacecmd/system.py:2060 ../src/spacecmd/system.py:2383
+#: ../src/spacecmd/system.py:2441 ../src/spacecmd/system.py:2660
+#: ../src/spacecmd/system.py:2715 ../src/spacecmd/system.py:3121
+#: ../src/spacecmd/system.py:3238 ../src/spacecmd/system.py:3295
+#, python-format
+msgid "System: %s"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:88
+#, python-format
+msgid "XID: %d Profile: %s Path: (%s) Completed: %s"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:96
+msgid ""
+"scap_getxccdfscanruleresults: Return a full list of RuleResults for given "
+"OpenSCAP XCCDF scan"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:97
+msgid "usage: scap_getxccdfscanruleresults <XID>"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:117
+#, python-format
+msgid "XID: %s"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:124
+#, python-format
+msgid "IDref: %s Result: %s Idents: (%s)"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:132
+msgid "scap_getxccdfscandetails: Get details of given OpenSCAP XCCDF scan"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:133
+msgid "usage: scap_getxccdfscandetails <XID>"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:159
+msgid "XID:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:159
+msgid "SID:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:159
+msgid "Action_ID:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:161
+msgid "OSCAP_Parameters:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:162
+msgid "Test_Result:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:162
+msgid "Benchmark:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:163
+msgid "Benchmark_Version:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:164
+msgid "Profile:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:165
+msgid "Profile_Title:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:165
+msgid "Start_Time:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:166
+msgid "End_Time:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:167
+msgid "Errors:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:175
+msgid "scap_schedulexccdfscan: Schedule Scap XCCDF scan"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:176
+msgid "usage: scap_schedulexccdfscan PATH_TO_XCCDF_FILE XCCDF_OPTIONS SYSTEMS"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:177
+msgid "       scap_schedulexccdfscan ssm PATH_TO_XCCDF_FILE XCCDF_OPTIONS"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:182
+msgid ""
+"\n"
+"To use systems in the ssm, pass the \"ssm\" keyword in front. Example:"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:88
+msgid "ID      Date                 C    F    P     Action"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:134
+msgid "schedule_cancel: Cancel scheduled actions"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:135
+msgid "usage: schedule_cancel ID|* ..."
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:157
+msgid "Cancel all pending actions [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:158
+msgid "All pending actions left untouched"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:173 ../src/spacecmd/schedule.py:234
+#, python-format
+msgid "\"%s\" is not a valid ID"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:179
+#, python-format
+msgid "Canceled action: %i"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:182
+#, python-format
+msgid "Failed action: %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:184
+#, python-format
+msgid "Canceled %i action(s)"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:192
+msgid "schedule_reschedule: Reschedule failed actions"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:193
+msgid "usage: schedule_reschedule ID|* ..."
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:220
+msgid "Reschedule all failed actions [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:232
+#, python-format
+msgid "\"%i\" is not a failed action"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:238
+msgid "No failed actions to reschedule"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:242
+#, python-format
+msgid "Rescheduled %i action(s)"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:250
+msgid "schedule_details: Show the details of a scheduled action"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:251
+msgid "usage: schedule_details ID"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:268
+#, python-format
+msgid "The ID \"%s\" is invalid"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:277
+#, python-format
+msgid "ID:        %i"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:278
+#, python-format
+msgid "Action:    %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:279
+#, python-format
+msgid "User:      %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:280
+#, python-format
+msgid "Date:      %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:282 ../src/spacecmd/schedule.py:379
+#: ../src/spacecmd/system.py:3245
+#, python-format
+msgid "Completed: %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:283
+#, python-format
+msgid "Failed:    %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:284
+#, python-format
+msgid "Pending:   %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:288
+msgid "Completed Systems"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:295
+msgid "Failed Systems"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:302
+msgid "Pending Systems"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:307
+#, python-format
+msgid "No action found with the ID \"%s\""
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:316
+msgid "schedule_getoutput: Show the output from an action"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:317
+msgid "usage: schedule_getoutput ID"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:332
+#, python-format
+msgid "\"%s\" is not a valid action ID"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:354
+#, python-format
+msgid "System:      %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:355
+#, python-format
+msgid "Start Time:  %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:356
+#, python-format
+msgid "Stop Time:   %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:357
+#, python-format
+msgid "Return Code: %i"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:359 ../src/spacecmd/schedule.py:381
+msgid "Output"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:378
+#, python-format
+msgid "System:    %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:394
+msgid "schedule_listpending: List pending actions"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:395
+msgid "usage: schedule_listpending [BEGINDATE] [ENDDATE]"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:407
+msgid "schedule_listcompleted: List completed actions"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:408
+msgid "usage: schedule_listcompleted [BEGINDATE] [ENDDATE]"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:420
+msgid "schedule_listfailed: List failed actions"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:421
+msgid "usage: schedule_listfailed [BEGINDATE] [ENDDATE]"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:433
+msgid "schedule_listarchived: List archived actions"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:434
+msgid "usage: schedule_listarchived [BEGINDATE] [ENDDATE]"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:446
+msgid "schedule_list: List all actions"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:447
+msgid "usage: schedule_list [BEGINDATE] [ENDDATE]"
+msgstr ""
+
+#: ../src/spacecmd/shell.py:120
+msgid "Could not read history file"
+msgstr ""
+
+#. pylint: disable=W0702
+#: ../src/spacecmd/shell.py:124
+msgid "Exception occurred: {}"
+msgstr ""
+
+#: ../src/spacecmd/shell.py:188 ../src/spacecmd/shell.py:227
+#, python-format
+msgid "%s: event not found"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:42
+msgid "snippet_list: List the available Kickstart snippets"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:43
+msgid "usage: snippet_list"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:60
+msgid "snippet_details: Show the contents of a snippet"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:61
+msgid "usage: snippet_details SNIPPET ..."
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:90
+#, python-format
+msgid "%s is not a valid snippet"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:97
+#, python-format
+msgid "Name:   %s"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:98
+#, python-format
+msgid "Macro:  %s"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:99
+#, python-format
+msgid "File:   %s"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:110
+msgid "snippet_create: Create a Kickstart snippet"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:111
+msgid ""
+"usage: snippet_create [options])\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -f FILE"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:149
+msgid "A name is required for the snippet"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:153
+msgid "A file is required"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:160
+#, python-format
+msgid "Snippet: %s"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:176
+msgid "snippet_update: Update a Kickstart snippet"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:177
+msgid "usage: snippet_update NAME"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:199
+msgid "snippet_delete: Delete a Kickstart snippet"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:200
+msgid "usage: snippet_delete NAME"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:218
+msgid "Remove this snippet [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:57
+msgid "softwarechannel_list: List all available software channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:58
+msgid ""
+"usage: softwarechannel_list [options]')\n"
+"options:\n"
+"  -v verbose (display label and summary)\n"
+"  -t tree view (pretty-print(child-channels))\n"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:106
+msgid "softwarechannel_listmanageablechannels: List all software channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:107
+msgid "                                        manageable by current user"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:108
+msgid ""
+"usage: softwarechannel_listmanageablechannels [options]\n"
+"options:\n"
+"  -v verbose (display label and summary)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:143
+msgid "softwarechannel_listbasechannels: List all base software channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:144
+msgid ""
+"usage: softwarechannel_listbasechannels [options])\n"
+"options:\n"
+"  -v verbose (display label and summary)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:172
+msgid "softwarechannel_listchildchannels: List child software channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:173
+#: ../src/spacecmd/softwarechannel.py:2735
+msgid "usage:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:174
+msgid "softwarechannel_listchildchannels [options]"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:175
+msgid "softwarechannel_listchildchannels : List all child channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:176
+msgid ""
+"softwarechannel_listchildchannels CHANNEL : List children for aspecific base "
+"channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:178
+msgid ""
+"options:\n"
+" -v verbose (display label and summary)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:206
+msgid "softwarechannel_listsystems: List all systems subscribed to"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:207
+msgid "                             a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:208
+msgid "usage: softwarechannel_listsystems CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:242
+msgid "softwarechannel_listpackages: List the most recent packages"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:243
+msgid "                              available from a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:244
+msgid "usage: softwarechannel_listpackages CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:281
+msgid "softwarechannel_listallpackages: List all packages in a channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:282
+msgid "usage: softwarechannel_listallpackages CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:340
+msgid ""
+"softwarechannel_listlatestpackages: List the newest version of all packages "
+"in a channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:341
+msgid "usage: softwarechannel_listlatestpackages CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:380
+msgid "softwarechannel_setdetails: Modify details of a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:381
+#, python-format
+msgid ""
+"usage: softwarechannel_setdetails [options] <CHANNEL ...>)\n"
+"\n"
+"options, at least one of which must be given:\n"
+"  -n NAME\n"
+"  -d DESCRIPTION\n"
+"  -s SUMMARY\n"
+"  -c CHECKSUM %s\n"
+"  -m MAINTAINER_NAME\n"
+"  -e MAINTAINER_EMAIL\n"
+"  -p MAINTAINER_PHONE\n"
+"  -u GPG_URL\n"
+"  -i GPG_ID\n"
+"  -f GPG_FINGERPRINT"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:443
+msgid "At least one attribute to set must be given"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:449
+msgid "No channels matching that label"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:461
+msgid "Setting same name for more than one channel will fail"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:469
+#, python-format
+msgid "Name \"%s\" already in use by channel %s"
+msgstr ""
+
+#. get confirmation
+#: ../src/spacecmd/softwarechannel.py:474
+msgid "Setting following attributes..."
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:477
+#, python-format
+msgid "Name:             %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:479
+#, python-format
+msgid "Summary:          %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:481
+#, python-format
+msgid "Description:      %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:483
+#, python-format
+msgid "Checksum:         %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:485
+#, python-format
+msgid "Maintainer name:  %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:487
+#, python-format
+msgid "Maintainer email: %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:489
+#, python-format
+msgid "Maintainer phone: %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:491
+#, python-format
+msgid "GPG Key:          %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:493
+#, python-format
+msgid "GPG Fingerprint:  %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:495
+#, python-format
+msgid "GPG URL:          %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:497
+msgid "... for the following channels:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:500
+msgid "Apply? [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:512
+#, python-format
+msgid "Could not get details for %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:524
+#, python-format
+msgid "Error while setting details for %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:527
+#, python-format
+msgid "Channels changed: %d"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:535
+msgid "softwarechannel_details: Show the details of a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:536
+msgid "usage: softwarechannel_details <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:576
+#, python-format
+msgid "Label:              %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:577
+#, python-format
+msgid "Name:               %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:578
+#, python-format
+msgid "Architecture:       %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:579
+#, python-format
+msgid "Parent:             %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:580
+#, python-format
+msgid "Systems Subscribed: %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:581
+#, python-format
+msgid "Number of Packages: %i"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:585
+msgid "Summary"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:596
+#, python-format
+msgid "GPG Key:            %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:597
+#, python-format
+msgid "GPG Fingerprint:    %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:598
+#, python-format
+msgid "GPG URL:            %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:599
+#, python-format
+msgid "GPG CHECK:          %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:603
+msgid "Kickstart Trees"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:621
+msgid "softwarechannel_listerrata: List the errata associated with a"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:622
+msgid "                            software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:623
+msgid ""
+"usage: softwarechannel_listerrata <CHANNEL ...> [from=yyyymmdd [to=yyyymmdd]]"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:681
+msgid "softwarechannel_listarches: lists the potential software"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:682
+msgid "                            channel architectures that can be created"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:683
+msgid "usage: softwarechannel_listarches"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:684 ../src/spacecmd/system.py:3826
+msgid "options:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:685
+msgid "    -v verbose (display label and name)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:706
+msgid "softwarechannel_delete: Delete a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:707
+msgid "usage: softwarechannel_delete <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:732
+msgid "Channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:760
+msgid "softwarechannel_update: Update a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:761
+#, python-format
+msgid ""
+"usage: softwarechannel_update LABEL(To identify the channel) [options]\n"
+"options:\n"
+"  -l LABEL(Required)\n"
+"  -n NAME\n"
+"  -s SUMMARY\n"
+"  -d DESCRIPTION\n"
+"  -c CHECKSUM %s\n"
+"  -u GPG-URL\n"
+"  -i GPG-ID\n"
+"  -f GPG-FINGERPRINT\n"
+"  -g DISABLE-GPG-CHECK"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:792
+#: ../src/spacecmd/softwarechannel.py:924
+#: ../src/spacecmd/softwarechannel.py:1094
+msgid "Channel Label:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:797
+msgid "New Name (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:803
+msgid "New Summary (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:806
+msgid "Summary:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:809
+msgid "New Description (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:815
+msgid "New Checksum type (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:822
+msgid "New GPG URL (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:825
+#: ../src/spacecmd/softwarechannel.py:953
+#: ../src/spacecmd/softwarechannel.py:1107
+#: ../src/spacecmd/softwarechannel.py:1196
+msgid "GPG URL:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:828
+msgid "New GPG ID (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:831
+#: ../src/spacecmd/softwarechannel.py:959
+#: ../src/spacecmd/softwarechannel.py:1108
+#: ../src/spacecmd/softwarechannel.py:1197
+msgid "GPG ID:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:834
+msgid "New GPG Fingerprint (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:837
+#: ../src/spacecmd/softwarechannel.py:965
+#: ../src/spacecmd/softwarechannel.py:1109
+#: ../src/spacecmd/softwarechannel.py:1198
+msgid "GPG Fingerprint:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:840
+msgid "Disable GPG CHECK (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:843
+#: ../src/spacecmd/softwarechannel.py:1110
+#: ../src/spacecmd/softwarechannel.py:1199
+msgid "Disable GPG Check [yes/no]? "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:846
+msgid "A channel label is required to identify the channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:849
+msgid "Only [yes/no] values are acceptable for --disable_gpg_check"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:889
+msgid "softwarechannel_create: Create a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:890
+#, python-format
+msgid ""
+"usage: softwarechannel_create [options])\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -l LABEL\n"
+"  -s SUMMARY\n"
+"  -p PARENT_CHANNEL\n"
+"  -a ARCHITECTURE\n"
+"  -c CHECKSUM %s\n"
+"  -u GPG_URL\n"
+"  -i GPG_ID\n"
+"  -f GPG_FINGERPRINT\n"
+"  -g DISABLE_GPG_CHECK"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:923
+#: ../src/spacecmd/softwarechannel.py:1093
+msgid "Channel Name:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:925
+msgid "Channel Summary:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:933
+#: ../src/spacecmd/softwarechannel.py:1101
+msgid "Select Parent [blank to create a base channel]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:936
+msgid "Architecture"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:943
+msgid "Checksum type"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:950
+msgid "GPG URL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:956
+msgid "GPG ID"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:962
+msgid "GPG Fingerprint"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:968
+msgid "GPG CHECK"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:971
+msgid "Disable GPG Check [y/N]? "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1023
+#: ../src/spacecmd/softwarechannel.py:1121
+msgid "A channel name is required"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1027
+#: ../src/spacecmd/softwarechannel.py:1125
+msgid "A channel label is required"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1040
+#, python-format
+msgid "Name %s already in use by channel %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1044
+#, python-format
+msgid "Label %s already in use by channel %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1052
+msgid "softwarechannel_clone: Clone a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1053
+msgid ""
+"usage: softwarechannel_clone [options])\n"
+"\n"
+"options:\n"
+"  -s SOURCE_CHANNEL\n"
+"  -n NAME\n"
+"  -l LABEL\n"
+"  -p PARENT_CHANNEL\n"
+"  --gpg-copy/-g (copy SOURCE_CHANNEL GPG details)\n"
+"  --gpg-url GPG_URL\n"
+"  --gpg-id GPG_ID\n"
+"  --gpg-fingerprint(GPG_FINGERPRINT)\n"
+"  --disable-gpg-check DISABLE_GPG_CHECK\n"
+"  -o do not clone any patches\n"
+"  --regex/-x \"s/foo/bar\" : Optional regex replacement,\n"
+"        replaces foo with bar in the clone name and label"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1088
+#: ../src/spacecmd/softwarechannel.py:1188
+msgid "Source Channels:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1092
+#: ../src/spacecmd/softwarechannel.py:1191
+msgid "Select source channel:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1096
+msgid "Base Channels:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1104
+#: ../src/spacecmd/softwarechannel.py:1194
+msgid "Copy source channel GPG details? [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1113
+#: ../src/spacecmd/softwarechannel.py:1202
+msgid "Original State (No Errata) [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1117
+#: ../src/spacecmd/softwarechannel.py:1205
+msgid "A source channel is required"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1138
+#: ../src/spacecmd/softwarechannel.py:1216
+msgid "Only [yes/no] values are acceptable for --disable-gpg-check"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1154
+msgid ""
+"softwarechannel_clonetree: Clone a software channel and its child channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1155
+msgid ""
+"usage: softwarechannel_clonetree [options])\n"
+"             e.g    softwarechannel_clonetree foobasechannel -p \"my_\"\n"
+"                    softwarechannel_clonetree foobasechannel -x \"s/foo/bar"
+"\"\n"
+"                    softwarechannel_clonetree foobasechannel -x \"s/^/my_\"\n"
+"\n"
+"options:\n"
+"  -s/--source-channel SOURCE_CHANNEL\n"
+"  -p/--prefix PREFIX (is prepended to the label and name of all channels)\n"
+"  --gpg-copy/-g (copy GPG details for correspondoing source channel))\n"
+"  --gpg-url GPG_URL (applied to all channels)\n"
+"  --gpg-id GPG_ID (applied to all channels)\n"
+"  --gpg-fingerprint(GPG_FINGERPRINT (applied to all channels))\n"
+"  --disable-gpg-check DISABLE_GPG_CHECK(applied to all channels)\n"
+"  -o do not clone any errata\n"
+"  --regex/-x \"s/foo/bar\" : Optional regex replacement,\n"
+"        replaces foo with bar in the clone name, label and description"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1192
+msgid "Prefix:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1209
+msgid "A prefix or regex is required"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1221
+#: ../src/spacecmd/softwarechannel.py:1994
+#: ../src/spacecmd/softwarechannel.py:2034
+msgid "Channel does not exist or is not a base channel!"
+msgstr ""
+
+#. Shouldn't ever get here due to earlier checks
+#: ../src/spacecmd/softwarechannel.py:1248
+msgid "called without prefix or regex option!"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1348
+msgid "softwarechannel_addpackages: Add packages to a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1349
+msgid "usage: softwarechannel_addpackages CHANNEL <PACKAGE ...>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1389
+msgid "No packages to add"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1396
+msgid "Add these packages [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1408
+msgid ""
+"softwarechannel_mergepackages: Merge packages from one software channel into "
+"another"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1409
+msgid "usage: softwarechannel_mergepackages SOURCE_CHANNEL TARGET_CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1433
+msgid "softwarechannel_removeerrata: Remove patches from a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1435
+msgid "usage: softwarechannel_removeerrata CHANNEL <ERRATA:search:XXX ...>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1488
+msgid "No patches to remove"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1499
+#: ../src/spacecmd/softwarechannel.py:1828
+#, python-format
+msgid "Total Errata:   %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1500
+#: ../src/spacecmd/softwarechannel.py:1831
+#, python-format
+msgid "Total Packages: %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1502
+msgid "Remove these patches [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1517
+msgid "softwarechannel_removepackages: Remove packages from a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1519
+msgid "usage: softwarechannel_removepackages CHANNEL <PACKAGE ...>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1573
+msgid "No packages to remove"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1593
+msgid ""
+"softwarechannel_adderratabydate: Add errata from one channel into another "
+"channel based on a date range"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1595
+msgid ""
+"usage: softwarechannel_adderratabydate [options] SOURCE DEST BEGINDATE "
+"ENDDATE"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1596
+#: ../src/spacecmd/softwarechannel.py:1671
+msgid "Date format : YYYYMMDD"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1597
+#: ../src/spacecmd/softwarechannel.py:1728
+#: ../src/spacecmd/softwarechannel.py:2620
+#: ../src/spacecmd/softwarechannel.py:2663
+#: ../src/spacecmd/softwarechannel.py:2879
+msgid "Options:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1598
+msgid "        -p/--publish : Publish errata to the channel (don't clone)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1625
+#: ../src/spacecmd/softwarechannel.py:1630
+#: ../src/spacecmd/softwarechannel.py:1696
+#: ../src/spacecmd/softwarechannel.py:1701
+#, python-format
+msgid "%s is an invalid date"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1643
+msgid "No patches found between the given dates"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1650
+#, python-format
+msgid "Publishing errata %s to %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1668
+msgid ""
+"softwarechannel_listerratabydate: list errata from channelbased on a date "
+"range"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1670
+msgid "usage: softwarechannel_listerratabydate CHANNEL BEGINDATE ENDDATE"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1714
+msgid "No errata found between the given dates"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1725
+msgid ""
+"softwarechannel_adderrata: Add patches from one channel into another channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1727
+msgid "usage: softwarechannel_adderrata SOURCE DEST <ERRATA|search:XXX ...>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1729
+msgid "    -q/--quick : Don't display list of packages (slightly faster)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1730
+msgid "    -s/--skip :  Skip errata which appear to exist already in DEST"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1756
+#, python-format
+msgid "source channel %s does not exist!"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1761
+#, python-format
+msgid "dest channel %s does not exist!"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1814
+msgid "No patch to add"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1833
+msgid "Add these patches [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1847
+msgid "Using the old errata.clone function"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1848
+msgid ""
+"If you have base channels for multiple OS versions, check no unexpected "
+"packages have been added"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1861
+msgid ""
+"softwarechannel_getorgaccess: Get the org-access for the software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1862
+msgid "usage: softwarechannel_getorgaccess [CHANNEL ...]"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1900
+msgid ""
+"softwarechannel_setorgaccess: Set the org-access for the software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1901
+msgid ""
+"usage : softwarechannel_setorgaccess <CHANNEL> [options])\n"
+"-d,--disable : disable org access (private, no org sharing)\n"
+"-e,--enable : enable org access (public access to all trusted orgs)\n"
+"-p,--protected ORG : protected org access for ORG only (multiple instances "
+"of -p ORG are allowed)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1941
+#, python-format
+msgid "Making org sharing public for channel : %s "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1946
+#, python-format
+msgid "Making org sharing private for channel : %s "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1951
+#, python-format
+msgid "Making org sharing protected for channel : %s "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1957
+#, python-format
+msgid "Enabling %s access for channel : %s "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1962
+#, python-format
+msgid "Disabling %s access for channel : %s "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1975
+msgid ""
+"softwarechannel_getorgaccesstree: Get the org-access for a software base "
+"channel and its children"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1976
+msgid "usage: softwarechannel_getorgaccesstree [CHANNEL]"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2009
+msgid ""
+"softwarechannel_setorgaccesstree: set the org-access for a software base "
+"channel and its children"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2010
+msgid ""
+"usage: softwarechannel_setorgaccesstree <CHANNEL> [options])\n"
+"-d,--disable : disable org access (private, no org sharing)\n"
+"-e,--enable : enable org access (public access to all trusted orgs)\n"
+"-p,--protected ORG : protected org access for ORG only (multiple instances "
+"of -p ORG are allowed)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2049
+msgid "softwarechannel_regenerateneededcache: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2050
+msgid "Regenerate the needed errata and package cache for all systems"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2052
+msgid "usage: softwarechannel_regenerateneededcache"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2066
+msgid "softwarechannel_regenerateyumcache: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2067
+msgid "Regenerate the YUM cache for a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2069
+msgid ""
+"usage: softwarechannel_regenerateyumcache [options] <CHANNEL ...>\n"
+"\n"
+"    options:\n"
+"      -f force cache regeneration\n"
+"    "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2113
+msgid "no softwarechannel label given"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2116
+msgid "invalid softwarechannel label "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2134
+msgid "softwarechannel_diff: diff softwarechannel files"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2136
+msgid "usage: softwarechannel_diff SOURCE_CHANNEL TARGET_CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2197
+msgid "softwarechannel_errata_diff: diff softwarechannel files"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2199
+msgid "usage: softwarechannel_errata_diff SOURCE_CHANNEL TARGET_CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2248
+msgid "softwarechannel_sync: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2249
+msgid "sync the packages of two software channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2251
+msgid ""
+"usage: softwarechannel_sync SOURCE_CHANNEL TARGET_CHANNEL [options])\n"
+"    -q,--quiet : quiet mode (omits the output of common packages in both "
+"channels)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2293
+#, python-format
+msgid "%s packages from softwarechannel %s to %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2312
+#: ../src/spacecmd/softwarechannel.py:2320
+#: ../src/spacecmd/softwarechannel.py:2434
+#: ../src/spacecmd/softwarechannel.py:2442
+#: ../src/spacecmd/softwarechannel.py:2574
+#: ../src/spacecmd/softwarechannel.py:2582
+msgid "failed to read key id"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2323
+msgid "packages common in both channels:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2328
+msgid "Omitting common packages in both specified channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2333
+msgid "packages to add to channel \""
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2341
+msgid "packages to remove from channel \""
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2347
+#: ../src/spacecmd/softwarechannel.py:2469
+#: ../src/spacecmd/softwarechannel.py:2599
+msgid "summary:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2348
+#: ../src/spacecmd/softwarechannel.py:2349
+msgid " packages"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2350
+msgid "    add    "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2351
+msgid " packages to   "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2354
+msgid "    remove "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2355
+msgid " packages from "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2357
+#: ../src/spacecmd/softwarechannel.py:2477
+msgid "Perform these changes to channel "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2378
+msgid "softwarechannel_errata_sync: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2379
+msgid "sync errata of two software channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2381
+msgid "usage: softwarechannel_errata_sync SOURCE_CHANNEL TARGET_CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2420
+msgid "syncing errata from softwarechannel "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2421
+#: ../src/spacecmd/softwarechannel.py:2553
+msgid " to "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2445
+msgid "errata common in both channels:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2454
+msgid "errata to add to channel \""
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2463
+msgid "errata to remove from channel \""
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2472
+#: ../src/spacecmd/softwarechannel.py:2602
+msgid "    add   "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2473
+msgid "errata to  "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2474
+msgid "    remove"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2475
+msgid "errata from"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2500
+msgid "softwarechannel_errata_merge: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2501
+msgid "merge errata of one software channel into another"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2503
+msgid ""
+"usage:   softwarechannel_errata_merge SOURCE_CHANNEL TARGET_CHANNEL "
+"[FROM_DATE] [TO_DATE]"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2504
+msgid ""
+"example: softwarechannel_errata_merge OldSoftChannel NewSoftChannel "
+"2018-01-01"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2505
+msgid ""
+"note:    Providing only FROM_DATE will merge all errata since that date."
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2506
+msgid "note:    When no date is provided, all errata will be merged."
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2536
+#: ../src/spacecmd/softwarechannel.py:2543
+msgid "wrong dateformat: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2536
+#: ../src/spacecmd/softwarechannel.py:2543
+msgid " please specify as: YYYY-MM-DD"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2552
+msgid "merging errata from softwarechannel "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2589
+msgid "{} contains no errata which is not already present in {}"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2594
+msgid "errata to add to channel {}: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2600
+#: ../src/spacecmd/softwarechannel.py:2601
+msgid " errata"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2603
+msgid " errata to  "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2605
+msgid "Perform these changes to channel {} [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2616
+msgid "softwarechannel_syncrepos: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2617
+msgid "Sync users repos for a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2619
+msgid "usage: softwarechannel_syncrepos <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2621
+#: ../src/spacecmd/softwarechannel.py:2664
+msgid "    -e/--no-errata : Do not sync errata"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2622
+#: ../src/spacecmd/softwarechannel.py:2665
+msgid "    -f/--fail : Terminate upon any error"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2623
+#: ../src/spacecmd/softwarechannel.py:2666
+msgid "    -k/--sync-kickstart : Create kickstartable tree"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2624
+#: ../src/spacecmd/softwarechannel.py:2667
+msgid "    -l/--latest : Only download latest package versions when repo syncs"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2659
+msgid "softwarechannel_setsyncschedule: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2660
+msgid "Sets the repo sync schedule for a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2662
+msgid "usage: softwarechannel_setsyncschedule <CHANNEL> <SCHEDULE>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2669
+msgid ""
+"The schedule is specified in Quartz CronTrigger format without enclosing "
+"quotes."
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2670
+msgid ""
+"For example, to set a schedule of every day at 1am, <SCHEDULE> would be 0 0 "
+"1 * * ?"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2671
+msgid "If <SCHEDULE> is left empty, it will be disabled."
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2734
+msgid ""
+"softwarechannel_listsyncschedule: List sync schedules for all software "
+"channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2736
+msgid "softwarechannel_listsyncschedule : List all channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2759
+msgid "key"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2759
+msgid "Channel Name"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2759
+msgid "Update Schedule"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2771
+msgid "softwarechannel_addrepo: Add a repo to a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2772
+msgid "usage: softwarechannel_addrepo CHANNEL REPO"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2805
+msgid "softwarechannel_removerepo: Remove a repo from a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2806
+msgid "usage: softwarechannel_removerepo CHANNEL REPO"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2846
+msgid "softwarechannel_listrepos: List the repos for a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2847
+msgid "usage: softwarechannel_listrepos CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2870
+msgid "No repos have been found for this channel."
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2877
+msgid "softwarechannel_mirrorpackages: Download packages of a given channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2878
+msgid "usage: softwarechannel_mirrorpackages CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2880
+msgid "    -l/--latest : Only mirror latest package version"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2911
+msgid "Skipping"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2913
+msgid "Fetching package"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2918
+#, python-format
+msgid "Received package %s from channel %s is broken. Content is too short"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2922
+#, python-format
+msgid "Could not fetch package %s from channel %s"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:42
+msgid "The System Set Manager (SSM) is a group of systems that you "
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:43
+msgid "can perform tasks on as a whole."
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:45
+msgid "Adding Systems:"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:51
+msgid "Intersections:"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:63
+msgid "ssm_add: Add systems to the SSM"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:64
+msgid "usage: ssm_add <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:66 ../src/spacecmd/ssm.py:115
+#: ../src/spacecmd/ssm.py:165 ../src/spacecmd/ssm.py:209
+msgid "see 'help ssm' for more details"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:92
+#, python-format
+msgid "%s is already in the list"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:110
+msgid "ssm_intersect: Replace the current SSM with the intersection"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:111
+msgid "               of the current list of systems and the list of"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:112
+msgid "               systems passed as arguments"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:113
+msgid "usage: ssm_intersect <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:162
+msgid "ssm_remove: Remove systems from the SSM"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:163
+msgid "usage: ssm_remove <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:206
+msgid "ssm_list: List the systems currently in the SSM"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:207
+msgid "usage: ssm_list"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:226
+msgid "ssm_clear: Remove all systems from the SSM"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:227
+msgid "usage: ssm_clear"
+msgstr ""
+
+#: ../src/spacecmd/system.py:49
+msgid "Same"
+msgstr ""
+
+#: ../src/spacecmd/system.py:50
+msgid "Only here"
+msgstr ""
+
+#: ../src/spacecmd/system.py:51
+msgid "Newer here"
+msgstr ""
+
+#: ../src/spacecmd/system.py:52
+msgid "Only there"
+msgstr ""
+
+#: ../src/spacecmd/system.py:53
+msgid "Newer there"
+msgstr ""
+
+#: ../src/spacecmd/system.py:73 ../src/spacecmd/system.py:3771
+msgid "Package"
+msgstr ""
+
+#: ../src/spacecmd/system.py:74
+msgid "This System"
+msgstr ""
+
+#: ../src/spacecmd/system.py:75
+msgid "Other System"
+msgstr ""
+
+#: ../src/spacecmd/system.py:76 ../src/spacecmd/system.py:3774
+msgid "Difference"
+msgstr ""
+
+#: ../src/spacecmd/system.py:124
+msgid "Removing Channels"
+msgstr ""
+
+#: ../src/spacecmd/system.py:127
+msgid "Adding Channels"
+msgstr ""
+
+#: ../src/spacecmd/system.py:163
+msgid "system_list: List all system profiles"
+msgstr ""
+
+#: ../src/spacecmd/system.py:164
+msgid "usage: system_list"
+msgstr ""
+
+#: ../src/spacecmd/system.py:180
+msgid "system_reboot: Reboot a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:181
+msgid ""
+"usage: system_reboot <SYSTEMS> [options])\n"
+"\n"
+"options:\n"
+"  -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:236
+msgid "Reboot these systems [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:252
+msgid "system_search: List systems that match the given criteria"
+msgstr ""
+
+#: ../src/spacecmd/system.py:253
+msgid "usage: system_search QUERY"
+msgstr ""
+
+#: ../src/spacecmd/system.py:255
+msgid "Available Fields:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:258
+msgid "Examples:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:259
+msgid "> system_search device:vmware"
+msgstr ""
+
+#: ../src/spacecmd/system.py:260
+msgid "> system_search ip:192.168.82"
+msgstr ""
+
+#: ../src/spacecmd/system.py:278 ../src/spacecmd/system.py:285
+msgid "Invalid query"
+msgstr ""
+
+#: ../src/spacecmd/system.py:321
+msgid "Invalid search field"
+msgstr ""
+
+#: ../src/spacecmd/system.py:351
+msgid "system_runscript: Schedule a script to run on the list of"
+msgstr ""
+
+#: ../src/spacecmd/system.py:352
+msgid "                  systems provided"
+msgstr ""
+
+#: ../src/spacecmd/system.py:353
+msgid ""
+"usage: system_runscript <SYSTEMS> [options])\n"
+"\n"
+"options:\n"
+"  -u USER\n"
+"  -g GROUP\n"
+"  -t TIMEOUT\n"
+"  -s START_TIME\n"
+"  -l LABEL\n"
+"  -f FILE"
+msgstr ""
+
+#: ../src/spacecmd/system.py:398
+msgid "User [root]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:399
+msgid "Group [root]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:408
+msgid "Timeout (in seconds) [600]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:414
+msgid "Invalid timeout"
+msgstr ""
+
+#: ../src/spacecmd/system.py:420
+msgid "Label/Short Description [default]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:424
+msgid "Script File [create]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:437
+msgid "No script provided"
+msgstr ""
+
+#: ../src/spacecmd/system.py:456
+msgid "A script file is required"
+msgstr ""
+
+#: ../src/spacecmd/system.py:464
+#, python-format
+msgid "User:       %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:465
+#, python-format
+msgid "Group:      %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:466
+#, python-format
+msgid "Timeout:    %i seconds"
+msgstr ""
+
+#: ../src/spacecmd/system.py:470
+#, python-format
+msgid "Label:      %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:471
+msgid "Script Contents"
+msgstr ""
+
+#: ../src/spacecmd/system.py:533 ../src/spacecmd/system.py:835
+#: ../src/spacecmd/system.py:962 ../src/spacecmd/system.py:1096
+#: ../src/spacecmd/system.py:4358
+#, python-format
+msgid "Failed to schedule %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:536
+#, python-format
+msgid "Scheduled: %i system(s)"
+msgstr ""
+
+#: ../src/spacecmd/system.py:543 ../src/spacecmd/utils.py:245
+#, python-format
+msgid "Could not remove %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:552
+msgid "system_listhardware: List the hardware details of a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:553
+msgid "usage: system_listhardware <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:612
+msgid "Network"
+msgstr ""
+
+#: ../src/spacecmd/system.py:621
+#, python-format
+msgid "Interface:   %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:622
+#, python-format
+msgid "MAC Address: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:623
+#, python-format
+msgid "IP Address:  %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:624
+#, python-format
+msgid "Netmask:     %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:625
+#, python-format
+msgid "Broadcast:   %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:626
+#, python-format
+msgid "Module:      %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:630
+msgid "CPU"
+msgstr ""
+
+#: ../src/spacecmd/system.py:632
+#, python-format
+msgid "Count:    %i"
+msgstr ""
+
+#: ../src/spacecmd/system.py:633
+#, python-format
+msgid "Arch:     %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:634
+#, python-format
+msgid "MHz:      %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:635
+#, python-format
+msgid "Cache:    %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:636
+#, python-format
+msgid "Vendor:   %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:637
+#, python-format
+msgid "Model:    %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:640
+msgid "Memory"
+msgstr ""
+
+#: ../src/spacecmd/system.py:642
+#, python-format
+msgid "RAM:  %i"
+msgstr ""
+
+#: ../src/spacecmd/system.py:643
+#, python-format
+msgid "Swap: %i"
+msgstr ""
+
+#: ../src/spacecmd/system.py:647
+msgid "DMI"
+msgstr ""
+
+#: ../src/spacecmd/system.py:648
+#, python-format
+msgid "Vendor:       %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:649
+#, python-format
+msgid "System:       %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:650
+#, python-format
+msgid "Product:      %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:651
+#, python-format
+msgid "Board:        %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:654
+msgid "Asset"
+msgstr ""
+
+#: ../src/spacecmd/system.py:660
+#, python-format
+msgid "BIOS Release: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:661
+#, python-format
+msgid "BIOS Vendor:  %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:662
+#, python-format
+msgid "BIOS Version: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:666
+msgid "Devices"
+msgstr ""
+
+#: ../src/spacecmd/system.py:676
+msgid "Description: None"
+msgstr ""
+
+#: ../src/spacecmd/system.py:680
+#, python-format
+msgid "Driver:      %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:681
+#, python-format
+msgid "Class:       %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:682
+#, python-format
+msgid "Bus:         %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:690
+msgid "system_installpackage: Install a package on a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:691
+msgid ""
+"usage: system_installpackage <SYSTEMS> <PACKAGE ...> [options])\n"
+"\n"
+"options:\n"
+"    -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:792
+msgid "No packages to install"
+msgstr ""
+
+#: ../src/spacecmd/system.py:816
+#, python-format
+msgid "%s does not have access to all requested packages"
+msgstr ""
+
+#: ../src/spacecmd/system.py:822
+msgid "Install these packages [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:837 ../src/spacecmd/system.py:964
+#: ../src/spacecmd/system.py:1098
+#, python-format
+msgid "Scheduled %i system(s)"
+msgstr ""
+
+#: ../src/spacecmd/system.py:845
+msgid "system_removepackage: Remove a package from a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:846
+msgid ""
+"usage: system_removepackage <SYSTEMS> <PACKAGE ...> [options])\n"
+"\n"
+"options:\n"
+"    -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:972
+msgid "system_upgradepackage: Upgrade a package on a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:973
+msgid ""
+"usage: system_upgradepackage <SYSTEMS> <PACKAGE ...>|* [options]')\n"
+"\n"
+"options:\n"
+"    -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1051 ../src/spacecmd/system.py:1147
+#, python-format
+msgid "No upgrades available for %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1074
+#, python-format
+msgid "Couldn't get name for package %i"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1081
+msgid "Upgrade these packages [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1106
+msgid "system_listupgrades: List the available upgrades for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1107
+msgid "usage: system_listupgrades <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1175
+msgid "system_listinstalledpackages: List the installed packages on a"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1176
+msgid "                              system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1177
+msgid "usage: system_listinstalledpackages <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1231
+msgid "system_listconfigchannels: List the config channels of a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1232
+msgid "usage: system_listconfigchannels <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1278 ../src/spacecmd/system.py:1381
+#, python-format
+msgid "%s does not support configuration channels"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1315
+msgid "system_listconfigfiles: List the managed config files of a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1316
+msgid ""
+"usage: system_listconfigfiles <SYSTEMS>')\n"
+"options:\n"
+"  -s/--sandbox : list only system-sandbox files\n"
+"  -l/--local   : list only locally managed files\n"
+"  -c/--central : list only centrally managed files\n"
+"  -q/--quiet   : quiet mode (omits the header)"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1416
+msgid "system_addconfigfile: Create a configuration file"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1417
+msgid "Note this is only for system sandbox or locally-managed files"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1418
+msgid "Centrally managed files should be created via configchannel_addfile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1419
+msgid ""
+"usage: system_addconfigfile [SYSTEM] [options]\n"
+"\n"
+"options:\n"
+"  -S/--sandbox : list only system-sandbox files\n"
+"  -L/--local   : list only locally managed files\n"
+"  -p PATH\n"
+"  -r REVISION\n"
+"  -o OWNER [default: root]\n"
+"  -g GROUP [default: root]\n"
+"  -m MODE [defualt: 0644]\n"
+"  -x SELINUX_CONTEXT\n"
+"  -d path is a directory\n"
+"  -s path is a symlink\n"
+"  -b path is a binary (or other file which needs base64 encoding)\n"
+"  -t SYMLINK_TARGET\n"
+"  -f local path to file contents\n"
+"\n"
+"  Note re binary/base64: Some text files, notably those containing trailing\n"
+"  newlines, those containing ASCII escape characters (or other charaters "
+"not\n"
+"  allowed in XML) need to be sent as binary (-b).  Some effort is made to "
+"auto-\n"
+"  detect files which require this, but you may need to explicitly specify.\n"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1487
+#, python-format
+msgid "%s is not a valid system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1497
+msgid "System-Sandbox or Locally-Managed? [S/L]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1513
+msgid "Must choose system-sandbox or locally-managed option"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1552
+msgid "system_addconfigchannels: Add config channels to a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1553
+msgid ""
+"usage: system_addconfigchannels <SYSTEMS> <CHANNEL ...> [options]\n"
+"\n"
+"options:\n"
+"  -t add channels to the top of the list\n"
+"  -b add channels to the bottom of the list"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1597
+msgid "Add to top or bottom? [T/b]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1621
+msgid "system_removeconfigchannels: Remove config channels from a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1622
+msgid "usage: system_removeconfigchannels <SYSTEMS> <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1671
+msgid ""
+"system_setconfigchannelorder: Set the ranked order of configuration channels"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1672
+msgid "usage: system_setconfigchannelorder <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1712
+msgid "New Configuration Channels"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1732
+msgid "system_deployconfigfiles: Deploy all configuration files for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1733
+msgid ""
+"usage: system_deployconfigfiles <SYSTEMS> [options]\n"
+"\n"
+"options:\n"
+"    -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1787
+msgid "Deploy ALL configuration files to these systems [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1797
+#, python-format
+msgid "Scheduled deployment for %i system(s)"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1805
+msgid "system_delete: Delete a system profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1806
+msgid ""
+"usage: system_delete [options] <SYSTEMS>\n"
+"\n"
+"    options:\n"
+"          -c TYPE - Possible values:\n"
+"             *  'FAIL_ON_CLEANUP_ERR' - fail in case of cleanup error,\n"
+"             *  'NO_CLEANUP' - do not cleanup, just delete,\n"
+"             *  'FORCE_DELETE' - Try cleanup first but delete server anyway "
+"in case of error\n"
+"    "
+msgstr ""
+
+#: ../src/spacecmd/system.py:1850
+msgid "No systems to delete"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1858
+#, python-format
+msgid "%s  System ID"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1858
+msgid "Profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1866
+msgid "Delete these systems [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1873
+#, python-format
+msgid "%i system(s) scheduled for removal"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1893
+msgid "system_lock: Lock a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1894
+msgid "usage: system_lock <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1935
+msgid "system_unlock: Unlock a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1936
+msgid "usage: system_unlock <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1977
+msgid "system_rename: Rename a system profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1978
+msgid "usage: system_rename OLDNAME NEWNAME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2023
+msgid "system_listcustomvalues: List the custom values for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2024
+msgid "usage: system_listcustomvalues <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2079
+msgid "system_addcustomvalue: Set a custom value for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2080
+msgid "usage: system_addcustomvalue KEY VALUE <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2134
+msgid "system_updatecustomvalue: Update a custom value for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2135
+msgid "usage: system_updatecustomvalue KEY VALUE <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2166
+msgid "system_removecustomvalues: Remove a custom value for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2167
+msgid "usage: system_removecustomvalues <SYSTEMS> <KEY ...>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2203
+msgid "Delete these values [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2221
+msgid "system_addnote: Set a note for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2222
+msgid ""
+"usage: system_addnote <SYSTEM> [options]\n"
+"\n"
+"options:\n"
+"  -s SUBJECT\n"
+"  -b BODY"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2257
+msgid "Subject of the Note:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2259
+msgid "Note Body (ctrl-D to finish):"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2263
+msgid "A subject is required"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2267
+msgid "A body is required"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2286
+msgid "system_deletenotes: Delete notes from a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2287
+msgid "usage: system_deletenotes <SYSTEM> <ID|*>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2319
+msgid "No notes to delete"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2346
+msgid "system_listnotes: List the available notes for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2347
+msgid "usage: system_listnotes <SYSTEM>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2405
+msgid "system_listfqdns: List the associated FQDNs for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2406
+msgid "usage: system_listfqdns <SYSTEM>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2458
+msgid "system_setbasechannel: Set a system's base software channel"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2459
+msgid "usage: system_setbasechannel <SYSTEMS> CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2506 ../src/spacecmd/system.py:2593
+#, python-format
+msgid "System:           %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2507 ../src/spacecmd/system.py:2594
+#, python-format
+msgid "Old Base Channel: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2508 ../src/spacecmd/system.py:2596
+#, python-format
+msgid "New Base Channel: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2527
+msgid ""
+"system_schedulechangechannels: Schedule changing a system's software channels"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2528
+msgid ""
+"usage: system_setbasechannel <SYSTEMS> [options]\n"
+"\n"
+"options:\n"
+"  -b BASE_CHANNEL base channel label\n"
+"  -c CHILD_CHANNEL child channel labels (allowed multiple times)\n"
+"  -s START_TIME time defaults to now"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2595
+#, python-format
+msgid "Old Child Channels: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2597
+#, python-format
+msgid "New Child channels %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2612 ../src/spacecmd/system.py:4243
+#, python-format
+msgid "Scheduled action id: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2619
+msgid "system_listbasechannel: List the base channel for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2620
+msgid "usage: system_listbasechannel <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2674
+msgid "system_listchildchannels: List the child channels for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2675
+msgid "usage: system_listchildchannels <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2729
+msgid "system_addchildchannels: Add child channels to a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2730
+msgid "usage: system_addchildchannels <SYSTEMS> <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2752
+msgid ""
+"system_listcrashedsystems: List all systems that have experienced a crash "
+"and reported by spacewalk-abrt"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2753
+msgid "usage: system_listcrashedsystems"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2759
+msgid "Count | System ID | Profile Name"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2773
+msgid "system_deletecrashes: Delete crashes reported by spacewalk-abrt."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2774
+msgid ""
+"usage: Delete all crashes for all systems    : system_deletecrashes [--"
+"verbose]"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2775
+msgid ""
+"usage: Delete all crashes for a single system: system_deletecrashes -i "
+"sys_id [--verbose]"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2776
+msgid ""
+"usage: Delete a single crash record          : system_deletecrashes -c "
+"crash_id [--verbose]"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2794
+#, python-format
+msgid "Deleting crash with id %s."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2801
+#, python-format
+msgid "Deleting all crashes from system with systemid %s [y/N]:"
+msgstr ""
+
+#. all systems
+#: ../src/spacecmd/system.py:2803
+msgid "Deleting all crashes from all systems [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2815
+#, python-format
+msgid "Deleting crash with id %s from system %s."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2824
+msgid "system_listcrashesbysystem: List all reported crashes for a system."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2825 ../src/spacecmd/system.py:2837
+msgid "usage: system_listcrashesbysystem -i sys_id"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2836
+msgid "# System id must be provided."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2842
+msgid "Crash ID | Crash Name"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2853
+msgid "system_getcrashfiles: Download all files for a crash record."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2854
+msgid "usage: system_getcrashfiles -c crash_id [--verbose]"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2855 ../src/spacecmd/system.py:2869
+msgid ""
+"usage: system_getcrashfiles -c crash_id [--dest_folder=/tmp/crash_files] [--"
+"verbose]"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2868
+msgid "# Crash id must be provided."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2895
+#, python-format
+msgid "# All files we downloaded to %s."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2904
+msgid "system_removechildchannels: Remove child channels from a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2905
+msgid "usage: system_removechildchannels <SYSTEMS> <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2927
+msgid "system_details: Show the details of a system profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2928
+msgid "usage: system_details <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2981
+#, python-format
+msgid "Name:          %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2982
+#, python-format
+msgid "System ID:     %i"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2985
+#, python-format
+msgid "UUID:          %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2987
+#, python-format
+msgid "Locked:        %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2988
+#, python-format
+msgid "Registered:    %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2989
+#, python-format
+msgid "Last Checkin:  %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2990
+#, python-format
+msgid "OSA Status:    %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2991
+#, python-format
+msgid "Last Boot:     %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2993
+#, python-format
+msgid "Contact Method:%s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3037
+#, python-format
+msgid "Hostname:      %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3038
+#, python-format
+msgid "IP Address:    %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3039
+#, python-format
+msgid "Kernel:        %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3080
+msgid "system_listerrata: List available errata for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3081
+msgid "usage: system_listerrata <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3135
+msgid "system_applyerrata: Apply errata to a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3136
+msgid ""
+"usage: system_applyerrata [options] <SYSTEMS>\n"
+"[ERRATA|search:XXX ...]\n"
+"\n"
+"options:\n"
+"  -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3197
+msgid "system_listevents: List the event history for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3198
+msgid "usage: system_listevents <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3244
+#, python-format
+msgid "Summary:   %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3246
+#, python-format
+msgid "Details:   %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3254
+msgid "system_listentitlements: List the entitlements for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3255
+msgid "usage: system_listentitlements <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3308
+msgid "system_addentitlements: Add entitlements to a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3309
+msgid "usage: system_addentitlements <SYSTEMS> ENTITLEMENT"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3364
+msgid "system_removeentitlement: Remove an entitlement from a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3365
+msgid "usage: system_removeentitlement <SYSTEMS> ENTITLEMENT"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3420
+msgid "system_listpackageprofiles: List all package profiles"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3421
+msgid "usage: system_listpackageprofiles"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3440
+msgid "system_deletepackageprofile: Delete a package profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3441
+msgid "usage: system_deletepackageprofile PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3465
+msgid "Delete this profile [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3476
+#, python-format
+msgid "%s is not a valid profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3487
+msgid "system_createpackageprofile: Create a package profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3488
+msgid ""
+"usage: system_createpackageprofile SYSTEM [options]\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -d DESCRIPTION"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3518
+msgid "Profile Label:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3522
+msgid "A profile name is required"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3526
+msgid "A profile description is required"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3534
+#, python-format
+msgid "Created package profile '%s'"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3542
+msgid ""
+"system_comparepackageprofile: Compare a system against a package profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3543
+msgid "usage: system_comparepackageprofile <SYSTEMS> PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3606
+msgid "system_comparepackages: Compare the packages between two systems"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3607
+msgid "usage: system_comparepackages SOME_SYSTEM ANOTHER_SYSTEM"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3638
+msgid "system_syncpackages: Sync packages between two systems"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3639
+msgid ""
+"usage: system_syncpackages SOURCE TARGET [options]\n"
+"\n"
+"options:\n"
+"    -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3687
+msgid "Sync packages [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3729
+#, python-format
+msgid "Failed to filter package list, package %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3730
+msgid "found with no arch or arch_label"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3772
+msgid "System Version"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3773
+msgid "Channel Version"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3795
+msgid "Channel_newer_than_system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3808
+msgid "System_newer_than_channel"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3817
+msgid "Missing_in_channel"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3821
+msgid "system_comparewithchannel: Compare the installed packages on a"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3822
+msgid "                           system with those in the channels it is"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3823
+msgid "                           registerd to, or optionally some other"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3824
+msgid "                           channel"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3825
+msgid "usage: system_comparewithchannel <SYSTEMS> [options]"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3827
+msgid "         -c/--channel : Specific channel to compare against,"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3828
+msgid "                        default is those subscribed to, including"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3829
+msgid "                        child channels"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3880
+msgid "Specified channel does not exist"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3891
+#, python-format
+msgid "system %s is not subscribed to any channel!"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3893
+msgid "Please subscribe to a channel, or specify achannel to compare with"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3927
+#, python-format
+msgid ""
+"\n"
+"System: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3953
+msgid ""
+"system_schedulehardwarerefresh: Schedule a hardware refresh for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3954
+msgid ""
+"usage: system_schedulehardwarerefresh <SYSTEMS> [options]\n"
+"\n"
+"options:\n"
+"  -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4016
+msgid ""
+"system_schedulepackagerefresh: Schedule a software package refresh for a "
+"system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4017
+msgid ""
+"usage: system_schedulepackagerefresh <SYSTEMS> [options])\n"
+"\n"
+"options:\n"
+"  -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4078
+msgid ""
+"system_show_packageversion: Shows version of installed package on given "
+"system(s)"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4079
+msgid "usage: system_show_packageversion <SYSTEM> <PACKAGE>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4111
+msgid "Package\tVersion\tRelease\tEpoch\tArch\tSystem"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4131
+msgid "system_setcontactmethod: Set the contact method for given system(s)."
+msgstr ""
+
+#: ../src/spacecmd/system.py:4133
+msgid "usage: system_setcontactmethod <SYSTEMS> <CONTACT_METHOD>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4182
+msgid ""
+"system_scheduleapplyconfigchannels: Schedule applying the assigned config "
+"channels to the System (Minion only)"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4183
+msgid ""
+"usage: scheduleapplyconfigchannels <SYSTEMS> [options]\n"
+"\n"
+"    options:\n"
+"        -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4234
+msgid "Schedule applying config channels to these systems [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4251
+msgid ""
+"system_listmigrationtargets: List possible migration targets for given "
+"systems."
+msgstr ""
+
+#: ../src/spacecmd/system.py:4252
+msgid "usage: system_listmigrationtargets <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4279
+msgid "WARN: Cannot find system "
+msgstr ""
+
+#: ../src/spacecmd/system.py:4286
+msgid "  No migration targets"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4289
+msgid "  Target #"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4290
+msgid "    IDs: "
+msgstr ""
+
+#: ../src/spacecmd/system.py:4291
+msgid "    Friendly names: "
+msgstr ""
+
+#: ../src/spacecmd/system.py:4297
+msgid ""
+"system_schedulespmigration: Schedule a Service Pack migration for systems."
+msgstr ""
+
+#: ../src/spacecmd/system.py:4298
+msgid ""
+"usage: system_schedulespmigration <SYSTEM> <BASE_CHANNEL_LABEL> "
+"<MIGRATION_TARGET> [options] \n"
+"    For MIGRATION_TARGET parameter see system_listmigrationtargets. \n"
+"    The MIGRATION_TARGET parameter must be passed in the following format: "
+"[3143,3146,3147,3145,3144,3148,3062]. \n"
+"    Options: \n"
+"        -s START_TIME \n"
+"        -d pass this flag, if you want to do a dry run \n"
+"        -c CHILD_CHANNELS (comma-separated child channels labels (with no "
+"spaces))"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4348
+msgid "Cannot find system "
+msgstr ""
+
+#: ../src/spacecmd/system.py:4348
+msgid ". Skipping it."
+msgstr ""
+
+#: ../src/spacecmd/system.py:4351
+msgid "Scheduling Service Pack migration for system "
+msgstr ""
+
+#: ../src/spacecmd/system.py:4356
+msgid "Scheduled action ID: "
+msgstr ""
+
+#: ../src/spacecmd/user.py:49
+msgid "user_create: Create an user"
+msgstr ""
+
+#: ../src/spacecmd/user.py:50
+msgid ""
+"usage: user_create [options])\n"
+"\n"
+"options:\n"
+"  -u USERNAME\n"
+"  -f FIRST_NAME\n"
+"  -l LAST_NAME\n"
+"  -e EMAIL\n"
+"  -p PASSWORD\n"
+"  --pam enable PAM authentication"
+msgstr ""
+
+#: ../src/spacecmd/user.py:119
+msgid "Note: password was ignored due to PAM mode"
+msgstr ""
+
+#: ../src/spacecmd/user.py:138
+msgid "user_delete: Delete an user"
+msgstr ""
+
+#: ../src/spacecmd/user.py:139
+msgid "usage: user_delete NAME"
+msgstr ""
+
+#: ../src/spacecmd/user.py:167
+msgid "user_disable: Disable an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:168
+msgid "usage: user_disable NAME"
+msgstr ""
+
+#: ../src/spacecmd/user.py:194
+msgid "user_enable: Enable an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:195
+msgid "usage: user_enable NAME"
+msgstr ""
+
+#: ../src/spacecmd/user.py:221
+msgid "user_list: List all users"
+msgstr ""
+
+#: ../src/spacecmd/user.py:222
+msgid "usage: user_list"
+msgstr ""
+
+#: ../src/spacecmd/user.py:239
+msgid "user_listavailableroles: List all available roles for users"
+msgstr ""
+
+#: ../src/spacecmd/user.py:240
+msgid "usage: user_listavailableroles"
+msgstr ""
+
+#: ../src/spacecmd/user.py:252
+msgid "No roles has been found"
+msgstr ""
+
+#: ../src/spacecmd/user.py:258
+msgid "user_addrole: Add a role to an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:259
+msgid "usage: user_addrole USER ROLE"
+msgstr ""
+
+#: ../src/spacecmd/user.py:292
+msgid "user_removerole: Remove a role from an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:293
+msgid "usage: user_removerole USER ROLE"
+msgstr ""
+
+#: ../src/spacecmd/user.py:327
+msgid "user_details: Show the details of an user"
+msgstr ""
+
+#: ../src/spacecmd/user.py:328
+msgid "usage: user_details USER ..."
+msgstr ""
+
+#: ../src/spacecmd/user.py:360
+#, python-format
+msgid "%s is not a valid user"
+msgstr ""
+
+#: ../src/spacecmd/user.py:361
+msgid "Error '{}' while getting data about user '{}': {}"
+msgstr ""
+
+#: ../src/spacecmd/user.py:371
+#, python-format
+msgid "Username:      %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:372
+#, python-format
+msgid "First Name:    %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:373
+#, python-format
+msgid "Last Name:     %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:374
+#, python-format
+msgid "Email Address: %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:375
+#, python-format
+msgid "Organisation:  %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:376
+#, python-format
+msgid "Last Login:    %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:377
+#, python-format
+msgid "Created:       %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:378
+#, python-format
+msgid "Enabled:       %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:382
+msgid "Roles"
+msgstr ""
+
+#: ../src/spacecmd/user.py:388
+msgid "Assigned Groups"
+msgstr ""
+
+#: ../src/spacecmd/user.py:394
+msgid "Default Groups"
+msgstr ""
+
+#: ../src/spacecmd/user.py:404
+msgid "user_addgroup: Add a group to an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:405
+msgid "usage: user_addgroup USER <GROUP ...>"
+msgstr ""
+
+#: ../src/spacecmd/user.py:442
+msgid "user_adddefaultgroup: Add a default group to an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:443
+msgid "usage: user_adddefaultgroup USER <GROUP ...>"
+msgstr ""
+
+#: ../src/spacecmd/user.py:479
+msgid "user_removegroup: Remove a group to an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:480
+msgid "usage: user_removegroup USER <GROUP ...>"
+msgstr ""
+
+#: ../src/spacecmd/user.py:520
+msgid "user_removedefaultgroup: Remove a default group from an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:522
+msgid "usage: user_removedefaultgroup USER <GROUP ...>"
+msgstr ""
+
+#: ../src/spacecmd/user.py:561
+msgid "user_setfirstname: Set an user accounts first name field"
+msgstr ""
+
+#: ../src/spacecmd/user.py:562
+msgid "usage: user_setfirstname USER FIRST_NAME"
+msgstr ""
+
+#: ../src/spacecmd/user.py:596
+msgid "user_setlastname: Set an user accounts last name field"
+msgstr ""
+
+#: ../src/spacecmd/user.py:597
+msgid "usage: user_setlastname USER LAST_NAME"
+msgstr ""
+
+#: ../src/spacecmd/user.py:631
+msgid "user_setemail: Set an user accounts email field"
+msgstr ""
+
+#: ../src/spacecmd/user.py:632
+msgid "usage: user_setemail USER EMAIL"
+msgstr ""
+
+#: ../src/spacecmd/user.py:666
+msgid "user_setprefix: Set an user accounts name prefix field"
+msgstr ""
+
+#: ../src/spacecmd/user.py:667
+msgid "usage: user_setprefix USER PREFIX"
+msgstr ""
+
+#: ../src/spacecmd/user.py:706
+msgid "user_setpassword: Set an user accounts name prefix field"
+msgstr ""
+
+#: ../src/spacecmd/user.py:707
+msgid "usage: user_setpassword USER PASSWORD"
+msgstr ""
+
+#. If cache generation is interrupted (e.g by ctrl-c) you can end up
+#. with an EOFError exception due to the partial picked file
+#. So we catch this error and remove the corrupt partial file
+#. If you don't do this then spacecmd will fail with an unhandled
+#. exception until the partial file is manually removed
+#: ../src/spacecmd/utils.py:133
+#, python-format
+msgid "Loading cache file %s failed"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:134
+#, python-format
+msgid "Cache generation was probably interrupted,removing corrupt %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:139
+#, python-format
+msgid "Couldn't load cache from %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:160
+#, python-format
+msgid "Couldn't write to %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:205
+msgid "Could not open the temporary file"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:225
+#, python-format
+msgid "Editor \"%s\" exited with code %i"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:227
+#, python-format
+msgid "General failure running editor: %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:230
+msgid "No editors found"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:367
+msgid "Invalid time provided"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:463
+msgid "Security Errata"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:472
+msgid "Bug Fix Errata"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:481
+msgid "Enhancement Errata"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:491
+msgid "Current Selections"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:501
+msgid "Available Configuration Channels"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:507 ../src/spacecmd/utils.py:527
+msgid "Channel:"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:510 ../src/spacecmd/utils.py:530
+msgid "Invalid channel"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:514
+msgid "New Rank:"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:521 ../src/spacecmd/utils.py:524
+msgid "Invalid rank"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:535
+msgid "Clearing current selections"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:690
+msgid "Could not generate json data object!"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:697
+#, python-format
+msgid "Could not open file %s for writing: %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:708
+#, python-format
+msgid "Could not open file %s for reading: %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:710
+#, python-format
+msgid "Could not parse JSON data from %s: %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:712
+#, python-format
+msgid "Error processing file %s: %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:740
+msgid "Skipping usage of common strings: both strings are equal"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:756
+msgid "Skipping usage of common strings: number of substrings differ"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:842
+msgid "Parameter {} not a string type, but {}."
+msgstr ""
+
+#: ../src/bin/spacecmd:74
+msgid "Unhandled exception occurred while getting FQDN:"
+msgstr ""

--- a/spacecmd/po/zh_CN.po
+++ b/spacecmd/po/zh_CN.po
@@ -1,0 +1,7456 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#: ../src/bin/spacecmd:59
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-09-24 17:29+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../src/spacecmd/activationkey.py:49
+msgid "activationkey_addpackages: Add packages to an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:50
+msgid "usage: activationkey_addpackages KEY <PACKAGE ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:83
+msgid "activationkey_removepackages: Remove packages from an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:85
+msgid "usage: activationkey_removepackages KEY <PACKAGE ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:121
+msgid "activationkey_addgroups: Add groups to an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:122
+msgid "usage: activationkey_addgroups KEY <GROUP ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:160
+msgid "activationkey_removegroups: Remove groups from an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:161
+msgid "usage: activationkey_removegroups KEY <GROUP ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:208
+msgid "activationkey_addentitlements: Add entitlements to an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:210
+msgid "usage: activationkey_addentitlements KEY <ENTITLEMENT ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:245
+msgid ""
+"activationkey_removeentitlements: Remove entitlements from an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:247
+msgid "usage: activationkey_removeentitlements KEY <ENTITLEMENT ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:285
+msgid "activationkey_addchildchannels: Add child channels to an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:287
+msgid "usage: activationkey_addchildchannels KEY <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:337
+msgid ""
+"activationkey_removechildchannels: Remove child channels from an activation "
+"key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:339
+msgid "usage: activationkey_removechildchannels KEY <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:376
+msgid ""
+"activationkey_listchildchannels: List the child channels for an activation "
+"key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:378
+msgid "usage: activationkey_listchildchannels KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:407
+msgid ""
+"activationkey_listbasechannel: List the base channels for an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:409
+msgid "usage: activationkey_listbasechannel KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:437
+msgid "activationkey_listgroups: List the groups for an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:439
+msgid "usage: activationkey_listgroups KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:470
+msgid ""
+"activationkey_listentitlements: List the entitlements for an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:472
+msgid "usage: activationkey_listentitlements KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:501
+msgid "activationkey_listpackages: List the packages for an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:503
+msgid "usage: activationkey_listpackages KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:535
+msgid ""
+"activationkey_listconfigchannels: List the configuration channels for an "
+"activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:537
+msgid "usage: activationkey_listconfigchannels KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:570
+msgid ""
+"activationkey_addconfigchannels: Add config channels to an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:572
+msgid ""
+"usage: activationkey_addconfigchannels KEY <CHANNEL ...> [options])\n"
+"\n"
+"options:\n"
+"  -t add channels to the top of the list\n"
+"  -b add channels to the bottom of the list"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:625
+msgid ""
+"activationkey_removeconfigchannels: Remove config channels from an "
+"activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:627
+msgid "usage: activationkey_removeconfigchannels KEY <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:666
+msgid ""
+"activationkey_setconfigchannelorder: Set the ranked order of configuration "
+"channels"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:668
+msgid "usage: activationkey_setconfigchannelorder KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:698
+msgid "New Configuration Channels:"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:712
+msgid "activationkey_create: Create an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:713
+msgid ""
+"usage: activationkey_create [options])\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -d DESCRIPTION\n"
+"  -b BASE_CHANNEL\n"
+"  -u set key as universal default\n"
+"  -e [enterprise_entitled,virtualization_host]"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:734
+msgid "Name (blank to autogenerate):"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:735
+msgid "Description [None]:"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:738 ../src/spacecmd/distribution.py:78
+#: ../src/spacecmd/softwarechannel.py:927
+msgid "Base Channels"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:743
+msgid "Base Channel (blank for default):"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:751
+#, python-format
+msgid "%s Entitlement [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:755
+msgid "Universal Default [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:782
+#, python-format
+msgid "Created activation key %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:790
+msgid "activationkey_delete: Delete an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:791
+msgid "usage: activationkey_delete KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:813 ../src/spacecmd/cryptokey.py:139
+#: ../src/spacecmd/cryptokey.py:197
+#, python-format
+msgid "No keys matched argument %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:819
+msgid "Delete activation key(s) [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:832
+msgid "activationkey_list: List all activation keys"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:833
+msgid "usage: activationkey_list"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:857
+msgid "activationkey_listsystems: List systems registered with a key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:858
+msgid "usage: activationkey_listsystems KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:881 ../src/spacecmd/activationkey.py:930
+#, python-format
+msgid "%s is not a valid activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:895
+msgid "activationkey_details: Show the details of an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:896
+msgid "usage: activationkey_details KEY ..."
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:943
+#, python-format
+msgid "Key:                    %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:944
+#, python-format
+msgid "Description:            %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:945
+#, python-format
+msgid "Universal Default:      %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:946
+#, python-format
+msgid "Usage Limit:            %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:947
+#, python-format
+msgid "Deploy Config Channels: %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:949
+#, python-format
+msgid "Contact Method:         %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:952 ../src/spacecmd/kickstart.py:425
+#: ../src/spacecmd/system.py:3048
+msgid "Software Channels"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:960 ../src/spacecmd/configchannel.py:765
+#: ../src/spacecmd/configchannel.py:870 ../src/spacecmd/system.py:3057
+msgid "Configuration Channels"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:966 ../src/spacecmd/system.py:3062
+msgid "Entitlements"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:971 ../src/spacecmd/system.py:3068
+msgid "System Groups"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:976 ../src/spacecmd/package.py:206
+#: ../src/spacecmd/package.py:263 ../src/spacecmd/softwarechannel.py:1392
+#: ../src/spacecmd/softwarechannel.py:1494
+#: ../src/spacecmd/softwarechannel.py:1576
+#: ../src/spacecmd/softwarechannel.py:1822
+msgid "Packages"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:991
+msgid "activationkey_enableconfigdeployment: Enable config channel deployment"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:993
+msgid "usage: activationkey_enableconfigdeployment KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1020
+msgid ""
+"activationkey_disableconfigdeployment: Disable config channel deployment"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1022
+msgid "usage: activationkey_disableconfigdeployment KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1049
+msgid "activationkey_setbasechannel: Set the base channel of an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1051
+msgid "usage: activationkey_setbasechannel KEY CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1098
+msgid ""
+"activationkey_setusagelimit: Set the usage limit of an activation key, can "
+"be a number or \"unlimited\""
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1100
+msgid "usage: activationkey_setusagelimit KEY <usage limit>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1101
+msgid "usage: activationkey_setusagelimit KEY unlimited "
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1131
+#, python-format
+msgid "Couldn't convert argument %s to an integer"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1153
+msgid ""
+"activationkey_setuniversaldefault: Set this key as the universal default"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1155
+msgid "usage: activationkey_setuniversaldefault KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1196
+msgid "activationkey_export: Export activation key(s) to JSON format file"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1197
+msgid ""
+"usage: activationkey_export [options] [<KEY> ...])\n"
+"\n"
+"options:\n"
+"    -f outfile.json : specify an output filename, defaults to <KEY>.json\n"
+"                      if exporting a single key, akeys.json for multiple "
+"keys,\n"
+"                      or akey_all.json if no KEY specified (export ALL)\n"
+"\n"
+"Note : KEY list is optional, default is to export ALL keys "
+msgstr ""
+
+#. Get the key details
+#: ../src/spacecmd/activationkey.py:1213
+#, python-format
+msgid "Getting activation key details for %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1267
+#, python-format
+msgid "Exporting ALL activation keys to %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1276
+msgid "Invalid activation key passed"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1291
+#, python-format
+msgid "Exporting key %s to %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1300
+#, python-format
+msgid "File %s exists, confirm overwrite file? (y/n)"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1305
+msgid "Failed to save exported keys to file: {}"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1314
+msgid "activationkey_import: import activation key(s) from JSON file(s)"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1315
+msgid "usage: activationkey_import <JSONFILE ...>"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1324
+msgid "No filename passed"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1333
+#, python-format
+msgid "Could not read json data from %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1338 ../src/spacecmd/activationkey.py:1382
+#, python-format
+msgid "Failed to import key %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1352
+#, python-format
+msgid "%s already exists! Skipping!"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1407
+#, python-format
+msgid "System group %s doesn't exist, creating"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1428
+msgid "activationkey_clone: Clone an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1429
+msgid ""
+"usage examples:\n"
+"                 activationkey_clone foo_key -c bar_key\n"
+"                 activationkey_clone foo_key1 foo_key2 -c prefix\n"
+"                 activationkey_clone foo_key -x \"s/foo/bar\"\n"
+"                 activationkey_clone foo_key1 foo_key2 -x \"s/foo/bar\"\n"
+"\n"
+"options:\n"
+"  -c CLONE_NAME  : Name of the resulting key, treated as a prefix for "
+"multiple\n"
+"                   keys\n"
+"  -x \"s/foo/bar\" : Optional regex replacement, replaces foo with bar in "
+"the\n"
+"                   clone description, base-channel label, child-channel\n"
+"                   labels, config-channel names "
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1457 ../src/spacecmd/kickstart.py:460
+#: ../src/spacecmd/system.py:3043
+msgid "Activation Keys"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1463
+#, python-format
+msgid "Key to clone: %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1467
+msgid "Original Key:"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1469
+msgid "Cloned Key:"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1472 ../src/spacecmd/configchannel.py:1376
+msgid "Error - must specify either -c or -x options!"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1477
+#, python-format
+msgid "Key %s already exists"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1481
+msgid "Error no activationkey to clone passed!"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1535
+#, python-format
+msgid "Found child channel %s key %s, %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1537
+msgid " does not exist, skipping!"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1544
+#, python-format
+msgid "Regex-replacement results in new base-channel %s which does not exist!"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1560
+#, python-format
+msgid "Found config channel %s for key %s, %s "
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1562
+msgid "does not exist, skipping!"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1584 ../src/spacecmd/configchannel.py:1428
+#, python-format
+msgid "Failed to clone %s to %s"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1602
+msgid "no activationkey label given"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1605
+msgid "invalid activationkey label "
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1622
+msgid "activationkey_diff: Diff activation keys"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1624
+msgid "usage: activationkey_diff SOURCE_KEY TARGET_KEY"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1673
+msgid "activationkey_disable: Disable an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1675
+msgid "usage: activationkey_disable KEY [KEY ...]"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1707
+msgid "activationkey_enable: Enable an activation key"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1709
+msgid "usage: activationkey_enable KEY [KEY ...]"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1741
+msgid "activationkey_setdescription: Set the activation key description"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1743
+msgid "usage: activationkey_setdescription KEY DESCRIPTION"
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1775
+msgid ""
+"activationkey_setcontactmethod: Set the contact method to use for systems "
+"registered with this key."
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1777 ../src/spacecmd/system.py:4132
+msgid "Available contact methods: "
+msgstr ""
+
+#: ../src/spacecmd/activationkey.py:1778
+msgid "usage: activationkey_setcontactmethod KEY CONTACT_METHOD"
+msgstr ""
+
+#: ../src/spacecmd/api.py:44
+msgid "api: call RHN API with arguments directly"
+msgstr ""
+
+#: ../src/spacecmd/api.py:45
+#, python-format
+msgid ""
+"usage: api [options] API_STRING)\n"
+"\n"
+"options:\n"
+"  -A, --args  Arguments for the API other than session id in comma "
+"separated\n"
+"              strings or JSON expression\n"
+"  -F, --format   Output format\n"
+"  -o, --output   Output file\n"
+"\n"
+"examples:\n"
+"  api api.getApiCallList\n"
+"  api --args \"sysgroup_A\" systemgroup.listSystems\n"
+"  api -A \"rhel-i386-server-5,2011-04-01,2011-05-01\" -F \"%(name)s\" \\\n"
+"      channel.software.listAllPackages\n"
+msgstr ""
+
+#: ../src/spacecmd/api.py:81
+msgid "Could not open to write: "
+msgstr ""
+
+#: ../src/spacecmd/api.py:82
+msgid "Fallback output to stdout"
+msgstr ""
+
+#: ../src/spacecmd/api.py:91
+msgid "No such API: "
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:50
+msgid "configchannel_list: List all configuration channels"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:51
+msgid "usage: configchannel_list"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:68
+msgid "configchannel_listsystems: List the systems subscribed to a"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:69
+msgid "                           configuration channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:70
+msgid "usage: configchannel_listsystems CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:79
+msgid "This version of the API doesn't support this method"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:103
+msgid "configchannel_listfiles: List the files in a config channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:104
+msgid "usage: configchannel_listfiles CHANNEL ..."
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:133
+msgid "configchannel_forcedeploy: Forces a redeployment"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:134
+msgid "                           of files within this channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:135
+msgid "                           on all subscribed systems"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:136
+msgid "usage: configchannel_forcedeploy CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:158
+msgid "No files within selected configchannel."
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:164
+msgid "Channel has no subscribed Systems"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:167
+msgid "Force deployment of the following configfiles:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:170
+msgid ""
+"\n"
+"On these systems:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:173
+msgid "Really force deployment [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:182
+msgid "configchannel_filedetails: Show the details of a file"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:183
+msgid "in a configuration channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:184
+msgid "usage: configchannel_filedetails CHANNEL FILE [REVISION]"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:216
+#, python-format
+msgid "Invalid revision: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:222
+#, python-format
+msgid "%s is not in this configuration channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:240
+#, python-format
+msgid "Path:     %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:241
+#, python-format
+msgid "Type:     %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:242
+#, python-format
+msgid "Revision: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:243
+#, python-format
+msgid "Created:  %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:244
+#, python-format
+msgid "Modified: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:248 ../src/spacecmd/configchannel.py:650
+#, python-format
+msgid "Target Path:     %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:251 ../src/spacecmd/configchannel.py:680
+#, python-format
+msgid "Owner:           %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:252 ../src/spacecmd/configchannel.py:681
+#, python-format
+msgid "Group:           %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:253 ../src/spacecmd/configchannel.py:682
+#, python-format
+msgid "Mode:            %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:255 ../src/spacecmd/configchannel.py:651
+#: ../src/spacecmd/configchannel.py:684
+#, python-format
+msgid "SELinux Context: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:258
+#, python-format
+msgid "SHA256:          %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:259 ../src/spacecmd/configchannel.py:683
+#, python-format
+msgid "Binary:          %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:263 ../src/spacecmd/configchannel.py:696
+#: ../src/spacecmd/configchannel.py:933 ../src/spacecmd/kickstart.py:1903
+#: ../src/spacecmd/snippet.py:161
+msgid "Contents"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:273
+msgid "configchannel_backup: backup a config channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:274
+msgid ""
+"usage: configchannel_backup CHANNEL [OUTDIR])\n"
+"\n"
+"OUTDIR defaults to $HOME/spacecmd-backup/configchannel/YYYY-MM-DD/CHANNEL\n"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:313 ../src/spacecmd/group.py:266
+#, python-format
+msgid "Could not create output directory: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:326
+#, python-format
+msgid "Could not create \"%s\" file: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:332
+#, python-format
+msgid "Output Path:   %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:371
+msgid "configchannel_details: Show the details of a config channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:372
+msgid "usage: configchannel_details CHANNEL ..."
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:402 ../src/spacecmd/kickstart.py:414
+#, python-format
+msgid "Label:       %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:403 ../src/spacecmd/kickstart.py:413
+#, python-format
+msgid "Name:        %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:404 ../src/spacecmd/cryptokey.py:214
+#: ../src/spacecmd/system.py:678
+#, python-format
+msgid "Description: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:405 ../src/spacecmd/cryptokey.py:215
+#: ../src/spacecmd/kickstart.py:500 ../src/spacecmd/kickstart.py:1899
+#, python-format
+msgid "Type:        %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:408
+msgid "Files"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:418
+msgid "configchannel_create: Create a configuration channel of specific type"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:419
+msgid ""
+"usage: configchannel_create [options])\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -l LABEL\n"
+"  -d DESCRIPTION\n"
+"  -t TYPE('normal,'state')"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:438 ../src/spacecmd/custominfo.py:54
+#: ../src/spacecmd/custominfo.py:198 ../src/spacecmd/distribution.py:71
+#: ../src/spacecmd/filepreservation.py:70 ../src/spacecmd/group.py:177
+#: ../src/spacecmd/repo.py:349 ../src/spacecmd/repo.py:461
+#: ../src/spacecmd/softwarechannel.py:800
+msgid "Name:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:439
+msgid "Label:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:440 ../src/spacecmd/cryptokey.py:66
+#: ../src/spacecmd/custominfo.py:59 ../src/spacecmd/custominfo.py:203
+#: ../src/spacecmd/group.py:182 ../src/spacecmd/softwarechannel.py:812
+#: ../src/spacecmd/system.py:3519
+msgid "Description:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:441
+msgid "Type [normal, state]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:448
+msgid "Only [normal/state] values are acceptable for type"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:452 ../src/spacecmd/distribution.py:109
+#: ../src/spacecmd/repo.py:357 ../src/spacecmd/repo.py:467
+msgid "A name is required"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:461
+msgid "Only [normal/state] values are acceptable for --type parameter"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:476
+msgid "configchannel_delete: Delete a configuration channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:477
+msgid "usage: configchannel_delete CHANNEL ..."
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:498
+#, python-format
+msgid "No channels matched argument(s): %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:504 ../src/spacecmd/softwarechannel.py:736
+msgid "Delete these channels [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:548
+msgid "Symlink [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:552
+msgid "Target Path:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:553
+msgid "SELinux Context [none]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:561
+msgid "Directory [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:570
+#, python-format
+msgid "Owner [%s]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:571
+#, python-format
+msgid "Group [%s]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:572
+#, python-format
+msgid "Mode [%s]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:574
+#, python-format
+msgid "SELinux Context [%s]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:575
+msgid "Revision [next]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:593
+msgid "The revision must be an integer"
+msgstr ""
+
+#. get the contents of the script
+#: ../src/spacecmd/configchannel.py:596 ../src/spacecmd/configchannel.py:896
+#: ../src/spacecmd/cryptokey.py:68 ../src/spacecmd/kickstart.py:1954
+#: ../src/spacecmd/snippet.py:141
+msgid "Read an existing file [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:598 ../src/spacecmd/kickstart.py:1956
+msgid "File:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:616
+msgid "The path is required"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:630 ../src/spacecmd/configchannel.py:913
+msgid "You must provide the file contents"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:634
+msgid "You must provide the target path for a symlink"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:649 ../src/spacecmd/configchannel.py:678
+#, python-format
+msgid "Path:            %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:679
+#, python-format
+msgid "Directory:       %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:689
+#, python-format
+msgid "Revision:        %i"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:694
+msgid "Contents not displayed (base64 encoded)"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:707
+msgid ""
+"configchannel_addfile/configchannel_updatefile: Create a configuration file"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:708
+msgid ""
+"usage: configchannel_addfile/configchannel_updatefile -c CHANNEL - p PATH -f "
+"LOCAL_FILE_PATH [OPTIONS])\n"
+"\n"
+"options:\n"
+"  -c CHANNEL\n"
+"  -p PATH\n"
+"  -r REVISION\n"
+"  -o OWNER [default: root]\n"
+"  -g GROUP [default: root]\n"
+"  -m MODE [defualt: 0644]\n"
+"  -x SELINUX_CONTEXT\n"
+"  -d path is a directory\n"
+"  -s path is a symlink\n"
+"  -b path is a binary (or other file which needs base64 encoding)\n"
+"  -t SYMLINK_TARGET\n"
+"  -f local path to file contents\n"
+"  -y automatically proceed with file contents\n"
+"\n"
+"  Note re binary/base64: Some text files, notably those containing trailing\n"
+"  newlines, those containing ASCII escape characters (or other charaters "
+"not\n"
+"  allowed in XML) need to be sent as binary (-b).  Some effort is made to "
+"auto-\n"
+"  detect files which require this, but you may need to explicitly specify.\n"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:770 ../src/spacecmd/softwarechannel.py:819
+#: ../src/spacecmd/softwarechannel.py:940
+#: ../src/spacecmd/softwarechannel.py:947
+msgid "Select:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:778 ../src/spacecmd/softwarechannel.py:1374
+#, python-format
+msgid "%s is not a valid channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:783
+msgid "Unable to obtain a valid channel. Aborting."
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:789 ../src/spacecmd/scap.py:160
+msgid "Path:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:805 ../src/spacecmd/configchannel.py:924
+msgid "No config channel specified!"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:810 ../src/spacecmd/configchannel.py:929
+msgid "Error obtaining file info"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:845
+msgid "configchannel_updateinitsls: Update init.sls file"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:846
+msgid ""
+"usage: configchannel_updateinitsls -c CHANNEL -f LOCAL_FILE_PATH [OPTIONS])\n"
+"\n"
+"options:\n"
+"  -c CHANNEL\n"
+"  -f local path to file contents\n"
+"  -y automatically proceed with file contents\n"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:892
+#, python-format
+msgid "No existing file information found for %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:932
+#, python-format
+msgid "contents_enc64:           %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:959
+msgid "configchannel_removefiles: Remove configuration files"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:960
+msgid "usage: configchannel_removefiles CHANNEL <FILE ...>"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:997
+msgid "configchannel_verifyfile: Verify a configuration file"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:998
+msgid "usage: configchannel_verifyfile CHANNEL FILE <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1037
+msgid "No valid system selected"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1045 ../src/spacecmd/system.py:509
+#: ../src/spacecmd/system.py:529 ../src/spacecmd/system.py:959
+#, python-format
+msgid "Action ID: %i"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1053
+msgid "configchannel_export: export config channel(s) to json format file"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1054
+msgid ""
+"usage: configchannel_export <CHANNEL>... [options])\n"
+"options:\n"
+"    -f outfile.json : specify an output filename, defaults to <CHANNEL>."
+"json\n"
+"                      if exporting a single channel, ccs.json for multiple\n"
+"                      channels, or cc_all.json if no CHANNEL specified\n"
+"                      e.g (export ALL)\n"
+"\n"
+"Note : CHANNEL list is optional, default is to export ALL"
+msgstr ""
+
+#. Get the cc details
+#: ../src/spacecmd/configchannel.py:1070
+#, python-format
+msgid "Getting config channel details for %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1090
+#, python-format
+msgid "Failed to get details for file %s from %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1136
+#, python-format
+msgid "File %s could not be exported "
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1137
+msgid "with this API version(needs base64 encoding)"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1139
+#, python-format
+msgid "File %s could not be exported as"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1140
+msgid " text...getting base64 encoded version"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1163
+#, python-format
+msgid "Passed filename '%s' to do_configchannel_export command."
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1171
+#, python-format
+msgid "Exporting ALL config channels to %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1178
+msgid ""
+"Error, no valid config channel passed, check name is  correct with spacecmd "
+"configchannel_list"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1193
+#, python-format
+msgid "Exporting cc %s to %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1200
+msgid "File '{}' exists, confirm overwrite file? (y/n)"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1203
+#, python-format
+msgid "Error saving exported config channels to file: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1212
+msgid "configchannel_import: import config channel(s) from json file"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1213
+msgid "usage: configchannel_import <JSONFILES...>"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1222 ../src/spacecmd/kickstart.py:2330
+msgid "Error, no filename passed"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1230 ../src/spacecmd/kickstart.py:2338
+#, python-format
+msgid "Error, could not read json data from %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1234
+#, python-format
+msgid "Error importing configchannel %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1246
+#, python-format
+msgid "Config channel %s already exists! Skipping!"
+msgstr ""
+
+#. create the cc, we need to drop the org prefix from the cc name
+#: ../src/spacecmd/configchannel.py:1251
+#, python-format
+msgid "Importing config channel  %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1294
+#, python-format
+msgid "Failed trying to import file %s (empty content)"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1296
+msgid "Older APIs can't export encoded files"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1319
+#, python-format
+msgid "Error adding file %s to %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1329
+msgid "configchannel_clone: Clone config channel(s)"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1330
+msgid ""
+"usage examples:\n"
+"                 configchannel_clone foo_label -c bar_label\n"
+"                 configchannel_clone foo_label1 foo_label2 -c prefix\n"
+"                 configchannel_clone foo_label -x \"s/foo/bar\"\n"
+"                 configchannel_clone foo_label1 foo_label2 -x \"s/foo/bar\"\n"
+"\n"
+"options:\n"
+"  -c CLONE_LABEL : name/label of the resulting cc (note does not update\n"
+"                   description, see -x option), treated as a prefix if\n"
+"                   multiple keys are passed\n"
+"  -x \"s/foo/bar\" : Optional regex replacement, replaces foo with bar in "
+"the\n"
+"                   clone name, label and description\n"
+"  Note : If no -c or -x option is specified, interactive is assumed"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1359
+msgid "No config channels found"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1362
+msgid "Config Channels"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1368
+#, python-format
+msgid "Channel to clone: %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1372
+msgid "Channel to clone:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1373
+msgid "Clone label:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1382
+msgid "Error no channel label passed!"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1391
+msgid "No suitable channels to clone has been found."
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1444
+msgid "no configchannel given"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1447
+msgid "invalid configchannel label "
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1473
+msgid "configchannel_diff: diff between config channels"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1475
+msgid "usage: configchannel_diff SOURCE_CHANNEL TARGET_CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1524
+msgid "configchannel_sync:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1525
+msgid "sync config files between two config channels"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1527
+msgid "usage: configchannel_sync SOURCE_CHANNEL TARGET_CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1565
+msgid "syncing files from configchannel "
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1572
+msgid "files common in both channels:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1578
+msgid "files only in source "
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1584
+msgid "files only in target "
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1589
+msgid ""
+"files that are in both channels will be overwritten in the target channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1591
+msgid "files only in the source channel will be added to the target channel"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1593
+msgid "files only in the target channel will be deleted"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1596
+msgid "nothing to do"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1600
+msgid "perform synchronisation [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:1652
+msgid "unknown file type "
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:43
+msgid "cryptokey_create: Create a cryptographic key"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:44
+msgid ""
+"usage: cryptokey_create [options])\n"
+"\n"
+"options:\n"
+"  -t GPG or SSL\n"
+"  -d DESCRIPTION\n"
+"  -f KEY_FILE"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:62
+msgid "GPG or SSL [G/S]:"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:75
+msgid "The key type is required"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:79
+msgid "A description is required"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:83
+msgid "A file containing the key is required"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:91
+msgid "No contents of the file"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:100
+msgid "Invalid key type"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:114
+msgid "cryptokey_delete: Delete a cryptographic key"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:115
+msgid "usage: cryptokey_delete NAME"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:145
+msgid "Delete key(s) [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:156
+msgid "cryptokey_list: List all cryptographic keys (SSL, GPG)"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:157
+msgid "usage: cryptokey_list"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:174
+msgid "cryptokey_details: Show the contents of a cryptographic key"
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:175
+msgid "usage: cryptokey_details KEY ..."
+msgstr ""
+
+#: ../src/spacecmd/cryptokey.py:207
+#, python-format
+msgid "%s is not a valid crypto key"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:39
+msgid "custominfo_createkey: Create a custom key"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:40
+msgid "usage: custominfo_createkey [NAME] [DESCRIPTION]"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:73
+msgid "custominfo_deletekey: Delete a custom key"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:74
+msgid "usage: custominfo_deletekey KEY ..."
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:114
+msgid "custominfo_listkeys: List all custom keys"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:115
+msgid "usage: custominfo_listkeys"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:132
+msgid "custominfo_details: Show the details of a custom key"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:133
+msgid "usage: custominfo_details KEY ..."
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:155
+msgid "No keys matched argument '{}'."
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:172
+#, python-format
+msgid "Label:        %s"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:173
+#, python-format
+msgid "Description:  %s"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:174
+#, python-format
+msgid "Modified:     %s"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:175
+#, python-format
+msgid "System Count: %i"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:183
+msgid "custominfo_updatekey: Update a custom key"
+msgstr ""
+
+#: ../src/spacecmd/custominfo.py:184
+msgid "usage: custominfo_updatekey [NAME] [DESCRIPTION]"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:42
+msgid "distribution_create: Create a Kickstart tree"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:43
+msgid ""
+"usage: distribution_create [options]\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -p path to tree\n"
+"  -b base channel to associate with\n"
+"  -t install type [fedora|rhel_4/5/6|generic_rpm]"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:66
+msgid "The name of the distribution is required"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:73
+msgid "Path to Kickstart Tree:"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:83
+msgid "Base Channel:"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:86
+msgid "Invalid channel label"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:97
+msgid "Install Types"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:102
+msgid "Install Type:"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:105
+msgid "Invalid install type"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:113
+msgid "A path is required"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:117 ../src/spacecmd/system.py:2556
+msgid "A base channel is required"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:121
+msgid "An install type is required"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:143
+msgid "distribution_list: List the available autoinstall trees"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:144
+msgid "usage: distribution_list"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:168
+msgid "distribution_delete: Delete a Kickstart tree"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:169
+msgid "usage: distribution_delete LABEL"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:193 ../src/spacecmd/distribution.py:232
+#, python-format
+msgid "No distributions matched argument %s"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:199
+msgid "Delete distribution tree(s) [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:209
+msgid "distribution_details: Show the details of a Kickstart tree"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:210
+msgid "usage: distribution_details LABEL"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:248 ../src/spacecmd/package.py:93
+#, python-format
+msgid "Name:    %s"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:249 ../src/spacecmd/package.py:100
+#, python-format
+msgid "Path:    %s"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:250
+#, python-format
+msgid "Channel: %s"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:258
+msgid "distribution_rename: Rename a Kickstart tree"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:259
+msgid "usage: distribution_rename OLDNAME NEWNAME"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:288
+msgid "distribution_update: Update the path of a Kickstart tree"
+msgstr ""
+
+#: ../src/spacecmd/distribution.py:289
+msgid ""
+"usage: distribution_update NAME [options]\n"
+"\n"
+"options:\n"
+"  -p path to tree\n"
+"  -b base channel to associate with\n"
+"  -t install type [fedora|rhel_4/5/6|generic_rpm]"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:49
+msgid "errata_list: List all patches"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:50
+msgid "usage: errata_list"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:66
+msgid "errata_summary: Print a summary of all errata"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:67
+msgid "usage: errata_summary"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:82
+msgid "errata_apply: Apply an erratum to all affected systems"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:83
+msgid ""
+"usage: errata_apply [options] ERRATA|search:XXX ...)\n"
+"\n"
+"options:\n"
+"  -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:110 ../src/spacecmd/system.py:417
+#: ../src/spacecmd/system.py:725 ../src/spacecmd/system.py:880
+#: ../src/spacecmd/system.py:1015 ../src/spacecmd/system.py:1762
+#: ../src/spacecmd/system.py:3673 ../src/spacecmd/system.py:3983
+#: ../src/spacecmd/system.py:4045 ../src/spacecmd/system.py:4209
+msgid "Start Time [now]:"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:158
+msgid "No patches to apply"
+msgstr ""
+
+#. a summary of which errata we're going to apply
+#: ../src/spacecmd/errata.py:162
+msgid "Errata             Systems"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:166 ../src/spacecmd/system.py:230
+#: ../src/spacecmd/system.py:467 ../src/spacecmd/system.py:820
+#: ../src/spacecmd/system.py:942 ../src/spacecmd/system.py:1079
+#: ../src/spacecmd/system.py:1781 ../src/spacecmd/system.py:3685
+#: ../src/spacecmd/system.py:4228
+#, python-format
+msgid "Start Time: %s"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:168
+msgid "Apply these patches [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:218
+#, python-format
+msgid "No patches to schedule for %s"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:227
+#, python-format
+msgid "Scheduled %i patches for %s"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:236
+msgid "errata_listaffectedsystems: List of systems affected by an patch"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:237
+msgid "usage: errata_listaffectedsystems ERRATA|search:XXX ..."
+msgstr ""
+
+#: ../src/spacecmd/errata.py:275
+msgid "errata_listcves: List of CVEs addressed by an patch"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:276
+msgid "usage: errata_listcves ERRATA|search:XXX ..."
+msgstr ""
+
+#: ../src/spacecmd/errata.py:312
+msgid "No errata has been found"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:319
+msgid "errata_findbycve: List errata addressing a CVE"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:320
+msgid "usage: errata_findbycve CVE-YYYY-NNNN ..."
+msgstr ""
+
+#: ../src/spacecmd/errata.py:354
+msgid "errata_details: Show the details of an patch"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:355
+msgid "usage: errata_details ERRATA|search:XXX ..."
+msgstr ""
+
+#: ../src/spacecmd/errata.py:390
+#, python-format
+msgid "%s is not a valid erratum"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:397
+#, python-format
+msgid "Name:       %s"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:398
+msgid "Product:   s"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:399
+msgid "Type:      s"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:400
+msgid "Issue Date:s"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:402
+msgid "Topic"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:406 ../src/spacecmd/package.py:107
+#: ../src/spacecmd/softwarechannel.py:591
+msgid "Description"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:412
+msgid "Notes"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:417
+msgid "CVEs"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:421
+msgid "Solution"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:425
+msgid "References"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:429
+msgid "Affected Channels"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:433 ../src/spacecmd/org.py:278
+msgid "Affected Systems"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:437
+msgid "Affected Packages"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:447
+msgid "errata_delete: Delete an patch"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:448
+msgid "usage: errata_delete ERRATA|search:XXX ..."
+msgstr ""
+
+#: ../src/spacecmd/errata.py:468
+msgid "No patches to delete"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:471
+msgid "Erratum            Channels"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:479
+msgid "Delete these patches [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:485
+#, python-format
+msgid "Deleted %i patches"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:495
+msgid "errata_publish: Publish an patch to a channel"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:496
+msgid "usage: errata_publish ERRATA|search:XXX <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:523
+msgid "No patches to publish"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:528
+msgid "Publish these patches [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:540
+msgid "errata_search: List patches that meet the given criteria"
+msgstr ""
+
+#: ../src/spacecmd/errata.py:541
+msgid "usage: errata_search CVE|RHSA|RHBA|RHEA|CLA ..."
+msgstr ""
+
+#: ../src/spacecmd/errata.py:543 ../src/spacecmd/scap.py:179
+msgid "Example:"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:42
+msgid "filepreservation_list: List all file preservations"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:43
+msgid "usage: filepreservation_list"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:58
+msgid "filepreservation_create: Create a file preservation list"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:59
+msgid "usage: filepreservation_create [NAME] [FILE ...]"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:78
+#: ../src/spacecmd/filepreservation.py:92
+msgid "File List"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:83
+msgid "File [blank to finish]:"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:109
+msgid "filepreservation_delete: Delete a file preservation list"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:110
+msgid "usage: filepreservation_delete NAME"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:128
+msgid "Delete this list [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:139
+msgid ""
+"filepreservation_details: Show the details of a file\n"
+"'preservation list"
+msgstr ""
+
+#: ../src/spacecmd/filepreservation.py:141
+msgid "usage: filepreservation_details NAME"
+msgstr ""
+
+#: ../src/spacecmd/group.py:50
+msgid "group_addsystems: Add systems to a group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:51
+msgid "usage: group_addsystems GROUP <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/group.py:52
+msgid "       group_addsystems GROUP <ssm>"
+msgstr ""
+
+#: ../src/spacecmd/group.py:103
+msgid "group_removesystems: Remove systems from a group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:104
+msgid "usage: group_removesystems GROUP <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/group.py:145 ../src/spacecmd/system.py:118
+#: ../src/spacecmd/system.py:232 ../src/spacecmd/system.py:475
+#: ../src/spacecmd/system.py:1475 ../src/spacecmd/system.py:1783
+#: ../src/spacecmd/system.py:4230
+msgid "Systems"
+msgstr ""
+
+#: ../src/spacecmd/group.py:149
+msgid "Remove these systems [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/group.py:158 ../src/spacecmd/schedule.py:385
+#: ../src/spacecmd/ssm.py:87 ../src/spacecmd/ssm.py:136
+#: ../src/spacecmd/ssm.py:186 ../src/spacecmd/system.py:4273
+#: ../src/spacecmd/system.py:4329
+msgid "No systems found"
+msgstr ""
+
+#: ../src/spacecmd/group.py:165
+msgid "group_create: Create a system group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:166
+msgid "usage: group_create [NAME] [DESCRIPTION]"
+msgstr ""
+
+#: ../src/spacecmd/group.py:192
+msgid "group_delete: Delete a system group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:193
+msgid "usage: group_delete NAME ..."
+msgstr ""
+
+#: ../src/spacecmd/group.py:212
+msgid "Delete these groups [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/group.py:224
+msgid "group_backup: backup a system group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:225
+msgid ""
+"usage: group_backup <NAME> [OUTDIR])\n"
+"                    group_backup ALL\n"
+"\n"
+"\"OUTDIR\" defaults to $HOME/spacecmd-backup/group/YYYY-MM-DD/NAME\n"
+"\"ALL\" is a keyword and collects all groups\n"
+msgstr ""
+
+#: ../src/spacecmd/group.py:270
+#, python-format
+msgid "Backup Group: %s"
+msgstr ""
+
+#: ../src/spacecmd/group.py:273
+#, python-format
+msgid "Output File: %s"
+msgstr ""
+
+#: ../src/spacecmd/group.py:284
+msgid "group_restore: restore a system group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:285
+msgid ""
+"\n"
+"usage: group_restore INPUTDIR [NAME] ...\n"
+"       group_restore INPUTDIR ALL\n"
+"       group_restore INPUTDIR\n"
+"       group_restore .\n"
+"\n"
+"Specifying only INPUTDIR will default to ALL groups.\n"
+"Setting dot (.) instead of full INPUTDIR will imply current directory.\n"
+"    "
+msgstr ""
+
+#: ../src/spacecmd/group.py:329
+#, python-format
+msgid "Restore dir %s does not exits or is not a directory"
+msgstr ""
+
+#: ../src/spacecmd/group.py:333
+#, python-format
+msgid "Restore dir %s has no restore items"
+msgstr ""
+
+#: ../src/spacecmd/group.py:340
+#, python-format
+msgid "Group %s was not found in backup"
+msgstr ""
+
+#: ../src/spacecmd/group.py:343
+#, python-format
+msgid "Found %s missing groups, terminating"
+msgstr ""
+
+#: ../src/spacecmd/group.py:358
+#, python-format
+msgid "Group %s already restored"
+msgstr ""
+
+#: ../src/spacecmd/group.py:365
+msgid "Changing description from:"
+msgstr ""
+
+#: ../src/spacecmd/group.py:367
+msgid "Continue [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/group.py:370 ../src/spacecmd/group.py:373
+#, python-format
+msgid "Updating description for group: %s"
+msgstr ""
+
+#: ../src/spacecmd/group.py:376
+#, python-format
+msgid "Creating new group %s"
+msgstr ""
+
+#: ../src/spacecmd/group.py:385
+msgid "group_list: List available system groups"
+msgstr ""
+
+#: ../src/spacecmd/group.py:386
+msgid "usage: group_list"
+msgstr ""
+
+#: ../src/spacecmd/group.py:403
+msgid "group_listsystems: List the members of a group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:404
+msgid "usage: group_listsystems GROUP"
+msgstr ""
+
+#: ../src/spacecmd/group.py:426
+#, python-format
+msgid "%s is not a valid group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:439
+msgid "group_details: Show the details of a system group"
+msgstr ""
+
+#: ../src/spacecmd/group.py:440
+msgid "usage: group_details GROUP ..."
+msgstr ""
+
+#: ../src/spacecmd/group.py:463
+#, python-format
+msgid "The group \"%s\" is invalid"
+msgstr ""
+
+#: ../src/spacecmd/group.py:470
+#, python-format
+msgid "ID:                %i"
+msgstr ""
+
+#: ../src/spacecmd/group.py:471
+#, python-format
+msgid "Name:              %s"
+msgstr ""
+
+#: ../src/spacecmd/group.py:472
+#, python-format
+msgid "Description:       %s"
+msgstr ""
+
+#: ../src/spacecmd/group.py:473
+#, python-format
+msgid "Number of Systems: %i"
+msgstr ""
+
+#: ../src/spacecmd/group.py:477
+msgid "Members"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:72
+msgid "kickstart_list: List the available Kickstart profiles"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:73
+msgid "usage: kickstart_list"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:85 ../src/spacecmd/kickstart.py:2108
+msgid "No kickstart profiles available"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:91
+msgid "kickstart_create: Create a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:92
+msgid ""
+"usage: kickstart_create [options])\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -d DISTRIBUTION\n"
+"  -p ROOT_PASSWORD\n"
+"  -v VIRT_TYPE ['none', 'para_host', 'qemu', 'xenfv', 'xenpv']"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:113 ../src/spacecmd/kickstart.py:249
+msgid "Virtualization Types"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:118 ../src/spacecmd/kickstart.py:254
+msgid "Virtualization Type [none]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:126 ../src/spacecmd/kickstart.py:262
+msgid "Distributions"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:136
+msgid "Root Password: "
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:137 ../src/spacecmd/org.py:90
+#: ../src/spacecmd/user.py:85
+msgid "Repeat Password: "
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:142 ../src/spacecmd/org.py:95
+#: ../src/spacecmd/user.py:90
+msgid "Password must be at least 5 characters"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:144 ../src/spacecmd/org.py:97
+#: ../src/spacecmd/user.py:92
+msgid "Passwords don't match"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:147 ../src/spacecmd/kickstart.py:270
+#: ../src/spacecmd/kickstart.py:1980 ../src/spacecmd/kickstart.py:2122
+msgid "The Kickstart name is required"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:151 ../src/spacecmd/kickstart.py:274
+msgid "The distribution is required"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:158
+msgid "A root password is required"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:177
+msgid "kickstart_delete: Delete kickstart profile(s)"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:178
+msgid "usage: kickstart_delete PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:179
+msgid "usage: kickstart_delete PROFILE1 PROFILE2"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:180
+msgid "usage: kickstart_delete \"PROF*\""
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:203 ../src/spacecmd/kickstart.py:2597
+#: ../src/spacecmd/kickstart.py:2653 ../src/spacecmd/kickstart.py:2695
+msgid "No valid kickstart labels passed as arguments!"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:209
+msgid "The following kickstart labels are invalid:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:214
+#, python-format
+msgid "Delete profile %s [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:222
+msgid "kickstart_import: Import a Kickstart profile from a file"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:223
+msgid ""
+"usage: kickstart_import [options])\n"
+"\n"
+"options:\n"
+"  -f FILE\n"
+"  -n NAME\n"
+"  -d DISTRIBUTION\n"
+"  -v VIRT_TYPE ['none', 'para_host', 'qemu', 'xenfv', 'xenpv']"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:278 ../src/spacecmd/kickstart.py:1984
+msgid "A filename is required"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:308
+msgid ""
+"kickstart_import_raw: Import a raw Kickstart or autoyast profile from a file"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:309
+msgid ""
+"usage: kickstart_import_raw [options])\n"
+"\n"
+"options:\n"
+"  -f FILE\n"
+"  -n NAME\n"
+"  -d DISTRIBUTION\n"
+"  -v VIRT_TYPE ['none', 'para_host', 'qemu', 'xenfv', 'xenpv']"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:325
+msgid "kickstart_details: Show the details of a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:326
+msgid "usage: kickstart_details PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:353
+msgid "Invalid Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:415
+#, python-format
+msgid "Tree:        %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:416
+#, python-format
+msgid "Active:      %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:417
+#, python-format
+msgid "Advanced:    %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:418
+#, python-format
+msgid "Org Default: %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:421
+#, python-format
+msgid "Configuration Management: %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:422
+#, python-format
+msgid "Remote Commands:          %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:434
+msgid "Advanced Options"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:442
+msgid "Custom Options"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:449
+msgid "Partitioning"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:454
+msgid "Software"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:467
+msgid "Crypto Keys"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:474
+msgid "File Preservations"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:483
+msgid "Variables"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:490
+msgid "Scripts"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:501 ../src/spacecmd/kickstart.py:1900
+#, python-format
+msgid "Chroot:      %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:504 ../src/spacecmd/kickstart.py:1901
+#, python-format
+msgid "Interpreter: %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:530
+msgid "Could not retrieve the Kickstart file"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:536
+msgid "kickstart_getcontents: Show the contents of a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:537
+msgid "                   as they would be presented to a client"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:538
+msgid "usage: kickstart_getcontents LABEL"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:572
+msgid "kickstart_rename: Rename a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:573
+msgid "usage: kickstart_rename OLDNAME NEWNAME"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:601
+msgid ""
+"kickstart_listcryptokeys: List the crypto keys associated with a Kickstart "
+"profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:603
+msgid "usage: kickstart_listcryptokeys PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:632
+msgid "No crypto keys has been found"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:638
+msgid "kickstart_addcryptokeys: Add crypto keys to a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:639
+msgid "usage: kickstart_addcryptokeys PROFILE <KEY ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:665
+msgid "kickstart_removecryptokeys: Remove crypto keys from a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:667
+msgid "usage: kickstart_removecryptokeys PROFILE <KEY ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:707
+msgid ""
+"kickstart_listactivationkeys: List the activation keys associated with a "
+"Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:709
+msgid "usage: kickstart_listactivationkeys PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:739
+msgid "kickstart_addactivationkeys: Add activation keys to a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:741
+msgid "usage: kickstart_addactivationkeys PROFILE <KEY ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:770
+msgid ""
+"kickstart_removeactivationkeys: Remove activation keys from a Kickstart "
+"profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:772
+msgid "usage: kickstart_removeactivationkeys PROFILE <KEY ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:796
+msgid "Remove these keys [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:811
+msgid ""
+"kickstart_enableconfigmanagement: Enable configuration management on a "
+"Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:813
+msgid "usage: kickstart_enableconfigmanagement PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:844
+msgid ""
+"kickstart_disableconfigmanagement: Disable configuration management on a "
+"Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:846
+msgid "usage: kickstart_disableconfigmanagement PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:877
+msgid ""
+"kickstart_enableremotecommands: Enable remote commands on a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:879
+msgid "usage: kickstart_enableremotecommands PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:910
+msgid ""
+"kickstart_disableremotecommands: Disable remote commands on a Kickstart "
+"profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:912
+msgid "usage: kickstart_disableremotecommands PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:942
+msgid "kickstart_setlocale: Set the locale for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:943
+msgid "usage: kickstart_setlocale PROFILE LOCALE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:981
+msgid "kickstart_setselinux: Set the SELinux mode for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:983
+msgid "usage: kickstart_setselinux PROFILE MODE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1018
+msgid ""
+"kickstart_setpartitions: Set the partitioning scheme for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1020
+msgid "usage: kickstart_setpartitions PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1069
+msgid "kickstart_setdistribution: Set the distribution for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1071
+msgid "usage: kickstart_setdistribution PROFILE DISTRIBUTION"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1105
+msgid "kickstart_enablelogging: Enable logging for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1106
+msgid "usage: kickstart_enablelogging PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1138
+msgid "kickstart_addvariable: Add a variable to a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1139
+msgid "usage: kickstart_addvariable PROFILE KEY VALUE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1177
+msgid "kickstart_updatevariable: Update a variable in a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1179
+msgid "usage: kickstart_updatevariable PROFILE KEY VALUE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1214
+msgid "kickstart_removevariables: Remove variables from a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1216
+msgid "usage: kickstart_removevariables PROFILE <KEY ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1265
+msgid "kickstart_listvariables: List the variables of a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1267
+msgid "usage: kickstart_listvariables PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1300
+msgid "kickstart_addoption: Set an option for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1301
+msgid "usage: kickstart_addoption PROFILE KEY [VALUE]"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1348
+#, python-format
+msgid "%s needs to be set as a custom option"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1356
+msgid "kickstart_removeoptions: Remove options from a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1357
+msgid "usage: kickstart_removeoptions PROFILE <OPTION ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1409
+msgid "kickstart_listoptions: List the options of a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1411
+msgid "usage: kickstart_listoptions PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1445
+msgid ""
+"kickstart_listcustomoptions: List the custom options of a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1447
+msgid "usage: kickstart_listcustomoptions PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1481
+msgid "kickstart_setcustomoptions: Set custom options for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1483
+msgid "usage: kickstart_setcustomoptions PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1531
+msgid "kickstart_addchildchannels: Add a child channels to a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1533
+msgid "usage: kickstart_addchildchannels PROFILE <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1591
+msgid ""
+"kickstart_removechildchannels: Remove child channels from a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1593
+msgid "usage: kickstart_removechildchannels PROFILE <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1636
+msgid ""
+"kickstart_listchildchannels: List the child channels of a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1638
+msgid "usage: kickstart_listchildchannels PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1672
+msgid ""
+"kickstart_addfilepreservations: Add file preservations to a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1674
+msgid "usage: kickstart_addfilepreservations PROFILE <FILELIST ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1709
+msgid ""
+"kickstart_removefilepreservations: Remove file preservations from a "
+"Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1711
+msgid "usage: kickstart_removefilepreservations PROFILE <FILE ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1756
+msgid "kickstart_listpackages: List the packages for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1758
+msgid "usage: kickstart_listpackages PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1790
+msgid "kickstart_addpackages: Add packages to a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1791
+msgid "usage: kickstart_addpackages PROFILE <PACKAGE ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1824
+msgid "kickstart_removepackages: Remove packages from a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1826
+msgid "usage: kickstart_removepackages PROFILE <PACKAGE ...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1869
+msgid "kickstart_listscripts: List the scripts for a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1871
+msgid "usage: kickstart_listscripts PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1890
+#, python-format
+msgid "No scripts has been found for profile '%s'"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1898
+#, python-format
+msgid "ID:          %i"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1913
+msgid "kickstart_addscript: Add a script to a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1914
+msgid ""
+"usage: kickstart_addscript PROFILE [options])\n"
+"\n"
+"options:\n"
+"  -p PROFILE\n"
+"  -e EXECUTION_TIME ['pre', 'post']\n"
+"  -i INTERPRETER\n"
+"  -f FILE\n"
+"  -c execute in a chroot environment\n"
+"  -t ENABLING_TEMPLATING"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1947
+msgid "Profile Name:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1949
+msgid "Pre/Post Script [post]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1950
+msgid "Chrooted [Y/n]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1951
+msgid "Interpreter [/bin/bash]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:1988
+msgid "The execution time is required"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2004
+#, python-format
+msgid "Profile Name:   %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2005
+#, python-format
+msgid "Execution Time: %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2006
+#, python-format
+msgid "Chroot:         %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2007
+#, python-format
+msgid "Template:       %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2008
+#, python-format
+msgid "Interpreter:    %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2009
+msgid "Contents:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2029
+msgid "kickstart_removescript: Remove a script from a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2030
+msgid "usage: kickstart_removescript PROFILE [ID]"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2058 ../src/spacecmd/kickstart.py:2071
+msgid "Invalid script ID"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2066
+msgid "Script ID:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2073
+msgid "Remove this script [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2086
+msgid "kickstart_clone: Clone a Kickstart profile"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2087
+msgid ""
+"usage: kickstart_clone [options])\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -c CLONE_NAME"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2112
+msgid "Kickstart Profiles"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2117
+msgid "Original Profile:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2118
+msgid "Cloned Profile:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2126
+msgid "The Kickstart clone name is required"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2131
+msgid "Kickstart profile you've entered was not found"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2144
+msgid "kickstart_export: export kickstart profile(s) to json format file"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2145
+msgid ""
+"usage: kickstart_export <KSPROFILE>... [options])\n"
+"options:\n"
+"    -f outfile.json : specify an output filename, defaults to <KSPROFILE>."
+"json\n"
+"                      if exporting a single kickstart, profiles.json for "
+"multiple\n"
+"                      kickstarts, or ks_all.json if no KSPROFILE specified\n"
+"                      e.g (export ALL)\n"
+"\n"
+"Note : KSPROFILE list is optional, default is to export ALL"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2271
+#, python-format
+msgid "Exporting ALL kickstart profiles to %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2279
+msgid ""
+"Error, no valid kickstart profile passed, check name is  correct with "
+"spacecmd kickstart_list"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2299
+#, python-format
+msgid "Exporting ks %s to %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2306
+#, python-format
+msgid "File %s exists, "
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2307
+msgid "confirm overwrite file? (y/n)"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2310
+msgid "Error saving exported kickstart profiles to file"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2320
+msgid "kickstart_import: import kickstart profile(s) from json file"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2321
+msgid "usage: kickstart_import <JSONFILES...>"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2342
+#, python-format
+msgid "Error importing kickstart %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2355
+#, python-format
+msgid "ERROR : kickstart profile %s already exists! Skipping!"
+msgstr ""
+
+#. create the ks, we need to drop the org prefix from the ks name
+#: ../src/spacecmd/kickstart.py:2359
+#, python-format
+msgid "Found ks %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2415
+#, python-format
+msgid "Error adding %s script"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2423
+#, python-format
+msgid "failed to add ip range %s-%s, continuing"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2437
+#, python-format
+msgid "failed to add file preservation %s, skipping"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2439
+#, python-format
+msgid "file preservation list %s doesn't exist, skipping"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2450
+#, python-format
+msgid "Actvationkey %s does not exist on the "
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2461
+#, python-format
+msgid "GPG/SSL key %s does not exist on the "
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2462
+msgid "satellite, skipping"
+msgstr ""
+
+#. There are some frustrating ommisions from the API which means we can't
+#. export/import some settings, so we post a warning that some manual
+#. fixup may be required
+#: ../src/spacecmd/kickstart.py:2471
+msgid ""
+"Due to API ommissions, there are some settings which cannot be imported, "
+"please check and fixup manually if necessary"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2473
+msgid " * Details->Preserve ks.cfg"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2474
+msgid " * Details->Comment"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2478
+msgid " * Details->Organization Default Profile"
+msgstr ""
+
+#. No way to set the kernel options
+#: ../src/spacecmd/kickstart.py:2480
+msgid " * Details->Kernel Options"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2484
+#, python-format
+msgid " * Details->Post Kernel Options : %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2500
+msgid "no kickstart label given"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2503
+msgid "invalid kickstart label "
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2520
+msgid "kickstart_diff: diff kickstart files"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2522
+msgid "usage: kickstart_diff SOURCE_CHANNEL TARGET_CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2571
+msgid "kickstart_getupdatetype: Get the update type for a kickstart profile(s)"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2572
+msgid "usage: kickstart_getupdatetype PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2573
+msgid "usage: kickstart_getupdatetype PROFILE1 PROFILE2"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2574
+msgid "usage: kickstart_getupdatetype \"PROF*\""
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2603 ../src/spacecmd/kickstart.py:2659
+#: ../src/spacecmd/kickstart.py:2701
+#, python-format
+msgid "kickstart label %s doesn't exist!"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2619
+msgid "kickstart_setupdatetype: Set the update type for a kickstart profile(s)"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2620
+msgid ""
+"usage: kickstart_setupdatetype [options] KS_LABEL)\n"
+"\n"
+"options:\n"
+"    -u UPDATE_TYPE ['red_hat', 'all', 'none']"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2634
+msgid "Update Types"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2639
+msgid "Update Type [none]:"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2670
+msgid "kickstart_getsoftwaredetails: Gets kickstart profile software details"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2671
+msgid "usage: kickstart_getsoftwaredetails KS_LABEL"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2672
+msgid "usage: kickstart_getsoftwaredetails KS_LABEL KS_LABEL2 ..."
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2707
+#, python-format
+msgid "noBase:        %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2708
+#, python-format
+msgid "ignoreMissing: %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2710
+#, python-format
+msgid "Kickstart Label: %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2711
+#, python-format
+msgid "noBase:          %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2712
+#, python-format
+msgid "ignoreMissing:   %s"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2721
+msgid "kickstart_setsoftwaredetails: Sets kickstart profile software details."
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2722
+msgid ""
+"usage: kickstart_setsoftwaredetails PROFILE KICKSTART_PACKAGES_INFO VALUE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2723
+msgid ""
+"usage: kickstart_setsoftwaredetails PROFILE KICKSTART_PACKAGES_INFO VALUE "
+"KICKSTART_PACKAGES_INFO VALUE"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2757
+msgid "Selected profile does not exist"
+msgstr ""
+
+#: ../src/spacecmd/kickstart.py:2760 ../src/spacecmd/kickstart.py:2765
+msgid "Enter valid input"
+msgstr ""
+
+#. list of system selection options for the help output
+#: ../src/spacecmd/misc.py:57
+msgid ""
+"<SYSTEMS> can be any of the following:\n"
+"name\n"
+"ssm (see 'help ssm')\n"
+"search:QUERY (see 'help system_search')\n"
+"group:GROUP\n"
+"channel:CHANNEL\n"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:65
+msgid ""
+"Dates can be any of the following:\n"
+"Explicit Dates:\n"
+"Dates can be expressed as explicit date strings in the YYYYMMDD[HHMMSS]\n"
+"format.  The year, month and day are required, while the hours and\n"
+"minutes are not; the hours and minutes will default to 0000 if no\n"
+"values are provided.\n"
+"\n"
+"Deltas:\n"
+"Dates can be expressed as delta values.  For example, '2h' would\n"
+"mean 2 hours in the future.  You can also use negative values to\n"
+"express times in the past (e.g., -7d would be one week ago).\n"
+"\n"
+"Units:\n"
+"s -> seconds\n"
+"m -> minutes\n"
+"h -> hours\n"
+"d -> days\n"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:120
+msgid "clear: clear the screen"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:121
+msgid "usage: clear"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:132
+msgid "clear_caches: Clear the internal caches kept for systems and packages"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:133
+msgid "usage: clear_caches"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:146
+msgid "get_apiversion: Display the API version of the server"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:147
+msgid "usage: get_apiversion"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:158
+msgid "get_serverversion: Display the version of the server"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:159
+msgid "usage: get_serverversion"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:171
+msgid "list_proxies: List the proxies within the user's organization "
+msgstr ""
+
+#: ../src/spacecmd/misc.py:172
+msgid "usage: list_proxies"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:184
+msgid "get_session: Show the current session string"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:185
+msgid "usage: get_session"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:193
+msgid "No session found"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:200
+msgid "help: Show help for the given command"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:201
+msgid "usage: help COMMAND"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:207
+msgid "history: List your command history"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:208
+msgid "usage: history"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:220
+msgid "toggle_confirmations: Toggle confirmation messages on/off"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:221
+msgid "usage: toggle_confirmations"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:226
+msgid "Confirmation messages are"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:226
+msgid "enabled"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:233
+msgid "login: Connect to a Spacewalk server"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:234
+msgid "usage: login [USERNAME] [SERVER]"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:244
+msgid "You are already logged in"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:256
+msgid "No server specified"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:301
+#, python-format
+msgid "Failed to connect to %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:309
+#, python-format
+msgid "API (%s) is too old (>= %s required)"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:339 ../src/spacecmd/utils.py:249
+#: ../src/spacecmd/utils.py:560
+#, python-format
+msgid "Could not read %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:348
+msgid "Cached credentials are invalid"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:355
+#, python-format
+msgid "Spacewalk Username: %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:357
+msgid "Spacewalk Username:"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:368
+msgid "Spacewalk Password: "
+msgstr ""
+
+#: ../src/spacecmd/misc.py:374
+msgid "Invalid credentials"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:392
+#, python-format
+msgid "Could not write session file: %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:401
+#, python-format
+msgid "Connected to %s as %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:409
+msgid "logout: Disconnect from the server"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:410
+msgid "usage: logout"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:427
+msgid "whoami: Print the name of the currently logged in user"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:428
+msgid "usage: whoami"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:436
+msgid "You are not logged in"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:443
+msgid "whoamitalkingto: Print the name of the server"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:444
+msgid "usage: whoamitalkingto"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:452
+msgid "Yourself"
+msgstr ""
+
+#. tell the user what's going on
+#: ../src/spacecmd/misc.py:524
+msgid "** Generating errata cache **"
+msgstr ""
+
+#. tell the user what's going on
+#: ../src/spacecmd/misc.py:573
+msgid "** Generating package cache **"
+msgstr ""
+
+#. tell the user what's going on
+#: ../src/spacecmd/misc.py:680
+msgid "** Generating system cache **"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:715
+#, python-format
+msgid "Could not create directory %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:787
+#, python-format
+msgid "Can't find system ID for %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:792
+msgid "Duplicate system profile names found!"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:793
+msgid "Please reference systems by ID or resolve the"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:794
+msgid "underlying issue with 'system_delete' or 'system_rename'"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:860
+#, python-format
+msgid "No systems in group %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:874
+#, python-format
+msgid "No systems subscribed to %s"
+msgstr ""
+
+#: ../src/spacecmd/misc.py:934
+msgid "Is this ok [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:47
+msgid "org_create: Create an organization"
+msgstr ""
+
+#: ../src/spacecmd/org.py:48
+#, python-format
+msgid ""
+"usage: org_create [options])\n"
+"\n"
+"options:\n"
+"  -n ORG_NAME\n"
+"  -u USERNAME\n"
+"  -P PREFIX (%s)\n"
+"  -f FIRST_NAME\n"
+"  -l LAST_NAME\n"
+"  -e EMAIL\n"
+"  -p PASSWORD\n"
+"  --pam enable PAM authentication"
+msgstr ""
+
+#: ../src/spacecmd/org.py:75
+msgid "Organization Name:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:76 ../src/spacecmd/user.py:73
+msgid "Username:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:77
+#, python-format
+msgid "Prefix (%s):"
+msgstr ""
+
+#: ../src/spacecmd/org.py:79 ../src/spacecmd/user.py:74
+msgid "First Name:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:80 ../src/spacecmd/user.py:75
+msgid "Last Name:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:81 ../src/spacecmd/user.py:76
+msgid "Email:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:82 ../src/spacecmd/user.py:77
+msgid "PAM Authentication [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:89 ../src/spacecmd/user.py:84
+msgid "Password: "
+msgstr ""
+
+#: ../src/spacecmd/org.py:100
+msgid "An organization name is required"
+msgstr ""
+
+#: ../src/spacecmd/org.py:104 ../src/spacecmd/user.py:95
+msgid "A username is required"
+msgstr ""
+
+#: ../src/spacecmd/org.py:108 ../src/spacecmd/user.py:99
+msgid "A first name is required"
+msgstr ""
+
+#: ../src/spacecmd/org.py:112 ../src/spacecmd/user.py:103
+msgid "A last name is required"
+msgstr ""
+
+#: ../src/spacecmd/org.py:116 ../src/spacecmd/user.py:107
+msgid "An email address is required"
+msgstr ""
+
+#: ../src/spacecmd/org.py:120 ../src/spacecmd/user.py:111
+msgid "A password is required"
+msgstr ""
+
+#: ../src/spacecmd/org.py:127
+msgid "Dr."
+msgstr ""
+
+#: ../src/spacecmd/org.py:129
+msgid "Miss"
+msgstr ""
+
+#: ../src/spacecmd/org.py:148
+msgid "org_delete: Delete an organization"
+msgstr ""
+
+#: ../src/spacecmd/org.py:149
+msgid "usage: org_delete NAME"
+msgstr ""
+
+#: ../src/spacecmd/org.py:168 ../src/spacecmd/org.py:199
+#: ../src/spacecmd/org.py:233 ../src/spacecmd/org.py:269
+#: ../src/spacecmd/org.py:377 ../src/spacecmd/org.py:413
+#, python-format
+msgid "No organisation found for the name %s"
+msgstr ""
+
+#: ../src/spacecmd/org.py:169 ../src/spacecmd/org.py:200
+#: ../src/spacecmd/org.py:234 ../src/spacecmd/org.py:270
+#: ../src/spacecmd/org.py:378 ../src/spacecmd/org.py:414
+msgid "Organisation '{}' was not found"
+msgstr ""
+
+#: ../src/spacecmd/org.py:171
+msgid "Delete this organization [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:179
+msgid "org_rename: Rename an organization"
+msgstr ""
+
+#: ../src/spacecmd/org.py:180
+msgid "usage: org_rename OLDNAME NEWNAME"
+msgstr ""
+
+#: ../src/spacecmd/org.py:211
+msgid "org_addtrust: Add a trust between two organizations"
+msgstr ""
+
+#: ../src/spacecmd/org.py:212
+msgid "usage: org_addtrust YOUR_ORG ORG_TO_TRUST"
+msgstr ""
+
+#: ../src/spacecmd/org.py:237 ../src/spacecmd/org.py:273
+#, python-format
+msgid "No trust organisation found for the name %s"
+msgstr ""
+
+#: ../src/spacecmd/org.py:238 ../src/spacecmd/org.py:274
+msgid "Organisation '{}' to trust for, was not found"
+msgstr ""
+
+#: ../src/spacecmd/org.py:248
+msgid "org_removetrust: Remove a trust between two organizations"
+msgstr ""
+
+#: ../src/spacecmd/org.py:249
+msgid "usage: org_removetrust YOUR_ORG TRUSTED_ORG"
+msgstr ""
+
+#: ../src/spacecmd/org.py:284
+msgid "None"
+msgstr ""
+
+#: ../src/spacecmd/org.py:286
+msgid "Remove this trust [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/org.py:292
+msgid "org_trustdetails: Show the details of an organizational trust"
+msgstr ""
+
+#: ../src/spacecmd/org.py:293
+msgid "usage: org_trustdetails TRUSTED_ORG"
+msgstr ""
+
+#: ../src/spacecmd/org.py:312
+#, python-format
+msgid "No trusted organisation found for the name %s"
+msgstr ""
+
+#: ../src/spacecmd/org.py:313
+msgid "Trusted organisation '{}' was not found"
+msgstr ""
+
+#: ../src/spacecmd/org.py:320
+#, python-format
+msgid "Trusted Organization:   %s"
+msgstr ""
+
+#: ../src/spacecmd/org.py:321
+#, python-format
+msgid "Trusted Since:          %s"
+msgstr ""
+
+#: ../src/spacecmd/org.py:322
+#, python-format
+msgid "Systems Migrated From:  %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:323
+#, python-format
+msgid "Systems Migrated To:    %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:325
+msgid "Channels Consumed"
+msgstr ""
+
+#: ../src/spacecmd/org.py:332
+msgid "Channels Provided"
+msgstr ""
+
+#: ../src/spacecmd/org.py:340
+msgid "org_list: List all organizations"
+msgstr ""
+
+#: ../src/spacecmd/org.py:341
+msgid "usage: org_list"
+msgstr ""
+
+#: ../src/spacecmd/org.py:358
+msgid "org_listtrusts: List an organization's trusts"
+msgstr ""
+
+#: ../src/spacecmd/org.py:359
+msgid "usage: org_listtrusts NAME"
+msgstr ""
+
+#: ../src/spacecmd/org.py:383 ../src/spacecmd/org.py:384
+msgid "No trust organisation has been found"
+msgstr ""
+
+#: ../src/spacecmd/org.py:394
+msgid "org_listusers: List an organization's users"
+msgstr ""
+
+#: ../src/spacecmd/org.py:395
+msgid "usage: org_listusers NAME"
+msgstr ""
+
+#: ../src/spacecmd/org.py:425
+msgid "org_details: Show the details of an organization"
+msgstr ""
+
+#: ../src/spacecmd/org.py:426
+msgid "usage: org_details NAME"
+msgstr ""
+
+#: ../src/spacecmd/org.py:446
+#, python-format
+msgid "Name:                   %s"
+msgstr ""
+
+#: ../src/spacecmd/org.py:447
+#, python-format
+msgid "Active Users:           %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:448
+#, python-format
+msgid "Systems:                %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:452 ../src/spacecmd/org.py:454
+#, python-format
+msgid "Trusts:                 %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:456
+#, python-format
+msgid "System Groups:          %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:457
+#, python-format
+msgid "Activation Keys:        %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:458
+#, python-format
+msgid "Kickstart Profiles:     %i"
+msgstr ""
+
+#: ../src/spacecmd/org.py:459
+#, python-format
+msgid "Configuration Channels: %i"
+msgstr ""
+
+#: ../src/spacecmd/package.py:68 ../src/spacecmd/package.py:302
+#: ../src/spacecmd/package.py:351 ../src/spacecmd/package.py:395
+msgid "No packages found"
+msgstr ""
+
+#: ../src/spacecmd/package.py:81 ../src/spacecmd/package.py:406
+#, python-format
+msgid "%s is not a valid package"
+msgstr ""
+
+#: ../src/spacecmd/package.py:94
+#, python-format
+msgid "Version: %s"
+msgstr ""
+
+#: ../src/spacecmd/package.py:95
+#, python-format
+msgid "Release: %s"
+msgstr ""
+
+#: ../src/spacecmd/package.py:96
+#, python-format
+msgid "Epoch:   %s"
+msgstr ""
+
+#: ../src/spacecmd/package.py:97
+#, python-format
+msgid "Arch:    %s"
+msgstr ""
+
+#: ../src/spacecmd/package.py:99
+#, python-format
+msgid "File:    %s"
+msgstr ""
+
+#: ../src/spacecmd/package.py:101
+#, python-format
+msgid "Size:    %s"
+msgstr ""
+
+#: ../src/spacecmd/package.py:105
+#, python-format
+msgid "Installed Systems: %i"
+msgstr ""
+
+#: ../src/spacecmd/package.py:111
+msgid "Available From Channels"
+msgstr ""
+
+#: ../src/spacecmd/package.py:122
+msgid "package_search: Find packages that meet the given criteria"
+msgstr ""
+
+#: ../src/spacecmd/package.py:123
+msgid "usage: package_search NAME|QUERY"
+msgstr ""
+
+#: ../src/spacecmd/package.py:125
+msgid "Example: package_search kernel"
+msgstr ""
+
+#: ../src/spacecmd/package.py:127
+msgid "Advanced Search:"
+msgstr ""
+
+#: ../src/spacecmd/package.py:128
+msgid ""
+"Available Fields: name, epoch, version, release, arch, description, summary"
+msgstr ""
+
+#: ../src/spacecmd/package.py:129
+msgid "Example: name:kernel AND version:2.6.18 AND -description:devel"
+msgstr ""
+
+#: ../src/spacecmd/package.py:178
+msgid "package_remove: Remove a package from Satellite"
+msgstr ""
+
+#: ../src/spacecmd/package.py:179
+msgid "usage: package_remove PACKAGE ..."
+msgstr ""
+
+#: ../src/spacecmd/package.py:199
+msgid "No packages found to remove"
+msgstr ""
+
+#: ../src/spacecmd/package.py:202 ../src/spacecmd/package.py:259
+#: ../src/spacecmd/softwarechannel.py:1580 ../src/spacecmd/system.py:944
+msgid "Remove these packages [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/package.py:203
+msgid "No packages has been removed"
+msgstr ""
+
+#: ../src/spacecmd/package.py:215 ../src/spacecmd/package.py:271
+#, python-format
+msgid "Failed to remove package ID %i"
+msgstr ""
+
+#: ../src/spacecmd/package.py:226
+msgid "package_listorphans: List packages that are not in a channel"
+msgstr ""
+
+#: ../src/spacecmd/package.py:227
+msgid "usage: package_listorphans"
+msgstr ""
+
+#: ../src/spacecmd/package.py:246
+msgid "package_removeorphans: Remove packages that are not in a channel"
+msgstr ""
+
+#: ../src/spacecmd/package.py:247
+msgid "usage: package_removeorphans"
+msgstr ""
+
+#: ../src/spacecmd/package.py:255
+msgid "No orphaned packages has been found"
+msgstr ""
+
+#: ../src/spacecmd/package.py:256
+msgid "No orphaned packages"
+msgstr ""
+
+#: ../src/spacecmd/package.py:260
+msgid "No packages were removed"
+msgstr ""
+
+#: ../src/spacecmd/package.py:280
+msgid "package_listinstalledsystems: List the systems with a package installed"
+msgstr ""
+
+#: ../src/spacecmd/package.py:281
+msgid "usage: package_listinstalledsystems PACKAGE ..."
+msgstr ""
+
+#: ../src/spacecmd/package.py:329
+msgid "package_listerrata: List the errata that provide this package"
+msgstr ""
+
+#: ../src/spacecmd/package.py:330
+msgid "usage: package_listerrata PACKAGE ..."
+msgstr ""
+
+#: ../src/spacecmd/package.py:377
+msgid "package_listdependencies: List the dependencies for a package"
+msgstr ""
+
+#: ../src/spacecmd/package.py:378
+msgid "usage: package_listdependencies PACKAGE"
+msgstr ""
+
+#: ../src/spacecmd/package.py:411
+#, python-format
+msgid "Package Name: %s"
+msgstr ""
+
+#: ../src/spacecmd/package.py:413
+#, python-format
+msgid "Dependency: %s Type: %s Modifier: %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:47
+msgid "repo_list: List all available user repos"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:48
+msgid "usage: repo_list"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:65
+msgid "repo_details: Show the details of a user repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:66
+msgid "usage: repo_details <repo ...>"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:94
+#, python-format
+msgid "Repository Label:                  %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:95
+#, python-format
+msgid "Repository URL:                    %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:96
+#, python-format
+msgid "Repository Type:                   %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:97
+#, python-format
+msgid "Repository SSL Ca Certificate:     %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:98
+#, python-format
+msgid "Repository SSL Client Certificate: %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:99
+#, python-format
+msgid "Repository SSL Client Key:         %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:101
+msgid "No repositories found for '{}' query"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:110
+msgid "repo_listfilters: Show the filters for a user repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:111
+msgid "usage: repo_listfilters repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:132
+msgid "No filters found"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:141
+msgid "repo_addfilters: Add filters for a user repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:142
+msgid "usage: repo_addfilters repo <filter ...>"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:166 ../src/spacecmd/repo.py:203
+#: ../src/spacecmd/repo.py:242
+msgid "Each filter must start with + or -"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:180
+msgid "repo_removefilters: Remove filters from a user repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:181
+msgid "usage: repo_removefilters repo <filter ...>"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:217
+msgid "repo_setfilters: Set the filters for a user repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:218
+msgid "usage: repo_setfilters repo <filter ...>"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:255
+msgid "repo_clearfilters: Clears the filters for a user repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:256
+msgid ""
+"usage: repo_clearfilters repo <options>\n"
+"\n"
+"options:\n"
+"  -y, --yes   Confirm without prompt\n"
+"\n"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:278
+msgid "Remove these filters [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:287
+msgid "repo_delete: Delete a user repo"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:288
+msgid "usage: repo_delete <repo ...>"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:307 ../src/spacecmd/softwarechannel.py:610
+msgid "Repos"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:311
+msgid "Delete these repos [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:316
+#, python-format
+msgid "Failed to remove repo %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:324
+msgid "repo_create: Create a user repository"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:325
+msgid ""
+"usage: repo_create <options>)\n"
+"\n"
+"options:\n"
+"  -n, --name   name of repository\n"
+"  -u, --url    url of repository\n"
+"  -t, --type   type of repository (defaults to yum)\n"
+"\n"
+"  --ca         SSL CA certificate (not required)\n"
+"  --cert       SSL Client certificate (not required)\n"
+"  --key        SSL Client key (not required)"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:350
+msgid "URL:"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:351
+msgid "Type:"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:352 ../src/spacecmd/repo.py:462
+msgid "SSL CA cert:"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:353 ../src/spacecmd/repo.py:463
+msgid "SSL Client cert:"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:354 ../src/spacecmd/repo.py:464
+msgid "SSL Client key:"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:361
+msgid "A URL is required"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:381
+msgid "repo_rename: Rename a user repository"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:382
+msgid "usage: repo_rename OLDNAME NEWNAME"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:404
+#, python-format
+msgid "Could not find repo %s"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:417
+msgid "repo_updateurl: Change the URL of a user repository"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:418
+msgid "usage: repo_updateurl <repo> <url>"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:443
+msgid "repo_updatessl: Change the SSL certificates of a user repository"
+msgstr ""
+
+#: ../src/spacecmd/repo.py:444
+msgid ""
+"usage: repo_updatessl <options>)\n"
+"options:\n"
+"  --ca         SSL CA certificate (not required)\n"
+"  --cert       SSL Client certificate (not required)\n"
+"  --key        SSL Client key (not required)"
+msgstr ""
+
+#: ../src/spacecmd/report.py:43
+msgid "report_inactivesystems: List all inactive systems"
+msgstr ""
+
+#: ../src/spacecmd/report.py:44
+msgid "usage: report_inactivesystems [DAYS]"
+msgstr ""
+
+#: ../src/spacecmd/report.py:84
+msgid "report_outofdatesystems: List all out-of-date systems"
+msgstr ""
+
+#: ../src/spacecmd/report.py:85
+msgid "usage: report_outofdatesystems"
+msgstr ""
+
+#: ../src/spacecmd/report.py:112
+msgid "report_ungroupedsystems: List all ungrouped systems"
+msgstr ""
+
+#: ../src/spacecmd/report.py:113
+msgid "usage: report_ungroupedsystems"
+msgstr ""
+
+#: ../src/spacecmd/report.py:130
+msgid "report_errata: List all errata and how many systems they affect"
+msgstr ""
+
+#: ../src/spacecmd/report.py:131
+msgid "usage: report_errata [ERRATA|search:XXX ...]"
+msgstr ""
+
+#: ../src/spacecmd/report.py:143
+msgid "All errata requested - this may take a few minutes, please be patient!"
+msgstr ""
+
+#: ../src/spacecmd/report.py:166
+#, python-format
+msgid "%s  # Systems"
+msgstr ""
+
+#: ../src/spacecmd/report.py:173
+msgid "No errata found for '{}'"
+msgstr ""
+
+#: ../src/spacecmd/report.py:180
+msgid "report_ipaddresses: List the hostname and IP of each system"
+msgstr ""
+
+#: ../src/spacecmd/report.py:181
+msgid "usage: report_ipaddresses [<SYSTEMS>]"
+msgstr ""
+
+#: ../src/spacecmd/report.py:201 ../src/spacecmd/report.py:265
+#: ../src/spacecmd/scap.py:67 ../src/spacecmd/scap.py:207
+#: ../src/spacecmd/system.py:213 ../src/spacecmd/system.py:394
+#: ../src/spacecmd/system.py:579 ../src/spacecmd/system.py:743
+#: ../src/spacecmd/system.py:898 ../src/spacecmd/system.py:1033
+#: ../src/spacecmd/system.py:1134 ../src/spacecmd/system.py:1204
+#: ../src/spacecmd/system.py:1259 ../src/spacecmd/system.py:1358
+#: ../src/spacecmd/system.py:1591 ../src/spacecmd/system.py:1654
+#: ../src/spacecmd/system.py:1697 ../src/spacecmd/system.py:1777
+#: ../src/spacecmd/system.py:1919 ../src/spacecmd/system.py:1961
+#: ../src/spacecmd/system.py:2049 ../src/spacecmd/system.py:2116
+#: ../src/spacecmd/system.py:2198 ../src/spacecmd/system.py:2253
+#: ../src/spacecmd/system.py:2313 ../src/spacecmd/system.py:2372
+#: ../src/spacecmd/system.py:2430 ../src/spacecmd/system.py:2489
+#: ../src/spacecmd/system.py:2566 ../src/spacecmd/system.py:2647
+#: ../src/spacecmd/system.py:2702 ../src/spacecmd/system.py:2955
+#: ../src/spacecmd/system.py:3108 ../src/spacecmd/system.py:3177
+#: ../src/spacecmd/system.py:3223 ../src/spacecmd/system.py:3282
+#: ../src/spacecmd/system.py:3346 ../src/spacecmd/system.py:3402
+#: ../src/spacecmd/system.py:3577 ../src/spacecmd/system.py:3855
+#: ../src/spacecmd/system.py:3998 ../src/spacecmd/system.py:4060
+#: ../src/spacecmd/system.py:4108 ../src/spacecmd/system.py:4166
+#: ../src/spacecmd/system.py:4224
+msgid "No systems selected"
+msgstr ""
+
+#: ../src/spacecmd/report.py:244
+msgid "report_kernels: List the running kernel of each system"
+msgstr ""
+
+#: ../src/spacecmd/report.py:245
+msgid "usage: report_kernels [<SYSTEMS>]"
+msgstr ""
+
+#: ../src/spacecmd/report.py:282
+#, python-format
+msgid "%s  Kernel"
+msgstr ""
+
+#: ../src/spacecmd/report.py:282
+msgid "System"
+msgstr ""
+
+#: ../src/spacecmd/report.py:296
+msgid "report_duplicates: List duplicate system profiles"
+msgstr ""
+
+#: ../src/spacecmd/report.py:297
+msgid "usage: report_duplicates"
+msgstr ""
+
+#: ../src/spacecmd/report.py:319 ../src/spacecmd/report.py:341
+#: ../src/spacecmd/report.py:359 ../src/spacecmd/report.py:377
+msgid "System ID   Last Checkin"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:43
+msgid ""
+"scap_listxccdfscans: Return a list of finished OpenSCAP scans for given "
+"systems"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:44
+msgid "usage: scap_listxccdfscans <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:78 ../src/spacecmd/system.py:608
+#: ../src/spacecmd/system.py:1220 ../src/spacecmd/system.py:1371
+#: ../src/spacecmd/system.py:2060 ../src/spacecmd/system.py:2383
+#: ../src/spacecmd/system.py:2441 ../src/spacecmd/system.py:2660
+#: ../src/spacecmd/system.py:2715 ../src/spacecmd/system.py:3121
+#: ../src/spacecmd/system.py:3238 ../src/spacecmd/system.py:3295
+#, python-format
+msgid "System: %s"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:88
+#, python-format
+msgid "XID: %d Profile: %s Path: (%s) Completed: %s"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:96
+msgid ""
+"scap_getxccdfscanruleresults: Return a full list of RuleResults for given "
+"OpenSCAP XCCDF scan"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:97
+msgid "usage: scap_getxccdfscanruleresults <XID>"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:117
+#, python-format
+msgid "XID: %s"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:124
+#, python-format
+msgid "IDref: %s Result: %s Idents: (%s)"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:132
+msgid "scap_getxccdfscandetails: Get details of given OpenSCAP XCCDF scan"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:133
+msgid "usage: scap_getxccdfscandetails <XID>"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:159
+msgid "XID:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:159
+msgid "SID:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:159
+msgid "Action_ID:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:161
+msgid "OSCAP_Parameters:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:162
+msgid "Test_Result:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:162
+msgid "Benchmark:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:163
+msgid "Benchmark_Version:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:164
+msgid "Profile:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:165
+msgid "Profile_Title:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:165
+msgid "Start_Time:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:166
+msgid "End_Time:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:167
+msgid "Errors:"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:175
+msgid "scap_schedulexccdfscan: Schedule Scap XCCDF scan"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:176
+msgid "usage: scap_schedulexccdfscan PATH_TO_XCCDF_FILE XCCDF_OPTIONS SYSTEMS"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:177
+msgid "       scap_schedulexccdfscan ssm PATH_TO_XCCDF_FILE XCCDF_OPTIONS"
+msgstr ""
+
+#: ../src/spacecmd/scap.py:182
+msgid ""
+"\n"
+"To use systems in the ssm, pass the \"ssm\" keyword in front. Example:"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:88
+msgid "ID      Date                 C    F    P     Action"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:134
+msgid "schedule_cancel: Cancel scheduled actions"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:135
+msgid "usage: schedule_cancel ID|* ..."
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:157
+msgid "Cancel all pending actions [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:158
+msgid "All pending actions left untouched"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:173 ../src/spacecmd/schedule.py:234
+#, python-format
+msgid "\"%s\" is not a valid ID"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:179
+#, python-format
+msgid "Canceled action: %i"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:182
+#, python-format
+msgid "Failed action: %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:184
+#, python-format
+msgid "Canceled %i action(s)"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:192
+msgid "schedule_reschedule: Reschedule failed actions"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:193
+msgid "usage: schedule_reschedule ID|* ..."
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:220
+msgid "Reschedule all failed actions [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:232
+#, python-format
+msgid "\"%i\" is not a failed action"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:238
+msgid "No failed actions to reschedule"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:242
+#, python-format
+msgid "Rescheduled %i action(s)"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:250
+msgid "schedule_details: Show the details of a scheduled action"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:251
+msgid "usage: schedule_details ID"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:268
+#, python-format
+msgid "The ID \"%s\" is invalid"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:277
+#, python-format
+msgid "ID:        %i"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:278
+#, python-format
+msgid "Action:    %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:279
+#, python-format
+msgid "User:      %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:280
+#, python-format
+msgid "Date:      %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:282 ../src/spacecmd/schedule.py:379
+#: ../src/spacecmd/system.py:3245
+#, python-format
+msgid "Completed: %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:283
+#, python-format
+msgid "Failed:    %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:284
+#, python-format
+msgid "Pending:   %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:288
+msgid "Completed Systems"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:295
+msgid "Failed Systems"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:302
+msgid "Pending Systems"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:307
+#, python-format
+msgid "No action found with the ID \"%s\""
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:316
+msgid "schedule_getoutput: Show the output from an action"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:317
+msgid "usage: schedule_getoutput ID"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:332
+#, python-format
+msgid "\"%s\" is not a valid action ID"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:354
+#, python-format
+msgid "System:      %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:355
+#, python-format
+msgid "Start Time:  %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:356
+#, python-format
+msgid "Stop Time:   %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:357
+#, python-format
+msgid "Return Code: %i"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:359 ../src/spacecmd/schedule.py:381
+msgid "Output"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:378
+#, python-format
+msgid "System:    %s"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:394
+msgid "schedule_listpending: List pending actions"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:395
+msgid "usage: schedule_listpending [BEGINDATE] [ENDDATE]"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:407
+msgid "schedule_listcompleted: List completed actions"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:408
+msgid "usage: schedule_listcompleted [BEGINDATE] [ENDDATE]"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:420
+msgid "schedule_listfailed: List failed actions"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:421
+msgid "usage: schedule_listfailed [BEGINDATE] [ENDDATE]"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:433
+msgid "schedule_listarchived: List archived actions"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:434
+msgid "usage: schedule_listarchived [BEGINDATE] [ENDDATE]"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:446
+msgid "schedule_list: List all actions"
+msgstr ""
+
+#: ../src/spacecmd/schedule.py:447
+msgid "usage: schedule_list [BEGINDATE] [ENDDATE]"
+msgstr ""
+
+#: ../src/spacecmd/shell.py:120
+msgid "Could not read history file"
+msgstr ""
+
+#. pylint: disable=W0702
+#: ../src/spacecmd/shell.py:124
+msgid "Exception occurred: {}"
+msgstr ""
+
+#: ../src/spacecmd/shell.py:188 ../src/spacecmd/shell.py:227
+#, python-format
+msgid "%s: event not found"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:42
+msgid "snippet_list: List the available Kickstart snippets"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:43
+msgid "usage: snippet_list"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:60
+msgid "snippet_details: Show the contents of a snippet"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:61
+msgid "usage: snippet_details SNIPPET ..."
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:90
+#, python-format
+msgid "%s is not a valid snippet"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:97
+#, python-format
+msgid "Name:   %s"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:98
+#, python-format
+msgid "Macro:  %s"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:99
+#, python-format
+msgid "File:   %s"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:110
+msgid "snippet_create: Create a Kickstart snippet"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:111
+msgid ""
+"usage: snippet_create [options])\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -f FILE"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:149
+msgid "A name is required for the snippet"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:153
+msgid "A file is required"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:160
+#, python-format
+msgid "Snippet: %s"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:176
+msgid "snippet_update: Update a Kickstart snippet"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:177
+msgid "usage: snippet_update NAME"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:199
+msgid "snippet_delete: Delete a Kickstart snippet"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:200
+msgid "usage: snippet_delete NAME"
+msgstr ""
+
+#: ../src/spacecmd/snippet.py:218
+msgid "Remove this snippet [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:57
+msgid "softwarechannel_list: List all available software channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:58
+msgid ""
+"usage: softwarechannel_list [options]')\n"
+"options:\n"
+"  -v verbose (display label and summary)\n"
+"  -t tree view (pretty-print(child-channels))\n"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:106
+msgid "softwarechannel_listmanageablechannels: List all software channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:107
+msgid "                                        manageable by current user"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:108
+msgid ""
+"usage: softwarechannel_listmanageablechannels [options]\n"
+"options:\n"
+"  -v verbose (display label and summary)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:143
+msgid "softwarechannel_listbasechannels: List all base software channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:144
+msgid ""
+"usage: softwarechannel_listbasechannels [options])\n"
+"options:\n"
+"  -v verbose (display label and summary)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:172
+msgid "softwarechannel_listchildchannels: List child software channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:173
+#: ../src/spacecmd/softwarechannel.py:2735
+msgid "usage:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:174
+msgid "softwarechannel_listchildchannels [options]"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:175
+msgid "softwarechannel_listchildchannels : List all child channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:176
+msgid ""
+"softwarechannel_listchildchannels CHANNEL : List children for aspecific base "
+"channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:178
+msgid ""
+"options:\n"
+" -v verbose (display label and summary)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:206
+msgid "softwarechannel_listsystems: List all systems subscribed to"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:207
+msgid "                             a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:208
+msgid "usage: softwarechannel_listsystems CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:242
+msgid "softwarechannel_listpackages: List the most recent packages"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:243
+msgid "                              available from a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:244
+msgid "usage: softwarechannel_listpackages CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:281
+msgid "softwarechannel_listallpackages: List all packages in a channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:282
+msgid "usage: softwarechannel_listallpackages CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:340
+msgid ""
+"softwarechannel_listlatestpackages: List the newest version of all packages "
+"in a channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:341
+msgid "usage: softwarechannel_listlatestpackages CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:380
+msgid "softwarechannel_setdetails: Modify details of a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:381
+#, python-format
+msgid ""
+"usage: softwarechannel_setdetails [options] <CHANNEL ...>)\n"
+"\n"
+"options, at least one of which must be given:\n"
+"  -n NAME\n"
+"  -d DESCRIPTION\n"
+"  -s SUMMARY\n"
+"  -c CHECKSUM %s\n"
+"  -m MAINTAINER_NAME\n"
+"  -e MAINTAINER_EMAIL\n"
+"  -p MAINTAINER_PHONE\n"
+"  -u GPG_URL\n"
+"  -i GPG_ID\n"
+"  -f GPG_FINGERPRINT"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:443
+msgid "At least one attribute to set must be given"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:449
+msgid "No channels matching that label"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:461
+msgid "Setting same name for more than one channel will fail"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:469
+#, python-format
+msgid "Name \"%s\" already in use by channel %s"
+msgstr ""
+
+#. get confirmation
+#: ../src/spacecmd/softwarechannel.py:474
+msgid "Setting following attributes..."
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:477
+#, python-format
+msgid "Name:             %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:479
+#, python-format
+msgid "Summary:          %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:481
+#, python-format
+msgid "Description:      %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:483
+#, python-format
+msgid "Checksum:         %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:485
+#, python-format
+msgid "Maintainer name:  %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:487
+#, python-format
+msgid "Maintainer email: %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:489
+#, python-format
+msgid "Maintainer phone: %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:491
+#, python-format
+msgid "GPG Key:          %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:493
+#, python-format
+msgid "GPG Fingerprint:  %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:495
+#, python-format
+msgid "GPG URL:          %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:497
+msgid "... for the following channels:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:500
+msgid "Apply? [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:512
+#, python-format
+msgid "Could not get details for %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:524
+#, python-format
+msgid "Error while setting details for %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:527
+#, python-format
+msgid "Channels changed: %d"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:535
+msgid "softwarechannel_details: Show the details of a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:536
+msgid "usage: softwarechannel_details <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:576
+#, python-format
+msgid "Label:              %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:577
+#, python-format
+msgid "Name:               %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:578
+#, python-format
+msgid "Architecture:       %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:579
+#, python-format
+msgid "Parent:             %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:580
+#, python-format
+msgid "Systems Subscribed: %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:581
+#, python-format
+msgid "Number of Packages: %i"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:585
+msgid "Summary"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:596
+#, python-format
+msgid "GPG Key:            %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:597
+#, python-format
+msgid "GPG Fingerprint:    %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:598
+#, python-format
+msgid "GPG URL:            %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:599
+#, python-format
+msgid "GPG CHECK:          %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:603
+msgid "Kickstart Trees"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:621
+msgid "softwarechannel_listerrata: List the errata associated with a"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:622
+msgid "                            software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:623
+msgid ""
+"usage: softwarechannel_listerrata <CHANNEL ...> [from=yyyymmdd [to=yyyymmdd]]"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:681
+msgid "softwarechannel_listarches: lists the potential software"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:682
+msgid "                            channel architectures that can be created"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:683
+msgid "usage: softwarechannel_listarches"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:684 ../src/spacecmd/system.py:3826
+msgid "options:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:685
+msgid "    -v verbose (display label and name)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:706
+msgid "softwarechannel_delete: Delete a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:707
+msgid "usage: softwarechannel_delete <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:732
+msgid "Channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:760
+msgid "softwarechannel_update: Update a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:761
+#, python-format
+msgid ""
+"usage: softwarechannel_update LABEL(To identify the channel) [options]\n"
+"options:\n"
+"  -l LABEL(Required)\n"
+"  -n NAME\n"
+"  -s SUMMARY\n"
+"  -d DESCRIPTION\n"
+"  -c CHECKSUM %s\n"
+"  -u GPG-URL\n"
+"  -i GPG-ID\n"
+"  -f GPG-FINGERPRINT\n"
+"  -g DISABLE-GPG-CHECK"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:792
+#: ../src/spacecmd/softwarechannel.py:924
+#: ../src/spacecmd/softwarechannel.py:1094
+msgid "Channel Label:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:797
+msgid "New Name (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:803
+msgid "New Summary (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:806
+msgid "Summary:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:809
+msgid "New Description (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:815
+msgid "New Checksum type (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:822
+msgid "New GPG URL (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:825
+#: ../src/spacecmd/softwarechannel.py:953
+#: ../src/spacecmd/softwarechannel.py:1107
+#: ../src/spacecmd/softwarechannel.py:1196
+msgid "GPG URL:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:828
+msgid "New GPG ID (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:831
+#: ../src/spacecmd/softwarechannel.py:959
+#: ../src/spacecmd/softwarechannel.py:1108
+#: ../src/spacecmd/softwarechannel.py:1197
+msgid "GPG ID:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:834
+msgid "New GPG Fingerprint (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:837
+#: ../src/spacecmd/softwarechannel.py:965
+#: ../src/spacecmd/softwarechannel.py:1109
+#: ../src/spacecmd/softwarechannel.py:1198
+msgid "GPG Fingerprint:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:840
+msgid "Disable GPG CHECK (blank to keep unchanged)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:843
+#: ../src/spacecmd/softwarechannel.py:1110
+#: ../src/spacecmd/softwarechannel.py:1199
+msgid "Disable GPG Check [yes/no]? "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:846
+msgid "A channel label is required to identify the channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:849
+msgid "Only [yes/no] values are acceptable for --disable_gpg_check"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:889
+msgid "softwarechannel_create: Create a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:890
+#, python-format
+msgid ""
+"usage: softwarechannel_create [options])\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -l LABEL\n"
+"  -s SUMMARY\n"
+"  -p PARENT_CHANNEL\n"
+"  -a ARCHITECTURE\n"
+"  -c CHECKSUM %s\n"
+"  -u GPG_URL\n"
+"  -i GPG_ID\n"
+"  -f GPG_FINGERPRINT\n"
+"  -g DISABLE_GPG_CHECK"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:923
+#: ../src/spacecmd/softwarechannel.py:1093
+msgid "Channel Name:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:925
+msgid "Channel Summary:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:933
+#: ../src/spacecmd/softwarechannel.py:1101
+msgid "Select Parent [blank to create a base channel]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:936
+msgid "Architecture"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:943
+msgid "Checksum type"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:950
+msgid "GPG URL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:956
+msgid "GPG ID"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:962
+msgid "GPG Fingerprint"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:968
+msgid "GPG CHECK"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:971
+msgid "Disable GPG Check [y/N]? "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1023
+#: ../src/spacecmd/softwarechannel.py:1121
+msgid "A channel name is required"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1027
+#: ../src/spacecmd/softwarechannel.py:1125
+msgid "A channel label is required"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1040
+#, python-format
+msgid "Name %s already in use by channel %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1044
+#, python-format
+msgid "Label %s already in use by channel %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1052
+msgid "softwarechannel_clone: Clone a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1053
+msgid ""
+"usage: softwarechannel_clone [options])\n"
+"\n"
+"options:\n"
+"  -s SOURCE_CHANNEL\n"
+"  -n NAME\n"
+"  -l LABEL\n"
+"  -p PARENT_CHANNEL\n"
+"  --gpg-copy/-g (copy SOURCE_CHANNEL GPG details)\n"
+"  --gpg-url GPG_URL\n"
+"  --gpg-id GPG_ID\n"
+"  --gpg-fingerprint(GPG_FINGERPRINT)\n"
+"  --disable-gpg-check DISABLE_GPG_CHECK\n"
+"  -o do not clone any patches\n"
+"  --regex/-x \"s/foo/bar\" : Optional regex replacement,\n"
+"        replaces foo with bar in the clone name and label"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1088
+#: ../src/spacecmd/softwarechannel.py:1188
+msgid "Source Channels:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1092
+#: ../src/spacecmd/softwarechannel.py:1191
+msgid "Select source channel:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1096
+msgid "Base Channels:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1104
+#: ../src/spacecmd/softwarechannel.py:1194
+msgid "Copy source channel GPG details? [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1113
+#: ../src/spacecmd/softwarechannel.py:1202
+msgid "Original State (No Errata) [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1117
+#: ../src/spacecmd/softwarechannel.py:1205
+msgid "A source channel is required"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1138
+#: ../src/spacecmd/softwarechannel.py:1216
+msgid "Only [yes/no] values are acceptable for --disable-gpg-check"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1154
+msgid ""
+"softwarechannel_clonetree: Clone a software channel and its child channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1155
+msgid ""
+"usage: softwarechannel_clonetree [options])\n"
+"             e.g    softwarechannel_clonetree foobasechannel -p \"my_\"\n"
+"                    softwarechannel_clonetree foobasechannel -x \"s/foo/bar"
+"\"\n"
+"                    softwarechannel_clonetree foobasechannel -x \"s/^/my_\"\n"
+"\n"
+"options:\n"
+"  -s/--source-channel SOURCE_CHANNEL\n"
+"  -p/--prefix PREFIX (is prepended to the label and name of all channels)\n"
+"  --gpg-copy/-g (copy GPG details for correspondoing source channel))\n"
+"  --gpg-url GPG_URL (applied to all channels)\n"
+"  --gpg-id GPG_ID (applied to all channels)\n"
+"  --gpg-fingerprint(GPG_FINGERPRINT (applied to all channels))\n"
+"  --disable-gpg-check DISABLE_GPG_CHECK(applied to all channels)\n"
+"  -o do not clone any errata\n"
+"  --regex/-x \"s/foo/bar\" : Optional regex replacement,\n"
+"        replaces foo with bar in the clone name, label and description"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1192
+msgid "Prefix:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1209
+msgid "A prefix or regex is required"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1221
+#: ../src/spacecmd/softwarechannel.py:1994
+#: ../src/spacecmd/softwarechannel.py:2034
+msgid "Channel does not exist or is not a base channel!"
+msgstr ""
+
+#. Shouldn't ever get here due to earlier checks
+#: ../src/spacecmd/softwarechannel.py:1248
+msgid "called without prefix or regex option!"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1348
+msgid "softwarechannel_addpackages: Add packages to a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1349
+msgid "usage: softwarechannel_addpackages CHANNEL <PACKAGE ...>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1389
+msgid "No packages to add"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1396
+msgid "Add these packages [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1408
+msgid ""
+"softwarechannel_mergepackages: Merge packages from one software channel into "
+"another"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1409
+msgid "usage: softwarechannel_mergepackages SOURCE_CHANNEL TARGET_CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1433
+msgid "softwarechannel_removeerrata: Remove patches from a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1435
+msgid "usage: softwarechannel_removeerrata CHANNEL <ERRATA:search:XXX ...>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1488
+msgid "No patches to remove"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1499
+#: ../src/spacecmd/softwarechannel.py:1828
+#, python-format
+msgid "Total Errata:   %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1500
+#: ../src/spacecmd/softwarechannel.py:1831
+#, python-format
+msgid "Total Packages: %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1502
+msgid "Remove these patches [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1517
+msgid "softwarechannel_removepackages: Remove packages from a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1519
+msgid "usage: softwarechannel_removepackages CHANNEL <PACKAGE ...>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1573
+msgid "No packages to remove"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1593
+msgid ""
+"softwarechannel_adderratabydate: Add errata from one channel into another "
+"channel based on a date range"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1595
+msgid ""
+"usage: softwarechannel_adderratabydate [options] SOURCE DEST BEGINDATE "
+"ENDDATE"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1596
+#: ../src/spacecmd/softwarechannel.py:1671
+msgid "Date format : YYYYMMDD"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1597
+#: ../src/spacecmd/softwarechannel.py:1728
+#: ../src/spacecmd/softwarechannel.py:2620
+#: ../src/spacecmd/softwarechannel.py:2663
+#: ../src/spacecmd/softwarechannel.py:2879
+msgid "Options:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1598
+msgid "        -p/--publish : Publish errata to the channel (don't clone)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1625
+#: ../src/spacecmd/softwarechannel.py:1630
+#: ../src/spacecmd/softwarechannel.py:1696
+#: ../src/spacecmd/softwarechannel.py:1701
+#, python-format
+msgid "%s is an invalid date"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1643
+msgid "No patches found between the given dates"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1650
+#, python-format
+msgid "Publishing errata %s to %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1668
+msgid ""
+"softwarechannel_listerratabydate: list errata from channelbased on a date "
+"range"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1670
+msgid "usage: softwarechannel_listerratabydate CHANNEL BEGINDATE ENDDATE"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1714
+msgid "No errata found between the given dates"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1725
+msgid ""
+"softwarechannel_adderrata: Add patches from one channel into another channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1727
+msgid "usage: softwarechannel_adderrata SOURCE DEST <ERRATA|search:XXX ...>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1729
+msgid "    -q/--quick : Don't display list of packages (slightly faster)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1730
+msgid "    -s/--skip :  Skip errata which appear to exist already in DEST"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1756
+#, python-format
+msgid "source channel %s does not exist!"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1761
+#, python-format
+msgid "dest channel %s does not exist!"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1814
+msgid "No patch to add"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1833
+msgid "Add these patches [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1847
+msgid "Using the old errata.clone function"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1848
+msgid ""
+"If you have base channels for multiple OS versions, check no unexpected "
+"packages have been added"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1861
+msgid ""
+"softwarechannel_getorgaccess: Get the org-access for the software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1862
+msgid "usage: softwarechannel_getorgaccess [CHANNEL ...]"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1900
+msgid ""
+"softwarechannel_setorgaccess: Set the org-access for the software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1901
+msgid ""
+"usage : softwarechannel_setorgaccess <CHANNEL> [options])\n"
+"-d,--disable : disable org access (private, no org sharing)\n"
+"-e,--enable : enable org access (public access to all trusted orgs)\n"
+"-p,--protected ORG : protected org access for ORG only (multiple instances "
+"of -p ORG are allowed)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1941
+#, python-format
+msgid "Making org sharing public for channel : %s "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1946
+#, python-format
+msgid "Making org sharing private for channel : %s "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1951
+#, python-format
+msgid "Making org sharing protected for channel : %s "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1957
+#, python-format
+msgid "Enabling %s access for channel : %s "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1962
+#, python-format
+msgid "Disabling %s access for channel : %s "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1975
+msgid ""
+"softwarechannel_getorgaccesstree: Get the org-access for a software base "
+"channel and its children"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:1976
+msgid "usage: softwarechannel_getorgaccesstree [CHANNEL]"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2009
+msgid ""
+"softwarechannel_setorgaccesstree: set the org-access for a software base "
+"channel and its children"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2010
+msgid ""
+"usage: softwarechannel_setorgaccesstree <CHANNEL> [options])\n"
+"-d,--disable : disable org access (private, no org sharing)\n"
+"-e,--enable : enable org access (public access to all trusted orgs)\n"
+"-p,--protected ORG : protected org access for ORG only (multiple instances "
+"of -p ORG are allowed)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2049
+msgid "softwarechannel_regenerateneededcache: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2050
+msgid "Regenerate the needed errata and package cache for all systems"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2052
+msgid "usage: softwarechannel_regenerateneededcache"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2066
+msgid "softwarechannel_regenerateyumcache: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2067
+msgid "Regenerate the YUM cache for a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2069
+msgid ""
+"usage: softwarechannel_regenerateyumcache [options] <CHANNEL ...>\n"
+"\n"
+"    options:\n"
+"      -f force cache regeneration\n"
+"    "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2113
+msgid "no softwarechannel label given"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2116
+msgid "invalid softwarechannel label "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2134
+msgid "softwarechannel_diff: diff softwarechannel files"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2136
+msgid "usage: softwarechannel_diff SOURCE_CHANNEL TARGET_CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2197
+msgid "softwarechannel_errata_diff: diff softwarechannel files"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2199
+msgid "usage: softwarechannel_errata_diff SOURCE_CHANNEL TARGET_CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2248
+msgid "softwarechannel_sync: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2249
+msgid "sync the packages of two software channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2251
+msgid ""
+"usage: softwarechannel_sync SOURCE_CHANNEL TARGET_CHANNEL [options])\n"
+"    -q,--quiet : quiet mode (omits the output of common packages in both "
+"channels)"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2293
+#, python-format
+msgid "%s packages from softwarechannel %s to %s"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2312
+#: ../src/spacecmd/softwarechannel.py:2320
+#: ../src/spacecmd/softwarechannel.py:2434
+#: ../src/spacecmd/softwarechannel.py:2442
+#: ../src/spacecmd/softwarechannel.py:2574
+#: ../src/spacecmd/softwarechannel.py:2582
+msgid "failed to read key id"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2323
+msgid "packages common in both channels:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2328
+msgid "Omitting common packages in both specified channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2333
+msgid "packages to add to channel \""
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2341
+msgid "packages to remove from channel \""
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2347
+#: ../src/spacecmd/softwarechannel.py:2469
+#: ../src/spacecmd/softwarechannel.py:2599
+msgid "summary:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2348
+#: ../src/spacecmd/softwarechannel.py:2349
+msgid " packages"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2350
+msgid "    add    "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2351
+msgid " packages to   "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2354
+msgid "    remove "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2355
+msgid " packages from "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2357
+#: ../src/spacecmd/softwarechannel.py:2477
+msgid "Perform these changes to channel "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2378
+msgid "softwarechannel_errata_sync: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2379
+msgid "sync errata of two software channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2381
+msgid "usage: softwarechannel_errata_sync SOURCE_CHANNEL TARGET_CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2420
+msgid "syncing errata from softwarechannel "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2421
+#: ../src/spacecmd/softwarechannel.py:2553
+msgid " to "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2445
+msgid "errata common in both channels:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2454
+msgid "errata to add to channel \""
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2463
+msgid "errata to remove from channel \""
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2472
+#: ../src/spacecmd/softwarechannel.py:2602
+msgid "    add   "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2473
+msgid "errata to  "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2474
+msgid "    remove"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2475
+msgid "errata from"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2500
+msgid "softwarechannel_errata_merge: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2501
+msgid "merge errata of one software channel into another"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2503
+msgid ""
+"usage:   softwarechannel_errata_merge SOURCE_CHANNEL TARGET_CHANNEL "
+"[FROM_DATE] [TO_DATE]"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2504
+msgid ""
+"example: softwarechannel_errata_merge OldSoftChannel NewSoftChannel "
+"2018-01-01"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2505
+msgid ""
+"note:    Providing only FROM_DATE will merge all errata since that date."
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2506
+msgid "note:    When no date is provided, all errata will be merged."
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2536
+#: ../src/spacecmd/softwarechannel.py:2543
+msgid "wrong dateformat: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2536
+#: ../src/spacecmd/softwarechannel.py:2543
+msgid " please specify as: YYYY-MM-DD"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2552
+msgid "merging errata from softwarechannel "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2589
+msgid "{} contains no errata which is not already present in {}"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2594
+msgid "errata to add to channel {}: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2600
+#: ../src/spacecmd/softwarechannel.py:2601
+msgid " errata"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2603
+msgid " errata to  "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2605
+msgid "Perform these changes to channel {} [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2616
+msgid "softwarechannel_syncrepos: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2617
+msgid "Sync users repos for a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2619
+msgid "usage: softwarechannel_syncrepos <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2621
+#: ../src/spacecmd/softwarechannel.py:2664
+msgid "    -e/--no-errata : Do not sync errata"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2622
+#: ../src/spacecmd/softwarechannel.py:2665
+msgid "    -f/--fail : Terminate upon any error"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2623
+#: ../src/spacecmd/softwarechannel.py:2666
+msgid "    -k/--sync-kickstart : Create kickstartable tree"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2624
+#: ../src/spacecmd/softwarechannel.py:2667
+msgid "    -l/--latest : Only download latest package versions when repo syncs"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2659
+msgid "softwarechannel_setsyncschedule: "
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2660
+msgid "Sets the repo sync schedule for a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2662
+msgid "usage: softwarechannel_setsyncschedule <CHANNEL> <SCHEDULE>"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2669
+msgid ""
+"The schedule is specified in Quartz CronTrigger format without enclosing "
+"quotes."
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2670
+msgid ""
+"For example, to set a schedule of every day at 1am, <SCHEDULE> would be 0 0 "
+"1 * * ?"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2671
+msgid "If <SCHEDULE> is left empty, it will be disabled."
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2734
+msgid ""
+"softwarechannel_listsyncschedule: List sync schedules for all software "
+"channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2736
+msgid "softwarechannel_listsyncschedule : List all channels"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2759
+msgid "key"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2759
+msgid "Channel Name"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2759
+msgid "Update Schedule"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2771
+msgid "softwarechannel_addrepo: Add a repo to a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2772
+msgid "usage: softwarechannel_addrepo CHANNEL REPO"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2805
+msgid "softwarechannel_removerepo: Remove a repo from a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2806
+msgid "usage: softwarechannel_removerepo CHANNEL REPO"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2846
+msgid "softwarechannel_listrepos: List the repos for a software channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2847
+msgid "usage: softwarechannel_listrepos CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2870
+msgid "No repos have been found for this channel."
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2877
+msgid "softwarechannel_mirrorpackages: Download packages of a given channel"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2878
+msgid "usage: softwarechannel_mirrorpackages CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2880
+msgid "    -l/--latest : Only mirror latest package version"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2911
+msgid "Skipping"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2913
+msgid "Fetching package"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2918
+#, python-format
+msgid "Received package %s from channel %s is broken. Content is too short"
+msgstr ""
+
+#: ../src/spacecmd/softwarechannel.py:2922
+#, python-format
+msgid "Could not fetch package %s from channel %s"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:42
+msgid "The System Set Manager (SSM) is a group of systems that you "
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:43
+msgid "can perform tasks on as a whole."
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:45
+msgid "Adding Systems:"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:51
+msgid "Intersections:"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:63
+msgid "ssm_add: Add systems to the SSM"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:64
+msgid "usage: ssm_add <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:66 ../src/spacecmd/ssm.py:115
+#: ../src/spacecmd/ssm.py:165 ../src/spacecmd/ssm.py:209
+msgid "see 'help ssm' for more details"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:92
+#, python-format
+msgid "%s is already in the list"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:110
+msgid "ssm_intersect: Replace the current SSM with the intersection"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:111
+msgid "               of the current list of systems and the list of"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:112
+msgid "               systems passed as arguments"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:113
+msgid "usage: ssm_intersect <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:162
+msgid "ssm_remove: Remove systems from the SSM"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:163
+msgid "usage: ssm_remove <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:206
+msgid "ssm_list: List the systems currently in the SSM"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:207
+msgid "usage: ssm_list"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:226
+msgid "ssm_clear: Remove all systems from the SSM"
+msgstr ""
+
+#: ../src/spacecmd/ssm.py:227
+msgid "usage: ssm_clear"
+msgstr ""
+
+#: ../src/spacecmd/system.py:49
+msgid "Same"
+msgstr ""
+
+#: ../src/spacecmd/system.py:50
+msgid "Only here"
+msgstr ""
+
+#: ../src/spacecmd/system.py:51
+msgid "Newer here"
+msgstr ""
+
+#: ../src/spacecmd/system.py:52
+msgid "Only there"
+msgstr ""
+
+#: ../src/spacecmd/system.py:53
+msgid "Newer there"
+msgstr ""
+
+#: ../src/spacecmd/system.py:73 ../src/spacecmd/system.py:3771
+msgid "Package"
+msgstr ""
+
+#: ../src/spacecmd/system.py:74
+msgid "This System"
+msgstr ""
+
+#: ../src/spacecmd/system.py:75
+msgid "Other System"
+msgstr ""
+
+#: ../src/spacecmd/system.py:76 ../src/spacecmd/system.py:3774
+msgid "Difference"
+msgstr ""
+
+#: ../src/spacecmd/system.py:124
+msgid "Removing Channels"
+msgstr ""
+
+#: ../src/spacecmd/system.py:127
+msgid "Adding Channels"
+msgstr ""
+
+#: ../src/spacecmd/system.py:163
+msgid "system_list: List all system profiles"
+msgstr ""
+
+#: ../src/spacecmd/system.py:164
+msgid "usage: system_list"
+msgstr ""
+
+#: ../src/spacecmd/system.py:180
+msgid "system_reboot: Reboot a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:181
+msgid ""
+"usage: system_reboot <SYSTEMS> [options])\n"
+"\n"
+"options:\n"
+"  -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:236
+msgid "Reboot these systems [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:252
+msgid "system_search: List systems that match the given criteria"
+msgstr ""
+
+#: ../src/spacecmd/system.py:253
+msgid "usage: system_search QUERY"
+msgstr ""
+
+#: ../src/spacecmd/system.py:255
+msgid "Available Fields:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:258
+msgid "Examples:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:259
+msgid "> system_search device:vmware"
+msgstr ""
+
+#: ../src/spacecmd/system.py:260
+msgid "> system_search ip:192.168.82"
+msgstr ""
+
+#: ../src/spacecmd/system.py:278 ../src/spacecmd/system.py:285
+msgid "Invalid query"
+msgstr ""
+
+#: ../src/spacecmd/system.py:321
+msgid "Invalid search field"
+msgstr ""
+
+#: ../src/spacecmd/system.py:351
+msgid "system_runscript: Schedule a script to run on the list of"
+msgstr ""
+
+#: ../src/spacecmd/system.py:352
+msgid "                  systems provided"
+msgstr ""
+
+#: ../src/spacecmd/system.py:353
+msgid ""
+"usage: system_runscript <SYSTEMS> [options])\n"
+"\n"
+"options:\n"
+"  -u USER\n"
+"  -g GROUP\n"
+"  -t TIMEOUT\n"
+"  -s START_TIME\n"
+"  -l LABEL\n"
+"  -f FILE"
+msgstr ""
+
+#: ../src/spacecmd/system.py:398
+msgid "User [root]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:399
+msgid "Group [root]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:408
+msgid "Timeout (in seconds) [600]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:414
+msgid "Invalid timeout"
+msgstr ""
+
+#: ../src/spacecmd/system.py:420
+msgid "Label/Short Description [default]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:424
+msgid "Script File [create]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:437
+msgid "No script provided"
+msgstr ""
+
+#: ../src/spacecmd/system.py:456
+msgid "A script file is required"
+msgstr ""
+
+#: ../src/spacecmd/system.py:464
+#, python-format
+msgid "User:       %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:465
+#, python-format
+msgid "Group:      %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:466
+#, python-format
+msgid "Timeout:    %i seconds"
+msgstr ""
+
+#: ../src/spacecmd/system.py:470
+#, python-format
+msgid "Label:      %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:471
+msgid "Script Contents"
+msgstr ""
+
+#: ../src/spacecmd/system.py:533 ../src/spacecmd/system.py:835
+#: ../src/spacecmd/system.py:962 ../src/spacecmd/system.py:1096
+#: ../src/spacecmd/system.py:4358
+#, python-format
+msgid "Failed to schedule %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:536
+#, python-format
+msgid "Scheduled: %i system(s)"
+msgstr ""
+
+#: ../src/spacecmd/system.py:543 ../src/spacecmd/utils.py:245
+#, python-format
+msgid "Could not remove %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:552
+msgid "system_listhardware: List the hardware details of a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:553
+msgid "usage: system_listhardware <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:612
+msgid "Network"
+msgstr ""
+
+#: ../src/spacecmd/system.py:621
+#, python-format
+msgid "Interface:   %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:622
+#, python-format
+msgid "MAC Address: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:623
+#, python-format
+msgid "IP Address:  %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:624
+#, python-format
+msgid "Netmask:     %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:625
+#, python-format
+msgid "Broadcast:   %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:626
+#, python-format
+msgid "Module:      %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:630
+msgid "CPU"
+msgstr ""
+
+#: ../src/spacecmd/system.py:632
+#, python-format
+msgid "Count:    %i"
+msgstr ""
+
+#: ../src/spacecmd/system.py:633
+#, python-format
+msgid "Arch:     %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:634
+#, python-format
+msgid "MHz:      %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:635
+#, python-format
+msgid "Cache:    %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:636
+#, python-format
+msgid "Vendor:   %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:637
+#, python-format
+msgid "Model:    %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:640
+msgid "Memory"
+msgstr ""
+
+#: ../src/spacecmd/system.py:642
+#, python-format
+msgid "RAM:  %i"
+msgstr ""
+
+#: ../src/spacecmd/system.py:643
+#, python-format
+msgid "Swap: %i"
+msgstr ""
+
+#: ../src/spacecmd/system.py:647
+msgid "DMI"
+msgstr ""
+
+#: ../src/spacecmd/system.py:648
+#, python-format
+msgid "Vendor:       %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:649
+#, python-format
+msgid "System:       %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:650
+#, python-format
+msgid "Product:      %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:651
+#, python-format
+msgid "Board:        %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:654
+msgid "Asset"
+msgstr ""
+
+#: ../src/spacecmd/system.py:660
+#, python-format
+msgid "BIOS Release: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:661
+#, python-format
+msgid "BIOS Vendor:  %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:662
+#, python-format
+msgid "BIOS Version: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:666
+msgid "Devices"
+msgstr ""
+
+#: ../src/spacecmd/system.py:676
+msgid "Description: None"
+msgstr ""
+
+#: ../src/spacecmd/system.py:680
+#, python-format
+msgid "Driver:      %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:681
+#, python-format
+msgid "Class:       %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:682
+#, python-format
+msgid "Bus:         %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:690
+msgid "system_installpackage: Install a package on a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:691
+msgid ""
+"usage: system_installpackage <SYSTEMS> <PACKAGE ...> [options])\n"
+"\n"
+"options:\n"
+"    -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:792
+msgid "No packages to install"
+msgstr ""
+
+#: ../src/spacecmd/system.py:816
+#, python-format
+msgid "%s does not have access to all requested packages"
+msgstr ""
+
+#: ../src/spacecmd/system.py:822
+msgid "Install these packages [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:837 ../src/spacecmd/system.py:964
+#: ../src/spacecmd/system.py:1098
+#, python-format
+msgid "Scheduled %i system(s)"
+msgstr ""
+
+#: ../src/spacecmd/system.py:845
+msgid "system_removepackage: Remove a package from a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:846
+msgid ""
+"usage: system_removepackage <SYSTEMS> <PACKAGE ...> [options])\n"
+"\n"
+"options:\n"
+"    -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:972
+msgid "system_upgradepackage: Upgrade a package on a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:973
+msgid ""
+"usage: system_upgradepackage <SYSTEMS> <PACKAGE ...>|* [options]')\n"
+"\n"
+"options:\n"
+"    -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1051 ../src/spacecmd/system.py:1147
+#, python-format
+msgid "No upgrades available for %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1074
+#, python-format
+msgid "Couldn't get name for package %i"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1081
+msgid "Upgrade these packages [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1106
+msgid "system_listupgrades: List the available upgrades for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1107
+msgid "usage: system_listupgrades <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1175
+msgid "system_listinstalledpackages: List the installed packages on a"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1176
+msgid "                              system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1177
+msgid "usage: system_listinstalledpackages <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1231
+msgid "system_listconfigchannels: List the config channels of a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1232
+msgid "usage: system_listconfigchannels <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1278 ../src/spacecmd/system.py:1381
+#, python-format
+msgid "%s does not support configuration channels"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1315
+msgid "system_listconfigfiles: List the managed config files of a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1316
+msgid ""
+"usage: system_listconfigfiles <SYSTEMS>')\n"
+"options:\n"
+"  -s/--sandbox : list only system-sandbox files\n"
+"  -l/--local   : list only locally managed files\n"
+"  -c/--central : list only centrally managed files\n"
+"  -q/--quiet   : quiet mode (omits the header)"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1416
+msgid "system_addconfigfile: Create a configuration file"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1417
+msgid "Note this is only for system sandbox or locally-managed files"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1418
+msgid "Centrally managed files should be created via configchannel_addfile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1419
+msgid ""
+"usage: system_addconfigfile [SYSTEM] [options]\n"
+"\n"
+"options:\n"
+"  -S/--sandbox : list only system-sandbox files\n"
+"  -L/--local   : list only locally managed files\n"
+"  -p PATH\n"
+"  -r REVISION\n"
+"  -o OWNER [default: root]\n"
+"  -g GROUP [default: root]\n"
+"  -m MODE [defualt: 0644]\n"
+"  -x SELINUX_CONTEXT\n"
+"  -d path is a directory\n"
+"  -s path is a symlink\n"
+"  -b path is a binary (or other file which needs base64 encoding)\n"
+"  -t SYMLINK_TARGET\n"
+"  -f local path to file contents\n"
+"\n"
+"  Note re binary/base64: Some text files, notably those containing trailing\n"
+"  newlines, those containing ASCII escape characters (or other charaters "
+"not\n"
+"  allowed in XML) need to be sent as binary (-b).  Some effort is made to "
+"auto-\n"
+"  detect files which require this, but you may need to explicitly specify.\n"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1487
+#, python-format
+msgid "%s is not a valid system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1497
+msgid "System-Sandbox or Locally-Managed? [S/L]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1513
+msgid "Must choose system-sandbox or locally-managed option"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1552
+msgid "system_addconfigchannels: Add config channels to a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1553
+msgid ""
+"usage: system_addconfigchannels <SYSTEMS> <CHANNEL ...> [options]\n"
+"\n"
+"options:\n"
+"  -t add channels to the top of the list\n"
+"  -b add channels to the bottom of the list"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1597
+msgid "Add to top or bottom? [T/b]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1621
+msgid "system_removeconfigchannels: Remove config channels from a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1622
+msgid "usage: system_removeconfigchannels <SYSTEMS> <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1671
+msgid ""
+"system_setconfigchannelorder: Set the ranked order of configuration channels"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1672
+msgid "usage: system_setconfigchannelorder <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1712
+msgid "New Configuration Channels"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1732
+msgid "system_deployconfigfiles: Deploy all configuration files for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1733
+msgid ""
+"usage: system_deployconfigfiles <SYSTEMS> [options]\n"
+"\n"
+"options:\n"
+"    -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1787
+msgid "Deploy ALL configuration files to these systems [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1797
+#, python-format
+msgid "Scheduled deployment for %i system(s)"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1805
+msgid "system_delete: Delete a system profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1806
+msgid ""
+"usage: system_delete [options] <SYSTEMS>\n"
+"\n"
+"    options:\n"
+"          -c TYPE - Possible values:\n"
+"             *  'FAIL_ON_CLEANUP_ERR' - fail in case of cleanup error,\n"
+"             *  'NO_CLEANUP' - do not cleanup, just delete,\n"
+"             *  'FORCE_DELETE' - Try cleanup first but delete server anyway "
+"in case of error\n"
+"    "
+msgstr ""
+
+#: ../src/spacecmd/system.py:1850
+msgid "No systems to delete"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1858
+#, python-format
+msgid "%s  System ID"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1858
+msgid "Profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1866
+msgid "Delete these systems [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1873
+#, python-format
+msgid "%i system(s) scheduled for removal"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1893
+msgid "system_lock: Lock a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1894
+msgid "usage: system_lock <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1935
+msgid "system_unlock: Unlock a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1936
+msgid "usage: system_unlock <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1977
+msgid "system_rename: Rename a system profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:1978
+msgid "usage: system_rename OLDNAME NEWNAME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2023
+msgid "system_listcustomvalues: List the custom values for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2024
+msgid "usage: system_listcustomvalues <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2079
+msgid "system_addcustomvalue: Set a custom value for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2080
+msgid "usage: system_addcustomvalue KEY VALUE <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2134
+msgid "system_updatecustomvalue: Update a custom value for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2135
+msgid "usage: system_updatecustomvalue KEY VALUE <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2166
+msgid "system_removecustomvalues: Remove a custom value for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2167
+msgid "usage: system_removecustomvalues <SYSTEMS> <KEY ...>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2203
+msgid "Delete these values [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2221
+msgid "system_addnote: Set a note for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2222
+msgid ""
+"usage: system_addnote <SYSTEM> [options]\n"
+"\n"
+"options:\n"
+"  -s SUBJECT\n"
+"  -b BODY"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2257
+msgid "Subject of the Note:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2259
+msgid "Note Body (ctrl-D to finish):"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2263
+msgid "A subject is required"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2267
+msgid "A body is required"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2286
+msgid "system_deletenotes: Delete notes from a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2287
+msgid "usage: system_deletenotes <SYSTEM> <ID|*>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2319
+msgid "No notes to delete"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2346
+msgid "system_listnotes: List the available notes for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2347
+msgid "usage: system_listnotes <SYSTEM>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2405
+msgid "system_listfqdns: List the associated FQDNs for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2406
+msgid "usage: system_listfqdns <SYSTEM>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2458
+msgid "system_setbasechannel: Set a system's base software channel"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2459
+msgid "usage: system_setbasechannel <SYSTEMS> CHANNEL"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2506 ../src/spacecmd/system.py:2593
+#, python-format
+msgid "System:           %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2507 ../src/spacecmd/system.py:2594
+#, python-format
+msgid "Old Base Channel: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2508 ../src/spacecmd/system.py:2596
+#, python-format
+msgid "New Base Channel: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2527
+msgid ""
+"system_schedulechangechannels: Schedule changing a system's software channels"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2528
+msgid ""
+"usage: system_setbasechannel <SYSTEMS> [options]\n"
+"\n"
+"options:\n"
+"  -b BASE_CHANNEL base channel label\n"
+"  -c CHILD_CHANNEL child channel labels (allowed multiple times)\n"
+"  -s START_TIME time defaults to now"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2595
+#, python-format
+msgid "Old Child Channels: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2597
+#, python-format
+msgid "New Child channels %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2612 ../src/spacecmd/system.py:4243
+#, python-format
+msgid "Scheduled action id: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2619
+msgid "system_listbasechannel: List the base channel for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2620
+msgid "usage: system_listbasechannel <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2674
+msgid "system_listchildchannels: List the child channels for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2675
+msgid "usage: system_listchildchannels <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2729
+msgid "system_addchildchannels: Add child channels to a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2730
+msgid "usage: system_addchildchannels <SYSTEMS> <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2752
+msgid ""
+"system_listcrashedsystems: List all systems that have experienced a crash "
+"and reported by spacewalk-abrt"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2753
+msgid "usage: system_listcrashedsystems"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2759
+msgid "Count | System ID | Profile Name"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2773
+msgid "system_deletecrashes: Delete crashes reported by spacewalk-abrt."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2774
+msgid ""
+"usage: Delete all crashes for all systems    : system_deletecrashes [--"
+"verbose]"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2775
+msgid ""
+"usage: Delete all crashes for a single system: system_deletecrashes -i "
+"sys_id [--verbose]"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2776
+msgid ""
+"usage: Delete a single crash record          : system_deletecrashes -c "
+"crash_id [--verbose]"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2794
+#, python-format
+msgid "Deleting crash with id %s."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2801
+#, python-format
+msgid "Deleting all crashes from system with systemid %s [y/N]:"
+msgstr ""
+
+#. all systems
+#: ../src/spacecmd/system.py:2803
+msgid "Deleting all crashes from all systems [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2815
+#, python-format
+msgid "Deleting crash with id %s from system %s."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2824
+msgid "system_listcrashesbysystem: List all reported crashes for a system."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2825 ../src/spacecmd/system.py:2837
+msgid "usage: system_listcrashesbysystem -i sys_id"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2836
+msgid "# System id must be provided."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2842
+msgid "Crash ID | Crash Name"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2853
+msgid "system_getcrashfiles: Download all files for a crash record."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2854
+msgid "usage: system_getcrashfiles -c crash_id [--verbose]"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2855 ../src/spacecmd/system.py:2869
+msgid ""
+"usage: system_getcrashfiles -c crash_id [--dest_folder=/tmp/crash_files] [--"
+"verbose]"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2868
+msgid "# Crash id must be provided."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2895
+#, python-format
+msgid "# All files we downloaded to %s."
+msgstr ""
+
+#: ../src/spacecmd/system.py:2904
+msgid "system_removechildchannels: Remove child channels from a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2905
+msgid "usage: system_removechildchannels <SYSTEMS> <CHANNEL ...>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2927
+msgid "system_details: Show the details of a system profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2928
+msgid "usage: system_details <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2981
+#, python-format
+msgid "Name:          %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2982
+#, python-format
+msgid "System ID:     %i"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2985
+#, python-format
+msgid "UUID:          %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2987
+#, python-format
+msgid "Locked:        %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2988
+#, python-format
+msgid "Registered:    %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2989
+#, python-format
+msgid "Last Checkin:  %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2990
+#, python-format
+msgid "OSA Status:    %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2991
+#, python-format
+msgid "Last Boot:     %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:2993
+#, python-format
+msgid "Contact Method:%s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3037
+#, python-format
+msgid "Hostname:      %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3038
+#, python-format
+msgid "IP Address:    %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3039
+#, python-format
+msgid "Kernel:        %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3080
+msgid "system_listerrata: List available errata for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3081
+msgid "usage: system_listerrata <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3135
+msgid "system_applyerrata: Apply errata to a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3136
+msgid ""
+"usage: system_applyerrata [options] <SYSTEMS>\n"
+"[ERRATA|search:XXX ...]\n"
+"\n"
+"options:\n"
+"  -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3197
+msgid "system_listevents: List the event history for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3198
+msgid "usage: system_listevents <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3244
+#, python-format
+msgid "Summary:   %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3246
+#, python-format
+msgid "Details:   %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3254
+msgid "system_listentitlements: List the entitlements for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3255
+msgid "usage: system_listentitlements <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3308
+msgid "system_addentitlements: Add entitlements to a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3309
+msgid "usage: system_addentitlements <SYSTEMS> ENTITLEMENT"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3364
+msgid "system_removeentitlement: Remove an entitlement from a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3365
+msgid "usage: system_removeentitlement <SYSTEMS> ENTITLEMENT"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3420
+msgid "system_listpackageprofiles: List all package profiles"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3421
+msgid "usage: system_listpackageprofiles"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3440
+msgid "system_deletepackageprofile: Delete a package profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3441
+msgid "usage: system_deletepackageprofile PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3465
+msgid "Delete this profile [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3476
+#, python-format
+msgid "%s is not a valid profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3487
+msgid "system_createpackageprofile: Create a package profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3488
+msgid ""
+"usage: system_createpackageprofile SYSTEM [options]\n"
+"\n"
+"options:\n"
+"  -n NAME\n"
+"  -d DESCRIPTION"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3518
+msgid "Profile Label:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3522
+msgid "A profile name is required"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3526
+msgid "A profile description is required"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3534
+#, python-format
+msgid "Created package profile '%s'"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3542
+msgid ""
+"system_comparepackageprofile: Compare a system against a package profile"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3543
+msgid "usage: system_comparepackageprofile <SYSTEMS> PROFILE"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3606
+msgid "system_comparepackages: Compare the packages between two systems"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3607
+msgid "usage: system_comparepackages SOME_SYSTEM ANOTHER_SYSTEM"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3638
+msgid "system_syncpackages: Sync packages between two systems"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3639
+msgid ""
+"usage: system_syncpackages SOURCE TARGET [options]\n"
+"\n"
+"options:\n"
+"    -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3687
+msgid "Sync packages [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3729
+#, python-format
+msgid "Failed to filter package list, package %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3730
+msgid "found with no arch or arch_label"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3772
+msgid "System Version"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3773
+msgid "Channel Version"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3795
+msgid "Channel_newer_than_system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3808
+msgid "System_newer_than_channel"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3817
+msgid "Missing_in_channel"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3821
+msgid "system_comparewithchannel: Compare the installed packages on a"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3822
+msgid "                           system with those in the channels it is"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3823
+msgid "                           registerd to, or optionally some other"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3824
+msgid "                           channel"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3825
+msgid "usage: system_comparewithchannel <SYSTEMS> [options]"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3827
+msgid "         -c/--channel : Specific channel to compare against,"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3828
+msgid "                        default is those subscribed to, including"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3829
+msgid "                        child channels"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3880
+msgid "Specified channel does not exist"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3891
+#, python-format
+msgid "system %s is not subscribed to any channel!"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3893
+msgid "Please subscribe to a channel, or specify achannel to compare with"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3927
+#, python-format
+msgid ""
+"\n"
+"System: %s"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3953
+msgid ""
+"system_schedulehardwarerefresh: Schedule a hardware refresh for a system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:3954
+msgid ""
+"usage: system_schedulehardwarerefresh <SYSTEMS> [options]\n"
+"\n"
+"options:\n"
+"  -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4016
+msgid ""
+"system_schedulepackagerefresh: Schedule a software package refresh for a "
+"system"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4017
+msgid ""
+"usage: system_schedulepackagerefresh <SYSTEMS> [options])\n"
+"\n"
+"options:\n"
+"  -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4078
+msgid ""
+"system_show_packageversion: Shows version of installed package on given "
+"system(s)"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4079
+msgid "usage: system_show_packageversion <SYSTEM> <PACKAGE>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4111
+msgid "Package\tVersion\tRelease\tEpoch\tArch\tSystem"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4131
+msgid "system_setcontactmethod: Set the contact method for given system(s)."
+msgstr ""
+
+#: ../src/spacecmd/system.py:4133
+msgid "usage: system_setcontactmethod <SYSTEMS> <CONTACT_METHOD>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4182
+msgid ""
+"system_scheduleapplyconfigchannels: Schedule applying the assigned config "
+"channels to the System (Minion only)"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4183
+msgid ""
+"usage: scheduleapplyconfigchannels <SYSTEMS> [options]\n"
+"\n"
+"    options:\n"
+"        -s START_TIME"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4234
+msgid "Schedule applying config channels to these systems [y/N]:"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4251
+msgid ""
+"system_listmigrationtargets: List possible migration targets for given "
+"systems."
+msgstr ""
+
+#: ../src/spacecmd/system.py:4252
+msgid "usage: system_listmigrationtargets <SYSTEMS>"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4279
+msgid "WARN: Cannot find system "
+msgstr ""
+
+#: ../src/spacecmd/system.py:4286
+msgid "  No migration targets"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4289
+msgid "  Target #"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4290
+msgid "    IDs: "
+msgstr ""
+
+#: ../src/spacecmd/system.py:4291
+msgid "    Friendly names: "
+msgstr ""
+
+#: ../src/spacecmd/system.py:4297
+msgid ""
+"system_schedulespmigration: Schedule a Service Pack migration for systems."
+msgstr ""
+
+#: ../src/spacecmd/system.py:4298
+msgid ""
+"usage: system_schedulespmigration <SYSTEM> <BASE_CHANNEL_LABEL> "
+"<MIGRATION_TARGET> [options] \n"
+"    For MIGRATION_TARGET parameter see system_listmigrationtargets. \n"
+"    The MIGRATION_TARGET parameter must be passed in the following format: "
+"[3143,3146,3147,3145,3144,3148,3062]. \n"
+"    Options: \n"
+"        -s START_TIME \n"
+"        -d pass this flag, if you want to do a dry run \n"
+"        -c CHILD_CHANNELS (comma-separated child channels labels (with no "
+"spaces))"
+msgstr ""
+
+#: ../src/spacecmd/system.py:4348
+msgid "Cannot find system "
+msgstr ""
+
+#: ../src/spacecmd/system.py:4348
+msgid ". Skipping it."
+msgstr ""
+
+#: ../src/spacecmd/system.py:4351
+msgid "Scheduling Service Pack migration for system "
+msgstr ""
+
+#: ../src/spacecmd/system.py:4356
+msgid "Scheduled action ID: "
+msgstr ""
+
+#: ../src/spacecmd/user.py:49
+msgid "user_create: Create an user"
+msgstr ""
+
+#: ../src/spacecmd/user.py:50
+msgid ""
+"usage: user_create [options])\n"
+"\n"
+"options:\n"
+"  -u USERNAME\n"
+"  -f FIRST_NAME\n"
+"  -l LAST_NAME\n"
+"  -e EMAIL\n"
+"  -p PASSWORD\n"
+"  --pam enable PAM authentication"
+msgstr ""
+
+#: ../src/spacecmd/user.py:119
+msgid "Note: password was ignored due to PAM mode"
+msgstr ""
+
+#: ../src/spacecmd/user.py:138
+msgid "user_delete: Delete an user"
+msgstr ""
+
+#: ../src/spacecmd/user.py:139
+msgid "usage: user_delete NAME"
+msgstr ""
+
+#: ../src/spacecmd/user.py:167
+msgid "user_disable: Disable an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:168
+msgid "usage: user_disable NAME"
+msgstr ""
+
+#: ../src/spacecmd/user.py:194
+msgid "user_enable: Enable an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:195
+msgid "usage: user_enable NAME"
+msgstr ""
+
+#: ../src/spacecmd/user.py:221
+msgid "user_list: List all users"
+msgstr ""
+
+#: ../src/spacecmd/user.py:222
+msgid "usage: user_list"
+msgstr ""
+
+#: ../src/spacecmd/user.py:239
+msgid "user_listavailableroles: List all available roles for users"
+msgstr ""
+
+#: ../src/spacecmd/user.py:240
+msgid "usage: user_listavailableroles"
+msgstr ""
+
+#: ../src/spacecmd/user.py:252
+msgid "No roles has been found"
+msgstr ""
+
+#: ../src/spacecmd/user.py:258
+msgid "user_addrole: Add a role to an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:259
+msgid "usage: user_addrole USER ROLE"
+msgstr ""
+
+#: ../src/spacecmd/user.py:292
+msgid "user_removerole: Remove a role from an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:293
+msgid "usage: user_removerole USER ROLE"
+msgstr ""
+
+#: ../src/spacecmd/user.py:327
+msgid "user_details: Show the details of an user"
+msgstr ""
+
+#: ../src/spacecmd/user.py:328
+msgid "usage: user_details USER ..."
+msgstr ""
+
+#: ../src/spacecmd/user.py:360
+#, python-format
+msgid "%s is not a valid user"
+msgstr ""
+
+#: ../src/spacecmd/user.py:361
+msgid "Error '{}' while getting data about user '{}': {}"
+msgstr ""
+
+#: ../src/spacecmd/user.py:371
+#, python-format
+msgid "Username:      %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:372
+#, python-format
+msgid "First Name:    %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:373
+#, python-format
+msgid "Last Name:     %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:374
+#, python-format
+msgid "Email Address: %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:375
+#, python-format
+msgid "Organisation:  %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:376
+#, python-format
+msgid "Last Login:    %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:377
+#, python-format
+msgid "Created:       %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:378
+#, python-format
+msgid "Enabled:       %s"
+msgstr ""
+
+#: ../src/spacecmd/user.py:382
+msgid "Roles"
+msgstr ""
+
+#: ../src/spacecmd/user.py:388
+msgid "Assigned Groups"
+msgstr ""
+
+#: ../src/spacecmd/user.py:394
+msgid "Default Groups"
+msgstr ""
+
+#: ../src/spacecmd/user.py:404
+msgid "user_addgroup: Add a group to an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:405
+msgid "usage: user_addgroup USER <GROUP ...>"
+msgstr ""
+
+#: ../src/spacecmd/user.py:442
+msgid "user_adddefaultgroup: Add a default group to an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:443
+msgid "usage: user_adddefaultgroup USER <GROUP ...>"
+msgstr ""
+
+#: ../src/spacecmd/user.py:479
+msgid "user_removegroup: Remove a group to an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:480
+msgid "usage: user_removegroup USER <GROUP ...>"
+msgstr ""
+
+#: ../src/spacecmd/user.py:520
+msgid "user_removedefaultgroup: Remove a default group from an user account"
+msgstr ""
+
+#: ../src/spacecmd/user.py:522
+msgid "usage: user_removedefaultgroup USER <GROUP ...>"
+msgstr ""
+
+#: ../src/spacecmd/user.py:561
+msgid "user_setfirstname: Set an user accounts first name field"
+msgstr ""
+
+#: ../src/spacecmd/user.py:562
+msgid "usage: user_setfirstname USER FIRST_NAME"
+msgstr ""
+
+#: ../src/spacecmd/user.py:596
+msgid "user_setlastname: Set an user accounts last name field"
+msgstr ""
+
+#: ../src/spacecmd/user.py:597
+msgid "usage: user_setlastname USER LAST_NAME"
+msgstr ""
+
+#: ../src/spacecmd/user.py:631
+msgid "user_setemail: Set an user accounts email field"
+msgstr ""
+
+#: ../src/spacecmd/user.py:632
+msgid "usage: user_setemail USER EMAIL"
+msgstr ""
+
+#: ../src/spacecmd/user.py:666
+msgid "user_setprefix: Set an user accounts name prefix field"
+msgstr ""
+
+#: ../src/spacecmd/user.py:667
+msgid "usage: user_setprefix USER PREFIX"
+msgstr ""
+
+#: ../src/spacecmd/user.py:706
+msgid "user_setpassword: Set an user accounts name prefix field"
+msgstr ""
+
+#: ../src/spacecmd/user.py:707
+msgid "usage: user_setpassword USER PASSWORD"
+msgstr ""
+
+#. If cache generation is interrupted (e.g by ctrl-c) you can end up
+#. with an EOFError exception due to the partial picked file
+#. So we catch this error and remove the corrupt partial file
+#. If you don't do this then spacecmd will fail with an unhandled
+#. exception until the partial file is manually removed
+#: ../src/spacecmd/utils.py:133
+#, python-format
+msgid "Loading cache file %s failed"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:134
+#, python-format
+msgid "Cache generation was probably interrupted,removing corrupt %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:139
+#, python-format
+msgid "Couldn't load cache from %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:160
+#, python-format
+msgid "Couldn't write to %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:205
+msgid "Could not open the temporary file"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:225
+#, python-format
+msgid "Editor \"%s\" exited with code %i"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:227
+#, python-format
+msgid "General failure running editor: %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:230
+msgid "No editors found"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:367
+msgid "Invalid time provided"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:463
+msgid "Security Errata"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:472
+msgid "Bug Fix Errata"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:481
+msgid "Enhancement Errata"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:491
+msgid "Current Selections"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:501
+msgid "Available Configuration Channels"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:507 ../src/spacecmd/utils.py:527
+msgid "Channel:"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:510 ../src/spacecmd/utils.py:530
+msgid "Invalid channel"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:514
+msgid "New Rank:"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:521 ../src/spacecmd/utils.py:524
+msgid "Invalid rank"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:535
+msgid "Clearing current selections"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:690
+msgid "Could not generate json data object!"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:697
+#, python-format
+msgid "Could not open file %s for writing: %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:708
+#, python-format
+msgid "Could not open file %s for reading: %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:710
+#, python-format
+msgid "Could not parse JSON data from %s: %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:712
+#, python-format
+msgid "Error processing file %s: %s"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:740
+msgid "Skipping usage of common strings: both strings are equal"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:756
+msgid "Skipping usage of common strings: number of substrings differ"
+msgstr ""
+
+#: ../src/spacecmd/utils.py:842
+msgid "Parameter {} not a string type, but {}."
+msgstr ""
+
+#: ../src/bin/spacecmd:74
+msgid "Unhandled exception occurred while getting FQDN:"
+msgstr ""

--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,4 @@
+- Added support for i18n of user-facing strings
 - Python3 fix for sorted usage (bsc#1167907)
 
 -------------------------------------------------------------------

--- a/spacecmd/spacecmd.spec
+++ b/spacecmd/spacecmd.spec
@@ -146,6 +146,9 @@ touch %{buildroot}/%{python_sitelib}/spacecmd/__init__.py
 %endif
 %endif
 
+make -C po install PREFIX=$RPM_BUILD_ROOT
+%find_lang spacecmd
+
 %check
 %if 0%{?pylint_check}
 %if 0%{?build_py3}
@@ -157,7 +160,7 @@ PYTHONPATH=$RPM_BUILD_ROOT%{python_sitelib} \
 %endif
 %endif
 
-%files
+%files -f spacecmd.lang
 %defattr(-,root,root)
 %{_bindir}/spacecmd
 %{python_sitelib}/spacecmd/

--- a/spacecmd/src/bin/spacecmd
+++ b/spacecmd/src/bin/spacecmd
@@ -21,6 +21,7 @@
 
 """ spacecmd - a command line interface to Spacewalk """
 
+import gettext
 import logging
 import os
 import re
@@ -38,12 +39,18 @@ except ImportError: # python 2
     from ConfigParser import SafeConfigParser
 import socket
 
-_INTRO = '''Welcome to spacecmd, a command-line interface to Spacewalk.
+translation = gettext.translation('spacecmd', fallback=True)
+try:
+    _ = translation.ugettext
+except AttributeError:
+    _ = translation.gettext
+
+_INTRO = _('''Welcome to spacecmd, a command-line interface to Spacewalk.
 
 Type: 'help' for a list of commands
       'help <cmd>' for command-specific help
       'quit' to quit
-'''
+''')
 
 _SYSTEM_CONF_FILE = '/etc/spacecmd.conf'
 
@@ -64,7 +71,7 @@ def get_localhost_fqdn():
     except socket.gaierror as exc:
         logging.debug("Error while getting FQDN over the network: %s", str(exc))
     except Exception as exc:
-        logging.error("Unhandled exception occurred while getting FQDN:", str(exc))
+        logging.error(_("Unhandled exception occurred while getting FQDN:"), str(exc))
 
     return fqdn or socket.getfqdn()
 
@@ -82,23 +89,23 @@ if __name__ == '__main__':
     usage = '%(prog)s [options] [command]'
     parser = argparse.ArgumentParser(usage=usage)
     parser.add_argument('-c', '--config',
-                         help='config file to use [default: ~/.spacecmd/config]')
+                         help=_('config file to use [default: ~/.spacecmd/config]'))
     parser.add_argument('-u', '--username',
-                        help='use this username to connect to the server')
+                        help=_('use this username to connect to the server'))
     parser.add_argument('-p', '--password',
-                        help='use this password to connect to the server (insecure). Use config instead or spacecmd will ask.')
+                        help=_('use this password to connect to the server (insecure). Use config instead or spacecmd will ask.'))
     parser.add_argument('-s', '--server',
-                        help='connect to this server [default: local hostname]')
+                        help=_('connect to this server [default: local hostname]'))
     parser.add_argument('--nossl', action='store_true',
-                        help='use HTTP instead of HTTPS')
+                        help=_('use HTTP instead of HTTPS'))
     parser.add_argument('--nohistory', action='store_true',
-                        help='do not store command history')
+                        help=_('do not store command history'))
     parser.add_argument('-y', '--yes', action='store_true',
-                        help='answer yes for all questions')
+                        help=_('answer yes for all questions'))
     parser.add_argument('-q', '--quiet', action='store_true',
-                        help='print only error messages')
+                        help=_('print only error messages'))
     parser.add_argument('-d', '--debug', action='count', default=0,
-                        help='print debug messages (can be passed multiple times)')
+                        help=_('print debug messages (can be passed multiple times)'))
     parser.add_argument('command', nargs='*',
                         help=argparse.SUPPRESS)
 
@@ -146,7 +153,7 @@ if __name__ == '__main__':
     # don't automatically create config files passed via --config
     if shell.options.config:
         if not os.path.isfile(shell.options.config):
-            logging.error('Config file %s does not exist.', shell.options.config)
+            logging.error(_('Config file %s does not exist.'), shell.options.config)
             sys.exit(1)
     else:
     # create an empty configuration file if one's not present
@@ -163,7 +170,7 @@ if __name__ == '__main__':
                 handle.write('[spacecmd]\n')
                 handle.close()
             except IOError:
-                logging.error('Could not create %s', user_conf_file)
+                logging.error(_('Could not create %s'), user_conf_file)
 
     # load options from configuration files
     if shell.options.config:
@@ -198,7 +205,7 @@ if __name__ == '__main__':
                 sys.exit(result)
         except KeyboardInterrupt:
             print
-            print('User Interrupt')
+            print(_('User Interrupt'))
         except UnknownCallException:
             sys.exit(1)
         except Exception as detail:
@@ -236,7 +243,7 @@ if __name__ == '__main__':
                     detail = detail.faultString
 
                     # the session expired
-                    if re.search('Could not find session', detail, re.I):
+                    if re.search(_('Could not find session'), detail, re.I):
                         shell.session = ''
 
                 if shell.options.debug:

--- a/spacecmd/src/spacecmd/activationkey.py
+++ b/spacecmd/src/spacecmd/activationkey.py
@@ -32,16 +32,22 @@
 
 import re
 import shlex
+import gettext
 try:
     from xmlrpc import client as xmlrpclib
 except ImportError:
     import xmlrpclib
 from spacecmd.utils import *
 
+translation = gettext.translation('spacecmd', fallback=True)
+try:
+    _ = translation.ugettext
+except AttributeError:
+    _ = translation.gettext
 
 def help_activationkey_addpackages(self):
-    print('activationkey_addpackages: Add packages to an activation key')
-    print('usage: activationkey_addpackages KEY <PACKAGE ...>')
+    print(_('activationkey_addpackages: Add packages to an activation key'))
+    print(_('usage: activationkey_addpackages KEY <PACKAGE ...>'))
 
 
 def complete_activationkey_addpackages(self, text, line, beg, end):
@@ -74,9 +80,9 @@ def do_activationkey_addpackages(self, args):
 
 
 def help_activationkey_removepackages(self):
-    print('activationkey_removepackages: Remove packages from an ' +
-          'activation key')
-    print('usage: activationkey_removepackages KEY <PACKAGE ...>')
+    print(_('activationkey_removepackages: Remove packages from an ' +
+          'activation key'))
+    print(_('usage: activationkey_removepackages KEY <PACKAGE ...>'))
 
 
 def complete_activationkey_removepackages(self, text, line, beg, end):
@@ -112,8 +118,8 @@ def do_activationkey_removepackages(self, args):
 
 
 def help_activationkey_addgroups(self):
-    print('activationkey_addgroups: Add groups to an activation key')
-    print('usage: activationkey_addgroups KEY <GROUP ...>')
+    print(_('activationkey_addgroups: Add groups to an activation key'))
+    print(_('usage: activationkey_addgroups KEY <GROUP ...>'))
 
 
 def complete_activationkey_addgroups(self, text, line, beg, end):
@@ -151,8 +157,8 @@ def do_activationkey_addgroups(self, args):
 
 
 def help_activationkey_removegroups(self):
-    print('activationkey_removegroups: Remove groups from an activation key')
-    print('usage: activationkey_removegroups KEY <GROUP ...>')
+    print(_('activationkey_removegroups: Remove groups from an activation key'))
+    print(_('usage: activationkey_removegroups KEY <GROUP ...>'))
 
 
 def complete_activationkey_removegroups(self, text, line, beg, end):
@@ -199,9 +205,9 @@ def do_activationkey_removegroups(self, args):
 
 
 def help_activationkey_addentitlements(self):
-    print('activationkey_addentitlements: Add entitlements to an ' +
-          'activation key')
-    print('usage: activationkey_addentitlements KEY <ENTITLEMENT ...>')
+    print(_('activationkey_addentitlements: Add entitlements to an ' +
+          'activation key'))
+    print(_('usage: activationkey_addentitlements KEY <ENTITLEMENT ...>'))
 
 
 def complete_activationkey_addentitlements(self, text, line, beg, end):
@@ -236,9 +242,9 @@ def do_activationkey_addentitlements(self, args):
 
 
 def help_activationkey_removeentitlements(self):
-    print('activationkey_removeentitlements: Remove entitlements from an ' +
-          'activation key')
-    print('usage: activationkey_removeentitlements KEY <ENTITLEMENT ...>')
+    print(_('activationkey_removeentitlements: Remove entitlements from an ' +
+          'activation key'))
+    print(_('usage: activationkey_removeentitlements KEY <ENTITLEMENT ...>'))
 
 
 def complete_activationkey_removeentitlements(self, text, line, beg, end):
@@ -276,9 +282,9 @@ def do_activationkey_removeentitlements(self, args):
 
 
 def help_activationkey_addchildchannels(self):
-    print('activationkey_addchildchannels: Add child channels to an ' +
-          'activation key')
-    print('usage: activationkey_addchildchannels KEY <CHANNEL ...>')
+    print(_('activationkey_addchildchannels: Add child channels to an ' +
+          'activation key'))
+    print(_('usage: activationkey_addchildchannels KEY <CHANNEL ...>'))
 
 
 def complete_activationkey_addchildchannels(self, text, line, beg, end):
@@ -328,9 +334,9 @@ def do_activationkey_addchildchannels(self, args):
 
 
 def help_activationkey_removechildchannels(self):
-    print('activationkey_removechildchannels: Remove child channels from ' +
-          'an activation key')
-    print('usage: activationkey_removechildchannels KEY <CHANNEL ...>')
+    print(_('activationkey_removechildchannels: Remove child channels from ' +
+          'an activation key'))
+    print(_('usage: activationkey_removechildchannels KEY <CHANNEL ...>'))
 
 
 def complete_activationkey_removechildchannels(self, text, line, beg, end):
@@ -367,9 +373,9 @@ def do_activationkey_removechildchannels(self, args):
 
 
 def help_activationkey_listchildchannels(self):
-    print('activationkey_listchildchannels: List the child channels ' +
-          'for an activation key')
-    print('usage: activationkey_listchildchannels KEY')
+    print(_('activationkey_listchildchannels: List the child channels ' +
+          'for an activation key'))
+    print(_('usage: activationkey_listchildchannels KEY'))
 
 
 def complete_activationkey_listchildchannels(self, text, line, beg, end):
@@ -398,9 +404,9 @@ def do_activationkey_listchildchannels(self, args):
 
 
 def help_activationkey_listbasechannel(self):
-    print('activationkey_listbasechannel: List the base channels ' +
-          'for an activation key')
-    print('usage: activationkey_listbasechannel KEY')
+    print(_('activationkey_listbasechannel: List the base channels ' +
+          'for an activation key'))
+    print(_('usage: activationkey_listbasechannel KEY'))
 
 
 def complete_activationkey_listbasechannel(self, text, line, beg, end):
@@ -428,9 +434,9 @@ def do_activationkey_listbasechannel(self, args):
 
 
 def help_activationkey_listgroups(self):
-    print('activationkey_listgroups: List the groups for an ' +
-          'activation key')
-    print('usage: activationkey_listgroups KEY')
+    print(_('activationkey_listgroups: List the groups for an ' +
+          'activation key'))
+    print(_('usage: activationkey_listgroups KEY'))
 
 
 def complete_activationkey_listgroups(self, text, line, beg, end):
@@ -461,9 +467,9 @@ def do_activationkey_listgroups(self, args):
 
 
 def help_activationkey_listentitlements(self):
-    print('activationkey_listentitlements: List the entitlements ' +
-          'for an activation key')
-    print('usage: activationkey_listentitlements KEY')
+    print(_('activationkey_listentitlements: List the entitlements ' +
+          'for an activation key'))
+    print(_('usage: activationkey_listentitlements KEY'))
 
 
 def complete_activationkey_listentitlements(self, text, line, beg, end):
@@ -492,9 +498,9 @@ def do_activationkey_listentitlements(self, args):
 
 
 def help_activationkey_listpackages(self):
-    print('activationkey_listpackages: List the packages for an ' +
-          'activation key')
-    print('usage: activationkey_listpackages KEY')
+    print(_('activationkey_listpackages: List the packages for an ' +
+          'activation key'))
+    print(_('usage: activationkey_listpackages KEY'))
 
 
 def complete_activationkey_listpackages(self, text, line, beg, end):
@@ -526,9 +532,9 @@ def do_activationkey_listpackages(self, args):
 
 
 def help_activationkey_listconfigchannels(self):
-    print('activationkey_listconfigchannels: List the configuration ' +
-          'channels for an activation key')
-    print('usage: activationkey_listconfigchannels KEY')
+    print(_('activationkey_listconfigchannels: List the configuration ' +
+          'channels for an activation key'))
+    print(_('usage: activationkey_listconfigchannels KEY'))
 
 
 def complete_activationkey_listconfigchannels(self, text, line, beg, end):
@@ -561,13 +567,13 @@ def do_activationkey_listconfigchannels(self, args):
 
 
 def help_activationkey_addconfigchannels(self):
-    print('activationkey_addconfigchannels: Add config channels ' +
-          'to an activation key')
-    print('''usage: activationkey_addconfigchannels KEY <CHANNEL ...> [options])
+    print(_('activationkey_addconfigchannels: Add config channels ' +
+          'to an activation key'))
+    print(_('''usage: activationkey_addconfigchannels KEY <CHANNEL ...> [options])
 
 options:
   -t add channels to the top of the list
-  -b add channels to the bottom of the list''')
+  -b add channels to the bottom of the list'''))
 
 
 def complete_activationkey_addconfigchannels(self, text, line, beg, end):
@@ -616,9 +622,9 @@ def do_activationkey_addconfigchannels(self, args):
 
 
 def help_activationkey_removeconfigchannels(self):
-    print('activationkey_removeconfigchannels: Remove config channels ' +
-          'from an activation key')
-    print('usage: activationkey_removeconfigchannels KEY <CHANNEL ...>')
+    print(_('activationkey_removeconfigchannels: Remove config channels ' +
+          'from an activation key'))
+    print(_('usage: activationkey_removeconfigchannels KEY <CHANNEL ...>'))
 
 
 def complete_activationkey_removeconfigchannels(self, text, line, beg, end):
@@ -657,9 +663,9 @@ def do_activationkey_removeconfigchannels(self, args):
 
 
 def help_activationkey_setconfigchannelorder(self):
-    print('activationkey_setconfigchannelorder: Set the ranked order of ' +
-          'configuration channels')
-    print('usage: activationkey_setconfigchannelorder KEY')
+    print(_('activationkey_setconfigchannelorder: Set the ranked order of ' +
+          'configuration channels'))
+    print(_('usage: activationkey_setconfigchannelorder KEY'))
 
 
 def complete_activationkey_setconfigchannelorder(self, text, line, beg,
@@ -689,7 +695,7 @@ def do_activationkey_setconfigchannelorder(self, args):
     new_channels = config_channel_order(all_channels, new_channels)
 
     print('')
-    print('New Configuration Channels:')
+    print(_('New Configuration Channels:'))
     for i, new_channel in enumerate(new_channels, 1):
         print('[%i] %s' % (i, new_channel))
 
@@ -703,15 +709,15 @@ def do_activationkey_setconfigchannelorder(self, args):
 
 
 def help_activationkey_create(self):
-    print('activationkey_create: Create an activation key')
-    print('''usage: activationkey_create [options])
+    print(_('activationkey_create: Create an activation key'))
+    print(_('''usage: activationkey_create [options])
 
 options:
   -n NAME
   -d DESCRIPTION
   -b BASE_CHANNEL
   -u set key as universal default
-  -e [enterprise_entitled,virtualization_host]''')
+  -e [enterprise_entitled,virtualization_host]'''))
 
 
 def do_activationkey_create(self, args):
@@ -725,16 +731,16 @@ def do_activationkey_create(self, args):
     (args, options) = parse_command_arguments(args, arg_parser)
 
     if is_interactive(options):
-        options.name = prompt_user('Name (blank to autogenerate):')
-        options.description = prompt_user('Description [None]:')
+        options.name = prompt_user(_('Name (blank to autogenerate):'))
+        options.description = prompt_user(_('Description [None]:'))
 
         print('')
-        print('Base Channels')
+        print(_('Base Channels'))
         print('-------------')
         print('\n'.join(sorted(self.list_base_channels())))
         print('')
 
-        options.base_channel = prompt_user('Base Channel (blank for default):')
+        options.base_channel = prompt_user(_('Base Channel (blank for default):'))
 
         options.entitlements = []
 
@@ -742,11 +748,11 @@ def do_activationkey_create(self, args):
             if e == 'enterprise_entitled':
                 continue
 
-            if self.user_confirm('%s Entitlement [y/N]:' % e,
+            if self.user_confirm(_('%s Entitlement [y/N]:') % e,
                                  ignore_yes=True):
                 options.entitlements.append(e)
 
-        options.universal = self.user_confirm('Universal Default [y/N]:',
+        options.universal = self.user_confirm(_('Universal Default [y/N]:'),
                                               ignore_yes=True)
     else:
         if not options.name:
@@ -773,7 +779,7 @@ def do_activationkey_create(self, args):
                                                options.entitlements,
                                                options.universal)
 
-    logging.info('Created activation key %s' % new_key)
+    logging.info(_('Created activation key %s') % new_key)
 
     return 0
 
@@ -781,8 +787,8 @@ def do_activationkey_create(self, args):
 
 
 def help_activationkey_delete(self):
-    print('activationkey_delete: Delete an activation key')
-    print('usage: activationkey_delete KEY')
+    print(_('activationkey_delete: Delete an activation key'))
+    print(_('usage: activationkey_delete KEY'))
 
 
 def complete_activationkey_delete(self, text, line, beg, end):
@@ -804,13 +810,13 @@ def do_activationkey_delete(self, args):
                   (args, keys))
 
     if not keys:
-        logging.error("No keys matched argument %s" % args)
+        logging.error(_("No keys matched argument %s") % args)
         return 1
 
     # Print the keys prior to the confimation
     print('\n'.join(sorted(keys)))
 
-    if not self.user_confirm('Delete activation key(s) [y/N]:'):
+    if not self.user_confirm(_('Delete activation key(s) [y/N]:')):
         return 1
 
     for key in keys:
@@ -823,8 +829,8 @@ def do_activationkey_delete(self, args):
 
 
 def help_activationkey_list(self):
-    print('activationkey_list: List all activation keys')
-    print('usage: activationkey_list')
+    print(_('activationkey_list: List all activation keys'))
+    print(_('usage: activationkey_list'))
 
 
 def do_activationkey_list(self, args, doreturn=False):
@@ -848,8 +854,8 @@ def do_activationkey_list(self, args, doreturn=False):
 
 
 def help_activationkey_listsystems(self):
-    print('activationkey_listsystems: List systems registered with a key')
-    print('usage: activationkey_listsystems KEY')
+    print(_('activationkey_listsystems: List systems registered with a key'))
+    print(_('usage: activationkey_listsystems KEY'))
 
 
 def complete_activationkey_listsystems(self, text, line, beg, end):
@@ -872,7 +878,7 @@ def do_activationkey_listsystems(self, args):
             self.client.activationkey.listActivatedSystems(self.session,
                                                            key)
     except xmlrpclib.Fault:
-        logging.warning('%s is not a valid activation key' % key)
+        logging.warning(_('%s is not a valid activation key') % key)
         return 1
 
     systems = sorted([s.get('hostname') for s in systems])
@@ -886,8 +892,8 @@ def do_activationkey_listsystems(self, args):
 
 
 def help_activationkey_details(self):
-    print('activationkey_details: Show the details of an activation key')
-    print('usage: activationkey_details KEY ...')
+    print(_('activationkey_details: Show the details of an activation key'))
+    print(_('usage: activationkey_details KEY ...'))
 
 
 def complete_activationkey_details(self, text, line, beg, end):
@@ -921,7 +927,7 @@ def do_activationkey_details(self, args):
             # API returns 0/1 instead of boolean
             config_channel_deploy = config_channel_deploy == 1
         except xmlrpclib.Fault:
-            logging.warning('%s is not a valid activation key' % key)
+            logging.warning(_('%s is not a valid activation key') % key)
             return
 
         groups = []
@@ -934,16 +940,16 @@ def do_activationkey_details(self, args):
             print(self.SEPARATOR)
         add_separator = True
 
-        result.append('Key:                    %s' % details.get('key'))
-        result.append('Description:            %s' % details.get('description'))
-        result.append('Universal Default:      %s' % details.get('universal_default'))
-        result.append('Usage Limit:            %s' % details.get('usage_limit'))
-        result.append('Deploy Config Channels: %s' % config_channel_deploy)
+        result.append(_('Key:                    %s') % details.get('key'))
+        result.append(_('Description:            %s') % details.get('description'))
+        result.append(_('Universal Default:      %s') % details.get('universal_default'))
+        result.append(_('Usage Limit:            %s') % details.get('usage_limit'))
+        result.append(_('Deploy Config Channels: %s') % config_channel_deploy)
         if 'contact_method' in details:
-            result.append('Contact Method:         %s' % details.get('contact_method'))
+            result.append(_('Contact Method:         %s') % details.get('contact_method'))
 
         result.append('')
-        result.append('Software Channels')
+        result.append(_('Software Channels'))
         result.append('-----------------')
         result.append(details.get('base_channel_label'))
 
@@ -951,23 +957,23 @@ def do_activationkey_details(self, args):
             result.append(' |-- %s' % channel)
 
         result.append('')
-        result.append('Configuration Channels')
+        result.append(_('Configuration Channels'))
         result.append('----------------------')
         for channel in config_channels:
             result.append(channel.get('label'))
 
         result.append('')
-        result.append('Entitlements')
+        result.append(_('Entitlements'))
         result.append('------------')
         result.append('\n'.join(sorted(details.get('entitlements'))))
 
         result.append('')
-        result.append('System Groups')
+        result.append(_('System Groups'))
         result.append('-------------')
         result.append('\n'.join(sorted(groups)))
 
         result.append('')
-        result.append('Packages')
+        result.append(_('Packages'))
         result.append('--------')
         for package in sorted(details.get('packages'), key=lambda x: (x['name']), reverse=False):
             name = package.get('name')
@@ -982,9 +988,9 @@ def do_activationkey_details(self, args):
 
 
 def help_activationkey_enableconfigdeployment(self):
-    print('activationkey_enableconfigdeployment: Enable config ' +
-          'channel deployment')
-    print('usage: activationkey_enableconfigdeployment KEY')
+    print(_('activationkey_enableconfigdeployment: Enable config ' +
+          'channel deployment'))
+    print(_('usage: activationkey_enableconfigdeployment KEY'))
 
 
 def complete_activationkey_enableconfigdeployment(self, text, line, beg,
@@ -1011,9 +1017,9 @@ def do_activationkey_enableconfigdeployment(self, args):
 
 
 def help_activationkey_disableconfigdeployment(self):
-    print('activationkey_disableconfigdeployment: Disable config ' +
-          'channel deployment')
-    print('usage: activationkey_disableconfigdeployment KEY')
+    print(_('activationkey_disableconfigdeployment: Disable config ' +
+          'channel deployment'))
+    print(_('usage: activationkey_disableconfigdeployment KEY'))
 
 
 def complete_activationkey_disableconfigdeployment(self, text, line, beg,
@@ -1040,9 +1046,9 @@ def do_activationkey_disableconfigdeployment(self, args):
 
 
 def help_activationkey_setbasechannel(self):
-    print('activationkey_setbasechannel: Set the base channel of an ' +
-          'activation key')
-    print('usage: activationkey_setbasechannel KEY CHANNEL')
+    print(_('activationkey_setbasechannel: Set the base channel of an ' +
+          'activation key'))
+    print(_('usage: activationkey_setbasechannel KEY CHANNEL'))
 
 
 def complete_activationkey_setbasechannel(self, text, line, beg, end):
@@ -1089,10 +1095,10 @@ def do_activationkey_setbasechannel(self, args):
 
 
 def help_activationkey_setusagelimit(self):
-    print('activationkey_setusagelimit: Set the usage limit of an ' +
-          'activation key, can be a number or \"unlimited\"')
-    print('usage: activationkey_setusagelimit KEY <usage limit>')
-    print('usage: activationkey_setusagelimit KEY unlimited ')
+    print(_('activationkey_setusagelimit: Set the usage limit of an ' +
+          'activation key, can be a number or \"unlimited\"'))
+    print(_('usage: activationkey_setusagelimit KEY <usage limit>'))
+    print(_('usage: activationkey_setusagelimit KEY unlimited '))
 
 
 def complete_activationkey_setusagelimit(self, text, line, beg, end):
@@ -1122,7 +1128,7 @@ def do_activationkey_setusagelimit(self, args):
             usage_limit = int(args[0])
             logging.debug("Setting usage for key %s to %d" % (key, usage_limit))
         except ValueError:
-            logging.error("Couldn't convert argument %s to an integer" %
+            logging.error(_("Couldn't convert argument %s to an integer") %
                           args[0])
             self.help_activationkey_setusagelimit()
             return 1
@@ -1144,9 +1150,9 @@ def do_activationkey_setusagelimit(self, args):
 
 
 def help_activationkey_setuniversaldefault(self):
-    print('activationkey_setuniversaldefault: Set this key as the ' +
-          'universal default')
-    print('usage: activationkey_setuniversaldefault KEY')
+    print(_('activationkey_setuniversaldefault: Set this key as the ' +
+          'universal default'))
+    print(_('usage: activationkey_setuniversaldefault KEY'))
 
 
 def complete_activationkey_setuniversaldefault(self, text, line, beg, end):
@@ -1187,15 +1193,15 @@ def do_activationkey_setuniversaldefault(self, args):
 
 
 def help_activationkey_export(self):
-    print('activationkey_export: Export activation key(s) to JSON format file')
-    print('''usage: activationkey_export [options] [<KEY> ...])
+    print(_('activationkey_export: Export activation key(s) to JSON format file'))
+    print(_('''usage: activationkey_export [options] [<KEY> ...])
 
 options:
     -f outfile.json : specify an output filename, defaults to <KEY>.json
                       if exporting a single key, akeys.json for multiple keys,
                       or akey_all.json if no KEY specified (export ALL)
 
-Note : KEY list is optional, default is to export ALL keys ''')
+Note : KEY list is optional, default is to export ALL keys '''))
 
 
 def complete_activationkey_export(self, text, line, beg, end):
@@ -1204,7 +1210,7 @@ def complete_activationkey_export(self, text, line, beg, end):
 
 def export_activationkey_getdetails(self, key):
     # Get the key details
-    logging.info("Getting activation key details for %s" % key)
+    logging.info(_("Getting activation key details for %s" % key))
     details = self.client.activationkey.getDetails(self.session, key)
 
     # Get the key config-channel data, add it to the existing details
@@ -1258,7 +1264,7 @@ def do_activationkey_export(self, args):
     if not args:
         if not filename:
             filename = "akey_all.json"
-        logging.info("Exporting ALL activation keys to %s" % filename)
+        logging.info(_("Exporting ALL activation keys to %s") % filename)
         keys = self.do_activationkey_list('', True)
     else:
         # allow globbing of activationkey names
@@ -1267,7 +1273,7 @@ def do_activationkey_export(self, args):
                       (args, keys))
 
         if not keys:
-            logging.error("Invalid activation key passed")
+            logging.error(_("Invalid activation key passed"))
             return 1
 
         if not filename:
@@ -1282,7 +1288,7 @@ def do_activationkey_export(self, args):
     # Dump as a list of dict
     keydetails_list = []
     for k in keys:
-        logging.info("Exporting key %s to %s" % (k, filename))
+        logging.info(_("Exporting key %s to %s") % (k, filename))
         keydetails_list.append(self.export_activationkey_getdetails(k))
 
     logging.debug("About to dump %d keys to %s" %
@@ -1291,12 +1297,12 @@ def do_activationkey_export(self, args):
     # Check if filepath exists, if it is an existing file
     # we prompt the user for confirmation
     if os.path.isfile(filename):
-        if not self.user_confirm("File %s exists, confirm overwrite file? (y/n)" %
+        if not self.user_confirm(_("File %s exists, confirm overwrite file? (y/n)") %
                                  filename):
             return 1
 
     if json_dump_to_file(keydetails_list, filename) != True:
-        logging.error("Failed to save exported keys to file: {}".format(filename))
+        logging.error(_("Failed to save exported keys to file: {}").format(filename))
         return 1
 
     return 0
@@ -1305,8 +1311,8 @@ def do_activationkey_export(self, args):
 
 
 def help_activationkey_import(self):
-    print('activationkey_import: import activation key(s) from JSON file(s)')
-    print('''usage: activationkey_import <JSONFILE ...>''')
+    print(_('activationkey_import: import activation key(s) from JSON file(s)'))
+    print(_('''usage: activationkey_import <JSONFILE ...>'''))
 
 
 def do_activationkey_import(self, args):
@@ -1315,7 +1321,7 @@ def do_activationkey_import(self, args):
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
-        logging.error("No filename passed")
+        logging.error(_("No filename passed"))
         self.help_activationkey_import()
         return 1
 
@@ -1324,12 +1330,12 @@ def do_activationkey_import(self, args):
         keydetails_list = json_read_from_file(filename)
 
         if not keydetails_list:
-            logging.error("Could not read json data from %s" % filename)
+            logging.error(_("Could not read json data from %s") % filename)
             return 1
 
         for keydetails in keydetails_list:
             if self.import_activationkey_fromdetails(keydetails) != True:
-                logging.error("Failed to import key %s" %
+                logging.error(_("Failed to import key %s") %
                               keydetails['key'])
                 return 1
 
@@ -1343,7 +1349,7 @@ def import_activationkey_fromdetails(self, keydetails):
     existing_keys = self.do_activationkey_list('', True)
 
     if keydetails['key'] in existing_keys:
-        logging.warning("%s already exists! Skipping!" % keydetails['key'])
+        logging.warning(_("%s already exists! Skipping!") % keydetails['key'])
         return False
     else:
         # create the key, we need to drop the org prefix from the key name
@@ -1373,7 +1379,7 @@ def import_activationkey_fromdetails(self, keydetails):
                                                       keydetails['entitlements'],
                                                       keydetails['universal_default'])
         if not newkey:
-            logging.error("Failed to import key %s" %
+            logging.error(_("Failed to import key %s") %
                           keyname)
             return False
 
@@ -1398,7 +1404,7 @@ def import_activationkey_fromdetails(self, keydetails):
         for grp in keydetails['server_groups']:
             grpdetails = self.client.systemgroup.getDetails(self.session, grp)
             if grpdetails is None:
-                logging.info("System group %s doesn't exist, creating" % grp)
+                logging.info(_("System group %s doesn't exist, creating") % grp)
                 grpdetails = self.client.systemgroup.create(self.session, grp,
                                                             grp)
             gids.append(grpdetails.get('id'))
@@ -1419,8 +1425,8 @@ def import_activationkey_fromdetails(self, keydetails):
 
 
 def help_activationkey_clone(self):
-    print('activationkey_clone: Clone an activation key')
-    print('''usage examples:)
+    print(_('activationkey_clone: Clone an activation key'))
+    print(_('''usage examples:
                  activationkey_clone foo_key -c bar_key
                  activationkey_clone foo_key1 foo_key2 -c prefix
                  activationkey_clone foo_key -x "s/foo/bar"
@@ -1431,7 +1437,7 @@ options:
                    keys
   -x "s/foo/bar" : Optional regex replacement, replaces foo with bar in the
                    clone description, base-channel label, child-channel
-                   labels, config-channel names ''')
+                   labels, config-channel names '''))
 
 
 def complete_activationkey_clone(self, text, line, beg, end):
@@ -1448,31 +1454,31 @@ def do_activationkey_clone(self, args):
 
     if is_interactive(options):
         print('')
-        print('Activation Keys')
+        print(_('Activation Keys'))
         print('------------------')
         print('\n'.join(sorted(allkeys)))
         print('')
 
         if len(args) == 1:
-            print("Key to clone: %s" % args[0])
+            print(_("Key to clone: %s") % args[0])
         else:
             # Clear out any args as interactive doesn't handle multiple keys
             args = []
-            args.append(prompt_user('Original Key:', noblank=True))
+            args.append(prompt_user(_('Original Key:'), noblank=True))
 
-        options.clonename = prompt_user('Cloned Key:', noblank=True)
+        options.clonename = prompt_user(_('Cloned Key:'), noblank=True)
     else:
         if not options.clonename and not options.regex:
-            logging.error("Error - must specify either -c or -x options!")
+            logging.error(_("Error - must specify either -c or -x options!"))
             self.help_activationkey_clone()
             return 1
 
     if options.clonename in allkeys:
-        logging.error("Key %s already exists" % options.clonename)
+        logging.error(_("Key %s already exists") % options.clonename)
         return 1
 
     if not args:
-        logging.error("Error no activationkey to clone passed!")
+        logging.error(_("Error no activationkey to clone passed!"))
         self.help_activationkey_clone()
         return 1
 
@@ -1526,17 +1532,17 @@ def do_activationkey_clone(self, args):
 
                         new_child_channel_labels.append(newc)
                     else:
-                        logging.warning("Found child channel %s key %s, %s" %
+                        logging.warning(_("Found child channel %s key %s, %s") %
                                         (c, keydetails['key'], newc) +
-                                        " does not exist, skipping!")
+                                        _(" does not exist, skipping!"))
 
                 logging.debug("Processed all child channels, " +
                               "new_child_channel_labels=%s" % new_child_channel_labels)
 
                 keydetails['child_channel_labels'] = new_child_channel_labels
             else:
-                logging.error("Regex-replacement results in new " +
-                              "base-channel %s which does not exist!" % newbasech)
+                logging.error(_("Regex-replacement results in new " +
+                              "base-channel %s which does not exist!") % newbasech)
 
             # Finally, any config-channels
             new_config_channels = []
@@ -1551,9 +1557,9 @@ def do_activationkey_clone(self, args):
 
                     new_config_channels.append(newcc)
                 else:
-                    logging.warning("Found config channel %s for key %s, %s "
+                    logging.warning(_("Found config channel %s for key %s, %s ")
                                     % (cc, keydetails['key'], newcc) +
-                                    "does not exist, skipping!")
+                                    _("does not exist, skipping!"))
 
             logging.debug("Processed all config channels, " +
                           "new_config_channels = %s" % new_config_channels)
@@ -1575,7 +1581,7 @@ def do_activationkey_clone(self, args):
 
         # Finally : import the key from the modified keydetails dict
         if self.import_activationkey_fromdetails(keydetails) != True:
-            logging.error("Failed to clone %s to %s" %
+            logging.error(_("Failed to clone %s to %s") %
                           (ak, keydetails['key']))
             return 1
 
@@ -1593,10 +1599,10 @@ def is_activationkey(self, name):
 
 def check_activationkey(self, name):
     if not name:
-        logging.error("no activationkey label given")
+        logging.error(_("no activationkey label given"))
         return False
     if not self.is_activationkey(name):
-        logging.error("invalid activationkey label " + name)
+        logging.error(_("invalid activationkey label ") + name)
         return False
     return True
 
@@ -1613,9 +1619,9 @@ def dump_activationkey(self, name, replacedict=None, excludes=None):
 
 
 def help_activationkey_diff(self):
-    print('activationkey_diff: Diff activation keys')
+    print(_('activationkey_diff: Diff activation keys'))
     print('')
-    print('usage: activationkey_diff SOURCE_KEY TARGET_KEY')
+    print(_('usage: activationkey_diff SOURCE_KEY TARGET_KEY'))
 
 
 def complete_activationkey_diff(self, text, line, beg, end):
@@ -1664,9 +1670,9 @@ def do_activationkey_diff(self, args):
 
 
 def help_activationkey_disable(self):
-    print('activationkey_disable: Disable an activation key')
+    print(_('activationkey_disable: Disable an activation key'))
     print('')
-    print('usage: activationkey_disable KEY [KEY ...]')
+    print(_('usage: activationkey_disable KEY [KEY ...]'))
 
 
 def complete_activationkey_disable(self, text, line, beg, end):
@@ -1698,9 +1704,9 @@ def do_activationkey_disable(self, args):
 
 
 def help_activationkey_enable(self):
-    print('activationkey_enable: Enable an activation key')
+    print(_('activationkey_enable: Enable an activation key'))
     print('')
-    print('usage: activationkey_enable KEY [KEY ...]')
+    print(_('usage: activationkey_enable KEY [KEY ...]'))
 
 
 def complete_activationkey_enable(self, text, line, beg, end):
@@ -1732,9 +1738,9 @@ def do_activationkey_enable(self, args):
 
 
 def help_activationkey_setdescription(self):
-    print('activationkey_setdescription: Set the activation key description')
+    print(_('activationkey_setdescription: Set the activation key description'))
     print('')
-    print('usage: activationkey_setdescription KEY DESCRIPTION')
+    print(_('usage: activationkey_setdescription KEY DESCRIPTION'))
 
 
 def complete_activationkey_setdescription(self, text, line, beg, end):
@@ -1766,10 +1772,10 @@ def do_activationkey_setdescription(self, args):
 
 
 def help_activationkey_setcontactmethod(self):
-    print('activationkey_setcontactmethod: Set the contact method to use for ' \
-          'systems registered with this key.')
-    print('Available contact methods: ' + str(self.CONTACT_METHODS))
-    print('usage: activationkey_setcontactmethod KEY CONTACT_METHOD')
+    print(_('activationkey_setcontactmethod: Set the contact method to use for ' \
+          'systems registered with this key.'))
+    print(_('Available contact methods: ') + str(self.CONTACT_METHODS))
+    print(_('usage: activationkey_setcontactmethod KEY CONTACT_METHOD'))
 
 
 def complete_activationkey_setcontactmethod(self, text, line, beg, end):

--- a/spacecmd/src/spacecmd/api.py
+++ b/spacecmd/src/spacecmd/api.py
@@ -27,16 +27,22 @@
 import codecs
 import logging
 import sys
+import gettext
 try:
     from xmlrpc import client as xmlrpclib
 except ImportError:
     import xmlrpclib
 from spacecmd.utils import *
 
+translation = gettext.translation('spacecmd', fallback=True)
+try:
+    _ = translation.ugettext
+except AttributeError:
+    _ = translation.gettext
 
 def help_api(self):
-    print('api: call RHN API with arguements directly')
-    print('''usage: api [options] API_STRING)
+    print(_('api: call RHN API with arguments directly'))
+    print(_('''usage: api [options] API_STRING)
 
 options:
   -A, --args  Arguments for the API other than session id in comma separated
@@ -49,7 +55,7 @@ examples:
   api --args "sysgroup_A" systemgroup.listSystems
   api -A "rhel-i386-server-5,2011-04-01,2011-05-01" -F "%(name)s" \\
       channel.software.listAllPackages
-''')
+'''))
 
 
 def do_api(self, args):
@@ -72,8 +78,8 @@ def do_api(self, args):
         try:
             output = open(options.output, "w")
         except IOError:
-            logging.warning("Could not open to write: " + options.output)
-            logging.info("Fallback output to stdout")
+            logging.warning(_("Could not open to write: ") + options.output)
+            logging.info(_("Fallback output to stdout"))
 
             output = sys.stdout
     else:
@@ -82,7 +88,7 @@ def do_api(self, args):
     api = getattr(self.client, api_name, None)
 
     if not callable(api):
-        logging.warning("No such API: " + api_name)
+        logging.warning(_("No such API: ") + api_name)
         return
 
     try:

--- a/spacecmd/src/spacecmd/configchannel.py
+++ b/spacecmd/src/spacecmd/configchannel.py
@@ -33,16 +33,22 @@
 from datetime import datetime
 import base64
 import codecs
+import gettext
 try:
     from xmlrpc import client as xmlrpclib
 except ImportError:
     import xmlrpclib
 from spacecmd.utils import *
 
+translation = gettext.translation('spacecmd', fallback=True)
+try:
+    _ = translation.ugettext
+except AttributeError:
+    _ = translation.gettext
 
 def help_configchannel_list(self):
-    print('configchannel_list: List all configuration channels')
-    print('usage: configchannel_list')
+    print(_('configchannel_list: List all configuration channels'))
+    print(_('usage: configchannel_list'))
 
 
 def do_configchannel_list(self, args, doreturn=False):
@@ -59,9 +65,9 @@ def do_configchannel_list(self, args, doreturn=False):
 
 
 def help_configchannel_listsystems(self):
-    print('configchannel_listsystems: List the systems subscribed to a')
-    print('                           configuration channel')
-    print('usage: configchannel_listsystems CHANNEL')
+    print(_('configchannel_listsystems: List the systems subscribed to a'))
+    print(_('                           configuration channel'))
+    print(_('usage: configchannel_listsystems CHANNEL'))
 
 
 def complete_configchannel_listsystems(self, text, line, beg, end):
@@ -70,7 +76,7 @@ def complete_configchannel_listsystems(self, text, line, beg, end):
 
 def do_configchannel_listsystems(self, args):
     if not self.check_api_version('10.11'):
-        logging.warning("This version of the API doesn't support this method")
+        logging.warning(_("This version of the API doesn't support this method"))
         return 1
 
     arg_parser = get_argument_parser()
@@ -94,8 +100,8 @@ def do_configchannel_listsystems(self, args):
 
 
 def help_configchannel_listfiles(self):
-    print('configchannel_listfiles: List the files in a config channel')
-    print('usage: configchannel_listfiles CHANNEL ...')
+    print(_('configchannel_listfiles: List the files in a config channel'))
+    print(_('usage: configchannel_listfiles CHANNEL ...'))
 
 
 def complete_configchannel_listfiles(self, text, line, beg, end):
@@ -124,10 +130,10 @@ def do_configchannel_listfiles(self, args, doreturn=False):
 
 
 def help_configchannel_forcedeploy(self):
-    print('configchannel_forcedeploy: Forces a redeployment')
-    print('                           of files within this channel')
-    print('                           on all subscribed systems')
-    print('usage: configchannel_forcedeploy CHANNEL')
+    print(_('configchannel_forcedeploy: Forces a redeployment'))
+    print(_('                           of files within this channel'))
+    print(_('                           on all subscribed systems'))
+    print(_('usage: configchannel_forcedeploy CHANNEL'))
 
 
 def complete_configchannel_forcedeploy(self, text, line, beg, end):
@@ -149,22 +155,22 @@ def do_configchannel_forcedeploy(self, args):
     files = [f['path'] for f in files if f.get("path")]
 
     if not files:
-        print('No files within selected configchannel.')
+        print(_('No files within selected configchannel.'))
         return 1
     else:
         systems = self.client.configchannel.listSubscribedSystems(self.session, channel)
         systems = sorted([s.get('name') for s in systems])
         if not systems:
-            print('Channel has no subscribed Systems')
+            print(_('Channel has no subscribed Systems'))
             return 1
         else:
-            print('Force deployment of the following configfiles:')
+            print(_('Force deployment of the following configfiles:'))
             print('==============================================')
             print('\n'.join(files))
-            print('\nOn these systems:')
+            print(_('\nOn these systems:'))
             print('=================')
             print('\n'.join(systems))
-    if self.user_confirm('Really force deployment [y/N]:'):
+    if self.user_confirm(_('Really force deployment [y/N]:')):
         self.client.configchannel.deployAllSystems(self.session, channel)
 
     return 0
@@ -173,9 +179,9 @@ def do_configchannel_forcedeploy(self, args):
 
 
 def help_configchannel_filedetails(self):
-    print('configchannel_filedetails: Show the details of a file')
-    print('in a configuration channel')
-    print('usage: configchannel_filedetails CHANNEL FILE [REVISION]')
+    print(_('configchannel_filedetails: Show the details of a file'))
+    print(_('in a configuration channel'))
+    print(_('usage: configchannel_filedetails CHANNEL FILE [REVISION]'))
 
 
 def complete_configchannel_filedetails(self, text, line, beg, end):
@@ -207,13 +213,13 @@ def do_configchannel_filedetails(self, args):
         try:
             revision = int(args[2])
         except (ValueError, IndexError):
-            logging.error("Invalid revision: %s", args[2])
+            logging.error(_("Invalid revision: %s"), args[2])
             return 1
 
     # the server return a null exception if an invalid file is passed
     valid_files = self.do_configchannel_listfiles(channel, True)
     if filename not in valid_files:
-        logging.warning('%s is not in this configuration channel' % filename)
+        logging.warning(_('%s is not in this configuration channel') % filename)
         return 1
 
     if revision:
@@ -231,30 +237,30 @@ def do_configchannel_filedetails(self, args):
 
     details = DictToDefault(details, default="N/A")
     result = []
-    result.append('Path:     %s' % details.get('path'))
-    result.append('Type:     %s' % details.get('type'))
-    result.append('Revision: %s' % details.get('revision'))
-    result.append('Created:  %s' % details.get('creation'))
-    result.append('Modified: %s' % details.get('modified'))
+    result.append(_('Path:     %s') % details.get('path'))
+    result.append(_('Type:     %s') % details.get('type'))
+    result.append(_('Revision: %s') % details.get('revision'))
+    result.append(_('Created:  %s') % details.get('creation'))
+    result.append(_('Modified: %s') % details.get('modified'))
 
     if details.get('type') == 'symlink':
         result.append('')
-        result.append('Target Path:     %s' % details.get('target_path'))
+        result.append(_('Target Path:     %s') % details.get('target_path'))
     else:
         result.append('')
-        result.append('Owner:           %s' % details.get('owner'))
-        result.append('Group:           %s' % details.get('group'))
-        result.append('Mode:            %s' % details.get('permissions_mode'))
+        result.append(_('Owner:           %s') % details.get('owner'))
+        result.append(_('Group:           %s') % details.get('group'))
+        result.append(_('Mode:            %s') % details.get('permissions_mode'))
 
-    result.append('SELinux Context: %s' % details.get('selinux_ctx'))
+    result.append(_('SELinux Context: %s') % details.get('selinux_ctx'))
 
     if details.get('type') == 'file':
-        result.append('SHA256:          %s' % details.get('sha256'))
-        result.append('Binary:          %s' % details.get('binary'))
+        result.append(_('SHA256:          %s') % details.get('sha256'))
+        result.append(_('Binary:          %s') % details.get('binary'))
 
         if not details.get('binary'):
             result.append('')
-            result.append('Contents')
+            result.append(_('Contents'))
             result.append('--------')
             result.append(details.get('contents'))
 
@@ -264,11 +270,11 @@ def do_configchannel_filedetails(self, args):
 
 
 def help_configchannel_backup(self):
-    print('configchannel_backup: backup a config channel')
-    print('''usage: configchannel_backup CHANNEL [OUTDIR])
+    print(_('configchannel_backup: backup a config channel'))
+    print(_('''usage: configchannel_backup CHANNEL [OUTDIR])
 
 OUTDIR defaults to $HOME/spacecmd-backup/configchannel/YYYY-MM-DD/CHANNEL
-''')
+'''))
 
 
 def complete_configchannel_backup(self, text, line, beg, end):
@@ -304,7 +310,7 @@ def do_configchannel_backup(self, args):
         if not os.path.isdir(outputpath_base):
             os.makedirs(outputpath_base)
     except OSError as exc:
-        logging.error('Could not create output directory: %s', str(exc))
+        logging.error(_('Could not create output directory: %s'), str(exc))
         return 1
 
     # the server return a null exception if an invalid file is passed
@@ -317,13 +323,13 @@ def do_configchannel_backup(self, args):
     try:
         fh = open(fh_path, 'w')
     except IOError as exc:
-        logging.error('Could not create "%s" file: %s', fh_path, str(exc))
+        logging.error(_('Could not create "%s" file: %s'), fh_path, str(exc))
         return 1
 
     for details in results:
         dumpfile = outputpath_base + details.get('path')
         dumpdir = dumpfile
-        print('Output Path:   %s' % dumpfile)
+        print(_('Output Path:   %s') % dumpfile)
         fh.write('[%s]\n' % details.get('path'))
         fh.write('type = %s\n' % details.get('type'))
         fh.write('revision = %s\n' % details.get('revision'))
@@ -362,8 +368,8 @@ def do_configchannel_backup(self, args):
 
 
 def help_configchannel_details(self):
-    print('configchannel_details: Show the details of a config channel')
-    print('usage: configchannel_details CHANNEL ...')
+    print(_('configchannel_details: Show the details of a config channel'))
+    print(_('usage: configchannel_details CHANNEL ...'))
 
 
 def complete_configchannel_details(self, text, line, beg, end):
@@ -393,13 +399,13 @@ def do_configchannel_details(self, args):
             result.append(self.SEPARATOR)
         add_separator = True
 
-        result.append('Label:       %s' % details.get('label'))
-        result.append('Name:        %s' % details.get('name'))
-        result.append('Description: %s' % details.get('description'))
-        result.append('Type:        %s' % details.get('configChannelType', {}).get('label'))
+        result.append(_('Label:       %s') % details.get('label'))
+        result.append(_('Name:        %s') % details.get('name'))
+        result.append(_('Description: %s') % details.get('description'))
+        result.append(_('Type:        %s') % details.get('configChannelType', {}).get('label'))
 
         result.append('')
-        result.append('Files')
+        result.append(_('Files'))
         result.append('-----')
         for f in files:
             result.append(f.get('path'))
@@ -409,14 +415,14 @@ def do_configchannel_details(self, args):
 
 
 def help_configchannel_create(self):
-    print('configchannel_create: Create a configuration channel of specific type')
-    print('''usage: configchannel_create [options])
+    print(_('configchannel_create: Create a configuration channel of specific type'))
+    print(_('''usage: configchannel_create [options])
 
 options:
   -n NAME
   -l LABEL
-  -d DESCRIPTION 
-  -t TYPE('normal,'state')''')
+  -d DESCRIPTION
+  -t TYPE('normal,'state')'''))
 
 
 def do_configchannel_create(self, args):
@@ -429,21 +435,21 @@ def do_configchannel_create(self, args):
     (args, options) = parse_command_arguments(args, arg_parser)
 
     if is_interactive(options):
-        options.name = prompt_user('Name:', noblank=True)
-        options.label = prompt_user('Label:')
-        options.description = prompt_user('Description:')
-        options.type = prompt_user('Type [normal, state]:')
+        options.name = prompt_user(_('Name:'), noblank=True)
+        options.label = prompt_user(_('Label:'))
+        options.description = prompt_user(_('Description:'))
+        options.type = prompt_user(_('Type [normal, state]:'))
 
         if options.label == '':
             options.label = options.name
         if options.description == '':
             options.description = options.name
         if options.type not in ('normal', 'state'):
-            logging.error('Only [normal/state] values are acceptable for type')
+            logging.error(_('Only [normal/state] values are acceptable for type'))
             return 1
     else:
         if not options.name:
-            logging.error('A name is required')
+            logging.error(_('A name is required'))
             return 1
         if not options.label:
             options.label = options.name
@@ -452,7 +458,7 @@ def do_configchannel_create(self, args):
         if not options.type:
             options.type = 'normal'
         if options.type not in ('normal', 'state'):
-            logging.error('Only [normal/state] values are acceptable for --type parameter')
+            logging.error(_('Only [normal/state] values are acceptable for --type parameter'))
             return 1
 
     self.client.configchannel.create(self.session,
@@ -467,8 +473,8 @@ def do_configchannel_create(self, args):
 
 
 def help_configchannel_delete(self):
-    print('configchannel_delete: Delete a configuration channel')
-    print('usage: configchannel_delete CHANNEL ...')
+    print(_('configchannel_delete: Delete a configuration channel'))
+    print(_('usage: configchannel_delete CHANNEL ...'))
 
 
 def complete_configchannel_delete(self, text, line, beg, end):
@@ -489,13 +495,13 @@ def do_configchannel_delete(self, args):
     logging.debug("configchannel_delete called with args %s, channels=%s" % (args, channels))
 
     if not channels:
-        logging.error("No channels matched argument(s): %s" % ", ".join(args))
+        logging.error(_("No channels matched argument(s): %s") % ", ".join(args))
         return 1
 
     # Print the channels prior to the confirmation
     print('\n'.join(sorted(channels)))
 
-    if self.user_confirm('Delete these channels [y/N]:'):
+    if self.user_confirm(_('Delete these channels [y/N]:')):
         self.client.configchannel.deleteChannels(self.session, channels)
 
     return 0
@@ -539,12 +545,12 @@ def configfile_getinfo(self, args, options, file_info=None, interactive=False):
 
         # if this is a new file, ask if it's a symlink
         if not options.symlink:
-            userinput = prompt_user('Symlink [y/N]:')
+            userinput = prompt_user(_('Symlink [y/N]:'))
             options.symlink = re.match('y', userinput, re.I)
 
         if options.symlink:
-            target_input = prompt_user('Target Path:', noblank=True)
-            selinux_input = prompt_user('SELinux Context [none]:')
+            target_input = prompt_user(_('Target Path:'), noblank=True)
+            selinux_input = prompt_user(_('SELinux Context [none]:'))
 
             if target_input:
                 options.target_path = target_input
@@ -552,7 +558,7 @@ def configfile_getinfo(self, args, options, file_info=None, interactive=False):
             if selinux_input:
                 options.selinux_ctx = selinux_input
         else:
-            userinput = prompt_user('Directory [y/N]:')
+            userinput = prompt_user(_('Directory [y/N]:'))
             options.directory = re.match('y', userinput, re.I)
 
             if not options.mode:
@@ -561,12 +567,12 @@ def configfile_getinfo(self, args, options, file_info=None, interactive=False):
                 else:
                     options.mode = '0644'
 
-            owner_input = prompt_user('Owner [%s]:' % options.owner)
-            group_input = prompt_user('Group [%s]:' % options.group)
-            mode_input = prompt_user('Mode [%s]:' % options.mode)
+            owner_input = prompt_user(_('Owner [%s]:') % options.owner)
+            group_input = prompt_user(_('Group [%s]:') % options.group)
+            mode_input = prompt_user(_('Mode [%s]:') % options.mode)
             selinux_input = \
-                prompt_user('SELinux Context [%s]:' % options.selinux_ctx)
-            revision_input = prompt_user('Revision [next]:')
+                prompt_user(_('SELinux Context [%s]:') % options.selinux_ctx)
+            revision_input = prompt_user(_('Revision [next]:'))
 
             if owner_input:
                 options.owner = owner_input
@@ -584,12 +590,12 @@ def configfile_getinfo(self, args, options, file_info=None, interactive=False):
                 try:
                     options.revision = int(revision_input)
                 except ValueError:
-                    logging.warning('The revision must be an integer')
+                    logging.warning(_('The revision must be an integer'))
 
             if not options.directory:
-                if self.user_confirm('Read an existing file [y/N]:',
+                if self.user_confirm(_('Read an existing file [y/N]:'),
                                      nospacer=True, ignore_yes=True):
-                    options.file = prompt_user('File:')
+                    options.file = prompt_user(_('File:'))
 
                     contents = read_file(options.file)
 
@@ -607,7 +613,7 @@ def configfile_getinfo(self, args, options, file_info=None, interactive=False):
                     (contents, _ignore) = editor(template=template, delete=True)
     else:
         if not options.path:
-            logging.error('The path is required')
+            logging.error(_('The path is required'))
             return
 
         if not options.symlink and not options.directory:
@@ -621,11 +627,11 @@ def configfile_getinfo(self, args, options, file_info=None, interactive=False):
                 elif options.binary:
                     logging.debug("Binary selected")
             else:
-                logging.error('You must provide the file contents')
+                logging.error(_('You must provide the file contents'))
                 return
 
         if options.symlink and not options.target_path:
-            logging.error('You must provide the target path for a symlink')
+            logging.error(_('You must provide the target path for a symlink'))
             return
 
     # selinux_ctx can't be None
@@ -640,9 +646,9 @@ def configfile_getinfo(self, args, options, file_info=None, interactive=False):
         file_info = {'target_path': options.target_path,
                      'selinux_ctx': options.selinux_ctx}
 
-        print('Path:            %s' % options.path)
-        print('Target Path:     %s' % file_info['target_path'])
-        print('SELinux Context: %s' % file_info['selinux_ctx'])
+        print(_('Path:            %s') % options.path)
+        print(_('Target Path:     %s') % file_info['target_path'])
+        print(_('SELinux Context: %s') % file_info['selinux_ctx'])
     else:
         if not options.owner:
             options.owner = 'root'
@@ -669,25 +675,25 @@ def configfile_getinfo(self, args, options, file_info=None, interactive=False):
         if options.binary:
             file_info['binary'] = True
 
-        print('Path:            %s' % options.path)
-        print('Directory:       %s' % options.directory)
-        print('Owner:           %s' % file_info['owner'])
-        print('Group:           %s' % file_info['group'])
-        print('Mode:            %s' % file_info['permissions'])
-        print('Binary:          %s' % file_info['binary'])
-        print('SELinux Context: %s' % file_info['selinux_ctx'])
+        print(_('Path:            %s') % options.path)
+        print(_('Directory:       %s') % options.directory)
+        print(_('Owner:           %s') % file_info['owner'])
+        print(_('Group:           %s') % file_info['group'])
+        print(_('Mode:            %s') % file_info['permissions'])
+        print(_('Binary:          %s') % file_info['binary'])
+        print(_('SELinux Context: %s') % file_info['selinux_ctx'])
 
         # only add the revision field if the user supplied it
         if options.revision:
             file_info['revision'] = int(options.revision)
-            print('Revision:        %i' % file_info['revision'])
+            print(_('Revision:        %i') % file_info['revision'])
 
         if not options.directory:
             print('')
             if options.binary:
-                print('Contents not displayed (base64 encoded)')
+                print(_('Contents not displayed (base64 encoded)'))
             else:
-                print('Contents')
+                print(_('Contents'))
                 print('--------')
                 if file_info['contents_enc64']:
                     print(base64.b64decode(file_info['contents']))
@@ -698,8 +704,8 @@ def configfile_getinfo(self, args, options, file_info=None, interactive=False):
 
 
 def help_configchannel_addfile(self):
-    print('configchannel_addfile/configchannel_updatefile: Create a configuration file')
-    print('''usage: configchannel_addfile/configchannel_updatefile -c CHANNEL - p PATH -f LOCAL_FILE_PATH [OPTIONS])
+    print(_('configchannel_addfile/configchannel_updatefile: Create a configuration file'))
+    print(_('''usage: configchannel_addfile/configchannel_updatefile -c CHANNEL - p PATH -f LOCAL_FILE_PATH [OPTIONS])
 
 options:
   -c CHANNEL
@@ -720,7 +726,7 @@ options:
   newlines, those containing ASCII escape characters (or other charaters not
   allowed in XML) need to be sent as binary (-b).  Some effort is made to auto-
   detect files which require this, but you may need to explicitly specify.
-''')
+'''))
 
 
 def complete_configchannel_addfile(self, text, line, beg, end):
@@ -756,12 +762,12 @@ def do_configchannel_addfile(self, args, update_path=''):
             failures = 0
             config_channels = sorted(self.do_configchannel_list('', True))
             while failures < 3:
-                print('Configuration Channels')
+                print(_('Configuration Channels'))
                 print('----------------------')
                 print('\n'.join(config_channels))
                 print('')
 
-                options.channel = prompt_user('Select:', noblank=True)
+                options.channel = prompt_user(_('Select:'), noblank=True)
 
                 # ensure the user enters a valid configuration channel
                 if options.channel in config_channels:
@@ -769,18 +775,18 @@ def do_configchannel_addfile(self, args, update_path=''):
                     break
                 else:
                     print('')
-                    logging.warning('%s is not a valid channel' %
+                    logging.warning(_('%s is not a valid channel') %
                                     options.channel)
                     print('')
                     failures += 1
             if failures > 0:
-                logging.error("Unable to obtain a valid channel. Aborting.")
+                logging.error(_("Unable to obtain a valid channel. Aborting."))
                 return 1
 
         if update_path:
             options.path = update_path
         else:
-            options.path = prompt_user('Path:', noblank=True)
+            options.path = prompt_user(_('Path:'), noblank=True)
 
         # check if this file already exists
         try:
@@ -796,12 +802,12 @@ def do_configchannel_addfile(self, args, update_path=''):
     file_info = self.configfile_getinfo(args, options, file_info, interactive)
 
     if not options.channel:
-        logging.error("No config channel specified!")
+        logging.error(_("No config channel specified!"))
         self.help_configchannel_addfile()
         return 1
 
     if not file_info:
-        logging.error("Error obtaining file info")
+        logging.error(_("Error obtaining file info"))
         self.help_configchannel_addfile()
         return 1
 
@@ -836,14 +842,14 @@ def do_configchannel_addfile(self, args, update_path=''):
 ####################
 
 def help_configchannel_updateinitsls(self):
-    print('configchannel_updateinitsls: Update init.sls file')
-    print('''usage: configchannel_updateinitsls -c CHANNEL -f LOCAL_FILE_PATH [OPTIONS])
+    print(_('configchannel_updateinitsls: Update init.sls file'))
+    print(_('''usage: configchannel_updateinitsls -c CHANNEL -f LOCAL_FILE_PATH [OPTIONS])
 
 options:
   -c CHANNEL
   -f local path to file contents
   -y automatically proceed with file contents
-''')
+'''))
 
 def do_configchannel_updateinitsls(self, args, update_path=''):
     arg_parser = get_argument_parser()
@@ -861,7 +867,7 @@ def do_configchannel_updateinitsls(self, args, update_path=''):
             options.channel = args[0]
         else:
             while True:
-                print('Configuration Channels')
+                print(_('Configuration Channels'))
                 print('----------------------')
                 print('\n'.join(sorted(self.do_configchannel_list('', True))))
                 print('')
@@ -883,11 +889,11 @@ def do_configchannel_updateinitsls(self, args, update_path=''):
                                                          options.channel,
                                                          [path])
         except xmlrpclib.Fault:
-            logging.error("No existing file information found for %s" %
+            logging.error(_("No existing file information found for %s") %
                           options.path)
             return 1
         contents = file_info[0].get('contents')
-        if self.user_confirm('Read an existing file [y/N]:',
+        if self.user_confirm(_('Read an existing file [y/N]:'),
                          nospacer=True, ignore_yes=True):
             options.file = prompt_user('File:')
             contents = read_file(options.file)
@@ -904,7 +910,7 @@ def do_configchannel_updateinitsls(self, args, update_path=''):
         if options.file:
             contents = read_file(options.file)
         else:
-            logging.error('You must provide the file contents')
+            logging.error(_('You must provide the file contents'))
             return 1
 
     contents = base64.b64encode(contents.encode('utf8')).decode()
@@ -915,16 +921,16 @@ def do_configchannel_updateinitsls(self, args, update_path=''):
 
 
     if not options.channel:
-        logging.error("No config channel specified!")
+        logging.error(_("No config channel specified!"))
         self.help_configchannel_updateinitsls()
         return 1
 
     if not file_info:
-        logging.error("Error obtaining file info")
+        logging.error(_("Error obtaining file info"))
         self.help_configchannel_updateinitsls()
         return 1
-    print('contents_enc64:           %s' % file_info['contents_enc64'])
-    print('Contents')
+    print(_('contents_enc64:           %s') % file_info['contents_enc64'])
+    print(_('Contents'))
     print('--------')
     print(base64.b64decode(file_info['contents']))
     if options.yes or self.user_confirm():
@@ -950,8 +956,8 @@ def do_configchannel_updatefile(self, args):
 
 
 def help_configchannel_removefiles(self):
-    print('configchannel_removefiles: Remove configuration files')
-    print('usage: configchannel_removefiles CHANNEL <FILE ...>')
+    print(_('configchannel_removefiles: Remove configuration files'))
+    print(_('usage: configchannel_removefiles CHANNEL <FILE ...>'))
 
 
 def complete_configchannel_removefiles(self, text, line, beg, end):
@@ -988,8 +994,8 @@ def do_configchannel_removefiles(self, args):
 
 
 def help_configchannel_verifyfile(self):
-    print('configchannel_verifyfile: Verify a configuration file')
-    print('usage: configchannel_verifyfile CHANNEL FILE <SYSTEMS>')
+    print(_('configchannel_verifyfile: Verify a configuration file'))
+    print(_('usage: configchannel_verifyfile CHANNEL FILE <SYSTEMS>'))
     print('')
     print(self.HELP_SYSTEM_OPTS)
 
@@ -1028,7 +1034,7 @@ def do_configchannel_verifyfile(self, args):
     system_ids = list(filter(None, (self.get_system_id(s) for s in systems)))
 
     if not system_ids:
-        logging.error('No valid system selected')
+        logging.error(_('No valid system selected'))
         return 1
     action_id = \
         self.client.configchannel.scheduleFileComparisons(self.session,
@@ -1036,7 +1042,7 @@ def do_configchannel_verifyfile(self, args):
                                                           path,
                                                           system_ids)
 
-    logging.info('Action ID: %i' % action_id)
+    logging.info(_('Action ID: %i') % action_id)
 
     return 0
 
@@ -1044,15 +1050,15 @@ def do_configchannel_verifyfile(self, args):
 
 
 def help_configchannel_export(self):
-    print('configchannel_export: export config channel(s) to json format file')
-    print('''usage: configchannel_export <CHANNEL>... [options])
+    print(_('configchannel_export: export config channel(s) to json format file'))
+    print(_('''usage: configchannel_export <CHANNEL>... [options])
 options:
     -f outfile.json : specify an output filename, defaults to <CHANNEL>.json
                       if exporting a single channel, ccs.json for multiple
                       channels, or cc_all.json if no CHANNEL specified
                       e.g (export ALL)
 
-Note : CHANNEL list is optional, default is to export ALL''')
+Note : CHANNEL list is optional, default is to export ALL'''))
 
 
 def complete_configchannel_export(self, text, line, beg, end):
@@ -1061,7 +1067,7 @@ def complete_configchannel_export(self, text, line, beg, end):
 
 def export_configchannel_getdetails(self, channel):
     # Get the cc details
-    logging.info("Getting config channel details for %s" % channel)
+    logging.info(_("Getting config channel details for %s") % channel)
     details = self.client.configchannel.getDetails(self.session, channel)
     files = self.client.configchannel.listFiles(self.session, channel)
     details['files'] = []
@@ -1081,7 +1087,7 @@ def export_configchannel_getdetails(self, channel):
             if pinfo:
                 fileinfo.append(pinfo[0])
         except xmlrpclib.Fault:
-            logging.error("Failed to get details for file %s from %s"
+            logging.error(_("Failed to get details for file %s from %s")
                           % (p, channel))
     # Now we strip the datetime fields from the Info structs, as they
     # are not JSON serializable with the default encoder, and we don't
@@ -1127,11 +1133,11 @@ def export_configchannel_getdetails(self, channel):
             if not 'contents' in f:
                 if f['type'] != 'directory':
                     if not self.check_api_version('11.1'):
-                        logging.warning("File %s could not be exported " % f['path'] +
-                                        "with this API version(needs base64 encoding)")
+                        logging.warning(_("File %s could not be exported ") % f['path'] +
+                                        _("with this API version(needs base64 encoding)"))
                     else:
-                        logging.info("File %s could not be exported as" % f['path'] +
-                                     " text...getting base64 encoded version")
+                        logging.info(_("File %s could not be exported as") % f['path'] +
+                                     _(" text...getting base64 encoded version"))
                         b64f = self.client.configchannel.getEncodedFileRevision(
                             self.session, channel, f['path'], f['revision'])
                         f['contents'] = b64f['contents']
@@ -1154,7 +1160,7 @@ def do_configchannel_export(self, args):
 
     filename = ""
     if options.file is not None:
-        logging.debug("Passed filename '%s' to do_configchannel_export command.", options.file)
+        logging.debug(_("Passed filename '%s' to do_configchannel_export command."), options.file)
         filename = options.file
 
     # Get the list of ccs to export and sort out the filename if required
@@ -1162,15 +1168,15 @@ def do_configchannel_export(self, args):
     if not args:
         if not filename:
             filename = "cc_all.json"
-        logging.info("Exporting ALL config channels to %s", filename)
+        logging.info(_("Exporting ALL config channels to %s"), filename)
         ccs = self.do_configchannel_list('', True)
     else:
         # allow globbing of configchannel names
         ccs = filter_results(self.do_configchannel_list('', True), args)
         logging.debug("configchannel_export called with args %s, ccs=%s", args, ccs)
         if not ccs:
-            logging.error("Error, no valid config channel passed, "
-                          "check name is  correct with spacecmd configchannel_list")
+            logging.error(_("Error, no valid config channel passed, "
+                          "check name is  correct with spacecmd configchannel_list"))
             return 1
         if not filename:
             # No filename arg, so we try to do something sensible:
@@ -1184,17 +1190,17 @@ def do_configchannel_export(self, args):
     # Dump as a list of dict
     ccdetails_list = []
     for c in ccs:
-        logging.info("Exporting cc %s to %s", c, filename)
+        logging.info(_("Exporting cc %s to %s"), c, filename)
         ccdetails_list.append(self.export_configchannel_getdetails(c))
 
     logging.debug("About to dump %d ccs to %s", len(ccdetails_list), filename)
     # Check if filepath exists, if it is an existing file
     # we prompt the user for confirmation
     if os.path.isfile(filename):
-        if not self.options.yes and not self.user_confirm("File '{}' exists, confirm overwrite file? (y/n)".format(filename)):
+        if not self.options.yes and not self.user_confirm(_("File '{}' exists, confirm overwrite file? (y/n)").format(filename)):
             return 1
     if not json_dump_to_file(ccdetails_list, filename):
-        logging.error("Error saving exported config channels to file: %s", filename)
+        logging.error(_("Error saving exported config channels to file: %s"), filename)
         return 1
 
     return 0
@@ -1203,8 +1209,8 @@ def do_configchannel_export(self, args):
 
 
 def help_configchannel_import(self):
-    print('configchannel_import: import config channel(s) from json file')
-    print('''usage: configchannel_import <JSONFILES...>''')
+    print(_('configchannel_import: import config channel(s) from json file'))
+    print(_('''usage: configchannel_import <JSONFILES...>'''))
 
 
 def do_configchannel_import(self, args):
@@ -1213,7 +1219,7 @@ def do_configchannel_import(self, args):
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
-        logging.error("Error, no filename passed")
+        logging.error(_("Error, no filename passed"))
         self.help_configchannel_import()
         return 1
 
@@ -1221,11 +1227,11 @@ def do_configchannel_import(self, args):
         logging.debug("Passed filename do_configchannel_import %s", filename)
         ccdetails_list = json_read_from_file(filename)
         if not ccdetails_list:
-            logging.error("Error, could not read json data from %s", filename)
+            logging.error(_("Error, could not read json data from %s"), filename)
             return 1
         for ccdetails in ccdetails_list:
             if not self.import_configchannel_fromdetails(ccdetails):
-                logging.error("Error importing configchannel %s", ccdetails['name'])
+                logging.error(_("Error importing configchannel %s"), ccdetails['name'])
 
     return 0
 
@@ -1237,12 +1243,12 @@ def import_configchannel_fromdetails(self, ccdetails):
     # First we check that an existing channel with the same name does not exist
     existing_ccs = self.do_configchannel_list('', True)
     if ccdetails['name'] in existing_ccs:
-        logging.warning("Config channel %s already exists! Skipping!" %
+        logging.warning(_("Config channel %s already exists! Skipping!") %
                         ccdetails['name'])
         return False
     else:
         # create the cc, we need to drop the org prefix from the cc name
-        logging.info("Importing config channel  %s" % ccdetails['name'])
+        logging.info(_("Importing config channel  %s") % ccdetails['name'])
 
         channeltype = 'normal'
         if 'configChannelType' in ccdetails:
@@ -1285,9 +1291,9 @@ def import_configchannel_fromdetails(self, ccdetails):
                     # import everything else
                     if not 'contents' in filedetails:
                         logging.error(
-                            "Failed trying to import file %s (empty content)"
+                            _("Failed trying to import file %s (empty content)")
                             % path)
-                        logging.error("Older APIs can't export encoded files")
+                        logging.error(_("Older APIs can't export encoded files"))
                         continue
 
                     if not filedetails['contents_enc64']:
@@ -1310,7 +1316,7 @@ def import_configchannel_fromdetails(self, ccdetails):
                 logging.debug("Added file %s to %s" %
                               (ret['path'], ccdetails['name']))
             else:
-                logging.error("Error adding file %s to %s" %
+                logging.error(_("Error adding file %s to %s") %
                               (filedetails['path'], ccdetails['label']))
                 continue
 
@@ -1320,8 +1326,8 @@ def import_configchannel_fromdetails(self, ccdetails):
 
 
 def help_configchannel_clone(self):
-    print('configchannel_clone: Clone config channel(s)')
-    print('''usage examples:)
+    print(_('configchannel_clone: Clone config channel(s)'))
+    print(_('''usage examples:
                  configchannel_clone foo_label -c bar_label
                  configchannel_clone foo_label1 foo_label2 -c prefix
                  configchannel_clone foo_label -x "s/foo/bar"
@@ -1333,7 +1339,7 @@ options:
                    multiple keys are passed
   -x "s/foo/bar" : Optional regex replacement, replaces foo with bar in the
                    clone name, label and description
-  Note : If no -c or -x option is specified, interactive is assumed''')
+  Note : If no -c or -x option is specified, interactive is assumed'''))
 
 
 def complete_configchannel_clone(self, text, line, beg, end):
@@ -1350,30 +1356,30 @@ def do_configchannel_clone(self, args):
 
     if is_interactive(options):
         if not allccs:
-            logging.error("No config channels found")
+            logging.error(_("No config channels found"))
             return 1
         print('')
-        print('Config Channels')
+        print(_('Config Channels'))
         print('------------------')
         print('\n'.join(allccs))
         print('')
 
         if len(args) == 1:
-            print("Channel to clone: %s" % args[0])
+            print(_("Channel to clone: %s") % args[0])
         else:
             # Clear out any args as interactive doesn't handle multiple ccs
             args = []
-            args.append(prompt_user('Channel to clone:', noblank=True))
-        options.clonelabel = prompt_user('Clone label:', noblank=True)
+            args.append(prompt_user(_('Channel to clone:'), noblank=True))
+        options.clonelabel = prompt_user(_('Clone label:'), noblank=True)
     else:
         if not options.clonelabel and not options.regex:
-            logging.error("Error - must specify either -c or -x options!")
+            logging.error(_("Error - must specify either -c or -x options!"))
             self.help_configchannel_clone()
         else:
             logging.debug("%s : %s", options.clonelabel, options.regex)
 
     if not args:
-        logging.error("Error no channel label passed!")
+        logging.error(_("Error no channel label passed!"))
         self.help_configchannel_clone()
         return 1
     logging.debug("Got args=%s %d", args, len(args))
@@ -1382,7 +1388,7 @@ def do_configchannel_clone(self, args):
     logging.debug("Filtered ccs %s", ccs)
 
     if not ccs:
-        logging.error("No suitable channels to clone has been found.")
+        logging.error(_("No suitable channels to clone has been found."))
 
     for cc in ccs:
         logging.debug("Cloning %s" % cc)
@@ -1419,7 +1425,7 @@ def do_configchannel_clone(self, args):
 
         # Finally : import the cc from the modified ccdetails
         if not self.import_configchannel_fromdetails(ccdetails):
-            logging.error("Failed to clone %s to %s", cc, ccdetails['label'])
+            logging.error(_("Failed to clone %s to %s"), cc, ccdetails['label'])
 
     return 0
 
@@ -1435,10 +1441,10 @@ def is_configchannel(self, name):
 
 def check_configchannel(self, name):
     if not name:
-        logging.error("no configchannel given")
+        logging.error(_("no configchannel given"))
         return False
     if not self.is_configchannel(name):
-        logging.error("invalid configchannel label " + name)
+        logging.error(_("invalid configchannel label ") + name)
         return False
     return True
 
@@ -1464,9 +1470,9 @@ def dump_configchannel(self, name, replacedict=None, excludes=None):
 
 
 def help_configchannel_diff(self):
-    print('configchannel_diff: diff between config channels')
+    print(_('configchannel_diff: diff between config channels'))
     print('')
-    print('usage: configchannel_diff SOURCE_CHANNEL TARGET_CHANNEL')
+    print(_('usage: configchannel_diff SOURCE_CHANNEL TARGET_CHANNEL'))
 
 
 def complete_configchannel_diff(self, text, line, beg, end):
@@ -1515,10 +1521,10 @@ def do_configchannel_diff(self, args):
 
 
 def help_configchannel_sync(self):
-    print('configchannel_sync:')
-    print('sync config files between two config channels')
+    print(_('configchannel_sync:'))
+    print(_('sync config files between two config channels'))
     print('')
-    print('usage: configchannel_sync SOURCE_CHANNEL TARGET_CHANNEL')
+    print(_('usage: configchannel_sync SOURCE_CHANNEL TARGET_CHANNEL'))
 
 
 def complete_configchannel_sync(self, text, line, beg, end):
@@ -1556,42 +1562,42 @@ def do_configchannel_sync(self, args, doreturn=False):
     if not self.check_configchannel(target_channel):
         return 1
 
-    logging.info("syncing files from configchannel " + source_channel + " to " + target_channel)
+    logging.info(_("syncing files from configchannel ") + source_channel + " to " + target_channel)
 
     source_files = set(self.do_configchannel_listfiles(source_channel, doreturn=True))
     target_files = set(self.do_configchannel_listfiles(target_channel, doreturn=True))
 
     both = source_files & target_files
     if both:
-        print("files common in both channels:")
+        print(_("files common in both channels:"))
         print("\n".join(both))
         print('')
 
     source_only = source_files.difference(target_files)
     if source_only:
-        print("files only in source " + source_channel)
+        print(_("files only in source ") + source_channel)
         print("\n".join(source_only))
         print('')
 
     target_only = target_files.difference(source_files)
     if target_only:
-        print("files only in target " + target_channel)
+        print(_("files only in target ") + target_channel)
         print("\n".join(target_only))
         print('')
 
     if both:
-        print("files that are in both channels will be overwritten in the target channel")
+        print(_("files that are in both channels will be overwritten in the target channel"))
     if source_only:
-        print("files only in the source channel will be added to the target channel")
+        print(_("files only in the source channel will be added to the target channel"))
     if target_only:
-        print("files only in the target channel will be deleted")
+        print(_("files only in the target channel will be deleted"))
 
     if not (both or source_only or target_only):
-        logging.info("nothing to do")
+        logging.info(_("nothing to do"))
         return 1
 
     if not self.options.yes:
-        if not self.user_confirm('perform synchronisation [y/N]:'):
+        if not self.user_confirm(_('perform synchronisation [y/N]:')):
             return 1
 
     source_data_list = self.client.configchannel.lookupFileInfo(
@@ -1643,7 +1649,7 @@ def do_configchannel_sync(self, args, doreturn=False):
                                                             target_data)
 
         else:
-            logging.warning("unknown file type " + source_data.type)
+            logging.warning(_("unknown file type ") + source_data.type)
 
     # removing all files from target channel that did not exist on source channel
     if target_only:

--- a/spacecmd/src/spacecmd/cryptokey.py
+++ b/spacecmd/src/spacecmd/cryptokey.py
@@ -26,21 +26,27 @@
 # unused argument
 # pylint: disable=W0613
 
+import gettext
 try:
     from xmlrpc import client as xmlrpclib
 except ImportError:
     import xmlrpclib
 from spacecmd.utils import *
 
+translation = gettext.translation('spacecmd', fallback=True)
+try:
+    _ = translation.ugettext
+except AttributeError:
+    _ = translation.gettext
 
 def help_cryptokey_create(self):
-    print('cryptokey_create: Create a cryptographic key')
-    print('''usage: cryptokey_create [options])
+    print(_('cryptokey_create: Create a cryptographic key'))
+    print(_('''usage: cryptokey_create [options])
 
 options:
   -t GPG or SSL
   -d DESCRIPTION
-  -f KEY_FILE''')
+  -f KEY_FILE'''))
 
 
 def do_cryptokey_create(self, args):
@@ -53,28 +59,28 @@ def do_cryptokey_create(self, args):
     options.contents = None
 
     if is_interactive(options):
-        options.type = prompt_user('GPG or SSL [G/S]:')
+        options.type = prompt_user(_('GPG or SSL [G/S]:'))
 
         options.description = ''
         while options.description == '':
-            options.description = prompt_user('Description:')
+            options.description = prompt_user(_('Description:'))
 
-        if self.user_confirm('Read an existing file [y/N]:',
+        if self.user_confirm(_('Read an existing file [y/N]:'),
                              nospacer=True, ignore_yes=True):
             options.file = prompt_user('File:')
         else:
             options.contents = editor(delete=True)
     else:
         if not options.type:
-            logging.error('The key type is required')
+            logging.error(_('The key type is required'))
             return 1
 
         if not options.description:
-            logging.error('A description is required')
+            logging.error(_('A description is required'))
             return 1
 
         if not options.file:
-            logging.error('A file containing the key is required')
+            logging.error(_('A file containing the key is required'))
             return 1
 
     # read the file the user specified
@@ -82,7 +88,7 @@ def do_cryptokey_create(self, args):
         options.contents = read_file(options.file)
 
     if not options.contents:
-        logging.error('No contents of the file')
+        logging.error(_('No contents of the file'))
         return 1
 
     # translate the key type to what the server expects
@@ -91,7 +97,7 @@ def do_cryptokey_create(self, args):
     elif re.match('S', options.type, re.I):
         options.type = 'SSL'
     else:
-        logging.error('Invalid key type')
+        logging.error(_('Invalid key type'))
         return 1
 
     self.client.kickstart.keys.create(self.session,
@@ -105,8 +111,8 @@ def do_cryptokey_create(self, args):
 
 
 def help_cryptokey_delete(self):
-    print('cryptokey_delete: Delete a cryptographic key')
-    print('usage: cryptokey_delete NAME')
+    print(_('cryptokey_delete: Delete a cryptographic key'))
+    print(_('usage: cryptokey_delete NAME'))
 
 
 def complete_cryptokey_delete(self, text, line, beg, end):
@@ -130,13 +136,13 @@ def do_cryptokey_delete(self, args):
                   (args, keys))
 
     if not keys:
-        logging.error("No keys matched argument %s" % args)
+        logging.error(_("No keys matched argument %s") % args)
         return 1
 
     # Print the keys prior to the confirmation
     print('\n'.join(sorted(keys)))
 
-    if self.user_confirm('Delete key(s) [y/N]:'):
+    if self.user_confirm(_('Delete key(s) [y/N]:')):
         for key in keys:
             self.client.kickstart.keys.delete(self.session, key)
         return 0
@@ -147,8 +153,8 @@ def do_cryptokey_delete(self, args):
 
 
 def help_cryptokey_list(self):
-    print('cryptokey_list: List all cryptographic keys (SSL, GPG)')
-    print('usage: cryptokey_list')
+    print(_('cryptokey_list: List all cryptographic keys (SSL, GPG)'))
+    print(_('usage: cryptokey_list'))
 
 
 def do_cryptokey_list(self, args, doreturn=False):
@@ -165,8 +171,8 @@ def do_cryptokey_list(self, args, doreturn=False):
 
 
 def help_cryptokey_details(self):
-    print('cryptokey_details: Show the contents of a cryptographic key')
-    print('usage: cryptokey_details KEY ...')
+    print(_('cryptokey_details: Show the contents of a cryptographic key'))
+    print(_('usage: cryptokey_details KEY ...'))
 
 
 def complete_cryptokey_details(self, text, line, beg, end):
@@ -188,7 +194,7 @@ def do_cryptokey_details(self, args):
                   (args, keys))
 
     if not keys:
-        logging.error("No keys matched argument %s" % args)
+        logging.error(_("No keys matched argument %s") % args)
         return 1
 
     add_separator = False
@@ -198,15 +204,15 @@ def do_cryptokey_details(self, args):
             details = self.client.kickstart.keys.getDetails(self.session,
                                                             key)
         except xmlrpclib.Fault:
-            logging.warning('%s is not a valid crypto key' % key)
+            logging.warning(_('%s is not a valid crypto key') % key)
             return 1
 
         if add_separator:
             print(self.SEPARATOR)
         add_separator = True
 
-        print('Description: %s' % details.get('description'))
-        print('Type:        %s' % details.get('type'))
+        print(_('Description: %s') % details.get('description'))
+        print(_('Type:        %s') % details.get('type'))
 
         print('')
         print(details.get('content'))

--- a/spacecmd/src/spacecmd/custominfo.py
+++ b/spacecmd/src/spacecmd/custominfo.py
@@ -26,12 +26,18 @@
 # unused argument
 # pylint: disable=W0613
 
+import gettext
 from spacecmd.utils import *
 
+translation = gettext.translation('spacecmd', fallback=True)
+try:
+    _ = translation.ugettext
+except AttributeError:
+    _ = translation.gettext
 
 def help_custominfo_createkey(self):
-    print('custominfo_createkey: Create a custom key')
-    print('usage: custominfo_createkey [NAME] [DESCRIPTION]')
+    print(_('custominfo_createkey: Create a custom key'))
+    print(_('usage: custominfo_createkey [NAME] [DESCRIPTION]'))
 
 
 def do_custominfo_createkey(self, args):
@@ -45,12 +51,12 @@ def do_custominfo_createkey(self, args):
         key = ''
 
     while key == '':
-        key = prompt_user('Name:')
+        key = prompt_user(_('Name:'))
 
     if len(args) > 1:
         description = ' '.join(args[1:])
     else:
-        description = prompt_user('Description:')
+        description = prompt_user(_('Description:'))
         if description == '':
             description = key
 
@@ -64,8 +70,8 @@ def do_custominfo_createkey(self, args):
 
 
 def help_custominfo_deletekey(self):
-    print('custominfo_deletekey: Delete a custom key')
-    print('usage: custominfo_deletekey KEY ...')
+    print(_('custominfo_deletekey: Delete a custom key'))
+    print(_('usage: custominfo_deletekey KEY ...'))
 
 
 def complete_custominfo_deletekey(self, text, line, beg, end):
@@ -105,8 +111,8 @@ def do_custominfo_deletekey(self, args):
 
 
 def help_custominfo_listkeys(self):
-    print('custominfo_listkeys: List all custom keys')
-    print('usage: custominfo_listkeys')
+    print(_('custominfo_listkeys: List all custom keys'))
+    print(_('usage: custominfo_listkeys'))
 
 
 def do_custominfo_listkeys(self, args, doreturn=False):
@@ -123,8 +129,8 @@ def do_custominfo_listkeys(self, args, doreturn=False):
 
 
 def help_custominfo_details(self):
-    print('custominfo_details: Show the details of a custom key')
-    print('usage: custominfo_details KEY ...')
+    print(_('custominfo_details: Show the details of a custom key'))
+    print(_('usage: custominfo_details KEY ...'))
 
 
 def complete_custominfo_details(self, text, line, beg, end):
@@ -146,7 +152,7 @@ def do_custominfo_details(self, args):
         ", ".join(args), ", ".join(keys)))
 
     if not keys:
-        logging.error("No keys matched argument '{}'.".format(", ".join(args)))
+        logging.error(_("No keys matched argument '{}'.").format(", ".join(args)))
         return 1
 
     add_separator = False
@@ -163,10 +169,10 @@ def do_custominfo_details(self, args):
             if add_separator:
                 print(self.SEPARATOR)
             add_separator = True
-            print('Label:        %s' % (details.get('label') or "N/A"))
-            print('Description:  %s' % (details.get('description') or "N/A"))
-            print('Modified:     %s' % (details.get('last_modified') or "N/A"))
-            print('System Count: %i' % (details.get('system_count') or 0))
+            print(_('Label:        %s') % (details.get('label') or "N/A"))
+            print(_('Description:  %s') % (details.get('description') or "N/A"))
+            print(_('Modified:     %s') % (details.get('last_modified') or "N/A"))
+            print(_('System Count: %i') % (details.get('system_count') or 0))
 
     return 0
 
@@ -174,8 +180,8 @@ def do_custominfo_details(self, args):
 
 
 def help_custominfo_updatekey(self):
-    print('custominfo_updatekey: Update a custom key')
-    print('usage: custominfo_updatekey [NAME] [DESCRIPTION]')
+    print(_('custominfo_updatekey: Update a custom key'))
+    print(_('usage: custominfo_updatekey [NAME] [DESCRIPTION]'))
 
 
 def do_custominfo_updatekey(self, args):
@@ -189,12 +195,12 @@ def do_custominfo_updatekey(self, args):
         key = ''
 
     while key == '':
-        key = prompt_user('Name:')
+        key = prompt_user(_('Name:'))
 
     if len(args) > 1:
         description = ' '.join(args[1:])
     else:
-        description = prompt_user('Description:')
+        description = prompt_user(_('Description:'))
         if description == '':
             description = key
 

--- a/spacecmd/src/spacecmd/distribution.py
+++ b/spacecmd/src/spacecmd/distribution.py
@@ -29,18 +29,24 @@
 # invalid function name
 # pylint: disable=C0103
 
+import gettext
 from spacecmd.utils import *
 
+translation = gettext.translation('spacecmd', fallback=True)
+try:
+    _ = translation.ugettext
+except AttributeError:
+    _ = translation.gettext
 
 def help_distribution_create(self):
-    print('distribution_create: Create a Kickstart tree')
-    print('''usage: distribution_create [options]
+    print(_('distribution_create: Create a Kickstart tree'))
+    print(_('''usage: distribution_create [options]
 
 options:
   -n NAME
   -p path to tree
   -b base channel to associate with
-  -t install type [fedora|rhel_4/5/6|generic_rpm]''')
+  -t install type [fedora|rhel_4/5/6|generic_rpm]'''))
 
 
 def do_distribution_create(self, args, update=False):
@@ -57,27 +63,27 @@ def do_distribution_create(self, args, update=False):
         if args:
             options.name = args[0]
         elif not options.name:
-            logging.error('The name of the distribution is required')
+            logging.error(_('The name of the distribution is required'))
             return 1
 
     if is_interactive(options):
         if not update:
-            options.name = prompt_user('Name:', noblank=True)
+            options.name = prompt_user(_('Name:'), noblank=True)
 
-        options.path = prompt_user('Path to Kickstart Tree:', noblank=True)
+        options.path = prompt_user(_('Path to Kickstart Tree:'), noblank=True)
 
         options.base_channel = ''
         while options.base_channel == '':
             print('')
-            print('Base Channels')
+            print(_('Base Channels'))
             print('-------------')
             print('\n'.join(sorted(self.list_base_channels())))
             print('')
 
-            options.base_channel = prompt_user('Base Channel:')
+            options.base_channel = prompt_user(_('Base Channel:'))
 
         if options.base_channel not in self.list_base_channels():
-            logging.warning('Invalid channel label')
+            logging.warning(_('Invalid channel label'))
             options.base_channel = ''
 
         install_types = \
@@ -88,31 +94,31 @@ def do_distribution_create(self, args, update=False):
         options.install_type = ''
         while options.install_type == '':
             print('')
-            print('Install Types')
+            print(_('Install Types'))
             print('-------------')
             print('\n'.join(sorted(install_types)))
             print('')
 
-            options.install_type = prompt_user('Install Type:')
+            options.install_type = prompt_user(_('Install Type:'))
 
             if options.install_type not in install_types:
-                logging.warning('Invalid install type')
+                logging.warning(_('Invalid install type'))
                 options.install_type = ''
     else:
         if not options.name:
-            logging.error('A name is required')
+            logging.error(_('A name is required'))
             return 1
 
         if not options.path:
-            logging.error('A path is required')
+            logging.error(_('A path is required'))
             return 1
 
         if not options.base_channel:
-            logging.error('A base channel is required')
+            logging.error(_('A base channel is required'))
             return 1
 
         if not options.install_type:
-            logging.error('An install type is required')
+            logging.error(_('An install type is required'))
             return 1
 
     if update:
@@ -134,8 +140,8 @@ def do_distribution_create(self, args, update=False):
 
 
 def help_distribution_list(self):
-    print('distribution_list: List the available autoinstall trees')
-    print('usage: distribution_list')
+    print(_('distribution_list: List the available autoinstall trees'))
+    print(_('usage: distribution_list'))
 
 def do_distribution_list(self, args, doreturn=False):
     channels = self.client.kickstart.listAutoinstallableChannels(self.session)
@@ -159,8 +165,8 @@ def do_distribution_list(self, args, doreturn=False):
 
 
 def help_distribution_delete(self):
-    print('distribution_delete: Delete a Kickstart tree')
-    print('usage: distribution_delete LABEL')
+    print(_('distribution_delete: Delete a Kickstart tree'))
+    print(_('usage: distribution_delete LABEL'))
 
 
 def complete_distribution_delete(self, text, line, beg, end):
@@ -184,13 +190,13 @@ def do_distribution_delete(self, args):
                   (args, dists))
 
     if not dists:
-        logging.error("No distributions matched argument %s" % args)
+        logging.error(_("No distributions matched argument %s") % args)
         return 1
 
     # Print the distributions prior to the confirmation
     print('\n'.join(sorted(dists)))
 
-    if self.user_confirm('Delete distribution tree(s) [y/N]:'):
+    if self.user_confirm(_('Delete distribution tree(s) [y/N]:')):
         for d in dists:
             self.client.kickstart.tree.delete(self.session, d)
 
@@ -200,8 +206,8 @@ def do_distribution_delete(self, args):
 
 
 def help_distribution_details(self):
-    print('distribution_details: Show the details of a Kickstart tree')
-    print('usage: distribution_details LABEL')
+    print(_('distribution_details: Show the details of a Kickstart tree'))
+    print(_('usage: distribution_details LABEL'))
 
 
 def complete_distribution_details(self, text, line, beg, end):
@@ -223,7 +229,7 @@ def do_distribution_details(self, args):
                   (args, dists))
 
     if not dists:
-        logging.error("No distributions matched argument %s" % args)
+        logging.error(_("No distributions matched argument %s") % args)
         return 1
 
     add_separator = False
@@ -239,9 +245,9 @@ def do_distribution_details(self, args):
             print(self.SEPARATOR)
         add_separator = True
 
-        print('Name:    %s' % details.get('label'))
-        print('Path:    %s' % details.get('abs_path'))
-        print('Channel: %s' % channel.get('label'))
+        print(_('Name:    %s') % details.get('label'))
+        print(_('Path:    %s') % details.get('abs_path'))
+        print(_('Channel: %s') % channel.get('label'))
 
     return 0
 
@@ -249,8 +255,8 @@ def do_distribution_details(self, args):
 
 
 def help_distribution_rename(self):
-    print('distribution_rename: Rename a Kickstart tree')
-    print('usage: distribution_rename OLDNAME NEWNAME')
+    print(_('distribution_rename: Rename a Kickstart tree'))
+    print(_('usage: distribution_rename OLDNAME NEWNAME'))
 
 
 def complete_distribution_rename(self, text, line, beg, end):
@@ -279,13 +285,13 @@ def do_distribution_rename(self, args):
 
 
 def help_distribution_update(self):
-    print('distribution_update: Update the path of a Kickstart tree')
-    print('''usage: distribution_update NAME [options]
+    print(_('distribution_update: Update the path of a Kickstart tree'))
+    print(_('''usage: distribution_update NAME [options]
 
 options:
   -p path to tree
   -b base channel to associate with
-  -t install type [fedora|rhel_4/5/6|generic_rpm]''')
+  -t install type [fedora|rhel_4/5/6|generic_rpm]'''))
 
 
 def complete_distribution_update(self, text, line, beg, end):

--- a/spacecmd/src/spacecmd/errata.py
+++ b/spacecmd/src/spacecmd/errata.py
@@ -30,6 +30,7 @@
 # invalid function name
 # pylint: disable=C0103
 
+import gettext
 from operator import itemgetter
 try:
     from xmlrpc import client as xmlrpclib
@@ -38,10 +39,15 @@ except ImportError:
 
 from spacecmd.utils import *
 
+translation = gettext.translation('spacecmd', fallback=True)
+try:
+    _ = translation.ugettext
+except AttributeError:
+    _ = translation.gettext
 
 def help_errata_list(self):
-    print('errata_list: List all patches')
-    print('usage: errata_list')
+    print(_('errata_list: List all patches'))
+    print(_('usage: errata_list'))
 
 
 def do_errata_list(self, args, doreturn=False):
@@ -57,8 +63,8 @@ def do_errata_list(self, args, doreturn=False):
 
 
 def help_errata_summary(self):
-    print('errata_summary: Print a summary of all errata')
-    print('usage: errata_summary')
+    print(_('errata_summary: Print a summary of all errata'))
+    print(_('usage: errata_summary'))
 
 
 def do_errata_summary(self, args):
@@ -73,11 +79,11 @@ def do_errata_summary(self, args):
 
 
 def help_errata_apply(self):
-    print('errata_apply: Apply an erratum to all affected systems')
-    print('''usage: errata_apply [options] ERRATA|search:XXX ...)
+    print(_('errata_apply: Apply an erratum to all affected systems'))
+    print(_('''usage: errata_apply [options] ERRATA|search:XXX ...)
 
 options:
-  -s START_TIME''')
+  -s START_TIME'''))
     print('')
     print(self.HELP_TIME_OPTS)
 
@@ -101,7 +107,7 @@ def do_errata_apply(self, args, only_systems=None):
     # skip the prompt if we are running with --yes
     # use "now" if no start time was given
     if is_interactive(options) and not self.options.yes:
-        options.start_time = prompt_user('Start Time [now]:')
+        options.start_time = prompt_user(_('Start Time [now]:'))
         options.start_time = parse_time_input(options.start_time)
     else:
         if not options.start_time:
@@ -149,17 +155,17 @@ def do_errata_apply(self, args, only_systems=None):
     systems = sorted(list(set(systems)))
 
     if not systems:
-        logging.warning('No patches to apply')
+        logging.warning(_('No patches to apply'))
         return 1
 
     # a summary of which errata we're going to apply
-    print('Errata             Systems')
+    print(_('Errata             Systems'))
     print('--------------     -------')
     print('\n'.join(sorted(summary)))
     print('')
-    print('Start Time: %s' % options.start_time)
+    print(_('Start Time: %s') % options.start_time)
 
-    if (is_interactive(options) and not self.user_confirm('Apply these patches [y/N]:')) or not self.options.yes:
+    if (is_interactive(options) and not self.user_confirm(_('Apply these patches [y/N]:'))) or not self.options.yes:
         return 1
 
     # if the API supports it, try to schedule multiple systems for one erratum
@@ -209,7 +215,7 @@ def do_errata_apply(self, args, only_systems=None):
                         break
 
             if not errata_to_apply:
-                logging.warning('No patches to schedule for %s' % system)
+                logging.warning(_('No patches to schedule for %s') % system)
                 continue
 
             # this results in one action per erratum for each server
@@ -218,7 +224,7 @@ def do_errata_apply(self, args, only_systems=None):
                                                    errata_to_apply,
                                                    options.start_time)
 
-            logging.info('Scheduled %i patches for %s' %
+            logging.info(_('Scheduled %i patches for %s') %
                          (len(errata_to_apply), system))
 
     return 0
@@ -227,8 +233,8 @@ def do_errata_apply(self, args, only_systems=None):
 
 
 def help_errata_listaffectedsystems(self):
-    print('errata_listaffectedsystems: List of systems affected by an patch')
-    print('usage: errata_listaffectedsystems ERRATA|search:XXX ...')
+    print(_('errata_listaffectedsystems: List of systems affected by an patch'))
+    print(_('usage: errata_listaffectedsystems ERRATA|search:XXX ...'))
 
 
 def complete_errata_listaffectedsystems(self, text, line, beg, end):
@@ -266,8 +272,8 @@ def do_errata_listaffectedsystems(self, args):
 
 
 def help_errata_listcves(self):
-    print('errata_listcves: List of CVEs addressed by an patch')
-    print('usage: errata_listcves ERRATA|search:XXX ...')
+    print(_('errata_listcves: List of CVEs addressed by an patch'))
+    print(_('usage: errata_listcves ERRATA|search:XXX ...'))
 
 
 def complete_errata_listcves(self, text, line, beg, end):
@@ -303,15 +309,15 @@ def do_errata_listcves(self, args):
                 print('\n'.join(sorted(cves)))
         return 0
     else:
-        print("No errata has been found")
+        print(_("No errata has been found"))
         return 1
 
 ####################
 
 
 def help_errata_findbycve(self):
-    print('errata_findbycve: List errata addressing a CVE')
-    print('usage: errata_findbycve CVE-YYYY-NNNN ...')
+    print(_('errata_findbycve: List errata addressing a CVE'))
+    print(_('usage: errata_findbycve CVE-YYYY-NNNN ...'))
 
 
 def complete_errata_findbycve(self, text, line, beg, end):
@@ -345,8 +351,8 @@ def do_errata_findbycve(self, args):
 
 
 def help_errata_details(self):
-    print('errata_details: Show the details of an patch')
-    print('usage: errata_details ERRATA|search:XXX ...')
+    print(_('errata_details: Show the details of an patch'))
+    print(_('usage: errata_details ERRATA|search:XXX ...'))
 
 
 def complete_errata_details(self, text, line, beg, end):
@@ -381,54 +387,54 @@ def do_errata_details(self, args):
             channels = \
                 self.client.errata.applicableToChannels(self.session, erratum)
         except xmlrpclib.Fault:
-            logging.warning('%s is not a valid erratum' % erratum)
+            logging.warning(_('%s is not a valid erratum') % erratum)
             continue
 
         if add_separator:
             print(self.SEPARATOR)
         add_separator = True
 
-        print('Name:       %s' % erratum)
-        print('Product:    %s' % (details.get('product') or "N/A"))
-        print('Type:       %s' % (details.get('type') or "N/A"))
-        print('Issue Date: %s' % (details.get('issue_date') or "N/A"))
+        print(_('Name:       %s') % erratum)
+        print(_('Product:    %s') % (details.get('product') or "N/A"))
+        print(_('Type:       %s') % (details.get('type') or "N/A"))
+        print(_('Issue Date: %s') % (details.get('issue_date') or "N/A"))
         print('')
-        print('Topic')
+        print(_('Topic'))
         print('-----')
         print('\n'.join(wrap(details.get('topic') or "N/A")))
         print('')
-        print('Description')
+        print(_('Description'))
         print('-----------')
         print('\n'.join(wrap(details.get('description') or "N/A")))
 
         if details.get('notes'):
             print('')
-            print('Notes')
+            print(_('Notes'))
             print('-----')
             print('\n'.join(wrap(details.get('notes') or "N/A")))
 
         print('')
-        print('CVEs')
+        print(_('CVEs'))
         print('----')
         print('\n'.join(sorted(cves)))
         print('')
-        print('Solution')
+        print(_('Solution'))
         print('--------')
         print('\n'.join(wrap(details.get('solution') or "N/A")))
         print('')
-        print('References')
+        print(_('References'))
         print('----------')
         print('\n'.join(wrap(details.get('references') or "N/A")))
         print('')
-        print('Affected Channels')
+        print(_('Affected Channels'))
         print('-----------------')
         print('\n'.join(sorted(filter(None, [c.get('label') or "" for c in channels]))))
         print('')
-        print('Affected Systems')
+        print(_('Affected Systems'))
         print('----------------')
         print(str(len(systems)))
         print('')
-        print('Affected Packages')
+        print(_('Affected Packages'))
         print('-----------------')
         print('\n'.join(sorted(build_package_names(packages))))
 
@@ -438,8 +444,8 @@ def do_errata_details(self, args):
 
 
 def help_errata_delete(self):
-    print('errata_delete: Delete an patch')
-    print('usage: errata_delete ERRATA|search:XXX ...')
+    print(_('errata_delete: Delete an patch'))
+    print(_('usage: errata_delete ERRATA|search:XXX ...'))
 
 
 def complete_errata_delete(self, text, line, beg, end):
@@ -459,10 +465,10 @@ def do_errata_delete(self, args):
     errata = self.expand_errata(args)
 
     if not errata:
-        logging.warning('No patches to delete')
+        logging.warning(_('No patches to delete'))
         return 1
 
-    print('Erratum            Channels')
+    print(_('Erratum            Channels'))
     print('-------            --------')
 
     # tell the user how many channels each erratum affects
@@ -470,13 +476,13 @@ def do_errata_delete(self, args):
         channels = self.client.errata.applicableToChannels(self.session, erratum)
         print('%s    %s' % (erratum.ljust(20), str(len(channels)).rjust(3)))
 
-    if not self.options.yes and not self.user_confirm('Delete these patches [y/N]:'):
+    if not self.options.yes and not self.user_confirm(_('Delete these patches [y/N]:')):
         return 1
 
     for erratum in errata:
         self.client.errata.delete(self.session, erratum)
 
-    logging.info('Deleted %i patches' % len(errata))
+    logging.info(_('Deleted %i patches') % len(errata))
 
     self.generate_errata_cache(True)
 
@@ -486,8 +492,8 @@ def do_errata_delete(self, args):
 
 
 def help_errata_publish(self):
-    print('errata_publish: Publish an patch to a channel')
-    print('usage: errata_publish ERRATA|search:XXX <CHANNEL ...>')
+    print(_('errata_publish: Publish an patch to a channel'))
+    print(_('usage: errata_publish ERRATA|search:XXX <CHANNEL ...>'))
 
 
 def complete_errata_publish(self, text, line, beg, end):
@@ -514,12 +520,12 @@ def do_errata_publish(self, args):
     channels = args[1:]
 
     if not errata:
-        logging.warning('No patches to publish')
+        logging.warning(_('No patches to publish'))
         return 1
 
     print('\n'.join(sorted(errata)))
 
-    if not self.options.yes and not self.user_confirm('Publish these patches [y/N]:'):
+    if not self.options.yes and not self.user_confirm(_('Publish these patches [y/N]:')):
         return 1
 
     for erratum in errata:
@@ -531,10 +537,10 @@ def do_errata_publish(self, args):
 
 
 def help_errata_search(self):
-    print('errata_search: List patches that meet the given criteria')
-    print('usage: errata_search CVE|RHSA|RHBA|RHEA|CLA ...')
+    print(_('errata_search: List patches that meet the given criteria'))
+    print(_('usage: errata_search CVE|RHSA|RHBA|RHEA|CLA ...'))
     print('')
-    print('Example:')
+    print(_('Example:'))
     print('> errata_search CVE-2009:1674')
     print('> errata_search RHSA-2009:1674')
 

--- a/spacecmd/src/spacecmd/filepreservation.py
+++ b/spacecmd/src/spacecmd/filepreservation.py
@@ -29,12 +29,18 @@
 # invalid function name
 # pylint: disable=C0103
 
+import gettext
 from spacecmd.utils import *
 
+translation = gettext.translation('spacecmd', fallback=True)
+try:
+    _ = translation.ugettext
+except AttributeError:
+    _ = translation.gettext
 
 def help_filepreservation_list(self):
-    print('filepreservation_list: List all file preservations')
-    print('usage: filepreservation_list')
+    print(_('filepreservation_list: List all file preservations'))
+    print(_('usage: filepreservation_list'))
 
 
 def do_filepreservation_list(self, args, doreturn=False):
@@ -49,8 +55,8 @@ def do_filepreservation_list(self, args, doreturn=False):
 
 
 def help_filepreservation_create(self):
-    print('filepreservation_create: Create a file preservation list')
-    print('usage: filepreservation_create [NAME] [FILE ...]')
+    print(_('filepreservation_create: Create a file preservation list'))
+    print(_('usage: filepreservation_create [NAME] [FILE ...]'))
 
 
 def do_filepreservation_create(self, args):
@@ -61,7 +67,7 @@ def do_filepreservation_create(self, args):
     if args:
         name = args[0]
     else:
-        name = prompt_user('Name:', noblank=True)
+        name = prompt_user(_('Name:'), noblank=True)
 
     if len(args) > 1:
         files = args[1:]
@@ -69,12 +75,12 @@ def do_filepreservation_create(self, args):
         files = []
 
         while True:
-            print('File List')
+            print(_('File List'))
             print('---------')
             print('\n'.join(sorted(files)))
             print('')
 
-            userinput = prompt_user('File [blank to finish]:')
+            userinput = prompt_user(_('File [blank to finish]:'))
 
             if userinput == '':
                 break
@@ -83,7 +89,7 @@ def do_filepreservation_create(self, args):
                     files.append(userinput)
 
     print('')
-    print('File List')
+    print(_('File List'))
     print('---------')
     print('\n'.join(sorted(files)))
 
@@ -100,8 +106,8 @@ def do_filepreservation_create(self, args):
 
 
 def help_filepreservation_delete(self):
-    print('filepreservation_delete: Delete a file preservation list')
-    print('usage: filepreservation_delete NAME')
+    print(_('filepreservation_delete: Delete a file preservation list'))
+    print(_('usage: filepreservation_delete NAME'))
 
 
 def complete_filepreservation_delete(self, text, line, beg, end):
@@ -119,7 +125,7 @@ def do_filepreservation_delete(self, args):
 
     name = args[0]
 
-    if not self.user_confirm('Delete this list [y/N]:'):
+    if not self.user_confirm(_('Delete this list [y/N]:')):
         return 1
 
     self.client.kickstart.filepreservation.delete(self.session, name)
@@ -130,9 +136,9 @@ def do_filepreservation_delete(self, args):
 
 
 def help_filepreservation_details(self):
-    print('''filepreservation_details: Show the details of a file
-'preservation list''')
-    print('usage: filepreservation_details NAME')
+    print(_('''filepreservation_details: Show the details of a file
+'preservation list'''))
+    print(_('usage: filepreservation_details NAME'))
 
 
 def complete_filepreservation_details(self, text, line, beg, end):

--- a/spacecmd/src/spacecmd/group.py
+++ b/spacecmd/src/spacecmd/group.py
@@ -29,6 +29,7 @@
 # invalid function name
 # pylint: disable=C0103
 
+import gettext
 import os
 import re
 import shlex
@@ -38,11 +39,17 @@ except ImportError:
     import xmlrpclib
 from spacecmd.utils import *
 
+translation = gettext.translation('spacecmd', fallback=True)
+try:
+    _ = translation.ugettext
+except AttributeError:
+    _ = translation.gettext
+
 
 def help_group_addsystems(self):
-    print('group_addsystems: Add systems to a group')
-    print('usage: group_addsystems GROUP <SYSTEMS>')
-    print('       group_addsystems GROUP <ssm>')
+    print(_('group_addsystems: Add systems to a group'))
+    print(_('usage: group_addsystems GROUP <SYSTEMS>'))
+    print(_('       group_addsystems GROUP <ssm>'))
     print('')
     print(self.HELP_SYSTEM_OPTS)
 
@@ -93,8 +100,8 @@ def do_group_addsystems(self, args):
 
 
 def help_group_removesystems(self):
-    print('group_removesystems: Remove systems from a group')
-    print('usage: group_removesystems GROUP <SYSTEMS>')
+    print(_('group_removesystems: Remove systems from a group'))
+    print(_('usage: group_removesystems GROUP <SYSTEMS>'))
     print('')
     print(self.HELP_SYSTEM_OPTS)
 
@@ -135,11 +142,11 @@ def do_group_removesystems(self, args):
         system_ids.append(system_id)
 
     if system_ids:
-        print('Systems')
+        print(_('Systems'))
         print('-------')
         print('\n'.join(sorted(systems)))
 
-        if not self.user_confirm('Remove these systems [y/N]:'):
+        if not self.user_confirm(_('Remove these systems [y/N]:')):
             return
 
         self.client.systemgroup.addOrRemoveSystems(self.session,
@@ -148,15 +155,15 @@ def do_group_removesystems(self, args):
                                                    False)
         return 0
     else:
-        print("No systems found")
+        print(_("No systems found"))
         return 1
 
 ####################
 
 
 def help_group_create(self):
-    print('group_create: Create a system group')
-    print('usage: group_create [NAME] [DESCRIPTION]')
+    print(_('group_create: Create a system group'))
+    print(_('usage: group_create [NAME] [DESCRIPTION]'))
 
 
 def do_group_create(self, args):
@@ -167,12 +174,12 @@ def do_group_create(self, args):
     if args:
         name = args[0]
     else:
-        name = prompt_user('Name:')
+        name = prompt_user(_('Name:'))
 
     if len(args) > 1:
         description = ' '.join(args[1:])
     else:
-        description = prompt_user('Description:')
+        description = prompt_user(_('Description:'))
 
     self.client.systemgroup.create(self.session, name, description)
 
@@ -182,8 +189,8 @@ def do_group_create(self, args):
 
 
 def help_group_delete(self):
-    print('group_delete: Delete a system group')
-    print('usage: group_delete NAME ...')
+    print(_('group_delete: Delete a system group'))
+    print(_('usage: group_delete NAME ...'))
 
 
 def complete_group_delete(self, text, line, beg, end):
@@ -202,7 +209,7 @@ def do_group_delete(self, args):
     groups = args
 
     self.do_group_details('', True)
-    if not self.user_confirm('Delete these groups [y/N]:'):
+    if not self.user_confirm(_('Delete these groups [y/N]:')):
         return 1
 
     for group in groups:
@@ -214,13 +221,13 @@ def do_group_delete(self, args):
 
 
 def help_group_backup(self):
-    print('group_backup: backup a system group')
-    print('''usage: group_backup <NAME> [OUTDIR])
+    print(_('group_backup: backup a system group'))
+    print(_('''usage: group_backup <NAME> [OUTDIR])
                     group_backup ALL
 
 "OUTDIR" defaults to $HOME/spacecmd-backup/group/YYYY-MM-DD/NAME
 "ALL" is a keyword and collects all groups
-''')
+'''))
 
 
 def complete_group_backup(self, text, line, beg, end):
@@ -256,14 +263,14 @@ def do_group_backup(self, args):
         if not os.path.isdir(outputpath_base):
             os.makedirs(outputpath_base)
     except OSError:
-        logging.error('Could not create output directory: %s', outputpath_base)
+        logging.error(_('Could not create output directory: %s'), outputpath_base)
         return 1
 
     for group in groups:
-        print("Backup Group: %s" % group)
+        print(_("Backup Group: %s") % group)
         details = self.client.systemgroup.getDetails(self.session, group)
         outputpath = outputpath_base + "/" + group
-        print("Output File: %s" % outputpath)
+        print(_("Output File: %s") % outputpath)
         fh = open(outputpath, 'w')
         fh.write(details['description'])
         fh.close()
@@ -274,8 +281,8 @@ def do_group_backup(self, args):
 
 
 def help_group_restore(self):
-    print('group_restore: restore a system group')
-    print('''
+    print(_('group_restore: restore a system group'))
+    print(_('''
 usage: group_restore INPUTDIR [NAME] ...
        group_restore INPUTDIR ALL
        group_restore INPUTDIR
@@ -283,7 +290,7 @@ usage: group_restore INPUTDIR [NAME] ...
 
 Specifying only INPUTDIR will default to ALL groups.
 Setting dot (.) instead of full INPUTDIR will imply current directory.
-    ''')
+    '''))
 
 
 def complete_group_restore(self, text, line, beg, end):
@@ -319,21 +326,21 @@ def do_group_restore(self, args):
                 logging.debug("Found file %s" % inputdir + "/" + d_item)
                 files[d_item] = inputdir + "/" + d_item
     else:
-        logging.error("Restore dir %s does not exits or is not a directory" % inputdir)
+        logging.error(_("Restore dir %s does not exits or is not a directory") % inputdir)
         return 1
 
     if not files:
-        logging.error("Restore dir %s has no restore items" % inputdir)
+        logging.error(_("Restore dir %s has no restore items") % inputdir)
         return 1
 
     missing_groups = 0
     if groups and next(iter(groups)) != 'ALL':
         for group in groups:
             if group not in files:
-                logging.error("Group %s was not found in backup" % (group))
+                logging.error(_("Group %s was not found in backup") % (group))
                 missing_groups += 1
     if missing_groups:
-        logging.error("Found %s missing groups, terminating", missing_groups)
+        logging.error(_("Found %s missing groups, terminating"), missing_groups)
         return 1
 
     for groupname in self.do_group_list('', True):
@@ -348,25 +355,25 @@ def do_group_restore(self, args):
         details = details.rstrip('\n')
 
         if groupname in current and current[groupname] == details:
-            logging.error("Group %s already restored" % groupname)
+            logging.error(_("Group %s already restored") % groupname)
             continue
 
         elif groupname in current:
             logging.debug("Already have %s but the description has changed" % groupname)
 
             if is_interactive(options):
-                print("Changing description from:")
+                print(_("Changing description from:"))
                 print("\n\"%s\"\nto\n\"%s\"\n" % (current[groupname], details))
-                userinput = prompt_user('Continue [y/N]:')
+                userinput = prompt_user(_('Continue [y/N]:'))
 
                 if re.match('y', userinput, re.I):
-                    logging.info("Updating description for group: %s" % groupname)
+                    logging.info(_("Updating description for group: %s") % groupname)
                     self.client.systemgroup.update(self.session, groupname, details)
             else:
-                logging.info("Updating description for group: %s" % groupname)
+                logging.info(_("Updating description for group: %s") % groupname)
                 self.client.systemgroup.update(self.session, groupname, details)
         else:
-            logging.info("Creating new group %s" % groupname)
+            logging.info(_("Creating new group %s") % groupname)
             self.client.systemgroup.create(self.session, groupname, details)
 
     return 0
@@ -375,8 +382,8 @@ def do_group_restore(self, args):
 
 
 def help_group_list(self):
-    print('group_list: List available system groups')
-    print('usage: group_list')
+    print(_('group_list: List available system groups'))
+    print(_('usage: group_list'))
 
 
 def do_group_list(self, args, doreturn=False):
@@ -393,8 +400,8 @@ def do_group_list(self, args, doreturn=False):
 
 
 def help_group_listsystems(self):
-    print('group_listsystems: List the members of a group')
-    print('usage: group_listsystems GROUP')
+    print(_('group_listsystems: List the members of a group'))
+    print(_('usage: group_listsystems GROUP'))
 
 
 def complete_group_listsystems(self, text, line, beg, end):
@@ -416,7 +423,7 @@ def do_group_listsystems(self, args, doreturn=False):
         systems = self.client.systemgroup.listSystems(self.session, group)
         systems = [s.get('profile_name') for s in systems]
     except xmlrpclib.Fault:
-        logging.warning('%s is not a valid group' % group)
+        logging.warning(_('%s is not a valid group') % group)
         return []
 
     if doreturn:
@@ -429,8 +436,8 @@ def do_group_listsystems(self, args, doreturn=False):
 
 
 def help_group_details(self):
-    print('group_details: Show the details of a system group')
-    print('usage: group_details GROUP ...')
+    print(_('group_details: Show the details of a system group'))
+    print(_('usage: group_details GROUP ...'))
 
 
 def complete_group_details(self, text, line, beg, end):
@@ -453,21 +460,21 @@ def do_group_details(self, args, short=False):
             details = self.client.systemgroup.getDetails(self.session, group)
             systems = [stm.get('profile_name') for stm in self.client.systemgroup.listSystems(self.session, group)]
         except xmlrpclib.Fault:
-            logging.warning('The group "%s" is invalid' % group)
+            logging.warning(_('The group "%s" is invalid') % group)
             return 1
 
         if add_separator:
             print(self.SEPARATOR)
         add_separator = True
 
-        print('ID:                %i' % details.get('id'))
-        print('Name:              %s' % details.get('name'))
-        print('Description:       %s' % details.get('description'))
-        print('Number of Systems: %i' % details.get('system_count'))
+        print(_('ID:                %i') % details.get('id'))
+        print(_('Name:              %s') % details.get('name'))
+        print(_('Description:       %s') % details.get('description'))
+        print(_('Number of Systems: %i') % details.get('system_count'))
 
         if not short:
             print('')
-            print('Members')
+            print(_('Members'))
             print('-------')
             print('\n'.join(sorted(systems)))
 

--- a/spacecmd/src/spacecmd/kickstart.py
+++ b/spacecmd/src/spacecmd/kickstart.py
@@ -30,6 +30,7 @@
 # invalid function name
 # pylint: disable=C0103
 
+import gettext
 import os
 from getpass import getpass
 from operator import itemgetter
@@ -44,6 +45,12 @@ try:
 except ImportError:
     import xmlrpclib
 from spacecmd.utils import *
+
+translation = gettext.translation('spacecmd', fallback=True)
+try:
+    _ = translation.ugettext
+except AttributeError:
+    _ = translation.gettext
 
 KICKSTART_OPTIONS = ['autostep', 'interactive', 'install', 'upgrade',
                      'text', 'network', 'cdrom', 'harddrive', 'nfs',
@@ -62,8 +69,8 @@ UPDATE_TYPES = ['red_hat', 'all', 'none']
 
 
 def help_kickstart_list(self):
-    print('kickstart_list: List the available Kickstart profiles')
-    print('usage: kickstart_list')
+    print(_('kickstart_list: List the available Kickstart profiles'))
+    print(_('usage: kickstart_list'))
 
 
 def do_kickstart_list(self, args, doreturn=False):
@@ -75,20 +82,20 @@ def do_kickstart_list(self, args, doreturn=False):
         if kickstarts:
             print(os.linesep.join(kickstarts))
         else:
-            logging.error("No kickstart profiles available")
+            logging.error(_("No kickstart profiles available"))
 
 ####################
 
 
 def help_kickstart_create(self):
-    print('kickstart_create: Create a Kickstart profile')
-    print('''usage: kickstart_create [options])
+    print(_('kickstart_create: Create a Kickstart profile'))
+    print(_('''usage: kickstart_create [options])
 
 options:
   -n NAME
   -d DISTRIBUTION
   -p ROOT_PASSWORD
-  -v VIRT_TYPE ['none', 'para_host', 'qemu', 'xenfv', 'xenpv']''')
+  -v VIRT_TYPE ['none', 'para_host', 'qemu', 'xenfv', 'xenpv']'''))
 
 
 def do_kickstart_create(self, args):
@@ -103,12 +110,12 @@ def do_kickstart_create(self, args):
     if is_interactive(options):
         options.name = prompt_user('Name:', noblank=True)
 
-        print('Virtualization Types')
+        print(_('Virtualization Types'))
         print('--------------------')
         print('\n'.join(sorted(self.VIRT_TYPES)))
         print('')
 
-        options.virt_type = prompt_user('Virtualization Type [none]:')
+        options.virt_type = prompt_user(_('Virtualization Type [none]:'))
         if options.virt_type == '' or options.virt_type not in self.VIRT_TYPES:
             options.virt_type = 'none'
 
@@ -116,7 +123,7 @@ def do_kickstart_create(self, args):
         while options.distribution == '':
             trees = self.do_distribution_list('', True)
             print('')
-            print('Distributions')
+            print(_('Distributions'))
             print('-------------')
             print('\n'.join(sorted(trees)))
             print('')
@@ -126,29 +133,29 @@ def do_kickstart_create(self, args):
         options.root_password = ''
         while options.root_password == '':
             print('')
-            password1 = getpass('Root Password: ')
-            password2 = getpass('Repeat Password: ')
+            password1 = getpass(_('Root Password: '))
+            password2 = getpass(_('Repeat Password: '))
 
             if password1 == password2:
                 options.root_password = password1
             elif password1 == '':
-                logging.warning('Password must be at least 5 characters')
+                logging.warning(_('Password must be at least 5 characters'))
             else:
-                logging.warning("Passwords don't match")
+                logging.warning(_("Passwords don't match"))
     else:
         if not options.name:
-            logging.error('The Kickstart name is required')
+            logging.error(_('The Kickstart name is required'))
             return 1
 
         if not options.distribution:
-            logging.error('The distribution is required')
+            logging.error(_('The distribution is required'))
             return 1
 
         if not options.virt_type:
             options.virt_type = 'none'
 
         if not options.root_password:
-            logging.error('A root password is required')
+            logging.error(_('A root password is required'))
             return 1
 
     # leave this blank to use the default server
@@ -167,10 +174,10 @@ def do_kickstart_create(self, args):
 
 
 def help_kickstart_delete(self):
-    print('kickstart_delete: Delete kickstart profile(s)')
-    print('usage: kickstart_delete PROFILE')
-    print('usage: kickstart_delete PROFILE1 PROFILE2')
-    print('usage: kickstart_delete \"PROF*\"')
+    print(_('kickstart_delete: Delete kickstart profile(s)'))
+    print(_('usage: kickstart_delete PROFILE'))
+    print(_('usage: kickstart_delete PROFILE1 PROFILE2'))
+    print(_('usage: kickstart_delete \"PROF*\"'))
 
 
 def complete_kickstart_delete(self, text, line, beg, end):
@@ -193,18 +200,18 @@ def do_kickstart_delete(self, args):
     logging.debug("Got labels to delete of %s" % labels)
 
     if not labels:
-        logging.error("No valid kickstart labels passed as arguments!")
+        logging.error(_("No valid kickstart labels passed as arguments!"))
         self.help_kickstart_delete()
         return 1
 
     mismatched = sorted(set(args).difference(set(all_labels)))
     if mismatched:
-        logging.error("The following kickstart labels are invalid:",
+        logging.error(_("The following kickstart labels are invalid:"),
                       ", ".join(mismatched))
         return 1
     else:
         for label in labels:
-            if self.options.yes or self.user_confirm("Delete profile %s [y/N]:" % label):
+            if self.options.yes or self.user_confirm(_("Delete profile %s [y/N]:") % label):
                 self.client.kickstart.deleteProfile(self.session, label)
         return 0
 
@@ -212,14 +219,14 @@ def do_kickstart_delete(self, args):
 
 
 def help_kickstart_import(self):
-    print('kickstart_import: Import a Kickstart profile from a file')
-    print('''usage: kickstart_import [options])
+    print(_('kickstart_import: Import a Kickstart profile from a file'))
+    print(_('''usage: kickstart_import [options])
 
 options:
   -f FILE
   -n NAME
   -d DISTRIBUTION
-  -v VIRT_TYPE ['none', 'para_host', 'qemu', 'xenfv', 'xenpv']''')
+  -v VIRT_TYPE ['none', 'para_host', 'qemu', 'xenfv', 'xenpv']'''))
 
 
 def do_kickstart_import(self, args):
@@ -239,12 +246,12 @@ def kickstart_import_file(self, raw, args):
         options.name = prompt_user('Name:', noblank=True)
         options.file = prompt_user('File:', noblank=True)
 
-        print('Virtualization Types')
+        print(_('Virtualization Types'))
         print('--------------------')
         print('\n'.join(sorted(self.VIRT_TYPES)))
         print('')
 
-        options.virt_type = prompt_user('Virtualization Type [none]:')
+        options.virt_type = prompt_user(_('Virtualization Type [none]:'))
         if options.virt_type == '' or options.virt_type not in self.VIRT_TYPES:
             options.virt_type = 'none'
 
@@ -252,7 +259,7 @@ def kickstart_import_file(self, raw, args):
         while options.distribution == '':
             trees = self.do_distribution_list('', True)
             print('')
-            print('Distributions')
+            print(_('Distributions'))
             print('-------------')
             print('\n'.join(sorted(trees)))
             print('')
@@ -260,15 +267,15 @@ def kickstart_import_file(self, raw, args):
             options.distribution = prompt_user('Select:')
     else:
         if not options.name:
-            logging.error('The Kickstart name is required')
+            logging.error(_('The Kickstart name is required'))
             return
 
         if not options.distribution:
-            logging.error('The distribution is required')
+            logging.error(_('The distribution is required'))
             return
 
         if not options.file:
-            logging.error('A filename is required')
+            logging.error(_('A filename is required'))
             return
 
         if not options.virt_type:
@@ -298,14 +305,14 @@ def kickstart_import_file(self, raw, args):
 
 
 def help_kickstart_import_raw(self):
-    print('kickstart_import_raw: Import a raw Kickstart or autoyast profile from a file')
-    print('''usage: kickstart_import_raw [options])
+    print(_('kickstart_import_raw: Import a raw Kickstart or autoyast profile from a file'))
+    print(_('''usage: kickstart_import_raw [options])
 
 options:
   -f FILE
   -n NAME
   -d DISTRIBUTION
-  -v VIRT_TYPE ['none', 'para_host', 'qemu', 'xenfv', 'xenpv']''')
+  -v VIRT_TYPE ['none', 'para_host', 'qemu', 'xenfv', 'xenpv']'''))
 
 
 def do_kickstart_import_raw(self, args):
@@ -315,8 +322,8 @@ def do_kickstart_import_raw(self, args):
 
 
 def help_kickstart_details(self):
-    print('kickstart_details: Show the details of a Kickstart profile')
-    print('usage: kickstart_details PROFILE')
+    print(_('kickstart_details: Show the details of a Kickstart profile'))
+    print(_('usage: kickstart_details PROFILE'))
 
 
 def complete_kickstart_details(self, text, line, beg, end):
@@ -343,7 +350,7 @@ def do_kickstart_details(self, args):
             break
 
     if not kickstart:
-        logging.warning('Invalid Kickstart profile')
+        logging.warning(_('Invalid Kickstart profile'))
         return
 
     act_keys = \
@@ -403,19 +410,19 @@ def do_kickstart_details(self, args):
                                                         label)
 
     result = []
-    result.append('Name:        %s' % kickstart.get('name'))
-    result.append('Label:       %s' % kickstart.get('label'))
-    result.append('Tree:        %s' % kickstart.get('tree_label'))
-    result.append('Active:      %s' % kickstart.get('active'))
-    result.append('Advanced:    %s' % kickstart.get('advanced_mode'))
-    result.append('Org Default: %s' % kickstart.get('org_default'))
+    result.append(_('Name:        %s') % kickstart.get('name'))
+    result.append(_('Label:       %s') % kickstart.get('label'))
+    result.append(_('Tree:        %s') % kickstart.get('tree_label'))
+    result.append(_('Active:      %s') % kickstart.get('active'))
+    result.append(_('Advanced:    %s') % kickstart.get('advanced_mode'))
+    result.append(_('Org Default: %s') % kickstart.get('org_default'))
 
     result.append('')
-    result.append('Configuration Management: %s' % config_manage)
-    result.append('Remote Commands:          %s' % remote_commands)
+    result.append(_('Configuration Management: %s') % config_manage)
+    result.append(_('Remote Commands:          %s') % remote_commands)
 
     result.append('')
-    result.append('Software Channels')
+    result.append(_('Software Channels'))
     result.append('-----------------')
     result.append(base_channel.get('label'))
 
@@ -424,7 +431,7 @@ def do_kickstart_details(self, args):
 
     if advanced_options:
         result.append('')
-        result.append('Advanced Options')
+        result.append(_('Advanced Options'))
         result.append('----------------')
         for o in sorted(advanced_options, key=itemgetter('name')):
             if o.get('arguments'):
@@ -432,39 +439,39 @@ def do_kickstart_details(self, args):
 
     if custom_options:
         result.append('')
-        result.append('Custom Options')
+        result.append(_('Custom Options'))
         result.append('--------------')
         for o in sorted(custom_options, key=itemgetter('arguments')):
             result.append(re.sub('\n', '', o.get('arguments')))
 
     if partitions:
         result.append('')
-        result.append('Partitioning')
+        result.append(_('Partitioning'))
         result.append('------------')
         result.append('\n'.join(partitions))
 
     result.append('')
-    result.append('Software')
+    result.append(_('Software'))
     result.append('--------')
     result.append('\n'.join(software))
 
     if act_keys:
         result.append('')
-        result.append('Activation Keys')
+        result.append(_('Activation Keys'))
         result.append('---------------')
         for k in sorted(act_keys, key=itemgetter('key')):
             result.append(k.get('key'))
 
     if crypto_keys:
         result.append('')
-        result.append('Crypto Keys')
+        result.append(_('Crypto Keys'))
         result.append('-----------')
         for k in sorted(crypto_keys, key=itemgetter('description')):
             result.append(k.get('description'))
 
     if file_preservations:
         result.append('')
-        result.append('File Preservations')
+        result.append(_('File Preservations'))
         result.append('------------------')
         for fp in sorted(file_preservations, key=itemgetter('name')):
             result.append(fp.get('name'))
@@ -473,14 +480,14 @@ def do_kickstart_details(self, args):
 
     if variables:
         result.append('')
-        result.append('Variables')
+        result.append(_('Variables'))
         result.append('---------')
         for k in sorted(variables.keys()):
             result.append('%s = %s' % (k, str(variables[k])))
 
     if scripts:
         result.append('')
-        result.append('Scripts')
+        result.append(_('Scripts'))
         result.append('-------')
 
         add_separator = False
@@ -490,11 +497,11 @@ def do_kickstart_details(self, args):
                 result.append(self.SEPARATOR)
             add_separator = True
 
-            result.append('Type:        %s' % s.get('script_type'))
-            result.append('Chroot:      %s' % s.get('chroot'))
+            result.append(_('Type:        %s') % s.get('script_type'))
+            result.append(_('Chroot:      %s') % s.get('chroot'))
 
             if s.get('interpreter'):
-                result.append('Interpreter: %s' % s.get('interpreter'))
+                result.append(_('Interpreter: %s') % s.get('interpreter'))
 
             result.append('')
             result.append(s.get('contents'))
@@ -520,15 +527,15 @@ def kickstart_getcontents(self, profile):
             response = urlopen(url)
             kickstart = response.read()
         except HTTPError:
-            logging.error('Could not retrieve the Kickstart file')
+            logging.error(_('Could not retrieve the Kickstart file'))
 
     return kickstart
 
 
 def help_kickstart_getcontents(self):
-    print('kickstart_getcontents: Show the contents of a Kickstart profile')
-    print('                   as they would be presented to a client')
-    print('usage: kickstart_getcontents LABEL')
+    print(_('kickstart_getcontents: Show the contents of a Kickstart profile'))
+    print(_('                   as they would be presented to a client'))
+    print(_('usage: kickstart_getcontents LABEL'))
 
 
 def complete_kickstart_getcontents(self, text, line, beg, end):
@@ -562,8 +569,8 @@ def do_kickstart_getcontents(self, args):
 
 
 def help_kickstart_rename(self):
-    print('kickstart_rename: Rename a Kickstart profile')
-    print('usage: kickstart_rename OLDNAME NEWNAME')
+    print(_('kickstart_rename: Rename a Kickstart profile'))
+    print(_('usage: kickstart_rename OLDNAME NEWNAME'))
 
 
 def complete_kickstart_rename(self, text, line, beg, end):
@@ -591,9 +598,9 @@ def do_kickstart_rename(self, args):
 
 
 def help_kickstart_listcryptokeys(self):
-    print('kickstart_listcryptokeys: List the crypto keys associated ' +
-          'with a Kickstart profile')
-    print('usage: kickstart_listcryptokeys PROFILE')
+    print(_('kickstart_listcryptokeys: List the crypto keys associated ' +
+          'with a Kickstart profile'))
+    print(_('usage: kickstart_listcryptokeys PROFILE'))
 
 
 def complete_kickstart_listcryptokeys(self, text, line, beg, end):
@@ -622,14 +629,14 @@ def do_kickstart_listcryptokeys(self, args, doreturn=False):
         if keys:
             print('\n'.join(keys))
         else:
-            logging.error("No crypto keys has been found")
+            logging.error(_("No crypto keys has been found"))
 
 ####################
 
 
 def help_kickstart_addcryptokeys(self):
-    print('kickstart_addcryptokeys: Add crypto keys to a Kickstart profile')
-    print('usage: kickstart_addcryptokeys PROFILE <KEY ...>')
+    print(_('kickstart_addcryptokeys: Add crypto keys to a Kickstart profile'))
+    print(_('usage: kickstart_addcryptokeys PROFILE <KEY ...>'))
 
 
 def complete_kickstart_addcryptokeys(self, text, line, beg, end):
@@ -655,9 +662,9 @@ def do_kickstart_addcryptokeys(self, args):
 
 
 def help_kickstart_removecryptokeys(self):
-    print('kickstart_removecryptokeys: Remove crypto keys from a ' +
-          'Kickstart profile')
-    print('usage: kickstart_removecryptokeys PROFILE <KEY ...>')
+    print(_('kickstart_removecryptokeys: Remove crypto keys from a ' +
+          'Kickstart profile'))
+    print(_('usage: kickstart_removecryptokeys PROFILE <KEY ...>'))
 
 
 def complete_kickstart_removecryptokeys(self, text, line, beg, end):
@@ -697,9 +704,9 @@ def do_kickstart_removecryptokeys(self, args):
 
 
 def help_kickstart_listactivationkeys(self):
-    print('kickstart_listactivationkeys: List the activation keys ' +
-          'associated with a Kickstart profile')
-    print('usage: kickstart_listactivationkeys PROFILE')
+    print(_('kickstart_listactivationkeys: List the activation keys ' +
+          'associated with a Kickstart profile'))
+    print(_('usage: kickstart_listactivationkeys PROFILE'))
 
 
 def complete_kickstart_listactivationkeys(self, text, line, beg, end):
@@ -729,9 +736,9 @@ def do_kickstart_listactivationkeys(self, args, doreturn=False):
 
 
 def help_kickstart_addactivationkeys(self):
-    print('kickstart_addactivationkeys: Add activation keys to a ' +
-          'Kickstart profile')
-    print('usage: kickstart_addactivationkeys PROFILE <KEY ...>')
+    print(_('kickstart_addactivationkeys: Add activation keys to a ' +
+          'Kickstart profile'))
+    print(_('usage: kickstart_addactivationkeys PROFILE <KEY ...>'))
 
 
 def complete_kickstart_addactivationkeys(self, text, line, beg, end):
@@ -760,9 +767,9 @@ def do_kickstart_addactivationkeys(self, args):
 
 
 def help_kickstart_removeactivationkeys(self):
-    print('kickstart_removeactivationkeys: Remove activation keys from ' +
-          'a Kickstart profile')
-    print('usage: kickstart_removeactivationkeys PROFILE <KEY ...>')
+    print(_('kickstart_removeactivationkeys: Remove activation keys from ' +
+          'a Kickstart profile'))
+    print(_('usage: kickstart_removeactivationkeys PROFILE <KEY ...>'))
 
 
 def complete_kickstart_removeactivationkeys(self, text, line, beg,
@@ -786,7 +793,7 @@ def do_kickstart_removeactivationkeys(self, args):
 
     if len(args) > 1:
         if not self.options.yes:
-            if not self.user_confirm('Remove these keys [y/N]:'):
+            if not self.user_confirm(_('Remove these keys [y/N]:')):
                 return 1
 
         profile = args[0]
@@ -801,9 +808,9 @@ def do_kickstart_removeactivationkeys(self, args):
 
 
 def help_kickstart_enableconfigmanagement(self):
-    print('kickstart_enableconfigmanagement: Enable configuration ' +
-          'management on a Kickstart profile')
-    print('usage: kickstart_enableconfigmanagement PROFILE')
+    print(_('kickstart_enableconfigmanagement: Enable configuration ' +
+          'management on a Kickstart profile'))
+    print(_('usage: kickstart_enableconfigmanagement PROFILE'))
 
 
 def complete_kickstart_enableconfigmanagement(self, text, line, beg,
@@ -834,9 +841,9 @@ def do_kickstart_enableconfigmanagement(self, args):
 
 
 def help_kickstart_disableconfigmanagement(self):
-    print('kickstart_disableconfigmanagement: Disable configuration ' +
-          'management on a Kickstart profile')
-    print('usage: kickstart_disableconfigmanagement PROFILE')
+    print(_('kickstart_disableconfigmanagement: Disable configuration ' +
+          'management on a Kickstart profile'))
+    print(_('usage: kickstart_disableconfigmanagement PROFILE'))
 
 
 def complete_kickstart_disableconfigmanagement(self, text, line, beg,
@@ -867,9 +874,9 @@ def do_kickstart_disableconfigmanagement(self, args):
 
 
 def help_kickstart_enableremotecommands(self):
-    print('kickstart_enableremotecommands: Enable remote commands ' +
-          'on a Kickstart profile')
-    print('usage: kickstart_enableremotecommands PROFILE')
+    print(_('kickstart_enableremotecommands: Enable remote commands ' +
+          'on a Kickstart profile'))
+    print(_('usage: kickstart_enableremotecommands PROFILE'))
 
 
 def complete_kickstart_enableremotecommands(self, text, line, beg,
@@ -900,9 +907,9 @@ def do_kickstart_enableremotecommands(self, args):
 
 
 def help_kickstart_disableremotecommands(self):
-    print('kickstart_disableremotecommands: Disable remote commands ' +
-          'on a Kickstart profile')
-    print('usage: kickstart_disableremotecommands PROFILE')
+    print(_('kickstart_disableremotecommands: Disable remote commands ' +
+          'on a Kickstart profile'))
+    print(_('usage: kickstart_disableremotecommands PROFILE'))
 
 
 def complete_kickstart_disableremotecommands(self, text, line, beg, end):
@@ -932,8 +939,8 @@ def do_kickstart_disableremotecommands(self, args):
 
 
 def help_kickstart_setlocale(self):
-    print('kickstart_setlocale: Set the locale for a Kickstart profile')
-    print('usage: kickstart_setlocale PROFILE LOCALE')
+    print(_('kickstart_setlocale: Set the locale for a Kickstart profile'))
+    print(_('usage: kickstart_setlocale PROFILE LOCALE'))
 
 
 def complete_kickstart_setlocale(self, text, line, beg, end):
@@ -971,9 +978,9 @@ def do_kickstart_setlocale(self, args):
 
 
 def help_kickstart_setselinux(self):
-    print('kickstart_setselinux: Set the SELinux mode for a Kickstart ' +
-          'profile')
-    print('usage: kickstart_setselinux PROFILE MODE')
+    print(_('kickstart_setselinux: Set the SELinux mode for a Kickstart ' +
+          'profile'))
+    print(_('usage: kickstart_setselinux PROFILE MODE'))
 
 
 def complete_kickstart_setselinux(self, text, line, beg, end):
@@ -1008,9 +1015,9 @@ def do_kickstart_setselinux(self, args):
 
 
 def help_kickstart_setpartitions(self):
-    print('kickstart_setpartitions: Set the partitioning scheme for a ' +
-          'Kickstart profile')
-    print('usage: kickstart_setpartitions PROFILE')
+    print(_('kickstart_setpartitions: Set the partitioning scheme for a ' +
+          'Kickstart profile'))
+    print(_('usage: kickstart_setpartitions PROFILE'))
 
 
 def complete_kickstart_setpartitions(self, text, line, beg, end):
@@ -1059,9 +1066,9 @@ def do_kickstart_setpartitions(self, args):
 
 
 def help_kickstart_setdistribution(self):
-    print('kickstart_setdistribution: Set the distribution for a ' +
-          'Kickstart profile')
-    print('usage: kickstart_setdistribution PROFILE DISTRIBUTION')
+    print(_('kickstart_setdistribution: Set the distribution for a ' +
+          'Kickstart profile'))
+    print(_('usage: kickstart_setdistribution PROFILE DISTRIBUTION'))
 
 
 def complete_kickstart_setdistribution(self, text, line, beg, end):
@@ -1095,8 +1102,8 @@ def do_kickstart_setdistribution(self, args):
 
 
 def help_kickstart_enablelogging(self):
-    print('kickstart_enablelogging: Enable logging for a Kickstart profile')
-    print('usage: kickstart_enablelogging PROFILE')
+    print(_('kickstart_enablelogging: Enable logging for a Kickstart profile'))
+    print(_('usage: kickstart_enablelogging PROFILE'))
 
 
 def complete_kickstart_enablelogging(self, text, line, beg, end):
@@ -1128,8 +1135,8 @@ def do_kickstart_enablelogging(self, args):
 
 
 def help_kickstart_addvariable(self):
-    print('kickstart_addvariable: Add a variable to a Kickstart profile')
-    print('usage: kickstart_addvariable PROFILE KEY VALUE')
+    print(_('kickstart_addvariable: Add a variable to a Kickstart profile'))
+    print(_('usage: kickstart_addvariable PROFILE KEY VALUE'))
 
 
 def complete_kickstart_addvariable(self, text, line, beg, end):
@@ -1167,9 +1174,9 @@ def do_kickstart_addvariable(self, args):
 
 
 def help_kickstart_updatevariable(self):
-    print('kickstart_updatevariable: Update a variable in a Kickstart ' +
-          'profile')
-    print('usage: kickstart_updatevariable PROFILE KEY VALUE')
+    print(_('kickstart_updatevariable: Update a variable in a Kickstart ' +
+          'profile'))
+    print(_('usage: kickstart_updatevariable PROFILE KEY VALUE'))
 
 
 def complete_kickstart_updatevariable(self, text, line, beg, end):
@@ -1204,9 +1211,9 @@ def do_kickstart_updatevariable(self, args):
 
 
 def help_kickstart_removevariables(self):
-    print('kickstart_removevariables: Remove variables from a ' +
-          'Kickstart profile')
-    print('usage: kickstart_removevariables PROFILE <KEY ...>')
+    print(_('kickstart_removevariables: Remove variables from a ' +
+          'Kickstart profile'))
+    print(_('usage: kickstart_removevariables PROFILE <KEY ...>'))
 
 
 def complete_kickstart_removevariables(self, text, line, beg, end):
@@ -1255,9 +1262,9 @@ def do_kickstart_removevariables(self, args):
 
 
 def help_kickstart_listvariables(self):
-    print('kickstart_listvariables: List the variables of a Kickstart ' +
-          'profile')
-    print('usage: kickstart_listvariables PROFILE')
+    print(_('kickstart_listvariables: List the variables of a Kickstart ' +
+          'profile'))
+    print(_('usage: kickstart_listvariables PROFILE'))
 
 
 def complete_kickstart_listvariables(self, text, line, beg, end):
@@ -1290,8 +1297,8 @@ def do_kickstart_listvariables(self, args):
 
 
 def help_kickstart_addoption(self):
-    print('kickstart_addoption: Set an option for a Kickstart profile')
-    print('usage: kickstart_addoption PROFILE KEY [VALUE]')
+    print(_('kickstart_addoption: Set an option for a Kickstart profile'))
+    print(_('usage: kickstart_addoption PROFILE KEY [VALUE]'))
 
 
 def complete_kickstart_addoption(self, text, line, beg, end):
@@ -1338,7 +1345,7 @@ def do_kickstart_addoption(self, args):
                                                          profile,
                                                          advanced)
     else:
-        logging.warning('%s needs to be set as a custom option' % key)
+        logging.warning(_('%s needs to be set as a custom option') % key)
 
     return 0
 
@@ -1346,8 +1353,8 @@ def do_kickstart_addoption(self, args):
 
 
 def help_kickstart_removeoptions(self):
-    print('kickstart_removeoptions: Remove options from a Kickstart profile')
-    print('usage: kickstart_removeoptions PROFILE <OPTION ...>')
+    print(_('kickstart_removeoptions: Remove options from a Kickstart profile'))
+    print(_('usage: kickstart_removeoptions PROFILE <OPTION ...>'))
 
 
 def complete_kickstart_removeoptions(self, text, line, beg, end):
@@ -1399,9 +1406,9 @@ def do_kickstart_removeoptions(self, args):
 
 
 def help_kickstart_listoptions(self):
-    print('kickstart_listoptions: List the options of a Kickstart ' +
-          'profile')
-    print('usage: kickstart_listoptions PROFILE')
+    print(_('kickstart_listoptions: List the options of a Kickstart ' +
+          'profile'))
+    print(_('usage: kickstart_listoptions PROFILE'))
 
 
 def complete_kickstart_listoptions(self, text, line, beg, end):
@@ -1435,9 +1442,9 @@ def do_kickstart_listoptions(self, args):
 
 
 def help_kickstart_listcustomoptions(self):
-    print('kickstart_listcustomoptions: List the custom options of a ' +
-          'Kickstart profile')
-    print('usage: kickstart_listcustomoptions PROFILE')
+    print(_('kickstart_listcustomoptions: List the custom options of a ' +
+          'Kickstart profile'))
+    print(_('usage: kickstart_listcustomoptions PROFILE'))
 
 
 def complete_kickstart_listcustomoptions(self, text, line, beg, end):
@@ -1471,9 +1478,9 @@ def do_kickstart_listcustomoptions(self, args):
 
 
 def help_kickstart_setcustomoptions(self):
-    print('kickstart_setcustomoptions: Set custom options for a ' +
-          'Kickstart profile')
-    print('usage: kickstart_setcustomoptions PROFILE')
+    print(_('kickstart_setcustomoptions: Set custom options for a ' +
+          'Kickstart profile'))
+    print(_('usage: kickstart_setcustomoptions PROFILE'))
 
 
 def complete_kickstart_setcustomoptions(self, text, line, beg, end):
@@ -1521,9 +1528,9 @@ def do_kickstart_setcustomoptions(self, args):
 
 
 def help_kickstart_addchildchannels(self):
-    print('kickstart_addchildchannels: Add a child channels to a ' +
-          'Kickstart profile')
-    print('usage: kickstart_addchildchannels PROFILE <CHANNEL ...>')
+    print(_('kickstart_addchildchannels: Add a child channels to a ' +
+          'Kickstart profile'))
+    print(_('usage: kickstart_addchildchannels PROFILE <CHANNEL ...>'))
 
 
 def complete_kickstart_addchildchannels(self, text, line, beg, end):
@@ -1581,9 +1588,9 @@ def do_kickstart_addchildchannels(self, args):
 
 
 def help_kickstart_removechildchannels(self):
-    print('kickstart_removechildchannels: Remove child channels from ' +
-          'a Kickstart profile')
-    print('usage: kickstart_removechildchannels PROFILE <CHANNEL ...>')
+    print(_('kickstart_removechildchannels: Remove child channels from ' +
+          'a Kickstart profile'))
+    print(_('usage: kickstart_removechildchannels PROFILE <CHANNEL ...>'))
 
 
 def complete_kickstart_removechildchannels(self, text, line, beg,
@@ -1626,9 +1633,9 @@ def do_kickstart_removechildchannels(self, args):
 
 
 def help_kickstart_listchildchannels(self):
-    print('kickstart_listchildchannels: List the child channels of a ' +
-          'Kickstart profile')
-    print('usage: kickstart_listchildchannels PROFILE')
+    print(_('kickstart_listchildchannels: List the child channels of a ' +
+          'Kickstart profile'))
+    print(_('usage: kickstart_listchildchannels PROFILE'))
 
 
 def complete_kickstart_listchildchannels(self, text, line, beg, end):
@@ -1662,9 +1669,9 @@ def do_kickstart_listchildchannels(self, args, doreturn=False):
 
 
 def help_kickstart_addfilepreservations(self):
-    print('kickstart_addfilepreservations: Add file preservations to a ' +
-          'Kickstart profile')
-    print('usage: kickstart_addfilepreservations PROFILE <FILELIST ...>')
+    print(_('kickstart_addfilepreservations: Add file preservations to a ' +
+          'Kickstart profile'))
+    print(_('usage: kickstart_addfilepreservations PROFILE <FILELIST ...>'))
 
 
 def complete_kickstart_addfilepreservations(self, text, line, beg, end):
@@ -1699,9 +1706,9 @@ def do_kickstart_addfilepreservations(self, args):
 
 
 def help_kickstart_removefilepreservations(self):
-    print('kickstart_removefilepreservations: Remove file ' +
-          'preservations from a Kickstart profile')
-    print('usage: kickstart_removefilepreservations PROFILE <FILE ...>')
+    print(_('kickstart_removefilepreservations: Remove file ' +
+          'preservations from a Kickstart profile'))
+    print(_('usage: kickstart_removefilepreservations PROFILE <FILE ...>'))
 
 
 def complete_kickstart_removefilepreservations(self, text, line, beg,
@@ -1746,9 +1753,9 @@ def do_kickstart_removefilepreservations(self, args):
 
 
 def help_kickstart_listpackages(self):
-    print('kickstart_listpackages: List the packages for a Kickstart ' +
-          'profile')
-    print('usage: kickstart_listpackages PROFILE')
+    print(_('kickstart_listpackages: List the packages for a Kickstart ' +
+          'profile'))
+    print(_('usage: kickstart_listpackages PROFILE'))
 
 
 def complete_kickstart_listpackages(self, text, line, beg, end):
@@ -1780,8 +1787,8 @@ def do_kickstart_listpackages(self, args, doreturn=False):
 
 
 def help_kickstart_addpackages(self):
-    print('kickstart_addpackages: Add packages to a Kickstart profile')
-    print('usage: kickstart_addpackages PROFILE <PACKAGE ...>')
+    print(_('kickstart_addpackages: Add packages to a Kickstart profile'))
+    print(_('usage: kickstart_addpackages PROFILE <PACKAGE ...>'))
 
 
 def complete_kickstart_addpackages(self, text, line, beg, end):
@@ -1814,9 +1821,9 @@ def do_kickstart_addpackages(self, args):
 
 
 def help_kickstart_removepackages(self):
-    print('kickstart_removepackages: Remove packages from a Kickstart ' +
-          'profile')
-    print('usage: kickstart_removepackages PROFILE <PACKAGE ...>')
+    print(_('kickstart_removepackages: Remove packages from a Kickstart ' +
+          'profile'))
+    print(_('usage: kickstart_removepackages PROFILE <PACKAGE ...>'))
 
 
 def complete_kickstart_removepackages(self, text, line, beg, end):
@@ -1859,9 +1866,9 @@ def do_kickstart_removepackages(self, args):
 
 
 def help_kickstart_listscripts(self):
-    print('kickstart_listscripts: List the scripts for a Kickstart ' +
-          'profile')
-    print('usage: kickstart_listscripts PROFILE')
+    print(_('kickstart_listscripts: List the scripts for a Kickstart ' +
+          'profile'))
+    print(_('usage: kickstart_listscripts PROFILE'))
 
 
 def complete_kickstart_listscripts(self, text, line, beg, end):
@@ -1880,7 +1887,7 @@ def do_kickstart_listscripts(self, args):
     profile = args[0]
     scripts = self.client.kickstart.profile.listScripts(self.session, profile)
     if not scripts:
-        logging.error("No scripts has been found for profile '%s'", profile)
+        logging.error(_("No scripts has been found for profile '%s'"), profile)
     else:
         add_separator = False
         for script in scripts:
@@ -1888,12 +1895,12 @@ def do_kickstart_listscripts(self, args):
                 print(self.SEPARATOR)
             add_separator = True
 
-            print('ID:          %i' % script.get('id'))
-            print('Type:        %s' % script.get('script_type'))
-            print('Chroot:      %s' % script.get('chroot'))
-            print('Interpreter: %s' % script.get('interpreter'))
+            print(_('ID:          %i') % script.get('id'))
+            print(_('Type:        %s') % script.get('script_type'))
+            print(_('Chroot:      %s') % script.get('chroot'))
+            print(_('Interpreter: %s') % script.get('interpreter'))
             print('')
-            print('Contents')
+            print(_('Contents'))
             print('--------')
             print(script.get('contents'))
 
@@ -1903,8 +1910,8 @@ def do_kickstart_listscripts(self, args):
 
 
 def help_kickstart_addscript(self):
-    print('kickstart_addscript: Add a script to a Kickstart profile')
-    print('''usage: kickstart_addscript PROFILE [options])
+    print(_('kickstart_addscript: Add a script to a Kickstart profile'))
+    print(_('''usage: kickstart_addscript PROFILE [options])
 
 options:
   -p PROFILE
@@ -1912,7 +1919,7 @@ options:
   -i INTERPRETER
   -f FILE
   -c execute in a chroot environment
-  -t ENABLING_TEMPLATING''')
+  -t ENABLING_TEMPLATING'''))
 
 
 def complete_kickstart_addscript(self, text, line, beg, end):
@@ -1937,16 +1944,16 @@ def do_kickstart_addscript(self, args):
         if args:
             options.profile = args[0]
         else:
-            options.profile = prompt_user('Profile Name:', noblank=True)
+            options.profile = prompt_user(_('Profile Name:'), noblank=True)
 
-        options.execution_time = prompt_user('Pre/Post Script [post]:')
-        options.chroot = prompt_user('Chrooted [Y/n]:')
-        options.interpreter = prompt_user('Interpreter [/bin/bash]:')
+        options.execution_time = prompt_user(_('Pre/Post Script [post]:'))
+        options.chroot = prompt_user(_('Chrooted [Y/n]:'))
+        options.interpreter = prompt_user(_('Interpreter [/bin/bash]:'))
 
         # get the contents of the script
-        if self.user_confirm('Read an existing file [y/N]:',
+        if self.user_confirm(_('Read an existing file [y/N]:'),
                              nospacer=True, ignore_yes=True):
-            options.file = prompt_user('File:')
+            options.file = prompt_user(_('File:'))
         else:
             (options.contents, _ignore) = editor(delete=True)
 
@@ -1970,15 +1977,15 @@ def do_kickstart_addscript(self, args):
             options.execution_time = 'post'
     else:
         if not options.profile:
-            logging.error('The Kickstart name is required')
+            logging.error(_('The Kickstart name is required'))
             return 1
 
         if not options.file:
-            logging.error('A filename is required')
+            logging.error(_('A filename is required'))
             return 1
 
         if not options.execution_time:
-            logging.error('The execution time is required')
+            logging.error(_('The execution time is required'))
             return 1
 
         if not options.chroot:
@@ -1994,12 +2001,12 @@ def do_kickstart_addscript(self, args):
         options.contents = read_file(options.file)
 
     print('')
-    print('Profile Name:   %s' % options.profile)
-    print('Execution Time: %s' % options.execution_time)
-    print('Chroot:         %s' % options.chroot)
-    print('Template:       %s' % options.template)
-    print('Interpreter:    %s' % options.interpreter)
-    print('Contents:')
+    print(_('Profile Name:   %s') % options.profile)
+    print(_('Execution Time: %s') % options.execution_time)
+    print(_('Chroot:         %s') % options.chroot)
+    print(_('Template:       %s') % options.template)
+    print(_('Interpreter:    %s') % options.interpreter)
+    print(_('Contents:'))
     print(options.contents)
 
     if not self.user_confirm():
@@ -2019,8 +2026,8 @@ def do_kickstart_addscript(self, args):
 
 
 def help_kickstart_removescript(self):
-    print('kickstart_removescript: Remove a script from a Kickstart profile')
-    print('usage: kickstart_removescript PROFILE [ID]')
+    print(_('kickstart_removescript: Remove a script from a Kickstart profile'))
+    print(_('usage: kickstart_removescript PROFILE [ID]'))
 
 
 def complete_kickstart_removescript(self, text, line, beg, end):
@@ -2048,7 +2055,7 @@ def do_kickstart_removescript(self, args):
         try:
             script_id = int(args[1])
         except ValueError:
-            logging.error('Invalid script ID')
+            logging.error(_('Invalid script ID'))
 
     # print(the scripts for the user to review)
     self.do_kickstart_listscripts(profile)
@@ -2056,14 +2063,14 @@ def do_kickstart_removescript(self, args):
     if not script_id:
         while script_id == 0:
             print('')
-            userinput = prompt_user('Script ID:', noblank=True)
+            userinput = prompt_user(_('Script ID:'), noblank=True)
 
             try:
                 script_id = int(userinput)
             except ValueError:
-                logging.error('Invalid script ID')
+                logging.error(_('Invalid script ID'))
 
-    if not self.user_confirm('Remove this script [y/N]:'):
+    if not self.user_confirm(_('Remove this script [y/N]:')):
         return 1
 
     self.client.kickstart.profile.removeScript(self.session,
@@ -2076,12 +2083,12 @@ def do_kickstart_removescript(self, args):
 
 
 def help_kickstart_clone(self):
-    print('kickstart_clone: Clone a Kickstart profile')
-    print('''usage: kickstart_clone [options])
+    print(_('kickstart_clone: Clone a Kickstart profile'))
+    print(_('''usage: kickstart_clone [options])
 
 options:
   -n NAME
-  -c CLONE_NAME''')
+  -c CLONE_NAME'''))
 
 
 def complete_kickstart_clone(self, text, line, beg, end):
@@ -2098,30 +2105,30 @@ def do_kickstart_clone(self, args):
 
     if is_interactive(options):
         if not profiles:
-            logging.error("No kickstart profiles available")
+            logging.error(_("No kickstart profiles available"))
             return 1
 
         print('')
-        print('Kickstart Profiles')
+        print(_('Kickstart Profiles'))
         print('------------------')
         print('\n'.join(profiles))
         print('')
 
-        options.name = prompt_user('Original Profile:', noblank=True)
-        options.clonename = prompt_user('Cloned Profile:', noblank=True)
+        options.name = prompt_user(_('Original Profile:'), noblank=True)
+        options.clonename = prompt_user(_('Cloned Profile:'), noblank=True)
     else:
 
         if not options.name:
-            logging.error('The Kickstart name is required')
+            logging.error(_('The Kickstart name is required'))
             return 1
 
         if not options.clonename:
-            logging.error('The Kickstart clone name is required')
+            logging.error(_('The Kickstart clone name is required'))
             return 1
 
     args.append(options.name)
     if not filter_results(profiles, args):
-        logging.error("Kickstart profile you've entered was not found")
+        logging.error(_("Kickstart profile you've entered was not found"))
         return 1
 
     self.client.kickstart.cloneProfile(self.session,
@@ -2134,15 +2141,15 @@ def do_kickstart_clone(self, args):
 
 
 def help_kickstart_export(self):
-    print('kickstart_export: export kickstart profile(s) to json format file')
-    print('''usage: kickstart_export <KSPROFILE>... [options])
+    print(_('kickstart_export: export kickstart profile(s) to json format file'))
+    print(_('''usage: kickstart_export <KSPROFILE>... [options])
 options:
     -f outfile.json : specify an output filename, defaults to <KSPROFILE>.json
                       if exporting a single kickstart, profiles.json for multiple
                       kickstarts, or ks_all.json if no KSPROFILE specified
                       e.g (export ALL)
 
-Note : KSPROFILE list is optional, default is to export ALL''')
+Note : KSPROFILE list is optional, default is to export ALL'''))
 
 
 def complete_kickstart_export(self, text, line, beg, end):
@@ -2261,7 +2268,7 @@ def do_kickstart_export(self, args):
     if not args:
         if not filename:
             filename = "ks_all.json"
-        logging.info("Exporting ALL kickstart profiles to %s" % filename)
+        logging.info(_("Exporting ALL kickstart profiles to %s") % filename)
         profiles = self.do_kickstart_list('', True)
     else:
         # allow globbing of kickstart kickstart names
@@ -2269,8 +2276,8 @@ def do_kickstart_export(self, args):
         logging.debug("kickstart_export called with args %s, profiles=%s" %
                       (args, profiles))
         if not profiles:
-            logging.error("Error, no valid kickstart profile passed, " +
-                          "check name is  correct with spacecmd kickstart_list")
+            logging.error(_("Error, no valid kickstart profile passed, " +
+                          "check name is  correct with spacecmd kickstart_list"))
             return 1
         if not filename:
             # No filename arg, so we try to do something sensible:
@@ -2289,18 +2296,18 @@ def do_kickstart_export(self, args):
     # Dump as a list of dict
     ksdetails_list = []
     for p in profiles:
-        logging.info("Exporting ks %s to %s" % (p, filename))
+        logging.info(_("Exporting ks %s to %s") % (p, filename))
         ksdetails_list.append(self.export_kickstart_getdetails(p, kickstarts))
 
     logging.debug("About to dump %d ks profiles to %s" %
                   (len(ksdetails_list), filename))
     # Check if filepath exists, if an existing file we prompt for confirmation
     if os.path.isfile(filename):
-        if not self.user_confirm("File %s exists, " % filename +
-                                 "confirm overwrite file? (y/n)"):
+        if not self.user_confirm(_("File %s exists, ") % filename +
+                                 _("confirm overwrite file? (y/n)")):
             return 1
     if json_dump_to_file(ksdetails_list, filename) != True:
-        logging.error("Error saving exported kickstart profiles to file" %
+        logging.error(_("Error saving exported kickstart profiles to file") %
                       filename)
         return 1
 
@@ -2310,8 +2317,8 @@ def do_kickstart_export(self, args):
 
 
 def help_kickstart_importjson(self):
-    print('kickstart_import: import kickstart profile(s) from json file')
-    print('''usage: kickstart_import <JSONFILES...>''')
+    print(_('kickstart_import: import kickstart profile(s) from json file'))
+    print(_('''usage: kickstart_import <JSONFILES...>'''))
 
 
 def do_kickstart_importjson(self, args):
@@ -2320,7 +2327,7 @@ def do_kickstart_importjson(self, args):
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
-        logging.error("Error, no filename passed")
+        logging.error(_("Error, no filename passed"))
         self.help_kickstart_import()
         return 1
 
@@ -2328,11 +2335,11 @@ def do_kickstart_importjson(self, args):
         logging.debug("Passed filename do_kickstart_import %s" % filename)
         ksdetails_list = json_read_from_file(filename)
         if not ksdetails_list:
-            logging.error("Error, could not read json data from %s" % filename)
+            logging.error(_("Error, could not read json data from %s") % filename)
             return 1
         for ksdetails in ksdetails_list:
             if self.import_kickstart_fromdetails(ksdetails) != True:
-                logging.error("Error importing kickstart %s" %
+                logging.error(_("Error importing kickstart %s") %
                               ksdetails['name'])
 
     return 0
@@ -2345,11 +2352,11 @@ def import_kickstart_fromdetails(self, ksdetails):
     # First we check that an existing kickstart with the same name does not exist
     existing_profiles = self.do_kickstart_list('', True)
     if ksdetails['name'] in existing_profiles:
-        logging.error("ERROR : kickstart profile %s already exists! Skipping!"
+        logging.error(_("ERROR : kickstart profile %s already exists! Skipping!")
                       % ksdetails['name'])
         return False
     # create the ks, we need to drop the org prefix from the ks name
-    logging.info("Found ks %s" % ksdetails['name'])
+    logging.info(_("Found ks %s") % ksdetails['name'])
 
     # Create the kickstart
     # for adding new profiles, we require a root password.
@@ -2405,7 +2412,7 @@ def import_kickstart_fromdetails(self, ksdetails):
         if ret:
             logging.debug("Added %s script to profile" % script['script_type'])
         else:
-            logging.error("Error adding %s script" % script['script_type'])
+            logging.error(_("Error adding %s script") % script['script_type'])
     # Specify ip ranges
     for iprange in ksdetails['ip_ranges']:
         if self.client.kickstart.profile.addIpRange(self.session,
@@ -2413,7 +2420,7 @@ def import_kickstart_fromdetails(self, ksdetails):
             logging.debug("added ip range %s-%s" %
                           iprange['min'], iprange['max'])
         else:
-            logging.warning("failed to add ip range %s-%s, continuing" %
+            logging.warning(_("failed to add ip range %s-%s, continuing") %
                             iprange['min'], iprange['max'])
             continue
     # File preservations, only if the list exists
@@ -2427,9 +2434,9 @@ def import_kickstart_fromdetails(self, ksdetails):
                         self.session, ksdetails['label'], [fp]):
                     logging.debug("added file preservation '%s'" % fp)
                 else:
-                    logging.warning("failed to add file preservation %s, skipping" % fp)
+                    logging.warning(_("failed to add file preservation %s, skipping") % fp)
             else:
-                logging.warning("file preservation list %s doesn't exist, skipping" % fp)
+                logging.warning(_("file preservation list %s doesn't exist, skipping") % fp)
 
     # Now add activationkeys, only if they exist
     existing_act_keys = [k['key'] for k in
@@ -2440,8 +2447,8 @@ def import_kickstart_fromdetails(self, ksdetails):
             self.client.kickstart.profile.keys.addActivationKey(self.session,
                                                                 ksdetails['label'], akey)
         else:
-            logging.warning("Actvationkey %s does not exist on the " % akey +
-                            "satellite, skipping")
+            logging.warning(_("Actvationkey %s does not exist on the ") % akey +
+                            ("satellite, skipping"))
 
     # The GPG/SSL keys, only if they exist
     existing_gpg_ssl_keys = [x['description'] for x in self.client.kickstart.keys.listAllKeys(self.session)]
@@ -2451,8 +2458,8 @@ def import_kickstart_fromdetails(self, ksdetails):
             self.client.kickstart.profile.system.addKeys(self.session,
                                                          ksdetails['label'], [key])
         else:
-            logging.warning("GPG/SSL key %s does not exist on the " % key +
-                            "satellite, skipping")
+            logging.warning(_("GPG/SSL key %s does not exist on the ") % key +
+                            _("satellite, skipping"))
 
     # The pre/post logging settings
     self.client.kickstart.profile.setLogging(self.session, ksdetails['label'],
@@ -2461,20 +2468,20 @@ def import_kickstart_fromdetails(self, ksdetails):
     # There are some frustrating ommisions from the API which means we can't
     # export/import some settings, so we post a warning that some manual
     # fixup may be required
-    logging.warning("Due to API ommissions, there are some settings which" +
-                    " cannot be imported, please check and fixup manually if necessary")
-    logging.warning(" * Details->Preserve ks.cfg")
-    logging.warning(" * Details->Comment")
+    logging.warning(_("Due to API ommissions, there are some settings which" +
+                    " cannot be imported, please check and fixup manually if necessary"))
+    logging.warning(_(" * Details->Preserve ks.cfg"))
+    logging.warning(_(" * Details->Comment"))
     # Org default gets exported but no way to set it, so we can just show this
     # warning if they are trying to import an org_default profile
     if ksdetails['org_default']:
-        logging.warning(" * Details->Organization Default Profile")
+        logging.warning(_(" * Details->Organization Default Profile"))
     # No way to set the kernel options
-    logging.warning(" * Details->Kernel Options")
+    logging.warning(_(" * Details->Kernel Options"))
     # We can export Post kernel options (sort of, see above)
     # if they exist on import, flag a warning
     if 'post_kopts' in ksdetails:
-        logging.warning(" * Details->Post Kernel Options : %s" %
+        logging.warning(_(" * Details->Post Kernel Options : %s") %
                         ksdetails['post_kopts'])
     return True
 
@@ -2490,10 +2497,10 @@ def is_kickstart(self, name):
 
 def check_kickstart(self, name):
     if not name:
-        logging.error("no kickstart label given")
+        logging.error(_("no kickstart label given"))
         return False
     if not self.is_kickstart(name):
-        logging.error("invalid kickstart label " + name)
+        logging.error(_("invalid kickstart label ") + name)
         return False
     return True
 
@@ -2510,9 +2517,9 @@ def dump_kickstart(self, name, replacedict=None, excludes=None):
 
 
 def help_kickstart_diff(self):
-    print('kickstart_diff: diff kickstart files')
+    print(_('kickstart_diff: diff kickstart files'))
     print('')
-    print('usage: kickstart_diff SOURCE_CHANNEL TARGET_CHANNEL')
+    print(_('usage: kickstart_diff SOURCE_CHANNEL TARGET_CHANNEL'))
 
 
 def complete_kickstart_diff(self, text, line, beg, end):
@@ -2561,10 +2568,10 @@ def do_kickstart_diff(self, args):
 
 
 def help_kickstart_getupdatetype(self):
-    print('kickstart_getupdatetype: Get the update type for a kickstart profile(s)')
-    print('usage: kickstart_getupdatetype PROFILE')
-    print('usage: kickstart_getupdatetype PROFILE1 PROFILE2')
-    print('usage: kickstart_getupdatetype \"PROF*\"')
+    print(_('kickstart_getupdatetype: Get the update type for a kickstart profile(s)'))
+    print(_('usage: kickstart_getupdatetype PROFILE'))
+    print(_('usage: kickstart_getupdatetype PROFILE1 PROFILE2'))
+    print(_('usage: kickstart_getupdatetype \"PROF*\"'))
 
 
 def complete_kickstart_getupdatetype(self, text, line, beg, end):
@@ -2587,13 +2594,13 @@ def do_kickstart_getupdatetype(self, args):
     logging.debug("Got labels to list the update type %s" % labels)
 
     if not labels:
-        logging.error("No valid kickstart labels passed as arguments!")
+        logging.error(_("No valid kickstart labels passed as arguments!"))
         self.help_kickstart_getupdatetype()
         return 1
 
     for label in labels:
         if not label in all_labels:
-            logging.error("kickstart label %s doesn't exist!" % label)
+            logging.error(_("kickstart label %s doesn't exist!") % label)
             continue
 
         updatetype = self.client.kickstart.profile.getUpdateType(self.session, label)
@@ -2609,11 +2616,11 @@ def do_kickstart_getupdatetype(self, args):
 
 
 def help_kickstart_setupdatetype(self):
-    print('kickstart_setupdatetype: Set the update type for a kickstart profile(s)')
-    print('''usage: kickstart_setupdatetype [options] KS_LABEL)
+    print(_('kickstart_setupdatetype: Set the update type for a kickstart profile(s)'))
+    print(_('''usage: kickstart_setupdatetype [options] KS_LABEL)
 
 options:
-    -u UPDATE_TYPE ['red_hat', 'all', 'none']''')
+    -u UPDATE_TYPE ['red_hat', 'all', 'none']'''))
 
 
 def do_kickstart_setupdatetype(self, args):
@@ -2624,12 +2631,12 @@ def do_kickstart_setupdatetype(self, args):
 
     if is_interactive(options):
 
-        print('Update Types')
+        print(_('Update Types'))
         print('--------------------')
         print('\n'.join(sorted(self.UPDATE_TYPES)))
         print('')
 
-        options.update_type = prompt_user('Update Type [none]:')
+        options.update_type = prompt_user(_('Update Type [none]:'))
         if options.update_type == '' or options.update_type not in self.UPDATE_TYPES:
             options.update_type = 'none'
 
@@ -2643,13 +2650,13 @@ def do_kickstart_setupdatetype(self, args):
     logging.debug("Got labels to set the update type %s" % labels)
 
     if not labels:
-        logging.error("No valid kickstart labels passed as arguments!")
+        logging.error(_("No valid kickstart labels passed as arguments!"))
         self.help_kickstart_setupdatetype()
         return 1
 
     for label in labels:
         if not label in all_labels:
-            logging.error("kickstart label %s doesn't exist!" % label)
+            logging.error(_("kickstart label %s doesn't exist!") % label)
             continue
 
         self.client.kickstart.profile.setUpdateType(self.session, label, options.update_type)
@@ -2660,9 +2667,9 @@ def do_kickstart_setupdatetype(self, args):
 
 
 def help_kickstart_getsoftwaredetails(self):
-    print('kickstart_getsoftwaredetails: Gets kickstart profile software details')
-    print('usage: kickstart_getsoftwaredetails KS_LABEL')
-    print('usage: kickstart_getsoftwaredetails KS_LABEL KS_LABEL2 ...')
+    print(_('kickstart_getsoftwaredetails: Gets kickstart profile software details'))
+    print(_('usage: kickstart_getsoftwaredetails KS_LABEL'))
+    print(_('usage: kickstart_getsoftwaredetails KS_LABEL KS_LABEL2 ...'))
 
 
 def complete_kickstart_getsoftwaredetails(self, text, line, beg, end):
@@ -2685,24 +2692,24 @@ def do_kickstart_getsoftwaredetails(self, args):
     logging.debug("Got labels to set the update type %s" % labels)
 
     if not labels:
-        logging.error("No valid kickstart labels passed as arguments!")
+        logging.error(_("No valid kickstart labels passed as arguments!"))
         self.help_kickstart_getsoftwaredetails()
         return 1
 
     for label in labels:
         if not label in all_labels:
-            logging.error("kickstart label %s doesn't exist!" % label)
+            logging.error(_("kickstart label %s doesn't exist!") % label)
             continue
 
         software_details = self.client.kickstart.profile.software.getSoftwareDetails(self.session, label)
 
         if len(labels) == 1:
-            print("noBase:        %s" % software_details.get("noBase"))
-            print("ignoreMissing: %s" % software_details.get("ignoreMissing"))
+            print(_("noBase:        %s") % software_details.get("noBase"))
+            print(_("ignoreMissing: %s") % software_details.get("ignoreMissing"))
         elif len(labels) > 1:
-            print("Kickstart Label: %s" % label)
-            print("noBase:          %s" % software_details.get("noBase"))
-            print("ignoreMissing:   %s" % software_details.get("ignoreMissing"))
+            print(_("Kickstart Label: %s") % label)
+            print(_("noBase:          %s") % software_details.get("noBase"))
+            print(_("ignoreMissing:   %s") % software_details.get("ignoreMissing"))
             print('')
 
     return 0
@@ -2711,9 +2718,9 @@ def do_kickstart_getsoftwaredetails(self, args):
 
 
 def help_kickstart_setsoftwaredetails(self):
-    print('kickstart_setsoftwaredetails: Sets kickstart profile software details.')
-    print('usage: kickstart_setsoftwaredetails PROFILE KICKSTART_PACKAGES_INFO VALUE')
-    print('usage: kickstart_setsoftwaredetails PROFILE KICKSTART_PACKAGES_INFO VALUE KICKSTART_PACKAGES_INFO VALUE')
+    print(_('kickstart_setsoftwaredetails: Sets kickstart profile software details.'))
+    print(_('usage: kickstart_setsoftwaredetails PROFILE KICKSTART_PACKAGES_INFO VALUE'))
+    print(_('usage: kickstart_setsoftwaredetails PROFILE KICKSTART_PACKAGES_INFO VALUE KICKSTART_PACKAGES_INFO VALUE'))
 
 def complete_kickstart_setsoftwaredetails(self, text, line, beg, end):
     parts = line.split(' ')
@@ -2747,15 +2754,15 @@ def do_kickstart_setsoftwaredetails(self, args):
         return 1
 
     if args[0] not in self.do_kickstart_list('', True):
-        print("Selected profile does not exist")
+        print(_("Selected profile does not exist"))
         return 1
     if args[1] not in kspkginfo or args[2] not in mode:
-        print("Enter valid input")
+        print(_("Enter valid input"))
         self.help_kickstart_setsoftwaredetails()
         return 1
     if length==5:
         if (args[3] not in kspkginfo or args[4] not in mode) or args[1] == args[3]:
-            print("Enter valid input")
+            print(_("Enter valid input"))
             self.help_kickstart_setsoftwaredetails()
             return 1
 

--- a/spacecmd/src/spacecmd/misc.py
+++ b/spacecmd/src/spacecmd/misc.py
@@ -30,6 +30,7 @@
 # invalid function name
 # pylint: disable=C0103
 
+import gettext
 import logging
 import readline
 import shlex
@@ -46,16 +47,22 @@ except ImportError: # python2
     import xmlrpclib
 from spacecmd.utils import *
 
+translation = gettext.translation('spacecmd', fallback=True)
+try:
+    _ = translation.ugettext
+except AttributeError:
+    _ = translation.gettext
+
 # list of system selection options for the help output
-HELP_SYSTEM_OPTS = '''<SYSTEMS> can be any of the following:
+HELP_SYSTEM_OPTS = _('''<SYSTEMS> can be any of the following:
 name
 ssm (see 'help ssm')
 search:QUERY (see 'help system_search')
 group:GROUP
 channel:CHANNEL
-'''
+''')
 
-HELP_TIME_OPTS = '''Dates can be any of the following:
+HELP_TIME_OPTS = _('''Dates can be any of the following:
 Explicit Dates:
 Dates can be expressed as explicit date strings in the YYYYMMDD[HHMMSS]
 format.  The year, month and day are required, while the hours and
@@ -72,7 +79,7 @@ s -> seconds
 m -> minutes
 h -> hours
 d -> days
-'''
+''')
 
 ####################
 
@@ -110,8 +117,8 @@ def help_time(self):
 
 
 def help_clear(self):
-    print('clear: clear the screen')
-    print('usage: clear')
+    print(_('clear: clear the screen'))
+    print(_('usage: clear'))
 
 
 def do_clear(self, args):
@@ -122,8 +129,8 @@ def do_clear(self, args):
 
 
 def help_clear_caches(self):
-    print('clear_caches: Clear the internal caches kept for systems and packages')
-    print('usage: clear_caches')
+    print(_('clear_caches: Clear the internal caches kept for systems and packages'))
+    print(_('usage: clear_caches'))
 
 
 def do_clear_caches(self, args):
@@ -136,8 +143,8 @@ def do_clear_caches(self, args):
 
 
 def help_get_apiversion(self):
-    print('get_apiversion: Display the API version of the server')
-    print('usage: get_apiversion')
+    print(_('get_apiversion: Display the API version of the server'))
+    print(_('usage: get_apiversion'))
 
 
 def do_get_apiversion(self, args):
@@ -148,8 +155,8 @@ def do_get_apiversion(self, args):
 
 
 def help_get_serverversion(self):
-    print('get_serverversion: Display the version of the server')
-    print('usage: get_serverversion')
+    print(_('get_serverversion: Display the version of the server'))
+    print(_('usage: get_serverversion'))
 
 
 def do_get_serverversion(self, args):
@@ -161,8 +168,8 @@ def do_get_serverversion(self, args):
 
 
 def help_list_proxies(self):
-    print('list_proxies: List the proxies within the user\'s organization ')
-    print('usage: list_proxies')
+    print(_('list_proxies: List the proxies within the user\'s organization '))
+    print(_('usage: list_proxies'))
 
 
 def do_list_proxies(self, args):
@@ -174,8 +181,8 @@ def do_list_proxies(self, args):
 
 
 def help_get_session(self):
-    print('get_session: Show the current session string')
-    print('usage: get_session')
+    print(_('get_session: Show the current session string'))
+    print(_('usage: get_session'))
 
 
 def do_get_session(self, args):
@@ -183,22 +190,22 @@ def do_get_session(self, args):
         print(self.session)
         return 0
     else:
-        logging.error('No session found')
+        logging.error(_('No session found'))
         return 1
 
 ####################
 
 
 def help_help(self):
-    print('help: Show help for the given command')
-    print('usage: help COMMAND')
+    print(_('help: Show help for the given command'))
+    print(_('usage: help COMMAND'))
 
 ####################
 
 
 def help_history(self):
-    print('history: List your command history')
-    print('usage: history')
+    print(_('history: List your command history'))
+    print(_('usage: history'))
 
 
 def do_history(self, args):
@@ -210,21 +217,21 @@ def do_history(self, args):
 
 
 def help_toggle_confirmations(self):
-    print('toggle_confirmations: Toggle confirmation messages on/off')
-    print('usage: toggle_confirmations')
+    print(_('toggle_confirmations: Toggle confirmation messages on/off'))
+    print(_('usage: toggle_confirmations'))
 
 
 def do_toggle_confirmations(self, args):
     self.options.yes = not self.options.yes
-    print('Confirmation messages are', "disabled" if self.options.yes else "enabled")
+    print(_('Confirmation messages are'), "disabled" if self.options.yes else _("enabled"))
     return 0
 
 ####################
 
 
 def help_login(self):
-    print('login: Connect to a Spacewalk server')
-    print('usage: login [USERNAME] [SERVER]')
+    print(_('login: Connect to a Spacewalk server'))
+    print(_('usage: login [USERNAME] [SERVER]'))
 
 
 def do_login(self, args):
@@ -234,7 +241,7 @@ def do_login(self, args):
 
     # logout before logging in again
     if self.session:
-        logging.warning('You are already logged in')
+        logging.warning(_('You are already logged in'))
         return True
 
     # an argument passed to the function get precedence
@@ -246,7 +253,7 @@ def do_login(self, args):
 
     # bail out if not server was given
     if not server:
-        logging.warning('No server specified')
+        logging.warning(_('No server specified'))
         return False
 
     # load the server-specific configuration
@@ -291,7 +298,7 @@ def do_login(self, args):
             e = sys.exc_info()[0]
             logging.exception(e)
 
-        logging.error('Failed to connect to %s', server_url)
+        logging.error(_('Failed to connect to %s'), server_url)
         logging.debug("Error while connecting to the server %s: %s",
                       server_url, str(exc))
         self.client = None
@@ -299,7 +306,7 @@ def do_login(self, args):
 
     # ensure the server is recent enough
     if float(self.api_version) < self.MINIMUM_API_VERSION:
-        logging.error('API (%s) is too old (>= %s required)',
+        logging.error(_('API (%s) is too old (>= %s required)'),
                       self.api_version, self.MINIMUM_API_VERSION)
 
         self.client = None
@@ -329,7 +336,7 @@ def do_login(self, args):
 
             sessionfile.close()
         except IOError:
-            logging.error('Could not read %s', session_file)
+            logging.error(_('Could not read %s'), session_file)
 
     # check the cached credentials by doing an API call
     if self.session:
@@ -338,16 +345,16 @@ def do_login(self, args):
 
             self.client.user.listAssignableRoles(self.session)
         except xmlrpclib.Fault:
-            logging.warning('Cached credentials are invalid')
+            logging.warning(_('Cached credentials are invalid'))
             self.current_user = ''
             self.session = ''
 
     # attempt to login if we don't have a valid session yet
     if not self.session:
         if username:
-            logging.info('Spacewalk Username: %s', username)
+            logging.info(_('Spacewalk Username: %s'), username)
         else:
-            username = prompt_user('Spacewalk Username:', noblank=True)
+            username = prompt_user(_('Spacewalk Username:'), noblank=True)
 
         if self.options.password:
             password = self.options.password
@@ -358,13 +365,13 @@ def do_login(self, args):
         elif 'password' in self.config:
             password = self.config['password']
         else:
-            password = getpass('Spacewalk Password: ')
+            password = getpass(_('Spacewalk Password: '))
 
         # login to the server
         try:
             self.session = self.client.auth.login(username, password)
         except xmlrpclib.Fault as exc:
-            logging.error('Invalid credentials')
+            logging.error(_('Invalid credentials'))
             logging.debug("Login error: %s (%s)", exc.faultString, exc.faultCode)
             return False
         try:
@@ -382,7 +389,7 @@ def do_login(self, args):
             sessionfile.write(line)
             sessionfile.close()
         except IOError as exc:
-            logging.error('Could not write session file: %s', str(exc))
+            logging.error(_('Could not write session file: %s'), str(exc))
 
     # load the system/package/errata caches
     self.load_caches(server, username)
@@ -391,7 +398,7 @@ def do_login(self, args):
     self.current_user = username
     self.server = server
 
-    logging.info('Connected to %s as %s', server_url, username)
+    logging.info(_('Connected to %s as %s'), server_url, username)
 
     return True
 
@@ -399,8 +406,8 @@ def do_login(self, args):
 
 
 def help_logout(self):
-    print('logout: Disconnect from the server')
-    print('usage: logout')
+    print(_('logout: Disconnect from the server'))
+    print(_('usage: logout'))
 
 
 def do_logout(self, args):
@@ -417,8 +424,8 @@ def do_logout(self, args):
 
 
 def help_whoami(self):
-    print('whoami: Print the name of the currently logged in user')
-    print('usage: whoami')
+    print(_('whoami: Print the name of the currently logged in user'))
+    print(_('usage: whoami'))
 
 
 def do_whoami(self, args):
@@ -426,15 +433,15 @@ def do_whoami(self, args):
         print(self.current_user)
         return 0
     else:
-        logging.warning("You are not logged in")
+        logging.warning(_("You are not logged in"))
         return 1
 
 ####################
 
 
 def help_whoamitalkingto(self):
-    print('whoamitalkingto: Print the name of the server')
-    print('usage: whoamitalkingto')
+    print(_('whoamitalkingto: Print the name of the server'))
+    print(_('usage: whoamitalkingto'))
 
 
 def do_whoamitalkingto(self, args):
@@ -442,7 +449,7 @@ def do_whoamitalkingto(self, args):
         print(self.server)
         return 0
     else:
-        logging.warning('Yourself')
+        logging.warning(_('Yourself'))
         return 1
 
 ####################
@@ -514,7 +521,7 @@ def generate_errata_cache(self, force=False):
 
     if not self.options.quiet:
         # tell the user what's going on
-        self.replace_line_buffer('** Generating errata cache **')
+        self.replace_line_buffer(_('** Generating errata cache **'))
 
     channels = self.client.channel.listSoftwareChannels(self.session)
     channels = [c.get('label') for c in channels]
@@ -563,7 +570,7 @@ def generate_package_cache(self, force=False):
 
     if not self.options.quiet:
         # tell the user what's going on
-        self.replace_line_buffer('** Generating package cache **')
+        self.replace_line_buffer(_('** Generating package cache **'))
 
     channels = self.client.channel.listSoftwareChannels(self.session)
     channels = [c.get('label') for c in channels]
@@ -670,7 +677,7 @@ def generate_system_cache(self, force=False, delay=0):
 
     if not self.options.quiet:
         # tell the user what's going on
-        self.replace_line_buffer('** Generating system cache **')
+        self.replace_line_buffer(_('** Generating system cache **'))
 
     # we might need to wait for some systems to delete
     if delay:
@@ -705,7 +712,7 @@ def load_caches(self, server, username):
         if not os.path.isdir(conf_dir):
             os.mkdir(conf_dir, int('0700', 8))
     except OSError:
-        logging.error('Could not create directory %s', conf_dir)
+        logging.error(_('Could not create directory %s'), conf_dir)
         return
 
     self.ssm_cache_file = os.path.join(conf_dir, 'ssm')
@@ -777,14 +784,14 @@ def get_system_id(self, name):
     if len(systems) == 1:
         return systems[0]
     elif not systems:
-        logging.warning("Can't find system ID for %s", name)
+        logging.warning(_("Can't find system ID for %s"), name)
         return 0
     else:
         if len(systems) == 2 and systems[0] == systems[1]:
             return systems[0]
-        logging.warning('Duplicate system profile names found!')
-        logging.warning("Please reference systems by ID or resolve the")
-        logging.warning("underlying issue with 'system_delete' or 'system_rename'")
+        logging.warning(_('Duplicate system profile names found!'))
+        logging.warning(_("Please reference systems by ID or resolve the"))
+        logging.warning(_("underlying issue with 'system_delete' or 'system_rename'"))
 
         id_list = '%s = ' % name
 
@@ -850,7 +857,7 @@ def expand_systems(self, args):
             if members:
                 systems.extend([re.escape(m) for m in members])
             else:
-                logging.warning('No systems in group %s', item)
+                logging.warning(_('No systems in group %s'), item)
         elif re.match('search:', item):
             query = item.split(':', 1)[1]
             results = self.do_system_search(query, True)
@@ -864,7 +871,7 @@ def expand_systems(self, args):
             if members:
                 systems.extend([re.escape(m) for m in members])
             else:
-                logging.warning('No systems subscribed to %s', item)
+                logging.warning(_('No systems subscribed to %s'), item)
         else:
             # translate system IDs that the user passes
             try:
@@ -924,7 +931,7 @@ def list_child_channels(self, system=None, parent=None, subscribed=False):
     return [c.get('label') for c in channels]
 
 
-def user_confirm(self, prompt='Is this ok [y/N]:', nospacer=False,
+def user_confirm(self, prompt=_('Is this ok [y/N]:'), nospacer=False,
                  integer=False, ignore_yes=False):
 
     if self.options.yes and not ignore_yes:

--- a/spacecmd/src/spacecmd/org.py
+++ b/spacecmd/src/spacecmd/org.py
@@ -29,6 +29,7 @@
 # invalid function name
 # pylint: disable=C0103
 
+import gettext
 import logging
 from getpass import getpass
 from operator import itemgetter
@@ -36,10 +37,15 @@ from spacecmd.utils import *
 
 _PREFIXES = ['Dr.', 'Mr.', 'Miss', 'Mrs.', 'Ms.']
 
+translation = gettext.translation('spacecmd', fallback=True)
+try:
+    _ = translation.ugettext
+except AttributeError:
+    _ = translation.gettext
 
 def help_org_create(self):
-    print('org_create: Create an organization')
-    print('''usage: org_create [options])
+    print(_('org_create: Create an organization'))
+    print(_('''usage: org_create [options])
 
 options:
   -n ORG_NAME
@@ -49,7 +55,7 @@ options:
   -l LAST_NAME
   -e EMAIL
   -p PASSWORD
-  --pam enable PAM authentication''' % ', '.join(_PREFIXES))
+  --pam enable PAM authentication''' % ', '.join(_PREFIXES)))
 
 
 def do_org_create(self, args):
@@ -66,61 +72,61 @@ def do_org_create(self, args):
     (args, options) = parse_command_arguments(args, arg_parser)
 
     if is_interactive(options):
-        options.org_name = prompt_user('Organization Name:', noblank=True)
-        options.username = prompt_user('Username:', noblank=True)
-        options.prefix = prompt_user('Prefix (%s):' % ', '.join(_PREFIXES),
+        options.org_name = prompt_user(_('Organization Name:'), noblank=True)
+        options.username = prompt_user(_('Username:'), noblank=True)
+        options.prefix = prompt_user(_('Prefix (%s):') % ', '.join(_PREFIXES),
                                      noblank=True)
-        options.first_name = prompt_user('First Name:', noblank=True)
-        options.last_name = prompt_user('Last Name:', noblank=True)
-        options.email = prompt_user('Email:', noblank=True)
-        options.pam = self.user_confirm('PAM Authentication [y/N]:',
+        options.first_name = prompt_user(_('First Name:'), noblank=True)
+        options.last_name = prompt_user(_('Last Name:'), noblank=True)
+        options.email = prompt_user(_('Email:'), noblank=True)
+        options.pam = self.user_confirm(_('PAM Authentication [y/N]:'),
                                         nospacer=True,
                                         integer=False,
                                         ignore_yes=True)
 
         options.password = ''
         while options.password == '':
-            password1 = getpass('Password: ')
-            password2 = getpass('Repeat Password: ')
+            password1 = getpass(_('Password: '))
+            password2 = getpass(_('Repeat Password: '))
 
             if password1 == password2:
                 options.password = password1
             elif len(password1) < 5:
-                logging.warning('Password must be at least 5 characters')
+                logging.warning(_('Password must be at least 5 characters'))
             else:
-                logging.warning("Passwords don't match")
+                logging.warning(_("Passwords don't match"))
     else:
         if not options.org_name:
-            logging.error('An organization name is required')
+            logging.error(_('An organization name is required'))
             return 1
 
         if not options.username:
-            logging.error('A username is required')
+            logging.error(_('A username is required'))
             return 1
 
         if not options.first_name:
-            logging.error('A first name is required')
+            logging.error(_('A first name is required'))
             return 1
 
         if not options.last_name:
-            logging.error('A last name is required')
+            logging.error(_('A last name is required'))
             return 1
 
         if not options.email:
-            logging.error('An email address is required')
+            logging.error(_('An email address is required'))
             return 1
 
         if not options.password:
-            logging.error('A password is required')
+            logging.error(_('A password is required'))
             return 1
 
         if not options.pam:
             options.pam = False
 
         if not options.prefix:
-            options.prefix = 'Dr.'
+            options.prefix = _('Dr.')
 
-    if options.prefix[-1] != '.' and options.prefix != 'Miss':
+    if options.prefix[-1] != '.' and options.prefix != _('Miss'):
         options.prefix = options.prefix + '.'
 
     self.client.org.create(self.session,
@@ -139,8 +145,8 @@ def do_org_create(self, args):
 
 
 def help_org_delete(self):
-    print('org_delete: Delete an organization')
-    print('usage: org_delete NAME')
+    print(_('org_delete: Delete an organization'))
+    print(_('usage: org_delete NAME'))
 
 
 def complete_org_delete(self, text, line, beg, end):
@@ -159,10 +165,10 @@ def do_org_delete(self, args):
     name = args[0]
     org_id = self.get_org_id(name)
     if not org_id:
-        logging.warning("No organisation found for the name %s", name)
-        print("Organisation '{}' was not found".format(name))
+        logging.warning(_("No organisation found for the name %s"), name)
+        print(_("Organisation '{}' was not found").format(name))
         return 1
-    elif self.user_confirm('Delete this organization [y/N]:'):
+    elif self.user_confirm(_('Delete this organization [y/N]:')):
         self.client.org.delete(self.session, org_id)
         return 0
 
@@ -170,8 +176,8 @@ def do_org_delete(self, args):
 
 
 def help_org_rename(self):
-    print('org_rename: Rename an organization')
-    print('usage: org_rename OLDNAME NEWNAME')
+    print(_('org_rename: Rename an organization'))
+    print(_('usage: org_rename OLDNAME NEWNAME'))
 
 
 def complete_org_rename(self, text, line, beg, end):
@@ -190,8 +196,8 @@ def do_org_rename(self, args):
     name, new_name = args
     org_id = self.get_org_id(name)
     if not org_id:
-        logging.warning("No organisation found for the name %s", name)
-        print("Organisation '{}' was not found".format(name))
+        logging.warning(_("No organisation found for the name %s"), name)
+        print(_("Organisation '{}' was not found").format(name))
         return 1
     else:
         new_name = args[1]
@@ -202,8 +208,8 @@ def do_org_rename(self, args):
 
 
 def help_org_addtrust(self):
-    print('org_addtrust: Add a trust between two organizations')
-    print('usage: org_addtrust YOUR_ORG ORG_TO_TRUST')
+    print(_('org_addtrust: Add a trust between two organizations'))
+    print(_('usage: org_addtrust YOUR_ORG ORG_TO_TRUST'))
 
 
 def complete_org_addtrust(self, text, line, beg, end):
@@ -224,12 +230,12 @@ def do_org_addtrust(self, args):
     org_to_trust_id = self.get_org_id(trust_org)
 
     if your_org_id is None:
-        logging.warning("No organisation found for the name %s", your_org)
-        print("Organisation '{}' was not found".format(your_org))
+        logging.warning(_("No organisation found for the name %s"), your_org)
+        print(_("Organisation '{}' was not found").format(your_org))
         return 1
     elif org_to_trust_id is None:
-        logging.warning("No trust organisation found for the name %s", trust_org)
-        print("Organisation '{}' to trust for, was not found".format(trust_org))
+        logging.warning(_("No trust organisation found for the name %s"), trust_org)
+        print(_("Organisation '{}' to trust for, was not found").format(trust_org))
         return 1
     else:
         self.client.org.trusts.addTrust(self.session, your_org_id, org_to_trust_id)
@@ -239,8 +245,8 @@ def do_org_addtrust(self, args):
 
 
 def help_org_removetrust(self):
-    print('org_removetrust: Remove a trust between two organizations')
-    print('usage: org_removetrust YOUR_ORG TRUSTED_ORG')
+    print(_('org_removetrust: Remove a trust between two organizations'))
+    print(_('usage: org_removetrust YOUR_ORG TRUSTED_ORG'))
 
 
 def complete_org_removetrust(self, text, line, beg, end):
@@ -260,31 +266,31 @@ def do_org_removetrust(self, args):
     your_org_id = self.get_org_id(your_org)
     trusted_org_id = self.get_org_id(trust_org)
     if your_org_id is None:
-        logging.warning("No organisation found for the name %s", your_org)
-        print("Organisation '{}' was not found".format(your_org))
+        logging.warning(_("No organisation found for the name %s"), your_org)
+        print(_("Organisation '{}' was not found").format(your_org))
         return 1
     elif trusted_org_id is None:
-        logging.warning("No trust organisation found for the name %s", trust_org)
-        print("Organisation '{}' to trust for, was not found".format(trust_org))
+        logging.warning(_("No trust organisation found for the name %s"), trust_org)
+        print(_("Organisation '{}' to trust for, was not found").format(trust_org))
         return 1
     else:
         systems = self.client.org.trusts.listSystemsAffected(self.session, your_org_id, trusted_org_id)
-        print('Affected Systems')
+        print(_('Affected Systems'))
         print('----------------')
 
         if systems:
             print('\n'.join(sorted([s.get('systemName') for s in systems])))
         else:
-            print('None')
+            print(_('None'))
 
-        if self.user_confirm('Remove this trust [y/N]:'):
+        if self.user_confirm(_('Remove this trust [y/N]:')):
             self.client.org.trusts.removeTrust(self.session, your_org_id, trusted_org_id)
         return 0
 
 
 def help_org_trustdetails(self):
-    print('org_trustdetails: Show the details of an organizational trust')
-    print('usage: org_trustdetails TRUSTED_ORG')
+    print(_('org_trustdetails: Show the details of an organizational trust'))
+    print(_('usage: org_trustdetails TRUSTED_ORG'))
 
 
 def complete_org_trustdetails(self, text, line, beg, end):
@@ -303,27 +309,27 @@ def do_org_trustdetails(self, args):
     trusted_org = args[0]
     org_id = self.get_org_id(trusted_org)
     if org_id is None:
-        logging.warning("No trusted organisation found for the name %s", trusted_org)
-        print("Trusted organisation '{}' was not found".format(trusted_org))
+        logging.warning(_("No trusted organisation found for the name %s"), trusted_org)
+        print(_("Trusted organisation '{}' was not found").format(trusted_org))
         return 1
     else:
         details = self.client.org.trusts.getDetails(self.session, org_id)
         consumed = self.client.org.trusts.listChannelsConsumed(self.session, org_id)
         provided = self.client.org.trusts.listChannelsProvided(self.session, org_id)
 
-        print('Trusted Organization:   %s' % trusted_org)
-        print('Trusted Since:          %s' % details.get('trusted_since'))
-        print('Systems Migrated From:  %i' % details.get('systems_migrated_from'))
-        print('Systems Migrated To:    %i' % details.get('systems_migrated_to'))
+        print(_('Trusted Organization:   %s') % trusted_org)
+        print(_('Trusted Since:          %s') % details.get('trusted_since'))
+        print(_('Systems Migrated From:  %i') % details.get('systems_migrated_from'))
+        print(_('Systems Migrated To:    %i') % details.get('systems_migrated_to'))
         print('')
-        print('Channels Consumed')
+        print(_('Channels Consumed'))
         print('-----------------')
         if consumed:
             print('\n'.join(sorted([c.get('name') for c in consumed])))
 
         print('')
 
-        print('Channels Provided')
+        print(_('Channels Provided'))
         print('-----------------')
         if provided:
             print('\n'.join(sorted([c.get('name') for c in provided])))
@@ -331,8 +337,8 @@ def do_org_trustdetails(self, args):
 
 
 def help_org_list(self):
-    print('org_list: List all organizations')
-    print('usage: org_list')
+    print(_('org_list: List all organizations'))
+    print(_('usage: org_list'))
 
 
 def do_org_list(self, args, doreturn=False):
@@ -349,8 +355,8 @@ def do_org_list(self, args, doreturn=False):
 
 
 def help_org_listtrusts(self):
-    print("org_listtrusts: List an organization's trusts")
-    print('usage: org_listtrusts NAME')
+    print(_("org_listtrusts: List an organization's trusts"))
+    print(_('usage: org_listtrusts NAME'))
 
 
 def complete_org_listtrusts(self, text, line, beg, end):
@@ -368,14 +374,14 @@ def do_org_listtrusts(self, args):
 
     org_id = self.get_org_id(args[0])
     if org_id is None:
-        logging.warning("No organisation found for the name %s", args[0])
-        print("Organisation '{}' was not found".format(args[0]))
+        logging.warning(_("No organisation found for the name %s"), args[0])
+        print(_("Organisation '{}' was not found").format(args[0]))
         return 1
     else:
         trusts = self.client.org.trusts.listTrusts(self.session, org_id)
         if not trusts:
-            print("No trust organisation has been found")
-            logging.warning("No trust organisation has been found")
+            print(_("No trust organisation has been found"))
+            logging.warning(_("No trust organisation has been found"))
             return 1
         else:
             for trust in sorted(trusts, key=itemgetter('orgName')):
@@ -385,8 +391,8 @@ def do_org_listtrusts(self, args):
 
 
 def help_org_listusers(self):
-    print("org_listusers: List an organization's users")
-    print('usage: org_listusers NAME')
+    print(_("org_listusers: List an organization's users"))
+    print(_('usage: org_listusers NAME'))
 
 
 def complete_org_listusers(self, text, line, beg, end):
@@ -404,8 +410,8 @@ def do_org_listusers(self, args):
 
     org_id = self.get_org_id(args[0])
     if org_id is None:
-        logging.warning("No organisation found for the name %s", args[0])
-        print("Organisation '{}' was not found".format(args[0]))
+        logging.warning(_("No organisation found for the name %s"), args[0])
+        print(_("Organisation '{}' was not found").format(args[0]))
         return 1
     else:
         users = self.client.org.listUsers(self.session, org_id)
@@ -416,8 +422,8 @@ def do_org_listusers(self, args):
 
 
 def help_org_details(self):
-    print('org_details: Show the details of an organization')
-    print('usage: org_details NAME')
+    print(_('org_details: Show the details of an organization'))
+    print(_('usage: org_details NAME'))
 
 
 def complete_org_details(self, text, line, beg, end):
@@ -437,19 +443,19 @@ def do_org_details(self, args):
 
     details = self.client.org.getDetails(self.session, name)
 
-    print('Name:                   %s' % details.get('name'))
-    print('Active Users:           %i' % details.get('active_users'))
-    print('Systems:                %i' % details.get('systems'))
+    print(_('Name:                   %s') % details.get('name'))
+    print(_('Active Users:           %i') % details.get('active_users'))
+    print(_('Systems:                %i') % details.get('systems'))
 
     # trusts is optional, which is annoying...
     if 'trusts' in details:
-        print('Trusts:                 %i' % details.get('trusts'))
+        print(_('Trusts:                 %i') % details.get('trusts'))
     else:
-        print('Trusts:                 %i' % 0)
+        print(_('Trusts:                 %i') % 0)
 
-    print('System Groups:          %i' % details.get('system_groups'))
-    print('Activation Keys:        %i' % details.get('activation_keys'))
-    print('Kickstart Profiles:     %i' % details.get('kickstart_profiles'))
-    print('Configuration Channels: %i' % details.get('configuration_channels'))
+    print(_('System Groups:          %i') % details.get('system_groups'))
+    print(_('Activation Keys:        %i') % details.get('activation_keys'))
+    print(_('Kickstart Profiles:     %i') % details.get('kickstart_profiles'))
+    print(_('Configuration Channels: %i') % details.get('configuration_channels'))
 
     return 0

--- a/spacecmd/src/spacecmd/package.py
+++ b/spacecmd/src/spacecmd/package.py
@@ -29,16 +29,22 @@
 # invalid function name
 # pylint: disable=C0103
 
+import gettext
 try:
     from xmlrpc import client as xmlrpclib
 except ImportError:
     import xmlrpclib
 from spacecmd.utils import *
 
+translation = gettext.translation('spacecmd', fallback=True)
+try:
+    _ = translation.ugettext
+except AttributeError:
+    _ = translation.gettext
 
 def help_package_details(self):
-    print('package_details: Show the details of a software package')
-    print('usage: package_details PACKAGE ...')
+    print(('package_details: Show the details of a software package'))
+    print(('usage: package_details PACKAGE ...'))
 
 
 def complete_package_details(self, text, line, beg, end):
@@ -59,7 +65,7 @@ def do_package_details(self, args):
         packages.extend(self.do_package_search(' '.join(args), True))
 
     if not packages:
-        logging.warning('No packages found')
+        logging.warning(_('No packages found'))
         return 1
 
     add_separator = False
@@ -72,7 +78,7 @@ def do_package_details(self, args):
         package_ids = self.get_package_id(package)
 
         if not package_ids:
-            logging.warning('%s is not a valid package' % package)
+            logging.warning(_('%s is not a valid package') % package)
             continue
 
         for package_id in package_ids:
@@ -84,25 +90,25 @@ def do_package_details(self, args):
             installed_systems = \
                 self.client.system.listSystemsWithPackage(self.session, package_id)
 
-            print('Name:    %s' % details.get('name'))
-            print('Version: %s' % details.get('version'))
-            print('Release: %s' % details.get('release'))
-            print('Epoch:   %s' % details.get('epoch'))
-            print('Arch:    %s' % details.get('arch_label'))
+            print(_('Name:    %s' % details.get('name')))
+            print(_('Version: %s' % details.get('version')))
+            print(_('Release: %s' % details.get('release')))
+            print(_('Epoch:   %s' % details.get('epoch')))
+            print(_('Arch:    %s' % details.get('arch_label')))
             print('')
-            print('File:    %s' % details.get('file'))
-            print('Path:    %s' % details.get('path'))
-            print('Size:    %s' % details.get('size'))
+            print(_('File:    %s' % details.get('file')))
+            print(_('Path:    %s' % details.get('path')))
+            print(_('Size:    %s' % details.get('size')))
             print('%s%s' % ((details.get('checksum_type').upper() + ":").ljust(9),
                              details.get('checksum')))
             print('')
-            print('Installed Systems: %i' % len(installed_systems))
+            print(_('Installed Systems: %i') % len(installed_systems))
             print('')
-            print('Description')
+            print(_('Description'))
             print('-----------')
             print('\n'.join(wrap(details.get('description'))))
             print('')
-            print('Available From Channels')
+            print(_('Available From Channels'))
             print('-----------------------')
             print('\n'.join(sorted([c.get('label') for c in channels])))
             print('')
@@ -113,14 +119,14 @@ def do_package_details(self, args):
 
 
 def help_package_search(self):
-    print('package_search: Find packages that meet the given criteria')
-    print('usage: package_search NAME|QUERY')
+    print(_('package_search: Find packages that meet the given criteria'))
+    print(_('usage: package_search NAME|QUERY'))
     print('')
-    print('Example: package_search kernel')
+    print(_('Example: package_search kernel'))
     print('')
-    print('Advanced Search:')
-    print('Available Fields: name, epoch, version, release, arch, description, summary')
-    print('Example: name:kernel AND version:2.6.18 AND -description:devel')
+    print(_('Advanced Search:'))
+    print(_('Available Fields: name, epoch, version, release, arch, description, summary'))
+    print(_('Example: name:kernel AND version:2.6.18 AND -description:devel'))
 
 
 def do_package_search(self, args, doreturn=False):
@@ -169,8 +175,8 @@ def do_package_search(self, args, doreturn=False):
 
 
 def help_package_remove(self):
-    print('package_remove: Remove a package from Satellite')
-    print('usage: package_remove PACKAGE ...')
+    print(_('package_remove: Remove a package from Satellite'))
+    print(_('usage: package_remove PACKAGE ...'))
 
 
 def complete_package_remove(self, text, line, beg, end):
@@ -190,14 +196,14 @@ def do_package_remove(self, args):
 
     if not to_remove:
         logging.debug("Failed to find packages for criteria %s", str(args))
-        print("No packages found to remove")
+        print(_("No packages found to remove"))
         return 1
 
-    if not self.user_confirm('Remove these packages [y/N]:'):
-        print("No packages has been removed")
+    if not self.user_confirm(_('Remove these packages [y/N]:')):
+        print(_("No packages has been removed"))
         return 1
 
-    print('Packages')
+    print(_('Packages'))
     print('--------')
     print('\n'.join(sorted(to_remove)))
 
@@ -206,7 +212,7 @@ def do_package_remove(self, args):
             try:
                 self.client.packages.removePackage(self.session, package_id)
             except xmlrpclib.Fault:
-                logging.error('Failed to remove package ID %i' % package_id)
+                logging.error(_('Failed to remove package ID %i') % package_id)
 
     # regenerate the package cache after removing these packages
     self.generate_package_cache(True)
@@ -217,8 +223,8 @@ def do_package_remove(self, args):
 
 
 def help_package_listorphans(self):
-    print('package_listorphans: List packages that are not in a channel')
-    print('usage: package_listorphans')
+    print(_('package_listorphans: List packages that are not in a channel'))
+    print(_('usage: package_listorphans'))
 
 
 def do_package_listorphans(self, args, doreturn=False):
@@ -237,8 +243,8 @@ def do_package_listorphans(self, args, doreturn=False):
 
 
 def help_package_removeorphans(self):
-    print('package_removeorphans: Remove packages that are not in a channel')
-    print('usage: package_removeorphans')
+    print(_('package_removeorphans: Remove packages that are not in a channel'))
+    print(_('usage: package_removeorphans'))
 
 
 def do_package_removeorphans(self, args):
@@ -246,15 +252,15 @@ def do_package_removeorphans(self, args):
         self.client.channel.software.listPackagesWithoutChannel(self.session)
 
     if not packages:
-        print("No orphaned packages has been found")
-        logging.warning('No orphaned packages')
+        print(_("No orphaned packages has been found"))
+        logging.warning(_('No orphaned packages'))
         return 1
 
-    if not self.user_confirm('Remove these packages [y/N]:'):
-        print("No packages were removed")
+    if not self.user_confirm(_('Remove these packages [y/N]:')):
+        print(_("No packages were removed"))
         return 1
 
-    print('Packages')
+    print(_('Packages'))
     print('--------')
     print('\n'.join(sorted(build_package_names(packages))))
 
@@ -262,7 +268,7 @@ def do_package_removeorphans(self, args):
         try:
             self.client.packages.removePackage(self.session, package.get('id'))
         except xmlrpclib.Fault:
-            logging.error('Failed to remove package ID %i' % package.get('id'))
+            logging.error(_('Failed to remove package ID %i') % package.get('id'))
             return 1
 
     return 0
@@ -271,8 +277,8 @@ def do_package_removeorphans(self, args):
 
 
 def help_package_listinstalledsystems(self):
-    print('package_listinstalledsystems: List the systems with a package installed')
-    print('usage: package_listinstalledsystems PACKAGE ...')
+    print(_('package_listinstalledsystems: List the systems with a package installed'))
+    print(_('usage: package_listinstalledsystems PACKAGE ...'))
 
 
 def complete_package_listinstalledsystems(self, text, line, beg, end):
@@ -293,7 +299,7 @@ def do_package_listinstalledsystems(self, args):
         packages.extend(self.do_package_search(package, True))
 
     if not packages:
-        logging.warning('No packages found')
+        logging.warning(_('No packages found'))
         return 1
 
     add_separator = False
@@ -320,8 +326,8 @@ def do_package_listinstalledsystems(self, args):
 
 
 def help_package_listerrata(self):
-    print('package_listerrata: List the errata that provide this package')
-    print('usage: package_listerrata PACKAGE ...')
+    print(_('package_listerrata: List the errata that provide this package'))
+    print(_('usage: package_listerrata PACKAGE ...'))
 
 
 def complete_package_listerrata(self, text, line, beg, end):
@@ -342,7 +348,7 @@ def do_package_listerrata(self, args):
         packages.extend(self.do_package_search(' '.join(args), True))
 
     if not packages:
-        logging.warning('No packages found')
+        logging.warning(_('No packages found'))
         return 1
 
     add_separator = False
@@ -368,8 +374,8 @@ def do_package_listerrata(self, args):
 
 
 def help_package_listdependencies(self):
-    print('package_listdependencies: List the dependencies for a package')
-    print('usage: package_listdependencies PACKAGE')
+    print(_('package_listdependencies: List the dependencies for a package'))
+    print(_('usage: package_listdependencies PACKAGE'))
 
 
 def do_package_listdependencies(self, args):
@@ -386,7 +392,7 @@ def do_package_listdependencies(self, args):
         packages.extend(self.do_package_search(' '.join(args), True))
 
     if not packages:
-        logging.warning('No packages found')
+        logging.warning(_('No packages found'))
         return 1
 
     add_separator = False
@@ -397,14 +403,14 @@ def do_package_listdependencies(self, args):
         add_separator = False
         for package_id in self.get_package_id(package):
             if not package_id:
-                logging.warning('%s is not a valid package' % package)
+                logging.warning(_('%s is not a valid package') % package)
                 continue
 
             package_id = int(package_id)
             pkgdeps = self.client.packages.list_dependencies(self.session, package_id)
-            print('Package Name: %s' % package)
+            print(_('Package Name: %s') % package)
             for dep in pkgdeps:
-                print('Dependency: %s Type: %s Modifier: %s' % \
+                print(_('Dependency: %s Type: %s Modifier: %s') % \
                       (dep['dependency'], dep['dependency_type'], dep['dependency_modifier']))
             print(self.SEPARATOR)
             add_separator = True

--- a/spacecmd/src/spacecmd/repo.py
+++ b/spacecmd/src/spacecmd/repo.py
@@ -29,6 +29,7 @@
 # invalid function name
 # pylint: disable=C0103
 
+import gettext
 import shlex
 try:
     from xmlrpc import client as xmlrpclib
@@ -36,11 +37,15 @@ except ImportError:
     import xmlrpclib
 from spacecmd.utils import *
 
-
+translation = gettext.translation('spacecmd', fallback=True)
+try:
+    _ = translation.ugettext
+except AttributeError:
+    _ = translation.gettext
 
 def help_repo_list(self):
-    print('repo_list: List all available user repos')
-    print('usage: repo_list')
+    print(_('repo_list: List all available user repos'))
+    print(_('usage: repo_list'))
 
 
 def do_repo_list(self, args, doreturn=False):
@@ -57,8 +62,8 @@ def do_repo_list(self, args, doreturn=False):
 
 
 def help_repo_details(self):
-    print('repo_details: Show the details of a user repo')
-    print('usage: repo_details <repo ...>')
+    print(_('repo_details: Show the details of a user repo'))
+    print(_('usage: repo_details <repo ...>'))
 
 
 def complete_repo_details(self, text, line, beg, end):
@@ -86,14 +91,14 @@ def do_repo_details(self, args):
                 print(self.SEPARATOR)
             add_separator = True
 
-            print('Repository Label:                  %s' % details.get('label'))
-            print('Repository URL:                    %s' % details.get('sourceUrl'))
-            print('Repository Type:                   %s' % details.get('type'))
-            print('Repository SSL Ca Certificate:     %s' % (details.get('sslCaDesc') or "None"))
-            print('Repository SSL Client Certificate: %s' % (details.get('sslCertDesc') or "None"))
-            print('Repository SSL Client Key:         %s' % (details.get('sslKeyDesc') or "None"))
+            print(_('Repository Label:                  %s') % details.get('label'))
+            print(_('Repository URL:                    %s') % details.get('sourceUrl'))
+            print(_('Repository Type:                   %s') % details.get('type'))
+            print(_('Repository SSL Ca Certificate:     %s') % (details.get('sslCaDesc') or "None"))
+            print(_('Repository SSL Client Certificate: %s') % (details.get('sslCertDesc') or "None"))
+            print(_('Repository SSL Client Key:         %s') % (details.get('sslKeyDesc') or "None"))
     else:
-        print("No repositories found for '{}' query".format(' '.join(args)))
+        print(_("No repositories found for '{}' query").format(' '.join(args)))
         return 1
 
     return 0
@@ -102,8 +107,8 @@ def do_repo_details(self, args):
 
 
 def help_repo_listfilters(self):
-    print('repo_listfilters: Show the filters for a user repo')
-    print('usage: repo_listfilters repo')
+    print(_('repo_listfilters: Show the filters for a user repo'))
+    print(_('usage: repo_listfilters repo'))
 
 
 def complete_repo_listfilters(self, text, line, beg, end):
@@ -124,7 +129,7 @@ def do_repo_listfilters(self, args):
         for flt in filters:
             print("%s%s" % (flt.get('flag'), flt.get('filter')))
     else:
-        print("No filters found")
+        print(_("No filters found"))
         return 1
 
     return 0
@@ -133,8 +138,8 @@ def do_repo_listfilters(self, args):
 
 
 def help_repo_addfilters(self):
-    print('repo_addfilters: Add filters for a user repo')
-    print('usage: repo_addfilters repo <filter ...>')
+    print(_('repo_addfilters: Add filters for a user repo'))
+    print(_('usage: repo_addfilters repo <filter ...>'))
 
 
 def complete_repo_addfilters(self, text, line, beg, end):
@@ -158,7 +163,7 @@ def do_repo_addfilters(self, args):
         repofilter = arg[1:]
 
         if not (flag == '+' or flag == '-'):
-            logging.error('Each filter must start with + or -')
+            logging.error(_('Each filter must start with + or -'))
             return 1
 
         self.client.channel.software.addRepoFilter(self.session,
@@ -172,8 +177,8 @@ def do_repo_addfilters(self, args):
 
 
 def help_repo_removefilters(self):
-    print('repo_removefilters: Remove filters from a user repo')
-    print('usage: repo_removefilters repo <filter ...>')
+    print(_('repo_removefilters: Remove filters from a user repo'))
+    print(_('usage: repo_removefilters repo <filter ...>'))
 
 
 def complete_repo_removefilters(self, text, line, beg, end):
@@ -195,7 +200,7 @@ def do_repo_removefilters(self, args):
         repofilter = arg[1:]
 
         if not (flag == '+' or flag == '-'):
-            logging.error('Each filter must start with + or -')
+            logging.error(_('Each filter must start with + or -'))
             return 1
 
         self.client.channel.software.removeRepoFilter(self.session,
@@ -209,8 +214,8 @@ def do_repo_removefilters(self, args):
 
 
 def help_repo_setfilters(self):
-    print('repo_setfilters: Set the filters for a user repo')
-    print('usage: repo_setfilters repo <filter ...>')
+    print(_('repo_setfilters: Set the filters for a user repo'))
+    print(_('usage: repo_setfilters repo <filter ...>'))
 
 
 def complete_repo_setfilters(self, text, line, beg, end):
@@ -234,7 +239,7 @@ def do_repo_setfilters(self, args):
         repofilter = arg[1:]
 
         if not (flag == '+' or flag == '-'):
-            logging.error('Each filter must start with + or -')
+            logging.error(_('Each filter must start with + or -'))
             return 1
 
         filters.append({'filter': repofilter, 'flag': flag})
@@ -247,13 +252,13 @@ def do_repo_setfilters(self, args):
 
 
 def help_repo_clearfilters(self):
-    print('repo_clearfilters: Clears the filters for a user repo')
-    print('''usage: repo_clearfilters repo <options>
+    print(_('repo_clearfilters: Clears the filters for a user repo'))
+    print(_('''usage: repo_clearfilters repo <options>
 
 options:
   -y, --yes   Confirm without prompt
 
-''')
+'''))
 
 
 def complete_repo_clearfilters(self, text, line, beg, end):
@@ -270,7 +275,7 @@ def do_repo_clearfilters(self, args):
         self.help_repo_clearfilters()
         return 1
 
-    if _options.yes or self.user_confirm('Remove these filters [y/N]:'):
+    if _options.yes or self.user_confirm(_('Remove these filters [y/N]:')):
         self.client.channel.software.clearRepoFilters(self.session, args[0])
 
     return 0
@@ -279,8 +284,8 @@ def do_repo_clearfilters(self, args):
 
 
 def help_repo_delete(self):
-    print('repo_delete: Delete a user repo')
-    print('usage: repo_delete <repo ...>')
+    print(_('repo_delete: Delete a user repo'))
+    print(_('usage: repo_delete <repo ...>'))
 
 
 def complete_repo_delete(self, text, line, beg, end):
@@ -299,16 +304,16 @@ def do_repo_delete(self, args):
     # allow globbing of repo names
     repos = filter_results(self.do_repo_list('', True), args)
 
-    print('Repos')
+    print(_('Repos'))
     print('-----')
     print('\n'.join(sorted(repos)))
 
-    if self.user_confirm('Delete these repos [y/N]:'):
+    if self.user_confirm(_('Delete these repos [y/N]:')):
         for repo in repos:
             try:
                 self.client.channel.software.removeRepo(self.session, repo)
             except xmlrpclib.Fault:
-                logging.error('Failed to remove repo %s' % repo)
+                logging.error(_('Failed to remove repo %s') % repo)
 
     return 0
 
@@ -316,8 +321,8 @@ def do_repo_delete(self, args):
 
 
 def help_repo_create(self):
-    print('repo_create: Create a user repository')
-    print('''usage: repo_create <options>)
+    print(_('repo_create: Create a user repository'))
+    print(_('''usage: repo_create <options>)
 
 options:
   -n, --name   name of repository
@@ -326,7 +331,7 @@ options:
 
   --ca         SSL CA certificate (not required)
   --cert       SSL Client certificate (not required)
-  --key        SSL Client key (not required)''')
+  --key        SSL Client key (not required)'''))
 
 
 def do_repo_create(self, args):
@@ -341,19 +346,19 @@ def do_repo_create(self, args):
     (args, options) = parse_command_arguments(args, arg_parser)
 
     if is_interactive(options):
-        options.name = prompt_user('Name:', noblank=True)
-        options.url = prompt_user('URL:', noblank=True)
-        options.type = prompt_user('Type:', noblank=True)
-        options.ca = prompt_user('SSL CA cert:')
-        options.cert = prompt_user('SSL Client cert:')
-        options.key = prompt_user('SSL Client key:')
+        options.name = prompt_user(_('Name:'), noblank=True)
+        options.url = prompt_user(_('URL:'), noblank=True)
+        options.type = prompt_user(_('Type:'), noblank=True)
+        options.ca = prompt_user(_('SSL CA cert:'))
+        options.cert = prompt_user(_('SSL Client cert:'))
+        options.key = prompt_user(_('SSL Client key:'))
     else:
         if not options.name:
-            logging.error('A name is required')
+            logging.error(_('A name is required'))
             return 1
 
         if not options.url:
-            logging.error('A URL is required')
+            logging.error(_('A URL is required'))
             return 1
 
         if not options.type:
@@ -373,8 +378,8 @@ def do_repo_create(self, args):
 
 
 def help_repo_rename(self):
-    print('repo_rename: Rename a user repository')
-    print('usage: repo_rename OLDNAME NEWNAME')
+    print(_('repo_rename: Rename a user repository'))
+    print(_('usage: repo_rename OLDNAME NEWNAME'))
 
 
 def complete_repo_rename(self, text, line, beg, end):
@@ -396,7 +401,7 @@ def do_repo_rename(self, args):
         details = self.client.channel.software.getRepoDetails(self.session, args[0])
         oldname = details.get('id')
     except xmlrpclib.Fault:
-        logging.error('Could not find repo %s' % args[0])
+        logging.error(_('Could not find repo %s') % args[0])
         return 1
 
     newname = args[1]
@@ -409,8 +414,8 @@ def do_repo_rename(self, args):
 
 
 def help_repo_updateurl(self):
-    print('repo_updateurl: Change the URL of a user repository')
-    print('usage: repo_updateurl <repo> <url>')
+    print(_('repo_updateurl: Change the URL of a user repository'))
+    print(_('usage: repo_updateurl <repo> <url>'))
 
 
 def complete_repo_updateurl(self, text, line, beg, end):
@@ -435,12 +440,12 @@ def do_repo_updateurl(self, args):
 
 
 def help_repo_updatessl(self):
-    print('repo_updatessl: Change the SSL certificates of a user repository')
-    print('''usage: repo_updatessl <options>)
+    print(_('repo_updatessl: Change the SSL certificates of a user repository'))
+    print(_('''usage: repo_updatessl <options>)
 options:
   --ca         SSL CA certificate (not required)
   --cert       SSL Client certificate (not required)
-  --key        SSL Client key (not required)''')
+  --key        SSL Client key (not required)'''))
 
 
 def do_repo_updatessl(self, args):
@@ -453,13 +458,13 @@ def do_repo_updatessl(self, args):
     (args, options) = parse_command_arguments(args, arg_parser)
 
     if is_interactive(options):
-        options.name = prompt_user('Name:', noblank=True)
-        options.ca = prompt_user('SSL CA cert:')
-        options.cert = prompt_user('SSL Client cert:')
-        options.key = prompt_user('SSL Client key:')
+        options.name = prompt_user(_('Name:'), noblank=True)
+        options.ca = prompt_user(_('SSL CA cert:'))
+        options.cert = prompt_user(_('SSL Client cert:'))
+        options.key = prompt_user(_('SSL Client key:'))
     else:
         if not options.name:
-            logging.error('A name is required')
+            logging.error(_('A name is required'))
             return 1
 
     self.client.channel.software.updateRepoSsl(self.session,

--- a/spacecmd/src/spacecmd/report.py
+++ b/spacecmd/src/spacecmd/report.py
@@ -29,13 +29,19 @@
 # invalid function name
 # pylint: disable=C0103
 
+import gettext
 from operator import itemgetter
 from spacecmd.utils import *
 
+translation = gettext.translation('spacecmd', fallback=True)
+try:
+    _ = translation.ugettext
+except AttributeError:
+    _ = translation.gettext
 
 def help_report_inactivesystems(self):
-    print('report_inactivesystems: List all inactive systems')
-    print('usage: report_inactivesystems [DAYS]')
+    print(_('report_inactivesystems: List all inactive systems'))
+    print(_('usage: report_inactivesystems [DAYS]'))
 
 
 def do_report_inactivesystems(self, args):
@@ -75,8 +81,8 @@ def do_report_inactivesystems(self, args):
 
 
 def help_report_outofdatesystems(self):
-    print('report_outofdatesystems: List all out-of-date systems')
-    print('usage: report_outofdatesystems')
+    print(_('report_outofdatesystems: List all out-of-date systems'))
+    print(_('usage: report_outofdatesystems'))
 
 
 def do_report_outofdatesystems(self, args):
@@ -103,8 +109,8 @@ def do_report_outofdatesystems(self, args):
 
 
 def help_report_ungroupedsystems(self):
-    print('report_ungroupedsystems: List all ungrouped systems')
-    print('usage: report_ungroupedsystems')
+    print(_('report_ungroupedsystems: List all ungrouped systems'))
+    print(_('usage: report_ungroupedsystems'))
 
 
 def do_report_ungroupedsystems(self, args):
@@ -121,8 +127,8 @@ def do_report_ungroupedsystems(self, args):
 
 
 def help_report_errata(self):
-    print('report_errata: List all errata and how many systems they affect')
-    print('usage: report_errata [ERRATA|search:XXX ...]')
+    print(_('report_errata: List all errata and how many systems they affect'))
+    print(_('usage: report_errata [ERRATA|search:XXX ...]'))
 
 # XXX: performance is terrible due to all the API calls
 
@@ -134,7 +140,7 @@ def do_report_errata(self, args):
     (_args, _options) = parse_command_arguments(args, arg_parser)
 
     if not _args:
-        print('All errata requested - this may take a few minutes, please be patient!')
+        print(_('All errata requested - this may take a few minutes, please be patient!'))
         partial_errata = False
 
     errata_list = self.expand_errata(_args)
@@ -157,22 +163,22 @@ def do_report_errata(self, args):
             max_size = size
 
     if report:
-        print('%s  # Systems' % ('Errata'.ljust(max_size)))
+        print(_('%s  # Systems') % _(('Errata').ljust(max_size)))
         print('%s  ---------' % ('------'.ljust(max_size)))
         for erratum in sorted(report):
             print('%s        %s' %
                   (erratum.ljust(max_size), str(report[erratum]).rjust(3)))
         return 0
     elif partial_errata:
-        print("No errata found for '{}'".format(args))
+        print(_("No errata found for '{}'").format(args))
         return 1
 
 ####################
 
 
 def help_report_ipaddresses(self):
-    print('report_ipaddresses: List the hostname and IP of each system')
-    print('usage: report_ipaddresses [<SYSTEMS>]')
+    print(_('report_ipaddresses: List the hostname and IP of each system'))
+    print(_('usage: report_ipaddresses [<SYSTEMS>]'))
     print('')
     print(self.HELP_SYSTEM_OPTS)
 
@@ -192,7 +198,7 @@ def do_report_ipaddresses(self, args):
         systems = self.get_system_names()
 
     if not systems:
-        logging.warning('No systems selected')
+        logging.warning(_('No systems selected'))
         return 1
 
     report = {}
@@ -235,8 +241,8 @@ def do_report_ipaddresses(self, args):
 
 
 def help_report_kernels(self):
-    print('report_kernels: List the running kernel of each system')
-    print('usage: report_kernels [<SYSTEMS>]')
+    print(_('report_kernels: List the running kernel of each system'))
+    print(_('usage: report_kernels [<SYSTEMS>]'))
     print('')
     print(self.HELP_SYSTEM_OPTS)
 
@@ -256,7 +262,7 @@ def do_report_kernels(self, args):
         systems = self.get_system_names()
 
     if not systems:
-        logging.warning('No systems selected')
+        logging.warning(_('No systems selected'))
         return 1
 
     report = {}
@@ -273,7 +279,7 @@ def do_report_kernels(self, args):
             system_max_size = size
 
     if report:
-        print('%s  Kernel' % ('System'.ljust(system_max_size)))
+        print(_('%s  Kernel') % (_('System').ljust(system_max_size)))
 
         print('%s  ------' % ('------'.ljust(system_max_size)))
 
@@ -287,8 +293,8 @@ def do_report_kernels(self, args):
 
 
 def help_report_duplicates(self):
-    print('report_duplicates: List duplicate system profiles')
-    print('usage: report_duplicates')
+    print(_('report_duplicates: List duplicate system profiles'))
+    print(_('usage: report_duplicates'))
 
 
 def do_report_duplicates(self, args):
@@ -310,7 +316,7 @@ def do_report_duplicates(self, args):
             systems = self.client.system.searchByName(self.session,
                                                       '^%s$' % item)
 
-            print('System ID   Last Checkin')
+            print(_('System ID   Last Checkin'))
             print('----------  -----------------')
 
             for dupe in systems:
@@ -332,7 +338,7 @@ def do_report_duplicates(self, args):
             for item in dupes_by_ip:
                 print('%s:' % item.get('ip'))
 
-                print('System ID   Last Checkin')
+                print(_('System ID   Last Checkin'))
                 print('----------  -----------------')
 
                 for dupe in item.get('systems'):
@@ -350,7 +356,7 @@ def do_report_duplicates(self, args):
             for item in dupes_by_mac:
                 print('%s:' % item.get('mac').upper())
 
-                print('System ID   Last Checkin')
+                print(_('System ID   Last Checkin'))
                 print('----------  -----------------')
 
                 for dupe in item.get('systems'):
@@ -368,7 +374,7 @@ def do_report_duplicates(self, args):
             for item in dupes_by_hostname:
                 print('%s:' % item.get('hostname'))
 
-                print('System ID   Last Checkin')
+                print(_('System ID   Last Checkin'))
                 print('----------  -----------------')
 
                 for dupe in item.get('systems'):

--- a/spacecmd/src/spacecmd/scap.py
+++ b/spacecmd/src/spacecmd/scap.py
@@ -30,12 +30,18 @@
 # invalid function name
 # pylint: disable=C0103
 
+import gettext
 from spacecmd.utils import *
 
+translation = gettext.translation('spacecmd', fallback=True)
+try:
+    _ = translation.ugettext
+except AttributeError:
+    _ = translation.gettext
 
 def help_scap_listxccdfscans(self):
-    print('scap_listxccdfscans: Return a list of finished OpenSCAP scans for given systems')
-    print('usage: scap_listxccdfscans <SYSTEMS>')
+    print(_('scap_listxccdfscans: Return a list of finished OpenSCAP scans for given systems'))
+    print(_('usage: scap_listxccdfscans <SYSTEMS>'))
 
 
 def complete_system_scap_listxccdfscans(self, text, line, beg, end):
@@ -58,7 +64,7 @@ def do_scap_listxccdfscans(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning('No systems selected')
+        logging.warning(_('No systems selected'))
         return 1
 
     add_separator = False
@@ -69,7 +75,7 @@ def do_scap_listxccdfscans(self, args):
         add_separator = True
 
         if len(systems) > 1:
-            print('System: %s' % system)
+            print(_('System: %s') % system)
             print('')
 
         system_id = self.get_system_id(system)
@@ -79,7 +85,7 @@ def do_scap_listxccdfscans(self, args):
         scan_list = self.client.system.scap.listXccdfScans(self.session, system_id)
 
         for s in scan_list:
-            print('XID: %d Profile: %s Path: (%s) Completed: %s' % (s['xid'], s['profile'], s['path'], s['completed']))
+            print(_('XID: %d Profile: %s Path: (%s) Completed: %s') % (s['xid'], s['profile'], s['path'], s['completed']))
 
     return 0
 
@@ -87,8 +93,8 @@ def do_scap_listxccdfscans(self, args):
 
 
 def help_scap_getxccdfscanruleresults(self):
-    print('scap_getxccdfscanruleresults: Return a full list of RuleResults for given OpenSCAP XCCDF scan')
-    print('usage: scap_getxccdfscanruleresults <XID>')
+    print(_('scap_getxccdfscanruleresults: Return a full list of RuleResults for given OpenSCAP XCCDF scan'))
+    print(_('usage: scap_getxccdfscanruleresults <XID>'))
 
 
 def do_scap_getxccdfscanruleresults(self, args):
@@ -108,14 +114,14 @@ def do_scap_getxccdfscanruleresults(self, args):
         add_separator = True
 
         if len(args) > 1:
-            print('XID: %s' % xid)
+            print(_('XID: %s') % xid)
             print('')
 
         xid = int(xid)
         scan_results = self.client.system.scap.getXccdfScanRuleResults(self.session, xid)
 
         for s in scan_results:
-            print('IDref: %s Result: %s Idents: (%s)' % (s['idref'], s['result'], s['idents']))
+            print(_('IDref: %s Result: %s Idents: (%s)') % (s['idref'], s['result'], s['idents']))
 
     return 0
 
@@ -123,8 +129,8 @@ def do_scap_getxccdfscanruleresults(self, args):
 
 
 def help_scap_getxccdfscandetails(self):
-    print('scap_getxccdfscandetails: Get details of given OpenSCAP XCCDF scan')
-    print('usage: scap_getxccdfscandetails <XID>')
+    print(_('scap_getxccdfscandetails: Get details of given OpenSCAP XCCDF scan'))
+    print(_('usage: scap_getxccdfscandetails <XID>'))
 
 
 def do_scap_getxccdfscandetails(self, args):
@@ -150,15 +156,15 @@ def do_scap_getxccdfscandetails(self, args):
         xid = int(xid)
         scan_details = self.client.system.scap.getXccdfScanDetails(self.session, xid)
 
-        print("XID:", scan_details['xid'], "SID:", scan_details['sid'], "Action_ID:",
-              scan_details['action_id'], "Path:", scan_details['path'], \
-              "OSCAP_Parameters:", scan_details['oscap_parameters'], \
-              "Test_Result:", scan_details['test_result'], "Benchmark:", \
-              scan_details['benchmark'], "Benchmark_Version:", \
-              scan_details['benchmark_version'], "Profile:", scan_details['profile'], \
-              "Profile_Title:", scan_details['profile_title'], "Start_Time:", \
-              scan_details['start_time'], "End_Time:", scan_details['end_time'], \
-              "Errors:", scan_details['errors'])
+        print(_("XID:"), scan_details['xid'], _("SID:"), scan_details['sid'], _("Action_ID:"),
+              scan_details['action_id'], _("Path:"), scan_details['path'], \
+              _("OSCAP_Parameters:"), scan_details['oscap_parameters'], \
+              _("Test_Result:"), scan_details['test_result'], _("Benchmark:"), \
+              scan_details['benchmark'], _("Benchmark_Version:"), \
+              scan_details['benchmark_version'], _("Profile:"), scan_details['profile'], \
+              _("Profile_Title:"), scan_details['profile_title'], _("Start_Time:"), \
+              scan_details['start_time'], _("End_Time:"), scan_details['end_time'], \
+              _("Errors:"), scan_details['errors'])
 
     return 0
 
@@ -166,14 +172,14 @@ def do_scap_getxccdfscandetails(self, args):
 
 
 def help_scap_schedulexccdfscan(self):
-    print('scap_schedulexccdfscan: Schedule Scap XCCDF scan')
-    print('usage: scap_schedulexccdfscan PATH_TO_XCCDF_FILE XCCDF_OPTIONS SYSTEMS')
-    print('       scap_schedulexccdfscan ssm PATH_TO_XCCDF_FILE XCCDF_OPTIONS')
+    print(_('scap_schedulexccdfscan: Schedule Scap XCCDF scan'))
+    print(_('usage: scap_schedulexccdfscan PATH_TO_XCCDF_FILE XCCDF_OPTIONS SYSTEMS'))
+    print(_('       scap_schedulexccdfscan ssm PATH_TO_XCCDF_FILE XCCDF_OPTIONS'))
     print('')
-    print('Example:')
+    print(_('Example:'))
     print('> scap_schedulexccdfscan \'/usr/share/openscap/scap-security-xccdf.xml\'' +
           ' \'profile Web-Default\' system-scap.example.com')
-    print('\nTo use systems in the ssm, pass the "ssm" keyword in front. Example:')
+    print(_('\nTo use systems in the ssm, pass the "ssm" keyword in front. Example:'))
     print("> scap_schedulexccdfscan ssm '/usr/share/openscap/scap-security-xccdf.xml'" +
           " 'profile Web-Default'")
 
@@ -198,7 +204,7 @@ def do_scap_schedulexccdfscan(self, args):
         systems = self.expand_systems(args[2:])
 
     if not systems:
-        logging.warning('No systems selected')
+        logging.warning(_('No systems selected'))
         return 1
 
     for system in systems:

--- a/spacecmd/src/spacecmd/schedule.py
+++ b/spacecmd/src/spacecmd/schedule.py
@@ -30,6 +30,7 @@
 # pylint: disable=C0103
 
 import base64
+import gettext
 from operator import itemgetter
 try:
     from xmlrpc import client as xmlrpclib
@@ -37,6 +38,11 @@ except ImportError:
     import xmlrpclib
 from spacecmd.utils import *
 
+translation = gettext.translation('spacecmd', fallback=True)
+try:
+    _ = translation.ugettext
+except AttributeError:
+    _ = translation.gettext
 
 def print_schedule_summary(self, action_type, args):
     args = args.split() or []
@@ -79,7 +85,7 @@ def print_schedule_summary(self, action_type, args):
     if not actions:
         return
 
-    print('ID      Date                 C    F    P     Action')
+    print(_('ID      Date                 C    F    P     Action'))
     print('--      ----                ---  ---  ---    ------')
 
     for action in sorted(actions, key=itemgetter('id'), reverse=True):
@@ -125,8 +131,8 @@ def print_schedule_summary(self, action_type, args):
 
 
 def help_schedule_cancel(self):
-    print('schedule_cancel: Cancel scheduled actions')
-    print('usage: schedule_cancel ID|* ...')
+    print(_('schedule_cancel: Cancel scheduled actions'))
+    print(_('usage: schedule_cancel ID|* ...'))
 
 
 def complete_schedule_cancel(self, text, line, beg, end):
@@ -148,8 +154,8 @@ def do_schedule_cancel(self, args):
 
     # cancel all actions
     if '.*' in args:
-        if not self.user_confirm('Cancel all pending actions [y/N]:'):
-            logging.info("All pending actions left untouched")
+        if not self.user_confirm(_('Cancel all pending actions [y/N]:')):
+            logging.info(_("All pending actions left untouched"))
             return 1
 
         actions = self.client.schedule.listInProgressActions(self.session)
@@ -164,18 +170,18 @@ def do_schedule_cancel(self, args):
         try:
             actions.append(int(a))
         except ValueError:
-            logging.warning('"%s" is not a valid ID' % str(a))
+            logging.warning(_('"%s" is not a valid ID') % str(a))
             failed_actions.append(a)
 
     if actions:
         self.client.schedule.cancelActions(self.session, actions)
         for a in actions:
-            logging.info('Canceled action: %i', a)
+            logging.info(_('Canceled action: %i'), a)
     if failed_actions:
         for action in failed_actions:
-            logging.info("Failed action: %s", action)
+            logging.info(_("Failed action: %s"), action)
 
-    print('Canceled %i action(s)' % len(actions))
+    print(_('Canceled %i action(s)') % len(actions))
 
     return 0
 
@@ -183,8 +189,8 @@ def do_schedule_cancel(self, args):
 
 
 def help_schedule_reschedule(self):
-    print('schedule_reschedule: Reschedule failed actions')
-    print('usage: schedule_reschedule ID|* ...')
+    print(_('schedule_reschedule: Reschedule failed actions'))
+    print(_('usage: schedule_reschedule ID|* ...'))
 
 
 def complete_schedule_reschedule(self, text, line, beg, end):
@@ -211,7 +217,7 @@ def do_schedule_reschedule(self, args):
 
     # reschedule all failed actions
     if '.*' in args:
-        if not self.user_confirm('Reschedule all failed actions [y/N]:'):
+        if not self.user_confirm(_('Reschedule all failed actions [y/N]:')):
             return 1
         to_reschedule = failed_actions
     else:
@@ -223,17 +229,17 @@ def do_schedule_reschedule(self, args):
                 if action_id in failed_actions:
                     to_reschedule.append(action_id)
                 else:
-                    logging.warning('"%i" is not a failed action' % action_id)
+                    logging.warning(_('"%i" is not a failed action') % action_id)
             except ValueError:
-                logging.warning('"%s" is not a valid ID' % str(a))
+                logging.warning(_('"%s" is not a valid ID') % str(a))
                 continue
 
     if not to_reschedule:
-        logging.warning('No failed actions to reschedule')
+        logging.warning(_('No failed actions to reschedule'))
         return 1
     else:
         self.client.schedule.rescheduleActions(self.session, to_reschedule, True)
-        print('Rescheduled %i action(s)' % len(to_reschedule))
+        print(_('Rescheduled %i action(s)') % len(to_reschedule))
 
     return 0
 
@@ -241,8 +247,8 @@ def do_schedule_reschedule(self, args):
 
 
 def help_schedule_details(self):
-    print('schedule_details: Show the details of a scheduled action')
-    print('usage: schedule_details ID')
+    print(_('schedule_details: Show the details of a scheduled action'))
+    print(_('usage: schedule_details ID'))
 
 
 def do_schedule_details(self, args):
@@ -259,7 +265,7 @@ def do_schedule_details(self, args):
     try:
         action_id = int(action_id)
     except ValueError:
-        logging.warning('The ID "%s" is invalid' % action_id)
+        logging.warning(_('The ID "%s" is invalid') % action_id)
         return 1
 
     completed = self.client.schedule.listCompletedSystems(self.session, action_id)
@@ -268,37 +274,37 @@ def do_schedule_details(self, args):
     action = {acn.get("id"): acn for acn in self.client.schedule.listAllActions(self.session)}.get(action_id)
 
     if action is not None:
-        print('ID:        %i' % action.get('id'))
-        print('Action:    %s' % action.get('name'))
-        print('User:      %s' % action.get('scheduler'))
-        print('Date:      %s' % action.get('earliest'))
+        print(_('ID:        %i') % action.get('id'))
+        print(_('Action:    %s') % action.get('name'))
+        print(_('User:      %s') % action.get('scheduler'))
+        print(_('Date:      %s') % action.get('earliest'))
         print('')
-        print('Completed: %s' % str(len(completed)).rjust(3))
-        print('Failed:    %s' % str(len(failed)).rjust(3))
-        print('Pending:   %s' % str(len(pending)).rjust(3))
+        print(_('Completed: %s') % str(len(completed)).rjust(3))
+        print(_('Failed:    %s') % str(len(failed)).rjust(3))
+        print(_('Pending:   %s') % str(len(pending)).rjust(3))
 
         if completed:
             print('')
-            print('Completed Systems')
+            print(_('Completed Systems'))
             print('-----------------')
             for s in completed:
                 print(s.get('server_name'))
 
         if failed:
             print('')
-            print('Failed Systems')
+            print(_('Failed Systems'))
             print('--------------')
             for s in failed:
                 print(s.get('server_name'))
 
         if pending:
             print('')
-            print('Pending Systems')
+            print(_('Pending Systems'))
             print('---------------')
             for s in pending:
                 print(s.get('server_name'))
     else:
-        logging.error('No action found with the ID "%s"' % action_id)
+        logging.error(_('No action found with the ID "%s"') % action_id)
         return 1
 
     return 0
@@ -307,8 +313,8 @@ def do_schedule_details(self, args):
 
 
 def help_schedule_getoutput(self):
-    print('schedule_getoutput: Show the output from an action')
-    print('usage: schedule_getoutput ID')
+    print(_('schedule_getoutput: Show the output from an action'))
+    print(_('usage: schedule_getoutput ID'))
 
 
 def do_schedule_getoutput(self, args):
@@ -323,7 +329,7 @@ def do_schedule_getoutput(self, args):
     try:
         action_id = int(args[0])
     except ValueError:
-        logging.error('"%s" is not a valid action ID' % str(args[0]))
+        logging.error(_('"%s" is not a valid action ID') % str(args[0]))
         return 1
 
     script_results = None
@@ -345,12 +351,12 @@ def do_schedule_getoutput(self, args):
             else:
                 system = 'UNKNOWN'
 
-            print('System:      %s' % system)
-            print('Start Time:  %s' % r.get('startDate'))
-            print('Stop Time:   %s' % r.get('stopDate'))
-            print('Return Code: %i' % r.get('returnCode'))
+            print(_('System:      %s') % system)
+            print(_('Start Time:  %s') % r.get('startDate'))
+            print(_('Stop Time:   %s') % r.get('stopDate'))
+            print(_('Return Code: %i') % r.get('returnCode'))
             print('')
-            print('Output')
+            print(_('Output'))
             print('------')
             if r.get('output_enc64'):
                 print(base64.b64decode(r.get('output') or b'Ti9B\n').decode("utf-8"))
@@ -369,14 +375,14 @@ def do_schedule_getoutput(self, args):
                     print(self.SEPARATOR)
                 add_separator = True
 
-                print('System:    %s' % action.get('server_name'))
-                print('Completed: %s' % action.get('timestamp'))
+                print(_('System:    %s') % action.get('server_name'))
+                print(_('Completed: %s') % action.get('timestamp'))
                 print('')
-                print('Output')
+                print(_('Output'))
                 print('------')
                 print(action.get('message'))
         else:
-            logging.error("No systems found")
+            logging.error(_("No systems found"))
             return 1
 
     return 0
@@ -385,8 +391,8 @@ def do_schedule_getoutput(self, args):
 
 
 def help_schedule_listpending(self):
-    print('schedule_listpending: List pending actions')
-    print('usage: schedule_listpending [BEGINDATE] [ENDDATE]')
+    print(_('schedule_listpending: List pending actions'))
+    print(_('usage: schedule_listpending [BEGINDATE] [ENDDATE]'))
     print('')
     print(self.HELP_TIME_OPTS)
 
@@ -398,8 +404,8 @@ def do_schedule_listpending(self, args):
 
 
 def help_schedule_listcompleted(self):
-    print('schedule_listcompleted: List completed actions')
-    print('usage: schedule_listcompleted [BEGINDATE] [ENDDATE]')
+    print(_('schedule_listcompleted: List completed actions'))
+    print(_('usage: schedule_listcompleted [BEGINDATE] [ENDDATE]'))
     print('')
     print(self.HELP_TIME_OPTS)
 
@@ -411,8 +417,8 @@ def do_schedule_listcompleted(self, args):
 
 
 def help_schedule_listfailed(self):
-    print('schedule_listfailed: List failed actions')
-    print('usage: schedule_listfailed [BEGINDATE] [ENDDATE]')
+    print(_('schedule_listfailed: List failed actions'))
+    print(_('usage: schedule_listfailed [BEGINDATE] [ENDDATE]'))
     print('')
     print(self.HELP_TIME_OPTS)
 
@@ -424,8 +430,8 @@ def do_schedule_listfailed(self, args):
 
 
 def help_schedule_listarchived(self):
-    print('schedule_listarchived: List archived actions')
-    print('usage: schedule_listarchived [BEGINDATE] [ENDDATE]')
+    print(_('schedule_listarchived: List archived actions'))
+    print(_('usage: schedule_listarchived [BEGINDATE] [ENDDATE]'))
     print('')
     print(self.HELP_TIME_OPTS)
 
@@ -437,8 +443,8 @@ def do_schedule_listarchived(self, args):
 
 
 def help_schedule_list(self):
-    print('schedule_list: List all actions')
-    print('usage: schedule_list [BEGINDATE] [ENDDATE]')
+    print(_('schedule_list: List all actions'))
+    print(_('usage: schedule_list [BEGINDATE] [ENDDATE]'))
     print('')
     print(self.HELP_TIME_OPTS)
 

--- a/spacecmd/src/spacecmd/shell.py
+++ b/spacecmd/src/spacecmd/shell.py
@@ -33,6 +33,7 @@
 # pylint: disable=W0122
 
 import atexit
+import gettext
 import logging
 import os
 import readline
@@ -42,6 +43,11 @@ import sys
 from cmd import Cmd
 from spacecmd.utils import *
 
+translation = gettext.translation('spacecmd', fallback=True)
+try:
+    _ = translation.ugettext
+except AttributeError:
+    _ = translation.gettext
 class UnknownCallException(Exception):
 
     def __init__(self):
@@ -111,11 +117,11 @@ class SpacewalkShell(Cmd):
                     atexit.register(readline.write_history_file,
                                     self.history_file)
                 except IOError:
-                    logging.error('Could not read history file')
+                    logging.error(_('Could not read history file'))
         # pylint: disable=W0702
         except Exception as exc:
             # pylint: disable=W0702
-            logging.error("Exception occurred: {}".format(exc))
+            logging.error(_("Exception occurred: {}").format(exc))
             sys.exit(1)
 
     # handle shell exits and history substitution
@@ -179,7 +185,7 @@ class SpacewalkShell(Cmd):
             if line:
                 history_match = True
             else:
-                logging.warning('%s: event not found', command)
+                logging.warning(_('%s: event not found'), command)
                 return ''
 
         # attempt to find a numbered history item
@@ -218,7 +224,7 @@ class SpacewalkShell(Cmd):
             print(line)
             return line
         else:
-            logging.warning('%s: event not found', command)
+            logging.warning(_('%s: event not found'), command)
             return ''
 
     @staticmethod

--- a/spacecmd/src/spacecmd/snippet.py
+++ b/spacecmd/src/spacecmd/snippet.py
@@ -29,12 +29,18 @@
 # invalid function name
 # pylint: disable=C0103
 
+import gettext
 from spacecmd.utils import *
 
+translation = gettext.translation('spacecmd', fallback=True)
+try:
+    _ = translation.ugettext
+except AttributeError:
+    _ = translation.gettext
 
 def help_snippet_list(self):
-    print('snippet_list: List the available Kickstart snippets')
-    print('usage: snippet_list')
+    print(_('snippet_list: List the available Kickstart snippets'))
+    print(_('usage: snippet_list'))
 
 
 def do_snippet_list(self, args, doreturn=False):
@@ -51,8 +57,8 @@ def do_snippet_list(self, args, doreturn=False):
 
 
 def help_snippet_details(self):
-    print('snippet_details: Show the contents of a snippet')
-    print('usage: snippet_details SNIPPET ...')
+    print(_('snippet_details: Show the contents of a snippet'))
+    print(_('usage: snippet_details SNIPPET ...'))
 
 
 def complete_snippet_details(self, text, line, beg, end):
@@ -81,16 +87,16 @@ def do_snippet_details(self, args):
                 break
 
         if not snippet:
-            logging.warning('%s is not a valid snippet' % name)
+            logging.warning(_('%s is not a valid snippet') % name)
             continue
 
         if add_separator:
             print(self.SEPARATOR)
         add_separator = True
 
-        print('Name:   %s' % snippet.get('name'))
-        print('Macro:  %s' % snippet.get('fragment'))
-        print('File:   %s' % snippet.get('file'))
+        print(_('Name:   %s') % snippet.get('name'))
+        print(_('Macro:  %s') % snippet.get('fragment'))
+        print(_('File:   %s') % snippet.get('file'))
 
         print('')
         print(snippet.get('contents'))
@@ -101,12 +107,12 @@ def do_snippet_details(self, args):
 
 
 def help_snippet_create(self):
-    print('snippet_create: Create a Kickstart snippet')
-    print('''usage: snippet_create [options])
+    print(_('snippet_create: Create a Kickstart snippet'))
+    print(_('''usage: snippet_create [options])
 
 options:
   -n NAME
-  -f FILE''')
+  -f FILE'''))
 
 
 def do_snippet_create(self, args, update_name=''):
@@ -132,7 +138,7 @@ def do_snippet_create(self, args, update_name=''):
         if not options.name:
             options.name = prompt_user('Name:', noblank=True)
 
-        if self.user_confirm('Read an existing file [y/N]:',
+        if self.user_confirm(_('Read an existing file [y/N]:'),
                              nospacer=True, ignore_yes=True):
             options.file = prompt_user('File:')
         else:
@@ -140,19 +146,19 @@ def do_snippet_create(self, args, update_name=''):
                                          delete=True)
     else:
         if not options.name:
-            logging.error('A name is required for the snippet')
+            logging.error(_('A name is required for the snippet'))
             return 1
 
         if not options.file:
-            logging.error('A file is required')
+            logging.error(_('A file is required'))
             return 1
 
     if options.file:
         contents = read_file(options.file)
 
     print('')
-    print('Snippet: %s' % options.name)
-    print('Contents')
+    print(_('Snippet: %s') % options.name)
+    print(_('Contents'))
     print('--------')
     print(contents)
 
@@ -167,8 +173,8 @@ def do_snippet_create(self, args, update_name=''):
 
 
 def help_snippet_update(self):
-    print('snippet_update: Update a Kickstart snippet')
-    print('usage: snippet_update NAME')
+    print(_('snippet_update: Update a Kickstart snippet'))
+    print(_('usage: snippet_update NAME'))
 
 
 def complete_snippet_update(self, text, line, beg, end):
@@ -190,8 +196,8 @@ def do_snippet_update(self, args):
 
 
 def help_snippet_delete(self):
-    print('snippet_delete: Delete a Kickstart snippet')
-    print('usage: snippet_delete NAME')
+    print(_('snippet_delete: Delete a Kickstart snippet'))
+    print(_('usage: snippet_delete NAME'))
 
 
 def complete_snippet_delete(self, text, line, beg, end):
@@ -209,7 +215,7 @@ def do_snippet_delete(self, args):
 
     snippet = args[0]
 
-    if self.user_confirm('Remove this snippet [y/N]:'):
+    if self.user_confirm(_('Remove this snippet [y/N]:')):
         self.client.kickstart.snippet.delete(self.session, snippet)
         return 0
     else:

--- a/spacecmd/src/spacecmd/softwarechannel.py
+++ b/spacecmd/src/spacecmd/softwarechannel.py
@@ -30,6 +30,7 @@
 # invalid function name
 # pylint: disable=C0103
 
+import gettext
 try:
     from urllib import ContentTooShortError
 except ImportError:
@@ -44,16 +45,21 @@ except ImportError:
     import xmlrpclib
 from spacecmd.utils import *
 
+translation = gettext.translation('spacecmd', fallback=True)
+try:
+    _ = translation.ugettext
+except AttributeError:
+    _ = translation.gettext
 
 CHECKSUM = ['sha1', 'sha256', 'sha384', 'sha512']
 
 def help_softwarechannel_list(self):
-    print('softwarechannel_list: List all available software channels')
-    print('''usage: softwarechannel_list [options]')
+    print(_('softwarechannel_list: List all available software channels'))
+    print(_('''usage: softwarechannel_list [options]')
 options:
   -v verbose (display label and summary)
   -t tree view (pretty-print(child-channels))
-''')
+'''))
 
 
 def do_softwarechannel_list(self, args, doreturn=False):
@@ -97,11 +103,11 @@ def do_softwarechannel_list(self, args, doreturn=False):
 
 
 def help_softwarechannel_listmanageablechannels(self):
-    print('softwarechannel_listmanageablechannels: List all software channels')
-    print('                                        manageable by current user')
-    print('''usage: softwarechannel_listmanageablechannels [options]
+    print(_('softwarechannel_listmanageablechannels: List all software channels'))
+    print(_('                                        manageable by current user'))
+    print(_('''usage: softwarechannel_listmanageablechannels [options]
 options:
-  -v verbose (display label and summary)''')
+  -v verbose (display label and summary)'''))
 
 
 def do_softwarechannel_listmanageablechannels(self, args, doreturn=False):
@@ -134,10 +140,10 @@ def do_softwarechannel_listmanageablechannels(self, args, doreturn=False):
 
 
 def help_softwarechannel_listbasechannels(self):
-    print('softwarechannel_listbasechannels: List all base software channels')
-    print('''usage: softwarechannel_listbasechannels [options])
+    print(_('softwarechannel_listbasechannels: List all base software channels'))
+    print(_('''usage: softwarechannel_listbasechannels [options])
 options:
-  -v verbose (display label and summary)''')
+  -v verbose (display label and summary)'''))
 
 
 def do_softwarechannel_listbasechannels(self, args):
@@ -163,13 +169,13 @@ def do_softwarechannel_listbasechannels(self, args):
 
 
 def help_softwarechannel_listchildchannels(self):
-    print('softwarechannel_listchildchannels: List child software channels')
-    print('usage:')
-    print('softwarechannel_listchildchannels [options]')
-    print('softwarechannel_listchildchannels : List all child channels')
-    print('softwarechannel_listchildchannels CHANNEL : List children for a' +
-          'specific base channel')
-    print('options:\n -v verbose (display label and summary)')
+    print(_('softwarechannel_listchildchannels: List child software channels'))
+    print(_('usage:'))
+    print(_('softwarechannel_listchildchannels [options]'))
+    print(_('softwarechannel_listchildchannels : List all child channels'))
+    print(_('softwarechannel_listchildchannels CHANNEL : List children for a' +
+          'specific base channel'))
+    print(_('options:\n -v verbose (display label and summary)'))
 
 
 def do_softwarechannel_listchildchannels(self, args):
@@ -197,9 +203,9 @@ def do_softwarechannel_listchildchannels(self, args):
 
 
 def help_softwarechannel_listsystems(self):
-    print('softwarechannel_listsystems: List all systems subscribed to')
-    print('                             a software channel')
-    print('usage: softwarechannel_listsystems CHANNEL')
+    print(_('softwarechannel_listsystems: List all systems subscribed to'))
+    print(_('                             a software channel'))
+    print(_('usage: softwarechannel_listsystems CHANNEL'))
 
 
 def complete_softwarechannel_listsystems(self, text, line, beg, end):
@@ -233,9 +239,9 @@ def do_softwarechannel_listsystems(self, args, doreturn=False):
 
 
 def help_softwarechannel_listpackages(self):
-    print('softwarechannel_listpackages: List the most recent packages')
-    print('                              available from a software channel')
-    print('usage: softwarechannel_listpackages CHANNEL')
+    print(_('softwarechannel_listpackages: List the most recent packages'))
+    print(_('                              available from a software channel'))
+    print(_('usage: softwarechannel_listpackages CHANNEL'))
 
 
 def complete_softwarechannel_listpackages(self, text, line, beg, end):
@@ -272,8 +278,8 @@ def do_softwarechannel_listpackages(self, args, doreturn=False):
 
 
 def help_softwarechannel_listallpackages(self):
-    print('softwarechannel_listallpackages: List all packages in a channel')
-    print('usage: softwarechannel_listallpackages CHANNEL')
+    print(_('softwarechannel_listallpackages: List all packages in a channel'))
+    print(_('usage: softwarechannel_listallpackages CHANNEL'))
 
 
 def complete_softwarechannel_listallpackages(self, text, line, beg, end):
@@ -331,8 +337,8 @@ def filter_latest_packages(pkglist):
 
 
 def help_softwarechannel_listlatestpackages(self):
-    print('softwarechannel_listlatestpackages: List the newest version of all packages in a channel')
-    print('usage: softwarechannel_listlatestpackages CHANNEL')
+    print(_('softwarechannel_listlatestpackages: List the newest version of all packages in a channel'))
+    print(_('usage: softwarechannel_listlatestpackages CHANNEL'))
 
 
 def complete_softwarechannel_listlatestpackages(self, text, line, beg, end):
@@ -371,8 +377,8 @@ def do_softwarechannel_listlatestpackages(self, args, doreturn=False):
 
 
 def help_softwarechannel_setdetails(self):
-    print('softwarechannel_setdetails: Modify details of a software channel')
-    print('''usage: softwarechannel_setdetails [options] <CHANNEL ...>)
+    print(_('softwarechannel_setdetails: Modify details of a software channel'))
+    print(_('''usage: softwarechannel_setdetails [options] <CHANNEL ...>)
 
 options, at least one of which must be given:
   -n NAME
@@ -384,7 +390,7 @@ options, at least one of which must be given:
   -p MAINTAINER_PHONE
   -u GPG_URL
   -i GPG_ID
-  -f GPG_FINGERPRINT''' % CHECKSUM)
+  -f GPG_FINGERPRINT''') % CHECKSUM)
 
 
 def complete_softwarechannel_setdetails(self, text, line, beg, end):
@@ -434,13 +440,13 @@ def do_softwarechannel_setdetails(self, args):
         new_details['gpg_key_fp'] = options.gpg_fingerprint
 
     if not new_details:
-        logging.error('At least one attribute to set must be given')
+        logging.error(_('At least one attribute to set must be given'))
         return 1
 
     # allow globbing of software channel names
     channels = filter_results(self.do_softwarechannel_list('', True), args)
     if len(channels) < 1:
-        logging.info('No channels matching that label')
+        logging.info(_('No channels matching that label'))
         return 1
 
     # channel names must be unique, so if we are asked to set it,
@@ -452,46 +458,46 @@ def do_softwarechannel_setdetails(self, args):
     # also fails on same label.
     if new_details.get('name'):
         if len(channels) > 1:
-            logging.error('Setting same name for more than ' + \
-                          'one channel will fail')
+            logging.error(_('Setting same name for more than ' + \
+                          'one channel will fail'))
             return 1
         logging.debug('checking other channels for name "%s"' %
                       new_details.get('name'))
         for c in self.list_base_channels() + self.list_child_channels():
             cd = self.client.channel.software.getDetails(self.session, c)
             if cd.get('name') == new_details.get('name'):
-                logging.error('Name "%s" already in use by channel %s' %
+                logging.error(_('Name "%s" already in use by channel %s') %
                               (cd.get('name'), cd.get('label')))
                 return 1
 
     # get confirmation
-    print('Setting following attributes...')
+    print(_('Setting following attributes...'))
     print('')
     if new_details.get('name'):
-        print('Name:             %s' % new_details.get('name'))
+        print(_('Name:             %s') % new_details.get('name'))
     if new_details.get('summary'):
-        print('Summary:          %s' % new_details.get('summary'))
+        print(_('Summary:          %s') % new_details.get('summary'))
     if new_details.get('description'):
-        print('Description:      %s' % new_details.get('description'))
+        print(_('Description:      %s') % new_details.get('description'))
     if new_details.get('checksum_label'):
-        print('Checksum:         %s' % new_details.get('checksum_label'))
+        print(_('Checksum:         %s') % new_details.get('checksum_label'))
     if new_details.get('maintainer_name'):
-        print('Maintainer name:  %s' % new_details.get('maintainer_name'))
+        print(_('Maintainer name:  %s') % new_details.get('maintainer_name'))
     if new_details.get('maintainer_email'):
-        print('Maintainer email: %s' % new_details.get('maintainer_email'))
+        print(_('Maintainer email: %s') % new_details.get('maintainer_email'))
     if new_details.get('maintainer_phone'):
-        print('Maintainer phone: %s' % new_details.get('maintainer_phone'))
+        print(_('Maintainer phone: %s') % new_details.get('maintainer_phone'))
     if new_details.get('gpg_key_id'):
-        print('GPG Key:          %s' % new_details.get('gpg_key_id'))
+        print(_('GPG Key:          %s') % new_details.get('gpg_key_id'))
     if new_details.get('gpg_key_fp'):
-        print('GPG Fingerprint:  %s' % new_details.get('gpg_key_fp'))
+        print(_('GPG Fingerprint:  %s') % new_details.get('gpg_key_fp'))
     if new_details.get('gpg_key_url'):
-        print('GPG URL:          %s' % new_details.get('gpg_key_url'))
+        print(_('GPG URL:          %s') % new_details.get('gpg_key_url'))
     print('')
-    print('... for the following channels:')
+    print(_('... for the following channels:'))
     print('\n'.join(channels))
     print('')
-    if not self.user_confirm('Apply? [y/N]:'):
+    if not self.user_confirm(_('Apply? [y/N]:')):
         return 1
 
     logging.debug('new channel details dictionary:')
@@ -503,7 +509,7 @@ def do_softwarechannel_setdetails(self, args):
             details = self.client.channel.software.getDetails(self.session,
                                                               channel)
         except xmlrpclib.Fault as e:
-            logging.error('Could not get details for %s' % channel)
+            logging.error(_('Could not get details for %s') % channel)
             logging.error(e)
             return 1
         channel_id = details.get('id')
@@ -515,10 +521,10 @@ def do_softwarechannel_setdetails(self, args):
                                                     new_details)
             num_changed += 1
         except xmlrpclib.Fault as e:
-            logging.error('Error while setting details for %s' % channel)
+            logging.error(_('Error while setting details for %s') % channel)
             logging.error(e)
             return 1
-    logging.info('Channels changed: %d' % num_changed)
+    logging.info(_('Channels changed: %d') % num_changed)
 
     return 0
 
@@ -526,8 +532,8 @@ def do_softwarechannel_setdetails(self, args):
 
 
 def help_softwarechannel_details(self):
-    print('softwarechannel_details: Show the details of a software channel')
-    print('usage: softwarechannel_details <CHANNEL ...>')
+    print(_('softwarechannel_details: Show the details of a software channel'))
+    print(_('usage: softwarechannel_details <CHANNEL ...>'))
 
 
 def complete_softwarechannel_details(self, text, line, beg, end):
@@ -567,41 +573,41 @@ def do_softwarechannel_details(self, args):
             print(self.SEPARATOR)
         add_separator = True
 
-        print('Label:              %s' % details.get('label'))
-        print('Name:               %s' % details.get('name'))
-        print('Architecture:       %s' % details.get('arch_name'))
-        print('Parent:             %s' % details.get('parent_channel_label'))
-        print('Systems Subscribed: %s' % len(systems))
-        print('Number of Packages: %i' % len(packages))
+        print(_('Label:              %s') % details.get('label'))
+        print(_('Name:               %s') % details.get('name'))
+        print(_('Architecture:       %s') % details.get('arch_name'))
+        print(_('Parent:             %s') % details.get('parent_channel_label'))
+        print(_('Systems Subscribed: %s') % len(systems))
+        print(_('Number of Packages: %i') % len(packages))
 
         if details.get('summary'):
             print('')
-            print('Summary')
+            print(_('Summary'))
             print('-------')
             print('\n'.join(wrap(details.get('summary'))))
 
         if details.get('description'):
             print('')
-            print('Description')
+            print(_('Description'))
             print('-----------')
             print('\n'.join(wrap(details.get('description'))))
 
         print('')
-        print('GPG Key:            %s' % details.get('gpg_key_id'))
-        print('GPG Fingerprint:    %s' % details.get('gpg_key_fp'))
-        print('GPG URL:            %s' % details.get('gpg_key_url'))
-        print('GPG CHECK:          %s' % details.get('gpg_check'))
+        print(_('GPG Key:            %s') % details.get('gpg_key_id'))
+        print(_('GPG Fingerprint:    %s') % details.get('gpg_key_fp'))
+        print(_('GPG URL:            %s') % details.get('gpg_key_url'))
+        print(_('GPG CHECK:          %s') % details.get('gpg_check'))
 
         if trees:
             print('')
-            print('Kickstart Trees')
+            print(_('Kickstart Trees'))
             print('---------------')
             for tree in trees:
                 print(tree.get('label'))
 
         if details.get('contentSources'):
             print('')
-            print('Repos')
+            print(_('Repos'))
             print('-----')
             for repo in details.get('contentSources'):
                 print(repo.get('label'))
@@ -612,9 +618,9 @@ def do_softwarechannel_details(self, args):
 
 
 def help_softwarechannel_listerrata(self):
-    print('softwarechannel_listerrata: List the errata associated with a')
-    print('                            software channel')
-    print('usage: softwarechannel_listerrata <CHANNEL ...> [from=yyyymmdd [to=yyyymmdd]]')
+    print(_('softwarechannel_listerrata: List the errata associated with a'))
+    print(_('                            software channel'))
+    print(_('usage: softwarechannel_listerrata <CHANNEL ...> [from=yyyymmdd [to=yyyymmdd]]'))
 
 
 def complete_softwarechannel_listerrata(self, text, line, beg, end):
@@ -672,11 +678,11 @@ def do_softwarechannel_listerrata(self, args):
 ####################
 
 def help_softwarechannel_listarches(self):
-    print("softwarechannel_listarches: lists the potential software")
-    print("                            channel architectures that can be created")
-    print("usage: softwarechannel_listarches")
-    print("options:")
-    print("    -v verbose (display label and name)")
+    print(_("softwarechannel_listarches: lists the potential software"))
+    print(_("                            channel architectures that can be created"))
+    print(_("usage: softwarechannel_listarches"))
+    print(_("options:"))
+    print(_("    -v verbose (display label and name)"))
 
 def do_softwarechannel_listarches(self, args):
     arg_parser = get_argument_parser()
@@ -697,8 +703,8 @@ def do_softwarechannel_listarches(self, args):
 ####################
 
 def help_softwarechannel_delete(self):
-    print('softwarechannel_delete: Delete a software channel')
-    print('usage: softwarechannel_delete <CHANNEL ...>')
+    print(_('softwarechannel_delete: Delete a software channel'))
+    print(_('usage: softwarechannel_delete <CHANNEL ...>'))
 
 
 def complete_softwarechannel_delete(self, text, line, beg, end):
@@ -723,11 +729,11 @@ def do_softwarechannel_delete(self, args):
     if not to_delete:
         return 1
 
-    print('Channels')
+    print(_('Channels'))
     print('--------')
     print('\n'.join(sorted(to_delete)))
 
-    if not self.user_confirm('Delete these channels [y/N]:'):
+    if not self.user_confirm(_('Delete these channels [y/N]:')):
         return 1
 
     # delete child channels first to avoid errors
@@ -751,8 +757,8 @@ def do_softwarechannel_delete(self, args):
 ####################
 
 def help_softwarechannel_update(self):
-    print('softwarechannel_update: Update a software channel')
-    print('''usage: softwarechannel_update LABEL(To identify the channel) [options]
+    print(_('softwarechannel_update: Update a software channel'))
+    print(_('''usage: softwarechannel_update LABEL(To identify the channel) [options]
 options:
   -l LABEL(Required)
   -n NAME
@@ -762,7 +768,7 @@ options:
   -u GPG-URL
   -i GPG-ID
   -f GPG-FINGERPRINT
-  -g DISABLE-GPG-CHECK''' % CHECKSUM)
+  -g DISABLE-GPG-CHECK''' % CHECKSUM))
 
 
 def do_softwarechannel_update(self, args):
@@ -783,64 +789,64 @@ def do_softwarechannel_update(self, args):
 
     if is_interactive(options):
 
-        options.label = prompt_user('Channel Label:', noblank=True)
+        options.label = prompt_user(_('Channel Label:'), noblank=True)
         vendor_channel = is_vendor_channel(self, options.label)
 
         if not vendor_channel:
             print('')
-            print('New Name (blank to keep unchanged)')
+            print(_('New Name (blank to keep unchanged)'))
             print('------------')
             print('')
-            options.name = prompt_user('Name:')
+            options.name = prompt_user(_('Name:'))
 
             print('')
-            print('New Summary (blank to keep unchanged)')
+            print(_('New Summary (blank to keep unchanged)'))
             print('------------')
             print('')
-            options.summary = prompt_user('Summary:')
+            options.summary = prompt_user(_('Summary:'))
 
             print('')
-            print('New Description (blank to keep unchanged)')
+            print(_('New Description (blank to keep unchanged)'))
             print('------------')
             print('')
-            options.description = prompt_user('Description:')
+            options.description = prompt_user(_('Description:'))
 
             print('')
-            print('New Checksum type (blank to keep unchanged)')
+            print(_('New Checksum type (blank to keep unchanged)'))
             print('------------')
             print('\n'.join(sorted(self.CHECKSUM)))
             print('')
-            options.checksum = prompt_user('Select:')
+            options.checksum = prompt_user(_('Select:'))
 
             print('')
-            print('New GPG URL (blank to keep unchanged)')
+            print(_('New GPG URL (blank to keep unchanged)'))
             print('------------')
             print('')
-            options.gpg_url = prompt_user('GPG URL:')
+            options.gpg_url = prompt_user(_('GPG URL:'))
 
             print('')
-            print('New GPG ID (blank to keep unchanged)')
+            print(_('New GPG ID (blank to keep unchanged)'))
             print('------------')
             print('')
-            options.gpg_id = prompt_user('GPG ID:')
+            options.gpg_id = prompt_user(_('GPG ID:'))
 
             print('')
-            print('New GPG Fingerprint (blank to keep unchanged)')
+            print(_('New GPG Fingerprint (blank to keep unchanged)'))
             print('------------')
             print('')
-            options.gpg_fingerprint = prompt_user('GPG Fingerprint:')
+            options.gpg_fingerprint = prompt_user(_('GPG Fingerprint:'))
 
         print('')
-        print('Disable GPG CHECK (blank to keep unchanged)')
+        print(_('Disable GPG CHECK (blank to keep unchanged)'))
         print('------------')
         print('')
-        options.disable_gpg_check = prompt_user('Disable GPG Check [yes/no]? ')
+        options.disable_gpg_check = prompt_user(_('Disable GPG Check [yes/no]? '))
 
     if not options.label:
-        logging.error('A channel label is required to identify the channel')
+        logging.error(_('A channel label is required to identify the channel'))
         return 1
     if options.disable_gpg_check and options.disable_gpg_check not in ('yes','no'):
-        logging.error('Only [yes/no] values are acceptable for --disable_gpg_check')
+        logging.error(_('Only [yes/no] values are acceptable for --disable_gpg_check'))
         return 1
     details = {}
     if not vendor_channel:
@@ -880,8 +886,8 @@ def do_softwarechannel_update(self, args):
 
 
 def help_softwarechannel_create(self):
-    print('softwarechannel_create: Create a software channel')
-    print('''usage: softwarechannel_create [options])
+    print(_('softwarechannel_create: Create a software channel'))
+    print(_('''usage: softwarechannel_create [options])
 
 options:
   -n NAME
@@ -893,7 +899,7 @@ options:
   -u GPG_URL
   -i GPG_ID
   -f GPG_FINGERPRINT
-  -g DISABLE_GPG_CHECK''' % CHECKSUM)
+  -g DISABLE_GPG_CHECK''' % CHECKSUM))
 
 
 def do_softwarechannel_create(self, args):
@@ -914,55 +920,55 @@ def do_softwarechannel_create(self, args):
     (args, options) = parse_command_arguments(args, arg_parser)
 
     if is_interactive(options):
-        options.name = prompt_user('Channel Name:', noblank=True)
-        options.label = prompt_user('Channel Label:', noblank=True)
-        options.summary = prompt_user('Channel Summary:', noblank=True)
+        options.name = prompt_user(_('Channel Name:'), noblank=True)
+        options.label = prompt_user(_('Channel Label:'), noblank=True)
+        options.summary = prompt_user(_('Channel Summary:'), noblank=True)
 
-        print('Base Channels')
+        print(_('Base Channels'))
         print('-------------')
         print('\n'.join(sorted(self.list_base_channels())))
         print('')
 
         options.parent_channel = \
-            prompt_user('Select Parent [blank to create a base channel]:')
+            prompt_user(_('Select Parent [blank to create a base channel]:'))
 
         print('')
-        print('Architecture')
+        print(_('Architecture'))
         print('------------')
         print('\n'.join(sorted(self.ARCH_LABELS)))
         print('')
-        options.arch = prompt_user('Select:')
+        options.arch = prompt_user(_('Select:'))
 
         print('')
-        print('Checksum type')
+        print(_('Checksum type'))
         print('------------')
         print('\n'.join(sorted(self.CHECKSUM)))
         print('')
-        options.checksum = prompt_user('Select:')
+        options.checksum = prompt_user(_('Select:'))
 
         print('')
-        print('GPG URL')
+        print(_('GPG URL'))
         print('------------')
         print('')
-        options.gpg_url = prompt_user('GPG URL:')
+        options.gpg_url = prompt_user(_('GPG URL:'))
 
         print('')
-        print('GPG ID')
+        print(_('GPG ID'))
         print('------------')
         print('')
-        options.gpg_id = prompt_user('GPG ID:')
+        options.gpg_id = prompt_user(_('GPG ID:'))
 
         print('')
-        print('GPG Fingerprint')
+        print(_('GPG Fingerprint'))
         print('---------------')
         print('')
-        options.gpg_fingerprint = prompt_user('GPG Fingerprint:')
+        options.gpg_fingerprint = prompt_user(_('GPG Fingerprint:'))
 
         print('')
-        print('GPG CHECK')
+        print(_('GPG CHECK'))
         print('---------------')
         print('')
-        options.disable_gpg_check = self.user_confirm('Disable GPG Check [y/N]? ',
+        options.disable_gpg_check = self.user_confirm(_('Disable GPG Check [y/N]? '),
                                 nospacer=True, ignore_yes=True)
 
     if validate_required_data(options):
@@ -1014,11 +1020,11 @@ def set_default_data(options):
 
 def validate_required_data(options):
     if not options.name:
-        logging.error('A channel name is required')
+        logging.error(_('A channel name is required'))
         return False
 
     if not options.label:
-        logging.error('A channel label is required')
+        logging.error(_('A channel label is required'))
         return False
 
     return True
@@ -1031,11 +1037,11 @@ def softwarechannel_check_existing(self, name, label):
     for c in self.list_base_channels() + self.list_child_channels():
         cd = self.client.channel.software.getDetails(self.session, c)
         if cd['name'] == name:
-            logging.error("Name %s already in use by channel %s" %
+            logging.error(_("Name %s already in use by channel %s") %
                           (name, cd['label']))
             return True
         if cd['label'] == label:
-            logging.error("Label %s already in use by channel %s" %
+            logging.error(_("Label %s already in use by channel %s") %
                           (label, cd['label']))
             return True
     return False
@@ -1043,8 +1049,8 @@ def softwarechannel_check_existing(self, name, label):
 
 
 def help_softwarechannel_clone(self):
-    print('softwarechannel_clone: Clone a software channel')
-    print('''usage: softwarechannel_clone [options])
+    print(_('softwarechannel_clone: Clone a software channel'))
+    print(_('''usage: softwarechannel_clone [options])
 
 options:
   -s SOURCE_CHANNEL
@@ -1058,7 +1064,7 @@ options:
   --disable-gpg-check DISABLE_GPG_CHECK
   -o do not clone any patches
   --regex/-x "s/foo/bar" : Optional regex replacement,
-        replaces foo with bar in the clone name and label''')
+        replaces foo with bar in the clone name and label'''))
 
 
 def do_softwarechannel_clone(self, args):
@@ -1079,44 +1085,44 @@ def do_softwarechannel_clone(self, args):
     (args, options) = parse_command_arguments(args, arg_parser)
 
     if is_interactive(options):
-        print('Source Channels:')
+        print(_('Source Channels:'))
         print('\n'.join(sorted(self.list_base_channels())))
         print('\n'.join(sorted(self.list_child_channels())))
 
-        options.source_channel = prompt_user('Select source channel:',noblank=True)
-        options.name = prompt_user('Channel Name:', noblank=True)
-        options.label = prompt_user('Channel Label:', noblank=True)
+        options.source_channel = prompt_user(_('Select source channel:'),noblank=True)
+        options.name = prompt_user(_('Channel Name:'), noblank=True)
+        options.label = prompt_user(_('Channel Label:'), noblank=True)
 
-        print('Base Channels:')
+        print(_('Base Channels:'))
         print('\n'.join(sorted(self.list_base_channels())))
         print('')
 
         options.parent_channel = \
-            prompt_user('Select Parent [blank to create a base channel]:')
+            prompt_user(_('Select Parent [blank to create a base channel]:'))
 
         options.gpg_copy = \
-            self.user_confirm('Copy source channel GPG details? [y/N]:',
+            self.user_confirm(_('Copy source channel GPG details? [y/N]:'),
                               ignore_yes=True)
         if not options.gpg_copy:
-            options.gpg_url = prompt_user('GPG URL:')
-            options.gpg_id = prompt_user('GPG ID:')
-            options.gpg_fingerprint = prompt_user('GPG Fingerprint:')
-            options.disable_gpg_check = prompt_user('Disable GPG Check [yes/no]? ')
+            options.gpg_url = prompt_user(_('GPG URL:'))
+            options.gpg_id = prompt_user(_('GPG ID:'))
+            options.gpg_fingerprint = prompt_user(_('GPG Fingerprint:'))
+            options.disable_gpg_check = prompt_user(_('Disable GPG Check [yes/no]? '))
 
         options.original_state = \
-            self.user_confirm('Original State (No Errata) [y/N]:',
+            self.user_confirm(_('Original State (No Errata) [y/N]:'),
                               ignore_yes=True)
     else:
         if not options.source_channel:
-            logging.error('A source channel is required')
+            logging.error(_('A source channel is required'))
             return 1
 
         if not options.name and not options.regex:
-            logging.error('A channel name is required')
+            logging.error(_('A channel name is required'))
             return 1
 
         if not options.label and not options.regex:
-            logging.error('A channel label is required')
+            logging.error(_('A channel label is required'))
             return 1
 
         if not options.original_state:
@@ -1129,7 +1135,7 @@ def do_softwarechannel_clone(self, args):
                 options.name = newvalues['name']
 
     if options.disable_gpg_check and options.disable_gpg_check not in ('yes', 'no'):
-        logging.error('Only [yes/no] values are acceptable for --disable-gpg-check')
+        logging.error(_('Only [yes/no] values are acceptable for --disable-gpg-check'))
         return 1
     if self.softwarechannel_check_existing(options.name, options.label):
         return 1
@@ -1145,8 +1151,8 @@ def do_softwarechannel_clone(self, args):
 
 ####################
 def help_softwarechannel_clonetree(self):
-    print('softwarechannel_clonetree: Clone a software channel and its child channels')
-    print('''usage: softwarechannel_clonetree [options])
+    print(_('softwarechannel_clonetree: Clone a software channel and its child channels'))
+    print(_('''usage: softwarechannel_clonetree [options])
              e.g    softwarechannel_clonetree foobasechannel -p "my_"
                     softwarechannel_clonetree foobasechannel -x "s/foo/bar"
                     softwarechannel_clonetree foobasechannel -x "s/^/my_"
@@ -1161,7 +1167,7 @@ options:
   --disable-gpg-check DISABLE_GPG_CHECK(applied to all channels)
   -o do not clone any errata
   --regex/-x "s/foo/bar" : Optional regex replacement,
-        replaces foo with bar in the clone name, label and description''')
+        replaces foo with bar in the clone name, label and description'''))
 
 
 def do_softwarechannel_clonetree(self, args):
@@ -1179,40 +1185,40 @@ def do_softwarechannel_clonetree(self, args):
     (args, options) = parse_command_arguments(args, arg_parser)
 
     if is_interactive(options):
-        print('Source Channels:')
+        print(_('Source Channels:'))
         print('\n'.join(sorted(self.list_base_channels())))
 
-        options.source_channel = prompt_user('Select source channel:',noblank=True)
-        options.prefix = prompt_user('Prefix:', noblank=True)
+        options.source_channel = prompt_user(_('Select source channel:'),noblank=True)
+        options.prefix = prompt_user(_('Prefix:'), noblank=True)
         options.gpg_copy = \
-            self.user_confirm('Copy source channel GPG details? [y/N]:', ignore_yes=True)
+            self.user_confirm(_('Copy source channel GPG details? [y/N]:'), ignore_yes=True)
         if not options.gpg_copy:
-            options.gpg_url = prompt_user('GPG URL:')
-            options.gpg_id = prompt_user('GPG ID:')
-            options.gpg_fingerprint = prompt_user('GPG Fingerprint:')
-            options.disable_gpg_check = prompt_user('Disable GPG Check [yes/no]? ')
+            options.gpg_url = prompt_user(_('GPG URL:'))
+            options.gpg_id = prompt_user(_('GPG ID:'))
+            options.gpg_fingerprint = prompt_user(_('GPG Fingerprint:'))
+            options.disable_gpg_check = prompt_user(_('Disable GPG Check [yes/no]? '))
 
         options.original_state = \
-            self.user_confirm('Original State (No Errata) [y/N]:', ignore_yes=True)
+            self.user_confirm(_('Original State (No Errata) [y/N]:'), ignore_yes=True)
     else:
         if not options.source_channel:
-            logging.error('A source channel is required')
+            logging.error(_('A source channel is required'))
             return 1
 
         if not options.prefix and not options.regex:
-            logging.error('A prefix or regex is required')
+            logging.error(_('A prefix or regex is required'))
             return 1
 
         if not options.original_state:
             options.original_state = False
 
     if options.disable_gpg_check and options.disable_gpg_check not in ('yes', 'no'):
-        logging.error('Only [yes/no] values are acceptable for --disable-gpg-check')
+        logging.error(_('Only [yes/no] values are acceptable for --disable-gpg-check'))
         return 1
 
     channels = [options.source_channel]
     if not options.source_channel in self.list_base_channels():
-        logging.error("Channel does not exist or is not a base channel!")
+        logging.error(_("Channel does not exist or is not a base channel!"))
         self.help_softwarechannel_clonetree()
         return 1
     logging.debug("--child mode specified, finding children of %s\n" % options.source_channel)
@@ -1239,7 +1245,7 @@ def do_softwarechannel_clonetree(self, args):
             name = options.prefix + srcdetails['name']
         else:
             # Shouldn't ever get here due to earlier checks
-            logging.error("called without prefix or regex option!")
+            logging.error(_("called without prefix or regex option!"))
             return 1
 
         # Catch label or name which already exists
@@ -1339,8 +1345,8 @@ def do_regx_replacement(self,channel, options):
 
 
 def help_softwarechannel_addpackages(self):
-    print('softwarechannel_addpackages: Add packages to a software channel')
-    print('usage: softwarechannel_addpackages CHANNEL <PACKAGE ...>')
+    print(_('softwarechannel_addpackages: Add packages to a software channel'))
+    print(_('usage: softwarechannel_addpackages CHANNEL <PACKAGE ...>'))
 
 
 def complete_softwarechannel_addpackages(self, text, line, beg, end):
@@ -1365,7 +1371,7 @@ def do_softwarechannel_addpackages(self, args):
     # Take the first argument as the channel and validate it
     channel = args.pop(0)
     if not channel in self.do_softwarechannel_list('', True):
-        logging.error("%s is not a valid channel" % channel)
+        logging.error(_("%s is not a valid channel") % channel)
         self.help_softwarechannel_addpackages()
         return 1
 
@@ -1380,14 +1386,14 @@ def do_softwarechannel_addpackages(self, args):
         package_ids += self.get_package_id(package)
 
     if not package_ids:
-        logging.warning('No packages to add')
+        logging.warning(_('No packages to add'))
         return 1
 
-    print('Packages')
+    print(_('Packages'))
     print('--------')
     print('\n'.join(sorted(package_names)))
 
-    if not self.user_confirm('Add these packages [y/N]:'):
+    if not self.user_confirm(_('Add these packages [y/N]:')):
         return 1
 
     self.client.channel.software.addPackages(self.session,
@@ -1399,8 +1405,8 @@ def do_softwarechannel_addpackages(self, args):
 ####################
 
 def help_softwarechannel_mergepackages(self):
-    print('softwarechannel_mergepackages: Merge packages from one software channel into another')
-    print('usage: softwarechannel_mergepackages SOURCE_CHANNEL TARGET_CHANNEL')
+    print(_('softwarechannel_mergepackages: Merge packages from one software channel into another'))
+    print(_('usage: softwarechannel_mergepackages SOURCE_CHANNEL TARGET_CHANNEL'))
 
 def complete_softwarechannel_mergepackages(self, text, line, beg, end):
     parts = line.split(' ')
@@ -1424,9 +1430,9 @@ def do_softwarechannel_mergepackages(self, args):
 
 
 def help_softwarechannel_removeerrata(self):
-    print('softwarechannel_removeerrata: Remove patches from a ' +
-          'software channel')
-    print('usage: softwarechannel_removeerrata CHANNEL <ERRATA:search:XXX ...>')
+    print(_('softwarechannel_removeerrata: Remove patches from a ' +
+          'software channel'))
+    print(_('usage: softwarechannel_removeerrata CHANNEL <ERRATA:search:XXX ...>'))
 
 
 def complete_softwarechannel_removeerrata(self, text, line, beg, end):
@@ -1479,21 +1485,21 @@ def do_softwarechannel_removeerrata(self, args):
                 package_ids.append(package.get('id'))
 
     if not errata_details:
-        logging.warning('No patches to remove')
+        logging.warning(_('No patches to remove'))
         return 1
 
     print_errata_list(errata_details)
 
     print('')
-    print('Packages')
+    print(_('Packages'))
     print('--------')
     print('\n'.join(sorted([ self.get_package_name(p) for p in package_ids if self.get_package_name(p) ])))
 
     print('')
-    print('Total Errata:   %s' % str(len(errata)).rjust(3))
-    print('Total Packages: %s' % str(len(package_ids)).rjust(3))
+    print(_('Total Errata:   %s') % str(len(errata)).rjust(3))
+    print(_('Total Packages: %s') % str(len(package_ids)).rjust(3))
 
-    if not self.user_confirm('Remove these patches [y/N]:'):
+    if not self.user_confirm(_('Remove these patches [y/N]:')):
         return 1
 
     # remove the errata and the packages they brought in
@@ -1508,9 +1514,9 @@ def do_softwarechannel_removeerrata(self, args):
 
 
 def help_softwarechannel_removepackages(self):
-    print('softwarechannel_removepackages: Remove packages from a ' +
-          'software channel')
-    print('usage: softwarechannel_removepackages CHANNEL <PACKAGE ...>')
+    print(_('softwarechannel_removepackages: Remove packages from a ' +
+          'software channel'))
+    print(_('usage: softwarechannel_removepackages CHANNEL <PACKAGE ...>'))
 
 
 def complete_softwarechannel_removepackages(self, text, line, beg,
@@ -1564,14 +1570,14 @@ def do_softwarechannel_removepackages(self, args):
         package_ids += self.get_package_id(package)
 
     if not package_ids:
-        logging.warning('No packages to remove')
+        logging.warning(_('No packages to remove'))
         return 1
 
-    print('Packages')
+    print(_('Packages'))
     print('--------')
     print('\n'.join(sorted(package_names)))
 
-    if not self.user_confirm('Remove these packages [y/N]:'):
+    if not self.user_confirm(_('Remove these packages [y/N]:')):
         return 1
 
     self.client.channel.software.removePackages(self.session,
@@ -1584,12 +1590,12 @@ def do_softwarechannel_removepackages(self, args):
 
 
 def help_softwarechannel_adderratabydate(self):
-    print('softwarechannel_adderratabydate: Add errata from one channel ' +
-          'into another channel based on a date range')
-    print('usage: softwarechannel_adderratabydate [options] SOURCE DEST BEGINDATE ENDDATE')
-    print('Date format : YYYYMMDD')
-    print('Options:')
-    print('        -p/--publish : Publish errata to the channel (don\'t clone)')
+    print(_('softwarechannel_adderratabydate: Add errata from one channel ' +
+          'into another channel based on a date range'))
+    print(_('usage: softwarechannel_adderratabydate [options] SOURCE DEST BEGINDATE ENDDATE'))
+    print(_('Date format : YYYYMMDD'))
+    print(_('Options:'))
+    print(_('        -p/--publish : Publish errata to the channel (don\'t clone)'))
 
 
 def complete_softwarechannel_adderratabydate(self, text, line, beg, end):
@@ -1616,12 +1622,12 @@ def do_softwarechannel_adderratabydate(self, args):
     end_date = args[3]
 
     if not re.match(r'\d{8}', begin_date):
-        logging.error('%s is an invalid date' % begin_date)
+        logging.error(_('%s is an invalid date') % begin_date)
         self.help_softwarechannel_adderratabydate()
         return 1
 
     if not re.match(r'\d{8}', end_date):
-        logging.error('%s is an invalid date' % end_date)
+        logging.error(_('%s is an invalid date') % end_date)
         self.help_softwarechannel_adderratabydate()
         return 1
 
@@ -1634,14 +1640,14 @@ def do_softwarechannel_adderratabydate(self, args):
                                                 parse_time_input(end_date))
 
     if not errata:
-        logging.warning('No patches found between the given dates')
+        logging.warning(_('No patches found between the given dates'))
         return 1
 
     if options.publish:
         # Just publish the errata one-by-one, rather than calling
         # do_softwarechannel_adderrata which clones the errata
         for e in errata:
-            logging.info("Publishing errata %s to %s" %
+            logging.info(_("Publishing errata %s to %s") %
                          (e.get('advisory_name'), dest_channel))
             self.client.errata.publish(self.session, e.get('advisory_name'),
                                        [dest_channel])
@@ -1659,10 +1665,10 @@ def do_softwarechannel_adderratabydate(self, args):
 
 
 def help_softwarechannel_listerratabydate(self):
-    print('softwarechannel_listerratabydate: list errata from channel' +
-          'based on a date range')
-    print('usage: softwarechannel_listerratabydate CHANNEL BEGINDATE ENDDATE')
-    print('Date format : YYYYMMDD')
+    print(_('softwarechannel_listerratabydate: list errata from channel' +
+          'based on a date range'))
+    print(_('usage: softwarechannel_listerratabydate CHANNEL BEGINDATE ENDDATE'))
+    print(_('Date format : YYYYMMDD'))
 
 
 def complete_softwarechannel_listerratabydate(self, text, line, beg, end):
@@ -1687,12 +1693,12 @@ def do_softwarechannel_listerratabydate(self, args):
     end_date = args[2]
 
     if not re.match(r'\d{8}', begin_date):
-        logging.error('%s is an invalid date' % begin_date)
+        logging.error(_('%s is an invalid date') % begin_date)
         self.help_softwarechannel_listerratabydate()
         return 1
 
     if not re.match(r'\d{8}', end_date):
-        logging.error('%s is an invalid date' % end_date)
+        logging.error(_('%s is an invalid date') % end_date)
         self.help_softwarechannel_listerratabydate()
         return 1
 
@@ -1705,7 +1711,7 @@ def do_softwarechannel_listerratabydate(self, args):
                                                 parse_time_input(end_date))
 
     if not errata:
-        logging.warning('No errata found between the given dates')
+        logging.warning(_('No errata found between the given dates'))
         return 1
 
     print_errata_list(errata)
@@ -1716,12 +1722,12 @@ def do_softwarechannel_listerratabydate(self, args):
 
 
 def help_softwarechannel_adderrata(self):
-    print('softwarechannel_adderrata: Add patches from one channel ' +
-          'into another channel')
-    print('usage: softwarechannel_adderrata SOURCE DEST <ERRATA|search:XXX ...>')
-    print('Options:')
-    print('    -q/--quick : Don\'t display list of packages (slightly faster)')
-    print('    -s/--skip :  Skip errata which appear to exist already in DEST')
+    print(_('softwarechannel_adderrata: Add patches from one channel ' +
+          'into another channel'))
+    print(_('usage: softwarechannel_adderrata SOURCE DEST <ERRATA|search:XXX ...>'))
+    print(_('Options:'))
+    print(_('    -q/--quick : Don\'t display list of packages (slightly faster)'))
+    print(_('    -s/--skip :  Skip errata which appear to exist already in DEST'))
 
 
 def complete_softwarechannel_adderrata(self, text, line, beg, end):
@@ -1747,12 +1753,12 @@ def do_softwarechannel_adderrata(self, args):
     allchannels = self.do_softwarechannel_list('', True)
     source_channel = args[0]
     if not source_channel in allchannels:
-        logging.error("source channel %s does not exist!" % source_channel)
+        logging.error(_("source channel %s does not exist!") % source_channel)
         self.help_softwarechannel_adderrata()
         return 1
     dest_channel = args[1]
     if not dest_channel in allchannels:
-        logging.error("dest channel %s does not exist!" % dest_channel)
+        logging.error(_("dest channel %s does not exist!") % dest_channel)
         self.help_softwarechannel_adderrata()
         return 1
     errata_wanted = self.expand_errata(args[2:])
@@ -1805,7 +1811,7 @@ def do_softwarechannel_adderrata(self, args):
                     package_ids.append(package.get('id'))
 
     if not errata:
-        logging.warning('No patch to add')
+        logging.warning(_('No patch to add'))
         return 1
 
     # show the user which errata will be added
@@ -1813,18 +1819,18 @@ def do_softwarechannel_adderrata(self, args):
 
     if not options.quick:
         print('')
-        print('Packages')
+        print(_('Packages'))
         print('--------')
         print('\n'.join(
             sorted([self.get_package_name(p) for p in package_ids])))
 
         print('')
-    print('Total Errata:   %s' % str(len(errata)).rjust(3))
+    print(_('Total Errata:   %s') % str(len(errata)).rjust(3))
 
     if not options.quick:
-        print('Total Packages: %s' % str(len(package_ids)).rjust(3))
+        print(_('Total Packages: %s') % str(len(package_ids)).rjust(3))
 
-    if not self.user_confirm('Add these patches [y/N]:'):
+    if not self.user_confirm(_('Add these patches [y/N]:')):
         return 1
 
     # clone each erratum individually because the process is slow and it can
@@ -1838,9 +1844,9 @@ def do_softwarechannel_adderrata(self, args):
             self.client.errata.cloneAsOriginal(self.session, dest_channel,
                                                [erratum])
         else:
-            logging.warning("Using the old errata.clone function")
-            logging.warning("If you have base channels for multiple OS" +
-                            " versions, check no unexpected packages have been added")
+            logging.warning(_("Using the old errata.clone function"))
+            logging.warning(_("If you have base channels for multiple OS" +
+                            " versions, check no unexpected packages have been added"))
             self.client.errata.clone(self.session, dest_channel, [erratum])
 
     # regenerate the errata cache since we just cloned errata
@@ -1852,8 +1858,8 @@ def do_softwarechannel_adderrata(self, args):
 
 
 def help_softwarechannel_getorgaccess(self):
-    print('softwarechannel_getorgaccess: Get the org-access for the software channel')
-    print('usage: softwarechannel_getorgaccess [CHANNEL ...]')
+    print(_('softwarechannel_getorgaccess: Get the org-access for the software channel'))
+    print(_('usage: softwarechannel_getorgaccess [CHANNEL ...]'))
 
 
 def complete_softwarechannel_getorgaccess(self, text, line, beg, end):
@@ -1891,11 +1897,11 @@ def do_softwarechannel_getorgaccess(self, args):
 
 
 def help_softwarechannel_setorgaccess(self):
-    print('softwarechannel_setorgaccess: Set the org-access for the software channel')
-    print('''usage : softwarechannel_setorgaccess <CHANNEL> [options])
+    print(_('softwarechannel_setorgaccess: Set the org-access for the software channel'))
+    print(_('''usage : softwarechannel_setorgaccess <CHANNEL> [options])
 -d,--disable : disable org access (private, no org sharing)
 -e,--enable : enable org access (public access to all trusted orgs)
--p,--protected ORG : protected org access for ORG only (multiple instances of -p ORG are allowed)''')
+-p,--protected ORG : protected org access for ORG only (multiple instances of -p ORG are allowed)'''))
 
 
 def complete_softwarechannel_setorgaccess(self, text, line, beg, end):
@@ -1932,28 +1938,28 @@ def do_softwarechannel_setorgaccess(self, args, options=None):
         # this implies public/private access
         if (options.enable):
             logging.info(
-                "Making org sharing public for channel : %s " % channel)
+                _("Making org sharing public for channel : %s ") % channel)
             self.client.channel.access.setOrgSharing(
                 self.session, channel, 'public')
         elif (options.disable):
             logging.info(
-                "Making org sharing private for channel : %s " % channel)
+                _("Making org sharing private for channel : %s ") % channel)
             self.client.channel.access.setOrgSharing(
                 self.session, channel, 'private')
         elif (options.protected):
             logging.info(
-                "Making org sharing protected for channel : %s " % channel)
+                _("Making org sharing protected for channel : %s ") % channel)
             self.client.channel.access.setOrgSharing(
                 self.session, channel, 'protected')
             for org in org_trust_list:
                 if org["org_name"] in options.protected:
                     logging.info(
-                        "Enabling %s access for channel : %s " % (org["org_name"],channel))
+                        _("Enabling %s access for channel : %s ") % (org["org_name"],channel))
                     self.client.channel.org.enableAccess(
                         self.session, channel, org["org_id"])
                 else:
                     logging.info(
-                        "Disabling %s access for channel : %s " % (org["org_name"],channel))
+                        _("Disabling %s access for channel : %s ") % (org["org_name"],channel))
                     self.client.channel.org.disableAccess(
                         self.session, channel, org["org_id"])
         else:
@@ -1966,8 +1972,8 @@ def do_softwarechannel_setorgaccess(self, args, options=None):
 
 
 def help_softwarechannel_getorgaccesstree(self):
-    print('softwarechannel_getorgaccesstree: Get the org-access for a software base channel and its children')
-    print('usage: softwarechannel_getorgaccesstree [CHANNEL]')
+    print(_('softwarechannel_getorgaccesstree: Get the org-access for a software base channel and its children'))
+    print(_('usage: softwarechannel_getorgaccesstree [CHANNEL]'))
 
 def complete_softwarechannel_getorgaccesstree(self, text, line, beg, end):
     return tab_completer(self.list_base_channels(), text)
@@ -1985,7 +1991,7 @@ def do_softwarechannel_getorgaccesstree(self, args):
         channels = filter_results(self.list_base_channels(), args)
 
     if not channels:
-        logging.error("Channel does not exist or is not a base channel!")
+        logging.error(_("Channel does not exist or is not a base channel!"))
         self.help_softwarechannel_getorgaccesstree()
         return 1
 
@@ -2000,11 +2006,11 @@ def do_softwarechannel_getorgaccesstree(self, args):
 
 
 def help_softwarechannel_setorgaccesstree(self):
-    print('softwarechannel_setorgaccesstree: set the org-access for a software base channel and its children')
-    print('''usage: softwarechannel_setorgaccesstree <CHANNEL> [options])
+    print(_('softwarechannel_setorgaccesstree: set the org-access for a software base channel and its children'))
+    print(_('''usage: softwarechannel_setorgaccesstree <CHANNEL> [options])
 -d,--disable : disable org access (private, no org sharing)
 -e,--enable : enable org access (public access to all trusted orgs)
--p,--protected ORG : protected org access for ORG only (multiple instances of -p ORG are allowed)''')
+-p,--protected ORG : protected org access for ORG only (multiple instances of -p ORG are allowed)'''))
 
 def complete_softwarechannel_setorgaccesstree(self, text, line, beg, end):
     return tab_completer(self.list_base_channels(), text)
@@ -2025,7 +2031,7 @@ def do_softwarechannel_setorgaccesstree(self, args):
     channels = filter_results(self.list_base_channels(), args)
 
     if not channels:
-        logging.error("Channel does not exist or is not a base channel!")
+        logging.error(_("Channel does not exist or is not a base channel!"))
         self.help_softwarechannel_setorgaccesstree()
         return 1
 
@@ -2040,10 +2046,10 @@ def do_softwarechannel_setorgaccesstree(self, args):
 
 
 def help_softwarechannel_regenerateneededcache(self):
-    print('softwarechannel_regenerateneededcache: ')
-    print('Regenerate the needed errata and package cache for all systems')
+    print(_('softwarechannel_regenerateneededcache: '))
+    print(_('Regenerate the needed errata and package cache for all systems'))
     print('')
-    print('usage: softwarechannel_regenerateneededcache')
+    print(_('usage: softwarechannel_regenerateneededcache'))
 
 
 def do_softwarechannel_regenerateneededcache(self, args):
@@ -2057,14 +2063,14 @@ def do_softwarechannel_regenerateneededcache(self, args):
 
 
 def help_softwarechannel_regenerateyumcache(self):
-    print('softwarechannel_regenerateyumcache: ')
-    print('Regenerate the YUM cache for a software channel')
+    print(_('softwarechannel_regenerateyumcache: '))
+    print(_('Regenerate the YUM cache for a software channel'))
     print('')
-    print('''usage: softwarechannel_regenerateyumcache [options] <CHANNEL ...>
+    print(_('''usage: softwarechannel_regenerateyumcache [options] <CHANNEL ...>
 
     options:
       -f force cache regeneration
-    ''')
+    '''))
     print('')
 
 
@@ -2104,10 +2110,10 @@ def is_softwarechannel(self, name):
 
 def check_softwarechannel(self, name):
     if not name:
-        logging.error("no softwarechannel label given")
+        logging.error(_("no softwarechannel label given"))
         return False
     if not self.is_softwarechannel(name):
-        logging.error("invalid softwarechannel label " + name)
+        logging.error(_("invalid softwarechannel label ") + name)
         return False
     return True
 
@@ -2125,9 +2131,9 @@ def dump_softwarechannel(self, name, replacedict=None, excludes=None):
 
 
 def help_softwarechannel_diff(self):
-    print('softwarechannel_diff: diff softwarechannel files')
+    print(_('softwarechannel_diff: diff softwarechannel files'))
     print('')
-    print('usage: softwarechannel_diff SOURCE_CHANNEL TARGET_CHANNEL')
+    print(_('usage: softwarechannel_diff SOURCE_CHANNEL TARGET_CHANNEL'))
 
 
 def complete_softwarechannel_diff(self, text, line, beg, end):
@@ -2188,9 +2194,9 @@ def dump_softwarechannel_errata(self, name):
 
 
 def help_softwarechannel_errata_diff(self):
-    print('softwarechannel_errata_diff: diff softwarechannel files')
+    print(_('softwarechannel_errata_diff: diff softwarechannel files'))
     print('')
-    print('usage: softwarechannel_errata_diff SOURCE_CHANNEL TARGET_CHANNEL')
+    print(_('usage: softwarechannel_errata_diff SOURCE_CHANNEL TARGET_CHANNEL'))
 
 
 def complete_softwarechannel_errata_diff(self, text, line, beg, end):
@@ -2239,11 +2245,11 @@ def do_softwarechannel_errata_diff(self, args):
 
 
 def help_softwarechannel_sync(self):
-    print('softwarechannel_sync: ')
-    print('sync the packages of two software channels')
+    print(_('softwarechannel_sync: '))
+    print(_('sync the packages of two software channels'))
     print('')
-    print('''usage: softwarechannel_sync SOURCE_CHANNEL TARGET_CHANNEL [options])
-    -q,--quiet : quiet mode (omits the output of common packages in both channels)''')
+    print(_('''usage: softwarechannel_sync SOURCE_CHANNEL TARGET_CHANNEL [options])
+    -q,--quiet : quiet mode (omits the output of common packages in both channels)'''))
 
 
 def complete_softwarechannel_sync(self, text, line, beg, end):
@@ -2284,7 +2290,7 @@ def do_softwarechannel_sync(self, args, deleteFromTarget=True):
         return 1
 
     command = "syncing" if deleteFromTarget else "merging"
-    logging.info("%s packages from softwarechannel %s to %s",
+    logging.info(_("%s packages from softwarechannel %s to %s"),
                  command, source_channel, target_channel)
 
     # use API call instead of spacecmd function
@@ -2303,7 +2309,7 @@ def do_softwarechannel_sync(self, args, deleteFromTarget=True):
         try:
             source_ids.add(package['id'])
         except KeyError:
-            logging.error("failed to read key id")
+            logging.error(_("failed to read key id"))
             continue
 
     target_ids = set()
@@ -2311,20 +2317,20 @@ def do_softwarechannel_sync(self, args, deleteFromTarget=True):
         try:
             target_ids.add(package['id'])
         except KeyError:
-            logging.error("failed to read key id")
+            logging.error(_("failed to read key id"))
             continue
     if not options.quiet:
-        print("packages common in both channels:")
+        print(_("packages common in both channels:"))
         for i in (source_ids & target_ids):
             print(self.get_package_name(i))
         print('')
     else:
-        logging.info("Omitting common packages in both specified channels")
+        logging.info(_("Omitting common packages in both specified channels"))
 
     # check for packages only in the source channel
     source_only = source_ids.difference(target_ids)
     if source_only:
-        print('packages to add to channel "' + target_channel + '":')
+        print(_('packages to add to channel "') + target_channel + '":')
         for i in source_only:
             print(self.get_package_name(i))
         print('')
@@ -2332,23 +2338,23 @@ def do_softwarechannel_sync(self, args, deleteFromTarget=True):
     # check for packages only in the target channel
     target_only = target_ids.difference(source_ids)
     if target_only and deleteFromTarget:
-        print('packages to remove from channel "' + target_channel + '":')
+        print(_('packages to remove from channel "') + target_channel + '":')
         for i in target_only:
             print(self.get_package_name(i))
         print('')
 
     if source_only or target_only:
-        print("summary:")
-        print("  " + source_channel + ": " + str(len(source_ids)).rjust(5) + " packages")
-        print("  " + target_channel + ": " + str(len(target_ids)).rjust(5) + " packages")
-        print("    add    " + str(
-            len(source_only)).rjust(5) + " packages to   " + target_channel)
+        print(_("summary:"))
+        print("  " + source_channel + ": " + str(len(source_ids)).rjust(5) + _(" packages"))
+        print("  " + target_channel + ": " + str(len(target_ids)).rjust(5) + _(" packages"))
+        print(_("    add    ") + str(
+            len(source_only)).rjust(5) + _(" packages to   ") + target_channel)
 
         if deleteFromTarget:
-            print("    remove " + str(
-                len(target_only)).rjust(5) + " packages from " + target_channel)
+            print(_("    remove ") + str(
+                len(target_only)).rjust(5) + _(" packages from ") + target_channel)
 
-        if not self.user_confirm('Perform these changes to channel ' + target_channel + ' [y/N]:'):
+        if not self.user_confirm(_('Perform these changes to channel ') + target_channel + ' [y/N]:'):
             return
 
         if deleteFromTarget:
@@ -2364,15 +2370,15 @@ def do_softwarechannel_sync(self, args, deleteFromTarget=True):
                                                     target_channel)
 
     return 0
-            
+
 ####################
 
 
 def help_softwarechannel_errata_sync(self):
-    print('softwarechannel_errata_sync: ')
-    print('sync errata of two software channels')
+    print(_('softwarechannel_errata_sync: '))
+    print(_('sync errata of two software channels'))
     print('')
-    print('usage: softwarechannel_errata_sync SOURCE_CHANNEL TARGET_CHANNEL')
+    print(_('usage: softwarechannel_errata_sync SOURCE_CHANNEL TARGET_CHANNEL'))
 
 
 def complete_softwarechannel_errata_sync(self, text, line, beg, end):
@@ -2411,8 +2417,8 @@ def do_softwarechannel_errata_sync(self, args):
     if not self.check_softwarechannel(target_channel):
         return 1
 
-    logging.info("syncing errata from softwarechannel " + source_channel +
-                 " to " + target_channel)
+    logging.info(_("syncing errata from softwarechannel ") + source_channel +
+                 _(" to ") + target_channel)
 
     source_errata = self.client.channel.software.listErrata(
         self.session, source_channel)
@@ -2425,7 +2431,7 @@ def do_softwarechannel_errata_sync(self, args):
         try:
             source_ids.add(erratum.get('advisory_name'))
         except KeyError:
-            logging.error("failed to read key id")
+            logging.error(_("failed to read key id"))
             continue
 
     target_ids = set()
@@ -2433,10 +2439,10 @@ def do_softwarechannel_errata_sync(self, args):
         try:
             target_ids.add(erratum.get('advisory_name'))
         except KeyError:
-            logging.error("failed to read key id")
+            logging.error(_("failed to read key id"))
             continue
 
-    print("errata common in both channels:")
+    print(_("errata common in both channels:"))
     for i in (source_ids & target_ids):
         print(i)
     print('')
@@ -2445,7 +2451,7 @@ def do_softwarechannel_errata_sync(self, args):
     source_only = list(source_ids.difference(target_ids))
     source_only.sort()
     if source_only:
-        print('errata to add to channel "' + target_channel + '":')
+        print(_('errata to add to channel "') + target_channel + '":')
         for i in source_only:
             print(i)
         print('')
@@ -2454,21 +2460,21 @@ def do_softwarechannel_errata_sync(self, args):
     target_only = list(target_ids.difference(source_ids))
     target_only.sort()
     if target_only:
-        print('errata to remove from channel "' + target_channel + '":')
+        print(_('errata to remove from channel "') + target_channel + '":')
         for i in target_only:
             print(i)
         print('')
 
     if source_only or target_only:
-        print("summary:")
+        print(_("summary:"))
         print("  " + source_channel + ": " + str(len(source_ids)).rjust(5), "errata")
         print("  " + target_channel + ": " + str(len(target_ids)).rjust(5), "errata")
-        print("    add   ", str(
-            len(source_only)).rjust(5), "errata to  ", target_channel)
-        print("    remove", str(
-            len(target_only)).rjust(5), "errata from", target_channel)
+        print(_("    add   "), str(
+            len(source_only)).rjust(5), _("errata to  "), target_channel)
+        print(_("    remove"), str(
+            len(target_only)).rjust(5), _("errata from"), target_channel)
 
-        if not self.user_confirm('Perform these changes to channel ' + target_channel + ' [y/N]:'):
+        if not self.user_confirm(_('Perform these changes to channel ') + target_channel + ' [y/N]:'):
             return 1
 
         for erratum in source_only:
@@ -2491,13 +2497,13 @@ def do_softwarechannel_errata_sync(self, args):
 
 
 def help_softwarechannel_errata_merge(self):
-    print('softwarechannel_errata_merge: ')
-    print('merge errata of one software channel into another')
+    print(_('softwarechannel_errata_merge: '))
+    print(_('merge errata of one software channel into another'))
     print('')
-    print('usage:   softwarechannel_errata_merge SOURCE_CHANNEL TARGET_CHANNEL [FROM_DATE] [TO_DATE]')
-    print('example: softwarechannel_errata_merge OldSoftChannel NewSoftChannel 2018-01-01')
-    print('note:    Providing only FROM_DATE will merge all errata since that date.')
-    print('note:    When no date is provided, all errata will be merged.')
+    print(_('usage:   softwarechannel_errata_merge SOURCE_CHANNEL TARGET_CHANNEL [FROM_DATE] [TO_DATE]'))
+    print(_('example: softwarechannel_errata_merge OldSoftChannel NewSoftChannel 2018-01-01'))
+    print(_('note:    Providing only FROM_DATE will merge all errata since that date.'))
+    print(_('note:    When no date is provided, all errata will be merged.'))
 
 def complete_softwarechannel_errata_merge(self, text, line, beg, end):
     parts = shlex.split(line)
@@ -2527,14 +2533,14 @@ def do_softwarechannel_errata_merge(self, args):
         try:
             FROM_DATE = datetime.strptime(args[2], "%Y-%m-%d")
         except ValueError:
-            print('wrong dateformat: ' + args[2] + ' please specify as: YYYY-MM-DD')
+            print(_('wrong dateformat: ') + args[2] + _(' please specify as: YYYY-MM-DD'))
             return 1
 
     if len(args) == 4:
         try:
             TO_DATE = datetime.strptime(args[3], "%Y-%m-%d")
         except ValueError:
-            print('wrong dateformat: ' + args[3] + ' please specify as: YYYY-MM-DD')
+            print(_('wrong dateformat: ') + args[3] + _(' please specify as: YYYY-MM-DD'))
             return 1
 
     source_channel = args[0]
@@ -2543,8 +2549,8 @@ def do_softwarechannel_errata_merge(self, args):
     if not self.check_softwarechannel(source_channel) or not self.check_softwarechannel(target_channel):
         return 1
 
-    logging.info("merging errata from softwarechannel " + source_channel +
-                 " to " + target_channel)
+    logging.info(_("merging errata from softwarechannel ") + source_channel +
+                 _(" to ") + target_channel)
 
     source_errata = self.client.channel.software.listErrata(
         self.session, source_channel)
@@ -2565,7 +2571,7 @@ def do_softwarechannel_errata_merge(self, args):
         try:
             source_ids.add(erratum.get('advisory_name'))
         except KeyError:
-            logging.error("failed to read key id")
+            logging.error(_("failed to read key id"))
             continue
 
     target_ids = set()
@@ -2573,32 +2579,32 @@ def do_softwarechannel_errata_merge(self, args):
         try:
             target_ids.add(erratum.get('advisory_name'))
         except KeyError:
-            logging.error("failed to read key id")
+            logging.error(_("failed to read key id"))
             continue
 
     # check for errata only in the source channel
     source_only = list(source_ids.difference(target_ids))
 
     if len(source_only) == 0:
-        print('{} contains no errata which is not already present in {}'.format(source_channel, target_channel))
+        print(_('{} contains no errata which is not already present in {}').format(source_channel, target_channel))
         return 1
 
     source_only.sort()
     if source_only:
-        print('errata to add to channel {}: '.format(target_channel))
+        print(_('errata to add to channel {}: ').format(target_channel))
         for i in source_only:
             print(i)
         print('')
 
-    print("summary:")
-    print("  " + source_channel + ": " + str(len(source_ids)).rjust(5) + " errata")
-    print("  " + target_channel + ": " + str(len(target_ids)).rjust(5) + " errata")
-    print ("    add   " + str(
-        len(source_only)).rjust(5) + " errata to  " + target_channel)
+    print(_("summary:"))
+    print("  " + source_channel + ": " + str(len(source_ids)).rjust(5) + _(" errata"))
+    print("  " + target_channel + ": " + str(len(target_ids)).rjust(5) + _(" errata"))
+    print (_("    add   ") + str(
+        len(source_only)).rjust(5) + _(" errata to  ") + target_channel)
 
-    if not self.user_confirm('Perform these changes to channel {} [y/N]:'.format(target_channel)):
+    if not self.user_confirm(_('Perform these changes to channel {} [y/N]:').format(target_channel)):
         return 1
-    
+
     self.client.channel.software.mergeErrata(self.session, source_channel, target_channel, source_only)
 
     return 0
@@ -2607,15 +2613,15 @@ def do_softwarechannel_errata_merge(self, args):
 
 
 def help_softwarechannel_syncrepos(self):
-    print('softwarechannel_syncrepos: ')
-    print('Sync users repos for a software channel')
+    print(_('softwarechannel_syncrepos: '))
+    print(_('Sync users repos for a software channel'))
     print('')
-    print('usage: softwarechannel_syncrepos <CHANNEL ...>')
-    print('Options:')
-    print('    -e/--no-errata : Do not sync errata')
-    print('    -f/--fail : Terminate upon any error')
-    print('    -k/--sync-kickstart : Create kickstartable tree')
-    print('    -l/--latest : Only download latest package versions when repo syncs')
+    print(_('usage: softwarechannel_syncrepos <CHANNEL ...>'))
+    print(_('Options:'))
+    print(_('    -e/--no-errata : Do not sync errata'))
+    print(_('    -f/--fail : Terminate upon any error'))
+    print(_('    -k/--sync-kickstart : Create kickstartable tree'))
+    print(_('    -l/--latest : Only download latest package versions when repo syncs'))
 
 
 def complete_softwarechannel_syncrepos(self, text, line, beg, end):
@@ -2650,19 +2656,19 @@ def do_softwarechannel_syncrepos(self, args):
 
 
 def help_softwarechannel_setsyncschedule(self):
-    print('softwarechannel_setsyncschedule: ')
-    print('Sets the repo sync schedule for a software channel')
+    print(_('softwarechannel_setsyncschedule: '))
+    print(_('Sets the repo sync schedule for a software channel'))
     print('')
-    print('usage: softwarechannel_setsyncschedule <CHANNEL> <SCHEDULE>')
-    print('Options:')
-    print('    -e/--no-errata : Do not sync errata')
-    print('    -f/--fail : Terminate upon any error')
-    print('    -k/--sync-kickstart : Create kickstartable tree')
-    print('    -l/--latest : Only download latest package versions when repo syncs')
+    print(_('usage: softwarechannel_setsyncschedule <CHANNEL> <SCHEDULE>'))
+    print(_('Options:'))
+    print(_('    -e/--no-errata : Do not sync errata'))
+    print(_('    -f/--fail : Terminate upon any error'))
+    print(_('    -k/--sync-kickstart : Create kickstartable tree'))
+    print(_('    -l/--latest : Only download latest package versions when repo syncs'))
     print('')
-    print('The schedule is specified in Quartz CronTrigger format without enclosing quotes.')
-    print('For example, to set a schedule of every day at 1am, <SCHEDULE> would be 0 0 1 * * ?')
-    print('If <SCHEDULE> is left empty, it will be disabled.')
+    print(_('The schedule is specified in Quartz CronTrigger format without enclosing quotes.'))
+    print(_('For example, to set a schedule of every day at 1am, <SCHEDULE> would be 0 0 1 * * ?'))
+    print(_('If <SCHEDULE> is left empty, it will be disabled.'))
     print('')
 
 
@@ -2725,9 +2731,9 @@ def do_softwarechannel_removesyncschedule(self, args):
 ####################
 
 def help_softwarechannel_listsyncschedule(self):
-    print('softwarechannel_listsyncschedule: List sync schedules for all software channels')
-    print('usage:')
-    print('softwarechannel_listsyncschedule : List all channels')
+    print(_('softwarechannel_listsyncschedule: List sync schedules for all software channels'))
+    print(_('usage:'))
+    print(_('softwarechannel_listsyncschedule : List all channels'))
 
 
 def do_softwarechannel_listsyncschedule(self, args):
@@ -2750,7 +2756,7 @@ def do_softwarechannel_listsyncschedule(self, args):
 
     # Print headers
     csched_fmt = '{0:>5s}  {1:<40s} {2:<20s}'
-    print(csched_fmt.format('key', 'Channel Name', 'Update Schedule'))
+    print(csched_fmt.format(_('key'), _('Channel Name'), _('Update Schedule')))
     print(csched_fmt.format('-----', '---------------------', '---------------'))
 
     # Sort and print(the channel names and associated repo-sync schedule (if any))
@@ -2762,8 +2768,8 @@ def do_softwarechannel_listsyncschedule(self, args):
 ####################
 
 def help_softwarechannel_addrepo(self):
-    print('softwarechannel_addrepo: Add a repo to a software channel')
-    print('usage: softwarechannel_addrepo CHANNEL REPO')
+    print(_('softwarechannel_addrepo: Add a repo to a software channel'))
+    print(_('usage: softwarechannel_addrepo CHANNEL REPO'))
 
 
 def complete_softwarechannel_addrepo(self, text, line, beg, end):
@@ -2796,8 +2802,8 @@ def do_softwarechannel_addrepo(self, args):
 
 
 def help_softwarechannel_removerepo(self):
-    print('softwarechannel_removerepo: Remove a repo from a software channel')
-    print('usage: softwarechannel_removerepo CHANNEL REPO')
+    print(_('softwarechannel_removerepo: Remove a repo from a software channel'))
+    print(_('usage: softwarechannel_removerepo CHANNEL REPO'))
 
 
 def complete_softwarechannel_removerepo(self, text, line, beg, end):
@@ -2837,8 +2843,8 @@ def do_softwarechannel_removerepo(self, args):
 
 
 def help_softwarechannel_listrepos(self):
-    print('softwarechannel_listrepos: List the repos for a software channel')
-    print('usage: softwarechannel_listrepos CHANNEL')
+    print(_('softwarechannel_listrepos: List the repos for a software channel'))
+    print(_('usage: softwarechannel_listrepos CHANNEL'))
 
 
 def complete_softwarechannel_listrepos(self, text, line, beg, end):
@@ -2861,17 +2867,17 @@ def do_softwarechannel_listrepos(self, args):
             print('\n'.join(sorted(repos)))
             return 0
         else:
-            print("No repos have been found for this channel.")
+            print(_("No repos have been found for this channel."))
             return 1
 
 ####################
 
 
 def help_softwarechannel_mirrorpackages(self):
-    print('softwarechannel_mirrorpackages: Download packages of a given channel')
-    print('usage: softwarechannel_mirrorpackages CHANNEL')
-    print('Options:')
-    print('    -l/--latest : Only mirror latest package version')
+    print(_('softwarechannel_mirrorpackages: Download packages of a given channel'))
+    print(_('usage: softwarechannel_mirrorpackages CHANNEL'))
+    print(_('Options:'))
+    print(_('    -l/--latest : Only mirror latest package version'))
 
 
 def complete_softwarechannel_mirrorpackages(self, text, line, beg, end):
@@ -2902,18 +2908,18 @@ def do_softwarechannel_mirrorpackages(self, args):
         package_file = self.client.packages.getDetails(
             self.session, package['id']).get('file')
         if os.path.isfile(package_file):
-            print("Skipping", package_file)
+            print(_("Skipping"), package_file)
         else:
-            print("Fetching package", package_file)
+            print(_("Fetching package"), package_file)
             try:
                 urlretrieve(package_url, package_file)
             except ContentTooShortError:
                 logging.error(
-                    "Received package %s from channel %s is broken. Content is too short",
+                    _("Received package %s from channel %s is broken. Content is too short"),
                     package_file, channel)
                 return 1
             except IOError:
-                logging.error("Could not fetch package %s from channel %s" %
+                logging.error(_("Could not fetch package %s from channel %s") %
                               (package_file, channel))
                 return 1
 

--- a/spacecmd/src/spacecmd/ssm.py
+++ b/spacecmd/src/spacecmd/ssm.py
@@ -29,20 +29,26 @@
 # invalid function name
 # pylint: disable=C0103
 
+import gettext
 from spacecmd.utils import *
 
+translation = gettext.translation('spacecmd', fallback=True)
+try:
+    _ = translation.ugettext
+except AttributeError:
+    _ = translation.gettext
 
 def help_ssm(self):
-    print('The System Set Manager (SSM) is a group of systems that you ')
-    print('can perform tasks on as a whole.')
+    print(_('The System Set Manager (SSM) is a group of systems that you '))
+    print(_('can perform tasks on as a whole.'))
     print('')
-    print('Adding Systems:')
+    print(_('Adding Systems:'))
     print('> ssm_add group:rhel5-x86_64')
     print('> ssm_add channel:rhel-x86_64-server-5')
     print('> ssm_add search:device:vmware')
     print('> ssm_add host.example.com')
     print('')
-    print('Intersections:')
+    print(_('Intersections:'))
     print('> ssm_add group:rhel5-x86_64')
     print('> ssm_intersect group:web-servers')
     print('')
@@ -54,10 +60,10 @@ def help_ssm(self):
 
 
 def help_ssm_add(self):
-    print('ssm_add: Add systems to the SSM')
-    print('usage: ssm_add <SYSTEMS>')
+    print(_('ssm_add: Add systems to the SSM'))
+    print(_('usage: ssm_add <SYSTEMS>'))
     print('')
-    print("see 'help ssm' for more details")
+    print(_("see 'help ssm' for more details"))
     print('')
     print(self.HELP_SYSTEM_OPTS)
 
@@ -78,12 +84,12 @@ def do_ssm_add(self, args):
     systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning('No systems found')
+        logging.warning(_('No systems found'))
         return 1
 
     for system in systems:
         if system in self.ssm:
-            logging.warning('%s is already in the list' % system)
+            logging.warning(_('%s is already in the list') % system)
             continue
         else:
             self.ssm[system] = self.get_system_id(system)
@@ -101,12 +107,12 @@ def do_ssm_add(self, args):
 
 
 def help_ssm_intersect(self):
-    print('ssm_intersect: Replace the current SSM with the intersection')
-    print('               of the current list of systems and the list of')
-    print('               systems passed as arguments')
-    print('usage: ssm_intersect <SYSTEMS>')
+    print(_('ssm_intersect: Replace the current SSM with the intersection'))
+    print(_('               of the current list of systems and the list of'))
+    print(_('               systems passed as arguments'))
+    print(_('usage: ssm_intersect <SYSTEMS>'))
     print('')
-    print("see 'help ssm' for more details")
+    print(_("see 'help ssm' for more details"))
     print('')
     print(self.HELP_SYSTEM_OPTS)
 
@@ -127,7 +133,7 @@ def do_ssm_intersect(self, args):
     systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning('No systems found')
+        logging.warning(_('No systems found'))
         return 1
 
     # tmp_ssm placeholder to gather systems that are both in original ssm
@@ -153,10 +159,10 @@ def do_ssm_intersect(self, args):
 
 
 def help_ssm_remove(self):
-    print('ssm_remove: Remove systems from the SSM')
-    print('usage: ssm_remove <SYSTEMS>')
+    print(_('ssm_remove: Remove systems from the SSM'))
+    print(_('usage: ssm_remove <SYSTEMS>'))
     print('')
-    print("see 'help ssm' for more details")
+    print(_("see 'help ssm' for more details"))
     print('')
     print(self.HELP_SYSTEM_OPTS)
 
@@ -177,7 +183,7 @@ def do_ssm_remove(self, args):
     systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning('No systems found')
+        logging.warning(_('No systems found'))
         return 1
 
     for system in systems:
@@ -197,10 +203,10 @@ def do_ssm_remove(self, args):
 
 
 def help_ssm_list(self):
-    print('ssm_list: List the systems currently in the SSM')
-    print('usage: ssm_list')
+    print(_('ssm_list: List the systems currently in the SSM'))
+    print(_('usage: ssm_list'))
     print('')
-    print("see 'help ssm' for more details")
+    print(_("see 'help ssm' for more details"))
 
 
 def do_ssm_list(self, args):
@@ -217,8 +223,8 @@ def do_ssm_list(self, args):
 
 
 def help_ssm_clear(self):
-    print('ssm_clear: Remove all systems from the SSM')
-    print('usage: ssm_clear')
+    print(_('ssm_clear: Remove all systems from the SSM'))
+    print(_('usage: ssm_clear'))
 
 
 def do_ssm_clear(self, args):

--- a/spacecmd/src/spacecmd/system.py
+++ b/spacecmd/src/spacecmd/system.py
@@ -30,6 +30,7 @@
 # invalid function name
 # pylint: disable=C0103
 
+import gettext
 import shlex
 try:
     from xmlrpc import client as xmlrpclib
@@ -39,11 +40,17 @@ from operator import itemgetter
 from xml.parsers.expat import ExpatError
 from spacecmd.utils import *
 
-__PKG_COMPARISONS = {0: 'Same',
-                     1: 'Only here',
-                     2: 'Newer here',
-                     3: 'Only there',
-                     4: 'Newer there'}
+translation = gettext.translation('spacecmd', fallback=True)
+try:
+    _ = translation.ugettext
+except AttributeError:
+    _ = translation.gettext
+
+__PKG_COMPARISONS = {0: _('Same'),
+                     1: _('Only here'),
+                     2: _('Newer here'),
+                     3: _('Only there'),
+                     4: _('Newer there')}
 
 
 def print_package_comparison(self, results):
@@ -63,10 +70,10 @@ def print_package_comparison(self, results):
 
     # print(headers)
     print('%s  %s  %s  %s' % (
-        'Package'.ljust(max_name),
-        'This System'.ljust(max_this),
-        'Other System'.ljust(max_other),
-        'Difference'.ljust(max_comparison)))
+        _('Package').ljust(max_name),
+        _('This System').ljust(max_this),
+        _('Other System').ljust(max_other),
+        _('Difference').ljust(max_comparison)))
 
     print('%s  %s  %s  %s' % (
         '-' * max_name,
@@ -108,16 +115,16 @@ def manipulate_child_channels(self, args, remove=False):
 
     new_channels = args
 
-    print('Systems')
+    print(_('Systems'))
     print('-------')
     print('\n'.join(sorted(["%s" % x for x in systems])))
     print('')
 
     if remove:
-        print('Removing Channels')
+        print(_('Removing Channels'))
         print('-----------------')
     else:
-        print('Adding Channels')
+        print(_('Adding Channels'))
         print('---------------')
 
     print('\n'.join(sorted(new_channels)))
@@ -153,8 +160,8 @@ def manipulate_child_channels(self, args, remove=False):
 
 
 def help_system_list(self):
-    print('system_list: List all system profiles')
-    print('usage: system_list')
+    print(_('system_list: List all system profiles'))
+    print(_('usage: system_list'))
 
 
 def do_system_list(self, args, doreturn=False):
@@ -170,11 +177,11 @@ def do_system_list(self, args, doreturn=False):
 
 
 def help_system_reboot(self):
-    print('system_reboot: Reboot a system')
-    print('''usage: system_reboot <SYSTEMS> [options])
+    print(_('system_reboot: Reboot a system'))
+    print(_('''usage: system_reboot <SYSTEMS> [options])
 
 options:
-  -s START_TIME''')
+  -s START_TIME'''))
 
     print('')
     print(self.HELP_SYSTEM_OPTS)
@@ -203,7 +210,7 @@ def do_system_reboot(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning('No systems selected')
+        logging.warning(_('No systems selected'))
         return 1
 
     # get the start time option
@@ -220,13 +227,13 @@ def do_system_reboot(self, args):
 
     print('')
 
-    print('Start Time: %s' % options.start_time)
+    print(_('Start Time: %s') % options.start_time)
     print('')
-    print('Systems')
+    print(_('Systems'))
     print('-------')
     print('\n'.join(sorted(systems)))
 
-    if not self.user_confirm('Reboot these systems [y/N]:'):
+    if not self.user_confirm(_('Reboot these systems [y/N]:')):
         return 1
 
     for system in systems:
@@ -242,15 +249,15 @@ def do_system_reboot(self, args):
 
 
 def help_system_search(self):
-    print('system_search: List systems that match the given criteria')
-    print('usage: system_search QUERY')
+    print(_('system_search: List systems that match the given criteria'))
+    print(_('usage: system_search QUERY'))
     print('')
-    print('Available Fields:')
+    print(_('Available Fields:'))
     print('\n'.join(self.SYSTEM_SEARCH_FIELDS))
     print('')
-    print('Examples:')
-    print('> system_search device:vmware')
-    print('> system_search ip:192.168.82')
+    print(_('Examples:'))
+    print(_('> system_search device:vmware'))
+    print(_('> system_search ip:192.168.82'))
 
 
 def do_system_search(self, args, doreturn=False):
@@ -268,14 +275,14 @@ def do_system_search(self, args, doreturn=False):
         try:
             (field, value) = query.split(':')
         except ValueError:
-            logging.error('Invalid query')
+            logging.error(_('Invalid query'))
             return []
     else:
         field = 'name'
         value = query
 
     if not value:
-        logging.warning('Invalid query')
+        logging.warning(_('Invalid query'))
         return []
 
     results = []
@@ -311,7 +318,7 @@ def do_system_search(self, args, doreturn=False):
         results = self.client.system.search.uuid(self.session, value)
         key = 'uuid'
     else:
-        logging.warning('Invalid search field')
+        logging.warning(_('Invalid search field'))
         return []
 
     systems = []
@@ -341,9 +348,9 @@ def do_system_search(self, args, doreturn=False):
 
 
 def help_system_runscript(self):
-    print('system_runscript: Schedule a script to run on the list of')
-    print('                  systems provided')
-    print('''usage: system_runscript <SYSTEMS> [options])
+    print(_('system_runscript: Schedule a script to run on the list of'))
+    print(_('                  systems provided'))
+    print(_('''usage: system_runscript <SYSTEMS> [options])
 
 options:
   -u USER
@@ -351,7 +358,7 @@ options:
   -t TIMEOUT
   -s START_TIME
   -l LABEL
-  -f FILE''')
+  -f FILE'''))
     print('')
     print(self.HELP_SYSTEM_OPTS)
     print('')
@@ -384,12 +391,12 @@ def do_system_runscript(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning('No systems selected')
+        logging.warning(_('No systems selected'))
         return 1
 
     if is_interactive(options):
-        options.user = prompt_user('User [root]:')
-        options.group = prompt_user('Group [root]:')
+        options.user = prompt_user(_('User [root]:'))
+        options.group = prompt_user(_('Group [root]:'))
 
         # defaults
         if not options.user:
@@ -398,23 +405,23 @@ def do_system_runscript(self, args):
             options.group = 'root'
 
         try:
-            options.timeout = prompt_user('Timeout (in seconds) [600]:')
+            options.timeout = prompt_user(_('Timeout (in seconds) [600]:'))
             if options.timeout:
                 options.timeout = int(options.timeout)
             else:
                 options.timeout = 600
         except ValueError:
-            logging.error('Invalid timeout')
+            logging.error(_('Invalid timeout'))
             return 1
 
-        options.start_time = prompt_user('Start Time [now]:')
+        options.start_time = prompt_user(_('Start Time [now]:'))
         options.start_time = parse_time_input(options.start_time)
 
-        options.label = prompt_user('Label/Short Description [default]:')
+        options.label = prompt_user(_('Label/Short Description [default]:'))
         if options.label == "":
             options.label = None
 
-        options.file = prompt_user('Script File [create]:')
+        options.file = prompt_user(_('Script File [create]:'))
 
         # read the script provided by the user
         if options.file:
@@ -427,7 +434,7 @@ def do_system_runscript(self, args):
             keep_script_file = False
 
         if not script_contents:
-            logging.error('No script provided')
+            logging.error(_('No script provided'))
             return 1
     else:
         if not options.user:
@@ -446,7 +453,7 @@ def do_system_runscript(self, args):
             options.start_time = parse_time_input(options.start_time)
 
         if not options.file:
-            logging.error('A script file is required')
+            logging.error(_('A script file is required'))
             return 1
 
         script_contents = read_file(options.file)
@@ -454,18 +461,18 @@ def do_system_runscript(self, args):
 
     # display a summary
     print('')
-    print('User:       %s' % options.user)
-    print('Group:      %s' % options.group)
-    print('Timeout:    %i seconds' % options.timeout)
-    print('Start Time: %s' % options.start_time)
+    print(_('User:       %s') % options.user)
+    print(_('Group:      %s') % options.group)
+    print(_('Timeout:    %i seconds') % options.timeout)
+    print(_('Start Time: %s') % options.start_time)
     print('')
     if options.label:
-        print('Label:      %s' % options.label)
-    print('Script Contents')
+        print(_('Label:      %s') % options.label)
+    print(_('Script Contents'))
     print('---------------')
     print(script_contents)
 
-    print('Systems')
+    print(_('Systems'))
     print('-------')
     print('\n'.join(sorted(systems)))
 
@@ -499,7 +506,7 @@ def do_system_runscript(self, args):
                                                              options.start_time)
 
 
-        logging.info('Action ID: %i' % action_id)
+        logging.info(_('Action ID: %i') % action_id)
         scheduled = len(system_ids)
     else:
         # older versions of the API require each system to be
@@ -519,21 +526,21 @@ def do_system_runscript(self, args):
                                                          script_contents,
                                                          options.start_time)
 
-                logging.info('Action ID: %i' % action_id)
+                logging.info(_('Action ID: %i') % action_id)
                 scheduled += 1
             except xmlrpclib.Fault as detail:
                 logging.debug(detail)
-                logging.error('Failed to schedule %s' % system)
+                logging.error(_('Failed to schedule %s') % system)
                 return 1
 
-    logging.info('Scheduled: %i system(s)' % scheduled)
+    logging.info(_('Scheduled: %i system(s)') % scheduled)
 
     # don't delete a pre-existing script that the user provided
     if not keep_script_file:
         try:
             os.remove(options.file)
         except OSError:
-            logging.error('Could not remove %s' % options.file)
+            logging.error(_('Could not remove %s') % options.file)
             return 1
 
     return 0
@@ -542,8 +549,8 @@ def do_system_runscript(self, args):
 
 
 def help_system_listhardware(self):
-    print('system_listhardware: List the hardware details of a system')
-    print('usage: system_listhardware <SYSTEMS>')
+    print(_('system_listhardware: List the hardware details of a system'))
+    print(_('usage: system_listhardware <SYSTEMS>'))
     print('')
     print(self.HELP_SYSTEM_OPTS)
 
@@ -569,7 +576,7 @@ def do_system_listhardware(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning('No systems selected')
+        logging.warning(_('No systems selected'))
         return 1
 
     for system in sorted(systems):
@@ -598,11 +605,11 @@ def do_system_listhardware(self, args):
         add_separator = True
 
         if len(systems) > 1:
-            print('System: %s' % system)
+            print(_('System: %s') % system)
             print('')
 
         if network:
-            print('Network')
+            print(_('Network'))
             print('-------')
 
             count = 0
@@ -611,52 +618,52 @@ def do_system_listhardware(self, args):
                     print('')
                 count += 1
 
-                print('Interface:   %s' % device.get('interface'))
-                print('MAC Address: %s' % device.get('hardware_address').upper())
-                print('IP Address:  %s' % device.get('ip'))
-                print('Netmask:     %s' % device.get('netmask'))
-                print('Broadcast:   %s' % device.get('broadcast'))
-                print('Module:      %s' % device.get('module'))
+                print(_('Interface:   %s') % device.get('interface'))
+                print(_('MAC Address: %s') % device.get('hardware_address').upper())
+                print(_('IP Address:  %s') % device.get('ip'))
+                print(_('Netmask:     %s') % device.get('netmask'))
+                print(_('Broadcast:   %s') % device.get('broadcast'))
+                print(_('Module:      %s') % device.get('module'))
 
             print('')
 
-        print('CPU')
+        print(_('CPU'))
         print('---')
-        print('Count:    %i' % cpu.get('count'))
-        print('Arch:     %s' % cpu.get('arch'))
-        print('MHz:      %s' % cpu.get('mhz'))
-        print('Cache:    %s' % cpu.get('cache'))
-        print('Vendor:   %s' % cpu.get('vendor'))
-        print('Model:    %s' % re.sub(r'\s+', ' ', cpu.get('model')))
+        print(_('Count:    %i') % cpu.get('count'))
+        print(_('Arch:     %s') % cpu.get('arch'))
+        print(_('MHz:      %s') % cpu.get('mhz'))
+        print(_('Cache:    %s') % cpu.get('cache'))
+        print(_('Vendor:   %s') % cpu.get('vendor'))
+        print(_('Model:    %s') % re.sub(r'\s+', ' ', cpu.get('model')))
 
         print('')
-        print('Memory')
+        print(_('Memory'))
         print('------')
-        print('RAM:  %i' % memory.get('ram'))
-        print('Swap: %i' % memory.get('swap'))
+        print(_('RAM:  %i') % memory.get('ram'))
+        print(_('Swap: %i') % memory.get('swap'))
 
         if dmi:
             print('')
-            print('DMI')
-            print('Vendor:       %s' % dmi.get('vendor'))
-            print('System:       %s' % dmi.get('system'))
-            print('Product:      %s' % dmi.get('product'))
-            print('Board:        %s' % dmi.get('board'))
+            print(_('DMI'))
+            print(_('Vendor:       %s') % dmi.get('vendor'))
+            print(_('System:       %s') % dmi.get('system'))
+            print(_('Product:      %s') % dmi.get('product'))
+            print(_('Board:        %s') % dmi.get('board'))
 
             print('')
-            print('Asset')
+            print(_('Asset'))
             print('-----')
             for asset in dmi.get('asset').split(') ('):
                 print(re.sub(r'\)|\(', '', asset))
 
             print('')
-            print('BIOS Release: %s' % dmi.get('bios_release'))
-            print('BIOS Vendor:  %s' % dmi.get('bios_vendor'))
-            print('BIOS Version: %s' % dmi.get('bios_version'))
+            print(_('BIOS Release: %s') % dmi.get('bios_release'))
+            print(_('BIOS Vendor:  %s') % dmi.get('bios_vendor'))
+            print(_('BIOS Version: %s') % dmi.get('bios_version'))
 
         if devices:
             print('')
-            print('Devices')
+            print(_('Devices'))
             print('-------')
 
             count = 0
@@ -666,13 +673,13 @@ def do_system_listhardware(self, args):
                 count += 1
 
                 if device.get('description') is None:
-                    print('Description: None')
+                    print(_('Description: None'))
                 else:
-                    print('Description: %s' % (
+                    print(_('Description: %s') % (
                         wrap(device.get('description'), 60)[0]))
-                print('Driver:      %s' % device.get('driver'))
-                print('Class:       %s' % device.get('device_class'))
-                print('Bus:         %s' % device.get('bus'))
+                print(_('Driver:      %s') % device.get('driver'))
+                print(_('Class:       %s') % device.get('device_class'))
+                print(_('Bus:         %s') % device.get('bus'))
 
     return 0
 
@@ -680,11 +687,11 @@ def do_system_listhardware(self, args):
 
 
 def help_system_installpackage(self):
-    print('system_installpackage: Install a package on a system')
-    print('''usage: system_installpackage <SYSTEMS> <PACKAGE ...> [options])
+    print(_('system_installpackage: Install a package on a system'))
+    print(_('''usage: system_installpackage <SYSTEMS> <PACKAGE ...> [options])
 
 options:
-    -s START_TIME''')
+    -s START_TIME'''))
 
     print('')
     print(self.HELP_SYSTEM_OPTS)
@@ -715,7 +722,7 @@ def do_system_installpackage(self, args):
     # skip the prompt if we are running with --yes
     # use "now" if no start time was given
     if is_interactive(options) and self.options.yes != True:
-        options.start_time = prompt_user('Start Time [now]:')
+        options.start_time = prompt_user(_('Start Time [now]:'))
         options.start_time = parse_time_input(options.start_time)
     else:
         if not options.start_time:
@@ -733,7 +740,7 @@ def do_system_installpackage(self, args):
         systems = self.expand_systems(args.pop(0))
 
     if not systems:
-        logging.warning('No systems selected')
+        logging.warning(_('No systems selected'))
         return 1
 
     packages_to_install = args
@@ -782,7 +789,7 @@ def do_system_installpackage(self, args):
                     jobs[system_id].append(package.get('id'))
 
     if not jobs:
-        logging.warning('No packages to install')
+        logging.warning(_('No packages to install'))
         return 1
 
     add_separator = False
@@ -806,13 +813,13 @@ def do_system_installpackage(self, args):
     if warnings:
         print('')
     for system_id in warnings:
-        logging.warning('%s does not have access to all requested packages' %
+        logging.warning(_('%s does not have access to all requested packages') %
                         self.get_system_name(system_id))
 
     print('')
-    print('Start Time: %s' % options.start_time)
+    print(_('Start Time: %s') % options.start_time)
 
-    if not self.user_confirm('Install these packages [y/N]:'):
+    if not self.user_confirm(_('Install these packages [y/N]:')):
         return 1
 
     scheduled = 0
@@ -825,9 +832,9 @@ def do_system_installpackage(self, args):
 
             scheduled += 1
         except xmlrpclib.Fault:
-            logging.error('Failed to schedule %s' % self.get_system_name(system_id))
+            logging.error(_('Failed to schedule %s') % self.get_system_name(system_id))
 
-    logging.info('Scheduled %i system(s)' % scheduled)
+    logging.info(_('Scheduled %i system(s)') % scheduled)
 
     return 0
 
@@ -835,11 +842,11 @@ def do_system_installpackage(self, args):
 
 
 def help_system_removepackage(self):
-    print('system_removepackage: Remove a package from a system')
-    print('''usage: system_removepackage <SYSTEMS> <PACKAGE ...> [options])
+    print(_('system_removepackage: Remove a package from a system'))
+    print(_('''usage: system_removepackage <SYSTEMS> <PACKAGE ...> [options])
 
 options:
-    -s START_TIME''')
+    -s START_TIME'''))
 
     print('')
     print(self.HELP_SYSTEM_OPTS)
@@ -870,7 +877,7 @@ def do_system_removepackage(self, args):
     # skip the prompt if we are running with --yes
     # use "now" if no start time was given
     if is_interactive(options) and self.options.yes != True:
-        options.start_time = prompt_user('Start Time [now]:')
+        options.start_time = prompt_user(_('Start Time [now]:'))
         options.start_time = parse_time_input(options.start_time)
     else:
         if not options.start_time:
@@ -888,7 +895,7 @@ def do_system_removepackage(self, args):
         systems = self.expand_systems(args.pop(0))
 
     if not systems:
-        logging.warning('No systems selected')
+        logging.warning(_('No systems selected'))
         return 1
 
     package_list = args
@@ -932,9 +939,9 @@ def do_system_removepackage(self, args):
         return 1
 
     print('')
-    print('Start Time: %s' % options.start_time)
+    print(_('Start Time: %s') % options.start_time)
 
-    if not self.user_confirm('Remove these packages [y/N]:'):
+    if not self.user_confirm(_('Remove these packages [y/N]:')):
         return 1
 
     scheduled = 0
@@ -949,12 +956,12 @@ def do_system_removepackage(self, args):
                                                                  jobs[system],
                                                                  options.start_time)
 
-            logging.info('Action ID: %i' % action_id)
+            logging.info(_('Action ID: %i') % action_id)
             scheduled += 1
         except xmlrpclib.Fault:
-            logging.error('Failed to schedule %s' % system)
+            logging.error(_('Failed to schedule %s') % system)
 
-    logging.info('Scheduled %i system(s)' % scheduled)
+    logging.info(_('Scheduled %i system(s)') % scheduled)
 
     return 0
 
@@ -962,11 +969,11 @@ def do_system_removepackage(self, args):
 
 
 def help_system_upgradepackage(self):
-    print('system_upgradepackage: Upgrade a package on a system')
-    print('''usage: system_upgradepackage <SYSTEMS> <PACKAGE ...>|* [options]')
+    print(_('system_upgradepackage: Upgrade a package on a system'))
+    print(_('''usage: system_upgradepackage <SYSTEMS> <PACKAGE ...>|* [options]')
 
 options:
-    -s START_TIME''')
+    -s START_TIME'''))
 
     print('')
     print(self.HELP_SYSTEM_OPTS)
@@ -1005,7 +1012,7 @@ def do_system_upgradepackage(self, args):
     # skip the prompt if we are running with --yes
     # use "now" if no start time was given
     if is_interactive(options) and self.options.yes != True:
-        options.start_time = prompt_user('Start Time [now]:')
+        options.start_time = prompt_user(_('Start Time [now]:'))
         options.start_time = parse_time_input(options.start_time)
     else:
         if not options.start_time:
@@ -1023,7 +1030,7 @@ def do_system_upgradepackage(self, args):
         systems = self.expand_systems(args.pop(0))
 
     if not systems:
-        logging.warning('No systems selected')
+        logging.warning(_('No systems selected'))
         return 1
 
     # make a dictionary of each system and the package IDs to install
@@ -1041,7 +1048,7 @@ def do_system_upgradepackage(self, args):
             package_ids = [p.get('to_package_id') for p in packages]
             jobs[system] = package_ids
         else:
-            logging.warning('No upgrades available for %s' % system)
+            logging.warning(_('No upgrades available for %s') % system)
 
     if not jobs:
         return 1
@@ -1064,14 +1071,14 @@ def do_system_upgradepackage(self, args):
             if name:
                 package_names.append(name)
             else:
-                logging.error("Couldn't get name for package %i" % package)
+                logging.error(_("Couldn't get name for package %i") % package)
 
         print('\n'.join(sorted(package_names)))
 
     print('')
-    print('Start Time: %s' % options.start_time)
+    print(_('Start Time: %s') % options.start_time)
 
-    if not self.user_confirm('Upgrade these packages [y/N]:'):
+    if not self.user_confirm(_('Upgrade these packages [y/N]:')):
         return 1
 
     scheduled = 0
@@ -1086,9 +1093,9 @@ def do_system_upgradepackage(self, args):
 
             scheduled += 1
         except xmlrpclib.Fault:
-            logging.error('Failed to schedule %s' % system)
+            logging.error(_('Failed to schedule %s') % system)
 
-    logging.info('Scheduled %i system(s)' % scheduled)
+    logging.info(_('Scheduled %i system(s)') % scheduled)
 
     return 0
 
@@ -1096,8 +1103,8 @@ def do_system_upgradepackage(self, args):
 
 
 def help_system_listupgrades(self):
-    print('system_listupgrades: List the available upgrades for a system')
-    print('usage: system_listupgrades <SYSTEMS>')
+    print(_('system_listupgrades: List the available upgrades for a system'))
+    print(_('usage: system_listupgrades <SYSTEMS>'))
     print('')
     print(self.HELP_SYSTEM_OPTS)
 
@@ -1124,7 +1131,7 @@ def do_system_listupgrades(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning('No systems selected')
+        logging.warning(_('No systems selected'))
         return 1
 
     for system in sorted(systems):
@@ -1137,7 +1144,7 @@ def do_system_listupgrades(self, args):
                                                             system_id)
 
         if not packages:
-            logging.warning('No upgrades available for %s' % system)
+            logging.warning(_('No upgrades available for %s') % system)
             continue
 
         if add_separator:
@@ -1165,9 +1172,9 @@ def do_system_listupgrades(self, args):
 
 
 def help_system_listinstalledpackages(self):
-    print('system_listinstalledpackages: List the installed packages on a')
-    print('                              system')
-    print('usage: system_listinstalledpackages <SYSTEMS>')
+    print(_('system_listinstalledpackages: List the installed packages on a'))
+    print(_('                              system'))
+    print(_('usage: system_listinstalledpackages <SYSTEMS>'))
     print('')
     print(self.HELP_SYSTEM_OPTS)
 
@@ -1194,7 +1201,7 @@ def do_system_listinstalledpackages(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning('No systems selected')
+        logging.warning(_('No systems selected'))
         return 1
 
     for system in sorted(systems):
@@ -1210,7 +1217,7 @@ def do_system_listinstalledpackages(self, args):
         add_separator = True
 
         if len(systems) > 1:
-            print('System: %s' % system)
+            print(_('System: %s') % system)
             print('')
 
         print('\n'.join(build_package_names(packages)))
@@ -1221,8 +1228,8 @@ def do_system_listinstalledpackages(self, args):
 
 
 def help_system_listconfigchannels(self):
-    print('system_listconfigchannels: List the config channels of a system')
-    print('usage: system_listconfigchannels <SYSTEMS>')
+    print(_('system_listconfigchannels: List the config channels of a system'))
+    print(_('usage: system_listconfigchannels <SYSTEMS>'))
     print('')
     print(self.HELP_SYSTEM_OPTS)
 
@@ -1249,7 +1256,7 @@ def do_system_listconfigchannels(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning('No systems selected')
+        logging.warning(_('No systems selected'))
         return 1
 
     for system in sorted(systems):
@@ -1268,7 +1275,7 @@ def do_system_listconfigchannels(self, args):
             channels = self.client.system.config.listChannels(self.session,
                                                               system_id)
         except xmlrpclib.Fault:
-            logging.warning('%s does not support configuration channels' %
+            logging.warning(_('%s does not support configuration channels') %
                             system)
             continue
 
@@ -1305,13 +1312,13 @@ def print_configfiles(self, quiet, filelist):
 
 
 def help_system_listconfigfiles(self):
-    print('system_listconfigfiles: List the managed config files of a system')
-    print('''usage: system_listconfigfiles <SYSTEMS>')
+    print(_('system_listconfigfiles: List the managed config files of a system'))
+    print(_('''usage: system_listconfigfiles <SYSTEMS>')
 options:
   -s/--sandbox : list only system-sandbox files
   -l/--local   : list only locally managed files
   -c/--central : list only centrally managed files
-  -q/--quiet   : quiet mode (omits the header)''')
+  -q/--quiet   : quiet mode (omits the header)'''))
     print('')
     print(self.HELP_SYSTEM_OPTS)
 
@@ -1348,7 +1355,7 @@ def do_system_listconfigfiles(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning('No systems selected')
+        logging.warning(_('No systems selected'))
         return 1
 
     for system in sorted(systems):
@@ -1361,7 +1368,7 @@ def do_system_listconfigfiles(self, args):
         add_separator = True
 
         if len(systems) > 1:
-            print('System: %s' % system)
+            print(_('System: %s') % system)
 
         try:
             # Pass 0 for system-sandbox files
@@ -1371,7 +1378,7 @@ def do_system_listconfigfiles(self, args):
             files += self.client.system.config.listFiles(self.session,
                                                          system_id, 1)
         except xmlrpclib.Fault:
-            logging.warning('%s does not support configuration channels' %
+            logging.warning(_('%s does not support configuration channels') %
                             system)
             continue
 
@@ -1406,10 +1413,10 @@ def do_system_listconfigfiles(self, args):
 
 
 def help_system_addconfigfile(self):
-    print('system_addconfigfile: Create a configuration file')
-    print('Note this is only for system sandbox or locally-managed files')
-    print('Centrally managed files should be created via configchannel_addfile')
-    print('''usage: system_addconfigfile [SYSTEM] [options]
+    print(_('system_addconfigfile: Create a configuration file'))
+    print(_('Note this is only for system sandbox or locally-managed files'))
+    print(_('Centrally managed files should be created via configchannel_addfile'))
+    print(_('''usage: system_addconfigfile [SYSTEM] [options]
 
 options:
   -S/--sandbox : list only system-sandbox files
@@ -1430,7 +1437,7 @@ options:
   newlines, those containing ASCII escape characters (or other charaters not
   allowed in XML) need to be sent as binary (-b).  Some effort is made to auto-
   detect files which require this, but you may need to explicitly specify.
-''')
+'''))
 
 
 def complete_system_addconfigfile(self, text, line, beg, end):
@@ -1465,7 +1472,7 @@ def do_system_addconfigfile(self, args, update_path=''):
     if interactive:
         if not options.system:
             while True:
-                print('Systems')
+                print(_('Systems'))
                 print('----------------------')
                 print('\n'.join(sorted(self.do_system_list('', True))))
                 print('')
@@ -1477,7 +1484,7 @@ def do_system_addconfigfile(self, args, update_path=''):
                     break
                 else:
                     print('')
-                    logging.warning('%s is not a valid system' %
+                    logging.warning(_('%s is not a valid system') %
                                     options.system)
                     print('')
 
@@ -1487,7 +1494,7 @@ def do_system_addconfigfile(self, args, update_path=''):
             options.path = prompt_user('Path:', noblank=True)
 
         while not options.local and not options.sandbox:
-            answer = prompt_user('System-Sandbox or Locally-Managed? [S/L]:')
+            answer = prompt_user(_('System-Sandbox or Locally-Managed? [S/L]:'))
             if re.match('L', answer, re.I):
                 options.local = True
                 localopt = 1
@@ -1503,7 +1510,7 @@ def do_system_addconfigfile(self, args, update_path=''):
     elif options.sandbox:
         logging.debug("Selected system-sandbox")
     else:
-        logging.error("Must choose system-sandbox or locally-managed option")
+        logging.error(_("Must choose system-sandbox or locally-managed option"))
         self.help_system_addconfigfile()
         return 1
 
@@ -1542,12 +1549,12 @@ def do_system_addconfigfile(self, args, update_path=''):
 
 
 def help_system_addconfigchannels(self):
-    print('system_addconfigchannels: Add config channels to a system')
-    print('''usage: system_addconfigchannels <SYSTEMS> <CHANNEL ...> [options]
+    print(_('system_addconfigchannels: Add config channels to a system'))
+    print(_('''usage: system_addconfigchannels <SYSTEMS> <CHANNEL ...> [options]
 
 options:
   -t add channels to the top of the list
-  -b add channels to the bottom of the list''')
+  -b add channels to the bottom of the list'''))
     print('')
     print(self.HELP_SYSTEM_OPTS)
 
@@ -1581,13 +1588,13 @@ def do_system_addconfigchannels(self, args):
         systems = self.expand_systems(args.pop(0))
 
     if not systems:
-        logging.warning('No systems selected')
+        logging.warning(_('No systems selected'))
         return 1
 
     channels = args
 
     if is_interactive(options):
-        answer = prompt_user('Add to top or bottom? [T/b]:')
+        answer = prompt_user(_('Add to top or bottom? [T/b]:'))
         if re.match('b', answer, re.I):
             options.top = False
         else:
@@ -1611,8 +1618,8 @@ def do_system_addconfigchannels(self, args):
 
 
 def help_system_removeconfigchannels(self):
-    print('system_removeconfigchannels: Remove config channels from a system')
-    print('usage: system_removeconfigchannels <SYSTEMS> <CHANNEL ...>')
+    print(_('system_removeconfigchannels: Remove config channels from a system'))
+    print(_('usage: system_removeconfigchannels <SYSTEMS> <CHANNEL ...>'))
     print('')
     print(self.HELP_SYSTEM_OPTS)
 
@@ -1644,7 +1651,7 @@ def do_system_removeconfigchannels(self, args):
         systems = self.expand_systems(args.pop(0))
 
     if not systems:
-        logging.warning('No systems selected')
+        logging.warning(_('No systems selected'))
         return 1
 
     channels = args
@@ -1661,8 +1668,8 @@ def do_system_removeconfigchannels(self, args):
 
 
 def help_system_setconfigchannelorder(self):
-    print('system_setconfigchannelorder: Set the ranked order of configuration channels')
-    print('usage: system_setconfigchannelorder <SYSTEMS>')
+    print(_('system_setconfigchannelorder: Set the ranked order of configuration channels'))
+    print(_('usage: system_setconfigchannelorder <SYSTEMS>'))
     print('')
     print(self.HELP_SYSTEM_OPTS)
 
@@ -1687,7 +1694,7 @@ def do_system_setconfigchannelorder(self, args):
         systems = self.expand_systems(args.pop(0))
 
     if not systems:
-        logging.warning('No systems selected')
+        logging.warning(_('No systems selected'))
         return 1
 
     # get the current configuration channels from the first system
@@ -1702,7 +1709,7 @@ def do_system_setconfigchannelorder(self, args):
     new_channels = config_channel_order(all_channels, new_channels)
 
     print('')
-    print('New Configuration Channels')
+    print(_('New Configuration Channels'))
     print('--------------------------')
     for i, new_channel in enumerate(new_channels, 1):
         print('[%i] %s' % (i, new_channel))
@@ -1722,11 +1729,11 @@ def do_system_setconfigchannelorder(self, args):
 
 
 def help_system_deployconfigfiles(self):
-    print('system_deployconfigfiles: Deploy all configuration files for a system')
-    print('''usage: system_deployconfigfiles <SYSTEMS> [options]
+    print(_('system_deployconfigfiles: Deploy all configuration files for a system'))
+    print(_('''usage: system_deployconfigfiles <SYSTEMS> [options]
 
 options:
-    -s START_TIME''')
+    -s START_TIME'''))
 
     print('')
     print(self.HELP_SYSTEM_OPTS)
@@ -1752,7 +1759,7 @@ def do_system_deployconfigfiles(self, args):
     # skip the prompt if we are running with --yes
     # use "now" if no start time was given
     if is_interactive(options) and self.options.yes != True:
-        options.start_time = prompt_user('Start Time [now]:')
+        options.start_time = prompt_user(_('Start Time [now]:'))
         options.start_time = parse_time_input(options.start_time)
     else:
         if not options.start_time:
@@ -1767,17 +1774,17 @@ def do_system_deployconfigfiles(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning('No systems selected')
+        logging.warning(_('No systems selected'))
         return 1
 
     print('')
-    print('Start Time: %s' % options.start_time)
+    print(_('Start Time: %s') % options.start_time)
     print('')
-    print('Systems')
+    print(_('Systems'))
     print('-------')
     print('\n'.join(sorted(systems)))
 
-    message = 'Deploy ALL configuration files to these systems [y/N]:'
+    message = _('Deploy ALL configuration files to these systems [y/N]:')
     if not self.user_confirm(message):
         return 1
 
@@ -1787,7 +1794,7 @@ def do_system_deployconfigfiles(self, args):
                                         system_ids,
                                         options.start_time)
 
-    logging.info('Scheduled deployment for %i system(s)' % len(system_ids))
+    logging.info(_('Scheduled deployment for %i system(s)') % len(system_ids))
 
     return 0
 
@@ -1795,15 +1802,15 @@ def do_system_deployconfigfiles(self, args):
 
 
 def help_system_delete(self):
-    print('system_delete: Delete a system profile')
-    print('''usage: system_delete [options] <SYSTEMS>
+    print(_('system_delete: Delete a system profile'))
+    print(_('''usage: system_delete [options] <SYSTEMS>
 
     options:
           -c TYPE - Possible values:
              *  'FAIL_ON_CLEANUP_ERR' - fail in case of cleanup error,
              *  'NO_CLEANUP' - do not cleanup, just delete,
              *  'FORCE_DELETE' - Try cleanup first but delete server anyway in case of error
-    ''')
+    '''))
     print('')
     print(self.HELP_SYSTEM_OPTS)
 
@@ -1840,7 +1847,7 @@ def do_system_delete(self, args):
         system_ids.append(system_id)
 
     if not system_ids:
-        logging.warning('No systems to delete')
+        logging.warning(_('No systems to delete'))
         return 1
 
     # make the column the right size
@@ -1848,7 +1855,7 @@ def do_system_delete(self, args):
     if colsize < 7:
         colsize = 7
 
-    print('%s  System ID' % 'Profile'.ljust(colsize))
+    print(_('%s  System ID') % _('Profile').ljust(colsize))
     print('%s  ---------' % ('-' * colsize))
 
     # print(a summary for the user)
@@ -1856,14 +1863,14 @@ def do_system_delete(self, args):
         print('%s  %i' %
               (self.get_system_name(system_id).ljust(colsize), system_id))
 
-    if not self.user_confirm('Delete these systems [y/N]:'):
+    if not self.user_confirm(_('Delete these systems [y/N]:')):
         return 1
 
     logging.debug("System IDs to remove: %s", system_ids)
     logging.debug("System names to IDs: %s", systems)
 
     self.client.system.deleteSystems(self.session, system_ids, options.cleanuptype)
-    logging.info('%i system(s) scheduled for removal', len(system_ids))
+    logging.info(_('%i system(s) scheduled for removal'), len(system_ids))
 
     # regenerate the system name cache
     self.generate_system_cache(True, delay=1)
@@ -1883,8 +1890,8 @@ def do_system_delete(self, args):
 
 
 def help_system_lock(self):
-    print('system_lock: Lock a system')
-    print('usage: system_lock <SYSTEMS>')
+    print(_('system_lock: Lock a system'))
+    print(_('usage: system_lock <SYSTEMS>'))
     print('')
     print(self.HELP_SYSTEM_OPTS)
 
@@ -1909,7 +1916,7 @@ def do_system_lock(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning('No systems selected')
+        logging.warning(_('No systems selected'))
         return 1
 
     for system in sorted(systems):
@@ -1925,8 +1932,8 @@ def do_system_lock(self, args):
 
 
 def help_system_unlock(self):
-    print('system_unlock: Unlock a system')
-    print('usage: system_unlock <SYSTEMS>')
+    print(_('system_unlock: Unlock a system'))
+    print(_('usage: system_unlock <SYSTEMS>'))
     print('')
     print(self.HELP_SYSTEM_OPTS)
 
@@ -1951,7 +1958,7 @@ def do_system_unlock(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning('No systems selected')
+        logging.warning(_('No systems selected'))
         return 1
 
     for system in sorted(systems):
@@ -1967,8 +1974,8 @@ def do_system_unlock(self, args):
 
 
 def help_system_rename(self):
-    print('system_rename: Rename a system profile')
-    print('usage: system_rename OLDNAME NEWNAME')
+    print(_('system_rename: Rename a system profile'))
+    print(_('usage: system_rename OLDNAME NEWNAME'))
 
 
 def complete_system_rename(self, text, line, beg, end):
@@ -2013,8 +2020,8 @@ def do_system_rename(self, args):
 
 
 def help_system_listcustomvalues(self):
-    print('system_listcustomvalues: List the custom values for a system')
-    print('usage: system_listcustomvalues <SYSTEMS>')
+    print(_('system_listcustomvalues: List the custom values for a system'))
+    print(_('usage: system_listcustomvalues <SYSTEMS>'))
     print('')
     print(self.HELP_SYSTEM_OPTS)
 
@@ -2039,7 +2046,7 @@ def do_system_listcustomvalues(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning('No systems selected')
+        logging.warning(_('No systems selected'))
         return 1
 
     add_separator = False
@@ -2050,7 +2057,7 @@ def do_system_listcustomvalues(self, args):
         add_separator = True
 
         if len(systems) > 1:
-            print('System: %s' % system)
+            print(_('System: %s') % system)
             print('')
 
         system_id = self.get_system_id(system)
@@ -2069,8 +2076,8 @@ def do_system_listcustomvalues(self, args):
 
 
 def help_system_addcustomvalue(self):
-    print('system_addcustomvalue: Set a custom value for a system')
-    print('usage: system_addcustomvalue KEY VALUE <SYSTEMS>')
+    print(_('system_addcustomvalue: Set a custom value for a system'))
+    print(_('usage: system_addcustomvalue KEY VALUE <SYSTEMS>'))
     print('')
     print(self.HELP_SYSTEM_OPTS)
 
@@ -2106,7 +2113,7 @@ def do_system_addcustomvalue(self, args):
         systems = self.expand_systems(args[2:])
 
     if not systems:
-        logging.warning('No systems selected')
+        logging.warning(_('No systems selected'))
         return 1
 
     for system in systems:
@@ -2124,8 +2131,8 @@ def do_system_addcustomvalue(self, args):
 
 
 def help_system_updatecustomvalue(self):
-    print('system_updatecustomvalue: Update a custom value for a system')
-    print('usage: system_updatecustomvalue KEY VALUE <SYSTEMS>')
+    print(_('system_updatecustomvalue: Update a custom value for a system'))
+    print(_('usage: system_updatecustomvalue KEY VALUE <SYSTEMS>'))
     print('')
     print(self.HELP_SYSTEM_OPTS)
 
@@ -2156,8 +2163,8 @@ def do_system_updatecustomvalue(self, args):
 
 
 def help_system_removecustomvalues(self):
-    print('system_removecustomvalues: Remove a custom value for a system')
-    print('usage: system_removecustomvalues <SYSTEMS> <KEY ...>')
+    print(_('system_removecustomvalues: Remove a custom value for a system'))
+    print(_('usage: system_removecustomvalues <SYSTEMS> <KEY ...>'))
     print('')
     print(self.HELP_SYSTEM_OPTS)
 
@@ -2188,12 +2195,12 @@ def do_system_removecustomvalues(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning('No systems selected')
+        logging.warning(_('No systems selected'))
         return 1
 
     keys = args[1:]
 
-    if not self.user_confirm('Delete these values [y/N]:'):
+    if not self.user_confirm(_('Delete these values [y/N]:')):
         return 1
 
     for system in systems:
@@ -2211,12 +2218,12 @@ def do_system_removecustomvalues(self, args):
 
 
 def help_system_addnote(self):
-    print('system_addnote: Set a note for a system')
-    print('''usage: system_addnote <SYSTEM> [options]
+    print(_('system_addnote: Set a note for a system'))
+    print(_('''usage: system_addnote <SYSTEM> [options]
 
 options:
   -s SUBJECT
-  -b BODY''')
+  -b BODY'''))
     print('')
     print(self.HELP_SYSTEM_OPTS)
 
@@ -2243,21 +2250,21 @@ def do_system_addnote(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning('No systems selected')
+        logging.warning(_('No systems selected'))
         return 1
 
     if is_interactive(options):
-        options.subject = prompt_user('Subject of the Note:', noblank=True)
+        options.subject = prompt_user(_('Subject of the Note:'), noblank=True)
 
-        message = 'Note Body (ctrl-D to finish):'
+        message = _('Note Body (ctrl-D to finish):')
         options.body = prompt_user(message, noblank=True, multiline=True)
     else:
         if not options.subject:
-            logging.error('A subject is required')
+            logging.error(_('A subject is required'))
             return 1
 
         if not options.body:
-            logging.error('A body is required')
+            logging.error(_('A body is required'))
             return 1
 
     for system in systems:
@@ -2276,8 +2283,8 @@ def do_system_addnote(self, args):
 
 
 def help_system_deletenotes(self):
-    print('system_deletenotes: Delete notes from a system')
-    print('usage: system_deletenotes <SYSTEM> <ID|*>')
+    print(_('system_deletenotes: Delete notes from a system'))
+    print(_('usage: system_deletenotes <SYSTEM> <ID|*>'))
     print('')
     print(self.HELP_SYSTEM_OPTS)
 
@@ -2303,13 +2310,13 @@ def do_system_deletenotes(self, args):
         systems = self.expand_systems(args.pop(0))
 
     if not systems:
-        logging.warning('No systems selected')
+        logging.warning(_('No systems selected'))
         return 1
 
     note_ids = args
 
     if not args:
-        logging.warning('No notes to delete')
+        logging.warning(_('No notes to delete'))
         return
 
     for system in systems:
@@ -2336,8 +2343,8 @@ def do_system_deletenotes(self, args):
 
 
 def help_system_listnotes(self):
-    print('system_listnotes: List the available notes for a system')
-    print('usage: system_listnotes <SYSTEM>')
+    print(_('system_listnotes: List the available notes for a system'))
+    print(_('usage: system_listnotes <SYSTEM>'))
     print('')
     print(self.HELP_SYSTEM_OPTS)
 
@@ -2362,7 +2369,7 @@ def do_system_listnotes(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning('No systems selected')
+        logging.warning(_('No systems selected'))
         return 1
 
     add_separator = False
@@ -2373,7 +2380,7 @@ def do_system_listnotes(self, args):
         add_separator = True
 
         if len(systems) > 1:
-            print('System: %s' % system)
+            print(_('System: %s') % system)
             print('')
 
         system_id = self.get_system_id(system)
@@ -2395,8 +2402,8 @@ def do_system_listnotes(self, args):
 
 
 def help_system_listfqdns(self):
-    print('system_listfqdns: List the associated FQDNs for a system')
-    print('usage: system_listfqdns <SYSTEM>')
+    print(_('system_listfqdns: List the associated FQDNs for a system'))
+    print(_('usage: system_listfqdns <SYSTEM>'))
     print(self.HELP_SYSTEM_OPTS)
 
 
@@ -2420,7 +2427,7 @@ def do_system_listfqdns(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning('No systems selected')
+        logging.warning(_('No systems selected'))
         return 1
 
     add_separator = False
@@ -2431,7 +2438,7 @@ def do_system_listfqdns(self, args):
         add_separator = True
 
         if len(systems) > 1:
-            print('System: %s' % system)
+            print(_('System: %s') % system)
             print('')
 
         system_id = self.get_system_id(system)
@@ -2448,8 +2455,8 @@ def do_system_listfqdns(self, args):
 ####################
 
 def help_system_setbasechannel(self):
-    print("system_setbasechannel: Set a system's base software channel")
-    print('usage: system_setbasechannel <SYSTEMS> CHANNEL')
+    print(_("system_setbasechannel: Set a system's base software channel"))
+    print(_('usage: system_setbasechannel <SYSTEMS> CHANNEL'))
     print('')
     print(self.HELP_SYSTEM_OPTS)
 
@@ -2479,7 +2486,7 @@ def do_system_setbasechannel(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning('No systems selected')
+        logging.warning(_('No systems selected'))
         return 1
 
     add_separator = False
@@ -2496,9 +2503,9 @@ def do_system_setbasechannel(self, args):
             print(self.SEPARATOR)
         add_separator = True
 
-        print('System:           %s' % system)
-        print('Old Base Channel: %s' % old.get('label'))
-        print('New Base Channel: %s' % new_channel)
+        print(_('System:           %s') % system)
+        print(_('Old Base Channel: %s') % old.get('label'))
+        print(_('New Base Channel: %s') % new_channel)
 
     if not self.user_confirm():
         return 1
@@ -2517,13 +2524,13 @@ def do_system_setbasechannel(self, args):
 ####################
 
 def help_system_schedulechangechannels(self):
-    print("system_schedulechangechannels: Schedule changing a system's software channels")
-    print('''usage: system_setbasechannel <SYSTEMS> [options]
+    print(_("system_schedulechangechannels: Schedule changing a system's software channels"))
+    print(_('''usage: system_setbasechannel <SYSTEMS> [options]
 
 options:
   -b BASE_CHANNEL base channel label
   -c CHILD_CHANNEL child channel labels (allowed multiple times)
-  -s START_TIME time defaults to now''')
+  -s START_TIME time defaults to now'''))
     print(self.HELP_SYSTEM_OPTS)
 
 
@@ -2546,7 +2553,7 @@ def do_system_schedulechangechannels(self, args):
         return 1
 
     if not options.base:
-        logging.error('A base channel is required')
+        logging.error(_('A base channel is required'))
         return 1
 
     # use the systems listed in the SSM
@@ -2556,7 +2563,7 @@ def do_system_schedulechangechannels(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning('No systems selected')
+        logging.warning(_('No systems selected'))
         return 1
 
     if not options.start_time:
@@ -2583,11 +2590,11 @@ def do_system_schedulechangechannels(self, args):
             print(self.SEPARATOR)
         add_separator = True
 
-        print('System:           %s' % system)
-        print('Old Base Channel: %s' % oldBase.get('label'))
-        print('Old Child Channels: %s' % ', '.join([k.get('label') for k in oldKids]))
-        print('New Base Channel: %s' % baseChannel)
-        print('New Child channels %s' % ', '.join(childChannels))
+        print(_('System:           %s') % system)
+        print(_('Old Base Channel: %s') % oldBase.get('label'))
+        print(_('Old Child Channels: %s') % ', '.join([k.get('label') for k in oldKids]))
+        print(_('New Base Channel: %s') % baseChannel)
+        print(_('New Child channels %s') % ', '.join(childChannels))
 
     if not self.user_confirm():
         return 1
@@ -2602,15 +2609,15 @@ def do_system_schedulechangechannels(self, args):
                                           baseChannel,
                                           childChannels,
                                           options.start_time)
-        print('Scheduled action id: %s' % actionId)
+        print(_('Scheduled action id: %s') % actionId)
 
     return 0
 
 ####################
 
 def help_system_listbasechannel(self):
-    print('system_listbasechannel: List the base channel for a system')
-    print('usage: system_listbasechannel <SYSTEMS>')
+    print(_('system_listbasechannel: List the base channel for a system'))
+    print(_('usage: system_listbasechannel <SYSTEMS>'))
     print('')
     print(self.HELP_SYSTEM_OPTS)
 
@@ -2637,7 +2644,7 @@ def do_system_listbasechannel(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning('No systems selected')
+        logging.warning(_('No systems selected'))
         return 1
 
     for system in sorted(systems):
@@ -2650,7 +2657,7 @@ def do_system_listbasechannel(self, args):
         add_separator = True
 
         if len(systems) > 1:
-            print('System: %s' % system)
+            print(_('System: %s') % system)
 
         channel = \
             self.client.system.getSubscribedBaseChannel(self.session,
@@ -2664,8 +2671,8 @@ def do_system_listbasechannel(self, args):
 
 
 def help_system_listchildchannels(self):
-    print('system_listchildchannels: List the child channels for a system')
-    print('usage: system_listchildchannels <SYSTEMS>')
+    print(_('system_listchildchannels: List the child channels for a system'))
+    print(_('usage: system_listchildchannels <SYSTEMS>'))
     print('')
     print(self.HELP_SYSTEM_OPTS)
 
@@ -2692,7 +2699,7 @@ def do_system_listchildchannels(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning('No systems selected')
+        logging.warning(_('No systems selected'))
         return 1
 
     for system in sorted(systems):
@@ -2705,7 +2712,7 @@ def do_system_listchildchannels(self, args):
         add_separator = True
 
         if len(systems) > 1:
-            print('System: %s' % system)
+            print(_('System: %s') % system)
 
         channels = \
             self.client.system.listSubscribedChildChannels(self.session,
@@ -2719,8 +2726,8 @@ def do_system_listchildchannels(self, args):
 
 
 def help_system_addchildchannels(self):
-    print("system_addchildchannels: Add child channels to a system")
-    print('usage: system_addchildchannels <SYSTEMS> <CHANNEL ...>')
+    print(_("system_addchildchannels: Add child channels to a system"))
+    print(_('usage: system_addchildchannels <SYSTEMS> <CHANNEL ...>'))
     print('')
     print(self.HELP_SYSTEM_OPTS)
 
@@ -2742,14 +2749,14 @@ def do_system_addchildchannels(self, args):
 
 
 def help_system_listcrashedsystems(self):
-    print("system_listcrashedsystems: List all systems that have experienced a crash and reported by spacewalk-abrt")
-    print('usage: system_listcrashedsystems')
+    print(_("system_listcrashedsystems: List all systems that have experienced a crash and reported by spacewalk-abrt"))
+    print(_('usage: system_listcrashedsystems'))
     print('')
 
 
 def do_system_listcrashedsystems(self, args):
     print('')
-    print('Count | System ID | Profile Name')
+    print(_('Count | System ID | Profile Name'))
     print('--------------------------------')
     res = self.client.system.listUserSystems(self.session)
     for s in res:
@@ -2763,10 +2770,10 @@ def do_system_listcrashedsystems(self, args):
 
 
 def help_system_deletecrashes(self):
-    print('system_deletecrashes: Delete crashes reported by spacewalk-abrt.')
-    print('usage: Delete all crashes for all systems    : system_deletecrashes [--verbose]')
-    print('usage: Delete all crashes for a single system: system_deletecrashes -i sys_id [--verbose]')
-    print('usage: Delete a single crash record          : system_deletecrashes -c crash_id [--verbose]')
+    print(_('system_deletecrashes: Delete crashes reported by spacewalk-abrt.'))
+    print(_('usage: Delete all crashes for all systems    : system_deletecrashes [--verbose]'))
+    print(_('usage: Delete all crashes for a single system: system_deletecrashes -i sys_id [--verbose]'))
+    print(_('usage: Delete a single crash record          : system_deletecrashes -c crash_id [--verbose]'))
     print('')
 
 
@@ -2784,16 +2791,16 @@ def do_system_deletecrashes(self, args):
     (args, options) = parse_command_arguments(args, arg_parser)
 
     if options.crashid:
-        print_msg("Deleting crash with id %s." % options.crashid, options.verbose)
+        print_msg(_("Deleting crash with id %s.") % options.crashid, options.verbose)
         self.client.system.crash.deleteCrash(self.session, int(options.crashid))
         return
 
     sys_id = []
     if options.sysid:
         sys_id.append(options.sysid)
-        prompt_string = "Deleting all crashes from system with systemid %s [y/N]:" % options.sysid
+        prompt_string = _("Deleting all crashes from system with systemid %s [y/N]:") % options.sysid
     else:  # all systems
-        prompt_string = 'Deleting all crashes from all systems [y/N]:'
+        prompt_string = _('Deleting all crashes from all systems [y/N]:')
         systems = self.client.system.listUserSystems(self.session)
         for s in systems:
             sys_id.append(s['id'])
@@ -2805,7 +2812,7 @@ def do_system_deletecrashes(self, args):
     for s_id in sys_id:
         list_crash = self.client.system.crash.listSystemCrashes(self.session, int(s_id))
         for crash in list_crash:
-            print_msg("Deleting crash with id %s from system %s." % (crash['id'], s_id), options.verbose)
+            print_msg(_("Deleting crash with id %s from system %s.") % (crash['id'], s_id), options.verbose)
             self.client.system.crash.deleteCrash(self.session, int(crash['id']))
 
     return 0
@@ -2814,8 +2821,8 @@ def do_system_deletecrashes(self, args):
 
 
 def help_system_listcrashesbysystem(self):
-    print('system_listcrashesbysystem: List all reported crashes for a system.')
-    print('usage: system_listcrashesbysystem -i sys_id')
+    print(_('system_listcrashesbysystem: List all reported crashes for a system.'))
+    print(_('usage: system_listcrashesbysystem -i sys_id'))
     print('')
 
 
@@ -2826,13 +2833,13 @@ def do_system_listcrashesbysystem(self, args):
     (args, options) = parse_command_arguments(args, arg_parser)
 
     if not options.sysid:
-        print("# System id must be provided.")
-        print("usage: system_listcrashesbysystem -i sys_id")
+        print(_("# System id must be provided."))
+        print(_("usage: system_listcrashesbysystem -i sys_id"))
         return 1
 
     l_crashes = self.client.system.crash.listSystemCrashes(self.session, int(options.sysid))
     print('')
-    print('Crash ID | Crash Name')
+    print(_('Crash ID | Crash Name'))
     print('---------------------')
 
     for cr in l_crashes:
@@ -2843,9 +2850,9 @@ def do_system_listcrashesbysystem(self, args):
 #######
 
 def help_system_getcrashfiles(self):
-    print('system_getcrashfiles: Download all files for a crash record.')
-    print('usage: system_getcrashfiles -c crash_id [--verbose]')
-    print('usage: system_getcrashfiles -c crash_id [--dest_folder=/tmp/crash_files] [--verbose]')
+    print(_('system_getcrashfiles: Download all files for a crash record.'))
+    print(_('usage: system_getcrashfiles -c crash_id [--verbose]'))
+    print(_('usage: system_getcrashfiles -c crash_id [--dest_folder=/tmp/crash_files] [--verbose]'))
     print('')
 
 
@@ -2858,8 +2865,8 @@ def do_system_getcrashfiles(self, args):
     (args, options) = parse_command_arguments(args, arg_parser)
 
     if not options.crashid:
-        print("# Crash id must be provided.")
-        print("usage: system_getcrashfiles -c crash_id [--dest_folder=/tmp/crash_files] [--verbose]")
+        print(_("# Crash id must be provided."))
+        print(_("usage: system_getcrashfiles -c crash_id [--dest_folder=/tmp/crash_files] [--verbose]"))
         return 1
 
     if not options.verbose:
@@ -2885,7 +2892,7 @@ def do_system_getcrashfiles(self, args):
             options.verbose))
 
     print('')
-    print("# All files we downloaded to %s." % options.dest_folder)
+    print(_("# All files we downloaded to %s.") % options.dest_folder)
     print('')
 
     return 0
@@ -2894,8 +2901,8 @@ def do_system_getcrashfiles(self, args):
 
 
 def help_system_removechildchannels(self):
-    print("system_removechildchannels: Remove child channels from a system")
-    print('usage: system_removechildchannels <SYSTEMS> <CHANNEL ...>')
+    print(_("system_removechildchannels: Remove child channels from a system"))
+    print(_('usage: system_removechildchannels <SYSTEMS> <CHANNEL ...>'))
     print('')
     print(self.HELP_SYSTEM_OPTS)
 
@@ -2917,8 +2924,8 @@ def do_system_removechildchannels(self, args):
 
 
 def help_system_details(self):
-    print('system_details: Show the details of a system profile')
-    print('usage: system_details <SYSTEMS>')
+    print(_('system_details: Show the details of a system profile'))
+    print(_('usage: system_details <SYSTEMS>'))
     print('')
     print(self.HELP_SYSTEM_OPTS)
 
@@ -2945,7 +2952,7 @@ def do_system_details(self, args, short=False):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning('No systems selected')
+        logging.warning(_('No systems selected'))
         return 1
 
     for system in sorted(systems):
@@ -2971,19 +2978,19 @@ def do_system_details(self, args, short=False):
             print(self.SEPARATOR)
         add_separator = True
 
-        print('Name:          %s' % details.get('profile_name'))
-        print('System ID:     %i' % system_id)
+        print(_('Name:          %s') % details.get('profile_name'))
+        print(_('System ID:     %i') % system_id)
 
         if uuid:
-            print('UUID:          %s' % uuid)
+            print(_('UUID:          %s') % uuid)
 
-        print('Locked:        %s' % details.get('lock_status'))
-        print('Registered:    %s' % registered)
-        print('Last Checkin:  %s' % last_checkin)
-        print('OSA Status:    %s' % details.get('osa_status'))
-        print('Last Boot:     %s' % details.get('last_boot'))
+        print(_('Locked:        %s') % details.get('lock_status'))
+        print(_('Registered:    %s') % registered)
+        print(_('Last Checkin:  %s') % last_checkin)
+        print(_('OSA Status:    %s') % details.get('osa_status'))
+        print(_('Last Boot:     %s') % details.get('last_boot'))
         if 'contact_method' in details:
-            print('Contact Method:%s' % details.get('contact_method'))
+            print(_('Contact Method:%s') % details.get('contact_method'))
 
         # only print(basic information if requested)
         if short:
@@ -3027,18 +3034,18 @@ def do_system_details(self, args, short=False):
                 ranked_config_channels.append(channel.get('label'))
 
         print('')
-        print('Hostname:      %s' % network.get('hostname'))
-        print('IP Address:    %s' % network.get('ip'))
-        print('Kernel:        %s' % kernel)
+        print(_('Hostname:      %s') % network.get('hostname'))
+        print(_('IP Address:    %s') % network.get('ip'))
+        print(_('Kernel:        %s') % kernel)
 
         if keys:
             print('')
-            print('Activation Keys')
+            print(_('Activation Keys'))
             print('---------------')
             print('\n'.join(sorted(keys)))
 
         print('')
-        print('Software Channels')
+        print(_('Software Channels'))
         print('-----------------')
         print(base_channel.get('label'))
 
@@ -3047,18 +3054,18 @@ def do_system_details(self, args, short=False):
 
         if ranked_config_channels:
             print('')
-            print('Configuration Channels')
+            print(_('Configuration Channels'))
             print('----------------------')
             print('\n'.join(ranked_config_channels))
 
         print('')
-        print('Entitlements')
+        print(_('Entitlements'))
         print('------------')
         print('\n'.join(sorted(entitlements)))
 
         if groups:
             print('')
-            print('System Groups')
+            print(_('System Groups'))
             print('-------------')
             for group in groups:
                 if group.get('subscribed') == 1:
@@ -3070,8 +3077,8 @@ def do_system_details(self, args, short=False):
 
 
 def help_system_listerrata(self):
-    print('system_listerrata: List available errata for a system')
-    print('usage: system_listerrata <SYSTEMS>')
+    print(_('system_listerrata: List available errata for a system'))
+    print(_('usage: system_listerrata <SYSTEMS>'))
     print('')
     print(self.HELP_SYSTEM_OPTS)
 
@@ -3098,7 +3105,7 @@ def do_system_listerrata(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning('No systems selected')
+        logging.warning(_('No systems selected'))
         return 1
 
     for system in sorted(systems):
@@ -3111,7 +3118,7 @@ def do_system_listerrata(self, args):
         add_separator = True
 
         if len(systems) > 1:
-            print('System: %s' % system)
+            print(_('System: %s') % system)
             print('')
 
         errata = self.client.system.getRelevantErrata(self.session,
@@ -3125,12 +3132,12 @@ def do_system_listerrata(self, args):
 
 
 def help_system_applyerrata(self):
-    print('system_applyerrata: Apply errata to a system')
-    print('''usage: system_applyerrata [options] <SYSTEMS>
+    print(_('system_applyerrata: Apply errata to a system'))
+    print(_('''usage: system_applyerrata [options] <SYSTEMS>
 [ERRATA|search:XXX ...]
 
 options:
-  -s START_TIME''')
+  -s START_TIME'''))
     print('')
     print(self.HELP_TIME_OPTS)
     print('')
@@ -3167,7 +3174,7 @@ def do_system_applyerrata(self, args):
         systems = self.expand_systems(args.pop(0))
 
     if not systems:
-        logging.warning('No systems selected')
+        logging.warning(_('No systems selected'))
         return 1
 
     # allow globbing and searching of errata
@@ -3187,8 +3194,8 @@ def do_system_applyerrata(self, args):
 
 
 def help_system_listevents(self):
-    print('system_listevents: List the event history for a system')
-    print('usage: system_listevents <SYSTEMS>')
+    print(_('system_listevents: List the event history for a system'))
+    print(_('usage: system_listevents <SYSTEMS>'))
     print('')
     print(self.HELP_SYSTEM_OPTS)
 
@@ -3213,7 +3220,7 @@ def do_system_listevents(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning('No systems selected')
+        logging.warning(_('No systems selected'))
         return 1
 
     add_separator = False
@@ -3228,15 +3235,15 @@ def do_system_listevents(self, args):
         add_separator = True
 
         if len(systems) > 1:
-            print('System: %s' % system)
+            print(_('System: %s') % system)
 
         events = self.client.system.getEventHistory(self.session, system_id)
 
         for e in events:
             print('')
-            print('Summary:   %s' % e.get('summary'))
-            print('Completed: %s' % e.get('completed'))
-            print('Details:   %s' % e.get('details'))
+            print(_('Summary:   %s') % e.get('summary'))
+            print(_('Completed: %s') % e.get('completed'))
+            print(_('Details:   %s') % e.get('details'))
 
     return 0
 
@@ -3244,8 +3251,8 @@ def do_system_listevents(self, args):
 
 
 def help_system_listentitlements(self):
-    print('system_listentitlements: List the entitlements for a system')
-    print('usage: system_listentitlements <SYSTEMS>')
+    print(_('system_listentitlements: List the entitlements for a system'))
+    print(_('usage: system_listentitlements <SYSTEMS>'))
     print('')
     print(self.HELP_SYSTEM_OPTS)
 
@@ -3272,7 +3279,7 @@ def do_system_listentitlements(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning('No systems selected')
+        logging.warning(_('No systems selected'))
         return 1
 
     for system in sorted(systems):
@@ -3285,7 +3292,7 @@ def do_system_listentitlements(self, args):
         add_separator = True
 
         if len(systems) > 1:
-            print('System: %s' % system)
+            print(_('System: %s') % system)
 
         entitlements = self.client.system.getEntitlements(self.session,
                                                           system_id)
@@ -3298,8 +3305,8 @@ def do_system_listentitlements(self, args):
 
 
 def help_system_addentitlements(self):
-    print('system_addentitlements: Add entitlements to a system')
-    print('usage: system_addentitlements <SYSTEMS> ENTITLEMENT')
+    print(_('system_addentitlements: Add entitlements to a system'))
+    print(_('usage: system_addentitlements <SYSTEMS> ENTITLEMENT'))
     print('')
     print(self.HELP_SYSTEM_OPTS)
 
@@ -3336,7 +3343,7 @@ def do_system_addentitlements(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning('No systems selected')
+        logging.warning(_('No systems selected'))
         return 1
 
     for system in systems:
@@ -3354,8 +3361,8 @@ def do_system_addentitlements(self, args):
 
 
 def help_system_removeentitlement(self):
-    print('system_removeentitlement: Remove an entitlement from a system')
-    print('usage: system_removeentitlement <SYSTEMS> ENTITLEMENT')
+    print(_('system_removeentitlement: Remove an entitlement from a system'))
+    print(_('usage: system_removeentitlement <SYSTEMS> ENTITLEMENT'))
     print('')
     print(self.HELP_SYSTEM_OPTS)
 
@@ -3392,7 +3399,7 @@ def do_system_removeentitlement(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning('No systems selected')
+        logging.warning(_('No systems selected'))
         return 1
 
     for system in systems:
@@ -3410,8 +3417,8 @@ def do_system_removeentitlement(self, args):
 
 
 def help_system_listpackageprofiles(self):
-    print('system_listpackageprofiles: List all package profiles')
-    print('usage: system_listpackageprofiles')
+    print(_('system_listpackageprofiles: List all package profiles'))
+    print(_('usage: system_listpackageprofiles'))
 
 
 def do_system_listpackageprofiles(self, args, doreturn=False):
@@ -3430,8 +3437,8 @@ def do_system_listpackageprofiles(self, args, doreturn=False):
 
 
 def help_system_deletepackageprofile(self):
-    print('system_deletepackageprofile: Delete a package profile')
-    print('usage: system_deletepackageprofile PROFILE')
+    print(_('system_deletepackageprofile: Delete a package profile'))
+    print(_('usage: system_deletepackageprofile PROFILE'))
 
 
 def complete_system_deletepackageprofile(self, text, line, beg, end):
@@ -3455,7 +3462,7 @@ def do_system_deletepackageprofile(self, args):
 
     label = args[0]
 
-    if not self.user_confirm('Delete this profile [y/N]:'):
+    if not self.user_confirm(_('Delete this profile [y/N]:')):
         return 1
 
     all_profiles = self.client.system.listPackageProfiles(self.session)
@@ -3466,7 +3473,7 @@ def do_system_deletepackageprofile(self, args):
             profile_id = profile.get('id')
 
     if not profile_id:
-        logging.warning('%s is not a valid profile' % label)
+        logging.warning(_('%s is not a valid profile') % label)
         return 1
 
     self.client.system.deletePackageProfile(self.session, profile_id)
@@ -3477,12 +3484,12 @@ def do_system_deletepackageprofile(self, args):
 
 
 def help_system_createpackageprofile(self):
-    print('system_createpackageprofile: Create a package profile')
-    print('''usage: system_createpackageprofile SYSTEM [options]
+    print(_('system_createpackageprofile: Create a package profile'))
+    print(_('''usage: system_createpackageprofile SYSTEM [options]
 
 options:
   -n NAME
-  -d DESCRIPTION''')
+  -d DESCRIPTION'''))
 
 
 def complete_system_createpackageprofile(self, text, line, beg, end):
@@ -3508,15 +3515,15 @@ def do_system_createpackageprofile(self, args):
         return 1
 
     if is_interactive(options):
-        options.name = prompt_user('Profile Label:', noblank=True)
-        options.description = prompt_user('Description:', multiline=True)
+        options.name = prompt_user(_('Profile Label:'), noblank=True)
+        options.description = prompt_user(_('Description:'), multiline=True)
     else:
         if not options.name:
-            logging.error('A profile name is required')
+            logging.error(_('A profile name is required'))
             return 1
 
         if not options.description:
-            logging.error('A profile description is required')
+            logging.error(_('A profile description is required'))
             return 1
 
     self.client.system.createPackageProfile(self.session,
@@ -3524,7 +3531,7 @@ def do_system_createpackageprofile(self, args):
                                             options.name,
                                             options.description)
 
-    logging.info("Created package profile '%s'" % options.name)
+    logging.info(_("Created package profile '%s'") % options.name)
 
     return 0
 
@@ -3532,8 +3539,8 @@ def do_system_createpackageprofile(self, args):
 
 
 def help_system_comparepackageprofile(self):
-    print('system_comparepackageprofile: Compare a system against a package profile')
-    print('usage: system_comparepackageprofile <SYSTEMS> PROFILE')
+    print(_('system_comparepackageprofile: Compare a system against a package profile'))
+    print(_('usage: system_comparepackageprofile <SYSTEMS> PROFILE'))
     print('')
     print(self.HELP_SYSTEM_OPTS)
 
@@ -3567,7 +3574,7 @@ def do_system_comparepackageprofile(self, args):
         systems = self.expand_systems(args[:-1])
 
     if not systems:
-        logging.warning('No systems selected')
+        logging.warning(_('No systems selected'))
         return 1
 
     profile = args[-1]
@@ -3596,8 +3603,8 @@ def do_system_comparepackageprofile(self, args):
 
 
 def help_system_comparepackages(self):
-    print('system_comparepackages: Compare the packages between two systems')
-    print('usage: system_comparepackages SOME_SYSTEM ANOTHER_SYSTEM')
+    print(_('system_comparepackages: Compare the packages between two systems'))
+    print(_('usage: system_comparepackages SOME_SYSTEM ANOTHER_SYSTEM'))
 
 
 def complete_system_comparepackages(self, text, line, beg, end):
@@ -3628,11 +3635,11 @@ def do_system_comparepackages(self, args):
 
 
 def help_system_syncpackages(self):
-    print('system_syncpackages: Sync packages between two systems')
-    print('''usage: system_syncpackages SOURCE TARGET [options]
+    print(_('system_syncpackages: Sync packages between two systems'))
+    print(_('''usage: system_syncpackages SOURCE TARGET [options]
 
 options:
-    -s START_TIME''')
+    -s START_TIME'''))
     print('')
     print(self.HELP_TIME_OPTS)
 
@@ -3663,7 +3670,7 @@ def do_system_syncpackages(self, args):
     # skip the prompt if we are running with --yes
     # use "now" if no start time was given
     if is_interactive(options) and self.options.yes != True:
-        options.start_time = prompt_user('Start Time [now]:')
+        options.start_time = prompt_user(_('Start Time [now]:'))
         options.start_time = parse_time_input(options.start_time)
     else:
         if not options.start_time:
@@ -3675,9 +3682,9 @@ def do_system_syncpackages(self, args):
     self.do_system_comparepackages('%s %s' % (source_id, target_id))
 
     print('')
-    print('Start Time: %s' % options.start_time)
+    print(_('Start Time: %s') % options.start_time)
 
-    if not self.user_confirm('Sync packages [y/N]:'):
+    if not self.user_confirm(_('Sync packages [y/N]:')):
         return 1
 
     # get package IDs
@@ -3719,8 +3726,8 @@ def filter_latest_packages(pkglist, version_key='version',
             p['arch'] = re.sub('AMD64', 'x86_64', p['arch'])
             tuplekey = p['name'], p['arch']
         else:
-            logging.error("Failed to filter package list, package %s" % p
-                          + "found with no arch or arch_label")
+            logging.error(_("Failed to filter package list, package %s") % p
+                          + _("found with no arch or arch_label"))
             return None
         if not tuplekey in latest:
             latest[tuplekey] = p
@@ -3761,10 +3768,10 @@ def print_comparison_withchannel(self, channelnewer, systemnewer,
 
     # print(headers)
     print('%s  %s  %s  %s' % (
-        'Package'.ljust(max_name),
-        'System Version'.ljust(max_system),
-        'Channel Version'.ljust(max_channel),
-        'Difference'.ljust(max_comparison)))
+        _('Package').ljust(max_name),
+        _('System Version').ljust(max_system),
+        _('Channel Version').ljust(max_channel),
+        _('Difference').ljust(max_comparison)))
 
     print('%s  %s  %s  %s' % (
         '-' * max_name,
@@ -3785,7 +3792,7 @@ def print_comparison_withchannel(self, channelnewer, systemnewer,
             name_string.ljust(max_name),
             version_string.ljust(max_system),
             channel_version.ljust(max_channel),
-            "Channel_newer_than_system".ljust(max_comparison)))
+            _("Channel_newer_than_system").ljust(max_comparison)))
     for item in systemnewer:
         name_string = "%(name)s.%(arch)s" % item
         version_string = "%(version)s-%(release)s" % item
@@ -3798,7 +3805,7 @@ def print_comparison_withchannel(self, channelnewer, systemnewer,
             name_string.ljust(max_name),
             version_string.ljust(max_system),
             channel_version.ljust(max_channel),
-            "System_newer_than_channel".ljust(max_comparison)))
+            _("System_newer_than_channel").ljust(max_comparison)))
     for item in channelmissing:
         name_string = "%(name)s.%(arch)s" % item
         version_string = "%(version)s-%(release)s" % item
@@ -3807,19 +3814,19 @@ def print_comparison_withchannel(self, channelnewer, systemnewer,
             name_string.ljust(max_name),
             version_string.ljust(max_system),
             channel_version.ljust(max_channel),
-            "Missing_in_channel".ljust(max_comparison)))
+            _("Missing_in_channel").ljust(max_comparison)))
 
 
 def help_system_comparewithchannel(self):
-    print('system_comparewithchannel: Compare the installed packages on a')
-    print('                           system with those in the channels it is')
-    print('                           registerd to, or optionally some other')
-    print('                           channel')
-    print('usage: system_comparewithchannel <SYSTEMS> [options]')
-    print('options:')
-    print('         -c/--channel : Specific channel to compare against,')
-    print('                        default is those subscribed to, including')
-    print('                        child channels')
+    print(_('system_comparewithchannel: Compare the installed packages on a'))
+    print(_('                           system with those in the channels it is'))
+    print(_('                           registerd to, or optionally some other'))
+    print(_('                           channel'))
+    print(_('usage: system_comparewithchannel <SYSTEMS> [options]'))
+    print(_('options:'))
+    print(_('         -c/--channel : Specific channel to compare against,'))
+    print(_('                        default is those subscribed to, including'))
+    print(_('                        child channels'))
     print('')
     print(self.HELP_SYSTEM_OPTS)
 
@@ -3845,7 +3852,7 @@ def do_system_comparewithchannel(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning('No systems selected')
+        logging.warning(_('No systems selected'))
         return 1
 
     channel_latest = {}
@@ -3870,7 +3877,7 @@ def do_system_comparewithchannel(self, args):
             allch = self.client.channel.listSoftwareChannels(self.session)
             allch_labels = [c['label'] for c in allch]
             if not options.channel in allch_labels:
-                logging.error("Specified channel does not exist")
+                logging.error(_("Specified channel does not exist"))
                 self.help_system_comparewithchannel()
                 return
             channels = [options.channel]
@@ -3881,10 +3888,10 @@ def do_system_comparewithchannel(self, args):
             basech = self.client.system.getSubscribedBaseChannel(self.session,
                                                                  system_id)
             if not basech:
-                logging.error("system %s is not subscribed to any channel!"
+                logging.error(_("system %s is not subscribed to any channel!")
                               % system)
-                logging.error("Please subscribe to a channel, or specify a" +
-                              "channel to compare with")
+                logging.error(_("Please subscribe to a channel, or specify a" +
+                              "channel to compare with"))
                 return 1
             logging.debug("base channel %s for %s" % (basech['name'], system))
             childch = self.client.system.listSubscribedChildChannels(
@@ -3917,7 +3924,7 @@ def do_system_comparewithchannel(self, args):
                     latestpkgs[key] = p_newest
 
         if len(systems) > 1:
-            print('\nSystem: %s' % system)
+            print(_('\nSystem: %s') % system)
 
         # Iterate over the installed packages
         channelnewer = []
@@ -3943,11 +3950,11 @@ def do_system_comparewithchannel(self, args):
 
 
 def help_system_schedulehardwarerefresh(self):
-    print('system_schedulehardwarerefresh: Schedule a hardware refresh for a system')
-    print('''usage: system_schedulehardwarerefresh <SYSTEMS> [options]
+    print(_('system_schedulehardwarerefresh: Schedule a hardware refresh for a system'))
+    print(_('''usage: system_schedulehardwarerefresh <SYSTEMS> [options]
 
 options:
-  -s START_TIME''')
+  -s START_TIME'''))
 
     print('')
     print(self.HELP_SYSTEM_OPTS)
@@ -3973,7 +3980,7 @@ def do_system_schedulehardwarerefresh(self, args):
     # skip the prompt if we are running with --yes
     # use "now" if no start time was given
     if is_interactive(options) and self.options.yes != True:
-        options.start_time = prompt_user('Start Time [now]:')
+        options.start_time = prompt_user(_('Start Time [now]:'))
         options.start_time = parse_time_input(options.start_time)
     else:
         if not options.start_time:
@@ -3988,7 +3995,7 @@ def do_system_schedulehardwarerefresh(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning('No systems selected')
+        logging.warning(_('No systems selected'))
         return 1
 
     for system in systems:
@@ -4006,11 +4013,11 @@ def do_system_schedulehardwarerefresh(self, args):
 
 
 def help_system_schedulepackagerefresh(self):
-    print('system_schedulepackagerefresh: Schedule a software package refresh for a system')
-    print('''usage: system_schedulepackagerefresh <SYSTEMS> [options])
+    print(_('system_schedulepackagerefresh: Schedule a software package refresh for a system'))
+    print(_('''usage: system_schedulepackagerefresh <SYSTEMS> [options])
 
 options:
-  -s START_TIME''')
+  -s START_TIME'''))
     print('')
     print(self.HELP_SYSTEM_OPTS)
     print('')
@@ -4035,7 +4042,7 @@ def do_system_schedulepackagerefresh(self, args):
     # skip the prompt if we are running with --yes
     # use "now" if no start time was given
     if is_interactive(options) and self.options.yes != True:
-        options.start_time = prompt_user('Start Time [now]:')
+        options.start_time = prompt_user(_('Start Time [now]:'))
         options.start_time = parse_time_input(options.start_time)
     else:
         if not options.start_time:
@@ -4050,7 +4057,7 @@ def do_system_schedulepackagerefresh(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning('No systems selected')
+        logging.warning(_('No systems selected'))
         return 1
 
     for system in systems:
@@ -4068,8 +4075,8 @@ def do_system_schedulepackagerefresh(self, args):
 
 
 def help_system_show_packageversion(self):
-    print('system_show_packageversion: Shows version of installed package on given system(s)')
-    print('usage: system_show_packageversion <SYSTEM> <PACKAGE>')
+    print(_('system_show_packageversion: Shows version of installed package on given system(s)'))
+    print(_('usage: system_show_packageversion <SYSTEM> <PACKAGE>'))
     print('')
     print(self.HELP_SYSTEM_OPTS)
 
@@ -4098,10 +4105,10 @@ def do_system_show_packageversion(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning('No systems selected')
+        logging.warning(_('No systems selected'))
         return 1
 
-    print("Package\tVersion\tRelease\tEpoch\tArch\tSystem")
+    print(_("Package\tVersion\tRelease\tEpoch\tArch\tSystem"))
     print("==============================================")
     for system in sorted(systems):
         system_id = self.get_system_id(system)
@@ -4121,9 +4128,9 @@ def do_system_show_packageversion(self, args):
 
 
 def help_system_setcontactmethod(self):
-    print('system_setcontactmethod: Set the contact method for given system(s).')
-    print('Available contact methods: ' + str(self.CONTACT_METHODS))
-    print('usage: system_setcontactmethod <SYSTEMS> <CONTACT_METHOD>')
+    print(_('system_setcontactmethod: Set the contact method for given system(s).'))
+    print(_('Available contact methods: ' + str(self.CONTACT_METHODS)))
+    print(_('usage: system_setcontactmethod <SYSTEMS> <CONTACT_METHOD>'))
     print('')
     print(self.HELP_SYSTEM_OPTS)
 
@@ -4156,7 +4163,7 @@ def do_system_setcontactmethod(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning('No systems selected')
+        logging.warning(_('No systems selected'))
         return 1
 
     for system in sorted(systems):
@@ -4172,11 +4179,11 @@ def do_system_setcontactmethod(self, args):
 
 
 def help_system_scheduleapplyconfigchannels(self):
-    print("system_scheduleapplyconfigchannels: Schedule applying the assigned config channels to the System (Minion only)")
-    print('''usage: scheduleapplyconfigchannels <SYSTEMS> [options]
+    print(_("system_scheduleapplyconfigchannels: Schedule applying the assigned config channels to the System (Minion only)"))
+    print(_('''usage: scheduleapplyconfigchannels <SYSTEMS> [options]
 
     options:
-        -s START_TIME''')
+        -s START_TIME'''))
     print('')
     print(self.HELP_SYSTEM_OPTS)
     print('')
@@ -4199,7 +4206,7 @@ def do_system_scheduleapplyconfigchannels(self, args):
     # skip the prompt if we are running with --yes
     # use "now" if no start time was given
     if is_interactive(options) and self.options.yes != True:
-        options.start_time = prompt_user('Start Time [now]:')
+        options.start_time = prompt_user(_('Start Time [now]:'))
         options.start_time = parse_time_input(options.start_time)
     else:
         if not options.start_time:
@@ -4214,17 +4221,17 @@ def do_system_scheduleapplyconfigchannels(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning('No systems selected')
+        logging.warning(_('No systems selected'))
         return 1
 
     print('')
-    print('Start Time: %s' % options.start_time)
+    print(_('Start Time: %s') % options.start_time)
     print('')
-    print('Systems')
+    print(_('Systems'))
     print('-------')
     print('\n'.join(sorted(systems)))
 
-    message = 'Schedule applying config channels to these systems [y/N]:'
+    message = _('Schedule applying config channels to these systems [y/N]:')
     if not self.user_confirm(message):
         return 1
 
@@ -4233,7 +4240,7 @@ def do_system_scheduleapplyconfigchannels(self, args):
     actionId = self.client.system.config.scheduleApplyConfigChannel(self.session,
                                                                     system_ids,
                                                                     options.start_time, False)
-    print('Scheduled action id: %s' % actionId)
+    print(_('Scheduled action id: %s') % actionId)
 
     return 0
 
@@ -4241,8 +4248,8 @@ def do_system_scheduleapplyconfigchannels(self, args):
 
 
 def help_system_listmigrationtargets(self):
-    print('system_listmigrationtargets: List possible migration targets for given systems.')
-    print('usage: system_listmigrationtargets <SYSTEMS>')
+    print(_('system_listmigrationtargets: List possible migration targets for given systems.'))
+    print(_('usage: system_listmigrationtargets <SYSTEMS>'))
     print('')
     print(self.HELP_SYSTEM_OPTS)
 
@@ -4263,38 +4270,38 @@ def do_system_listmigrationtargets(self, args):
         systems = self.expand_systems(args[0])
 
     if not systems:
-        print('No systems found')
+        print(_('No systems found'))
         return
 
     for system in sorted(systems):
         system_id = self.get_system_id(system)
         if not system_id:
-            print('WARN: Cannot find system ' + str(system))
+            print(_('WARN: Cannot find system ') + str(system))
             continue
 
         print('System ' + str(system))
         tgts = self.client.system.listMigrationTargets(self.session, system_id)
 
         if not tgts:
-            print('  No migration targets')
+            print(_('  No migration targets'))
 
         for num, tgt in enumerate(tgts, start=1):
-            print('  Target #' + str(num) + ":")
-            print('    IDs: ' + tgt['ident'])
-            print('    Friendly names: ' + tgt['friendly'])
+            print(_('  Target #') + str(num) + ":")
+            print(_('    IDs: ') + tgt['ident'])
+            print(_('    Friendly names: ') + tgt['friendly'])
 
 ####################
 
 
 def help_system_schedulespmigration(self):
-    print('system_schedulespmigration: Schedule a Service Pack migration for systems.')
-    print('usage: system_schedulespmigration <SYSTEM> <BASE_CHANNEL_LABEL> <MIGRATION_TARGET> [options] \
+    print(_('system_schedulespmigration: Schedule a Service Pack migration for systems.'))
+    print(_('usage: system_schedulespmigration <SYSTEM> <BASE_CHANNEL_LABEL> <MIGRATION_TARGET> [options] \
 \n    For MIGRATION_TARGET parameter see system_listmigrationtargets. \
 \n    The MIGRATION_TARGET parameter must be passed in the following format: [3143,3146,3147,3145,3144,3148,3062]. \
 \n    Options: \
 \n        -s START_TIME \
 \n        -d pass this flag, if you want to do a dry run \
-\n        -c CHILD_CHANNELS (comma-separated child channels labels (with no spaces))')
+\n        -c CHILD_CHANNELS (comma-separated child channels labels (with no spaces))'))
     print('')
     print(self.HELP_SYSTEM_OPTS)
 
@@ -4319,7 +4326,7 @@ def do_system_schedulespmigration(self, args):
         systems = self.expand_systems(args[0])
 
     if not systems:
-        print('No systems found')
+        print(_('No systems found'))
         return
 
     base_channel_label = args[1]
@@ -4338,17 +4345,16 @@ def do_system_schedulespmigration(self, args):
     for system in sorted(systems):
         system_id = self.get_system_id(system)
         if not system_id:
-            logging.warning('Cannot find system ' + str(system) + '. Skipping it.')
+            logging.warning(_('Cannot find system ') + str(system) + _('. Skipping it.'))
             continue
 
-        print('Scheduling Service Pack migration for system ' + str(system))
+        print(_('Scheduling Service Pack migration for system ') + str(system))
         try:
             result = self.client.system.scheduleSPMigration(self.session,
                     system_id, migration_target, base_channel_label,
                     child_channels, options.dry_run, options.start_time)
-            print('Scheduled action ID: '+ str(result))
+            print(_('Scheduled action ID: ') + str(result))
         except xmlrpclib.Fault as detail:
-            logging.error('Failed to schedule %s' % detail)
+            logging.error(_('Failed to schedule %s') % detail)
 
 ####################
-

--- a/spacecmd/src/spacecmd/user.py
+++ b/spacecmd/src/spacecmd/user.py
@@ -30,6 +30,7 @@
 # invalid function name
 # pylint: disable=C0103
 
+import gettext
 import shlex
 from getpass import getpass
 try:
@@ -38,10 +39,15 @@ except ImportError:
     import xmlrpclib
 from spacecmd.utils import *
 
+translation = gettext.translation('spacecmd', fallback=True)
+try:
+    _ = translation.ugettext
+except AttributeError:
+    _ = translation.gettext
 
 def help_user_create(self):
-    print('user_create: Create an user')
-    print('''usage: user_create [options])
+    print(_('user_create: Create an user'))
+    print(_('''usage: user_create [options])
 
 options:
   -u USERNAME
@@ -49,7 +55,7 @@ options:
   -l LAST_NAME
   -e EMAIL
   -p PASSWORD
-  --pam enable PAM authentication''')
+  --pam enable PAM authentication'''))
 
 
 def do_user_create(self, args):
@@ -64,45 +70,45 @@ def do_user_create(self, args):
     (args, options) = parse_command_arguments(args, arg_parser)
 
     if is_interactive(options):
-        options.username = prompt_user('Username:', noblank=True)
-        options.first_name = prompt_user('First Name:', noblank=True)
-        options.last_name = prompt_user('Last Name:', noblank=True)
-        options.email = prompt_user('Email:', noblank=True)
-        options.pam = self.user_confirm('PAM Authentication [y/N]:',
+        options.username = prompt_user(_('Username:'), noblank=True)
+        options.first_name = prompt_user(_('First Name:'), noblank=True)
+        options.last_name = prompt_user(_('Last Name:'), noblank=True)
+        options.email = prompt_user(_('Email:'), noblank=True)
+        options.pam = self.user_confirm(_('PAM Authentication [y/N]:'),
                                         nospacer=True,
                                         integer=True,
                                         ignore_yes=True)
 
         options.password = ''
         while options.password == '':
-            password1 = getpass('Password: ')
-            password2 = getpass('Repeat Password: ')
+            password1 = getpass(_('Password: '))
+            password2 = getpass(_('Repeat Password: '))
 
             if password1 == password2:
                 options.password = password1
             elif password1 == '':
-                logging.warning('Password must be at least 5 characters')
+                logging.warning(_('Password must be at least 5 characters'))
             else:
-                logging.warning("Passwords don't match")
+                logging.warning(_("Passwords don't match"))
     else:
         if not options.username:
-            logging.error('A username is required')
+            logging.error(_('A username is required'))
             return 1
 
         if not options.first_name:
-            logging.error('A first name is required')
+            logging.error(_('A first name is required'))
             return 1
 
         if not options.last_name:
-            logging.error('A last name is required')
+            logging.error(_('A last name is required'))
             return 1
 
         if not options.email:
-            logging.error('An email address is required')
+            logging.error(_('An email address is required'))
             return 1
 
         if not options.password and not options.pam:
-            logging.error('A password is required')
+            logging.error(_('A password is required'))
             return 1
 
         if options.pam:
@@ -110,7 +116,7 @@ def do_user_create(self, args):
             # API requires a non-None password even though it's not used
             # when PAM is enabled
             if options.password:
-                logging.warning("Note: password was ignored due to PAM mode")
+                logging.warning(_("Note: password was ignored due to PAM mode"))
             options.password = ""
         else:
             options.pam = 0
@@ -129,8 +135,8 @@ def do_user_create(self, args):
 
 
 def help_user_delete(self):
-    print('user_delete: Delete an user')
-    print('usage: user_delete NAME')
+    print(_('user_delete: Delete an user'))
+    print(_('usage: user_delete NAME'))
 
 
 def complete_user_delete(self, text, line, beg, end):
@@ -158,8 +164,8 @@ def do_user_delete(self, args):
 
 
 def help_user_disable(self):
-    print('user_disable: Disable an user account')
-    print('usage: user_disable NAME')
+    print(_('user_disable: Disable an user account'))
+    print(_('usage: user_disable NAME'))
 
 
 def complete_user_disable(self, text, line, beg, end):
@@ -185,8 +191,8 @@ def do_user_disable(self, args):
 
 
 def help_user_enable(self):
-    print('user_enable: Enable an user account')
-    print('usage: user_enable NAME')
+    print(_('user_enable: Enable an user account'))
+    print(_('usage: user_enable NAME'))
 
 
 def complete_user_enable(self, text, line, beg, end):
@@ -212,8 +218,8 @@ def do_user_enable(self, args):
 
 
 def help_user_list(self):
-    print('user_list: List all users')
-    print('usage: user_list')
+    print(_('user_list: List all users'))
+    print(_('usage: user_list'))
 
 
 def do_user_list(self, args, doreturn=False):
@@ -230,8 +236,8 @@ def do_user_list(self, args, doreturn=False):
 
 
 def help_user_listavailableroles(self):
-    print('user_listavailableroles: List all available roles for users')
-    print('usage: user_listavailableroles')
+    print(_('user_listavailableroles: List all available roles for users'))
+    print(_('usage: user_listavailableroles'))
 
 
 def do_user_listavailableroles(self, args, doreturn=False):
@@ -243,14 +249,14 @@ def do_user_listavailableroles(self, args, doreturn=False):
         if roles:
             print('\n'.join(sorted(roles)))
         else:
-            logging.error("No roles has been found")
+            logging.error(_("No roles has been found"))
 
 ####################
 
 
 def help_user_addrole(self):
-    print('user_addrole: Add a role to an user account')
-    print('usage: user_addrole USER ROLE')
+    print(_('user_addrole: Add a role to an user account'))
+    print(_('usage: user_addrole USER ROLE'))
 
 
 def complete_user_addrole(self, text, line, beg, end):
@@ -283,8 +289,8 @@ def do_user_addrole(self, args):
 
 
 def help_user_removerole(self):
-    print('user_removerole: Remove a role from an user account')
-    print('usage: user_removerole USER ROLE')
+    print(_('user_removerole: Remove a role from an user account'))
+    print(_('usage: user_removerole USER ROLE'))
 
 
 def complete_user_removerole(self, text, line, beg, end):
@@ -318,8 +324,8 @@ def do_user_removerole(self, args):
 
 
 def help_user_details(self):
-    print('user_details: Show the details of an user')
-    print('usage: user_details USER ...')
+    print(_('user_details: Show the details of an user'))
+    print(_('usage: user_details USER ...'))
 
 
 def complete_user_details(self, text, line, beg, end):
@@ -351,8 +357,8 @@ def do_user_details(self, args):
                 self.client.user.listDefaultSystemGroups(self.session,
                                                          user)
         except xmlrpclib.Fault as exc:
-            logging.warning('%s is not a valid user' % user)
-            logging.debug("Error '{}' while getting data about user '{}': {}".format(
+            logging.warning(_('%s is not a valid user') % user)
+            logging.debug(_("Error '{}' while getting data about user '{}': {}").format(
                 exc.faultCode, user, exc.faultString))
             continue
 
@@ -362,30 +368,30 @@ def do_user_details(self, args):
             print(self.SEPARATOR)
         add_separator = True
 
-        print('Username:      %s' % user)
-        print('First Name:    %s' % details.get('first_name'))
-        print('Last Name:     %s' % details.get('last_name'))
-        print('Email Address: %s' % details.get('email'))
-        print('Organisation:  %s' % org_name)
-        print('Last Login:    %s' % details.get('last_login_date'))
-        print('Created:       %s' % details.get('created_date'))
-        print('Enabled:       %s' % details.get('enabled'))
+        print(_('Username:      %s') % user)
+        print(_('First Name:    %s') % details.get('first_name'))
+        print(_('Last Name:     %s') % details.get('last_name'))
+        print(_('Email Address: %s') % details.get('email'))
+        print(_('Organisation:  %s') % org_name)
+        print(_('Last Login:    %s') % details.get('last_login_date'))
+        print(_('Created:       %s') % details.get('created_date'))
+        print(_('Enabled:       %s') % details.get('enabled'))
 
         if roles:
             print('')
-            print('Roles')
+            print(_('Roles'))
             print('-----')
             print('\n'.join(sorted(roles)))
 
         if groups:
             print('')
-            print('Assigned Groups')
+            print(_('Assigned Groups'))
             print('---------------')
             print('\n'.join(sorted([g.get('name') for g in groups])))
 
         if default_groups:
             print('')
-            print('Default Groups')
+            print(_('Default Groups'))
             print('--------------')
             print('\n'.join(sorted([g.get('name') for g in default_groups])))
 
@@ -395,8 +401,8 @@ def do_user_details(self, args):
 
 
 def help_user_addgroup(self):
-    print('user_addgroup: Add a group to an user account')
-    print('usage: user_addgroup USER <GROUP ...>')
+    print(_('user_addgroup: Add a group to an user account'))
+    print(_('usage: user_addgroup USER <GROUP ...>'))
 
 
 def complete_user_addgroup(self, text, line, beg, end):
@@ -433,8 +439,8 @@ def do_user_addgroup(self, args):
 
 
 def help_user_adddefaultgroup(self):
-    print('user_adddefaultgroup: Add a default group to an user account')
-    print('usage: user_adddefaultgroup USER <GROUP ...>')
+    print(_('user_adddefaultgroup: Add a default group to an user account'))
+    print(_('usage: user_adddefaultgroup USER <GROUP ...>'))
 
 
 def complete_user_adddefaultgroup(self, text, line, beg, end):
@@ -470,8 +476,8 @@ def do_user_adddefaultgroup(self, args):
 
 
 def help_user_removegroup(self):
-    print('user_removegroup: Remove a group to an user account')
-    print('usage: user_removegroup USER <GROUP ...>')
+    print(_('user_removegroup: Remove a group to an user account'))
+    print(_('usage: user_removegroup USER <GROUP ...>'))
 
 
 def complete_user_removegroup(self, text, line, beg, end):
@@ -511,9 +517,9 @@ def do_user_removegroup(self, args):
 
 
 def help_user_removedefaultgroup(self):
-    print('user_removedefaultgroup: Remove a default group from an ' +
-          'user account')
-    print('usage: user_removedefaultgroup USER <GROUP ...>')
+    print(_('user_removedefaultgroup: Remove a default group from an ' +
+          'user account'))
+    print(_('usage: user_removedefaultgroup USER <GROUP ...>'))
 
 
 def complete_user_removedefaultgroup(self, text, line, beg, end):
@@ -552,8 +558,8 @@ def do_user_removedefaultgroup(self, args):
 
 
 def help_user_setfirstname(self):
-    print('user_setfirstname: Set an user accounts first name field')
-    print('usage: user_setfirstname USER FIRST_NAME')
+    print(_('user_setfirstname: Set an user accounts first name field'))
+    print(_('usage: user_setfirstname USER FIRST_NAME'))
 
 
 def complete_user_setfirstname(self, text, line, beg, end):
@@ -587,8 +593,8 @@ def do_user_setfirstname(self, args):
 
 
 def help_user_setlastname(self):
-    print('user_setlastname: Set an user accounts last name field')
-    print('usage: user_setlastname USER LAST_NAME')
+    print(_('user_setlastname: Set an user accounts last name field'))
+    print(_('usage: user_setlastname USER LAST_NAME'))
 
 
 def complete_user_setlastname(self, text, line, beg, end):
@@ -622,8 +628,8 @@ def do_user_setlastname(self, args):
 
 
 def help_user_setemail(self):
-    print('user_setemail: Set an user accounts email field')
-    print('usage: user_setemail USER EMAIL')
+    print(_('user_setemail: Set an user accounts email field'))
+    print(_('usage: user_setemail USER EMAIL'))
 
 
 def complete_user_setemail(self, text, line, beg, end):
@@ -657,8 +663,8 @@ def do_user_setemail(self, args):
 
 
 def help_user_setprefix(self):
-    print('user_setprefix: Set an user accounts name prefix field')
-    print('usage: user_setprefix USER PREFIX')
+    print(_('user_setprefix: Set an user accounts name prefix field'))
+    print(_('usage: user_setprefix USER PREFIX'))
 
 
 def complete_user_setprefix(self, text, line, beg, end):
@@ -697,8 +703,8 @@ def do_user_setprefix(self, args):
 
 
 def help_user_setpassword(self):
-    print('user_setpassword: Set an user accounts name prefix field')
-    print('usage: user_setpassword USER PASSWORD')
+    print(_('user_setpassword: Set an user accounts name prefix field'))
+    print(_('usage: user_setpassword USER PASSWORD'))
 
 
 def complete_user_setpassword(self, text, line, beg, end):


### PR DESCRIPTION
## What does this PR change?

Feat: add gettext translation hook to strings
Only user-facing strings have been touched and a gettext hook has been
added `_('...')`
Debug strings are left untouched

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: translation related

This page should be modified to remove spacecmd when this is merged: https://github.com/uyuni-project/uyuni/wiki/Translating-Uyuni-to-your-language#limitations

- [x] **DONE**

## Test coverage

- No tests: internal

- [X] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/12327

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
