### PR TITLE
Take care of ownership for spacewalk-koan test output files

### DIFF
--- a/client/tools/spacewalk-koan/Makefile.spacewalk-koan
+++ b/client/tools/spacewalk-koan/Makefile.spacewalk-koan
@@ -20,11 +20,14 @@ DOCKER_IMAGE          = suma-head-spacewalkkoan
 DOCKER_REGISTRY       = registry.mgr.suse.de
 DOCKER_RUN_EXPORT     = "PYTHONPATH=/manager/client/tools/"
 DOCKER_VOLUMES        = -v "$(CURDIR)/../../../:/manager"
+INITIAL_CMD           = /manager/susemanager-utils/testing/automation/initial-objects.sh
+TEST_CMD              = nosetests --with-xunit --xunit-file /manager/client/tools/spacewalk-koan/reports/spacewalk-koan_tests.xml -s /manager/client/tools/spacewalk-koan/test
+CHOWN_CMD             = /manager/susemanager-utils/testing/automation/chown-objects.sh $(shell id -u) $(shell id -g)
 
 docker_tests ::
 	mkdir -p $(CURDIR)/reports
 	docker pull $(DOCKER_REGISTRY)/$(DOCKER_IMAGE)
-	docker run --rm -e $(DOCKER_RUN_EXPORT) $(DOCKER_VOLUMES) $(DOCKER_REGISTRY)/$(DOCKER_IMAGE) nosetests --with-xunit --xunit-file /manager/client/tools/spacewalk-koan/reports/spacewalk-koan_tests.xml -s /manager/client/tools/spacewalk-koan/test
+	docker run --rm -e $(DOCKER_RUN_EXPORT) $(DOCKER_VOLUMES) $(DOCKER_REGISTRY)/$(DOCKER_IMAGE) /bin/bash -c "$(INITIAL_CMD); $(TEST_CMD); RET=\$${?}; $(CHOWN_CMD) && exit \$${RET}"
 
 docker_shell ::
 	docker run --rm -ti -e $(DOCKER_RUN_EXPORT) $(DOCKER_VOLUMES) $(DOCKER_REGISTRY)/$(DOCKER_IMAGE) /bin/bash


### PR DESCRIPTION
## What does this PR change?

Takes care of ownership for spacewalk-koan test output files.

This fixes problems with have now that we wipe workspaces on the Jenkins jobs, before cloning repositories.

As the spacewalk-koan tests run inside a docker container and they generate files on a folder that's a bind mount, such files are owned by root from the docker host POV, so the Jenkins user can't remove them.

So this fix basically adds two scripts, before and after running the test, to generate a list of files created during testing, and adjust the ownership.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Test fixes

- [x] **DONE**

## Test coverage
- Text fixes

- [x] **DONE**

## Links

None, but this needs backporting to SUSE Manager 4.1 and 4.0.

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
