### PR TITLE
enable redfish by default

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -6956,6 +6956,12 @@ Follow this url to see the full list of inactive systems:
           <context context-type="sourcefile">/rhn/systems/details/kickstart/PowerManagement.do</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="cobbler.powermanagement.redfish" xml:space="preserve">
+        <source>Redfish</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/systems/details/kickstart/PowerManagement.do</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="cobbler.powermanagement.ldom" xml:space="preserve">
         <source>SPARC Logical Domains</source>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/template/StringResource_sk.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/template/StringResource_sk.xml
@@ -212,7 +212,7 @@ Summary:
 {4} {5} {6}
 {7}
 ------------------------------------------------------------------------------
-    </source> <target state="needs-adaptation">@@ PRODUCT_NAME @@ určil, že na jeden alebo viac systémov, ktoré ste zaregistrovali, sa vzťahujú nasledujúce upozornenia: Kompletné informácie o tejto oprave nájdete na nasledujúcom mieste: {0} {1} - {2} ------------------------------------------------------------------------------ Súhrn: {3} {4} {5} {6} {7} ------------------------------------------------------------------------------</target><context-group name="ctx">
+    </source> <target state="needs-adaptation">@@PRODUCT_NAME@@ určil, že na jeden alebo viac systémov, ktoré ste zaregistrovali, sa vzťahujú nasledujúce upozornenia: Kompletné informácie o tejto oprave nájdete na nasledujúcom mieste: {0} {1} - {2} ------------------------------------------------------------------------------ Súhrn: {3} {4} {5} {6} {7} ------------------------------------------------------------------------------</target><context-group name="ctx">
             <context context-type="paramnotes">
         {0} - Errata Details URL
         {1} - errata advisory type

--- a/java/conf/rhn_java.conf
+++ b/java/conf/rhn_java.conf
@@ -96,7 +96,7 @@ java.cobbler_bootstrap.extra_kernel_options = ROOTFS_FSCK=0
 # Power management settings
 # A comma-separated list of fence agents that are allowable.
 # Agent name is X where agent command is /usr/sbin/fence_X
-java.power_management.types = ipmitool
+java.power_management.types = ipmitool, redfish
 
 # how large can config file be to be editable in webUI (in kilobytes)
 java.config_file_edit_size = 32

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- enable redfish power management by default
 - renaming autoinstall distro didn't change the name of the Cobbler distro (bsc#1175876)
 - Fix: reinspecting a container image (bsc#1177092)
 - add power management xmlrpc api

--- a/testsuite/features/secondary/srv_distro_cobbler.feature
+++ b/testsuite/features/secondary/srv_distro_cobbler.feature
@@ -146,9 +146,9 @@ Feature: Cobbler and distribution autoinstallation
     When I am logged in via XML-RPC system as user "admin" and password "admin"
     And I create a System Record
     Then I wait until file "/srv/tftpboot/pxelinux.cfg/01-00-22-22-77-ee-cc" contains "ks=.*testserver:1" on server
-    And the cobbler report contains "testserver.example.com" for system "testserver"
-    And the cobbler report contains "1.1.1.1" for system "testserver"
-    And the cobbler report contains "00:22:22:77:ee:cc" for system "testserver"
+    And the cobbler report contains "testserver.example.com" for cobbler system "testserver"
+    And the cobbler report contains "1.1.1.1" for cobbler system "testserver"
+    And the cobbler report contains "00:22:22:77:ee:cc" for cobbler system "testserver"
 
   Scenario: Cleanup: delete test distro and profiles
     Then I remove kickstart profiles and distros

--- a/testsuite/features/secondary/srv_distro_cobbler.feature
+++ b/testsuite/features/secondary/srv_distro_cobbler.feature
@@ -146,9 +146,9 @@ Feature: Cobbler and distribution autoinstallation
     When I am logged in via XML-RPC system as user "admin" and password "admin"
     And I create a System Record
     Then I wait until file "/srv/tftpboot/pxelinux.cfg/01-00-22-22-77-ee-cc" contains "ks=.*testserver:1" on server
-    And the cobbler report contains "testserver.example.com" for cobbler system "testserver"
-    And the cobbler report contains "1.1.1.1" for cobbler system "testserver"
-    And the cobbler report contains "00:22:22:77:ee:cc" for cobbler system "testserver"
+    And the cobbler report should contain "testserver.example.com" for cobbler system name "testserver:1"
+    And the cobbler report should contain "1.1.1.1" for cobbler system name "testserver:1"
+    And the cobbler report should contain "00:22:22:77:ee:cc" for cobbler system name "testserver:1"
 
   Scenario: Cleanup: delete test distro and profiles
     Then I remove kickstart profiles and distros

--- a/testsuite/features/secondary/srv_power_management.feature
+++ b/testsuite/features/secondary/srv_power_management.feature
@@ -1,14 +1,14 @@
 # Copyright (c) 2015 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-Feature: Power management
+Feature: IPMI Power management
 
-  Scenario: Fake an IPMI host
-    Given the server starts mocking an IPMI host
+  Scenario: Setup an IPMI host
+    When the server starts mocking an IPMI host
 
   Scenario: Check the power management page
     Given I am on the Systems overview page of this "sle_client"
-    And I follow "Provisioning" in the content area
+    When I follow "Provisioning" in the content area
     And I follow "Power Management" in the content area
     Then I should see a "Power Management Settings" text
     And I should see a "IPMI" text
@@ -16,44 +16,43 @@ Feature: Power management
 
   Scenario: Save power management values
     Given I am on the Systems overview page of this "sle_client"
-    And I follow "Provisioning" in the content area
+    When I follow "Provisioning" in the content area
     And I follow "Power Management" in the content area
-    When I enter "127.0.0.1" as "powerAddress"
+    And I enter "127.0.0.1" as "powerAddress"
     And I enter "ipmiusr" as "powerUsername"
     And I enter "test" as "powerPassword"
     And I click on "Save"
     Then I should see a "Power settings saved" text
-    And the cobbler report contains "Power Management Address       : 127.0.0.1"
-    And the cobbler report contains "Power Management Username      : ipmiusr"
-    And the cobbler report contains "Power Management Password      : test"
-    And the cobbler report contains "Power Management Type          : ipmitool"
+    And the cobbler report should contain "Power Management Address       : 127.0.0.1" for "sle_client"
+    And the cobbler report should contain "Power Management Username      : ipmiusr" for "sle_client"
+    And the cobbler report should contain "Power Management Password      : test" for "sle_client"
+    And the cobbler report should contain "Power Management Type          : ipmitool" for "sle_client"
 
   Scenario: Test IPMI functions
     Given I am on the Systems overview page of this "sle_client"
-    And I follow "Provisioning" in the content area
+    When I follow "Provisioning" in the content area
     And I follow "Power Management" in the content area
-    Then I click on "Power On"
+    And I click on "Power On"
     And I click on "Get status"
-    And I should see the power is "On"
-    And I click on "Power Off"
-    And I should see a "system has been powered off" text
-    And I wait for "20" seconds
+    Then I should see the power is "On"
+    When I click on "Power Off"
+    Then I should see a "system has been powered off" text
     And I should see the power is "Unknown"
-    Then I click on "Get status"
-    And I should see the power is "Off"
-    Then I click on "Power On"
-    And I should see a "system has been powered on" text
-    Then I click on "Get status"
-    And I should see the power is "On"
-    Then I click on "Reboot"
-    And I should see a "system has been rebooted" text
-    Then I click on "Get status"
-    And I should see the power is "On"
+    When I click on "Get status"
+    Then I should see the power is "Off"
+    When I click on "Power On"
+    Then I should see a "system has been powered on" text
+    When I click on "Get status"
+    Then I should see the power is "On"
+    When I click on "Reboot"
+    Then I should see a "system has been rebooted" text
+    When I click on "Get status"
+    Then I should see the power is "On"
 
   Scenario: Check power management SSM configuration
     Given I am authorized
     And I am on the System Overview page
-    And I check the "sle_client" client
+    When I check the "sle_client" client
     And I am on System Set Manager Overview
     And I follow "Configure power management" in the content area
     Then I should see "sle_client" as link
@@ -68,15 +67,15 @@ Feature: Power management
     And I enter "qwertz" as "powerPassword"
     And I click on "Update"
     Then I should see a "Configuration successfully saved for 1 system(s)" text
-    And the cobbler report contains "Power Management Username      : testing"
-    And the cobbler report contains "Power Management Password      : qwertz"
-    And the cobbler report contains "Power Management Address       : 127.0.0.1"
-    And the cobbler report contains "Power Management Type          : ipmitool"
+    And the cobbler report should contain "Power Management Username      : testing" for "sle_client"
+    And the cobbler report should contain "Power Management Password      : qwertz" for "sle_client"
+    And the cobbler report should contain "Power Management Address       : 127.0.0.1" for "sle_client"
+    And the cobbler report should contain "Power Management Type          : ipmitool" for "sle_client"
 
   Scenario: Check power management SSM operation
     Given I am authorized
     And I am on System Set Manager Overview
-    And I follow "power management operations" in the content area
+    When I follow "power management operations" in the content area
     Then I should see "sle_client" as link
     And I should see a "Power On" button
     And I should see a "Power Off" button
@@ -85,16 +84,16 @@ Feature: Power management
   Scenario: Cleanup: reset IPMI values
     Given I am logged in via XML-RPC powermgmt as user "admin" and password "admin"
     And I want to operate on this "sle_client"
-    Then I set power management value "" for "powerAddress"
+    When I set power management value "" for "powerAddress"
     And I set power management value "" for "powerUsername"
     And I set power management value "" for "powerPassword"
-    And the cobbler report contains "Power Management Address       :"
-    And the cobbler report contains "Power Management Username      :"
-    And the cobbler report contains "Power Management Password      :"
-    And the cobbler report contains "Power Management Type          : ipmitool"
+    Then the cobbler report should contain "Power Management Address       :" for "sle_client"
+    And the cobbler report should contain "Power Management Username      :" for "sle_client"
+    And the cobbler report should contain "Power Management Password      :" for "sle_client"
+    And the cobbler report should contain "Power Management Type          : ipmitool" for "sle_client"
 
-  Scenario: Cleanup: don't fake an IPMI host
-    Given the server stops mocking an IPMI host
+  Scenario: Cleanup: tear down the IPMI host
+    When the server stops mocking an IPMI host
 
   Scenario: Cleanup: remove remaining systems from SSM after power management tests
     When I am authorized as "admin" with password "admin"

--- a/testsuite/features/secondary/srv_power_management.feature
+++ b/testsuite/features/secondary/srv_power_management.feature
@@ -52,7 +52,8 @@ Feature: IPMI Power management
   Scenario: Check power management SSM configuration
     Given I am authorized
     And I am on the System Overview page
-    When I check the "sle_client" client
+    When I follow "Clear"
+    And I check the "sle_client" client
     And I am on System Set Manager Overview
     And I follow "Configure power management" in the content area
     Then I should see "sle_client" as link

--- a/testsuite/features/secondary/srv_power_management_redfish.feature
+++ b/testsuite/features/secondary/srv_power_management_redfish.feature
@@ -45,7 +45,8 @@ Feature: Redfish Power management
   Scenario: Check power management SSM configuration for Redfish
     Given I am authorized
     And I am on the System Overview page
-    When I check the "sle_minion" client
+    When I follow "Clear"
+    And I check the "sle_minion" client
     And I am on System Set Manager Overview
     And I follow "Configure power management" in the content area
     Then I should see "sle_minion" as link

--- a/testsuite/features/secondary/srv_power_management_redfish.feature
+++ b/testsuite/features/secondary/srv_power_management_redfish.feature
@@ -1,0 +1,95 @@
+# Copyright (c) 2020 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+Feature: Power management
+
+  Scenario: Fake a Redfish host
+    Given the server starts mocking a Redfish host
+
+  Scenario: Save power management values for Redfish
+    Given I am on the Systems overview page of this "sle_minion"
+    And I follow "Provisioning" in the content area
+    And I follow "Power Management" in the content area
+    When I enter "server" as the redfish server address
+    And I enter "ipmiusr" as "powerUsername"
+    And I enter "test" as "powerPassword"
+    And I select "Redfish" from "powerType"
+    And I click on "Save"
+    Then I should see a "Power settings saved" text
+    And the cobbler report contains ":8443" for system "sle_minion"
+    And the cobbler report contains "Power Management Username      : ipmiusr" for system "sle_minion"
+    And the cobbler report contains "Power Management Password      : test" for system "sle_minion"
+    And the cobbler report contains "Power Management Type          : redfish" for system "sle_minion"
+
+  Scenario: Test Redfish functions
+    Given I am on the Systems overview page of this "sle_minion"
+    And I follow "Provisioning" in the content area
+    And I follow "Power Management" in the content area
+    Then I click on "Power On"
+    And I click on "Get status"
+    And I should see the power is "On"
+    And I click on "Power Off"
+    And I should see a "system has been powered off" text
+    And I wait for "20" seconds
+    And I should see the power is "Unknown"
+    Then I click on "Get status"
+    And I should see the power is "Off"
+    Then I click on "Power On"
+    And I should see a "system has been powered on" text
+    Then I click on "Get status"
+    And I should see the power is "On"
+    Then I click on "Reboot"
+    And I should see a "system has been rebooted" text
+    Then I click on "Get status"
+    And I should see the power is "On"
+
+  Scenario: Check power management SSM configuration for Redfish
+    Given I am authorized
+    And I am on the System Overview page
+    And I check the "sle_minion" client
+    And I am on System Set Manager Overview
+    And I follow "Configure power management" in the content area
+    Then I should see "sle_minion" as link
+    And I should see a "Change Power Management Configuration" text
+    And I should see a "Type" text
+    And I should see a "Network address" text
+    And I should see a "Username" text
+    And I should see a "Password" text
+    And I should see a "System identifier" text
+    And I should see a "Update" button
+    When I enter "testing" as "powerUsername"
+    And I enter "qwertz" as "powerPassword"
+    And I click on "Update"
+    Then I should see a "Configuration successfully saved for 1 system(s)" text
+    And the cobbler report contains "Power Management Username      : testing" for system "sle_minion"
+    And the cobbler report contains "Power Management Password      : qwertz" for system "sle_minion"
+    And the cobbler report contains ":8443" for system "sle_minion"
+    And the cobbler report contains "Power Management Type          : redfish" for system "sle_minion"
+
+  Scenario: Check power management SSM operation for Redfish
+    Given I am authorized
+    And I am on System Set Manager Overview
+    And I follow "power management operations" in the content area
+    Then I should see "sle_minion" as link
+    And I should see a "Power On" button
+    And I should see a "Power Off" button
+    And I should see a "Reboot" button
+
+  Scenario: Cleanup: reset Redfish values
+    Given I am logged in via XML-RPC powermgmt as user "admin" and password "admin"
+    And I want to operate on this "sle_minion"
+    Then I set power management value "" for "powerAddress"
+    And I set power management value "" for "powerUsername"
+    And I set power management value "" for "powerPassword"
+    And I set power management value "ipmitool" for "powerType"
+    And the cobbler report contains "Power Management Address       :" for system "sle_minion"
+    And the cobbler report contains "Power Management Username      :" for system "sle_minion"
+    And the cobbler report contains "Power Management Password      :" for system "sle_minion"
+    And the cobbler report contains "Power Management Type          : ipmitool" for system "sle_minion"
+
+  Scenario: Cleanup: don't fake a Redfish host
+    Given the server stops mocking a Redfish host
+
+  Scenario: Cleanup: remove remaining systems from SSM after Redfish power management tests
+    When I am authorized as "admin" with password "admin"
+    And I follow "Clear"

--- a/testsuite/features/secondary/srv_power_management_redfish.feature
+++ b/testsuite/features/secondary/srv_power_management_redfish.feature
@@ -1,52 +1,51 @@
 # Copyright (c) 2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-Feature: Power management
+Feature: Redfish Power management
 
-  Scenario: Fake a Redfish host
-    Given the server starts mocking a Redfish host
+  Scenario: Setup a Redfish host
+    When the server starts mocking a Redfish host
 
   Scenario: Save power management values for Redfish
     Given I am on the Systems overview page of this "sle_minion"
-    And I follow "Provisioning" in the content area
+    When I follow "Provisioning" in the content area
     And I follow "Power Management" in the content area
-    When I enter "server" as the redfish server address
+    And I enter the server hostname as the redfish server address
     And I enter "ipmiusr" as "powerUsername"
     And I enter "test" as "powerPassword"
     And I select "Redfish" from "powerType"
     And I click on "Save"
     Then I should see a "Power settings saved" text
-    And the cobbler report contains ":8443" for system "sle_minion"
-    And the cobbler report contains "Power Management Username      : ipmiusr" for system "sle_minion"
-    And the cobbler report contains "Power Management Password      : test" for system "sle_minion"
-    And the cobbler report contains "Power Management Type          : redfish" for system "sle_minion"
+    And the cobbler report should contain ":8443" for "sle_minion"
+    And the cobbler report should contain "Power Management Username      : ipmiusr" for "sle_minion"
+    And the cobbler report should contain "Power Management Password      : test" for "sle_minion"
+    And the cobbler report should contain "Power Management Type          : redfish" for "sle_minion"
 
   Scenario: Test Redfish functions
     Given I am on the Systems overview page of this "sle_minion"
-    And I follow "Provisioning" in the content area
+    When I follow "Provisioning" in the content area
     And I follow "Power Management" in the content area
-    Then I click on "Power On"
+    And I click on "Power On"
     And I click on "Get status"
-    And I should see the power is "On"
-    And I click on "Power Off"
-    And I should see a "system has been powered off" text
-    And I wait for "20" seconds
+    Then I should see the power is "On"
+    When I click on "Power Off"
+    Then I should see a "system has been powered off" text
     And I should see the power is "Unknown"
-    Then I click on "Get status"
-    And I should see the power is "Off"
-    Then I click on "Power On"
-    And I should see a "system has been powered on" text
-    Then I click on "Get status"
-    And I should see the power is "On"
-    Then I click on "Reboot"
-    And I should see a "system has been rebooted" text
-    Then I click on "Get status"
-    And I should see the power is "On"
+    When I click on "Get status"
+    Then I should see the power is "Off"
+    When I click on "Power On"
+    Then I should see a "system has been powered on" text
+    When I click on "Get status"
+    Then I should see the power is "On"
+    When I click on "Reboot"
+    Then I should see a "system has been rebooted" text
+    When I click on "Get status"
+    Then I should see the power is "On"
 
   Scenario: Check power management SSM configuration for Redfish
     Given I am authorized
     And I am on the System Overview page
-    And I check the "sle_minion" client
+    When I check the "sle_minion" client
     And I am on System Set Manager Overview
     And I follow "Configure power management" in the content area
     Then I should see "sle_minion" as link
@@ -61,15 +60,15 @@ Feature: Power management
     And I enter "qwertz" as "powerPassword"
     And I click on "Update"
     Then I should see a "Configuration successfully saved for 1 system(s)" text
-    And the cobbler report contains "Power Management Username      : testing" for system "sle_minion"
-    And the cobbler report contains "Power Management Password      : qwertz" for system "sle_minion"
-    And the cobbler report contains ":8443" for system "sle_minion"
-    And the cobbler report contains "Power Management Type          : redfish" for system "sle_minion"
+    And the cobbler report should contain "Power Management Username      : testing" for "sle_minion"
+    And the cobbler report should contain "Power Management Password      : qwertz" for "sle_minion"
+    And the cobbler report should contain ":8443" for "sle_minion"
+    And the cobbler report should contain "Power Management Type          : redfish" for "sle_minion"
 
   Scenario: Check power management SSM operation for Redfish
     Given I am authorized
     And I am on System Set Manager Overview
-    And I follow "power management operations" in the content area
+    When I follow "power management operations" in the content area
     Then I should see "sle_minion" as link
     And I should see a "Power On" button
     And I should see a "Power Off" button
@@ -78,17 +77,17 @@ Feature: Power management
   Scenario: Cleanup: reset Redfish values
     Given I am logged in via XML-RPC powermgmt as user "admin" and password "admin"
     And I want to operate on this "sle_minion"
-    Then I set power management value "" for "powerAddress"
+    When I set power management value "" for "powerAddress"
     And I set power management value "" for "powerUsername"
     And I set power management value "" for "powerPassword"
     And I set power management value "ipmitool" for "powerType"
-    And the cobbler report contains "Power Management Address       :" for system "sle_minion"
-    And the cobbler report contains "Power Management Username      :" for system "sle_minion"
-    And the cobbler report contains "Power Management Password      :" for system "sle_minion"
-    And the cobbler report contains "Power Management Type          : ipmitool" for system "sle_minion"
+    Then the cobbler report should contain "Power Management Address       :" for "sle_minion"
+    And the cobbler report should contain "Power Management Username      :" for "sle_minion"
+    And the cobbler report should contain "Power Management Password      :" for "sle_minion"
+    And the cobbler report should contain "Power Management Type          : ipmitool" for "sle_minion"
 
-  Scenario: Cleanup: don't fake a Redfish host
-    Given the server stops mocking a Redfish host
+  Scenario: Cleanup: tear down the Redfish host
+    When the server stops mocking a Redfish host
 
   Scenario: Cleanup: remove remaining systems from SSM after Redfish power management tests
     When I am authorized as "admin" with password "admin"

--- a/testsuite/features/secondary/srv_xmlrpc_power_management.feature
+++ b/testsuite/features/secondary/srv_xmlrpc_power_management.feature
@@ -1,10 +1,10 @@
 # Copyright (c) 2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-Feature: Power management test for XMLRPC
+Feature: IPMI Power management test for XMLRPC
 
-  Scenario: Fake an IPMI host for XMLRPC test
-    Given the server starts mocking an IPMI host
+  Scenario: Setup an IPMI host for XMLRPC test
+    When the server starts mocking an IPMI host
 
   Scenario: Check the power management settings for XMLRPC test
     Given I am logged in via XML-RPC powermgmt as user "admin" and password "admin"
@@ -15,35 +15,35 @@ Feature: Power management test for XMLRPC
   Scenario: Save power management values  for XMLRPC test
     Given I am logged in via XML-RPC powermgmt as user "admin" and password "admin"
     And I want to operate on this "sle_client"
-    Then I set power management value "127.0.0.1" for "powerAddress"
+    When I set power management value "127.0.0.1" for "powerAddress"
     And I set power management value "ipmiusr" for "powerUsername"
     And I set power management value "test" for "powerPassword"
     And I set power management value "ipmitool" for "powerType"
-    And the cobbler report contains "Power Management Address       : 127.0.0.1"
-    And the cobbler report contains "Power Management Username      : ipmiusr"
-    And the cobbler report contains "Power Management Password      : test"
-    And the cobbler report contains "Power Management Type          : ipmitool"
+    Then the cobbler report should contain "Power Management Address       : 127.0.0.1" for "sle_client"
+    And the cobbler report should contain "Power Management Username      : ipmiusr" for "sle_client"
+    And the cobbler report should contain "Power Management Password      : test" for "sle_client"
+    And the cobbler report should contain "Power Management Type          : ipmitool" for "sle_client"
 
   Scenario: Test IPMI functions for XMLRPC test
     Given I am logged in via XML-RPC powermgmt as user "admin" and password "admin"
     And I want to operate on this "sle_client"
-    Then I turn power on
-    And the power status is "on"
-    And I turn power off
-    And the power status is "off"
-    And I do power management reboot
-    And the power status is "on"
+    When I turn power on
+    Then the power status is "on"
+    When I turn power off
+    Then the power status is "off"
+    When I do power management reboot
+    Then the power status is "on"
 
   Scenario: Cleanup: reset IPMI values for XMLRPC test
     Given I am logged in via XML-RPC powermgmt as user "admin" and password "admin"
     And I want to operate on this "sle_client"
-    Then I set power management value "" for "powerAddress"
+    When I set power management value "" for "powerAddress"
     And I set power management value "" for "powerUsername"
     And I set power management value "" for "powerPassword"
-    And the cobbler report contains "Power Management Address       :"
-    And the cobbler report contains "Power Management Username      :"
-    And the cobbler report contains "Power Management Password      :"
-    And the cobbler report contains "Power Management Type          : ipmitool"
+    Then the cobbler report should contain "Power Management Address       :" for "sle_client"
+    And the cobbler report should contain "Power Management Username      :" for "sle_client"
+    And the cobbler report should contain "Power Management Password      :" for "sle_client"
+    And the cobbler report should contain "Power Management Type          : ipmitool" for "sle_client"
 
-  Scenario: Cleanup: don't fake an IPMI host for XMLRPC test
-    Given the server stops mocking an IPMI host
+  Scenario: Cleanup: tear down the IPMI host for XMLRPC test
+    When the server stops mocking an IPMI host

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -430,7 +430,7 @@ When(/^I install the GPG key of the test packages repository on the PXE boot min
 end
 
 When(/^the server starts mocking an IPMI host$/) do
-  ["ipmisim1.emu", "lan.conf", "fake_ipmi_host.sh"].each do |file|
+  ['ipmisim1.emu', 'lan.conf', 'fake_ipmi_host.sh'].each do |file|
     source = File.dirname(__FILE__) + '/../upload_files/' + file
     dest = "/etc/ipmi/" + file
     return_code = file_inject($server, source, dest)
@@ -447,7 +447,7 @@ end
 
 When(/^the server starts mocking a Redfish host$/) do
   $server.run("mkdir -p /root/Redfish-Mockup-Server/")
-  ["redfishMockupServer.py", "rfSsdpServer.py"].each do |file|
+  ['redfishMockupServer.py', 'rfSsdpServer.py'].each do |file|
     source = File.dirname(__FILE__) + '/../upload_files/Redfish-Mockup-Server/' + file
     dest = "/root/Redfish-Mockup-Server/" + file
     return_code = file_inject($server, source, dest)
@@ -455,8 +455,11 @@ When(/^the server starts mocking a Redfish host$/) do
   end
   $server.run("curl --output DSP2043_2019.1.zip https://www.dmtf.org/sites/default/files/standards/documents/DSP2043_2019.1.zip")
   $server.run("unzip DSP2043_2019.1.zip")
-  cmd = "/usr/bin/python3 /root/Redfish-Mockup-Server/redfishMockupServer.py -H #{$server.full_hostname} -p 8443 -S " \
-        "-D /root/DSP2043_2019.1/public-catfish/ --ssl --cert /etc/pki/tls/certs/spacewalk.crt --key /etc/pki/tls/private/spacewalk.key < /dev/null > /dev/null 2>&1 &"
+  cmd = "/usr/bin/python3 /root/Redfish-Mockup-Server/redfishMockupServer.py " \
+        "-H #{$server.full_hostname} -p 8443 " \
+        "-S -D /root/DSP2043_2019.1/public-catfish/ " \
+        "--ssl --cert /etc/pki/tls/certs/spacewalk.crt --key /etc/pki/tls/private/spacewalk.key " \
+        "< /dev/null > /dev/null 2>&1 &"
   $server.run(cmd)
 end
 
@@ -493,19 +496,15 @@ When(/^I uninstall the managed file from "([^"]*)"$/) do |host|
   node.run('rm /tmp/test_user_defined_state')
 end
 
-Then(/^the cobbler report contains "([^"]*)" for system "([^"]*)"$/) do |arg1, host|
+Then(/^the cobbler report should contain "([^"]*)" for "([^"]*)"$/) do |arg1, host|
   node = get_target(host)
   output = sshcmd("cobbler system report --name #{node.full_hostname}:1", ignore_err: true)[:stdout]
-  raise "Not found: #{output}" unless output.include?(arg1)
+  raise "Not found:\n#{output}" unless output.include?(arg1)
 end
 
-Then(/^the cobbler report contains "([^"]*)" for cobbler system "([^"]*)"$/) do |arg1, system|
-  output = sshcmd("cobbler system report --name #{system}:1", ignore_err: true)[:stdout]
-  raise "Not found: #{output}" unless output.include?(arg1)
-end
-
-Then(/^the cobbler report contains "([^"]*)"$/) do |arg1|
-  step %(the cobbler report contains "#{arg1}" for system "sle_client")
+Then(/^the cobbler report should contain "([^"]*)" for cobbler system name "([^"]*)"$/) do |arg1, name|
+  output = sshcmd("cobbler system report --name #{name}", ignore_err: true)[:stdout]
+  raise "Not found:\n#{output}" unless output.include?(arg1)
 end
 
 Then(/^I clean the search index on the server$/) do

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -446,8 +446,13 @@ When(/^the server stops mocking an IPMI host$/) do
 end
 
 When(/^the server starts mocking a Redfish host$/) do
-  $server.run("zypper --non-interactive install git python3-greenlet python3-gevent python3-grequests python-grequests")
-  $server.run("git clone -b mock-simple-actions https://github.com/mcalmer/Redfish-Mockup-Server.git")
+  $server.run("mkdir -p /root/Redfish-Mockup-Server/")
+  ["redfishMockupServer.py", "rfSsdpServer.py"].each do |file|
+    source = File.dirname(__FILE__) + '/../upload_files/Redfish-Mockup-Server/' + file
+    dest = "/root/Redfish-Mockup-Server/" + file
+    return_code = file_inject($server, source, dest)
+    raise 'File injection failed' unless return_code.zero?
+  end
   $server.run("curl --output DSP2043_2019.1.zip https://www.dmtf.org/sites/default/files/standards/documents/DSP2043_2019.1.zip")
   $server.run("unzip DSP2043_2019.1.zip")
   cmd = "/usr/bin/python3 /root/Redfish-Mockup-Server/redfishMockupServer.py -H #{$server.full_hostname} -p 8443 -S " \

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -951,7 +951,6 @@ When(/^I select the next maintenance window$/) do
   find(:xpath, "//select[@id='maintenance-window-select']/option", match: :first).select_option
 end
 
-When(/^I enter "([^"]*)" as the redfish server address$/) do |host|
-  node = get_target(host)
-  step %(I enter "#{node.full_hostname}:8443" as "powerAddress")
+When(/^I enter the server hostname as the redfish server address$/) do
+  step %(I enter "#{$server.full_hostname}:8443" as "powerAddress")
 end

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -950,3 +950,8 @@ end
 When(/^I select the next maintenance window$/) do
   find(:xpath, "//select[@id='maintenance-window-select']/option", match: :first).select_option
 end
+
+When(/^I enter "([^"]*)" as the redfish server address$/) do |host|
+  node = get_target(host)
+  step %(I enter "#{node.full_hostname}:8443" as "powerAddress")
+end

--- a/testsuite/features/upload_files/Redfish-Mockup-Server/AUTHORS.md
+++ b/testsuite/features/upload_files/Redfish-Mockup-Server/AUTHORS.md
@@ -1,0 +1,7 @@
+# Original Contribution:
+
+* Paul Vancil - Dell Inc. -- Dell Extreme Scale Infrastructure (ESI) Architecture Team
+
+# Other Key Contributions:
+
+* Abhiram Ampabathina - Dell Inc. -- Dell Extreme Scale Infrastructure (ESI) Software Developer

--- a/testsuite/features/upload_files/Redfish-Mockup-Server/CHANGELOG.md
+++ b/testsuite/features/upload_files/Redfish-Mockup-Server/CHANGELOG.md
@@ -1,0 +1,66 @@
+# Change Log
+
+## [1.1.0] - 2020-05-09
+- Added ability to POST to actions shown in the mockups so that a 2xx code is returned
+
+## [1.0.9] - 2020-03-21
+- Made corrections to the spelling of SSDP in the code
+
+## [1.0.8] - 2019-03-26
+- Fixed some issues with command line argument handling
+- Fixed SSDP functionality
+- Fixed issues with pathing on Windows
+
+## [1.0.7] - 2019-02-08
+- Fixed handling of PATCH/POST/PUT requests that do not contain a JSON body
+- Added support for the SubmitTestMetricReport action
+
+## [1.0.6] - 2018-10-12
+- Added SSDP support within the service
+- Added support for $top and $skip
+
+## [1.0.5] - 2018-09-07
+- Added Transfer-Encoding to the list of HTTP headers to not use
+
+## [1.0.4] - 2018-07-16
+- Fixed behavior of how the URIs are managed when issuing DELETE to members of a collection
+- Added Location header in the service response when creating new resources
+
+## [1.0.3] - 2018-05-25
+- Added logic to remove the @Redfish.Copyright statement from payloads
+
+## [1.0.2] - 2018-05-11
+- Corrected Submit Test Event Action; it now verifies all required parameters are given, and the format of the Event it sends matches the Event schema
+
+## [1.0.1] - 2018-04-13
+- Made fixes for how POST and DELETE are handled with the Event Destination Collection
+- Made fixes to the Submit Test Event action
+
+## [1.0.0] - 2018-02-02
+- Added support for HTTPS
+- Added support for using "short" mockups (ones without the /redfish/v1 resource)
+- Added support for submitting test events
+- Added support for PATCH and PUT
+
+## [0.9.7] - 2017-03-10
+- Added support to delay time from json for GET and HEAD API  
+    - "-T" option to include delay in time. If option not specified, there is no delay in response. Checks for time.json.
+    - "-t <time_in_seconds>" to specify default time if time.json is not present.
+- Added Response Header support for GETs: 
+    - Checks for headers.json and includes required headers from it.
+    - Certain headers like ("Connection", "Keep-Alive", "Content-Length") are not included in GET request.
+- Added Support for HEAD Method
+    - Checks for headers.json and includes required headers from it.
+- Changed TestETag option to "-E" from "-T" 
+
+## [0.9.3] - 2016-12-05
+- -t <responseTime> option to specify a response delay for responses--to simulate a real system better
+- fixed bug where GET /redfish/v1/$metadata was not being returned
+
+## [0.9.2] - 2016-09-07
+- added flush to server prints so that buffered stdout on cygwin would work
+- added -T option to enable returning fake etags on certain APIs -instead of always doing it
+- added -D <dir>  option  where <dir> is the abs or relative path to the mockup.  if no -D option, then CWD is assumed
+
+## [0.9.1] - 2016-09-06
+- Initial Public Release

--- a/testsuite/features/upload_files/Redfish-Mockup-Server/LICENSE.md
+++ b/testsuite/features/upload_files/Redfish-Mockup-Server/LICENSE.md
@@ -1,0 +1,57 @@
+The Distributed Management Task Force (DMTF) grants rights under copyright in
+this software on the terms of the BSD 3-Clause License as set forth below; no
+other rights are granted by DMTF. This software might be subject to other rights
+(such as patent rights) of other parties.
+
+
+### Copyrights.
+
+Copyright (c) 2016, Contributing Member(s) of Distributed Management Task Force,
+Inc.. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+* Redistributions in binary form must reproduce the above copyright notice, this
+list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+* Neither the name of the Distributed Management Task Force (DMTF) nor the names
+of its contributors may be used to endorse or promote products derived from this
+software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+### Patents.
+
+This software may be subject to third party patent rights, including provisional
+patent rights ("patent rights"). DMTF makes no representations to users of the
+standard as to the existence of such rights, and is not responsible to
+recognize, disclose, or identify any or all such third party patent right,
+owners or claimants, nor for any incomplete or inaccurate identification or
+disclosure of such rights, owners or claimants. DMTF shall have no liability to
+any party, in any manner or circumstance, under any legal theory whatsoever, for
+failure to recognize, disclose, or identify any such third party patent rights,
+or for such party's reliance on the software or incorporation thereof in its
+product, protocols or testing procedures. DMTF shall have no liability to any
+party using such software, whether such use is foreseeable or not, nor to any
+patent owner or claimant, and shall have no liability or responsibility for
+costs or losses incurred if software is withdrawn or modified after publication,
+and shall be indemnified and held harmless by any party using the software from
+any and all claims of infringement by a patent owner for such use.
+
+DMTF Members that contributed to this software source code might have made
+patent licensing commitments in connection with their participation in the DMTF.
+For details, see http://dmtf.org/sites/default/files/patent-10-18-01.pdf and
+http://www.dmtf.org/about/policies/disclosures.

--- a/testsuite/features/upload_files/Redfish-Mockup-Server/README.md
+++ b/testsuite/features/upload_files/Redfish-Mockup-Server/README.md
@@ -1,0 +1,107 @@
+Copyright 2016-2020 DMTF. All rights reserved.
+
+# The Redfish mockup server
+
+The Redfish mockup server, `redfishMockupServer.py`, runs at a specified IP address and port or at the default IP address and port, `127.0.0.1:8000`, and serves Redfish GET, PATCH, POST, and DELETE requests and implements the `SubmitTestEvent` action.
+
+## Prerequisite software
+
+* **Python 3.4 or later**
+
+    If Python 3.4 or later is not already installed, [download Python](https://www.python.org/downloads/ "https://www.python.org/downloads/") for your operating system.
+
+    Verify the Python installation:
+        
+    ```
+    $ python --version
+    ```
+
+    Ensure that Python 3.4 or later is in your path.
+* **[pip](https://pip.pypa.io/en/stable/ "https://pip.pypa.io/en/stable/")**
+
+    If pip is not installed, install it:
+    
+    ```
+    $ curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
+    $ python get-pip.py
+    ```
+
+    Upgrade pip and then verify the pip installation:
+    
+    ```
+    $ pip install --upgrade pip
+    $ pip --version
+    ```
+* **Required Python packages**
+
+    Install the required Python packages:
+
+    ```
+    $ pip install -r requirements.txt
+    ```
+
+## Start the server
+
+To start the server, run `redfishMockupServer.py` from your command shell:
+
+```
+$ python redfishMockupServer.py -D <DIR>
+```
+
+where
+
+* `-D <DIR>` is the absolute or relative path to the mockup directory from the current working directory (CWD). Default is the CWD.
+
+For example, if you copy `redfishMockupServer.py` to the `MyServerMockup9` folder, run this command to start the server on port 8001:
+
+```
+$ python redfishMockupServer.py -p 8001 -D ./MyServerMockup9
+```
+
+> **Note:** You can run the server can accept *tall* or *short* mockups:
+> 
+> | Form  | Description | Note |
+> | :---  | :---        | :--- |
+> | Tall  | The version resource, `/redfish`, is at the top of the mockup directory structure. | Default is tall form. |
+> | Short | The service root resource, `/redfish/v1/`, is at the top of the mockup directory structure. | Use the `-S` option to run in short form. |
+
+## redfishMockupServer usage
+
+```
+usage: redfishMockupServer.py [-h] [-H HOST] [-p PORT] [-D DIR] [-E] [-X]
+                              [-t TIME] [-T] [-s] [--cert CERT] [--key KEY]
+                              [-S] [-P]
+
+Serve a static Redfish mockup.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -H HOST, --host HOST, --Host HOST
+                        hostname or IP address (default 127.0.0.1)
+  -p PORT, --port PORT, --Port PORT
+                        host port (default 8000)
+  -D DIR, --dir DIR, --Dir DIR
+                        path to mockup dir (may be relative to CWD)
+  -E, --test-etag, --TestEtag
+                        (unimplemented) etag testing
+  -X, --headers         load headers from headers.json files in mockup
+  -t TIME, --time TIME  delay in seconds added to responses (float or int)
+  -T                    delay response based on times in time.json files in
+                        mockup
+  -s, --ssl             place server in SSL (HTTPS) mode; requires a cert and
+                        key
+  --cert CERT           the certificate for SSL
+  --key KEY             the key for SSL
+  -S, --short-form, --shortForm
+                        apply short form to mockup (omit filepath /redfish/v1)
+  -P, --ssdp            make mockup SSDP discoverable
+```
+
+## Release process
+
+To create a release of the Redfish mockup server:
+
+1. Update `CHANGELOG.md` with the list of changes since the last release.
+2. Update the `tool_version` variable in `redfishMockupServer.py` to the new version of the tool.
+3. Push changes to GitHub.
+4. Create a release in GitHub.

--- a/testsuite/features/upload_files/Redfish-Mockup-Server/redfishMockupServer.py
+++ b/testsuite/features/upload_files/Redfish-Mockup-Server/redfishMockupServer.py
@@ -12,8 +12,11 @@ import collections
 import json
 import threading
 import datetime
-
-import grequests
+try:
+    import grequests
+except:
+    # only used for EventService and TelemetryService
+    pass
 
 import os
 import ssl

--- a/testsuite/features/upload_files/Redfish-Mockup-Server/redfishMockupServer.py
+++ b/testsuite/features/upload_files/Redfish-Mockup-Server/redfishMockupServer.py
@@ -1,0 +1,789 @@
+# Copyright Notice:
+# Copyright 2016-2019 DMTF. All rights reserved.
+# License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/Redfish-Mockup-Server/blob/master/LICENSE.md
+
+# redfishMockupServer.py
+# tested and developed Python 3.4
+
+import sys
+import argparse
+import time
+import collections
+import json
+import threading
+import datetime
+
+import grequests
+
+import os
+import ssl
+import logging
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import urlparse, urlunparse, parse_qs
+from rfSsdpServer import RfSSDPServer
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+ch = logging.StreamHandler(sys.stdout)
+ch.setLevel(logging.INFO)
+logger.addHandler(ch)
+
+tool_version = "1.1.0"
+
+dont_send = ["connection", "keep-alive", "content-length", "transfer-encoding"]
+
+
+def dict_merge(dct, merge_dct):
+        """
+        https://gist.github.com/angstwad/bf22d1822c38a92ec0a9 modified
+        Recursive dict merge. Inspired by :meth:``dict.update()``, instead of
+        updating only top-level keys, dict_merge recurses down into dicts nested
+        to an arbitrary depth, updating keys. The ``merge_dct`` is merged into
+        ``dct``.
+        :param dct: dict onto which the merge is executed
+        :param merge_dct: dct merged into dct
+        :return: None
+        """
+        for k in merge_dct:
+            if (k in dct and isinstance(dct[k], dict) and isinstance(merge_dct[k], collections.Mapping)):
+                dict_merge(dct[k], merge_dct[k])
+            else:
+                dct[k] = merge_dct[k]
+
+
+def clean_path(path, isShort):
+    """clean_path
+
+    :param path:
+    :param isShort:
+    """
+    path = path.strip('/')
+    path = path.split('?', 1)[0]
+    path = path.split('#', 1)[0]
+    if isShort:
+        path = path.replace('redfish/v1', '').strip('/')
+    return path
+
+
+class RfMockupServer(BaseHTTPRequestHandler):
+        '''
+        returns index.json file for Serverthe specified URL
+        '''
+        patchedLinks = dict()
+
+        def construct_path(self, path, filename):
+            """construct_path
+
+            :param path:
+            :param filename:
+            """
+            apath = self.server.mockDir
+            rpath = clean_path(path, self.server.shortForm)
+            return '/'.join([ apath, rpath, filename ]) if filename not in ['', None] else '/'.join([ apath, rpath ])
+
+        def get_cached_link(self, path):
+            """get_cached_link
+
+            :param path:
+            """
+            if path not in self.patchedLinks:
+                if os.path.isfile(path):
+                    with open(path) as f:
+                        jsonData = json.load(f)
+                        f.close()
+                else:
+                    jsonData = None
+            else:
+                jsonData = self.patchedLinks[path]
+            return jsonData is not None and jsonData != '404', jsonData
+
+        def try_to_sleep(self, method, path):
+            """try_to_sleep
+
+            :param method:
+            :param path:
+            """
+            if self.server.timefromJson:
+                responseTime = self.getResponseTime(method, path)
+                try:
+                    time.sleep(float(responseTime))
+                except ValueError as e:
+                    logger.info("Time is not a float value. Sleeping with default response time")
+                    time.sleep(float(self.server.responseTime))
+            else:
+                time.sleep(float(self.server.responseTime))
+
+        def send_header_file(self, fpath):
+            """send_header_file
+
+            :param fpath:
+            """
+            with open(fpath) as headers_data:
+                d = json.load(headers_data)
+            if isinstance(d.get("GET"), dict):
+                for k, v in d["GET"].items():
+                    if k.lower() not in dont_send:
+                        self.send_header(k, v)
+
+        def add_new_member(self, payload, data_received):
+            members = payload.get('Members')
+            n = 1
+            newpath_id = data_received.get('Id', 'Member')
+            newpath = '/'.join([ self.path, newpath_id ])
+            while newpath in [m.get('@odata.id') for m in members]:
+                n = n + 1
+                newpath_id = data_received.get('Id', 'Member') + str(n)
+                newpath = '/'.join([ self.path, newpath_id ])
+            members.append({'@odata.id': newpath})
+
+            payload['Members'] = members
+            payload['Members@odata.count'] = len(members)
+            return newpath
+
+        def handle_eventing(self, data_received):
+            sub_path = self.construct_path('/redfish/v1/EventService/Subscriptions', 'index.json')
+            success, sub_payload = self.get_cached_link(sub_path)
+            logger.info(sub_path)
+            if not success:
+                # Eventing not supported
+                return (404)
+            else:
+                # Check if all of the parameters are given
+                if ( ('EventType' not in data_received) or ('EventId' not in data_received) or
+                     ('EventTimestamp' not in data_received) or ('Severity' not in data_received) or
+                     ('Message' not in data_received) or ('MessageId' not in data_received) or
+                     ('MessageArgs' not in data_received) or ('OriginOfCondition' not in data_received) ):
+                    return (400)
+                else:
+                    # Need to reformat to make Origin Of Condition a proper link
+                    origin_of_cond = data_received['OriginOfCondition']
+                    data_received['OriginOfCondition'] = {}
+                    data_received['OriginOfCondition']['@odata.id'] = origin_of_cond
+                    event_payload = {}
+                    event_payload['@odata.type'] = '#Event.v1_2_1.Event'
+                    event_payload['Name'] = 'Test Event'
+                    event_payload['Id'] = str(self.event_id)
+                    event_payload['Events'] = []
+                    event_payload['Events'].append(data_received)
+
+                    # Go through each subscriber
+                    events = []
+                    for member in sub_payload.get('Members', []):
+                        entry = member['@odata.id']
+                        entrypath = self.construct_path(entry, 'index.json')
+                        success, subscription = self.get_cached_link(entrypath)
+                        if not success:
+                            logger.info('No such resource')
+                        else:
+                            # Sanity check the subscription for required properties
+                            if ('Destination' in subscription) and ('EventTypes' in subscription):
+                                logger.info(('Target', subscription['Destination']))
+                                logger.info((data_received['EventType'], subscription['EventTypes']))
+
+                                # If the EventType in the request is one of interest to the subscriber, build an event payload
+                                if data_received['EventType'] in subscription['EventTypes']:
+                                    http_headers = {}
+                                    http_headers['Content-Type'] = 'application/json'
+
+                                    event_payload['Context'] = subscription.get('Context', 'Default Context')
+
+                                    # Send the event
+                                    events.append(grequests.post(subscription['Destination'], timeout=20, data=json.dumps(event_payload), headers=http_headers))
+                                else:
+                                    logger.info('event not in eventtypes')
+                    try:
+                        threading.Thread(target=grequests.map, args=(events,)).start()
+                    except Exception as e:
+                        logger.info('post error {}'.format( str(e)))
+                    return (204)
+                    self.event_id = self.event_id + 1
+
+        def handle_telemetry(self, data_received):
+            sub_path = self.construct_path('/redfish/v1/EventService/Subscriptions', 'index.json')
+            success, sub_payload = self.get_cached_link(sub_path)
+            logger.info(sub_path)
+            if not success:
+                # Eventing not supported
+                return (404)
+            else:
+                # Check if all of the parameters are given
+                if (('MetricReportName' in data_received) and ('MetricReportValues' in data_received)) or\
+                   (('MetricReportName' in data_received) and ('GeneratedMetricReportValues' in data_received)) or\
+                        (('MetricName' in data_received) and ('MetricValues' in data_received)):
+                    # If the EventType in the request is one of interest to the subscriber, build an event payload
+                    expected_keys = ['MetricId', 'MetricValue', 'Timestamp', 'MetricProperty', 'MetricDefinition']
+                    other_keys = ['MetricProperty']
+                    my_name = data_received.get('MetricName',
+                            data_received.get('MetricReportName'))
+                    my_data = data_received.get('MetricValues',
+                            data_received.get('MetricReportValues',
+                            data_received.get('GeneratedMetricReportValues')))
+                    event_payload = {}
+                    value_list = []
+                    # event_payload['@Redfish.Copyright'] = 'Copyright 2014-2016 Distributed Management Task Force, Inc. (DMTF). All rights reserved.'
+                    event_payload['@odata.context'] = '/redfish/v1/$metadata#MetricReport.MetricReport'
+                    event_payload['@odata.type'] = '#MetricReport.v1_0_0.MetricReport'
+                    event_payload['@odata.id'] = '/redfish/v1/TelemetryService/MetricReports/' + my_name
+                    event_payload['Id'] = my_name
+                    event_payload['Name'] = my_name
+                    event_payload['MetricReportDefinition'] = {
+                        "@odata.id": "/redfish/v1/TelemetryService/MetricReportDefinitions/" + my_name}
+                    now = datetime.datetime.now()
+                    event_payload['Timestamp'] = now.strftime('%Y-%m-%dT%H:%M:%S') + ('-%02d' % (now.microsecond / 10000))
+
+                    for tup in my_data:
+                        if all(x in tup for x in expected_keys):
+                            # uncomment for stricter payload check
+                            # ex: if all(x in expected_keys + other_keys for x in tup):
+                            value_list.append(tup)
+                    event_payload['MetricValues'] = value_list
+                    logger.info(event_payload)
+
+                    # construct path "mockdir/path/to/resource/<filename>"
+                    event_fpath = self.construct_path(event_payload['@odata.id'], 'index.json')
+                    self.patchedLinks[event_fpath] = event_payload
+
+                    report_path = '/redfish/v1/TelemetryService/MetricReports'
+                    report_path = self.construct_path(report_path, 'index.json')
+                    success, collection_payload = self.get_cached_link(report_path)
+
+                    if not success:
+                        collection_payload = {'Members': []}
+                        collection_payload['@odata.context'] = '/redfish/v1/$metadata#MetricReportCollection.MetricReportCollection'
+                        collection_payload['@odata.type'] = '#MetricReportCollection.v1_0_0.MetricReportCollection'
+                        collection_payload['@odata.id'] = '/redfish/v1/TelemetryService/MetricReports'
+                        collection_payload['Name'] = 'MetricReports'
+
+                    if event_payload['@odata.id'] not in [member.get('@odata.id') for member in collection_payload['Members']]:
+                        collection_payload['Members'].append({'@odata.id': event_payload['@odata.id']})
+                    collection_payload['Members@odata.count'] = len(collection_payload['Members'])
+                    self.patchedLinks[report_path] = collection_payload
+
+                    # Go through each subscriber
+                    events = []
+                    for member in sub_payload.get('Members', []):
+                        entry = member['@odata.id']
+                        entrypath = self.construct_path(entry, 'index.json')
+                        success, subscription = self.get_cached_link(entrypath)
+                        if not success:
+                            logger.info('No such resource')
+                        else:
+                            # Sanity check the subscription for required properties
+                            if ('Destination' in subscription) and ('EventTypes' in subscription):
+                                logger.info(('Target', subscription['Destination']))
+                                http_headers = {}
+                                http_headers['Content-Type'] = 'application/json'
+
+                                # Send the event
+                                events.append(grequests.post(subscription['Destination'], timeout=20, data=json.dumps(event_payload), headers=http_headers))
+                            else:
+                                logger.info('event not in eventtypes')
+                    try:
+                        threading.Thread(target=grequests.map, args=(events,)).start()
+                    except Exception as e:
+                        logger.info('post error {}'.format( str(e)))
+                    self.event_id = self.event_id + 1
+                    return (204)
+                else:
+                    return (400)
+
+        server_version = "RedfishMockupHTTPD_v" + tool_version
+        event_id = 1
+
+        # Headers only request
+        def do_HEAD(self):
+            """do_HEAD"""
+            logger.info("Headers: ")
+            logger.info(self.server.headers)
+
+            # construct path "mockdir/path/to/resource/headers.json"
+            fpath = self.construct_path(self.path, 'index.json')
+            fpath_xml = self.construct_path(self.path, 'index.xml')
+            fpath_headers = self.construct_path(self.path, 'headers.json')
+            fpath_direct = self.construct_path(self.path, '')
+
+            # If bool headers is true and headers.json exists...
+            # else, send normal headers for given resource
+            if self.server.headers and (os.path.isfile(fpath_headers)):
+                self.send_response(200)
+                self.send_header_file(fpath_headers)
+            elif (self.server.headers is False) or (os.path.isfile(fpath_headers) is False):
+                if self.get_cached_link(fpath)[0]:
+                    self.send_response(200)
+                    self.send_header("Content-Type", "application/json")
+                    self.send_header("OData-Version", "4.0")
+                elif os.path.isfile(fpath_xml) or os.path.isfile(fpath_direct):
+                    if os.path.isfile(fpath_xml):
+                        file_extension = 'xml'
+                    elif os.path.isfile(fpath_direct):
+                        filename, file_extension = os.path.splitext(fpath_direct)
+                        file_extension = file_extension.strip('.')
+                    self.send_response(200)
+                    self.send_header("Content-Type", "application/" + file_extension + ";odata.metadata=minimal;charset=utf-8")
+                    self.send_header("OData-Version", "4.0")
+                else:
+                    self.send_response(404)
+            else:
+                self.send_response(404)
+            self.end_headers()
+
+        def do_GET(self):
+            """do_GET"""
+            # for GETs always dump the request headers to the console
+            # there is no request data, so no need to dump that
+            logger.info(("GET", self.path))
+            logger.info("   GET: Headers: {}".format(self.headers))
+
+            # construct path "mockdir/path/to/resource/<filename>"
+            fpath = self.construct_path(self.path, 'index.json')
+            fpath_xml = self.construct_path(self.path, 'index.xml')
+            fpath_headers = self.construct_path(self.path, 'headers.json')
+            fpath_direct = self.construct_path(self.path, '')
+
+            success, payload = self.get_cached_link(fpath)
+
+            scheme, netloc, path, params, query, fragment = urlparse(self.path)
+            query_pieces = parse_qs(query, keep_blank_values=True)
+
+            self.try_to_sleep('GET', self.path)
+
+            # handle resource paths that don't exist for shortForm
+            # '/' and '/redfish'
+            if(self.path == '/' and self.server.shortForm):
+                self.send_response(404)
+                self.end_headers()
+
+            elif(self.path in ['/redfish', '/redfish/'] and self.server.shortForm):
+                self.send_response(200)
+                if self.server.headers and (os.path.isfile(fpath_headers)):
+                    self.send_header_file(fpath_headers)
+                else:
+                    self.send_header("Content-Type", "application/json")
+                    self.send_header("OData-Version", "4.0")
+                self.end_headers()
+                self.wfile.write(json.dumps({'v1': '/redfish/v1'}, indent=4).encode())
+
+            # if this location exists in memory or as file
+            elif(success):
+                # if headers exist... send information (except for chunk info)
+                # end headers here (always end headers after response)
+                self.send_response(200)
+                if self.server.headers and (os.path.isfile(fpath_headers)):
+                    self.send_header_file(fpath_headers)
+                else:
+                    self.send_header("Content-Type", "application/json")
+                    self.send_header("OData-Version", "4.0")
+                self.end_headers()
+
+                # Strip the @Redfish.Copyright property
+                output_data = payload
+                output_data.pop("@Redfish.Copyright", None)
+
+                # Query evaluate
+                if output_data.get('Members') is not None:
+                    my_members = output_data['Members']
+                    top_count = int(query_pieces.get('$top', [str(len(my_members))])[0])
+                    top_skip = int(query_pieces.get('$skip', ['0'])[0])
+
+                    my_members = my_members[top_skip:]
+                    if top_count < len(my_members):
+                        my_members = my_members[:top_count]
+                        query_out = {'$skip': top_skip + top_count, '$top': top_count}
+                        query_string = '&'.join(['{}={}'.format(k, v) for k, v in query_out.items()])
+                        output_data['Members@odata.nextLink'] = urlunparse(('', '', path, '', query_string, ''))
+                    else:
+                        pass
+
+                    output_data['Members'] = my_members
+                    pass
+
+                encoded_data = json.dumps(output_data, sort_keys=True, indent=4, separators=(",", ": ")).encode()
+                self.wfile.write(encoded_data)
+
+            # if XML...
+            elif(os.path.isfile(fpath_xml) or os.path.isfile(fpath_direct)):
+                if os.path.isfile(fpath_xml):
+                    file_extension = 'xml'
+                    f = open(fpath_xml, "r")
+                elif os.path.isfile(fpath_direct):
+                    filename, file_extension = os.path.splitext(fpath_direct)
+                    file_extension = file_extension.strip('.')
+                    f = open(fpath_direct, "r")
+                self.send_response(200)
+                self.send_header("Content-Type", "application/" + file_extension + ";odata.metadata=minimal;charset=utf-8")
+                self.send_header("OData-Version", "4.0")
+                self.end_headers()
+                self.wfile.write(f.read().encode())
+                f.close()
+            else:
+                self.send_response(404)
+                self.end_headers()
+
+        def do_PATCH(self):
+                logger.info("   PATCH: Headers: {}".format(self.headers))
+                self.try_to_sleep('PATCH', self.path)
+
+                if("content-length" in self.headers):
+                    lenn = int(self.headers["content-length"])
+                    try:
+                        data_received = json.loads(self.rfile.read(lenn).decode("utf-8"))
+                    except ValueError:
+                        print ('Decoding JSON has failed, sending 400')
+                        data_received = None
+
+                if data_received:
+                    logger.info("   PATCH: Data: {}".format(data_received))
+
+                    # construct path "mockdir/path/to/resource/<filename>"
+                    fpath = self.construct_path(self.path, 'index.json')
+                    success, payload = self.get_cached_link(fpath)
+
+                    # check if resource exists, otherwise 404
+                    #   if it's a file, open it, if its in memory, grab it
+                    #   405 if Collection
+                    #   204 if patch success
+                    #   404 if payload DNE
+                    #   400 if no patch payload
+                    # end headers
+                    if success:
+                        # If this is a collection, throw a 405
+                        if payload.get('Members') is not None:
+                            self.send_response(405)
+                        else:
+                            # After getting resource, merge the data.
+                            logger.info(self.headers.get('content-type'))
+                            logger.info(data_received)
+                            logger.info(payload)
+                            dict_merge(payload, data_received)
+                            logger.info(payload)
+                            # put into self.patchedLinks
+                            self.patchedLinks[fpath] = payload
+                            self.send_response(204)
+                    else:
+                        self.send_response(404)
+                else:
+                    self.send_response(400)
+
+                self.end_headers()
+
+        def do_PUT(self):
+                logger.info("   PUT: Headers: {}".format(self.headers))
+                self.try_to_sleep('PUT', self.path)
+
+                if("content-length" in self.headers):
+                    lenn = int(self.headers["content-length"])
+                    try:
+                        data_received = json.loads(self.rfile.read(lenn).decode("utf-8"))
+                    except ValueError:
+                        print ('Decoding JSON has failed, sending 400')
+                        data_received = None
+                    logger.info("   PUT: Data: {}".format(data_received))
+
+                # we don't support this service
+                #   405
+                # end headers
+                self.send_response(405)
+
+                self.end_headers()
+
+        def do_POST(self):
+                logger.info("   POST: Headers: {}".format(self.headers))
+                if("content-length" in self.headers):
+                    lenn = int(self.headers["content-length"])
+                    if lenn == 0:
+                        data_received = {}
+                    else:
+                        try:
+                            data_received = json.loads(self.rfile.read(lenn).decode("utf-8"))
+                        except ValueError:
+                            print ('Decoding JSON has failed, sending 400')
+                            data_received = None
+                else:
+                    self.send_response(411)
+                    self.end_headers()
+                    return
+
+                self.try_to_sleep('POST', self.path)
+
+                if data_received is not None:
+                    logger.info("   POST: Data: {}".format(data_received))
+                    # construct path "mockdir/path/to/resource/<filename>"
+                    fpath = self.construct_path(self.path, 'index.json')
+                    success, payload = self.get_cached_link(fpath)
+
+                    # don't bother if this item exists, otherwise, check if its an action or a file
+                    # if file
+                    #   405 if not Collection
+                    #   204 if success
+                    #   404 if no file present
+                    if success:
+                        if payload.get('Members') is None:
+                            self.send_response(405)
+                        else:
+                            logger.info(data_received)
+                            logger.info(type(data_received))
+                            # with members, form unique ID
+                            #   must NOT exist in Members
+                            #   add ID to members, change count
+                            #   store as necessary in self.patchedLinks
+
+                            newpath = self.add_new_member(payload, data_received)
+
+                            newfpath = self.construct_path(newpath, 'index.json')
+
+                            logger.info(newfpath)
+
+                            self.patchedLinks[newfpath] = data_received
+                            self.patchedLinks[fpath] = payload
+                            self.send_response(204)
+                            self.send_header("Location", newpath)
+                            self.send_header("Content-Length", "0")
+                            self.end_headers()
+
+                    # Actions framework
+                    else:
+                        # SubmitTestEvent
+                        if 'EventService/Actions/EventService.SubmitTestEvent' in self.path:
+                            r_code = self.handle_eventing(data_received)
+                            self.send_response(r_code)
+                        # SubmitTestMetricReport
+                        elif 'TelemetryService/Actions/TelemetryService.SubmitTestMetricReport' in self.path:
+                            r_code = self.handle_telemetry(data_received)
+                            self.send_response(r_code)
+                        # All other actions (no data checking or response data)
+                        elif '/Actions/' in self.path:
+                            fpath = self.construct_path(self.path.split('/Actions/', 1)[0], 'index.json')
+                            success, payload = self.get_cached_link(fpath)
+                            if success:
+                                action_found = False
+                                try:
+                                    for action in payload['Actions']:
+                                        if action == 'Oem':
+                                            for oem_action in payload['Actions'][action]:
+                                                if payload['Actions'][action][oem_action]['target'] == self.path:
+                                                    action_found = True
+                                        else:
+                                            if payload['Actions'][action]['target'] == self.path:
+                                                action_found = True
+                                                if 'ResetType' in data_received and 'ResetType@Redfish.AllowableValues' in payload['Actions'][action]:
+                                                    if data_received['ResetType'] not in payload['Actions'][action]['ResetType@Redfish.AllowableValues']:
+                                                        action_found = False
+                                                        continue
+
+                                                    if data_received['ResetType'] in ('ForceOff', 'GracefulShutdown'):
+                                                        payload['PowerState'] = "Off"
+                                                    elif data_received['ResetType'] in ('On', 'ForceOn'):
+                                                        payload['PowerState'] = "On"
+                                                    elif data_received['ResetType'] in ('ForceRestart', 'GracefulRestart'):
+                                                        if payload['PowerState'] == "On":
+                                                            payload['PowerState'] == "Off"
+                                                        else:
+                                                            payload['PowerState'] == "On"
+                                                self.patchedLinks[fpath] = payload
+                                except:
+                                    pass
+                                if action_found:
+                                    self.send_response(204)
+                                else:
+                                    self.send_response(404)
+                            else:
+                                self.send_response(404)
+                        # Not found
+                        else:
+                            self.send_response(404)
+                else:
+                    self.send_response(400)
+                self.end_headers()
+
+        def do_DELETE(self):
+                """
+                Delete a resource
+                """
+                logger.info("DELETE: Headers: {}".format(self.headers))
+                self.try_to_sleep('DELETE', self.path)
+
+                fpath = self.construct_path(self.path, 'index.json')
+                ppath = '/'.join(self.path.split('/')[:-1])
+                parent_path = self.construct_path(ppath, 'index.json')
+                success, payload = self.get_cached_link(fpath)
+
+                # 404 if file doesn't exist
+                # 204 if success, override payload with 404
+                #   modify payload to exclude expected URI, subtract count
+                # 405 if parent is not Collection
+                # end headers
+                if success:
+                    success, parentData = self.get_cached_link(parent_path)
+                    if success and parentData.get('Members') is not None:
+                        self.patchedLinks[fpath] = '404'
+                        parentData['Members'] = [x for x in parentData['Members'] if not x['@odata.id'] == self.path]
+                        parentData['Members@odata.count'] = len(parentData['Members'])
+                        self.patchedLinks[parent_path] = parentData
+                        self.send_response(204)
+                    else:
+                        self.send_response(405)
+                else:
+                    self.send_response(404)
+
+                self.end_headers()
+
+        # Response time calculation Algorithm
+        def getResponseTime(self, method, path):
+                fpath = self.construct_path(path, 'time.json')
+                success, item = self.get_cached_link(path)
+                if not any(x in method for x in ("GET", "HEAD", "POST", "PATCH", "DELETE")):
+                    logger.info("Not a valid method")
+                    return (0)
+
+                if(os.path.isfile(fpath)):
+                    with open(fpath) as time_data:
+                        d = json.load(time_data)
+                        time_str = method + "_Time"
+                        if time_str in d:
+                            try:
+                                float(d[time_str])
+                            except Exception as e:
+                                logger.info(
+                                    "Time in the json file, not a float/int value. Reading the default time.")
+                                return (self.server.responseTime)
+                            return (float(d[time_str]))
+                else:
+                    logger.info(('response time:', self.server.responseTime))
+                    return (self.server.responseTime)
+
+
+def main():
+
+        logger.info("Redfish Mockup Server, version {}".format(tool_version))
+
+        parser = argparse.ArgumentParser(description='Serve a static Redfish mockup.')
+        parser.add_argument('-H', '--host', '--Host', default='127.0.0.1',
+                            help='hostname or IP address (default 127.0.0.1)')
+        parser.add_argument('-p', '--port', '--Port', default=8000, type=int,
+                            help='host port (default 8000)')
+        parser.add_argument('-D', '--dir', '--Dir',
+                            help='path to mockup dir (may be relative to CWD)')
+        parser.add_argument('-E', '--test-etag', '--TestEtag',
+                            action='store_true',
+                            help='(unimplemented) etag testing')
+        parser.add_argument('-X', '--headers', action='store_true',
+                            help='load headers from headers.json files in mockup')
+        parser.add_argument('-t', '--time', default=0,
+                            help='delay in seconds added to responses (float or int)')
+        parser.add_argument('-T', action='store_true',
+                            help='delay response based on times in time.json files in mockup')
+        parser.add_argument('-s', '--ssl', action='store_true',
+                            help='place server in SSL (HTTPS) mode; requires a cert and key')
+        parser.add_argument('--cert', help='the certificate for SSL')
+        parser.add_argument('--key', help='the key for SSL')
+        parser.add_argument('-S', '--short-form', '--shortForm', action='store_true',
+                            help='apply short form to mockup (omit filepath /redfish/v1)')
+        parser.add_argument('-P', '--ssdp', action='store_true',
+                            help='make mockup SSDP discoverable')
+
+        args = parser.parse_args()
+        hostname = args.host
+        port = args.port
+        mockDirPath = args.dir
+        testEtagFlag = args.test_etag
+        headers = args.headers
+        responseTime = args.time
+        timefromJson = args.T
+        sslMode = args.ssl
+        sslCert = args.cert
+        sslKey = args.key
+        shortForm = args.short_form
+        ssdpStart = args.ssdp
+
+        logger.info('Hostname: {}'.format(hostname))
+        logger.info('Port: {}'.format(port))
+        logger.info("Mockup directory path specified: {}".format(mockDirPath))
+        logger.info("Response time: {} seconds".format(responseTime))
+
+        # check if mockup path was specified.  If not, use current working directory
+        if mockDirPath is None:
+            mockDirPath = os.getcwd()
+
+        # create the full path to the top directory holding the Mockup
+        mockDir = os.path.realpath(mockDirPath)  # creates real full path including path for CWD to the -D<mockDir> dir path
+        logger.info("Serving Mockup in absolute path: {}".format(mockDir))
+
+        # check that we have a valid tall mockup--with /redfish in mockDir before proceeding
+        if not shortForm:
+            slashRedfishDir = os.path.join(mockDir, "redfish")
+            if os.path.isdir(slashRedfishDir) is not True:
+                logger.info("ERROR: Invalid Mockup Directory--no /redfish directory at top. Aborting")
+                sys.stderr.flush()
+                sys.exit(1)
+
+        if shortForm:
+            if os.path.isdir(mockDir) is not True or os.path.isfile(os.path.join(mockDir, "index.json")) is not True:
+                logger.info("ERROR: Invalid Mockup Directory--dir or index.json does not exist")
+                sys.stderr.flush()
+                sys.exit(1)
+
+        myServer = HTTPServer((hostname, port), RfMockupServer)
+
+        if sslMode:
+            logger.info("Using SSL with certfile: {}".format(sslCert))
+            myServer.socket = ssl.wrap_socket(myServer.socket, certfile=sslCert, keyfile=sslKey, server_side=True)
+
+        # save the test flag, and real path to the mockup dir for the handler to use
+        myServer.mockDir = mockDir
+        myServer.testEtagFlag = testEtagFlag
+        myServer.headers = headers
+        myServer.timefromJson = timefromJson
+        myServer.shortForm = shortForm
+        try:
+            myServer.responseTime = float(responseTime)
+        except ValueError as e:
+            logger.info("Enter an integer or float value")
+            sys.exit(2)
+        # myServer.me="HELLO"
+
+        mySSDP = None
+        if ssdpStart:
+            from gevent import monkey
+            monkey.patch_all()
+            # construct path "mockdir/path/to/resource/<filename>"
+            path, filename, jsonData = '/redfish/v1', 'index.json', None
+            apath = myServer.mockDir
+            rpath = clean_path(path, myServer.shortForm)
+            fpath = os.path.join(apath, rpath, filename) if filename not in ['', None] else os.path.join(apath, rpath)
+            if os.path.isfile(fpath):
+                with open(fpath) as f:
+                    jsonData = json.load(f)
+                    f.close()
+            else:
+                jsonData = None
+            protocol = '{}://'.format('https' if sslMode else 'http')
+            mySSDP = RfSSDPServer(jsonData, '{}{}:{}{}'.format(protocol, hostname, port, '/redfish/v1'), hostname)
+
+        logger.info("Serving Redfish mockup on port: {}".format(port))
+        try:
+            if mySSDP is not None:
+                t2 = threading.Thread(target=mySSDP.start)
+                t2.daemon = True
+                t2.start()
+            logger.info('running Server...')
+            myServer.serve_forever()
+
+        except KeyboardInterrupt:
+            pass
+
+        myServer.server_close()
+        logger.info("Shutting down http server")
+
+
+# the below is only executed if the program is run as a script
+if __name__ == "__main__":
+        main()
+
+'''
+TODO:
+1. add -L option to load json and dump output from python dictionary
+2. add authentication support -- note that in redfish some api don't require auth
+3. add https support
+
+
+'''

--- a/testsuite/features/upload_files/Redfish-Mockup-Server/requirements.txt
+++ b/testsuite/features/upload_files/Redfish-Mockup-Server/requirements.txt
@@ -1,0 +1,2 @@
+requests
+grequests

--- a/testsuite/features/upload_files/Redfish-Mockup-Server/rfSsdpServer.py
+++ b/testsuite/features/upload_files/Redfish-Mockup-Server/rfSsdpServer.py
@@ -1,0 +1,153 @@
+# Copyright Notice:
+# Copyright 2016-2019 DMTF. All rights reserved.
+# License: BSD 3-Clause License. For full text see link: https://github.com/DMTF/python-redfish-library/blob/master/LICENSE.md
+
+" Lib to receive ssdp packets "
+
+import socket
+import sys
+import logging
+
+# based on https://github.com/ZeWaren/python-upnp-ssdp-example/blob/master/lib/ssdp.py
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+ch = logging.StreamHandler(sys.stdout)
+ch.setLevel(logging.INFO)
+logger.addHandler(ch)
+
+class RfSSDPServer():
+    def addSearchTarget(self, target):
+        self.searchtargets.append(target)
+
+    def __init__(self, root, location, ip=None, port=1900, timeout=5):
+        """__init__
+
+        Initialize an SSDP server
+
+        :param root: /redfish/v1 payload
+        :param location: http location of server
+        :param ip: address to bind to (IPV4 only?)
+        :param port: port for server to exist on, default port 1900
+        :param timeout: int for packet timeout
+        """
+        ip = ip if ip is not None else "0.0.0.0"
+        self.searchtargets = ['ssdp:all', 'upnp:rootdevice', 'urn:dmtf-org:service:redfish-rest:1']
+        self.ip, self.port = ip, port
+        self.timeout = timeout
+
+        # setup payload info
+        self.location = location
+        self.UUID = root.get('UUID', 'nouuid')
+        self.cachecontrol = 1800
+        myVersion = root.get('RedfishVersion', '1.0.0')
+        self.major, self.minor, self.errata = tuple(myVersion.split('.'))
+        self.addSearchTarget('urn:dmtf-org:service:redfish-rest:1:{}'.format(self.minor))
+
+        # initiate multicast socket
+        # rf-spec:
+        #   must use TTL 2
+        #   must use port 1900
+        #   optional MSEARCH messages: Notify, Alive, Shutdown
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, 2)  # ttl 2
+        sock.settimeout(timeout)
+
+        # To receive a multicast datagram, it is necessary to advise the kernel which
+        # multicast groups we are interested in and ask the kernel to "join" those multicast groups
+        # Depending on the underlying hardware, multicast datagrams are filtered
+        # by the hardware or by the IP layer (and, in some cases, by both)
+        # Only those with a destination group previously registered via a join are accepted
+        # (ref: https://www.tldp.org/HOWTO/Multicast-HOWTO-2.html)
+        # adding this membership, causes other applications to receive data from the kernel as well
+        addr = socket.inet_aton('239.255.255.250')  # multicast address
+        interface = socket.inet_aton(self.ip)
+        sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, addr + interface)
+
+        sock.bind((self.ip, self.port))
+        """
+        Redfish Service Search Target (ST): "urn:dmtf-org:service:redfish-rest:1"
+        For ssdp, "ssdp:all".
+        For UPnP compatibility, the managed device should respond to MSEARCH
+        queries searching for Search Target (ST) of "upnp:rootdevice"
+        """
+        self.sock = sock
+        logger.info('SSDP Server Created')
+
+    def start(self):
+        logger.info('SSDP Server Running...')
+        countTimeout = pcount = 0
+        while True:
+            try:
+                if countTimeout % 5 == 0:
+                    logger.info('Ssdp Poll... {} pings'.format(pcount))
+                    pcount = 0
+                    countTimeout = 1
+                data, addr = self.sock.recvfrom(1024)
+                pcount += 1
+                self.check(data, addr)
+            except socket.timeout:
+                countTimeout += 1
+                continue
+            except Exception as e:
+                logger.info('error occurred ' + str(e))
+                pass
+        pass
+
+    def check(self, data, addr):
+        logger.info('SSDP Packet received from {}'.format(addr))
+        decoded = data.decode().replace('\r', '').split('\n')
+        msgtype, decoded = decoded[0], decoded[1:]
+        decodeddict = {x.split(':',  1)[0].upper(): x.split(':', 1)[1].strip(' ') for x in decoded if x != ''}
+
+        if 'M-SEARCH' in msgtype:
+            st = decodeddict.get('ST')
+            if st in self.searchtargets:
+                response = ['HTTP/1.1 200 OK',
+                            'CACHE-CONTROL: max-age={}'.format(self.cachecontrol),
+                            'ST:urn:dmtf-org:service:redfish-rest:1:{}'.format(self.minor),
+                            'USN:uuid:{}::urn:dmtf-org:service:redfish-rest:1:{}'.format(self.UUID, self.minor),
+                            'AL:{}'.format(self.location),
+                            'EXT:']
+
+                response.extend(('', ''))
+                response = '\r\n'.join(response)
+
+                self.sock.sendto(response.encode(), addr)
+                logger.info('SSDP Packet sent to {}'.format(addr))
+
+
+"""
+example return payload
+HTTP/1.1 200 OK
+CACHE-CONTROL:max-age=<seconds, at least 1800>
+ST:urn:dmtf-org:service:redfish-rest:1:<minor>
+USN:uuid:<UUID of Manager>::urn:dmtf-org:service:redfish-rest:1:<minor>
+AL:<URL of Redfish service root>
+EXT:
+"""
+
+
+def main(argv=None):
+    """
+    main program
+    """
+    hostname = "127.0.0.1"
+    location = "http://127.0.0.1"
+
+    server = RfSSDPServer({}, '{}:{}{}'.format(location, '8000', '/redfish/v1'), hostname)
+
+    try:
+        server.start()
+    except KeyboardInterrupt:
+        pass
+
+    # on exit will auto close sockets
+    logger.info("Shutting down Ssdp server")
+    sys.stdout.flush()
+
+
+# the below is only executed if the program is run as a script
+if __name__ == "__main__":
+    sys.exit(main())

--- a/testsuite/run_sets/secondary.yml
+++ b/testsuite/run_sets/secondary.yml
@@ -34,6 +34,7 @@
 - features/secondary/min_empty_system_profiles.feature
 - features/secondary/srv_power_management.feature
 - features/secondary/srv_xmlrpc_power_management.feature
+- features/secondary/srv_power_management_redfish.feature
 - features/secondary/trad_need_reboot.feature
 - features/secondary/trad_action_chain.feature
 - features/secondary/min_action_chain.feature


### PR DESCRIPTION
## What does this PR change?

Enable Redfish power management by default

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- Documentation issue was created: https://github.com/SUSE/spacewalk/issues/12767

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/9866


- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
