### PR TITLE
Fix SLE12 >= SP1 JeOS bootstrap issues (bsc#1176913)

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -202,9 +202,12 @@ ENHANCE12 = [
 ENHANCE12SP1 = [
     "libyui-ncurses-pkg7",
     "libyui-qt-pkg7",
+    "python-asn1crypto",
     "python-enum34",
     "python-idna",
     "python-ipaddress",
+    "python-packaging",
+    "python-pyparsing",
     "python-setuptools",
 ]
 

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,5 @@
+- Add missing packages to SLE12 >= SP1 bootstrap data to fix JeOS
+  bootstrap problems (bsc#1176913)
 - add missing packages to ubuntu20.04 bootstrap data (bsc#1176629)
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

python-cryptograpy now has new requirements at least on SP4 and SP5.

```
# Description

Package python-packaging is not included in bootstrap repository for SLE12SP5, which causes bootstrap of SLE12SP5 traditional client to fail as you can see bellow:

4 Problems:
Problem: nothing provides python-packaging needed by python-cryptography-2.1.4-7.28.2.x86_64
Problem: nothing provides python-packaging needed by python-cryptography-2.1.4-7.28.2.x86_64
Problem: nothing provides python-packaging needed by python-cryptography-2.1.4-7.28.2.x86_64
Problem: nothing provides python-packaging needed by python-cryptography-2.1.4-7.28.2.x86_64
```

If I check at a SLE12SP5 JeOS image:

![Screenshot_20200925_120108](https://user-images.githubusercontent.com/4226070/94257372-7cc23380-ff2b-11ea-8f7e-3e1743cae266.png)

This PR adds the missing packages to the bootstrap scripts for SLE12 >= SP1.

I verified that all packages I am adding are available for SLE12 >= SP1, even if for some reason python-cryptograpy was not updated to require them for old SPs.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Bugfix.

- [x] **DONE**

## Test coverage
- No tests: Bootstrap repositories are not really covered in all cases.

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/12554

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
