### PR TITLE
Include build id in boot image local path

### DIFF
--- a/java/code/src/com/suse/manager/webui/services/SaltStateGeneratorService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltStateGeneratorService.java
@@ -89,8 +89,10 @@ public enum SaltStateGeneratorService {
             String version = image.getVersion();
             String bootImageName = name + "-" + version;
             String localPath = "image/" + bundle.getBasename() + "-" + bundle.getId();
+            String bootLocalPath = bundle.getBasename() + "-" + bundle.getId();
 
-            Map<String, Object> bootImagePillar = generateBootImagePillar(bootImage, bootImageName, localPath);
+            Map<String, Object> bootImagePillar = generateBootImagePillar(bootImage, bootImageName,
+                                                                          localPath, bootLocalPath);
 
             Map<String, Object> imagePillar = generateImagePillar(image, bundle, bootImage, urlBase, name, version,
                     localPath);
@@ -148,7 +150,8 @@ public enum SaltStateGeneratorService {
     }
 
     private Map<String, Object> generateBootImagePillar(OSImageInspectSlsResult.BootImage bootImage,
-                                                            String bootImageName, String localPath) {
+                                                        String bootImageName,
+                                                        String systemLocalPath, String bootLocalPath) {
         Map<String, Object> bootImagePillar = new TreeMap<String, Object>();
         Map<String, Object> bootImagePillarBase = new TreeMap<String, Object>();
         Map<String, Object> bootImagePillarInitrd = new TreeMap<String, Object>();
@@ -173,9 +176,9 @@ public enum SaltStateGeneratorService {
         bootImagePillarKernel.put("url", "tftp://tftp/boot/" + bootImageName + '/' +
                 bootImage.getKernel().getFilename());
 
-        bootImagePillarSync.put("local_path", bootImageName);
-        bootImagePillarSync.put("kernel_link", "../../" + localPath + '/' + bootImage.getKernel().getFilename());
-        bootImagePillarSync.put("initrd_link", "../../" + localPath + '/' + bootImage.getInitrd().getFilename());
+        bootImagePillarSync.put("local_path", bootLocalPath);
+        bootImagePillarSync.put("kernel_link", "../../" + systemLocalPath + '/' + bootImage.getKernel().getFilename());
+        bootImagePillarSync.put("initrd_link", "../../" + systemLocalPath + '/' + bootImage.getInitrd().getFilename());
 
         bootImagePillarBase.put("initrd", bootImagePillarInitrd);
         bootImagePillarBase.put("kernel", bootImagePillarKernel);

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Include build id in boot image local path
 - fix max password length check at user creation (bsc#1176765)
 - Fix the links for downloading the binaries in the package details UI (bsc#1176603)
 - Notify about missing libvirt or hypervisor on virtual host


### PR DESCRIPTION
## What does this PR change?

Boot image pillar generated after build of PXE OS image contains local path, which is used for storing the image on Branch Server.
Until now, the path was based on boot image name. This caused conflicts when an image was rebuilt with new kernel but the image version stayed unchanged (we recommend to increase image version in such situations, but we do not enforce it).

This PR adds build id to the path, so new directory is used for each build.

## GUI diff

No difference.

## Documentation
- No documentation needed: bugfix

## Test coverage

- partially covered by OpenQA tests

## Links

Fixes # https://github.com/SUSE/spacewalk/issues/11811


- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
