### PR TITLE
QAM: add missing 'a' at step

### DIFF
--- a/testsuite/features/qam/smoke_tests/smoke_tests.template
+++ b/testsuite/features/qam/smoke_tests/smoke_tests.template
@@ -61,7 +61,7 @@ Feature: Smoke tests for <client>
     When I enter command "echo 'My remote command output'"
     And I enter the hostname of "<client>" as "target"
     And I click on preview
-    Then I should see "Target systems (1)" text
+    Then I should see a "Target systems (1)" text
     When I wait until I do not see "pending" text
     And I click on run
     And I wait until I see "show response" text


### PR DESCRIPTION
## What does this PR change?
Fix a step name.

## Links
It completes: https://github.com/SUSE/spacewalk/pull/12601
### Ports
- Manager-4.1

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)
