### PR TITLE
Fix: do not break when pod status is empty (bsc#1161903)

### DIFF
--- a/susemanager-utils/susemanager-sls/modules/runners/mgrk8s.py
+++ b/susemanager-utils/susemanager-sls/modules/runners/mgrk8s.py
@@ -47,7 +47,7 @@ def get_all_containers(kubeconfig=None, context=None):
     pods = api.list_pod_for_all_namespaces(watch=False)
     output = dict(containers=[])
     for pod in pods.items:
-        try:
+        if pod.status.container_statuses is not None:
             for container in pod.status.container_statuses:
                 res_cont = dict()
                 res_cont['container_id'] = container.container_id
@@ -56,7 +56,7 @@ def get_all_containers(kubeconfig=None, context=None):
                 res_cont['pod_name'] = pod.metadata.name
                 res_cont['pod_namespace'] = pod.metadata.namespace
                 output['containers'].append(res_cont)
-        except:
+        else:
             log.error("Failed to parse pod container statuses")
 
     return output

--- a/susemanager-utils/susemanager-sls/modules/runners/mgrk8s.py
+++ b/susemanager-utils/susemanager-sls/modules/runners/mgrk8s.py
@@ -1,4 +1,7 @@
 from salt.exceptions import SaltInvocationError
+import logging
+
+log = logging.getLogger(__name__)
 
 try:
     from kubernetes import client, config # pylint: disable=import-self
@@ -44,13 +47,16 @@ def get_all_containers(kubeconfig=None, context=None):
     pods = api.list_pod_for_all_namespaces(watch=False)
     output = dict(containers=[])
     for pod in pods.items:
-        for container in pod.status.container_statuses:
-            res_cont = dict()
-            res_cont['container_id'] = container.container_id
-            res_cont['image'] = container.image
-            res_cont['image_id'] = container.image_id
-            res_cont['pod_name'] = pod.metadata.name
-            res_cont['pod_namespace'] = pod.metadata.namespace
-            output['containers'].append(res_cont)
+        try:
+            for container in pod.status.container_statuses:
+                res_cont = dict()
+                res_cont['container_id'] = container.container_id
+                res_cont['image'] = container.image
+                res_cont['image_id'] = container.image_id
+                res_cont['pod_name'] = pod.metadata.name
+                res_cont['pod_namespace'] = pod.metadata.namespace
+                output['containers'].append(res_cont)
+        except:
+            log.error("Failed to parse pod container statuses")
 
     return output

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Fix: do not break when pod status is empty (bsc#1161903)
 - Move channel token information from sources.list to auth.conf on Debian 10 and Ubuntu 18 and newer
 - Add support for activation keys on server configuration Salt modules
 - ensure the yum/dnf plugins are enabled


### PR DESCRIPTION
## What does this PR change?

Fix a corner case in which the pod status are empty

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: internal

- [X] **DONE**

## Test coverage
- No tests: Salt runner

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests" (Test skipped, there are no changes to test)
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
