### PR TITLE
QAM: Fixing mount path on CentOS and including extra repos in the activation keys

### DIFF
--- a/testsuite/features/qam/add_activation_keys/add_activation_key.template
+++ b/testsuite/features/qam/add_activation_keys/add_activation_key.template
@@ -14,7 +14,7 @@ Feature: Create an activation key for <client>
     And I enter "<client>_key" as "description"
     And I enter "<client>_key" as "key"
     And I select the base channel for the "<client>" from "selectedBaseChannel"
-    And I check the custom channel for "<client>"
+    And I check the custom channels for "<client>"
     And I include the recommended child channels
     And I select the contact method for the "<client>" from "contact-method"
     And I click on "Create Activation Key"

--- a/testsuite/features/qam/add_custom_repositories/add_ceos6_repositories.feature
+++ b/testsuite/features/qam/add_custom_repositories/add_ceos6_repositories.feature
@@ -23,10 +23,10 @@ Feature: Adding the CentOS 6 distribution custom repositories
     When I follow the left menu "Software > Manage > Repositories"
     And I follow "Create Repository"
     And I enter "centos-6-iso" as "label"
-    And I enter "https://127.0.0.1/pub/centos-6-iso" as "url"
+    And I enter "http://127.0.0.1/centos-6-iso" as "url"
+    And I uncheck "metadataSigned"
     And I click on "Create Repository"
     Then I should see a "Repository created successfully" text
-    And I should see "metadataSigned" as checked
 
   Scenario: Add the repository to the Custom Channel for <label>
     Given I am authorized as "admin" with password "admin"

--- a/testsuite/features/qam/add_custom_repositories/add_ceos7_repositories.feature
+++ b/testsuite/features/qam/add_custom_repositories/add_ceos7_repositories.feature
@@ -23,10 +23,10 @@ Feature: Adding the CentOS 7 distribution custom repositories
     When I follow the left menu "Software > Manage > Repositories"
     And I follow "Create Repository"
     And I enter "centos-7-iso" as "label"
-    And I enter "https://127.0.0.1/pub/centos-7-iso" as "url"
+    And I enter "http://127.0.0.1/centos-7-iso" as "url"
+    And I uncheck "metadataSigned"
     And I click on "Create Repository"
     Then I should see a "Repository created successfully" text
-    And I should see "metadataSigned" as checked
 
   Scenario: Add the repository to the Custom Channel for <label>
     Given I am authorized as "admin" with password "admin"

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -520,7 +520,17 @@ When(/^I check the child channel "([^"]*)"$/) do |channel|
   checkbox.set(true)
 end
 
-When(/^I check the custom channel for "([^"]*)"$/) do |client|
+When(/^I check the custom channels for "([^"]*)"$/) do |client|
+  node = get_target(client)
+  _os_version, os_family = get_os_version(node)
+  if os_family =~ /^ubuntu/
+    steps %(
+      When I check the child channel "main"
+      And I check the child channel "main-updates"
+    )
+  elsif os_family =~ /^centos/
+    step %(I check the child channel "DVD")
+  end
   # Both minion and ssh_minion uses the same repositories, so the custom channels
   client.sub! 'ssh_minion', 'minion'
   channel = "Custom Channel for #{client}"


### PR DESCRIPTION
## What does this PR change?

Port of https://github.com/SUSE/spacewalk/pull/12664

- Fixing mount path on CentOS
- Unchecking the metadataSigned option on CentOS mounted DVD
- Including extra repos in the activation keys

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests 

- [x] **DONE**

## Links

Ports needed:
 - Manager-4.1 https://github.com/SUSE/spacewalk/pull/12664
 - Manager-4.0 https://github.com/SUSE/spacewalk/pull/12666

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
