### PR TITLE
Update configuration for latest obs-to-maven

### DIFF
--- a/.github/workflows/java-checkstyle.yml
+++ b/.github/workflows/java-checkstyle.yml
@@ -27,7 +27,6 @@ jobs:
     - name: Resolve dependencies
       if: steps.cache-dependencies.outputs.cache-hit != 'true'
       run: |
-        echo '${{ secrets.OSCRC_CONTENTS }}' > ~/.oscrc
         ant -f java/manager-build.xml ivy
 
     - name: Run checkstyle

--- a/java/buildconf/ivy/obs-maven-config.yaml
+++ b/java/buildconf/ivy/obs-maven-config.yaml
@@ -14,6 +14,7 @@ artifacts:
     jar: asm3-all
     repository: Leap
   - artifact: antlr
+    package: antlr-java
     repository: Leap
   - artifact: bcel
     repository: Leap
@@ -28,7 +29,6 @@ artifacts:
     repository: Uyuni_Other
   - artifact: classpathx-mail-1.3.1-monolithic
     package: classpathx-mail
-    jar: classpathx-mail-1.3.1-monolithic
     repository: Leap
   - artifact: commons-beanutils
     package: apache-commons-beanutils
@@ -76,7 +76,6 @@ artifacts:
   - artifact: concurrentlinkedhashmap-lru
     repository: Uyuni_Other
   - artifact: dom4j
-    jar: dom4j-[0-9.]+
     repository: Leap
   - artifact: dwr
     repository: Uyuni_Other
@@ -84,8 +83,7 @@ artifacts:
     package: ehcache
     repository: Uyuni_Other
   - artifact: geronimo-jta-1.1-api
-    package: geronimo-specs
-    rpm: geronimo-jta-1_1
+    package: geronimo-jta-1_1-api
     repository: Leap
   - artifact: google-gson
     repository: Leap
@@ -97,11 +95,9 @@ artifacts:
     repository: Uyuni_Other
   - artifact: hibernate-core
     package: hibernate5
-    jar: hibernate-core
     repository: Uyuni_Other
   - artifact: hibernate-ehcache
     package: hibernate5
-    jar: hibernate-ehcache
     repository: Uyuni_Other
   - artifact: httpasyncclient
     package: httpcomponents-asyncclient
@@ -109,8 +105,6 @@ artifacts:
     repository: Uyuni_Other
   - artifact: httpclient
     package: httpcomponents-client
-    rpm: httpcomponents-client-[0-9]+
-    jar: httpclient
     repository: Leap
   - artifact: httpcore
     package: httpcomponents-core
@@ -118,7 +112,6 @@ artifacts:
     repository: Leap
   - artifact: httpcore-nio
     package: httpcomponents-core
-    jar: httpcore-nio
     repository: Leap
   - artifact: jade4j
     repository: Uyuni_Other
@@ -133,7 +126,6 @@ artifacts:
     repository: Uyuni_Other
   - artifact: java-saml-core
     package: java-saml
-    jar: java-saml-core
     repository: Uyuni_Other
   - artifact: javassist
     repository: Uyuni_Other
@@ -142,7 +134,6 @@ artifacts:
   - artifact: jcommon
     repository: Uyuni_Other
   - artifact: jdom
-    rpm: jdom
     repository: Leap
   - artifact: joda-time
     repository: Uyuni_Other
@@ -155,23 +146,18 @@ artifacts:
     repository: Uyuni_Other
   - artifact: netty-buffer
     package: netty
-    jar: netty-buffer
     repository: Uyuni_Other
   - artifact: netty-codec
     package: netty
-    jar: netty-codec
     repository: Uyuni_Other
   - artifact: netty-common
     package: netty
-    jar: netty-common
     repository: Uyuni_Other
   - artifact: netty-handler
     package: netty
-    jar: netty-handler
     repository: Uyuni_Other
   - artifact: netty-resolver
     package: netty
-    jar: netty-resolver
     repository: Uyuni_Other
   - artifact: netty-transport
     package: netty
@@ -179,12 +165,10 @@ artifacts:
     repository: Uyuni_Other
   - artifact: netty-transport-native-unix-common
     package: netty
-    jar: netty-transport-native-unix-common
     repository: Uyuni_Other
   - artifact: oro
     repository: Leap
   - artifact: pgjdbc-ng
-    jar: pgjdbc-ng
     repository: Uyuni_Other
   - artifact: postgresql-jdbc
     repository: Uyuni_Other
@@ -195,7 +179,6 @@ artifacts:
     repository: Uyuni_Other
   - artifact: redstone-xmlrpc-client
     package: redstone-xmlrpc
-    jar: redstone-xmlrpc-client
     repository: Uyuni_Other
   - artifact: salt-netapi-client
     repository: Uyuni
@@ -205,33 +188,26 @@ artifacts:
     repository: Uyuni_Other
   - artifact: simpleclient_common
     package: prometheus-client-java
-    jar: simpleclient_common
     repository: Uyuni_Other
   - artifact: simpleclient_httpserver
     package: prometheus-client-java
-    jar: simpleclient_httpserver
     repository: Uyuni_Other
   - artifact: simpleclient_servlet
     package: prometheus-client-java
-    jar: simpleclient_servlet
     repository: Uyuni_Other
   - artifact: simple-core
     # How comes that package is not noarch?
     arch: x86_64
-    jar: simple-core
     repository: Uyuni_Other
   - artifact: simple-xml
     repository: Uyuni_Other
   - artifact: sitemesh
     repository: Uyuni_Other
   - artifact: slf4j-api
-    rpm: slf4j-[0-9]+
     package: slf4j
     jar: api
     repository: Leap
   - artifact: slf4j-log4j12
-    package: slf4j
-    rpm: slf4j-log4j12
     jar: log4j12
     repository: Leap
   - artifact: snakeyaml
@@ -242,50 +218,38 @@ artifacts:
     repository: Uyuni_Other
   - artifact: spy
     package: pgjdbc-ng
-    jar: spy
     repository: Uyuni_Other
   - artifact: statistics
     repository: Uyuni_Other
   - artifact: stax-api
     package: woodstox
-    jar: stax-api
     repository: Uyuni_Other
   - artifact: stax2-api
     package: woodstox
-    jar: stax2-api
     repository: Uyuni_Other
   - artifact: stringtree-json
     repository: Uyuni_Other
   - artifact: struts
-    rpm: struts-[0-9.]+
     repository: Uyuni_Other
   - artifact: taglibs-standard-impl
     package: tomcat-taglibs-standard-1_2_5
-    jar: taglibs-standard-impl
     repository: Uyuni_Other
   - artifact: taglibs-standard-jstlel
     package: tomcat-taglibs-standard-1_2_5
-    jar: taglibs-standard-jstlel
     repository: Uyuni_Other
   - artifact: taglibs-standard-spec
     package: tomcat-taglibs-standard-1_2_5
-    jar: taglibs-standard-spec
     repository: Uyuni_Other
   - artifact: woodstox-core-asl
     package: woodstox
-    jar: woodstox-core-asl
     repository: Uyuni_Other
   - artifact: xalan-j2
-    rpm: xalan-j2-[0-9.]+
     jar: xalan-j2-[0-9.]+
     repository: Leap
   - artifact: xalan-j2-serializer
     package: xalan-j2
-    rpm: xalan-j2-[0-9.]+
-    jar: xalan-j2-serializer
     repository: Leap
   - artifact: xerces-j2
-    rpm: xerces-j2-[0-9.]+
     repository: Leap
   - artifact: xmlsec
     repository: Uyuni_Other
@@ -296,48 +260,32 @@ artifacts:
     repository: Uyuni_Other
 
   - artifact: jasper
-    package: tomcat
-    rpm: tomcat-lib
+    package: tomcat-lib
     jar: jasper\.jar
     repository: Leap
   - artifact: jasper-el
-    package: tomcat
-    rpm: tomcat-lib
-    jar: jasper-el
+    package: tomcat-lib
     repository: Leap
   - artifact: tomcat-el-3.0-api
-    package: tomcat
-    rpm: tomcat-el-3_0-api
-    jar: tomcat-el-3.0-api
+    package: tomcat-el-3_0-api
     repository: Leap
   - artifact: tomcat-jsp-2.3-api
-    package: tomcat
-    rpm: tomcat-jsp-2_3-api
+    package: tomcat-jsp-2_3-api
     repository: Leap
   - artifact: tomcat-juli
-    package: tomcat
-    rpm: tomcat-lib
-    jar: tomcat-juli
+    package: tomcat-lib
     repository: Leap
   - artifact: tomcat-servlet-4.0-api
-    package: tomcat
-    rpm: tomcat-servlet-4_0-api
+    package: tomcat-servlet-4_0-api
     repository: Leap
 
   - artifact: hamcrest-core
-    package: hamcrest
-    rpm: hamcrest-core
     repository: Leap
   - artifact: hamcrest-library
     package: hamcrest
-    rpm: hamcrest-[0-9]+
     jar: hamcrest/library
     repository: Leap
   - artifact: junit
-    package: junit
     repository: Leap
   - artifact: ical4j
-    package: ical4j
-    rpm: ical4j-[0-9.]+
-    jar: ical4j
     repository: Uyuni_Other

--- a/susemanager-utils/testing/automation/java-checkstyle.sh
+++ b/susemanager-utils/testing/automation/java-checkstyle.sh
@@ -4,24 +4,14 @@ HERE=`dirname $0`
 . $HERE/VERSION
 GITROOT=`readlink -f $HERE/../../../`
 
-CREDENTIALS="${HOME}/.oscrc"
-
 help() {
   echo ""
   echo "Script to run a docker container to verify java code style"
-  echo ""
-  echo "Syntax: "
-  echo ""
-  echo "${SCRIPT} -c /path/to/oscrc"
-  echo ""
-  echo "Where: "
-  echo "  -c  Path to the OSC credentials. Default: ${CREDENTIALS}"
   echo ""
 }
 
 while getopts "c:h" opts; do
   case "${opts}" in
-    c) CREDENTIALS=${OPTARG};;
     h) help
        exit 0;;
     *) echo "Invalid syntax. Use ${SCRIPT} -h"
@@ -30,22 +20,11 @@ while getopts "c:h" opts; do
 done
 shift $((OPTIND-1))
 
-if [ "${CREDENTIALS}" == "" ]; then
-  echo "ERROR: Mandatory paramenter -c is missing!"
-  exit 1
-fi
-
-if [ ! -f ${CREDENTIALS} ]; then
-  echo "ERROR: File ${CREDENTIALS} does not exist!"
-  exit 1
-fi
-
 INITIAL_CMD="/manager/susemanager-utils/testing/automation/initial-objects.sh"
 CMD="/manager/java/scripts/docker-checkstyle.sh"
 CHOWN_CMD="/manager/susemanager-utils/testing/automation/chown-objects.sh $(id -u) $(id -g)"
 
 docker pull $REGISTRY/$PGSQL_CONTAINER
 docker run --privileged --rm=true -v "$GITROOT:/manager" \
-    --mount type=bind,source=${CREDENTIALS},target=/root/.oscrc \
     $REGISTRY/$PGSQL_CONTAINER \
     /bin/bash -c "${INITIAL_CMD}; ${CMD}; RET=\${?}; ${CHOWN_CMD} && exit \${RET}"

--- a/susemanager-utils/testing/automation/java-unittests-pgsql.sh
+++ b/susemanager-utils/testing/automation/java-unittests-pgsql.sh
@@ -6,25 +6,21 @@ HERE=`dirname $0`
 . $HERE/VERSION
 GITROOT=`readlink -f $HERE/../../../`
 
-CREDENTIALS="${HOME}/.oscrc"
-
 help() {
   echo ""
   echo "Script to run a docker container to run the pgsql Java unit tests"
   echo ""
   echo "Syntax: "
   echo ""
-  echo "${SCRIPT} -c /path/to/oscrc [-t ant-target]"
+  echo "${SCRIPT} [-t ant-target]"
   echo ""
   echo "Where: "
-  echo "  -c  Path to the OSC credentials. Default: ${CREDENTIALS}"
   echo "  -t  Ant target to run. Default: ${TARGET}"
   echo ""
 }
 
 while getopts "c:t:h" opts; do
   case "${opts}" in
-    c) CREDENTIALS=${OPTARG};;
     t) TARGET=${OPTARG};;
     h) help
        exit 0;;
@@ -34,22 +30,11 @@ while getopts "c:t:h" opts; do
 done
 shift $((OPTIND-1))
 
-if [ "${CREDENTIALS}" == "" ]; then
-  echo "ERROR: Mandatory paramenter -c is missing!"
-  exit 1
-fi
-
-if [ ! -f ${CREDENTIALS} ]; then
-  echo "ERROR: File ${CREDENTIALS} does not exist!"
-  exit 1
-fi
-
 INITIAL_CMD="/manager/susemanager-utils/testing/automation/initial-objects.sh"
 CMD="/manager/java/scripts/docker-testing-pgsql.sh ${TARGET}"
 CHOWN_CMD="/manager/susemanager-utils/testing/automation/chown-objects.sh $(id -u) $(id -g)"
 
 docker pull $REGISTRY/$PGSQL_CONTAINER
 docker run --privileged --rm=true -v "$GITROOT:/manager" \
-    --mount type=bind,source=${CREDENTIALS},target=/root/.oscrc \
     $REGISTRY/$PGSQL_CONTAINER \
     /bin/bash -c "${INITIAL_CMD}; ${CMD}; RET=\${?}; ${CHOWN_CMD} && exit \${RET}"


### PR DESCRIPTION
## What does this PR change?

The latest obs-to-maven doesn't depend on osc anymore. However this
introduces a few changes in the configuration file.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: tooling

- [X] **DONE**

## Test coverage
- No tests: tooling change

- [X] **DONE**

## Links

- Requires: https://github.com/uyuni-project/obs-to-maven/pull/3

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
