### PR TITLE
Resolve cglib from Leap 15.2 and update it (2.2 -> 3.2.4)

### DIFF
--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -7,7 +7,7 @@
         <dependency org="suse" name="bcel" rev="5.2" />
         <dependency org="suse" name="byte-buddy" rev="1.8.17" />
         <dependency org="suse" name="c3p0" rev="0.9.5.2" />
-        <dependency org="suse" name="cglib" rev="2.2" />
+        <dependency org="suse" name="cglib" rev="3.2.4" />
         <dependency org="suse" name="classmate" rev="1.3.4" />
         <dependency org="suse" name="classpathx-mail-1.3.1-monolithic" rev="1.1.2" />
         <dependency org="suse" name="commons-beanutils" rev="1.9.4" />

--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -115,9 +115,9 @@
         <dependency org="com.sun.xml.bind" name="jaxb-core" rev="2.3.0" transitive="false"/>
         <dependency org="com.sun.xml.bind" name="jaxb-impl" rev="2.3.0" transitive="false"/>
         <dependency org="suse" name="junit" rev="4.12" transitive="false"/>
-        <dependency org="org.jmock" name="jmock" rev="2.6.0" transitive="false"/>
-        <dependency org="org.jmock" name="jmock-junit3" rev="2.6.0" transitive="false"/>
-        <dependency org="org.jmock" name="jmock-legacy" rev="2.6.0" transitive="false"/>
+        <dependency org="org.jmock" name="jmock" rev="2.12.0" transitive="false"/>
+        <dependency org="org.jmock" name="jmock-junit3" rev="2.12.0" transitive="false"/>
+        <dependency org="org.jmock" name="jmock-legacy" rev="2.12.0" transitive="false"/>
         <dependency org="mockobjects" name="mockobjects-core" rev="0.09" transitive="false"/>
         <dependency org="mockobjects" name="mockobjects-jdk1.4-j2ee1.3" rev="0.09" transitive="false"/>
         <dependency org="org.objenesis" name="objenesis" rev="1.0" transitive="false"/>

--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -118,6 +118,7 @@
         <dependency org="org.jmock" name="jmock" rev="2.12.0" transitive="false"/>
         <dependency org="org.jmock" name="jmock-junit3" rev="2.12.0" transitive="false"/>
         <dependency org="org.jmock" name="jmock-legacy" rev="2.12.0" transitive="false"/>
+        <dependency org="org.jmock" name="jmock-imposters" rev="2.12.0" transitive="false"/>
         <dependency org="mockobjects" name="mockobjects-core" rev="0.09" transitive="false"/>
         <dependency org="mockobjects" name="mockobjects-jdk1.4-j2ee1.3" rev="0.09" transitive="false"/>
         <dependency org="org.objenesis" name="objenesis" rev="1.0" transitive="false"/>

--- a/java/buildconf/ivy/obs-maven-config.yaml
+++ b/java/buildconf/ivy/obs-maven-config.yaml
@@ -2,9 +2,6 @@ repositories:
   Leap:
     project: openSUSE:Leap:15.2
     repository: standard
-  Leap15.1:
-    project: openSUSE:Leap:15.1
-    repository: standard
   Uyuni_Other:
     project: systemsmanagement:Uyuni:Master:Other
     repository: openSUSE_Leap_15.2
@@ -26,7 +23,7 @@ artifacts:
     repository: Uyuni_Other
   - artifact: cglib
     jar: cglib.jar
-    repository: Leap15.1
+    repository: Leap
   - artifact: classmate
     repository: Uyuni_Other
   - artifact: classpathx-mail-1.3.1-monolithic

--- a/java/code/src/com/redhat/rhn/common/errors/test/BadParameterExceptionHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/common/errors/test/BadParameterExceptionHandlerTest.java
@@ -31,8 +31,8 @@ import org.apache.struts.action.ActionForward;
 import org.apache.struts.action.ActionMapping;
 import org.apache.struts.config.ExceptionConfig;
 import org.jmock.Expectations;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.jmock.integration.junit3.MockObjectTestCase;
-import org.jmock.lib.legacy.ClassImposteriser;
 
 import java.util.Vector;
 
@@ -45,7 +45,7 @@ public class BadParameterExceptionHandlerTest extends MockObjectTestCase {
     private TraceBackAction tba;
 
     public void setUp() throws Exception {
-        setImposteriser(ClassImposteriser.INSTANCE);
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         tba = new TraceBackAction();
         MessageQueue.registerAction(tba, TraceBackEvent.class);
         MessageQueue.startMessaging();

--- a/java/code/src/com/redhat/rhn/common/errors/test/LookupExceptionHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/common/errors/test/LookupExceptionHandlerTest.java
@@ -31,8 +31,8 @@ import org.apache.struts.action.ActionForward;
 import org.apache.struts.action.ActionMapping;
 import org.apache.struts.config.ExceptionConfig;
 import org.jmock.Expectations;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.jmock.integration.junit3.MockObjectTestCase;
-import org.jmock.lib.legacy.ClassImposteriser;
 
 import java.util.Vector;
 
@@ -46,7 +46,7 @@ public class LookupExceptionHandlerTest extends MockObjectTestCase {
 
     public void setUp() throws Exception {
         super.setUp();
-        setImposteriser(ClassImposteriser.INSTANCE);
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         tba = new TraceBackAction();
         MessageQueue.registerAction(tba, TraceBackEvent.class);
         MessageQueue.startMessaging();

--- a/java/code/src/com/redhat/rhn/common/errors/test/PermissionExceptionHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/common/errors/test/PermissionExceptionHandlerTest.java
@@ -31,8 +31,8 @@ import org.apache.struts.action.ActionForward;
 import org.apache.struts.action.ActionMapping;
 import org.apache.struts.config.ExceptionConfig;
 import org.jmock.Expectations;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.jmock.integration.junit3.MockObjectTestCase;
-import org.jmock.lib.legacy.ClassImposteriser;
 
 import java.util.Vector;
 
@@ -45,7 +45,7 @@ public class PermissionExceptionHandlerTest extends MockObjectTestCase {
     private TraceBackAction tba;
 
     public void setUp() {
-        setImposteriser(ClassImposteriser.INSTANCE);
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         tba = new TraceBackAction();
         MessageQueue.registerAction(tba, TraceBackEvent.class);
         MessageQueue.startMessaging();

--- a/java/code/src/com/redhat/rhn/domain/action/cluster/test/ClusterActionCommandTest.java
+++ b/java/code/src/com/redhat/rhn/domain/action/cluster/test/ClusterActionCommandTest.java
@@ -27,7 +27,7 @@ import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
 import com.suse.manager.model.clusters.Cluster;
 import org.jmock.Expectations;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 
 import java.util.Date;
 import java.util.Optional;
@@ -38,7 +38,7 @@ public class ClusterActionCommandTest extends JMockBaseTestCaseWithUser {
 
     public void setUp() throws Exception {
         super.setUp();
-        setImposteriser(ClassImposteriser.INSTANCE);
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         taskomaticMock = mock(TaskomaticApi.class);
         ActionManager.setTaskomaticApi(taskomaticMock);
         ClusterActionCommand.setTaskomaticApi(taskomaticMock);

--- a/java/code/src/com/redhat/rhn/domain/image/test/ImageInfoFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/image/test/ImageInfoFactoryTest.java
@@ -65,9 +65,9 @@ import com.suse.manager.webui.utils.salt.custom.ImageChecksum;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.jmock.integration.junit3.JUnit3Mockery;
 import org.jmock.lib.concurrent.Synchroniser;
-import org.jmock.lib.legacy.ClassImposteriser;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -97,7 +97,7 @@ public class ImageInfoFactoryTest extends BaseTestCaseWithUser {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        CONTEXT.setImposteriser(ClassImposteriser.INSTANCE);
+        CONTEXT.setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     }
 
     public final void testConvertChecksum() {

--- a/java/code/src/com/redhat/rhn/frontend/action/errata/test/AffectedSystemsActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/errata/test/AffectedSystemsActionTest.java
@@ -34,8 +34,8 @@ import com.redhat.rhn.testing.TestUtils;
 import org.apache.struts.action.ActionForward;
 import org.apache.struts.action.ActionMapping;
 import org.jmock.Expectations;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.jmock.integration.junit3.MockObjectTestCase;
-import org.jmock.lib.legacy.ClassImposteriser;
 
 /**
  * AffectedSystemsActionTest
@@ -46,7 +46,7 @@ public class AffectedSystemsActionTest extends MockObjectTestCase {
     @Override
     protected void setUp() throws Exception {
         super.setUp();
-        setImposteriser(ClassImposteriser.INSTANCE);
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     }
 
     public void testApply() throws Exception {

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/entitlements/test/SystemEntitlementsSetupActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/entitlements/test/SystemEntitlementsSetupActionTest.java
@@ -46,7 +46,7 @@ import com.suse.manager.webui.services.impl.SaltService;
 
 import org.jmock.Expectations;
 import org.jmock.Mockery;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 
 import java.util.Iterator;
 import java.util.Map;
@@ -67,7 +67,7 @@ public class SystemEntitlementsSetupActionTest extends RhnMockStrutsTestCase {
     public void setUp() throws Exception {
         super.setUp();
         Config.get().setBoolean(ConfigDefaults.KIWI_OS_IMAGE_BUILDING_ENABLED, "true");
-        context.setImposteriser(ClassImposteriser.INSTANCE);
+        context.setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         saltServiceMock = context.mock(SaltService.class);
         ServerGroupManager serverGroupManager = new ServerGroupManager();
         systemEntitlementManager = new SystemEntitlementManager(

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/list/test/CSVTagTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/list/test/CSVTagTest.java
@@ -22,8 +22,8 @@ import com.redhat.rhn.testing.RhnBaseTestCase;
 import com.redhat.rhn.testing.RhnMockJspWriter;
 
 import org.jmock.Expectations;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.jmock.integration.junit3.MockObjectTestCase;
-import org.jmock.lib.legacy.ClassImposteriser;
 
 import java.util.List;
 
@@ -45,7 +45,7 @@ public class CSVTagTest extends MockObjectTestCase {
 
     public void setUp() throws Exception {
         super.setUp();
-        setImposteriser(ClassImposteriser.INSTANCE);
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         RhnBaseTestCase.disableLocalizationServiceLogging();
 
         req = mock(HttpServletRequest.class);

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/list/test/ListTagTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/list/test/ListTagTest.java
@@ -26,8 +26,8 @@ import java.io.Writer;
 
 import org.jmock.Expectations;
 import org.jmock.api.Action;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.jmock.integration.junit3.MockObjectTestCase;
-import org.jmock.lib.legacy.ClassImposteriser;
 
 import java.util.List;
 
@@ -51,7 +51,7 @@ public class ListTagTest extends MockObjectTestCase {
 
     public void setUp() throws Exception {
         super.setUp();
-        setImposteriser(ClassImposteriser.INSTANCE);
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         RhnBaseTestCase.disableLocalizationServiceLogging();
         final List dataList = CSVWriterTest.getTestListOfMaps();
 

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/test/ListDisplayTagTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/test/ListDisplayTagTest.java
@@ -23,8 +23,8 @@ import com.redhat.rhn.testing.RhnBaseTestCase;
 import com.redhat.rhn.testing.RhnMockJspWriter;
 import com.redhat.rhn.testing.RhnMockServletOutputStream;
 import org.jmock.Expectations;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.jmock.integration.junit3.MockObjectTestCase;
-import org.jmock.lib.legacy.ClassImposteriser;
 
 import java.io.Writer;
 import javax.servlet.http.HttpServletRequest;
@@ -49,7 +49,7 @@ public class ListDisplayTagTest extends MockObjectTestCase {
 
     public void setUp() throws Exception {
         super.setUp();
-        setImposteriser(ClassImposteriser.INSTANCE);
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         RhnBaseTestCase.disableLocalizationServiceLogging();
         request = mock(HttpServletRequest.class);
         response = mock(HttpServletResponse.class);

--- a/java/code/src/com/redhat/rhn/frontend/taglibs/test/UnpagedListDisplayTagTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/test/UnpagedListDisplayTagTest.java
@@ -24,8 +24,8 @@ import com.redhat.rhn.testing.RhnMockJspWriter;
 import com.redhat.rhn.testing.RhnMockServletOutputStream;
 
 import org.jmock.Expectations;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.jmock.integration.junit3.MockObjectTestCase;
-import org.jmock.lib.legacy.ClassImposteriser;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -48,7 +48,7 @@ public class UnpagedListDisplayTagTest extends MockObjectTestCase {
 
     public void setUp() throws Exception {
         super.setUp();
-        setImposteriser(ClassImposteriser.INSTANCE);
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         RhnBaseTestCase.disableLocalizationServiceLogging();
 
         request = mock(HttpServletRequest.class);

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/test/ChannelSoftwareHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/test/ChannelSoftwareHandlerTest.java
@@ -72,9 +72,9 @@ import com.suse.manager.webui.services.test.TestSaltApi;
 import com.suse.manager.webui.services.test.TestSystemQuery;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.jmock.integration.junit3.JUnit3Mockery;
 import org.jmock.lib.concurrent.Synchroniser;
-import org.jmock.lib.legacy.ClassImposteriser;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -119,7 +119,7 @@ public class ChannelSoftwareHandlerTest extends BaseHandlerTestCase {
     private ErrataHandler errataHandler = new ErrataHandler();
     private final Mockery MOCK_CONTEXT = new JUnit3Mockery() {{
         setThreadingPolicy(new Synchroniser());
-        setImposteriser(ClassImposteriser.INSTANCE);
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     }};
     /**
      * {@inheritDoc}

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/test/ImageInfoHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/test/ImageInfoHandlerTest.java
@@ -72,9 +72,9 @@ import com.suse.manager.webui.services.test.TestSaltApi;
 import com.suse.manager.webui.services.test.TestSystemQuery;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.jmock.integration.junit3.JUnit3Mockery;
 import org.jmock.lib.concurrent.Synchroniser;
-import org.jmock.lib.legacy.ClassImposteriser;
 
 import java.util.HashSet;
 import java.util.List;
@@ -103,7 +103,7 @@ public class ImageInfoHandlerTest extends BaseHandlerTestCase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        CONTEXT.setImposteriser(ClassImposteriser.INSTANCE);
+        CONTEXT.setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         Config.get().setBoolean(ConfigDefaults.KIWI_OS_IMAGE_BUILDING_ENABLED, "true");
     }
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/recurringaction/test/RecurringActionHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/recurringaction/test/RecurringActionHandlerTest.java
@@ -32,7 +32,7 @@ import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
 import com.redhat.rhn.testing.TestUtils;
 
 import org.jmock.Expectations;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -51,7 +51,7 @@ public class RecurringActionHandlerTest extends JMockBaseTestCaseWithUser {
     private TaskomaticApi taskomaticMock;
 
     {
-        context().setImposteriser(ClassImposteriser.INSTANCE);
+        context().setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     }
 
     @Override

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/test/ManagedServerGroupSerializerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/test/ManagedServerGroupSerializerTest.java
@@ -19,8 +19,8 @@ import com.redhat.rhn.domain.server.ManagedServerGroup;
 import com.redhat.rhn.frontend.xmlrpc.serializer.ManagedServerGroupSerializer;
 
 import org.jmock.Expectations;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.jmock.integration.junit3.MockObjectTestCase;
-import org.jmock.lib.legacy.ClassImposteriser;
 
 import java.io.StringWriter;
 import java.io.Writer;
@@ -34,7 +34,7 @@ public class ManagedServerGroupSerializerTest extends MockObjectTestCase {
 
     public void setUp() throws Exception {
         super.setUp();
-        setImposteriser(ClassImposteriser.INSTANCE);
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         serializer = new XmlRpcSerializer();
     }
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/config/test/ServerConfigHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/config/test/ServerConfigHandlerTest.java
@@ -55,9 +55,9 @@ import com.suse.manager.webui.services.test.TestSaltApi;
 import com.suse.manager.webui.services.test.TestSystemQuery;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.jmock.integration.junit3.JUnit3Mockery;
 import org.jmock.lib.concurrent.Synchroniser;
-import org.jmock.lib.legacy.ClassImposteriser;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -85,7 +85,7 @@ public class ServerConfigHandlerTest extends BaseHandlerTestCase {
     private ServerConfigHandler handler = new ServerConfigHandler(taskomaticApi, xmlRpcSystemHelper);
     private final Mockery MOCK_CONTEXT = new JUnit3Mockery() {{
         setThreadingPolicy(new Synchroniser());
-        setImposteriser(ClassImposteriser.INSTANCE);
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     }};
 
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
@@ -148,9 +148,9 @@ import com.suse.manager.webui.services.test.TestSystemQuery;
 import org.apache.commons.lang3.StringUtils;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.jmock.integration.junit3.JUnit3Mockery;
 import org.jmock.lib.concurrent.Synchroniser;
-import org.jmock.lib.legacy.ClassImposteriser;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -195,7 +195,7 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
 
     private final Mockery MOCK_CONTEXT = new JUnit3Mockery() {{
         setThreadingPolicy(new Synchroniser());
-        setImposteriser(ClassImposteriser.INSTANCE);
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     }};
 
     @Override

--- a/java/code/src/com/redhat/rhn/manager/action/test/ActionChainManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/action/test/ActionChainManagerTest.java
@@ -33,7 +33,8 @@ import com.redhat.rhn.manager.errata.cache.test.ErrataCacheManagerTest;
 import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
 
 import com.redhat.rhn.testing.TestUtils;
-import org.jmock.lib.legacy.ClassImposteriser;
+
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -52,7 +53,7 @@ public class ActionChainManagerTest extends JMockBaseTestCaseWithUser {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        setImposteriser(ClassImposteriser.INSTANCE);
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/action/test/ActionManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/action/test/ActionManagerTest.java
@@ -108,9 +108,9 @@ import org.hibernate.Session;
 import org.hibernate.query.Query;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.jmock.integration.junit3.JUnit3Mockery;
 import org.jmock.lib.concurrent.Synchroniser;
-import org.jmock.lib.legacy.ClassImposteriser;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -145,13 +145,13 @@ public class ActionManagerTest extends JMockBaseTestCaseWithUser {
 
     private final Mockery MOCK_CONTEXT = new JUnit3Mockery() {{
         setThreadingPolicy(new Synchroniser());
-        setImposteriser(ClassImposteriser.INSTANCE);
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     }};
 
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        setImposteriser(ClassImposteriser.INSTANCE);
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         Config.get().setString("server.secret_key",
                 DigestUtils.sha256Hex(TestUtils.randomString()));
     }

--- a/java/code/src/com/redhat/rhn/manager/action/test/MinionActionManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/action/test/MinionActionManagerTest.java
@@ -64,7 +64,7 @@ import org.hamcrest.Matcher;
 import org.hamcrest.collection.IsMapContaining;
 import org.hamcrest.core.AllOf;
 import org.jmock.Expectations;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -108,7 +108,7 @@ public class MinionActionManagerTest extends JMockBaseTestCaseWithUser {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        setImposteriser(ClassImposteriser.INSTANCE);
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/audit/test/ScapManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/audit/test/ScapManagerTest.java
@@ -14,7 +14,7 @@ import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
 import com.redhat.rhn.testing.TestUtils;
 
 import org.jmock.Expectations;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -33,7 +33,7 @@ public class ScapManagerTest extends JMockBaseTestCaseWithUser {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        setImposteriser(ClassImposteriser.INSTANCE);
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     }
 
     public void testXccdfEvalTransform_xccdf11() throws Exception {

--- a/java/code/src/com/redhat/rhn/manager/channel/test/ChannelManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/test/ChannelManagerTest.java
@@ -72,9 +72,9 @@ import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.jmock.integration.junit3.JUnit3Mockery;
 import org.jmock.lib.concurrent.Synchroniser;
-import org.jmock.lib.legacy.ClassImposteriser;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -96,7 +96,7 @@ public class ChannelManagerTest extends BaseTestCaseWithUser {
     private static final String MAP_RELEASE = "4AS";
     private final Mockery MOCK_CONTEXT = new JUnit3Mockery() {{
         setThreadingPolicy(new Synchroniser());
-        setImposteriser(ClassImposteriser.INSTANCE);
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     }};
     private static TaskomaticApi taskomaticApi;
 

--- a/java/code/src/com/redhat/rhn/manager/configuration/test/ConfigurationManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/configuration/test/ConfigurationManagerTest.java
@@ -63,9 +63,9 @@ import com.redhat.rhn.testing.UserTestUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.jmock.integration.junit3.JUnit3Mockery;
 import org.jmock.lib.concurrent.Synchroniser;
-import org.jmock.lib.legacy.ClassImposteriser;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -98,7 +98,7 @@ public class ConfigurationManagerTest extends BaseTestCaseWithUser {
         pc.setStart(1);
         pc.setPageSize(20);
         cm = ConfigurationManager.getInstance();
-        CONTEXT.setImposteriser(ClassImposteriser.INSTANCE);
+        CONTEXT.setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     }
 
     @Override

--- a/java/code/src/com/redhat/rhn/manager/distupgrade/test/DistUpgradeManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/distupgrade/test/DistUpgradeManagerTest.java
@@ -59,9 +59,9 @@ import com.redhat.rhn.testing.TestUtils;
 
 import org.jmock.Expectations;
 import org.jmock.Mockery;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.jmock.integration.junit3.JUnit3Mockery;
 import org.jmock.lib.concurrent.Synchroniser;
-import org.jmock.lib.legacy.ClassImposteriser;
 
 import java.util.*;
 
@@ -77,7 +77,7 @@ public class DistUpgradeManagerTest extends BaseTestCaseWithUser {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        CONTEXT.setImposteriser(ClassImposteriser.INSTANCE);
+        CONTEXT.setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/errata/test/ErrataManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/test/ErrataManagerTest.java
@@ -74,7 +74,7 @@ import com.redhat.rhn.testing.UserTestUtils;
 import org.apache.commons.lang3.time.StopWatch;
 import org.hibernate.criterion.Restrictions;
 import org.jmock.Expectations;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -101,7 +101,7 @@ public class ErrataManagerTest extends JMockBaseTestCaseWithUser {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        setImposteriser(ClassImposteriser.INSTANCE);
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     }
 
     public static Bug createNewPublishedBug(Long id, String summary) {

--- a/java/code/src/com/redhat/rhn/manager/formula/test/FormulaManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/formula/test/FormulaManagerTest.java
@@ -43,7 +43,7 @@ import com.suse.utils.Json;
 import org.apache.commons.io.FileUtils;
 import org.cobbler.test.MockConnection;
 import org.jmock.Expectations;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -75,7 +75,7 @@ public class FormulaManagerTest extends JMockBaseTestCaseWithUser {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        setImposteriser(ClassImposteriser.INSTANCE);
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         MockConnection.clear();
         saltServiceMock = mock(SaltService.class);
         metadataDir = Files.createTempDirectory("metadata");

--- a/java/code/src/com/redhat/rhn/manager/recurringactions/test/RecurringActionManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/recurringactions/test/RecurringActionManagerTest.java
@@ -28,9 +28,9 @@ import com.redhat.rhn.testing.UserTestUtils;
 
 import org.jmock.Expectations;
 import org.jmock.Mockery;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.jmock.integration.junit3.JUnit3Mockery;
 import org.jmock.lib.concurrent.Synchroniser;
-import org.jmock.lib.legacy.ClassImposteriser;
 
 import java.util.List;
 
@@ -49,7 +49,7 @@ public class RecurringActionManagerTest extends BaseTestCaseWithUser {
     private static final String CRON_EXPR = "0 * * * * ?";
 
     static {
-        CONTEXT.setImposteriser(ClassImposteriser.INSTANCE);
+        CONTEXT.setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         taskomaticMock = CONTEXT.mock(TaskomaticApi.class);
         RecurringActionManager.setTaskomaticApi(taskomaticMock);
     }

--- a/java/code/src/com/redhat/rhn/manager/ssm/test/SsmManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/ssm/test/SsmManagerTest.java
@@ -42,7 +42,7 @@ import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
 import com.redhat.rhn.testing.UserTestUtils;
 import com.suse.manager.webui.utils.gson.SsmBaseChannelChangesDto;
 import org.jmock.Expectations;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -129,7 +129,7 @@ public class SsmManagerTest extends JMockBaseTestCaseWithUser {
             createTestSUSEProductChannel(childChannel2_1, product2, true);
             createTestSUSEProductChannel(childChannel2_2, product2, true);
         }
-        setImposteriser(ClassImposteriser.INSTANCE);
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         taskomaticMock = mock(TaskomaticApi.class);
         ActionChainManager.setTaskomaticApi(taskomaticMock);
     }

--- a/java/code/src/com/redhat/rhn/manager/system/entitling/test/SystemEntitlementManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/entitling/test/SystemEntitlementManagerTest.java
@@ -41,8 +41,7 @@ import com.suse.manager.webui.services.impl.SaltSSHService;
 import com.suse.manager.webui.services.impl.SaltService;
 
 import org.jmock.Expectations;
-import org.jmock.lib.legacy.ClassImposteriser;
-
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 
 public class SystemEntitlementManagerTest extends JMockBaseTestCaseWithUser {
 
@@ -52,7 +51,7 @@ public class SystemEntitlementManagerTest extends JMockBaseTestCaseWithUser {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        setImposteriser(ClassImposteriser.INSTANCE);
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         saltServiceMock = mock(SaltService.class);
         ServerGroupManager serverGroupManager = new ServerGroupManager();
         systemEntitlementManager = new SystemEntitlementManager(

--- a/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerMockTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerMockTest.java
@@ -36,7 +36,7 @@ import com.suse.manager.webui.services.impl.SaltService;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.cobbler.test.MockConnection;
 import org.jmock.Expectations;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 
 import java.util.Collections;
 
@@ -51,7 +51,7 @@ public class SystemManagerMockTest extends RhnJmockBaseTestCase {
         super.setUp();
         Config.get().setString(CobblerXMLRPCHelper.class.getName(),
                 MockXMLRPCInvoker.class.getName());
-        setImposteriser(ClassImposteriser.INSTANCE);
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         MockConnection.clear();
     }
 

--- a/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
@@ -123,7 +123,7 @@ import org.cobbler.test.MockConnection;
 import org.hibernate.Session;
 import org.hibernate.type.IntegerType;
 import org.jmock.Expectations;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -166,7 +166,7 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
         Config.get().setString(CobblerXMLRPCHelper.class.getName(),
                 MockXMLRPCInvoker.class.getName());
         MockConnection.clear();
-        setImposteriser(ClassImposteriser.INSTANCE);
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         TaskomaticApi taskomaticMock = mock(TaskomaticApi.class);
         ActionManager.setTaskomaticApi(taskomaticMock);
         saltServiceMock = mock(SaltService.class);

--- a/java/code/src/com/redhat/rhn/taskomatic/task/sshpush/test/SSHPushWorkerSaltTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/sshpush/test/SSHPushWorkerSaltTest.java
@@ -48,7 +48,7 @@ import com.suse.salt.netapi.utils.Xor;
 import com.suse.utils.Json;
 import org.apache.log4j.Logger;
 import org.jmock.Expectations;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 
 import java.io.File;
 import java.time.Instant;
@@ -83,7 +83,7 @@ public class SSHPushWorkerSaltTest extends JMockBaseTestCaseWithUser {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        setImposteriser(ClassImposteriser.INSTANCE);
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         sshPushSystemMock = mock(SystemSummary.class);
         saltSSHServiceMock = mock(SaltSSHService.class);
         minion = MinionServerFactoryTest.createTestMinionServer(user);

--- a/java/code/src/com/redhat/rhn/taskomatic/task/test/MinionCheckinTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/test/MinionCheckinTest.java
@@ -29,7 +29,7 @@ import com.suse.salt.netapi.datatypes.target.MinionList;
 
 import org.apache.commons.lang3.time.DateUtils;
 import org.jmock.Expectations;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 
 import java.util.Date;
 import java.util.Optional;
@@ -45,7 +45,7 @@ public class MinionCheckinTest extends JMockBaseTestCaseWithUser {
     public void setUp() throws Exception {
         super.setUp();
         this.thresholdMax =  Config.get().getInt(ConfigDefaults.SYSTEM_CHECKIN_THRESHOLD) * 86400;
-        setImposteriser(ClassImposteriser.INSTANCE);
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/taskomatic/task/test/SubscribeChannelsActionTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/test/SubscribeChannelsActionTest.java
@@ -34,7 +34,7 @@ import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
 import com.redhat.rhn.testing.TestUtils;
 import com.suse.manager.webui.services.SaltServerActionService;
 import org.jmock.Expectations;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.quartz.JobDataMap;
 import org.quartz.JobDetail;
 import org.quartz.JobExecutionContext;
@@ -55,7 +55,7 @@ public class SubscribeChannelsActionTest extends JMockBaseTestCaseWithUser {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        setImposteriser(ClassImposteriser.INSTANCE);
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     }
 
     public void testSubscribeChannels_minions() throws Exception {

--- a/java/code/src/com/suse/manager/kubernetes/test/KubernetesManagerTest.java
+++ b/java/code/src/com/suse/manager/kubernetes/test/KubernetesManagerTest.java
@@ -31,7 +31,7 @@ import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.manager.webui.services.impl.runner.MgrK8sRunner;
 import com.suse.salt.netapi.parser.JsonParser;
 import org.jmock.Expectations;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -51,7 +51,7 @@ public class KubernetesManagerTest extends JMockBaseTestCaseWithUser {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        setImposteriser(ClassImposteriser.INSTANCE);
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
 
         saltServiceMock = mock(SaltService.class);
         manager = new KubernetesManager(saltServiceMock);

--- a/java/code/src/com/suse/manager/maintenance/test/MaintenanceManagerScheduleActionsTest.java
+++ b/java/code/src/com/suse/manager/maintenance/test/MaintenanceManagerScheduleActionsTest.java
@@ -41,7 +41,7 @@ import com.suse.manager.model.maintenance.MaintenanceSchedule;
 import com.suse.manager.reactor.messaging.ApplyStatesEventMessage;
 
 import org.jmock.Expectations;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 
 import java.io.File;
 import java.time.ZonedDateTime;
@@ -65,7 +65,7 @@ public class MaintenanceManagerScheduleActionsTest extends JMockBaseTestCaseWith
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        setImposteriser(ClassImposteriser.INSTANCE);
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
 
         user.addPermanentRole(ORG_ADMIN);
 

--- a/java/code/src/com/suse/manager/matcher/test/MatcherJsonIOTest.java
+++ b/java/code/src/com/suse/manager/matcher/test/MatcherJsonIOTest.java
@@ -44,7 +44,7 @@ import com.suse.matcher.json.VirtualizationGroupJson;
 import com.suse.scc.model.SCCSubscriptionJson;
 
 import org.jmock.Expectations;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -80,7 +80,7 @@ public class MatcherJsonIOTest extends JMockBaseTestCaseWithUser {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        setImposteriser(ClassImposteriser.INSTANCE);
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
 
         VirtManager virtManager = new TestVirtManager() {
             @Override

--- a/java/code/src/com/suse/manager/reactor/messaging/test/ImageDeployedEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/ImageDeployedEventMessageActionTest.java
@@ -35,7 +35,7 @@ import com.suse.salt.netapi.calls.modules.Grains;
 import com.suse.salt.netapi.calls.modules.Zypper;
 import com.suse.salt.netapi.parser.JsonParser;
 import org.jmock.Expectations;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 
 import java.io.File;
 import java.io.IOException;
@@ -64,7 +64,7 @@ public class ImageDeployedEventMessageActionTest extends JMockBaseTestCaseWithUs
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        setImposteriser(ClassImposteriser.INSTANCE);
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
 
         saltMock = mock(SaltService.class);
         taskomaticMock = mock(TaskomaticApi.class);

--- a/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
@@ -106,7 +106,7 @@ import com.google.gson.reflect.TypeToken;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.jmock.Expectations;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.yaml.snakeyaml.Yaml;
 
 import java.io.File;
@@ -154,7 +154,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        setImposteriser(ClassImposteriser.INSTANCE);
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         Config.get().setString("server.secret_key",
                 DigestUtils.sha256Hex(TestUtils.randomString()));
         saltServiceMock = context().mock(SaltService.class);

--- a/java/code/src/com/suse/manager/reactor/messaging/test/LibvirtEngineDomainLifecycleMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/LibvirtEngineDomainLifecycleMessageActionTest.java
@@ -45,7 +45,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.reflect.TypeToken;
 
 import org.apache.commons.lang3.StringUtils;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -75,7 +75,7 @@ public class LibvirtEngineDomainLifecycleMessageActionTest extends JMockBaseTest
     public void setUp() throws Exception {
         super.setUp();
         user.addPermanentRole(RoleFactory.ORG_ADMIN);
-        setImposteriser(ClassImposteriser.INSTANCE);
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
 
         virtManager = new TestVirtManager() {
 

--- a/java/code/src/com/suse/manager/reactor/messaging/test/MinionActionCleanupTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/MinionActionCleanupTest.java
@@ -51,7 +51,7 @@ import com.suse.salt.netapi.parser.JsonParser;
 import com.suse.salt.netapi.results.Result;
 import com.suse.salt.netapi.utils.Xor;
 import org.jmock.Expectations;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 
 import java.io.File;
 import java.nio.file.Files;
@@ -78,7 +78,7 @@ public class MinionActionCleanupTest extends JMockBaseTestCaseWithUser {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        setImposteriser(ClassImposteriser.INSTANCE);
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     }
 
     /**

--- a/java/code/src/com/suse/manager/reactor/test/MinionStartupActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/test/MinionStartupActionTest.java
@@ -23,7 +23,7 @@ import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.salt.netapi.datatypes.target.MinionList;
 import org.cobbler.test.MockConnection;
 import org.jmock.Expectations;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 
 /**
  * Tests for {@link MinionStartEventMessageAction}.
@@ -36,7 +36,7 @@ public class MinionStartupActionTest extends JMockBaseTestCaseWithUser {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        setImposteriser(ClassImposteriser.INSTANCE);
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         MockConnection.clear();
         saltServiceMock = mock(SaltService.class);
     }

--- a/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
@@ -99,7 +99,7 @@ import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.apache.commons.io.FileUtils;
 import org.jmock.Expectations;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 
 import static com.redhat.rhn.testing.ErrataTestUtils.createTestChannelFamily;
 import static com.redhat.rhn.testing.ErrataTestUtils.createTestChannelProduct;
@@ -245,7 +245,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        setImposteriser(ClassImposteriser.INSTANCE);
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         Config.get().setString("server.secret_key", "d8d796b3322d65928511769d180d284d2b15158165eb83083efa02c9024aa6cc");
         FormulaFactory.setDataDir(tmpSaltRoot.resolve("formulas/").toString() + "/");
 

--- a/java/code/src/com/suse/manager/reactor/utils/test/RhelUtilsTest.java
+++ b/java/code/src/com/suse/manager/reactor/utils/test/RhelUtilsTest.java
@@ -34,7 +34,8 @@ import com.suse.manager.reactor.utils.RhelUtils;
 import com.suse.salt.netapi.calls.modules.State;
 import com.suse.salt.netapi.parser.JsonParser;
 import com.suse.salt.netapi.results.CmdResult;
-import org.jmock.lib.legacy.ClassImposteriser;
+
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 
 import java.util.Collections;
 import java.util.Map;
@@ -69,7 +70,7 @@ public class RhelUtilsTest extends JMockBaseTestCaseWithUser {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        setImposteriser(ClassImposteriser.INSTANCE);
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     }
 
     public void testParseReleaseFileRedHat() {

--- a/java/code/src/com/suse/manager/webui/controllers/test/BaseControllerTestCase.java
+++ b/java/code/src/com/suse/manager/webui/controllers/test/BaseControllerTestCase.java
@@ -20,7 +20,7 @@ import com.redhat.rhn.testing.RhnMockHttpServletResponse;
 
 import com.suse.manager.webui.utils.SparkTestUtils;
 
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 
 import java.io.UnsupportedEncodingException;
 import java.util.Collections;
@@ -46,7 +46,7 @@ public class BaseControllerTestCase extends JMockBaseTestCaseWithUser {
         super.setUp();
 
         user.addPermanentRole(RoleFactory.ORG_ADMIN);
-        setImposteriser(ClassImposteriser.INSTANCE);
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         response = RequestResponseFactory.create(new RhnMockHttpServletResponse());
     }
 

--- a/java/code/src/com/suse/manager/webui/controllers/test/RecurringActionControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/test/RecurringActionControllerTest.java
@@ -34,7 +34,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
 import org.jmock.Expectations;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 
 import java.io.UnsupportedEncodingException;
 import java.util.List;
@@ -57,7 +57,7 @@ public class RecurringActionControllerTest extends BaseControllerTestCase {
     private TaskomaticApi taskomaticMock;
 
     {
-        context().setImposteriser(ClassImposteriser.INSTANCE);
+        context().setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     }
 
     @Override

--- a/java/code/src/com/suse/manager/webui/controllers/utils/test/AbstractMinionBootstrapperTestBase.java
+++ b/java/code/src/com/suse/manager/webui/controllers/utils/test/AbstractMinionBootstrapperTestBase.java
@@ -31,7 +31,7 @@ import com.suse.salt.netapi.results.Result;
 import com.suse.salt.netapi.results.SSHResult;
 import com.suse.salt.netapi.utils.Xor;
 import org.jmock.Expectations;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -55,7 +55,7 @@ public abstract class AbstractMinionBootstrapperTestBase extends JMockBaseTestCa
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        setImposteriser(ClassImposteriser.INSTANCE);
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         saltServiceMock = mock(SaltService.class);
     }
 

--- a/java/code/src/com/suse/manager/webui/services/impl/test/SaltSSHServiceTest.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/test/SaltSSHServiceTest.java
@@ -3,7 +3,8 @@ package com.suse.manager.webui.services.impl.test;
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
 import com.suse.manager.webui.services.impl.SaltSSHService;
-import org.jmock.lib.legacy.ClassImposteriser;
+
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -17,7 +18,7 @@ public class SaltSSHServiceTest extends JMockBaseTestCaseWithUser {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        setImposteriser(ClassImposteriser.INSTANCE);
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         Config.get().setString("ssh_push_port_https", "1233");
         Config.get().setString("ssh_push_sudo_user", "mgruser");
     }

--- a/java/code/src/com/suse/manager/webui/services/impl/test/SaltServiceTest.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/test/SaltServiceTest.java
@@ -11,7 +11,8 @@ import com.suse.manager.webui.services.test.TestSystemQuery;
 import com.suse.manager.webui.services.impl.MinionPendingRegistrationService;
 import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.manager.webui.services.impl.runner.MgrUtilRunner;
-import org.jmock.lib.legacy.ClassImposteriser;
+
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -31,7 +32,7 @@ public class SaltServiceTest extends JMockBaseTestCaseWithUser {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        setImposteriser(ClassImposteriser.INSTANCE);
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
         tempDir = Files.createTempDirectory("saltservice");
     }
 

--- a/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
+++ b/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
@@ -85,7 +85,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 import org.jmock.Expectations;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -116,7 +116,7 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        setImposteriser(ClassImposteriser.INSTANCE);
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
 
         VirtManager virtManager = new TestVirtManager() {
             @Override

--- a/java/code/src/com/suse/manager/webui/utils/gson/test/SaltMinionTestJson.java
+++ b/java/code/src/com/suse/manager/webui/utils/gson/test/SaltMinionTestJson.java
@@ -19,8 +19,8 @@ import com.suse.manager.webui.utils.gson.SaltMinionJson;
 import com.suse.salt.netapi.calls.wheel.Key;
 
 import org.jmock.Expectations;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.jmock.integration.junit3.MockObjectTestCase;
-import org.jmock.lib.legacy.ClassImposteriser;
 
 import java.util.HashMap;
 import java.util.List;
@@ -34,7 +34,7 @@ public class SaltMinionTestJson extends MockObjectTestCase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        setImposteriser(ClassImposteriser.INSTANCE);
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     }
 
     public void testFromFingerprints() {

--- a/java/code/src/com/suse/manager/webui/utils/salt/test/ImageDeployedEventTest.java
+++ b/java/code/src/com/suse/manager/webui/utils/salt/test/ImageDeployedEventTest.java
@@ -19,7 +19,7 @@ import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
 import com.suse.manager.webui.utils.salt.custom.ImageDeployedEvent;
 import com.suse.salt.netapi.datatypes.Event;
 import org.jmock.Expectations;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 
 import java.util.Map;
 import java.util.Optional;
@@ -37,7 +37,7 @@ public class ImageDeployedEventTest extends JMockBaseTestCaseWithUser {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        setImposteriser(ClassImposteriser.INSTANCE);
+        setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
     }
 
     /**


### PR DESCRIPTION
## What does this PR change?

This patch will resolve the `cglib` library from Leap 15.2 which updates it from version 2.2 to 3.2.4, this is the last dependency we are still using from 15.1:

The `ClassImposteriser` class is deprecated, see here: https://www.mvndoc.com/c/org.jmock/jmock-legacy/org/jmock/lib/legacy/ClassImposteriser.html, so the patch is migrating to the latest version of jmock (2.12.0) and migrating the code to use `ByteBuddyClassImposteriser` everywhere.

## GUI diff

No difference.

- [X] **DONE**

## Documentation

- No documentation needed, affects only dependencies.

- [X] **DONE**

## Test coverage

- No tests needed, , affects only dependencies.

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/12541.

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below).

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
