### PR TITLE
[Port] QAM: Find generic text to match after reboot

### DIFF
--- a/testsuite/features/qam/smoke_tests/smoke_tests.template
+++ b/testsuite/features/qam/smoke_tests/smoke_tests.template
@@ -117,4 +117,4 @@ Feature: Smoke tests for <client>
     Then I should see a "Reboot scheduled for system" text
     When I force picking pending events on "<client>" if necessary
     And I wait at most 600 seconds until event "System reboot scheduled by admin" is completed
-    Then I should see a "Reboot completed." text
+    Then I should see a "This action's status is: Completed" text


### PR DESCRIPTION
## What does this PR change?

Port of  https://github.com/SUSE/spacewalk/pull/12628

Not all the systems gave a text "Reboot completed" after they finish successfully a reboot. Form the systems currently deployed in qam environment, only CentOS provide it. So, we need to use a text more generic for all our systems.

Example:
![image](https://user-images.githubusercontent.com/2827771/94898479-eee9c980-0491-11eb-9421-9bcb85b8b33b.png)


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber test changed

- [x] **DONE**

## Links

Need ports:
 - Manager-4.1:  https://github.com/SUSE/spacewalk/pull/12628
 - Manager-4.0: https://github.com/SUSE/spacewalk/pull/12638

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"Fixes #
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
