### PR TITLE
add hint about container-suseconnect in Dockerfile for SLES

### DIFF
--- a/susemanager-utils/testing/docker/master/uyuni-master-root/Dockerfile
+++ b/susemanager-utils/testing/docker/master/uyuni-master-root/Dockerfile
@@ -5,6 +5,10 @@
 FROM opensuse/leap:15.2
 MAINTAINER Michael Calmer "Michael.Calmer@suse.com"
 
+# When using SLES images better remove container-suseconnect
+# We setup our own repositories
+#RUN zypper rm -y container-suseconnect ||:
+
 # Add the repositories
 ADD add_repositories.sh /root/add_repositories.sh
 RUN /root/add_repositories.sh


### PR DESCRIPTION
## What does this PR change?

As uyuni-master acts as templates for SUSE Manager container, add a hint about special handling of container-suseconnect which exist in SLES containers

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **tooling only**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
