### PR TITLE
Ensure yum plugin is enabled

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/channels/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/channels/init.sls
@@ -22,6 +22,14 @@ mgrchannels_susemanagerplugin_conf_dnf:
     - user: root
     - group: root
     - mode: 644
+
+mgrchannels_enable_dnf_plugins:
+  file.replace:
+    - name: /etc/dnf/dnf.conf
+    - pattern: plugins=.*
+    - repl: plugins=1
+{#- default is '1' when option is not specififed #}
+    - onlyif: grep -e 'plugins=0' -e 'plugins=False' -e 'plugins=no' /etc/dnf/dnf.conf
 {%- endif %}
 
 {%- if is_yum %}
@@ -42,6 +50,14 @@ mgrchannels_susemanagerplugin_conf_yum:
     - user: root
     - group: root
     - mode: 644
+
+mgrchannels_enable_yum_plugins:
+  file.replace:
+    - name: /etc/yum.conf
+    - pattern: plugins=.*
+    - repl: plugins=1
+    - onlyif: grep plugins=0 /etc/yum.conf
+
 {%- endif %}
 {%- endif %}
 

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,5 @@
+- ensure the yum/dnf plugins are enabled
+
 -------------------------------------------------------------------
 Fri Sep 18 12:29:55 CEST 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

When yum has disabled plugins, Uyuni cannot work properly. Enable them during bootstrapping

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **should work as described**

- [x] **DONE**

## Test coverage
- No tests: **manual**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/10579
Tracks https://github.com/SUSE/spacewalk/pull/12576 https://github.com/SUSE/spacewalk/pull/12577

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
