### PR TITLE
Testsuite: Minor refactor on kiwi images navigation steps

### DIFF
--- a/testsuite/features/secondary/buildhost_docker_auth_registry.feature
+++ b/testsuite/features/secondary/buildhost_docker_auth_registry.feature
@@ -28,7 +28,7 @@ Feature: Build image with authenticated registry
 @auth_registry
   Scenario: Build an image in the authenticated image store
     Given I am authorized as "docker" with password "docker"
-    When I navigate to images build webpage
+    When I follow the left menu "Images > Build"
     And I select "portus_profile" from "profileId"
     And I enter "latest" as "version"
     And I select the hostname of "build_host" from "buildHostId"

--- a/testsuite/features/secondary/buildhost_docker_build_image.feature
+++ b/testsuite/features/secondary/buildhost_docker_build_image.feature
@@ -84,7 +84,7 @@ Feature: Build container images
 @no_auth_registry
   Scenario: Build an image via the GUI
     Given I am authorized as "admin" with password "admin"
-    When I navigate to images build webpage
+    When I follow the left menu "Images > Build"
     And I select "suse_real_key" from "profileId"
     And I enter "GUI_BUILT_IMAGE" as "version"
     And I select the hostname of "build_host" from "buildHostId"
@@ -94,7 +94,7 @@ Feature: Build container images
 @no_auth_registry
   Scenario: Login as Docker image administrator and build an image
     Given I am authorized as "docker" with password "docker"
-    When I navigate to images build webpage
+    When I follow the left menu "Images > Build"
     And I select "suse_real_key" from "profileId"
     And I enter "GUI_DOCKERADMIN" as "version"
     And I select the hostname of "build_host" from "buildHostId"

--- a/testsuite/features/secondary/buildhost_osimage_build_image.feature
+++ b/testsuite/features/secondary/buildhost_osimage_build_image.feature
@@ -29,7 +29,7 @@ Feature: Build OS images
 
   Scenario: Login as Kiwi image administrator and build an image
     Given I am authorized as "kiwikiwi" with password "kiwikiwi"
-    When I navigate to images build webpage
+    When I follow the left menu "Images > Build"
     And I select "suse_os_image" from "profileId"
     And I select the hostname of "build_host" from "buildHostId"
     And I click on "submit-btn"
@@ -52,7 +52,7 @@ Feature: Build OS images
 
   Scenario: Cleanup: remove the image from SUSE Manager server
     Given I am authorized as "admin" with password "admin"
-    When I navigate to images webpage
+    When I follow the left menu "Images > Image List
     And I wait until I do not see "There are no entries to show." text
     And I check the first image
     And I click on "Delete"

--- a/testsuite/features/secondary/buildhost_osimage_build_image.feature
+++ b/testsuite/features/secondary/buildhost_osimage_build_image.feature
@@ -38,7 +38,7 @@ Feature: Build OS images
     Given I am on the Systems overview page of this "build_host"
     Then I should see a "[OS Image Build Host]" text
     When I wait until the image build "suse_os_image" is completed
-    And I am on the image page of "suse_os_image"
+    And I am on the image store of the kiwi image for organization "1"
     Then I should see the name of the image
 
 @proxy

--- a/testsuite/features/secondary/min_bootstrap_ssh_key.feature
+++ b/testsuite/features/secondary/min_bootstrap_ssh_key.feature
@@ -47,7 +47,7 @@ Feature: Bootstrap a Salt minion via the GUI using SSH key
     Given I am authorized
     When I go to the minion onboarding page
     Then I should see a "accepted" text
-    When I navigate to "rhn/systems/Overview.do" page
+    When I am on the Systems page
     And I wait until I see the name of "sle_minion", refreshing the page
     And I wait until onboarding is completed for "sle_minion"
     Then the Salt master can reach "sle_minion"

--- a/testsuite/features/step_definitions/docker_steps.rb
+++ b/testsuite/features/step_definitions/docker_steps.rb
@@ -23,14 +23,6 @@ def retrieve_build_host_id
 end
 
 # OS image build
-When(/^I navigate to images webpage$/) do
-  step %(I follow the left menu "Images > Image List")
-end
-
-When(/^I navigate to images build webpage$/) do
-  step %(I follow the left menu "Images > Build")
-end
-
 Then(/^I wait until the image build "([^"]*)" is completed$/) do |image_name|
   steps %(
     When I wait at most 3300 seconds until event "Image Build #{image_name} scheduled by kiwikiwi" is completed
@@ -70,7 +62,7 @@ end
 When(/^I wait at most (\d+) seconds until all "([^"]*)" container images are built correctly in the GUI$/) do |timeout, count|
   def ck_container_imgs(timeout, count)
     repeat_until_timeout(timeout: timeout.to_i, message: 'at least one image was not built correctly') do
-      step %(I navigate to images webpage)
+      step %(I follow the left menu "Images > Image List)
       step %(I wait until I do not see "There are no entries to show." text)
       raise 'error detected while building images' if all(:xpath, "//*[contains(@title, 'Failed')]").any?
       break if has_xpath?("//*[contains(@title, 'Built')]", count: count)

--- a/testsuite/features/step_definitions/docker_steps.rb
+++ b/testsuite/features/step_definitions/docker_steps.rb
@@ -24,11 +24,11 @@ end
 
 # OS image build
 When(/^I navigate to images webpage$/) do
-  visit("https://#{$server.full_hostname}/rhn/manager/cm/images")
+  step %(I follow the left menu "Images > Image List")
 end
 
 When(/^I navigate to images build webpage$/) do
-  visit("https://#{$server.full_hostname}/rhn/manager/cm/build")
+  step %(I follow the left menu "Images > Build")
 end
 
 Then(/^I wait until the image build "([^"]*)" is completed$/) do |image_name|
@@ -38,8 +38,8 @@ Then(/^I wait until the image build "([^"]*)" is completed$/) do |image_name|
   )
 end
 
-Then(/^I am on the image page of "([^"]*)"$/) do |image_name|
-  step %(I navigate to "#{compute_image_url(image_name)}" page)
+Then(/^I am on the image store of the kiwi image for organization "([^"]*)"$/) do |org|
+  step %(I navigate to "os-images/#{org}/" page)
 end
 
 Then(/^I should see the name of the image$/) do

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -63,11 +63,6 @@ def compute_image_name
   end
 end
 
-def compute_image_url(image_name)
-  raise "Unknown image #{image_name}" unless image_name == 'suse_os_image'
-  'os-images/1/'
-end
-
 # compute list of reposyncs to avoid killing because they might be involved in bootstrapping
 # this is a safety net only, the best thing to do is to not start the reposync at all
 def compute_list_to_leave_running


### PR DESCRIPTION
## What does this PR change?

Drop internal details from Cucumber
Mimic the way how the users navigate the UI.

- testsuite/features/secondary/buildhost_osimage_build_image.feature:
Rewrite the step that navigates to the kiwi image store.
Navigate to image build/list like users do (i.e. by menu clicks).

- testsuite/features/support/commonlib.rb (compute_image_url):
Delete this function.

- testsuite/features/step_definitions/docker_steps.rb:
Mimic how users navigate os images.
Deleted unused steps.

- testsuite/features/secondary/min_bootstrap_ssh_key.feature:
Hide systems page url from cucumber.

## Links
https://github.com/SUSE/spacewalk/issues/12540
### Ports:
- Manger-4.1: 
- Manager-4.0: 
- Manager-3.2: 



## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)
