### PR TITLE
Testsuite: Add missing quote in one step

### DIFF
--- a/testsuite/features/secondary/buildhost_osimage_build_image.feature
+++ b/testsuite/features/secondary/buildhost_osimage_build_image.feature
@@ -52,7 +52,7 @@ Feature: Build OS images
 
   Scenario: Cleanup: remove the image from SUSE Manager server
     Given I am authorized as "admin" with password "admin"
-    When I follow the left menu "Images > Image List
+    When I follow the left menu "Images > Image List"
     And I wait until I do not see "There are no entries to show." text
     And I check the first image
     And I click on "Delete"

--- a/testsuite/features/step_definitions/docker_steps.rb
+++ b/testsuite/features/step_definitions/docker_steps.rb
@@ -62,7 +62,7 @@ end
 When(/^I wait at most (\d+) seconds until all "([^"]*)" container images are built correctly in the GUI$/) do |timeout, count|
   def ck_container_imgs(timeout, count)
     repeat_until_timeout(timeout: timeout.to_i, message: 'at least one image was not built correctly') do
-      step %(I follow the left menu "Images > Image List)
+      step %(I follow the left menu "Images > Image List")
       step %(I wait until I do not see "There are no entries to show." text)
       raise 'error detected while building images' if all(:xpath, "//*[contains(@title, 'Failed')]").any?
       break if has_xpath?("//*[contains(@title, 'Built')]", count: count)


### PR DESCRIPTION
## What does this PR change?
Add closing double quote around the argument in one step.

## Links
- https://github.com/SUSE/spacewalk/issues/12540
It fixes a commit from:  https://github.com/uyuni-project/uyuni/pull/2680/
### Ports:
(No port needed for Manager-4.0)
- Manager-3.2: https://github.com/SUSE/spacewalk/pull/12661
- Manager-4.1: https://github.com/SUSE/spacewalk/pull/12660


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)
