### PR TITLE
powermanagement xmlrpc api

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -15871,6 +15871,9 @@ the &lt;a href="/rhn/kickstart/ActivationKeysList.do?ksid={0}"&gt;Activation Key
           <context context-type="sourcefile">/rhn/systems/details/kickstart/PowerManagement.do</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="kickstart.powermanagement.system_not_found" xml:space="preserve">
+        <source>System not found</source>
+      </trans-unit>
       <trans-unit id="kickstart.channel.label.jsp" xml:space="preserve">
         <source>Base Software Channel</source>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/HandlerFactory.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/HandlerFactory.java
@@ -66,6 +66,7 @@ import com.redhat.rhn.frontend.xmlrpc.system.XmlRpcSystemHelper;
 import com.redhat.rhn.frontend.xmlrpc.system.config.ServerConfigHandler;
 import com.redhat.rhn.frontend.xmlrpc.system.crash.CrashHandler;
 import com.redhat.rhn.frontend.xmlrpc.system.custominfo.CustomInfoHandler;
+import com.redhat.rhn.frontend.xmlrpc.system.provisioning.powermanagement.PowerManagementHandler;
 import com.redhat.rhn.frontend.xmlrpc.system.provisioning.snapshot.SnapshotHandler;
 import com.redhat.rhn.frontend.xmlrpc.system.scap.SystemScapHandler;
 import com.redhat.rhn.frontend.xmlrpc.system.search.SystemSearchHandler;
@@ -189,6 +190,7 @@ public class HandlerFactory {
         factory.addHandler("system.config", new ServerConfigHandler(taskomaticApi, xmlRpcSystemHelper));
         factory.addHandler("system.crash", new CrashHandler(xmlRpcSystemHelper));
         factory.addHandler("system.custominfo", new CustomInfoHandler());
+        factory.addHandler("system.provisioning.powermanagement", new PowerManagementHandler());
         factory.addHandler("system.provisioning.snapshot", new SnapshotHandler(xmlRpcSystemHelper));
         factory.addHandler("system.scap", new SystemScapHandler());
         factory.addHandler("system.search", new SystemSearchHandler());

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/PowerManagementOperationFailedException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/PowerManagementOperationFailedException.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.frontend.xmlrpc;
+
+import com.redhat.rhn.FaultException;
+
+/**
+ * Operation not supported.
+ */
+public class PowerManagementOperationFailedException extends FaultException {
+
+    /**
+     * Constructor
+     */
+    public PowerManagementOperationFailedException() {
+        super(10013, "operationFailed", "operation_failed");
+    }
+
+    /**
+     * Constructor
+     *
+     * @param message exception message
+     */
+    public PowerManagementOperationFailedException(String message) {
+        super(10013, "operationFailed", message);
+    }
+
+    /**
+     * Constructor
+     *
+     * @param cause the cause
+     */
+    public PowerManagementOperationFailedException(Throwable cause) {
+        super(10013, "operationFailed", "operation_failed", cause);
+    }
+}

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/provisioning/powermanagement/PowerManagementHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/provisioning/powermanagement/PowerManagementHandler.java
@@ -1,0 +1,423 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.frontend.xmlrpc.system.provisioning.powermanagement;
+
+import com.redhat.rhn.common.conf.ConfigDefaults;
+import com.redhat.rhn.common.hibernate.LookupException;
+import com.redhat.rhn.common.validator.ValidatorError;
+import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.frontend.action.kickstart.PowerManagementAction;
+import com.redhat.rhn.frontend.xmlrpc.BaseHandler;
+import com.redhat.rhn.frontend.xmlrpc.InvalidParameterException;
+import com.redhat.rhn.frontend.xmlrpc.NoSuchSystemException;
+import com.redhat.rhn.frontend.xmlrpc.PowerManagementOperationFailedException;
+import com.redhat.rhn.manager.kickstart.cobbler.CobblerPowerCommand;
+import com.redhat.rhn.manager.kickstart.cobbler.CobblerPowerSettingsUpdateCommand;
+import com.redhat.rhn.manager.kickstart.cobbler.CobblerUnregisteredPowerSettingsUpdateCommand;
+import com.redhat.rhn.manager.kickstart.cobbler.CobblerXMLRPCHelper;
+import com.redhat.rhn.manager.system.SystemManager;
+
+import org.apache.log4j.Logger;
+import org.cobbler.SystemRecord;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * PowerManagementHandler
+ * @xmlrpc.namespace system.provisioning.powermanagement
+ * @xmlrpc.doc Provides methods to access and modify power management for systems.
+ * Some functions exist in 2 variants. Either with server id or with a name.
+ * The function with server id is useful when a system exists with a full profile.
+ * Everybody allowed to manage that system can execute these functions.
+ * The variant with name expects a cobbler system name prefix. These functions
+ * enhance the name by adding the org id of the user to limit access to systems
+ * from the own organization. Additionally Org Admin permissions are required to
+ * call these functions.
+ */
+public class PowerManagementHandler extends BaseHandler {
+    private static Logger log = Logger.getLogger(PowerManagementHandler.class);
+
+    /**
+     * Return a list of available power management types
+     *
+     * @param loggedInUser the user
+     * @return a list of available power management types
+     *
+     * @xmlrpc.doc Return a list of available power management types
+     * @xmlrpc.param #param("string", "sessionKey")
+     * @xmlrpc.returntype #array_single("string", "power management types")
+     */
+    public List<String> listTypes(User loggedInUser) {
+        String typeString = ConfigDefaults.get().getCobblerPowerTypes();
+        if (typeString != null) {
+            return Arrays.asList(typeString.split(" *, *"));
+        }
+        return new ArrayList<>();
+    }
+
+    /**
+     * Get current power management settings of the given system
+     *
+     * @param loggedInUser the user
+     * @param serverId the requested server id
+     * @return current power management settings when available
+     *
+     * @xmlrpc.doc Get current power management settings of the given system
+     * @xmlrpc.param #param("string", "sessionKey")
+     * @xmlrpc.param #param("int", "serverId")
+     * @xmlrpc.returntype
+     *  #struct_begin("powerManagementParameters")
+     *    #prop_desc("string", "powerType", "Power management type")
+     *    #prop_desc("string", "powerAddress", "IP address for power management")
+     *    #prop_desc("string", "powerUsername", "The Username")
+     *    #prop_desc("string", "powerPassword", "The Password")
+     *    #prop_desc("string", "powerId", "Identifier")
+     *  #struct_end()
+     */
+    public Map<String, String> getDetails(User loggedInUser, Integer serverId) {
+        SystemRecord record = SystemRecord.lookupById(
+                CobblerXMLRPCHelper.getConnection(loggedInUser),
+                lookupServer(loggedInUser, serverId).getCobblerId());
+        return getDetails(loggedInUser, record);
+    }
+
+    /**
+     * Get current power management settings of the given system
+     *
+     * @param loggedInUser the user
+     * @param nameIn the cobbler name prefix
+     * @return current power management settings when available
+     *
+     * @xmlrpc.doc Get current power management settings of the given system
+     * @xmlrpc.param #param("string", "sessionKey")
+     * @xmlrpc.param #param("string", "name")
+     * @xmlrpc.returntype
+     *  #struct_begin("powerManagementParameters")
+     *    #prop_desc("string", "powerType", "Power management type")
+     *    #prop_desc("string", "powerAddress", "IP address for power management")
+     *    #prop_desc("string", "powerUsername", "The Username")
+     *    #prop_desc("string", "powerPassword", "The Password")
+     *    #prop_desc("string", "powerId", "Identifier")
+     *  #struct_end()
+     */
+    public Map<String, String> getDetails(User loggedInUser, String nameIn) {
+        ensureOrgAdmin(loggedInUser);
+        SystemRecord record = lookupExistingCobblerRecord(loggedInUser, nameIn);
+        return getDetails(loggedInUser, record);
+    }
+
+    private Map<String, String> getDetails(User loggedInUser, SystemRecord record) {
+        Map<String, String> result = new HashMap<>();
+        List<String> types = listTypes(loggedInUser);
+        if (record == null) {
+            result.put(PowerManagementAction.POWER_TYPE, types.get(0));
+        }
+        else {
+            result.put(PowerManagementAction.POWER_TYPE, record.getPowerType());
+            result.put(PowerManagementAction.POWER_ADDRESS, record.getPowerAddress());
+            result.put(PowerManagementAction.POWER_USERNAME, record.getPowerUsername());
+            result.put(PowerManagementAction.POWER_PASSWORD, record.getPowerPassword());
+            result.put(PowerManagementAction.POWER_ID, record.getPowerId());
+        }
+        return result;
+    }
+
+    /**
+     * Set power management settings for the given system
+     *
+     * @param loggedInUser the user
+     * @param serverId the requested server id
+     * @param data power management parameters
+     * @return current power management settings when available
+     *
+     * @xmlrpc.doc Get current power management settings of the given system
+     * @xmlrpc.param #param("string", "sessionKey")
+     * @xmlrpc.param #param("int", "serverId")
+     * @xmlrpc.param
+     *  #struct_begin("data")
+     *    #prop_desc("string", "powerType", "Power management type")
+     *    #prop_desc("string", "powerAddress", "IP address for power management")
+     *    #prop_desc("string", "powerUsername", "The Username")
+     *    #prop_desc("string", "powerPassword", "The Password")
+     *    #prop_desc("string", "powerId", "Identifier")
+     *  #struct_end()
+     * @xmlrpc.returntype #return_int_success()
+     */
+    public int setDetails(User loggedInUser, Integer serverId, Map<String, String> data) {
+        CobblerPowerSettingsUpdateCommand cmd = new CobblerPowerSettingsUpdateCommand(
+                loggedInUser, lookupServer(loggedInUser, serverId),
+                data.get(PowerManagementAction.POWER_TYPE),
+                data.get(PowerManagementAction.POWER_ADDRESS),
+                data.get(PowerManagementAction.POWER_USERNAME),
+                data.get(PowerManagementAction.POWER_PASSWORD),
+                data.get(PowerManagementAction.POWER_ID));
+        ValidatorError error = cmd.store();
+        if (error != null) {
+            throw new InvalidParameterException(error.getMessage());
+        }
+
+        return 1;
+    }
+
+    /**
+     * Set power management settings for the given system
+     *
+     * @param loggedInUser the user
+     * @param nameIn the cobbler name prefix
+     * @param data power management parameters
+     * @return current power management settings when available
+     *
+     * @xmlrpc.doc Get current power management settings of the given system
+     * @xmlrpc.param #param("string", "sessionKey")
+     * @xmlrpc.param #param("string", "name")
+     * @xmlrpc.param
+     *  #struct_begin("data")
+     *    #prop_desc("string", "powerType", "Power management type")
+     *    #prop_desc("string", "powerAddress", "IP address for power management")
+     *    #prop_desc("string", "powerUsername", "The Username")
+     *    #prop_desc("string", "powerPassword", "The Password")
+     *    #prop_desc("string", "powerId", "Identifier")
+     *  #struct_end()
+     * @xmlrpc.returntype #return_int_success()
+     */
+    public int setDetails(User loggedInUser, String nameIn, Map<String, String> data) {
+        ensureOrgAdmin(loggedInUser);
+        CobblerUnregisteredPowerSettingsUpdateCommand cmd =
+                new CobblerUnregisteredPowerSettingsUpdateCommand(
+                loggedInUser, nameIn,
+                data.get(PowerManagementAction.POWER_TYPE),
+                data.get(PowerManagementAction.POWER_ADDRESS),
+                data.get(PowerManagementAction.POWER_USERNAME),
+                data.get(PowerManagementAction.POWER_PASSWORD),
+                data.get(PowerManagementAction.POWER_ID));
+        ValidatorError error = cmd.store();
+        if (error != null) {
+            throw new InvalidParameterException(error.getMessage());
+        }
+
+        return 1;
+    }
+
+    /**
+     * Execute power management action 'powerOn'
+     *
+     * @param loggedInUser the user
+     * @param serverId the requested server id
+     * @return 1 on success
+     *
+     * @xmlrpc.doc Execute power management action 'powerOn'
+     * @xmlrpc.param #param("string", "sessionKey")
+     * @xmlrpc.param #param("int", "serverId")
+     * @xmlrpc.returntype #return_int_success()
+     */
+    public int powerOn(User loggedInUser, Integer serverId) {
+        ValidatorError error = new CobblerPowerCommand(loggedInUser, lookupServer(loggedInUser, serverId),
+                CobblerPowerCommand.Operation.PowerOn).store();
+        if (error != null) {
+            log.error("Power management action 'powerOn' failed");
+            throw new PowerManagementOperationFailedException(error.getMessage());
+        }
+        log.info("Power management action 'powerOn' succeeded");
+        return 1;
+    }
+
+    /**
+     * Execute power management action 'powerOn'
+     *
+     * @param loggedInUser the user
+     * @param nameIn the cobbler name prefix
+     * @return 1 on success
+     *
+     * @xmlrpc.doc Execute power management action 'powerOn'
+     * @xmlrpc.param #param("string", "sessionKey")
+     * @xmlrpc.param #param("string", "name")
+     * @xmlrpc.returntype #return_int_success()
+     */
+    public int powerOn(User loggedInUser, String nameIn) {
+        ensureOrgAdmin(loggedInUser);
+        ValidatorError error = new CobblerPowerCommand(loggedInUser, nameIn,
+                CobblerPowerCommand.Operation.PowerOn).store();
+        if (error != null) {
+            log.error("Power management action 'powerOn' failed");
+            throw new PowerManagementOperationFailedException(error.getMessage());
+        }
+        log.info("Power management action 'powerOn' succeeded");
+        return 1;
+    }
+
+    /**
+     * Execute power management action 'powerOff'
+     *
+     * @param loggedInUser the user
+     * @param serverId the requested server id
+     * @return 1 on success
+     *
+     * @xmlrpc.doc Execute power management action 'powerOff'
+     * @xmlrpc.param #param("string", "sessionKey")
+     * @xmlrpc.param #param("int", "serverId")
+     * @xmlrpc.returntype #return_int_success()
+     */
+    public int powerOff(User loggedInUser, Integer serverId) {
+        ValidatorError error = new CobblerPowerCommand(loggedInUser, lookupServer(loggedInUser, serverId),
+                CobblerPowerCommand.Operation.PowerOff).store();
+        if (error != null) {
+            log.error("Power management action 'powerOff' failed");
+            throw new PowerManagementOperationFailedException(error.getMessage());
+        }
+        log.info("Power management action 'powerOff' succeeded");
+        return 1;
+    }
+
+    /**
+     * Execute power management action 'powerOff'
+     *
+     * @param loggedInUser the user
+     * @param nameIn the cobbler name prefix
+     * @return 1 on success
+     *
+     * @xmlrpc.doc Execute power management action 'powerOff'
+     * @xmlrpc.param #param("string", "sessionKey")
+     * @xmlrpc.param #param("string", "name")
+     * @xmlrpc.returntype #return_int_success()
+     */
+    public int powerOff(User loggedInUser, String nameIn) {
+        ensureOrgAdmin(loggedInUser);
+        ValidatorError error = new CobblerPowerCommand(loggedInUser, nameIn,
+                CobblerPowerCommand.Operation.PowerOff).store();
+        if (error != null) {
+            log.error("Power management action 'powerOff' failed");
+            throw new PowerManagementOperationFailedException(error.getMessage());
+        }
+        log.info("Power management action 'powerOff' succeeded");
+        return 1;
+    }
+
+    /**
+     * Execute power management action 'Reboot'
+     *
+     * @param loggedInUser the user
+     * @param serverId the requested server id
+     * @return 1 on success
+     *
+     * @xmlrpc.doc Execute power management action 'Reboot'
+     * @xmlrpc.param #param("string", "sessionKey")
+     * @xmlrpc.param #param("int", "serverId")
+     * @xmlrpc.returntype #return_int_success()
+     */
+    public int reboot(User loggedInUser, Integer serverId) {
+        ValidatorError error = new CobblerPowerCommand(loggedInUser, lookupServer(loggedInUser, serverId),
+                CobblerPowerCommand.Operation.Reboot).store();
+        if (error != null) {
+            log.error("Power management action 'reboot' failed");
+            throw new PowerManagementOperationFailedException(error.getMessage());
+        }
+        log.info("Power management action 'reboot' succeeded");
+        return 1;
+    }
+
+    /**
+     * Execute power management action 'Reboot'
+     *
+     * @param loggedInUser the user
+     * @param nameIn the cobbler name prefix
+     * @return 1 on success
+     *
+     * @xmlrpc.doc Execute power management action 'Reboot'
+     * @xmlrpc.param #param("string", "sessionKey")
+     * @xmlrpc.param #param("string", "name")
+     * @xmlrpc.returntype #return_int_success()
+     */
+    public int reboot(User loggedInUser, String nameIn) {
+        ensureOrgAdmin(loggedInUser);
+        ValidatorError error = new CobblerPowerCommand(loggedInUser, nameIn,
+                CobblerPowerCommand.Operation.Reboot).store();
+        if (error != null) {
+            log.error("Power management action 'reboot' failed");
+            throw new PowerManagementOperationFailedException(error.getMessage());
+        }
+        log.info("Power management action 'reboot' succeeded");
+        return 1;
+    }
+
+    /**
+     * Return power status of a system
+     *
+     * @param loggedInUser the user
+     * @param serverId the requested server id
+     * @return 1 on success
+     *
+     * @xmlrpc.doc Execute powermanagement actions
+     * @xmlrpc.param #param("string", "sessionKey")
+     * @xmlrpc.param #param("int", "serverId")
+     * @xmlrpc.param #param("string", "action")
+     * @xmlrpc.returntype #param_desc("boolean", "status", "True when power is on, otherwise False")
+     */
+    public boolean getStatus(User loggedInUser, Integer serverId) {
+        SystemRecord record = SystemRecord.lookupById(
+                CobblerXMLRPCHelper.getConnection(loggedInUser),
+                lookupServer(loggedInUser, serverId).getCobblerId());
+        return record.getPowerStatus();
+    }
+
+    /**
+     * Return power status of a system
+     *
+     * @param loggedInUser the user
+     * @param nameIn the requested server name (prefix)
+     * @return 1 on success
+     *
+     * @xmlrpc.doc Execute powermanagement actions
+     * @xmlrpc.param #param("string", "sessionKey")
+     * @xmlrpc.param #param("string", "name")
+     * @xmlrpc.param #param("string", "action")
+     * @xmlrpc.returntype #param_desc("boolean", "status", "True when power is on, otherwise False")
+     */
+    public boolean getStatus(User loggedInUser, String nameIn) {
+        ensureOrgAdmin(loggedInUser);
+        SystemRecord record = lookupExistingCobblerRecord(loggedInUser, nameIn);
+        if (record == null) {
+            throw new NoSuchSystemException();
+        }
+        return record.getPowerStatus();
+    }
+
+    private SystemRecord lookupExistingCobblerRecord(User loggedInUser, String label) {
+        String sep = ConfigDefaults.get().getCobblerNameSeparator();
+        label = label.replace(' ', '_').replaceAll("[^a-zA-Z0-9_\\-\\.]", "");
+        String name = label + sep + loggedInUser.getOrg().getId();
+        SystemRecord rec = SystemRecord.lookupByName(
+                CobblerXMLRPCHelper.getConnection(loggedInUser), name);
+        if (rec == null) {
+            log.error("System with cobbler name " + name + " not found.");
+        }
+        return rec;
+    }
+
+    private Server lookupServer(User loggedInUser, Integer serverId) {
+        Server server = null;
+        try {
+            server = SystemManager.lookupByIdAndUser(serverId.longValue(), loggedInUser);
+        }
+        catch (LookupException e) {
+            throw new NoSuchSystemException();
+        }
+        return server;
+    }
+}

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerUnregisteredPowerSettingsUpdateCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerUnregisteredPowerSettingsUpdateCommand.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.manager.kickstart.cobbler;
+
+import com.redhat.rhn.common.conf.ConfigDefaults;
+import com.redhat.rhn.domain.user.User;
+
+import org.apache.log4j.Logger;
+import org.cobbler.SystemRecord;
+
+/**
+ * Changes power management settings for a server.
+ */
+public class CobblerUnregisteredPowerSettingsUpdateCommand extends CobblerPowerSettingsUpdateCommand {
+
+    /** The log. */
+    private static Logger log = Logger.getLogger(CobblerUnregisteredPowerSettingsUpdateCommand.class);
+
+    /** The server to update. */
+    private String label;
+
+    /**
+     * Standard constructor. Empty parameters strings can be used to leave
+     * existing values untouched.
+     * @param userIn the user running this command
+     * @param labelIn cobbler system name (prefix)
+     * @param powerTypeIn the new power management scheme
+     * @param powerAddressIn the new power management IP address or hostname
+     * @param powerUsernameIn the new power management username
+     * @param powerPasswordIn the new power management password
+     * @param powerIdIn the new power management id
+     */
+    public CobblerUnregisteredPowerSettingsUpdateCommand(User userIn, String labelIn,
+        String powerTypeIn, String powerAddressIn, String powerUsernameIn,
+        String powerPasswordIn, String powerIdIn) {
+        super(userIn, null, powerTypeIn, powerAddressIn, powerUsernameIn, powerPasswordIn, powerIdIn);
+        label = labelIn;
+    }
+
+    protected String getIdent() {
+        String sep = ConfigDefaults.get().getCobblerNameSeparator();
+        label = label.replace(' ', '_').replaceAll("[^a-zA-Z0-9_\\-\\.]", "");
+        return label + sep + user.getOrg().getId();
+    }
+
+    protected SystemRecord getSystemRecordForSystem() {
+        SystemRecord rec = SystemRecord.lookupByName(
+                CobblerXMLRPCHelper.getConnection(user), getIdent());
+        if (rec == null) {
+            log.info("System with cobbler name " + getIdent() + " not found.");
+        }
+        return rec;
+    }
+}

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- add power management xmlrpc api
 - allow nightly ISS sync to also cover custom channels
 - Include build id in boot image local path
 - fix max password length check at user creation (bsc#1176765)

--- a/testsuite/features/secondary/srv_power_management.feature
+++ b/testsuite/features/secondary/srv_power_management.feature
@@ -82,6 +82,17 @@ Feature: Power management
     And I should see a "Power Off" button
     And I should see a "Reboot" button
 
+  Scenario: Cleanup: reset IPMI values
+    Given I am logged in via XML-RPC powermgmt as user "admin" and password "admin"
+    And I want to operate on this "sle_client"
+    Then I set power management value "" for "powerAddress"
+    And I set power management value "" for "powerUsername"
+    And I set power management value "" for "powerPassword"
+    And the cobbler report contains "Power Management Address       :"
+    And the cobbler report contains "Power Management Username      :"
+    And the cobbler report contains "Power Management Password      :"
+    And the cobbler report contains "Power Management Type          : ipmitool"
+
   Scenario: Cleanup: don't fake an IPMI host
     Given the server stops mocking an IPMI host
 

--- a/testsuite/features/secondary/srv_xmlrpc_power_management.feature
+++ b/testsuite/features/secondary/srv_xmlrpc_power_management.feature
@@ -1,0 +1,49 @@
+# Copyright (c) 2020 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+Feature: Power management test for XMLRPC
+
+  Scenario: Fake an IPMI host for XMLRPC test
+    Given the server starts mocking an IPMI host
+
+  Scenario: Check the power management settings for XMLRPC test
+    Given I am logged in via XML-RPC powermgmt as user "admin" and password "admin"
+    And I want to operate on this "sle_client"
+    When I fetch power management values
+    Then power management results should have "ipmitool" for "powerType"
+
+  Scenario: Save power management values  for XMLRPC test
+    Given I am logged in via XML-RPC powermgmt as user "admin" and password "admin"
+    And I want to operate on this "sle_client"
+    Then I set power management value "127.0.0.1" for "powerAddress"
+    And I set power management value "ipmiusr" for "powerUsername"
+    And I set power management value "test" for "powerPassword"
+    And I set power management value "ipmitool" for "powerType"
+    And the cobbler report contains "Power Management Address       : 127.0.0.1"
+    And the cobbler report contains "Power Management Username      : ipmiusr"
+    And the cobbler report contains "Power Management Password      : test"
+    And the cobbler report contains "Power Management Type          : ipmitool"
+
+  Scenario: Test IPMI functions for XMLRPC test
+    Given I am logged in via XML-RPC powermgmt as user "admin" and password "admin"
+    And I want to operate on this "sle_client"
+    Then I turn power on
+    And the power status is "on"
+    And I turn power off
+    And the power status is "off"
+    And I do power management reboot
+    And the power status is "on"
+
+  Scenario: Cleanup: reset IPMI values for XMLRPC test
+    Given I am logged in via XML-RPC powermgmt as user "admin" and password "admin"
+    And I want to operate on this "sle_client"
+    Then I set power management value "" for "powerAddress"
+    And I set power management value "" for "powerUsername"
+    And I set power management value "" for "powerPassword"
+    And the cobbler report contains "Power Management Address       :"
+    And the cobbler report contains "Power Management Username      :"
+    And the cobbler report contains "Power Management Password      :"
+    And the cobbler report contains "Power Management Type          : ipmitool"
+
+  Scenario: Cleanup: don't fake an IPMI host for XMLRPC test
+    Given the server stops mocking an IPMI host

--- a/testsuite/features/step_definitions/xmlrpc_common.rb
+++ b/testsuite/features/step_definitions/xmlrpc_common.rb
@@ -507,6 +507,44 @@ Given(/^I am logged in via XML\-RPC api as user "([^"]*)" and password "([^"]*)"
   assert(rpc_api_tester.login(luser, password))
 end
 
+# power management namespace
+
+Given(/^I am logged in via XML\-RPC powermgmt as user "([^"]*)" and password "([^"]*)"$/) do |luser, password|
+  @rpctest = XMLRPCPowermanagementTest.new(ENV['SERVER'])
+  @rpctest.login(luser, password)
+  syschaintest.login(luser, password)
+end
+
+When(/^I fetch power management values$/) do
+  @powermgmt_result = @rpctest.get_details($client_id)
+end
+
+Then(/^power management results should have "([^"]*)" for "([^"]*)"$/) do |value, hkey|
+  assert_equal(value, @powermgmt_result[hkey])
+end
+
+Then(/^I set power management value "([^"]*)" for "([^"]*)"$/) do |value, hkey|
+  @rpctest.set_details($client_id, { hkey => value })
+end
+
+Then(/^I turn power on$/) do
+  @rpctest.power_on($client_id)
+end
+
+Then(/^I turn power off$/) do
+  @rpctest.power_off($client_id)
+end
+
+Then(/^I do power management reboot$/) do
+  @rpctest.reboot($client_id)
+end
+
+Then(/^the power status is "([^"]*)"$/) do |estat|
+  stat = @rpctest.get_status($client_id)
+  assert(stat) if estat == 'on'
+  assert(!stat) if estat == 'off'
+end
+
 # cveaudit namespace
 
 Given(/^I am logged in via XML\-RPC cve audit as user "([^"]*)" and password "([^"]*)"$/) do |luser, password|

--- a/testsuite/features/support/xmlrpc_powermanagement.rb
+++ b/testsuite/features/support/xmlrpc_powermanagement.rb
@@ -1,0 +1,56 @@
+# Copyright (c) 2020 SUSE LLC.
+# Licensed under the terms of the MIT license.
+
+require_relative 'xmlrpctest'
+
+# channel class
+class XMLRPCPowermanagementTest < XMLRPCBaseTest
+  #
+  # list power management types
+  #
+  def list_types
+    @connection.call('system.provisioning.powermanagement.list_types', @sid)
+  end
+
+  #
+  # get power management configuration details
+  #
+  def get_details(server)
+    @connection.call('system.provisioning.powermanagement.get_details', @sid, server)
+  end
+
+  #
+  # get power status
+  #
+  def get_status(server)
+    @connection.call('system.provisioning.powermanagement.get_status', @sid, server)
+  end
+
+  #
+  # set power management configuration details
+  #
+  def set_details(server, data)
+    @connection.call('system.provisioning.powermanagement.set_details', @sid, server, data)
+  end
+
+  #
+  # power on
+  #
+  def power_on(server)
+    @connection.call('system.provisioning.powermanagement.power_on', @sid, server)
+  end
+
+  #
+  # power off
+  #
+  def power_off(server)
+    @connection.call('system.provisioning.powermanagement.power_off', @sid, server)
+  end
+
+  #
+  # reboot
+  #
+  def reboot(server)
+    @connection.call('system.provisioning.powermanagement.reboot', @sid, server)
+  end
+end

--- a/testsuite/run_sets/secondary.yml
+++ b/testsuite/run_sets/secondary.yml
@@ -33,6 +33,7 @@
 - features/secondary/minxen_guests.feature
 - features/secondary/min_empty_system_profiles.feature
 - features/secondary/srv_power_management.feature
+- features/secondary/srv_xmlrpc_power_management.feature
 - features/secondary/trad_need_reboot.feature
 - features/secondary/trad_action_chain.feature
 - features/secondary/min_action_chain.feature


### PR DESCRIPTION
## What does this PR change?

Implement XMLRPC interface for Power Management.

There are 2 use cases:

1. we have an existing registered system
2. we just created a cobbler system record for an initial installation (system.createSystemRecord(...))

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- XMLRPC docs are autogenerated

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/9860
Tracks 

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
