### PR TITLE
Bugfix: renaming autoinstall distro didn't change the name of the Cobbler distro (bsc#1175876)

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerDistroHelper.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerDistroHelper.java
@@ -108,6 +108,7 @@ public class CobblerDistroHelper {
      public void updateDistroFromTree(Distro distro, KickstartableTree tree) {
         Map<String, String> ksmeta = createKsMetadataFromTree(tree);
 
+        distro.setName(CobblerCommand.makeCobblerName(tree));
         distro.setInitrd(tree.getInitrdPath());
         distro.setKernel(tree.getKernelPath());
         distro.setBreed(tree.getInstallType().getCobblerBreed());

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- renaming autoinstall distro didn't change the name of the Cobbler distro (bsc#1175876)
 - Fix: reinspecting a container image (bsc#1177092)
 - add power management xmlrpc api
 - allow nightly ISS sync to also cover custom channels


### PR DESCRIPTION
## What does this PR change?

Renaming an autoinstall distro changed the name in the db but not in Cobbler (bsc#1175876) resulting in an error at autoinstall time:
```
trace:java.lang.NullPointerException
        at com.suse.manager.webui.services.SaltServerActionService.autoinstallInitAction(SaltServerActionService.java:1699)
        at com.suse.manager.webui.services.SaltServerActionService.callsForAction(SaltServerActionService.java:381)
        at com.suse.manager.webui.services.SaltServerActionService.executeForRegularMinions(SaltServerActionService.java:484)
        at com.suse.manager.webui.services.SaltServerActionService.execute(SaltServerActionService.java:470)
        at com.redhat.rhn.taskomatic.task.MinionActionExecutor.execute(MinionActionExecutor.java:125)
        at com.redhat.rhn.taskomatic.task.RhnJavaJob.execute(RhnJavaJob.java:88)
        at com.redhat.rhn.taskomatic.TaskoJob.execute(TaskoJob.java:199)
        at org.quartz.core.JobRunShell.run(JobRunShell.java:202)
        at org.quartz.simpl.SimpleThreadPool$WorkerThread.run(SimpleThreadPool.java:573)
```

This happens because the autoinstall action tries to lookup the distro in the db but using the name used by Cobbler. The name of the distro was changed in the db but not in Cobbler therefore a null is returned.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bugfix

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/12668
https://github.com/SUSE/spacewalk/issues/12317

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
