### PR TITLE
Salt configuration modules for Activation Keys

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/activationkey/XmlRpcActivationKeysHelper.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/activationkey/XmlRpcActivationKeysHelper.java
@@ -15,6 +15,7 @@
 package com.redhat.rhn.frontend.xmlrpc.activationkey;
 
 import com.redhat.rhn.FaultException;
+import com.redhat.rhn.common.hibernate.LookupException;
 import com.redhat.rhn.domain.token.ActivationKey;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.token.ActivationKeyManager;
@@ -55,12 +56,13 @@ public class XmlRpcActivationKeysHelper {
      */
     public ActivationKey lookupKey(User user, String key) {
         ActivationKeyManager manager = ActivationKeyManager.getInstance();
-        ActivationKey activationKey = manager.lookupByKey(key, user);
-        if (activationKey == null) {
+        try {
+            return manager.lookupByKey(key, user);
+        }
+        catch (LookupException e) {
             String msg = "Activation Key [" + key + "] Not Found!";
             throw new FaultException(-212, "ActivationKeyNotFound", msg);
         }
-        return activationKey;
     }
 
     /**

--- a/susemanager-utils/susemanager-sls/src/doc/uyuni_config_execution_module_doc.txt
+++ b/susemanager-utils/susemanager-sls/src/doc/uyuni_config_execution_module_doc.txt
@@ -530,3 +530,246 @@ org_admin_password: organization admin password
 ....
 
     return: boolean, True indicates success
+
+=== activation_key_get_details
+**(id, org_admin_user=None, org_admin_password=None)**
+
+Get details of an Uyuni Activation Key
+
+....
+id: the Activation Key ID
+org_admin_user: organization admin username
+org_admin_password: organization admin password
+....
+
+    return:Activation Key information
+
+=== activation_key_delete
+**(id, org_admin_user=None, org_admin_password=None)**
+
+Deletes an Uyuni Activation Key
+
+....
+id: the Activation Key ID
+org_admin_user: organization admin username
+org_admin_password: organization admin password
+....
+
+    return: boolean, True indicates success
+
+=== activation_key_create
+**(key, description, base_channel_label='', usage_limit=0, system_types=[], universal_default=False, org_admin_user=None, org_admin_password=None)**
+
+Creates an Uyuni Activation Key
+
+....
+key: activation key name
+description: activation key description
+base_channel_label: base channel to be used
+usage_limit: activation key usage limit. Default value is 0, which means unlimited usage
+system_types: system types to be assigned.
+              Can be one of: 'virtualization_host', 'container_build_host',
+              'monitoring_entitled', 'osimage_build_host', 'virtualization_host'
+universal_default: sets this activation key as organization universal default
+org_admin_user: organization admin username
+org_admin_password: organization admin password
+....
+
+    return: boolean, True indicates success
+
+=== activation_key_set_details
+**(key, description=None, contact_method=None, base_channel_label=None, usage_limit=None, universal_default=False, org_admin_user=None, org_admin_password=None)**
+
+Updates an Uyuni Activation Key
+
+....
+key: activation key name
+description: activation key description
+base_channel_label: base channel to be used
+contact_method: contact method to the used. Can be one of: 'default', 'ssh-push' or 'ssh-push-tunnel'
+usage_limit: activation key usage limit. Default value is 0, which means unlimited usage
+universal_default: sets this activation key as organization universal default
+org_admin_user: organization admin username
+org_admin_password: organization admin password
+....
+
+    return: boolean, True indicates success
+
+=== activation_key_add_entitlements
+**(key, system_types, org_admin_user=None, org_admin_password=None)**
+
+Add a list of entitlements to an activation key.
+
+....
+key: activation key name
+system_types: list of system types to be added
+org_admin_user: organization admin username
+org_admin_password: organization admin password
+....
+
+    return: boolean, True indicates success
+
+=== activation_key_remove_entitlements
+**(key, system_types, org_admin_user=None, org_admin_password=None)**
+
+Remove a list of entitlements from an activation key.
+
+....
+key: activation key name
+system_types: list of system types to be removed
+org_admin_user: organization admin username
+org_admin_password: organization admin password
+....
+
+    return: boolean, True indicates success
+
+=== activation_key_add_child_channels
+**(key, child_channels, org_admin_user=None, org_admin_password=None)**
+
+Add child channels list to an activation key.
+
+....
+key: activation key name
+child_channels: List of child channels to be added
+org_admin_user: organization admin username
+org_admin_password: organization admin password
+....
+
+    return: boolean, True indicates success
+
+=== activation_key_remove_child_channels
+**(key, child_channels, org_admin_user=None, org_admin_password=None)**
+
+Remove child channels list from an activation key.
+
+....
+key: activation key name
+child_channels: List of child channels to be removed
+org_admin_user: organization admin username
+org_admin_password: organization admin password
+....
+
+    return: boolean, True indicates success
+
+=== activation_key_check_config_deployment
+**(key, org_admin_user=None, org_admin_password=None)**
+
+Return configuration status for 'configure_after_registration' flag.
+
+....
+key: activation key name
+org_admin_user: organization admin username
+org_admin_password: organization admin password
+....
+
+    return: boolean, true if enabled, false if disabled
+
+=== activation_key_enable_config_deployment
+**(key, org_admin_user=None, org_admin_password=None)**
+
+Set configuration status for 'configure_after_registration' flag to true.
+
+....
+key: activation key name
+org_admin_user: organization admin username
+org_admin_password: organization admin password
+....
+
+    return: boolean, True indicates success
+
+=== activation_key_disable_config_deployment
+**(key, org_admin_user=None, org_admin_password=None)**
+
+Set configuration status for 'configure_after_registration' flag to false.
+
+....
+key: activation key name
+org_admin_user: organization admin username
+org_admin_password: organization admin password
+....
+
+    return: boolean, True indicates success
+
+=== activation_key_add_packages
+**(key, packages, org_admin_user=None, org_admin_password=None)**
+
+Add a list of packages to an activation key.
+
+....
+key: activation key name
+packages: list of packages to be added
+org_admin_user: organization admin username
+org_admin_password: organization admin password
+....
+
+    return: boolean, True indicates success
+
+=== activation_key_remove_packages
+**(key, packages, org_admin_user=None, org_admin_password=None)**
+
+remove a list of packages from an activation key.
+
+....
+key: activation key name
+packages: list of packages to be removed
+org_admin_user: organization admin username
+org_admin_password: organization admin password
+....
+
+    return: boolean, True indicates success
+
+=== activation_key_add_server_groups
+**(key, server_groups, org_admin_user=None, org_admin_password=None)**
+
+Add a list of server groups to an activation key.
+
+....
+key: activation key name
+server_groups: list of packages to be added
+org_admin_user: organization admin username
+org_admin_password: organization admin password
+....
+
+    return: boolean, True indicates success
+
+=== activation_key_remove_server_groups
+**(key, server_groups, org_admin_user=None, org_admin_password=None)**
+
+Remove a list of server groups from an activation key.
+
+....
+key: activation key name
+server_groups: list of packages to be removed
+org_admin_user: organization admin username
+org_admin_password: organization admin password
+....
+
+    return: boolean, True indicates success
+
+=== activation_key_list_config_channels
+**(key, org_admin_user=None, org_admin_password=None)**
+
+List configuration channels associated to an activation key.
+
+....
+key: activation key name
+org_admin_user: organization admin username
+org_admin_password: organization admin password
+....
+
+    return: List of configuration channels
+
+=== activation_key_set_config_channels
+**(keys, config_channel_label, org_admin_user=None, org_admin_password=None)**
+
+Replace the existing set of configuration channels on the given activation keys.
+Channels are ranked by their order in the array.
+
+....
+keys: list of activation key names
+config_channel_label: list of configuration channels labels
+org_admin_user: organization admin username
+org_admin_password: organization admin password
+....
+
+    return: boolean, True indicates success

--- a/susemanager-utils/susemanager-sls/src/doc/uyuni_config_execution_module_doc.txt
+++ b/susemanager-utils/susemanager-sls/src/doc/uyuni_config_execution_module_doc.txt
@@ -586,7 +586,7 @@ Updates an Uyuni Activation Key
 key: activation key name
 description: activation key description
 base_channel_label: base channel to be used
-contact_method: contact method to the used. Can be one of: 'default', 'ssh-push' or 'ssh-push-tunnel'
+contact_method: contact method to be used. Can be one of: 'default', 'ssh-push' or 'ssh-push-tunnel'
 usage_limit: activation key usage limit. Default value is 0, which means unlimited usage
 universal_default: sets this activation key as organization universal default
 org_admin_user: organization admin username
@@ -626,7 +626,7 @@ org_admin_password: organization admin password
 === activation_key_add_child_channels
 **(key, child_channels, org_admin_user=None, org_admin_password=None)**
 
-Add child channels list to an activation key.
+Add child channels to an activation key.
 
 ....
 key: activation key name
@@ -640,7 +640,7 @@ org_admin_password: organization admin password
 === activation_key_remove_child_channels
 **(key, child_channels, org_admin_user=None, org_admin_password=None)**
 
-Remove child channels list from an activation key.
+Remove child channels from an activation key.
 
 ....
 key: activation key name
@@ -654,7 +654,7 @@ org_admin_password: organization admin password
 === activation_key_check_config_deployment
 **(key, org_admin_user=None, org_admin_password=None)**
 
-Return configuration status for 'configure_after_registration' flag.
+Return the status of the 'configure_after_registration' flag for an Activation Key.
 
 ....
 key: activation key name
@@ -667,7 +667,7 @@ org_admin_password: organization admin password
 === activation_key_enable_config_deployment
 **(key, org_admin_user=None, org_admin_password=None)**
 
-Set configuration status for 'configure_after_registration' flag to true.
+Enables the 'configure_after_registration' flag for an Activation Key.
 
 ....
 key: activation key name
@@ -680,7 +680,7 @@ org_admin_password: organization admin password
 === activation_key_disable_config_deployment
 **(key, org_admin_user=None, org_admin_password=None)**
 
-Set configuration status for 'configure_after_registration' flag to false.
+Disables the 'configure_after_registration' flag for an Activation Key.
 
 ....
 key: activation key name
@@ -707,7 +707,7 @@ org_admin_password: organization admin password
 === activation_key_remove_packages
 **(key, packages, org_admin_user=None, org_admin_password=None)**
 
-remove a list of packages from an activation key.
+Remove a list of packages from an activation key.
 
 ....
 key: activation key name
@@ -725,7 +725,7 @@ Add a list of server groups to an activation key.
 
 ....
 key: activation key name
-server_groups: list of packages to be added
+server_groups: list of server groups to be added
 org_admin_user: organization admin username
 org_admin_password: organization admin password
 ....
@@ -739,7 +739,7 @@ Remove a list of server groups from an activation key.
 
 ....
 key: activation key name
-server_groups: list of packages to be removed
+server_groups: list of server groups to be removed
 org_admin_user: organization admin username
 org_admin_password: organization admin password
 ....

--- a/susemanager-utils/susemanager-sls/src/doc/uyuni_config_state_module_doc.txt
+++ b/susemanager-utils/susemanager-sls/src/doc/uyuni_config_state_module_doc.txt
@@ -138,7 +138,7 @@ name: the Activation Key name
 description: the Activation description
 base_channel: base channel to be used
 usage_limit: activation key usage limit. Default value is 0, which means unlimited usage
-contact_method: contact method to the used. Can be one of: 'default', 'ssh-push' or 'ssh-push-tunnel'
+contact_method: contact method to be used. Can be one of: 'default', 'ssh-push' or 'ssh-push-tunnel'
 system_types: system types to be assigned.
               Can be one of: 'virtualization_host', 'container_build_host',
               'monitoring_entitled', 'osimage_build_host', 'virtualization_host'

--- a/susemanager-utils/susemanager-sls/src/doc/uyuni_config_state_module_doc.txt
+++ b/susemanager-utils/susemanager-sls/src/doc/uyuni_config_state_module_doc.txt
@@ -125,3 +125,44 @@ org_admin_password: organization administrator password
 ....
 
     return: dict for Salt communication
+
+=== activation_key_present
+**(name, description, base_channel='', usage_limit=0, contact_method='default', system_types=[],
+   universal_default=False, child_channels=[], configuration_channels=[], packages=[],
+   server_groups=[], configure_after_registration=False, org_admin_user=None, org_admin_password=None)**
+
+Ensure an Uyuni Activation Key is present.
+
+....
+name: the Activation Key name
+description: the Activation description
+base_channel: base channel to be used
+usage_limit: activation key usage limit. Default value is 0, which means unlimited usage
+contact_method: contact method to the used. Can be one of: 'default', 'ssh-push' or 'ssh-push-tunnel'
+system_types: system types to be assigned.
+              Can be one of: 'virtualization_host', 'container_build_host',
+              'monitoring_entitled', 'osimage_build_host', 'virtualization_host'
+universal_default: sets this activation key as organization universal default
+child_channels: list of child channels to be assigned
+configuration_channels: list of configuration channels to be assigned
+packages: list of packages which will be installed
+server_groups: list of server groups to assign the activation key with
+configure_after_registration: deploy configuration files to systems on registration
+org_admin_user: organization administrator username
+org_admin_password: organization administrator password
+....
+
+    return: dict for Salt communication
+
+=== activation_key_absent
+**(nname, org_admin_user=None, org_admin_password=None)**
+
+Ensure an Uyuni Activation Key is not present.
+
+....
+name: the Activation Key ID
+org_admin_user: organization administrator username
+org_admin_password: organization administrator password
+....
+
+    return: dict for Salt communication

--- a/susemanager-utils/susemanager-sls/src/examples/uyuni_config_hardcode.sls
+++ b/susemanager-utils/susemanager-sls/src/examples/uyuni_config_hardcode.sls
@@ -50,3 +50,25 @@ user_1_channels:
       - my_local_channel
     - subscribable_channels:
       - new_local
+
+define_custom_activation_key:
+    uyuni.activation_key_present:
+        - name: my-suse
+        - description: "My Activation Key created via Salt"
+        - org_admin_user: my_org_user
+        - org_admin_password: my_org_user
+        - base_channel: sle-product-sles15-sp2-pool-x86_64
+        - child_channels:
+            - sle-module-server-applications15-sp2-pool-x86_64
+            - sle-module-server-applications15-sp2-updates-x86_64
+        - configuration_channels:
+            - firewall
+        - packages:
+            - name: emacs
+              arch: x86_64
+        - server_groups:
+            - httpd_servers
+        - usage_limit: 10
+        - system_types:
+            - virtualization_host
+        - configure_after_registration: true

--- a/susemanager-utils/susemanager-sls/src/modules/uyuni_config.py
+++ b/susemanager-utils/susemanager-sls/src/modules/uyuni_config.py
@@ -153,7 +153,6 @@ class UyuniRemoteObject:
     def _convert_bool_response(response: int):
         return response == 1
 
-
 class UyuniUser(UyuniRemoteObject):
     """
     CRUD operation on users.
@@ -600,6 +599,32 @@ class UyuniSystems(UyuniRemoteObject):
         return __context__[minions_token_key]
 
 
+class UyuniActivationKey(UyuniRemoteObject):
+    """
+    CRUD operations on Activation Keys.
+    """
+
+    def get_details(self, id: str) -> Dict[str, Any]:
+        """
+        Retrieve details of an Uyuni Activation Key.
+
+        :param id: the Activation Key ID
+
+        :return: Dictionary with Activation Key details
+        """
+        return self.client("activationkey.getDetails", id)
+
+    def delete(self, id: str) -> bool:
+        """
+        Remove an Uyuni Activation Key.
+
+        :param id: the Activation Key ID
+
+        :return: boolean, True indicates success
+        """
+        return self._convert_bool_response(self.client("activationkey.delete", id))
+
+
 class UyuniChildMasterIntegration:
     """
     Integration with the Salt Master which is running
@@ -646,6 +671,8 @@ def __virtual__():
 
     return __virtualname__
 
+
+# Users
 
 def user_get_details(login, password=None, org_admin_user=None, org_admin_password=None):
     """
@@ -828,7 +855,8 @@ def user_remove_assigned_system_groups(login, server_group_names, set_default=Fa
                                                                        set_default=set_default)
 
 
-## channel.software
+# Software channels
+
 def channel_list_manageable_channels(login, password):
     """
     List all of manageable channels for the authenticated user
@@ -1097,10 +1125,7 @@ def org_trust_remove_trust(org_id, org_untrust_id, admin_user=None, admin_passwo
     return UyuniOrgTrust(admin_user, admin_password).remove_trust(org_id, org_untrust_id)
 
 
-"""
-System group management
-"""
-
+# System Groups
 
 def systemgroup_create(name, descr, org_admin_user=None, org_admin_password=None):
     """
@@ -1213,3 +1238,30 @@ def systems_get_minion_id_map(username=None, password=None, refresh=False):
     :return: Map between minion ID and system ID of all system accessible by authenticated user
     """
     return UyuniSystems(username, password).get_minion_id_map(refresh)
+
+
+# Activation Keys
+
+def activation_key_get_details(id, org_admin_user=None, org_admin_password=None):
+    """
+    Get details of an Uyuni Activation Key
+
+    :param id: the Activation Key ID
+    :param org_admin_user: organization admin username
+    :param org_admin_password: organization admin password
+
+    :return: Activation Key information
+    """
+    return UyuniActivationKey(org_admin_user, org_admin_password).get_details(id)
+
+def activation_key_delete(id, org_admin_user=None, org_admin_password=None):
+    """
+    Deletes an Uyuni Activation Key
+
+    :param id: the Activation Key ID
+    :param org_admin_user: organization admin username
+    :param org_admin_password: organization admin password
+
+    :return: boolean, True indicates success
+    """
+    return UyuniActivationKey(org_admin_user, org_admin_password).delete(id)

--- a/susemanager-utils/susemanager-sls/src/modules/uyuni_config.py
+++ b/susemanager-utils/susemanager-sls/src/modules/uyuni_config.py
@@ -672,6 +672,27 @@ class UyuniActivationKey(UyuniRemoteObject):
             data['unlimited_usage_limit'] = True
         return self._convert_bool_response(self.client("activationkey.setDetails", key, data))
 
+    def add_entitlements(self, key, system_types):
+        return self._convert_bool_response(self.client("activationkey.addEntitlements", key, system_types))
+
+    def remove_entitlements(self, key, system_types):
+        return self._convert_bool_response(self.client("activationkey.removeEntitlements", key, system_types))
+
+    def add_child_channels(self, key, child_channels):
+        return self._convert_bool_response(self.client("activationkey.addChildChannels", key, child_channels))
+
+    def remove_child_channels(self, key, child_channels):
+        return self._convert_bool_response(self.client("activationkey.removeChildChannels", key, child_channels))
+
+    def check_config_deployment(self, key):
+        return self._convert_bool_response(self.client("activationkey.checkConfigDeployment", key))
+
+    def enable_config_deployment(self, key):
+        return self._convert_bool_response(self.client("activationkey.enableConfigDeployment", key))
+
+    def disable_config_deployment(self, key):
+        return self._convert_bool_response(self.client("activationkey.disableConfigDeployment", key))
+
 
 class UyuniChildMasterIntegration:
     """
@@ -1364,3 +1385,84 @@ def activation_key_set_details(key, description,
                                                                               base_channel_label,
                                                                               usage_limit,
                                                                               universal_default)
+
+
+def activation_key_add_entitlements(key, system_types, org_admin_user=None, org_admin_password=None):
+    """
+
+    :param key:
+    :param system_types:
+    :param org_admin_user:
+    :param org_admin_password:
+    :return:
+    """
+    return UyuniActivationKey(org_admin_user, org_admin_password).add_entitlements(key, system_types)
+
+
+def activation_key_remove_entitlements(key, system_types, org_admin_user=None, org_admin_password=None):
+    """
+
+    :param key:
+    :param system_types:
+    :param org_admin_user:
+    :param org_admin_password:
+    :return:
+    """
+    return UyuniActivationKey(org_admin_user, org_admin_password).remove_entitlements(key, system_types)
+
+
+def activation_key_add_child_channels(key, child_channels, org_admin_user=None, org_admin_password=None):
+    """
+
+    :param key:
+    :param child_channels:
+    :param org_admin_user:
+    :param org_admin_password:
+    :return:
+    """
+    return UyuniActivationKey(org_admin_user, org_admin_password).add_child_channels(key, child_channels)
+
+
+def activation_key_remove_child_channels(key, child_channels, org_admin_user=None, org_admin_password=None):
+    """
+
+    :param key:
+    :param child_channels:
+    :param org_admin_user:
+    :param org_admin_password:
+    :return:
+    """
+    return UyuniActivationKey(org_admin_user, org_admin_password).remove_child_channels(key, child_channels)
+
+
+def activation_key_check_config_deployment(key, org_admin_user=None, org_admin_password=None):
+    """
+
+    :param key:
+    :param org_admin_user:
+    :param org_admin_password:
+    :return:
+    """
+    return UyuniActivationKey(org_admin_user, org_admin_password).check_config_deployment(key)
+
+
+def activation_key_enable_config_deployment(key, org_admin_user=None, org_admin_password=None):
+    """
+
+    :param key:
+    :param org_admin_user:
+    :param org_admin_password:
+    :return:
+    """
+    return UyuniActivationKey(org_admin_user, org_admin_password).enable_config_deployment(key)
+
+
+def activation_key_disable_config_deployment(key, org_admin_user=None, org_admin_password=None):
+    """
+
+    :param key:
+    :param org_admin_user:
+    :param org_admin_password:
+    :return:
+    """
+    return UyuniActivationKey(org_admin_user, org_admin_password).disable_config_deployment(key)

--- a/susemanager-utils/susemanager-sls/src/modules/uyuni_config.py
+++ b/susemanager-utils/susemanager-sls/src/modules/uyuni_config.py
@@ -624,6 +624,54 @@ class UyuniActivationKey(UyuniRemoteObject):
         """
         return self._convert_bool_response(self.client("activationkey.delete", id))
 
+    def create(self, key: str, description: str,
+               base_channel_label: str = '', usage_limit: int = None,
+               system_types: List[int] = [],
+               universal_default: bool = False) -> bool:
+        """
+        Create an Uyuni Activation Key.
+
+        :param key: activation key name
+        :param description: activation key description
+        :param base_channel_label:
+        :param usage_limit:
+        :param system_types:
+        :param universal_default:
+
+        :return: boolean, True indicates success
+        """
+        if usage_limit:
+            return self._convert_bool_response(self.client("activationkey.create", key, description, base_channel_label,
+                                                            usage_limit, system_types, universal_default))
+        else:
+            return self._convert_bool_response(self.client("activationkey.create", key, description, base_channel_label,
+                                                           system_types, universal_default))
+
+    def set_details(self, key: str, description: str,
+                    base_channel_label: str = '', usage_limit: int = None,
+                    universal_default: bool = False):
+        """
+        Create an Uyuni Activation Key.
+
+        :param key: activation key name
+        :param description: activation key description
+        :param base_channel_label:
+        :param usage_limit:
+        :param universal_default:
+
+        :return: boolean, True indicates success
+        """
+        data = {
+            'description': description,
+            'base_channel_label': base_channel_label,
+            'universal_default': universal_default
+        }
+        if usage_limit:
+            data['usage_limit'] = usage_limit
+        else:
+            data['unlimited_usage_limit'] = True
+        return self._convert_bool_response(self.client("activationkey.setDetails", key, data))
+
 
 class UyuniChildMasterIntegration:
     """
@@ -1265,3 +1313,54 @@ def activation_key_delete(id, org_admin_user=None, org_admin_password=None):
     :return: boolean, True indicates success
     """
     return UyuniActivationKey(org_admin_user, org_admin_password).delete(id)
+
+
+def activation_key_create(key, description,
+                          base_channel_label='', usage_limit=None,
+                          system_types=[], universal_default=False,
+                          org_admin_user=None, org_admin_password=None):
+    """
+    Creates an Uyuni Activation Key
+
+    :param key: activation key name
+    :param description: activation key description
+    :param base_channel_label:
+    :param usage_limit:
+    :param system_types:
+    :param universal_default:
+    :param org_admin_user: organization admin username
+    :param org_admin_password: organization admin password
+
+    :return: boolean, True indicates success
+    """
+    return UyuniActivationKey(org_admin_user, org_admin_password).create(key,
+                                                                         description,
+                                                                         base_channel_label,
+                                                                         usage_limit,
+                                                                         system_types,
+                                                                         universal_default)
+
+
+def activation_key_set_details(key, description,
+                               base_channel_label='',
+                               usage_limit=None,
+                               universal_default=False,
+                               org_admin_user=None, org_admin_password=None):
+    """
+    Updates an Uyuni Activation Key
+
+    :param key: activation key name
+    :param description: activation key description
+    :param base_channel_label:
+    :param usage_limit:
+    :param universal_default:
+    :param org_admin_user: organization admin username
+    :param org_admin_password: organization admin password
+
+    :return: boolean, True indicates success
+    """
+    return UyuniActivationKey(org_admin_user, org_admin_password).set_details(key,
+                                                                              description,
+                                                                              base_channel_label,
+                                                                              usage_limit,
+                                                                              universal_default)

--- a/susemanager-utils/susemanager-sls/src/modules/uyuni_config.py
+++ b/susemanager-utils/susemanager-sls/src/modules/uyuni_config.py
@@ -686,45 +686,44 @@ class UyuniActivationKey(UyuniRemoteObject):
             data['unlimited_usage_limit'] = True
         return self._convert_bool_response(self.client("activationkey.setDetails", key, data))
 
-    def add_entitlements(self, key, system_types: List[str]):
+    def add_entitlements(self, key: str, system_types: List[str]) -> bool:
         return self._convert_bool_response(self.client("activationkey.addEntitlements", key, system_types))
 
-    def remove_entitlements(self, key, system_types: List[str]):
+    def remove_entitlements(self, key: str, system_types: List[str]) -> bool:
         return self._convert_bool_response(self.client("activationkey.removeEntitlements", key, system_types))
 
-    def add_child_channels(self, key, child_channels: List[str]):
+    def add_child_channels(self, key: str, child_channels: List[str]) -> bool:
         return self._convert_bool_response(self.client("activationkey.addChildChannels", key, child_channels))
 
-    def remove_child_channels(self, key, child_channels: List[str]):
+    def remove_child_channels(self, key: str, child_channels: List[str]) -> bool:
         return self._convert_bool_response(self.client("activationkey.removeChildChannels", key, child_channels))
 
-    def check_config_deployment(self, key):
+    def check_config_deployment(self, key: str) -> bool:
         return self._convert_bool_response(self.client("activationkey.checkConfigDeployment", key))
 
-    def enable_config_deployment(self, key):
+    def enable_config_deployment(self, key: str) -> bool:
         return self._convert_bool_response(self.client("activationkey.enableConfigDeployment", key))
 
-    def disable_config_deployment(self, key):
+    def disable_config_deployment(self, key: str) -> bool:
         return self._convert_bool_response(self.client("activationkey.disableConfigDeployment", key))
 
-    def add_packages(self, key, packages: List[Any]):
+    def add_packages(self, key: str, packages: List[Any]) -> bool:
         return self._convert_bool_response(self.client("activationkey.addPackages", key, packages))
 
-    def remove_packages(self, key, packages: List[Any]):
+    def remove_packages(self, key: str, packages: List[Any]) -> bool:
         return self._convert_bool_response(self.client("activationkey.removePackages", key, packages))
 
-    def add_server_groups(self, key, server_groups: List[int]) -> bool:
+    def add_server_groups(self, key: str, server_groups: List[int]) -> bool:
         return self._convert_bool_response(self.client("activationkey.addServerGroups", key, server_groups))
 
-    def remove_server_groups(self, key, server_groups: List[int]) -> bool:
+    def remove_server_groups(self, key: str, server_groups: List[int]) -> bool:
         return self._convert_bool_response(self.client("activationkey.removeServerGroups", key, server_groups))
 
-    def list_config_channels(self, key):
+    def list_config_channels(self, key: str) -> List[Dict[str, Any]]:
         return self.client("activationkey.listConfigChannels", key)
 
     def set_config_channels(self, keys: List[str], config_channel_label: List[str]) -> bool:
         return self._convert_bool_response(self.client("activationkey.setConfigChannels", keys, config_channel_label))
-
 
 
 class UyuniChildMasterIntegration:
@@ -1437,140 +1436,164 @@ def activation_key_set_details(key,
 
 def activation_key_add_entitlements(key, system_types, org_admin_user=None, org_admin_password=None):
     """
+    Add a list of entitlements to an activation key.
 
-    :param key:
-    :param system_types:
-    :param org_admin_user:
-    :param org_admin_password:
-    :return:
+    :param key: activation key name
+    :param system_types: list of system types to be added
+    :param org_admin_user: organization admin username
+    :param org_admin_password: organization admin password
+
+    :return: boolean, True indicates success
     """
     return UyuniActivationKey(org_admin_user, org_admin_password).add_entitlements(key, system_types)
 
 
 def activation_key_remove_entitlements(key, system_types, org_admin_user=None, org_admin_password=None):
     """
+    Remove a list of entitlements from an activation key.
 
-    :param key:
-    :param system_types:
-    :param org_admin_user:
-    :param org_admin_password:
-    :return:
+    :param key: activation key name
+    :param system_types: list of system types to be removed
+    :param org_admin_user: organization admin username
+    :param org_admin_password: organization admin password
+
+    :return: boolean, True indicates success
     """
     return UyuniActivationKey(org_admin_user, org_admin_password).remove_entitlements(key, system_types)
 
 
 def activation_key_add_child_channels(key, child_channels, org_admin_user=None, org_admin_password=None):
     """
+    Add child channels list to an activation key.
 
-    :param key:
-    :param child_channels:
-    :param org_admin_user:
-    :param org_admin_password:
-    :return:
+    :param key: activation key name
+    :param child_channels: List of child channels to be added
+    :param org_admin_user: organization admin username
+    :param org_admin_password: organization admin password
+
+    :return: boolean, True indicates success
     """
     return UyuniActivationKey(org_admin_user, org_admin_password).add_child_channels(key, child_channels)
 
 
 def activation_key_remove_child_channels(key, child_channels, org_admin_user=None, org_admin_password=None):
     """
+    Remove child channels list from an activation key.
 
-    :param key:
-    :param child_channels:
-    :param org_admin_user:
-    :param org_admin_password:
-    :return:
+    :param key: activation key name
+    :param child_channels: List of child channels to be removed
+    :param org_admin_user: organization admin username
+    :param org_admin_password: organization admin password
+
+    :return: boolean, True indicates success
     """
     return UyuniActivationKey(org_admin_user, org_admin_password).remove_child_channels(key, child_channels)
 
 
 def activation_key_check_config_deployment(key, org_admin_user=None, org_admin_password=None):
     """
+    Return configuration status for 'configure_after_registration' flag.
 
-    :param key:
-    :param org_admin_user:
-    :param org_admin_password:
-    :return:
+    :param key: activation key name
+    :param org_admin_user: organization admin username
+    :param org_admin_password: organization admin password
+
+    :return: boolean, true if enabled, false if disabled,
     """
     return UyuniActivationKey(org_admin_user, org_admin_password).check_config_deployment(key)
 
 
 def activation_key_enable_config_deployment(key, org_admin_user=None, org_admin_password=None):
     """
+    Set configuration status for 'configure_after_registration' flag to true.
 
-    :param key:
-    :param org_admin_user:
-    :param org_admin_password:
-    :return:
+    :param key: activation key name
+    :param org_admin_user: organization admin username
+    :param org_admin_password: organization admin password
+
+    :return: boolean, True indicates success
     """
     return UyuniActivationKey(org_admin_user, org_admin_password).enable_config_deployment(key)
 
 
 def activation_key_disable_config_deployment(key, org_admin_user=None, org_admin_password=None):
     """
+    Set configuration status for 'configure_after_registration' flag to false.
 
-    :param key:
-    :param org_admin_user:
-    :param org_admin_password:
-    :return:
+    :param key: activation key name
+    :param org_admin_user: organization admin username
+    :param org_admin_password: organization admin password
+
+    :return: boolean, True indicates success
     """
     return UyuniActivationKey(org_admin_user, org_admin_password).disable_config_deployment(key)
 
 
 def activation_key_add_packages(key, packages, org_admin_user=None, org_admin_password=None):
     """
+    Add a list of packages to an activation key.
 
-    :param key:
-    :param packages:
-    :param org_admin_user:
-    :param org_admin_password:
-    :return:
+    :param key: activation key name
+    :param packages: list of packages to be added
+    :param org_admin_user: organization admin username
+    :param org_admin_password: organization admin password
+
+    :return: boolean, True indicates success
     """
     return UyuniActivationKey(org_admin_user, org_admin_password).add_packages(key, packages)
 
 
 def activation_key_remove_packages(key, packages, org_admin_user=None, org_admin_password=None):
     """
+    remove a list of packages from an activation key.
 
-    :param key:
-    :param packages:
-    :param org_admin_user:
-    :param org_admin_password:
-    :return:
+    :param key: activation key name
+    :param packages: list of packages to be removed
+    :param org_admin_user: organization admin username
+    :param org_admin_password: organization admin password
+
+    :return: boolean, True indicates success
     """
     return UyuniActivationKey(org_admin_user, org_admin_password).remove_packages(key, packages)
 
 
 def activation_key_add_server_groups(key, server_groups, org_admin_user=None, org_admin_password=None):
     """
+    Add a list of server groups to an activation key.
 
-    :param key:
-    :param server_groups:
-    :param org_admin_user:
-    :param org_admin_password:
-    :return:
+    :param key: activation key name
+    :param server_groups: list of packages to be added
+    :param org_admin_user: organization admin username
+    :param org_admin_password: organization admin password
+
+    :return: boolean, True indicates success
     """
     return UyuniActivationKey(org_admin_user, org_admin_password).add_server_groups(key, server_groups)
 
 
 def activation_key_remove_server_groups(key, server_groups, org_admin_user=None, org_admin_password=None):
     """
+    Remove a list of server groups from an activation key.
 
-    :param key:
-    :param server_groups:
-    :param org_admin_user:
-    :param org_admin_password:
-    :return:
+    :param key: activation key name
+    :param server_groups: list of packages to be removed
+    :param org_admin_user: organization admin username
+    :param org_admin_password: organization admin password
+
+    :return: boolean, True indicates success
     """
     return UyuniActivationKey(org_admin_user, org_admin_password).remove_server_groups(key, server_groups)
 
 
 def activation_key_list_config_channels(key, org_admin_user=None, org_admin_password=None):
     """
+    List configuration channels associated to an activation key.
 
-    :param key:
-    :param org_admin_user:
-    :param org_admin_password:
-    :return:
+    :param key: activation key name
+    :param org_admin_user: organization admin username
+    :param org_admin_password: organization admin password
+
+    :return: List of configuration channels
     """
     return UyuniActivationKey(org_admin_user, org_admin_password).list_config_channels(key)
 
@@ -1578,11 +1601,14 @@ def activation_key_list_config_channels(key, org_admin_user=None, org_admin_pass
 def activation_key_set_config_channels(keys, config_channel_label,
                                        org_admin_user=None, org_admin_password=None):
     """
+    Replace the existing set of configuration channels on the given activation keys.
+    Channels are ranked by their order in the array.
 
-    :param keys:
-    :param config_channel_label:
-    :param org_admin_user:
-    :param org_admin_password:
-    :return:
+    :param keys: list of activation key names
+    :param config_channel_label: list of configuration channels lables
+    :param org_admin_user: organization admin username
+    :param org_admin_password: organization admin password
+
+    :return: boolean, True indicates success
     """
     return UyuniActivationKey(org_admin_user, org_admin_password).set_config_channels(keys, config_channel_label)

--- a/susemanager-utils/susemanager-sls/src/modules/uyuni_config.py
+++ b/susemanager-utils/susemanager-sls/src/modules/uyuni_config.py
@@ -700,6 +700,13 @@ class UyuniActivationKey(UyuniRemoteObject):
     def disable_config_deployment(self, key):
         return self._convert_bool_response(self.client("activationkey.disableConfigDeployment", key))
 
+    def add_packages(self, key, packages):
+        return self._convert_bool_response(self.client("activationkey.addPackages", key, packages))
+
+    def remove_packages(self, key, packages):
+        return self._convert_bool_response(self.client("activationkey.removePackages", key, packages))
+
+
 
 class UyuniChildMasterIntegration:
     """
@@ -1477,3 +1484,27 @@ def activation_key_disable_config_deployment(key, org_admin_user=None, org_admin
     :return:
     """
     return UyuniActivationKey(org_admin_user, org_admin_password).disable_config_deployment(key)
+
+
+def activation_key_add_packages(key, packages, org_admin_user=None, org_admin_password=None):
+    """
+
+    :param key:
+    :param packages:
+    :param org_admin_user:
+    :param org_admin_password:
+    :return:
+    """
+    return UyuniActivationKey(org_admin_user, org_admin_password).add_packages(key, packages)
+
+
+def activation_key_remove_packages(key, packages, org_admin_user=None, org_admin_password=None):
+    """
+
+    :param key:
+    :param packages:
+    :param org_admin_user:
+    :param org_admin_password:
+    :return:
+    """
+    return UyuniActivationKey(org_admin_user, org_admin_password).remove_packages(key, packages)

--- a/susemanager-utils/susemanager-sls/src/modules/uyuni_config.py
+++ b/susemanager-utils/susemanager-sls/src/modules/uyuni_config.py
@@ -686,16 +686,16 @@ class UyuniActivationKey(UyuniRemoteObject):
             data['unlimited_usage_limit'] = True
         return self._convert_bool_response(self.client("activationkey.setDetails", key, data))
 
-    def add_entitlements(self, key, system_types):
+    def add_entitlements(self, key, system_types: List[str]):
         return self._convert_bool_response(self.client("activationkey.addEntitlements", key, system_types))
 
-    def remove_entitlements(self, key, system_types):
+    def remove_entitlements(self, key, system_types: List[str]):
         return self._convert_bool_response(self.client("activationkey.removeEntitlements", key, system_types))
 
-    def add_child_channels(self, key, child_channels):
+    def add_child_channels(self, key, child_channels: List[str]):
         return self._convert_bool_response(self.client("activationkey.addChildChannels", key, child_channels))
 
-    def remove_child_channels(self, key, child_channels):
+    def remove_child_channels(self, key, child_channels: List[str]):
         return self._convert_bool_response(self.client("activationkey.removeChildChannels", key, child_channels))
 
     def check_config_deployment(self, key):
@@ -707,17 +707,23 @@ class UyuniActivationKey(UyuniRemoteObject):
     def disable_config_deployment(self, key):
         return self._convert_bool_response(self.client("activationkey.disableConfigDeployment", key))
 
-    def add_packages(self, key, packages):
+    def add_packages(self, key, packages: List[Any]):
         return self._convert_bool_response(self.client("activationkey.addPackages", key, packages))
 
-    def remove_packages(self, key, packages):
+    def remove_packages(self, key, packages: List[Any]):
         return self._convert_bool_response(self.client("activationkey.removePackages", key, packages))
 
-    def add_server_groups(self, key, server_groups):
+    def add_server_groups(self, key, server_groups: List[int]) -> bool:
         return self._convert_bool_response(self.client("activationkey.addServerGroups", key, server_groups))
 
-    def remove_server_groups(self, key, server_groups):
+    def remove_server_groups(self, key, server_groups: List[int]) -> bool:
         return self._convert_bool_response(self.client("activationkey.removeServerGroups", key, server_groups))
+
+    def list_config_channels(self, key):
+        return self.client("activationkey.listConfigChannels", key)
+
+    def set_config_channels(self, keys: List[str], config_channel_label: List[str]) -> bool:
+        return self._convert_bool_response(self.client("activationkey.setConfigChannels", keys, config_channel_label))
 
 
 
@@ -1556,3 +1562,27 @@ def activation_key_remove_server_groups(key, server_groups, org_admin_user=None,
     :return:
     """
     return UyuniActivationKey(org_admin_user, org_admin_password).remove_server_groups(key, server_groups)
+
+
+def activation_key_list_config_channels(key, org_admin_user=None, org_admin_password=None):
+    """
+
+    :param key:
+    :param org_admin_user:
+    :param org_admin_password:
+    :return:
+    """
+    return UyuniActivationKey(org_admin_user, org_admin_password).list_config_channels(key)
+
+
+def activation_key_set_config_channels(keys, config_channel_label,
+                                       org_admin_user=None, org_admin_password=None):
+    """
+
+    :param keys:
+    :param config_channel_label:
+    :param org_admin_user:
+    :param org_admin_password:
+    :return:
+    """
+    return UyuniActivationKey(org_admin_user, org_admin_password).set_config_channels(keys, config_channel_label)

--- a/susemanager-utils/susemanager-sls/src/modules/uyuni_config.py
+++ b/susemanager-utils/susemanager-sls/src/modules/uyuni_config.py
@@ -517,6 +517,13 @@ class UyuniSystemgroup(UyuniRemoteObject):
     Provides methods to access and modify system groups.
     """
 
+    def list_all_groups(self) -> List[Dict[str, Union[int, str]]]:
+        """
+        Retrieve a list of system groups that are accessible by the user
+        :return: list with group information
+        """
+        return self.client("systemgroup.listAllGroups")
+
     def get_details(self, name: str) -> Dict[str, Union[int, str]]:
         """
         Retrieve details of a system group.
@@ -705,6 +712,12 @@ class UyuniActivationKey(UyuniRemoteObject):
 
     def remove_packages(self, key, packages):
         return self._convert_bool_response(self.client("activationkey.removePackages", key, packages))
+
+    def add_server_groups(self, key, server_groups):
+        return self._convert_bool_response(self.client("activationkey.addServerGroups", key, server_groups))
+
+    def remove_server_groups(self, key, server_groups):
+        return self._convert_bool_response(self.client("activationkey.removeServerGroups", key, server_groups))
 
 
 
@@ -1224,6 +1237,17 @@ def systemgroup_create(name, descr, org_admin_user=None, org_admin_password=None
     return UyuniSystemgroup(org_admin_user, org_admin_password).create(name=name, description=descr)
 
 
+def systemgroup_list_all_groups(username, password):
+    """
+    Retrieve a list of system groups that are accessible by the user
+
+    :param username: username to authenticate with
+    :param password: password to authenticate with
+    :return:
+    """
+    return UyuniSystemgroup(username, password).list_all_groups()
+
+
 def systemgroup_get_details(name, org_admin_user=None, org_admin_password=None):
     """
     Return system group details.
@@ -1508,3 +1532,27 @@ def activation_key_remove_packages(key, packages, org_admin_user=None, org_admin
     :return:
     """
     return UyuniActivationKey(org_admin_user, org_admin_password).remove_packages(key, packages)
+
+
+def activation_key_add_server_groups(key, server_groups, org_admin_user=None, org_admin_password=None):
+    """
+
+    :param key:
+    :param server_groups:
+    :param org_admin_user:
+    :param org_admin_password:
+    :return:
+    """
+    return UyuniActivationKey(org_admin_user, org_admin_password).add_server_groups(key, server_groups)
+
+
+def activation_key_remove_server_groups(key, server_groups, org_admin_user=None, org_admin_password=None):
+    """
+
+    :param key:
+    :param server_groups:
+    :param org_admin_user:
+    :param org_admin_password:
+    :return:
+    """
+    return UyuniActivationKey(org_admin_user, org_admin_password).remove_server_groups(key, server_groups)

--- a/susemanager-utils/susemanager-sls/src/modules/uyuni_config.py
+++ b/susemanager-utils/susemanager-sls/src/modules/uyuni_config.py
@@ -613,17 +613,17 @@ class UyuniActivationKey(UyuniRemoteObject):
 
     def get_details(self, id: str) -> Dict[str, Any]:
         """
-        Retrieve details of an Uyuni Activation Key.
+        Get details of an Uyuni Activation Key
 
         :param id: the Activation Key ID
 
-        :return: Dictionary with Activation Key details
+        :return: Activation Key information
         """
         return self.client("activationkey.getDetails", id)
 
     def delete(self, id: str) -> bool:
         """
-        Remove an Uyuni Activation Key.
+        Deletes an Uyuni Activation Key
 
         :param id: the Activation Key ID
 
@@ -632,27 +632,26 @@ class UyuniActivationKey(UyuniRemoteObject):
         return self._convert_bool_response(self.client("activationkey.delete", id))
 
     def create(self, key: str, description: str,
-               base_channel_label: str = '', usage_limit: int = None,
+               base_channel_label: str = '',
+               usage_limit: int = 0,
                system_types: List[int] = [],
                universal_default: bool = False) -> bool:
         """
-        Create an Uyuni Activation Key.
+        Creates an Uyuni Activation Key
 
         :param key: activation key name
         :param description: activation key description
-        :param base_channel_label:
-        :param usage_limit:
-        :param system_types:
-        :param universal_default:
+        :param base_channel_label: base channel to be used
+        :param usage_limit: activation key usage limit. Default value is 0, which means unlimited usage
+        :param system_types: system types to be assigned.
+                             Can be one of: 'virtualization_host', 'container_build_host',
+                             'monitoring_entitled', 'osimage_build_host', 'virtualization_host'
+        :param universal_default: sets this activation key as organization universal default
 
         :return: boolean, True indicates success
         """
-        if usage_limit:
-            return self._convert_bool_response(self.client("activationkey.create", key, description, base_channel_label,
-                                                            usage_limit, system_types, universal_default))
-        else:
-            return self._convert_bool_response(self.client("activationkey.create", key, description, base_channel_label,
-                                                           system_types, universal_default))
+        return self._convert_bool_response(self.client("activationkey.create", key, description, base_channel_label,
+                                                        usage_limit, system_types, universal_default))
 
     def set_details(self, key: str,
                     description: str = None,
@@ -661,14 +660,14 @@ class UyuniActivationKey(UyuniRemoteObject):
                     usage_limit: int = None,
                     universal_default: bool = False):
         """
-        Create an Uyuni Activation Key.
+        Updates an Uyuni Activation Key
 
         :param key: activation key name
         :param description: activation key description
-        :param contact_method:
-        :param base_channel_label:
-        :param usage_limit:
-        :param universal_default:
+        :param base_channel_label: base channel to be used
+        :param contact_method: contact method to the used. Can be one of: 'default', 'ssh-push' or 'ssh-push-tunnel'
+        :param usage_limit: activation key usage limit. Default value is 0, which means unlimited usage
+        :param universal_default: sets this activation key as organization universal default
 
         :return: boolean, True indicates success
         """
@@ -687,42 +686,143 @@ class UyuniActivationKey(UyuniRemoteObject):
         return self._convert_bool_response(self.client("activationkey.setDetails", key, data))
 
     def add_entitlements(self, key: str, system_types: List[str]) -> bool:
+        """
+        Add a list of entitlements to an activation key.
+
+        :param key: activation key name
+        :param system_types: list of system types to be added
+
+        :return: boolean, True indicates success
+        """
         return self._convert_bool_response(self.client("activationkey.addEntitlements", key, system_types))
 
     def remove_entitlements(self, key: str, system_types: List[str]) -> bool:
+        """
+        Remove a list of entitlements from an activation key.
+
+        :param key: activation key name
+        :param system_types: list of system types to be removed
+
+        :return: boolean, True indicates success
+        """
         return self._convert_bool_response(self.client("activationkey.removeEntitlements", key, system_types))
 
     def add_child_channels(self, key: str, child_channels: List[str]) -> bool:
+        """
+        Add child channels list to an activation key.
+
+        :param key: activation key name
+        :param child_channels: List of child channels to be added
+
+        :return: boolean, True indicates success
+        """
         return self._convert_bool_response(self.client("activationkey.addChildChannels", key, child_channels))
 
     def remove_child_channels(self, key: str, child_channels: List[str]) -> bool:
+        """
+        Remove child channels list from an activation key.
+
+        :param key: activation key name
+        :param child_channels: List of child channels to be removed
+
+        :return: boolean, True indicates success
+        """
         return self._convert_bool_response(self.client("activationkey.removeChildChannels", key, child_channels))
 
     def check_config_deployment(self, key: str) -> bool:
+        """
+        Return configuration status for 'configure_after_registration' flag.
+
+        :param key: activation key name
+
+        :return: boolean, true if enabled, false if disabled,
+        """
         return self._convert_bool_response(self.client("activationkey.checkConfigDeployment", key))
 
     def enable_config_deployment(self, key: str) -> bool:
+        """
+        Set configuration status for 'configure_after_registration' flag to true.
+
+        :param key: activation key name
+
+        :return: boolean, True indicates success
+        """
         return self._convert_bool_response(self.client("activationkey.enableConfigDeployment", key))
 
     def disable_config_deployment(self, key: str) -> bool:
+        """
+        Set configuration status for 'configure_after_registration' flag to false.
+
+        :param key: activation key name
+
+        :return: boolean, True indicates success
+        """
         return self._convert_bool_response(self.client("activationkey.disableConfigDeployment", key))
 
     def add_packages(self, key: str, packages: List[Any]) -> bool:
+        """
+        Add a list of packages to an activation key.
+
+        :param key: activation key name
+        :param packages: list of packages to be added
+
+        :return: boolean, True indicates success
+        """
         return self._convert_bool_response(self.client("activationkey.addPackages", key, packages))
 
     def remove_packages(self, key: str, packages: List[Any]) -> bool:
+        """
+        remove a list of packages from an activation key.
+
+        :param key: activation key name
+        :param packages: list of packages to be removed
+
+        :return: boolean, True indicates success
+        """
         return self._convert_bool_response(self.client("activationkey.removePackages", key, packages))
 
     def add_server_groups(self, key: str, server_groups: List[int]) -> bool:
+        """
+        Add a list of server groups to an activation key.
+
+        :param key: activation key name
+        :param server_groups: list of packages to be added
+
+        :return: boolean, True indicates success
+        """
         return self._convert_bool_response(self.client("activationkey.addServerGroups", key, server_groups))
 
     def remove_server_groups(self, key: str, server_groups: List[int]) -> bool:
+        """
+        Remove a list of server groups from an activation key.
+
+        :param key: activation key name
+        :param server_groups: list of packages to be removed
+
+        :return: boolean, True indicates success
+        """
         return self._convert_bool_response(self.client("activationkey.removeServerGroups", key, server_groups))
 
     def list_config_channels(self, key: str) -> List[Dict[str, Any]]:
+        """
+        List configuration channels associated to an activation key.
+    
+        :param key: activation key name
+
+        :return: List of configuration channels
+        """
         return self.client("activationkey.listConfigChannels", key)
 
     def set_config_channels(self, keys: List[str], config_channel_label: List[str]) -> bool:
+        """
+        Replace the existing set of configuration channels on the given activation keys.
+        Channels are ranked by their order in the array.
+
+        :param keys: list of activation key names
+        :param config_channel_label: list of configuration channels lables
+
+        :return: boolean, True indicates success
+        """
         return self._convert_bool_response(self.client("activationkey.setConfigChannels", keys, config_channel_label))
 
 
@@ -1366,6 +1466,7 @@ def activation_key_get_details(id, org_admin_user=None, org_admin_password=None)
     """
     return UyuniActivationKey(org_admin_user, org_admin_password).get_details(id)
 
+
 def activation_key_delete(id, org_admin_user=None, org_admin_password=None):
     """
     Deletes an Uyuni Activation Key
@@ -1380,7 +1481,8 @@ def activation_key_delete(id, org_admin_user=None, org_admin_password=None):
 
 
 def activation_key_create(key, description,
-                          base_channel_label='', usage_limit=None,
+                          base_channel_label='',
+                          usage_limit=0,
                           system_types=[], universal_default=False,
                           org_admin_user=None, org_admin_password=None):
     """
@@ -1388,10 +1490,12 @@ def activation_key_create(key, description,
 
     :param key: activation key name
     :param description: activation key description
-    :param base_channel_label:
-    :param usage_limit:
-    :param system_types:
-    :param universal_default:
+    :param base_channel_label: base channel to be used
+    :param usage_limit: activation key usage limit. Default value is 0, which means unlimited usage
+    :param system_types: system types to be assigned.
+                         Can be one of: 'virtualization_host', 'container_build_host',
+                         'monitoring_entitled', 'osimage_build_host', 'virtualization_host'
+    :param universal_default: sets this activation key as organization universal default
     :param org_admin_user: organization admin username
     :param org_admin_password: organization admin password
 
@@ -1417,10 +1521,10 @@ def activation_key_set_details(key,
 
     :param key: activation key name
     :param description: activation key description
-    :param base_channel_label:
-    :param contact_method:
-    :param usage_limit:
-    :param universal_default:
+    :param base_channel_label: base channel to be used
+    :param contact_method: contact method to the used. Can be one of: 'default', 'ssh-push' or 'ssh-push-tunnel'
+    :param usage_limit: activation key usage limit. Default value is 0, which means unlimited usage
+    :param universal_default: sets this activation key as organization universal default
     :param org_admin_user: organization admin username
     :param org_admin_password: organization admin password
 
@@ -1498,7 +1602,7 @@ def activation_key_check_config_deployment(key, org_admin_user=None, org_admin_p
     :param org_admin_user: organization admin username
     :param org_admin_password: organization admin password
 
-    :return: boolean, true if enabled, false if disabled,
+    :return: boolean, true if enabled, false if disabled
     """
     return UyuniActivationKey(org_admin_user, org_admin_password).check_config_deployment(key)
 
@@ -1605,7 +1709,7 @@ def activation_key_set_config_channels(keys, config_channel_label,
     Channels are ranked by their order in the array.
 
     :param keys: list of activation key names
-    :param config_channel_label: list of configuration channels lables
+    :param config_channel_label: list of configuration channels labels
     :param org_admin_user: organization admin username
     :param org_admin_password: organization admin password
 

--- a/susemanager-utils/susemanager-sls/src/modules/uyuni_config.py
+++ b/susemanager-utils/susemanager-sls/src/modules/uyuni_config.py
@@ -665,7 +665,7 @@ class UyuniActivationKey(UyuniRemoteObject):
         :param key: activation key name
         :param description: activation key description
         :param base_channel_label: base channel to be used
-        :param contact_method: contact method to the used. Can be one of: 'default', 'ssh-push' or 'ssh-push-tunnel'
+        :param contact_method: contact method to be used. Can be one of: 'default', 'ssh-push' or 'ssh-push-tunnel'
         :param usage_limit: activation key usage limit. Default value is 0, which means unlimited usage
         :param universal_default: sets this activation key as organization universal default
 
@@ -709,7 +709,7 @@ class UyuniActivationKey(UyuniRemoteObject):
 
     def add_child_channels(self, key: str, child_channels: List[str]) -> bool:
         """
-        Add child channels list to an activation key.
+        Add child channels to an activation key.
 
         :param key: activation key name
         :param child_channels: List of child channels to be added
@@ -720,7 +720,7 @@ class UyuniActivationKey(UyuniRemoteObject):
 
     def remove_child_channels(self, key: str, child_channels: List[str]) -> bool:
         """
-        Remove child channels list from an activation key.
+        Remove child channels from an activation key.
 
         :param key: activation key name
         :param child_channels: List of child channels to be removed
@@ -731,7 +731,7 @@ class UyuniActivationKey(UyuniRemoteObject):
 
     def check_config_deployment(self, key: str) -> bool:
         """
-        Return configuration status for 'configure_after_registration' flag.
+        Return the status of the 'configure_after_registration' flag for an Activation Key.
 
         :param key: activation key name
 
@@ -741,7 +741,7 @@ class UyuniActivationKey(UyuniRemoteObject):
 
     def enable_config_deployment(self, key: str) -> bool:
         """
-        Set configuration status for 'configure_after_registration' flag to true.
+        Enables the 'configure_after_registration' flag for an Activation Key.
 
         :param key: activation key name
 
@@ -751,7 +751,7 @@ class UyuniActivationKey(UyuniRemoteObject):
 
     def disable_config_deployment(self, key: str) -> bool:
         """
-        Set configuration status for 'configure_after_registration' flag to false.
+        Disables the 'configure_after_registration' flag for an Activation Key.
 
         :param key: activation key name
 
@@ -772,7 +772,7 @@ class UyuniActivationKey(UyuniRemoteObject):
 
     def remove_packages(self, key: str, packages: List[Any]) -> bool:
         """
-        remove a list of packages from an activation key.
+        Remove a list of packages from an activation key.
 
         :param key: activation key name
         :param packages: list of packages to be removed
@@ -786,7 +786,7 @@ class UyuniActivationKey(UyuniRemoteObject):
         Add a list of server groups to an activation key.
 
         :param key: activation key name
-        :param server_groups: list of packages to be added
+        :param server_groups: list of server groups to be added
 
         :return: boolean, True indicates success
         """
@@ -797,7 +797,7 @@ class UyuniActivationKey(UyuniRemoteObject):
         Remove a list of server groups from an activation key.
 
         :param key: activation key name
-        :param server_groups: list of packages to be removed
+        :param server_groups: list of server groups to be removed
 
         :return: boolean, True indicates success
         """
@@ -1522,7 +1522,7 @@ def activation_key_set_details(key,
     :param key: activation key name
     :param description: activation key description
     :param base_channel_label: base channel to be used
-    :param contact_method: contact method to the used. Can be one of: 'default', 'ssh-push' or 'ssh-push-tunnel'
+    :param contact_method: contact method to be used. Can be one of: 'default', 'ssh-push' or 'ssh-push-tunnel'
     :param usage_limit: activation key usage limit. Default value is 0, which means unlimited usage
     :param universal_default: sets this activation key as organization universal default
     :param org_admin_user: organization admin username
@@ -1568,7 +1568,7 @@ def activation_key_remove_entitlements(key, system_types, org_admin_user=None, o
 
 def activation_key_add_child_channels(key, child_channels, org_admin_user=None, org_admin_password=None):
     """
-    Add child channels list to an activation key.
+    Add child channels to an activation key.
 
     :param key: activation key name
     :param child_channels: List of child channels to be added
@@ -1582,7 +1582,7 @@ def activation_key_add_child_channels(key, child_channels, org_admin_user=None, 
 
 def activation_key_remove_child_channels(key, child_channels, org_admin_user=None, org_admin_password=None):
     """
-    Remove child channels list from an activation key.
+    Remove child channels from an activation key.
 
     :param key: activation key name
     :param child_channels: List of child channels to be removed
@@ -1596,7 +1596,7 @@ def activation_key_remove_child_channels(key, child_channels, org_admin_user=Non
 
 def activation_key_check_config_deployment(key, org_admin_user=None, org_admin_password=None):
     """
-    Return configuration status for 'configure_after_registration' flag.
+    Return the status of the 'configure_after_registration' flag for an Activation Key.
 
     :param key: activation key name
     :param org_admin_user: organization admin username
@@ -1609,7 +1609,7 @@ def activation_key_check_config_deployment(key, org_admin_user=None, org_admin_p
 
 def activation_key_enable_config_deployment(key, org_admin_user=None, org_admin_password=None):
     """
-    Set configuration status for 'configure_after_registration' flag to true.
+    Enables the 'configure_after_registration' flag for an Activation Key.
 
     :param key: activation key name
     :param org_admin_user: organization admin username
@@ -1622,7 +1622,7 @@ def activation_key_enable_config_deployment(key, org_admin_user=None, org_admin_
 
 def activation_key_disable_config_deployment(key, org_admin_user=None, org_admin_password=None):
     """
-    Set configuration status for 'configure_after_registration' flag to false.
+    Disables the 'configure_after_registration' flag for an Activation Key.
 
     :param key: activation key name
     :param org_admin_user: organization admin username
@@ -1649,7 +1649,7 @@ def activation_key_add_packages(key, packages, org_admin_user=None, org_admin_pa
 
 def activation_key_remove_packages(key, packages, org_admin_user=None, org_admin_password=None):
     """
-    remove a list of packages from an activation key.
+    Remove a list of packages from an activation key.
 
     :param key: activation key name
     :param packages: list of packages to be removed
@@ -1666,7 +1666,7 @@ def activation_key_add_server_groups(key, server_groups, org_admin_user=None, or
     Add a list of server groups to an activation key.
 
     :param key: activation key name
-    :param server_groups: list of packages to be added
+    :param server_groups: list of server groups to be added
     :param org_admin_user: organization admin username
     :param org_admin_password: organization admin password
 
@@ -1680,7 +1680,7 @@ def activation_key_remove_server_groups(key, server_groups, org_admin_user=None,
     Remove a list of server groups from an activation key.
 
     :param key: activation key name
-    :param server_groups: list of packages to be removed
+    :param server_groups: list of server groups to be removed
     :param org_admin_user: organization admin username
     :param org_admin_password: organization admin password
 

--- a/susemanager-utils/susemanager-sls/src/modules/uyuni_config.py
+++ b/susemanager-utils/susemanager-sls/src/modules/uyuni_config.py
@@ -647,25 +647,32 @@ class UyuniActivationKey(UyuniRemoteObject):
             return self._convert_bool_response(self.client("activationkey.create", key, description, base_channel_label,
                                                            system_types, universal_default))
 
-    def set_details(self, key: str, description: str,
-                    base_channel_label: str = '', usage_limit: int = None,
+    def set_details(self, key: str,
+                    description: str = None,
+                    contact_method: str = None,
+                    base_channel_label: str = None,
+                    usage_limit: int = None,
                     universal_default: bool = False):
         """
         Create an Uyuni Activation Key.
 
         :param key: activation key name
         :param description: activation key description
+        :param contact_method:
         :param base_channel_label:
         :param usage_limit:
         :param universal_default:
 
         :return: boolean, True indicates success
         """
-        data = {
-            'description': description,
-            'base_channel_label': base_channel_label,
-            'universal_default': universal_default
-        }
+        data = {'universal_default': universal_default}
+        if description:
+            data['description'] = description
+        if base_channel_label is not None:
+            data['base_channel_label'] = base_channel_label
+        if contact_method:
+            data['contact_method'] = contact_method
+
         if usage_limit:
             data['usage_limit'] = usage_limit
         else:
@@ -1362,8 +1369,10 @@ def activation_key_create(key, description,
                                                                          universal_default)
 
 
-def activation_key_set_details(key, description,
-                               base_channel_label='',
+def activation_key_set_details(key,
+                               description=None,
+                               contact_method=None,
+                               base_channel_label=None,
                                usage_limit=None,
                                universal_default=False,
                                org_admin_user=None, org_admin_password=None):
@@ -1373,6 +1382,7 @@ def activation_key_set_details(key, description,
     :param key: activation key name
     :param description: activation key description
     :param base_channel_label:
+    :param contact_method:
     :param usage_limit:
     :param universal_default:
     :param org_admin_user: organization admin username
@@ -1381,10 +1391,11 @@ def activation_key_set_details(key, description,
     :return: boolean, True indicates success
     """
     return UyuniActivationKey(org_admin_user, org_admin_password).set_details(key,
-                                                                              description,
-                                                                              base_channel_label,
-                                                                              usage_limit,
-                                                                              universal_default)
+                                                                              description=description,
+                                                                              contact_method=contact_method,
+                                                                              base_channel_label=base_channel_label,
+                                                                              usage_limit=usage_limit,
+                                                                              universal_default=universal_default)
 
 
 def activation_key_add_entitlements(key, system_types, org_admin_user=None, org_admin_password=None):

--- a/susemanager-utils/susemanager-sls/src/states/uyuni_config.py
+++ b/susemanager-utils/susemanager-sls/src/states/uyuni_config.py
@@ -799,7 +799,10 @@ class UyuniActivationKeys:
         }
         try:
             all_groups = __salt__['uyuni.systemgroup_list_all_groups'](org_admin_user, org_admin_password)
-            system_groups_keys = {g.get('name'): g.get('id') for g in all_groups}
+            group_id_to_name = {}
+            for g in (all_groups or []):
+                system_groups_keys[g.get('name')] = g.get('id')
+                group_id_to_name[g.get('id')] = g.get('name')
 
             current_org_user = __salt__['uyuni.user_get_details'](org_admin_user, org_admin_password)
 
@@ -810,8 +813,6 @@ class UyuniActivationKeys:
             for returned_name, output_name in output_field_names.items():
                 current_ak[output_name] = returned_ak[returned_name]
 
-            # FIXME we should iterate only once over the groups output
-            group_id_to_name = {g.get('id'): g.get('name') for g in all_groups}
             current_ak['server_groups'] = [group_id_to_name[s] for s in (current_ak['server_groups'] or [])]
 
             if current_ak.get('base_channel', None) == 'none':

--- a/susemanager-utils/susemanager-sls/src/states/uyuni_config.py
+++ b/susemanager-utils/susemanager-sls/src/states/uyuni_config.py
@@ -771,7 +771,7 @@ class UyuniActivationKeys:
         :param description: the Activation description
         :param base_channel: base channel to be used
         :param usage_limit: activation key usage limit
-        :param contact_method: contact method to the used. Can be one of: 'default', 'ssh-push' or 'ssh-push-tunnel'
+        :param contact_method: contact method to be used. Can be one of: 'default', 'ssh-push' or 'ssh-push-tunnel'
         :param system_types: system types to be assigned.
                              Can be one of: 'virtualization_host', 'container_build_host',
                              'monitoring_entitled', 'osimage_build_host', 'virtualization_host'
@@ -1145,7 +1145,7 @@ def activation_key_present(name,
     :param description: the Activation description
     :param base_channel: base channel to be used
     :param usage_limit: activation key usage limit. Default value is 0, which means unlimited usage
-    :param contact_method: contact method to the used. Can be one of: 'default', 'ssh-push' or 'ssh-push-tunnel'
+    :param contact_method: contact method to be used. Can be one of: 'default', 'ssh-push' or 'ssh-push-tunnel'
     :param system_types: system types to be assigned.
                          Can be one of: 'virtualization_host', 'container_build_host',
                          'monitoring_entitled', 'osimage_build_host', 'virtualization_host'

--- a/susemanager-utils/susemanager-sls/src/states/uyuni_config.py
+++ b/susemanager-utils/susemanager-sls/src/states/uyuni_config.py
@@ -673,7 +673,7 @@ class UyuniActivationKeys:
                 changes['configure_after_registration']["old"] = current_configure_after_registration
 
         # we don't want to sort configuration channels since the order matters in this case
-        if current_config_channels or [] != configuration_channels or []:
+        if (current_config_channels or []) != (configuration_channels or []):
             changes['configuration_channels'] = {"new": configuration_channels}
             if current_config_channels:
                 changes['configuration_channels']['old'] = current_config_channels

--- a/susemanager-utils/susemanager-sls/src/states/uyuni_config.py
+++ b/susemanager-utils/susemanager-sls/src/states/uyuni_config.py
@@ -904,9 +904,10 @@ class UyuniActivationKeys:
                                                                               org_admin_user=org_admin_user,
                                                                               org_admin_password=org_admin_password)
                 else:
-                    __salt__['uyuni.activation_key_disable_config_deployment'](key,
-                                                                               org_admin_user=org_admin_user,
-                                                                               org_admin_password=org_admin_password)
+                    if current_ak:
+                        __salt__['uyuni.activation_key_disable_config_deployment'](key,
+                                                                                   org_admin_user=org_admin_user,
+                                                                                   org_admin_password=org_admin_password)
 
             if changes.get('packages', False):
                 self._update_packages(current_ak.get('packages', []),
@@ -1111,7 +1112,7 @@ def activation_key_absent(name, org_admin_user=None, org_admin_password=None):
     """
     Ensure an Uyuni Activation Key is not present.
 
-    :param id: the Activation Key ID
+    :param name: the Activation Key ID
     :param org_admin_user: organization administrator username
     :param org_admin_password: organization administrator password
 
@@ -1131,7 +1132,7 @@ def activation_key_present(name,
                            configuration_channels=[],
                            packages=[],
                            server_groups=[],
-                           configure_after_registration = False,
+                           configure_after_registration=False,
                            org_admin_user=None, org_admin_password=None):
     """
     Ensure an Uyuni Activation Key is present.

--- a/susemanager-utils/susemanager-sls/src/states/uyuni_config.py
+++ b/susemanager-utils/susemanager-sls/src/states/uyuni_config.py
@@ -672,7 +672,8 @@ class UyuniActivationKeys:
             if current_configure_after_registration is not None:
                 changes['configure_after_registration']["old"] = current_configure_after_registration
 
-        if sorted(current_config_channels or []) != sorted(configuration_channels or []):
+        # we don't want to sort configuration channels since the order matters in this case
+        if current_config_channels or [] != configuration_channels or []:
             changes['configuration_channels'] = {"new": configuration_channels}
             if current_config_channels:
                 changes['configuration_channels']['old'] = current_config_channels
@@ -755,7 +756,7 @@ class UyuniActivationKeys:
                base_channel: str = '',
                usage_limit: int = 0,
                contact_method: str = 'default',
-               system_types: List[int] = [],
+               system_types: List[str] = [],
                universal_default: bool = False,
                child_channels: List[str] = [],
                configuration_channels: List[str] = [],

--- a/susemanager-utils/susemanager-sls/src/states/uyuni_config.py
+++ b/susemanager-utils/susemanager-sls/src/states/uyuni_config.py
@@ -765,22 +765,26 @@ class UyuniActivationKeys:
                configure_after_registration: bool = False,
                org_admin_user: str = None, org_admin_password: str = None) -> Dict[str, Any]:
         """
+        Ensure an Uyuni Activation Key is present.
 
-        :param name:
-        :param description:
-        :param base_channel:
-        :param usage_limit:
-        :param contact_method:
-        :param system_types:
-        :param universal_default:
-        :param child_channels:
-        :param configuration_channels:
-        :param packages:
-        :param server_groups:
-        :param configure_after_registration:
-        :param org_admin_user:
-        :param org_admin_password:
-        :return:
+        :param name: the Activation Key name
+        :param description: the Activation description
+        :param base_channel: base channel to be used
+        :param usage_limit: activation key usage limit
+        :param contact_method: contact method to the used. Can be one of: 'default', 'ssh-push' or 'ssh-push-tunnel'
+        :param system_types: system types to be assigned.
+                             Can be one of: 'virtualization_host', 'container_build_host',
+                             'monitoring_entitled', 'osimage_build_host', 'virtualization_host'
+        :param universal_default: sets this activation key as organization universal default
+        :param child_channels: list of child channels to be assigned
+        :param configuration_channels: list of configuration channels to be assigned
+        :param packages: list of packages which will be installed
+        :param server_groups: list of server groups to assign the activation key with
+        :param configure_after_registration: deploy configuration files to systems on registration
+        :param org_admin_user: organization administrator username
+        :param org_admin_password: organization administrator password
+
+        :return:  dict for Salt communication
         """
         current_ak = {}
         key = None
@@ -937,7 +941,7 @@ class UyuniActivationKeys:
         """
         try:
             ak = __salt__['uyuni.activation_key_get_details'](id, org_admin_user=org_admin_user,
-                                                      org_admin_password=org_admin_password)
+                                                              org_admin_password=org_admin_password)
         except Exception as exc:
             if exc.faultCode == ACTIVATION_KEY_NOT_FOUND_ERROR:
                 return StateResult.prepare_result(id, True, "{0} is already absent".format(id))
@@ -1137,18 +1141,20 @@ def activation_key_present(name,
     """
     Ensure an Uyuni Activation Key is present.
 
-    :param name: the Activation Key ID
-    :param description: the Activation Key ID
-    :param base_channel:
-    :param usage_limit:
-    :param contact_method:
-    :param system_types:
-    :param universal_default:
-    :param child_channels:
-    :param configuration_channels:
-    :param packages:
-    :param server_groups:
-    :param configure_after_registration:
+    :param name: the Activation Key name
+    :param description: the Activation description
+    :param base_channel: base channel to be used
+    :param usage_limit: activation key usage limit. Default value is 0, which means unlimited usage
+    :param contact_method: contact method to the used. Can be one of: 'default', 'ssh-push' or 'ssh-push-tunnel'
+    :param system_types: system types to be assigned.
+                         Can be one of: 'virtualization_host', 'container_build_host',
+                         'monitoring_entitled', 'osimage_build_host', 'virtualization_host'
+    :param universal_default: sets this activation key as organization universal default
+    :param child_channels: list of child channels to be assigned
+    :param configuration_channels: list of configuration channels to be assigned
+    :param packages: list of packages which will be installed
+    :param server_groups: list of server groups to assign the activation key with
+    :param configure_after_registration: deploy configuration files to systems on registration
     :param org_admin_user: organization administrator username
     :param org_admin_password: organization administrator password
 

--- a/susemanager-utils/susemanager-sls/src/tests/test_state_uyuni_config.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_state_uyuni_config.py
@@ -927,3 +927,44 @@ class TestManageOrgsTrust:
             uyuni_config.__salt__['uyuni.org_get_details'].assert_called_once_with('my_org',
                                                                                    admin_user='admin_user',
                                                                                    admin_password='admin_password')
+
+
+class TestUyuniActivationKeys:
+    def test_ak_absent_not_present(self):
+        exc = Exception("ak not found")
+        exc.faultCode = -212
+
+        with patch.dict(uyuni_config.__salt__, {'uyuni.activation_key_get_details': MagicMock(side_effect=exc)}):
+            result = uyuni_config.activation_key_absent('1-ak',
+                                                        org_admin_user='org_admin_user',
+                                                        org_admin_password='org_admin_password')
+
+            assert result is not None
+            assert result['name'] == '1-ak'
+            assert result['result']
+            assert result['comment'] == '1-ak is already absent'
+            assert result['changes'] == {}
+            uyuni_config.__salt__['uyuni.activation_key_get_details'].assert_called_once_with('1-ak',
+                                                                                              org_admin_user='org_admin_user',
+                                                                                              org_admin_password='org_admin_password')
+
+    def test_ak_absent_present(self):
+
+        with patch.dict(uyuni_config.__salt__, {'uyuni.activation_key_get_details': MagicMock(return_value={}),
+                                                'uyuni.activation_key_delete': MagicMock()}):
+
+            result = uyuni_config.activation_key_absent('1-ak',
+                                                        org_admin_user='org_admin_user',
+                                                        org_admin_password='org_admin_password')
+
+            assert result is not None
+            assert result['name'] == '1-ak'
+            assert result['result']
+            assert result['comment'] == 'Activation Key 1-ak has been deleted'
+            assert result['changes'] == {'id': {'old': '1-ak'}}
+            uyuni_config.__salt__['uyuni.activation_key_get_details'].assert_called_once_with('1-ak',
+                                                                                              org_admin_user='org_admin_user',
+                                                                                              org_admin_password='org_admin_password')
+            uyuni_config.__salt__['uyuni.activation_key_delete'].assert_called_once_with('1-ak',
+                                                                                          org_admin_user='org_admin_user',
+                                                                                          org_admin_password='org_admin_password')

--- a/susemanager-utils/susemanager-sls/src/tests/test_state_uyuni_config.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_state_uyuni_config.py
@@ -1129,10 +1129,77 @@ class TestUyuniActivationKeys:
                                                                                                   org_admin_password='admin')
 
     def test_ak_present_update_minimal_data(self):
-        pass
+        return_ak = {
+            'description': 'old description',
+            'base_channel_label': 'none',
+            'usage_limit': 0,
+            'universal_default': False,
+            'contact_method': 'default',
+            'entitlements': [],
+            'child_channel_labels': [],
+            'server_group_ids': [],
+            'packages': []
+        }
+        with patch.dict(uyuni_config.__salt__, {
+            'uyuni.systemgroup_list_all_groups': MagicMock(return_value=self.ALL_GROUPS),
+            'uyuni.user_get_details': MagicMock(return_value=self.ORG_USER_DETAILS),
+            'uyuni.activation_key_get_details': MagicMock(return_value=return_ak),
+            'uyuni.activation_key_check_config_deployment': MagicMock(return_value=False),
+            'uyuni.activation_key_list_config_channels': MagicMock(return_value=[]),
+            'uyuni.activation_key_set_details': MagicMock()
+        }):
+
+            result = uyuni_config.activation_key_present(**self.MINIMAL_AK_PRESENT)
+            assert result is not None
+            assert result['name'] == '1-ak'
+            assert result['result']
+            assert result['comment'] == '1-ak activation key successfully modified'
+            assert result['changes'] == {'description': {'new': 'ak description', 'old': 'old description'}}
+
+            uyuni_config.__salt__['uyuni.systemgroup_list_all_groups'].assert_called_once_with('admin', 'admin')
+            uyuni_config.__salt__['uyuni.user_get_details'].assert_called_once_with('admin', 'admin')
+            uyuni_config.__salt__['uyuni.activation_key_get_details'].assert_called_once_with('1-ak',
+                                                                                              org_admin_user='admin',
+                                                                                              org_admin_password='admin')
+            uyuni_config.__salt__['uyuni.activation_key_check_config_deployment'].assert_called_once_with('1-ak','admin','admin')
+            uyuni_config.__salt__['uyuni.activation_key_list_config_channels'].assert_called_once_with('1-ak','admin','admin')
+
+            uyuni_config.__salt__['uyuni.activation_key_set_details'].assert_called_once_with('1-ak',
+                                                                                              description=self.MINIMAL_AK_PRESENT['description'],
+                                                                                              contact_method='default',
+                                                                                              base_channel_label='',
+                                                                                              usage_limit=0,
+                                                                                              universal_default=False,
+                                                                                              org_admin_user=self.MINIMAL_AK_PRESENT['org_admin_user'],
+                                                                                              org_admin_password=self.MINIMAL_AK_PRESENT['org_admin_password'])
 
     def test_ak_present_no_changes_minimal_data(self):
-        pass
+        return_ak = {
+            'description': self.MINIMAL_AK_PRESENT['description'],
+            'base_channel_label': 'none',
+            'usage_limit': 0,
+            'universal_default': False,
+            'contact_method': 'default',
+            'entitlements': [],
+            'child_channel_labels': [],
+            'server_group_ids': [],
+            'packages': []
+        }
+        with patch.dict(uyuni_config.__salt__, {
+            'uyuni.systemgroup_list_all_groups': MagicMock(return_value=self.ALL_GROUPS),
+            'uyuni.user_get_details': MagicMock(return_value=self.ORG_USER_DETAILS),
+            'uyuni.activation_key_get_details': MagicMock(return_value=return_ak),
+            'uyuni.activation_key_check_config_deployment': MagicMock(return_value=False),
+            'uyuni.activation_key_list_config_channels': MagicMock(return_value=[]),
+            'uyuni.activation_key_set_details': MagicMock()
+        }):
+
+            result = uyuni_config.activation_key_present(**self.MINIMAL_AK_PRESENT)
+            assert result is not None
+            assert result['name'] == '1-ak'
+            assert result['result']
+            assert result['comment'] == '1-ak is already in the desired state'
+            assert result['changes'] == {}
 
     def test_ak_present_update_full_data(self):
 

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Add support for activation keys on server configuration Salt modules
 - ensure the yum/dnf plugins are enabled
 
 -------------------------------------------------------------------

--- a/testsuite/features/secondary/srv_user_configuration_salt_states.feature
+++ b/testsuite/features/secondary/srv_user_configuration_salt_states.feature
@@ -1,7 +1,7 @@
 # Copyright (c) 2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-Feature: Create organizations, users and groups using Salt states
+Feature: Create organizations, users, groups, and activation keys using Salt states
 
   Scenario: Apply configuration salt state to server
     When I manually install the "uyuni-config" formula on the server
@@ -51,6 +51,15 @@ Feature: Create organizations, users and groups using Salt states
     And I should see "role_channel_admin" as unchecked
     And I should see "role_system_group_admin" as unchecked
 
+  Scenario: Activation Key was correctly created
+    Given I am on the Systems page
+    When I follow the left menu "Systems > Activation Keys"
+    And I follow "My Activation Key created via Salt"
+    Then I should see "10" in field "usageLimit"
+    And I should see "virtualization_host" as checked
+    And I should see a "Push via SSH" text
+    And I should see "enable-config-auto-deploy" as checked
+
   Scenario: Cleanup: apply configuration teardown salt state to server
     When I apply "teardown_users_configuration" local salt state on "server"
     And I manually uninstall the "uyuni-config" formula from the server
@@ -63,3 +72,8 @@ Feature: Create organizations, users and groups using Salt states
   Scenario: Cleanup: user was successfully removed
     Given I am on the active Users page
     Then I should not see a "user2" text
+
+  Scenario: Cleanup: activation key was successfully removed
+    Given I am on the Systems page
+    When I follow the left menu "Systems > Activation Keys"
+    Then I should not see a "My Activation Key created via Salt" text

--- a/testsuite/features/upload_files/salt/setup_users_configuration.sls
+++ b/testsuite/features/upload_files/salt/setup_users_configuration.sls
@@ -60,3 +60,16 @@ user_2_channels:
       - test-channel-x86_64
     - subscribable_channels:
       - test_base_channel
+
+
+define_custom_activation_key:
+    uyuni.activation_key_present:
+        - name: my-suse
+        - description: "My Activation Key created via Salt"
+        - org_admin_user: admin
+        - org_admin_password: admin
+        - usage_limit: 10
+        - system_types:
+            - virtualization_host
+        - contact_method: ssh-push
+        - configure_after_registration: true

--- a/testsuite/features/upload_files/salt/teardown_users_configuration.sls
+++ b/testsuite/features/upload_files/salt/teardown_users_configuration.sls
@@ -21,3 +21,9 @@ user2_absent:
     - name: user2
     - org_admin_user: admin
     - org_admin_password: admin
+
+delete_obsolete_activation_key:
+    uyuni.activation_key_absent:
+        - name: 1-my-suse
+        - org_admin_user: admin
+        - org_admin_password: admin


### PR DESCRIPTION
## What does this PR change?

Add support for activation keys on the salt configuration modules.


## GUI diff

No difference.


- [x] **DONE**

## Documentation
- [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pull/577)

- [x] **DONE**

## Test coverage
- Unit tests were added
- Cucumber tests were added

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/12495
Tracks:
Needs backport to 4.1

- [ ] **DONE**

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
