### PR TITLE
XMLRPC: Report architecture label in the list of installed packages

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
@@ -1515,26 +1515,6 @@ ORDER BY PN.name, PE.evr
   </query>
 </mode>
 
-<mode name="system_installed_packages_expanded">
-  <query params="sid">
-SELECT PN.name,
-       PE.version,
-       PE.release,
-       coalesce(PE.epoch, ' ') as epoch,
-       PA.name as arch,
-       SP.installtime,
-       PE.id evr_id,
-       PA.id arch_id,
-       PN.id name_id
-  FROM rhnServerPackage SP inner join
-       rhnPackageName PN on PN.id = SP.name_id inner join
-       rhnPackageEVR PE on PE.id = SP.evr_id left join
-       rhnPackageArch PA on SP.package_arch_id = PA.id
- WHERE SP.server_id = :sid
-ORDER BY PN.name, PE.evr
-  </query>
-</mode>
-
 <mode name="list_server_software_crashes" class="com.redhat.rhn.frontend.dto.SoftwareCrashDto">
   <query params="server_id">
 SELECT id,

--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
@@ -1515,6 +1515,24 @@ ORDER BY PN.name, PE.evr
   </query>
 </mode>
 
+<!--  Same ase system_installed_packages, but reports arch label instead of name -->
+<mode name="system_installed_packages_arch_as_label">
+    <query params="sid">
+SELECT PN.name,
+       PE.version,
+       PE.release,
+       coalesce(PE.epoch, ' ') as epoch,
+       PA.label as arch,
+       SP.installtime
+  FROM rhnServerPackage SP inner join
+       rhnPackageName PN on PN.id = SP.name_id inner join
+       rhnPackageEVR PE on PE.id = SP.evr_id left join
+       rhnPackageArch PA on SP.package_arch_id = PA.id
+ WHERE SP.server_id = :sid
+ORDER BY PN.name, PE.evr
+    </query>
+</mode>
+
 <mode name="list_server_software_crashes" class="com.redhat.rhn.frontend.dto.SoftwareCrashDto">
   <query params="server_id">
 SELECT id,

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -1508,6 +1508,46 @@ public class SystemHandler extends BaseHandler {
 
     /**
      * List the installed packages for a given system.
+     *
+     * @xmlrpc.doc List the installed packages for a given system. The attribute
+     * installtime is returned since API version 10.10. Usage of listInstalledPackages is preferred, as it returns
+     * architecture label (not name).
+     * @param loggedInUser The current user
+     * @param sid The id of the system in question
+     * @return Returns an array of maps representing the packages installed on a system
+     * @throws FaultException A FaultException is thrown if the server corresponding to
+     * sid cannot be found.
+     * @deprecated This is here for backwards compatibility: The method returns architecture name,
+     * whereas the other endpoints return/accept architecture label.
+     * Instead of this method, use listInstalledPackages preferably.
+     *
+     * @xmlrpc.doc List the installed packages for a given system.
+     * @xmlrpc.param #param("string", "sessionKey")
+     * @xmlrpc.param #param("int", "serverId")
+     * @xmlrpc.returntype
+     *      #array_begin()
+     *          #struct_begin("package")
+     *                 #prop("string", "name")
+     *                 #prop("string", "version")
+     *                 #prop("string", "release")
+     *                 #prop("string", "epoch")
+     *                 #prop_desc("string", "arch", "Architecture name")
+     *                 #prop_desc("date", "installtime", "returned only if known")
+     *          #struct_end()
+     *      #array_end()
+     */
+    @Deprecated
+    public List<Map<String, Object>> listPackages(User loggedInUser, Integer sid)
+            throws FaultException {
+        // Get the logged in user and server
+        Server server = lookupServer(loggedInUser, sid);
+
+        return SystemManager.installedPackages(server.getId());
+    }
+
+    /**
+     * List the installed packages for a given system.
+     *
      * @xmlrpc.doc List the installed packages for a given system. The attribute
      * installtime is returned since API version 10.10.
      * @param loggedInUser The current user
@@ -1526,17 +1566,16 @@ public class SystemHandler extends BaseHandler {
      *                 #prop("string", "version")
      *                 #prop("string", "release")
      *                 #prop("string", "epoch")
-     *                 #prop("string", "arch")
+     *                 #prop_desc("string", "arch", "architecture label")
      *                 #prop_desc("date", "installtime", "returned only if known")
      *          #struct_end()
      *      #array_end()
      */
-    public List<Map<String, Object>> listPackages(User loggedInUser, Integer sid)
+    public List<Map<String, Object>> listInstalledPackages(User loggedInUser, Integer sid)
             throws FaultException {
         // Get the logged in user and server
         Server server = lookupServer(loggedInUser, sid);
-
-        return SystemManager.installedPackages(server.getId());
+        return SystemManager.installedPackages(server.getId(), true);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -1509,9 +1509,6 @@ public class SystemHandler extends BaseHandler {
     /**
      * List the installed packages for a given system.
      *
-     * @xmlrpc.doc List the installed packages for a given system. The attribute
-     * installtime is returned since API version 10.10. Usage of listInstalledPackages is preferred, as it returns
-     * architecture label (not name).
      * @param loggedInUser The current user
      * @param sid The id of the system in question
      * @return Returns an array of maps representing the packages installed on a system
@@ -1521,7 +1518,8 @@ public class SystemHandler extends BaseHandler {
      * whereas the other endpoints return/accept architecture label.
      * Instead of this method, use listInstalledPackages preferably.
      *
-     * @xmlrpc.doc List the installed packages for a given system.
+     * @xmlrpc.doc List the installed packages for a given system. Usage of listInstalledPackages is preferred,
+     * as it returns architecture label (not name).
      * @xmlrpc.param #param("string", "sessionKey")
      * @xmlrpc.param #param("int", "serverId")
      * @xmlrpc.returntype
@@ -1548,8 +1546,6 @@ public class SystemHandler extends BaseHandler {
     /**
      * List the installed packages for a given system.
      *
-     * @xmlrpc.doc List the installed packages for a given system. The attribute
-     * installtime is returned since API version 10.10.
      * @param loggedInUser The current user
      * @param sid The id of the system in question
      * @return Returns an array of maps representing the packages installed on a system

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -1141,8 +1141,7 @@ public class SystemHandler extends BaseHandler {
      */
     private List<Map<String, Object>> packagesToCheck(Server server, String name)
             throws NoSuchPackageException {
-        DataResult<Map<String, Object>> installed =
-                SystemManager.installedPackages(server.getId(), false);
+        DataResult<Map<String, Object>> installed = SystemManager.installedPackages(server.getId());
 
         List<Map<String, Object>> toCheck = new ArrayList<Map<String, Object>>();
         // Get a list of packages with matching name
@@ -1233,8 +1232,7 @@ public class SystemHandler extends BaseHandler {
         // Get the logged in user and server
         Server server = lookupServer(loggedInUser, sid);
 
-        DataResult<Map<String, Object>> packages =
-                SystemManager.installedPackages(server.getId(), false);
+        DataResult<Map<String, Object>> packages = SystemManager.installedPackages(server.getId());
 
         /*
          * Loop through the packages for this system and check each attribute. Use
@@ -1538,7 +1536,7 @@ public class SystemHandler extends BaseHandler {
         // Get the logged in user and server
         Server server = lookupServer(loggedInUser, sid);
 
-        return SystemManager.installedPackages(server.getId(), false);
+        return SystemManager.installedPackages(server.getId());
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
@@ -826,7 +826,7 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
     public void testListPackages() throws Exception {
         Server server = ServerFactoryTest.createTestServer(admin, true);
 
-        int numPackages = SystemManager.installedPackages(server.getId(), false).size();
+        int numPackages = SystemManager.installedPackages(server.getId()).size();
 
         List<Map<String, Object>> result =
                 handler.listPackages(admin,

--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -419,7 +419,19 @@ public class SystemManager extends BaseManager {
      * @return Returns a list of packages for a system
      */
     public static DataResult<Map<String, Object>> installedPackages(Long sid) {
-        SelectMode m = ModeFactory.getMode("System_queries", "system_installed_packages", Map.class);
+        return installedPackages(sid, false);
+    }
+
+    /**
+     * Gets the installed packages on a system
+     * @param sid The system in question
+     * @param archAsLabel set to true to return architecture as label, otherwise architecture name is used
+     * @return Returns a list of packages for a system
+     */
+    public static DataResult<Map<String, Object>> installedPackages(Long sid, boolean archAsLabel) {
+        String suffix = archAsLabel ? "_arch_as_label" : "";
+        String query = "system_installed_packages" + suffix;
+        SelectMode m = ModeFactory.getMode("System_queries", query, Map.class);
         Map<String, Object> params = new HashMap<String, Object>();
         params.put("sid", sid);
         DataResult<Map<String, Object>> pkgs = m.execute(params);

--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -416,15 +416,10 @@ public class SystemManager extends BaseManager {
     /**
      * Gets the installed packages on a system
      * @param sid The system in question
-     * @param expanded If true, also adds EVR, Arch and package name to the result.
      * @return Returns a list of packages for a system
      */
-    public static DataResult<Map<String, Object>> installedPackages(Long sid,
-            boolean expanded) {
-        String suffix = expanded ? "_expanded" : "";
-        SelectMode m = ModeFactory.getMode("System_queries",
-                                           "system_installed_packages" + suffix,
-                                           Map.class);
+    public static DataResult<Map<String, Object>> installedPackages(Long sid) {
+        SelectMode m = ModeFactory.getMode("System_queries", "system_installed_packages", Map.class);
         Map<String, Object> params = new HashMap<String, Object>();
         params.put("sid", sid);
         DataResult<Map<String, Object>> pkgs = m.execute(params);

--- a/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
@@ -1651,4 +1651,59 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
         assertEquals(systemGroupIDInfo.getGroupID(), group.getId());
         assertEquals(systemGroupIDInfo.getGroupName(), group.getName());
     }
+
+    /**
+     * Test that installedPackages method of {@link SystemManager} returns both packages known and unknown
+     * to Uyuni. For the known packages it includes the package id.
+     *
+     * This tests 2 cases:
+     * - reporting architecture by its label
+     * - reporting architecture by its name
+     *
+     * @throws Exception
+     */
+    public void testInstalledPackages() throws Exception {
+        doTestInstalledPackages(true);
+        doTestInstalledPackages(false);
+    }
+
+    private void doTestInstalledPackages(boolean archAsLabel) throws Exception {
+        Server server = ServerTestUtils.createTestSystem(user);
+
+        // installed on server and known to Uyuni
+        Package pack = PackageTest.createTestPackage(user.getOrg());
+        InstalledPackage knownPackage = new InstalledPackage();
+        knownPackage.setArch(pack.getPackageArch());
+        knownPackage.setName(pack.getPackageName());
+        knownPackage.setEvr(pack.getPackageEvr());
+        knownPackage.setServer(server);
+        server.getPackages().add(knownPackage);
+
+        // installed on server but unknown to Uyuni (no package id)
+        InstalledPackage unknownPackage = new InstalledPackage();
+        unknownPackage.setArch(PackageFactory.lookupPackageArchByLabel("ia32e")); // for this one, name differs from label
+        unknownPackage.setName(PackageFactory.lookupOrCreatePackageByName("testpak-123"));
+        unknownPackage.setEvr(PackageEvrFactoryTest.createTestPackageEvr());
+        unknownPackage.setServer(server);
+        server.getPackages().add(unknownPackage);
+
+        DataResult<Map<String, Object>> packages = SystemManager.installedPackages(server.getId(), archAsLabel);
+
+        Map<String, Object> known = packages.stream()
+                .filter(p -> p.get("name").equals(knownPackage.getName().getName())).findFirst().orElseThrow();
+        Map<String, Object> unknown = packages.stream()
+                .filter(p -> p.get("name").equals(unknownPackage.getName().getName())).findFirst().orElseThrow();
+
+        assertEquals(knownPackage.getName().getName(), known.get("name"));
+        assertEquals(knownPackage.getEvr().getEpoch(), known.get("epoch"));
+        assertEquals(knownPackage.getEvr().getVersion(), known.get("version"));
+        assertEquals(knownPackage.getEvr().getRelease(), known.get("release"));
+        assertEquals(archAsLabel ? knownPackage.getArch().getLabel() : knownPackage.getArch().getName(), known.get("arch"));
+
+        assertEquals(unknownPackage.getName().getName(), unknown.get("name"));
+        assertEquals(unknownPackage.getEvr().getEpoch(), unknown.get("epoch"));
+        assertEquals(unknownPackage.getEvr().getVersion(), unknown.get("version"));
+        assertEquals(unknownPackage.getEvr().getRelease(), unknown.get("release"));
+        assertEquals(archAsLabel ? unknownPackage.getArch().getLabel() : unknownPackage.getArch().getName(), unknown.get("arch"));
+    }
 }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- XMLRPC: Report architecture label in the list of installed packages (bsc#1176898)
 - get media.1/products for cloned channels (bsc#1178303)
 - calculate size to truncate a history message based on the htmlified version (bsc#1178503)
 - Sync state modules when starting action chain execution (bsc#1177336)


### PR DESCRIPTION
Introduce an endpoint (`system.listInstalledPackages`) that reports package architecture label.

Previously, we had an endpoint (`system.listPackages`) that reported architecture **name**, which is useless in other endpoints (they return/accept arch label). This PR does **NOT** remove this endpoint, as it would break backwards compatibility.

Moreover: get rid of one unused query.


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- xmlrpc doc

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Tracks SUSE/spacewalk#12589

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [x] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"