### PR TITLE
Testsuite - move expect package installation to different feature

### DIFF
--- a/testsuite/features/core/proxy_branch_network.feature
+++ b/testsuite/features/core/proxy_branch_network.feature
@@ -130,7 +130,6 @@ Feature: Setup SUSE Manager for Retail branch network
 @private_net
   Scenario: Enable repositories for installing branch services
     When I enable repositories before installing branch server
-    And I install package "expect" on this "proxy"
 
 @proxy
 @private_net

--- a/testsuite/features/core/proxy_register_as_minion_with_gui.feature
+++ b/testsuite/features/core/proxy_register_as_minion_with_gui.feature
@@ -47,6 +47,12 @@ Feature: Setup SUSE Manager proxy
     Then I should see a "Proxy" link in the content area
 
 @proxy
+  Scenario: Install expect package on proxy for bootstrapping minion with GUI via script
+    When I enable repositories before installing branch server
+    And I install package "expect" on this "proxy"
+    And I disable repositories after installing branch server
+
+@proxy
   Scenario: Check events history for failures on the proxy
     Given I am on the Systems overview page of this "proxy"
     Then I check for failed events on history event page

--- a/testsuite/features/core/proxy_register_as_minion_with_script.feature
+++ b/testsuite/features/core/proxy_register_as_minion_with_script.feature
@@ -50,6 +50,12 @@ Feature: Setup SUSE Manager proxy
     Then I should see a "Proxy" link in the content area
 
 @proxy
+  Scenario: Install expect package on proxy for bootstrapping minion via script via script
+    When I enable repositories before installing branch server
+    And I install package "expect" on this "proxy"
+    And I disable repositories after installing branch server
+
+@proxy
   Scenario: Cleanup: remove proxy bootstrap scripts
     When I run "rm /srv/www/htdocs/pub/bootstrap/bootstrap-proxy.sh" on "server"
     And I run "rm /root/bootstrap-proxy.sh" on "proxy"

--- a/testsuite/features/core/proxy_register_as_trad_with_script.feature
+++ b/testsuite/features/core/proxy_register_as_trad_with_script.feature
@@ -34,6 +34,12 @@ Feature: Setup SUSE Manager proxy
     Then I should see a "Proxy" link in the content area
 
 @proxy
+  Scenario: Install expect package on proxy for bootstrapping client via script via script
+    When I enable repositories before installing branch server
+    And I install package "expect" on this "proxy"
+    And I disable repositories after installing branch server
+
+@proxy
   Scenario: Cleanup: remove proxy bootstrap scripts
     When I run "rm /srv/www/htdocs/pub/bootstrap/bootstrap-proxy.sh" on "server"
     And I run "rm /root/bootstrap-proxy.sh" on "proxy"


### PR DESCRIPTION
## What does this PR change?

Package `expect` is no more needed only for retail setup, but also for client bootstrapping via script. As a result it is necessary to move its installation to more generic features, which are these providing proxy setup in this case. 

Current state of things can cause failure of bootstrap of client via bootstrap script if no private network is specified (which is specific for retail setup).

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **testsuite**
- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/12653

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
