### PR TITLE
More debug output if bootstrap fails

### DIFF
--- a/testsuite/.rubocop_todo.yml
+++ b/testsuite/.rubocop_todo.yml
@@ -357,6 +357,7 @@ Style/DateTime:
 # Cop supports --auto-correct.
 Style/DisableCopsWithinSourceCodeDirective:
   Exclude:
+    - 'features/step_definitions/common_steps.rb'
     - 'features/step_definitions/command_steps.rb'
     - 'features/step_definitions/salt_steps.rb'
 

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -644,15 +644,17 @@ When(/^I accept key of pxeboot minion in the Salt master$/) do
   $server.run("salt-key -y --accept=pxeboot.example.org")
 end
 
+# rubocop:disable Metrics/BlockLength
 When(/^I bootstrap (traditional|minion) client "([^"]*)" using bootstrap script with activation key "([^"]*)" from the (server|proxy)$/) do |client_type, host, key, target_type|
-  # Preparation of bootstrap script for different types of clients
-  client = client_type == 'traditional' ? '--traditional' : ''
   # Use server if proxy is not defined as proxy is not mandatory
   target = $proxy
   if target_type.include? 'server' or $proxy.nil?
     puts 'WARN: Bootstrapping to server, because proxy is not defined.' unless target_type.include? 'server'
     target = $server
   end
+
+  # Prepare bootstrap script for different types of clients
+  client = client_type == 'traditional' ? '--traditional' : ''
   cmd = "mgr-bootstrap #{client} &&
   sed -i s\'/^exit 1//\' /srv/www/htdocs/pub/bootstrap/bootstrap.sh &&
   sed -i '/^ACTIVATION_KEYS=/c\\ACTIVATION_KEYS=#{key}' /srv/www/htdocs/pub/bootstrap/bootstrap.sh &&
@@ -660,7 +662,11 @@ When(/^I bootstrap (traditional|minion) client "([^"]*)" using bootstrap script 
   sed -i '/^ORG_GPG_KEY=/c\\ORG_GPG_KEY=RHN-ORG-TRUSTED-SSL-CERT' /srv/www/htdocs/pub/bootstrap/bootstrap.sh &&
   cat /srv/www/htdocs/pub/bootstrap/bootstrap.sh"
   output, = target.run(cmd)
-  raise "Key: #{key} not included" unless output.include? key
+  unless output.include? key
+    STDOUT.puts output
+    raise "Key: #{key} not included"
+  end
+
   # Run bootstrap script and check for result
   boostrap_script = 'bootstrap-general.exp'
   source = File.dirname(__FILE__) + '/../upload_files/' + boostrap_script
@@ -669,8 +675,12 @@ When(/^I bootstrap (traditional|minion) client "([^"]*)" using bootstrap script 
   raise 'File injection failed' unless return_code.zero?
   system_name = get_system_name(host)
   output, = target.run("expect -f /tmp/#{boostrap_script} #{system_name}")
-  raise "Bootstrapp didn't finish properly: #{output}" unless output.include? '-bootstrap complete-'
+  unless output.include? '-bootstrap complete-'
+    STDOUT.puts output
+    raise "Bootstrap didn't finish properly"
+  end
 end
+# rubocop:enable Metrics/BlockLength
 
 Then(/^file "([^"]*)" should contain "([^"]*)" on "([^"]*)"$/) do |filename, content, host|
   node = get_target(host)


### PR DESCRIPTION
## What does this PR change?

Print commands output if bootstrap with script fails

## Links

Ports:
* 4.1: SUSE/spacewalk#12633
* 4.0: SUSE/spacewalk#12634
* 3.2: SUSE/spacewalk#12636


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
