### PR TITLE
Only show the missing hypervisor error message on Salt systems

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/virtualization/VirtualGuestsController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/virtualization/VirtualGuestsController.java
@@ -144,7 +144,7 @@ public class VirtualGuestsController extends AbstractVirtualizationController {
         data.put("salt_entitled", server.hasEntitlement(EntitlementManager.SALT));
         data.put("foreign_entitled", server.hasEntitlement(EntitlementManager.FOREIGN));
         data.put("is_admin", user.hasRole(RoleFactory.ORG_ADMIN));
-        data.put("hypervisor", server.hasVirtualizationEntitlement() ?
+        data.put("hypervisor", server.hasVirtualizationEntitlement() && server.asMinionServer().isPresent() ?
                 virtManager.getHypervisor(server.getMinionId()).orElse("") :
                 "");
 

--- a/web/html/src/manager/virtualization/HypervisorCheck.js
+++ b/web/html/src/manager/virtualization/HypervisorCheck.js
@@ -6,11 +6,11 @@ import { Utils as MessagesUtils } from 'components/messages';
 
 type Props = {
     hypervisor: string,
-    foreignEntitled: boolean,
+    saltVirtHost: boolean,
 };
 
 export function HypervisorCheck(props: Props) {
-    if (props.foreignEntitled) {
+    if (!props.saltVirtHost) {
         return null;
     }
 
@@ -28,5 +28,5 @@ export function HypervisorCheck(props: Props) {
 };
 
 HypervisorCheck.defaultProps = {
-    foreignEntitled: false,
+    saltVirtHost: true,
 };

--- a/web/html/src/manager/virtualization/guests/list/guests-list.js
+++ b/web/html/src/manager/virtualization/guests/list/guests-list.js
@@ -39,7 +39,7 @@ export function GuestsList(props: Props) {
 
   return (
     <>
-      <HypervisorCheck foreignEntitled={props.foreignEntitled} hypervisor={props.hypervisor}/>
+      <HypervisorCheck saltVirtHost={!props.foreignEntitled && props.saltEntitled} hypervisor={props.hypervisor}/>
       <ListTab
         serverId={props.serverId}
         saltEntitled={props.saltEntitled}


### PR DESCRIPTION
## What does this PR change?

Fix visual annoyance introduced by  https://github.com/uyuni-project/uyuni/pull/2611
The missing virtualization hypervisor message should only be shown for Salt systems, not traditional ones.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: just hiding a message when not needed

- [X] **DONE**

## Test coverage
- No tests: hard to test
- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
