### PR TITLE
Re-enable caching for the checkstyle workflow

### DIFF
--- a/.github/workflows/java-checkstyle.yml
+++ b/.github/workflows/java-checkstyle.yml
@@ -17,6 +17,13 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Cache dependencies
+      id: cache-dependencies
+      uses: actions/cache@v2
+      with:
+        path: java/lib
+        key: ${{ runner.os }}-jars-${{ hashFiles('java/buildconf/ivy/*.*') }}
+
     - name: Resolve dependencies
       if: steps.cache-dependencies.outputs.cache-hit != 'true'
       run: |


### PR DESCRIPTION
## What does this PR change?

This patch reverts commit c76f1e1ca2d891b14bcb7cc51eabbcba1791a775 to re-enable caching of the dependencies for the checkstyle workflow after a problem with one of the cached libraries not being updated.

## GUI diff

No difference.

- [X] **DONE**

## Documentation

- No documentation needed, only CI is affected.

- [X] **DONE**

## Test coverage

- No tests needed, only CI is affected.

- [X] **DONE**

## Links

Reverts #2642.

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below).

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
