### PR TITLE
salt config state: activation key absent accepts name

### DIFF
--- a/susemanager-utils/susemanager-sls/src/doc/uyuni_config_state_module_doc.txt
+++ b/susemanager-utils/susemanager-sls/src/doc/uyuni_config_state_module_doc.txt
@@ -155,12 +155,12 @@ org_admin_password: organization administrator password
     return: dict for Salt communication
 
 === activation_key_absent
-**(nname, org_admin_user=None, org_admin_password=None)**
+**(name, org_admin_user=None, org_admin_password=None)**
 
 Ensure an Uyuni Activation Key is not present.
 
 ....
-name: the Activation Key ID
+name: the Activation Key name
 org_admin_user: organization administrator username
 org_admin_password: organization administrator password
 ....

--- a/susemanager-utils/susemanager-sls/src/tests/test_state_uyuni_config.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_state_uyuni_config.py
@@ -1354,34 +1354,39 @@ class TestUyuniActivationKeys:
         exc = Exception("ak not found")
         exc.faultCode = -212
 
-        with patch.dict(uyuni_config.__salt__, {'uyuni.activation_key_get_details': MagicMock(side_effect=exc)}):
-            result = uyuni_config.activation_key_absent('1-ak',
+        with patch.dict(uyuni_config.__salt__, {'uyuni.user_get_details': MagicMock(return_value=self.ORG_USER_DETAILS),
+                                                'uyuni.activation_key_get_details': MagicMock(side_effect=exc)}):
+            result = uyuni_config.activation_key_absent('ak',
                                                         org_admin_user='org_admin_user',
                                                         org_admin_password='org_admin_password')
 
             assert result is not None
-            assert result['name'] == '1-ak'
+            assert result['name'] == 'ak'
             assert result['result']
             assert result['comment'] == '1-ak is already absent'
             assert result['changes'] == {}
+            uyuni_config.__salt__['uyuni.user_get_details'].assert_called_once_with('org_admin_user', 'org_admin_password')
             uyuni_config.__salt__['uyuni.activation_key_get_details'].assert_called_once_with('1-ak',
                                                                                               org_admin_user='org_admin_user',
                                                                                               org_admin_password='org_admin_password')
 
     def test_ak_absent_present(self):
 
-        with patch.dict(uyuni_config.__salt__, {'uyuni.activation_key_get_details': MagicMock(return_value={}),
-                                                'uyuni.activation_key_delete': MagicMock()}):
+        with patch.dict(uyuni_config.__salt__, {
+            'uyuni.user_get_details': MagicMock(return_value=self.ORG_USER_DETAILS),
+            'uyuni.activation_key_get_details': MagicMock(return_value={}),
+            'uyuni.activation_key_delete': MagicMock()}):
 
-            result = uyuni_config.activation_key_absent('1-ak',
+            result = uyuni_config.activation_key_absent('ak',
                                                         org_admin_user='org_admin_user',
                                                         org_admin_password='org_admin_password')
 
             assert result is not None
-            assert result['name'] == '1-ak'
+            assert result['name'] == 'ak'
             assert result['result']
             assert result['comment'] == 'Activation Key 1-ak has been deleted'
             assert result['changes'] == {'id': {'old': '1-ak'}}
+            uyuni_config.__salt__['uyuni.user_get_details'].assert_called_once_with('org_admin_user', 'org_admin_password')
             uyuni_config.__salt__['uyuni.activation_key_get_details'].assert_called_once_with('1-ak',
                                                                                               org_admin_user='org_admin_user',
                                                                                               org_admin_password='org_admin_password')


### PR DESCRIPTION
Signed-off-by: Ricardo Mateus <rmateus@suse.com>

## What does this PR change?

Follow up PR of: https://github.com/uyuni-project/uyuni/pull/2666

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: follow up pr

- [X] **DONE**

## Test coverage
- Unit tests were added
- Cucumber tests were added

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/12495

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
