### PR TITLE
Change the cache key to enforce a clean cache

### DIFF
--- a/.github/workflows/java-checkstyle.yml
+++ b/.github/workflows/java-checkstyle.yml
@@ -22,7 +22,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: java/lib
-        key: ${{ runner.os }}-jars-${{ hashFiles('java/buildconf/ivy/*.*') }}
+        key: ${{ runner.os }}-java-lib-${{ hashFiles('java/buildconf/ivy/*.*') }}
 
     - name: Resolve dependencies
       if: steps.cache-dependencies.outputs.cache-hit != 'true'


### PR DESCRIPTION
## What does this PR change?

This should help to enforce a fresh cache for the checkstyle workflow in order to fix the [checkstyle runs on master](https://github.com/uyuni-project/uyuni/actions?query=workflow%3A%22Java+checkstyle%22).

## GUI diff

No difference.

- [X] **DONE**

## Documentation

- No documentation needed, only affects CI.

- [X] **DONE**

## Test coverage

- No tests needed, only affects CI.

- [X] **DONE**

## Links

Fixes hopefully the checkstyle workflow caching issue.

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below).

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
