### PR TITLE
Fix the broken module dependencies introduced by parametrizing product string

### DIFF
--- a/client/rhel/spacewalk-client-tools/src/up2date_client/rpcServer.py
+++ b/client/rhel/spacewalk-client-tools/src/up2date_client/rpcServer.py
@@ -10,7 +10,6 @@ from up2date_client import clientCaps
 from up2date_client import up2dateLog
 from up2date_client import up2dateErrors
 from up2date_client import up2dateUtils
-from up2date_client.rhnreg_constants import PRODUCT_NAME
 
 from rhn import SSL
 from rhn import rpclib
@@ -180,7 +179,7 @@ def getServer(refreshCallback=None, serverOverride=None, timeout=None, caChain=N
     if need_ca:
         for rhns_ca_cert in rhns_ca_certs:
             if not os.access(rhns_ca_cert, os.R_OK):
-                msg = "%s: %s" % (_("ERROR: can not find {PRODUCT_NAME} CA file").format(PRODUCT_NAME=PRODUCT_NAME),
+                msg = "%s: %s" % (_("ERROR: can not find server CA file"),
                                      rhns_ca_cert)
                 log.log_me("%s" % msg)
                 raise up2dateErrors.SSLCertificateFileNotFound(msg)

--- a/client/rhel/spacewalk-client-tools/src/up2date_client/up2dateErrors.py
+++ b/client/rhel/spacewalk-client-tools/src/up2date_client/up2dateErrors.py
@@ -32,7 +32,6 @@ from rhn.i18n import ustr
 from up2date_client import config
 from up2date_client import up2dateLog
 from up2date_client.pkgplatform import getPlatform
-from up2date_client.rhnreg_constants import PRODUCT_NAME
 
 import sys
 sys.path = sys.path[1:] + sys.path[:1]
@@ -192,8 +191,8 @@ class RegistrationDeniedError(RhnServerException):
 
     def changeExplanation(self):
         return _("""
-Red Hat Network Classic is not supported in {PRODUCT_NAME} .
-    """).format(PRODUCT_NAME=PRODUCT_NAME)
+Red Hat Network Classic is not supported.
+    """)
 
 class InvalidProductRegistrationError(NoLogError):
     """indicates an error during server input validation"""
@@ -297,7 +296,7 @@ class InsuffMgmntEntsError(RhnServerException):
     def changeExplanation(self, msg):
         newExpln = _("""
     Your organization does not have enough Management entitlements to register this
-    system to {PRODUCT_NAME}. Please notify your organization administrator of this error.
+    system. Please notify your organization administrator of this error.
     You should be able to register this system after your organization frees existing
     or purchases additional entitlements. Additional entitlements may be purchased by your
     organization administrator in the SUSE Customer Center.
@@ -305,7 +304,7 @@ class InsuffMgmntEntsError(RhnServerException):
     A common cause of this error code is due to having mistakenly setup an
     Activation Key which is set as the universal default.  If an activation key is set
     on the account as a universal default, you can disable this key and retry to avoid
-    requiring a Management entitlement.""").format(PRODUCT_NAME=PRODUCT_NAME)
+    requiring a Management entitlement.""")
 
         term = "Explanation:"
         loc = msg.rindex(term) + len(term)


### PR DESCRIPTION
Fixed by rephrasing messages in a product-neutral way.


## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: fix
- [x] **DONE**

## Test coverage
- No tests: no tests there

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"