### PR TITLE
Prevent IntegrityError during mgr-inter-sync execution (bsc#1177235)

### DIFF
--- a/backend/satellite_tools/xmlSource.py
+++ b/backend/satellite_tools/xmlSource.py
@@ -578,7 +578,8 @@ class BaseChecksummedItem(BaseItem):
         item['checksums'] = {}
         if 'md5sum' in item:
             # xml dumps < 3.6 (aka pre-sha256)
-            item['checksums']['md5'] = item['md5sum']
+            if item['md5sum']:
+                item['checksums']['md5'] = item['md5sum']
             del(item['md5sum'])
         if 'checksum_list' in item and item['checksum_list']:
             for csum in item['checksum_list']:

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,5 @@
+- prevent IntegrityError during mgr-inter-sync execution (bsc#1177235)
+
 -------------------------------------------------------------------
 Mon Sep 21 11:59:42 CEST 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

This addresses the following error:

```
Importing:  ERROR: Encountered IntegrityError:
null value in column "checksum" violates not-null constraint
```

In some cases, the `md5sum` backwards-compatibility attribute might be present but None. This patch conditionally filters out such attributes.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- No tests: **there is no Cucumber coverage for ISS, adding it is a major separate topic**
- [x] **DONE**

## Links

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1177235

- [x] **DONE**

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
