### PR TITLE
Disable flush

### DIFF
--- a/susemanager/rhn-conf/rhn_server_susemanager.conf
+++ b/susemanager/rhn-conf/rhn_server_susemanager.conf
@@ -29,8 +29,8 @@ token_lifetime = 525600
 # automatically deploy tokens once they are refreshed
 token_refresh_auto_deploy = true
 
-# when re-generating bootstrap repos remove old content first
-bootstrap_repo_flush = 1
+# when enabled re-generating bootstrap repos remove old content first
+bootstrap_repo_flush = 0
 
 # data module used for mgr-create-bootstrap-repo
 bootstrap_repo_datamodule = mgr_bootstrap_data

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- create bootstrap repo should not flush by default (bsc#1175843)
 - improve detection of base channels for products (bsc#1177478)
 - Add LTSS PIDs for SLE12SP1, SLE12SP2, SLE12SP3 and SLE12SP4 to
   the bootstrap definitions as some packages from LTSS are


### PR DESCRIPTION
## What does this PR change?

Using auto flush slow down the repo building process a lot. In addition it removed special crafted bootstrap repos.
The downsides of `flush = on` are bigger than with `flush = off` so we decided to change the default.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- https://github.com/uyuni-project/uyuni-docs/pull/597

- [x] **DONE**

## Test coverage
- Already covered

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/12712

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
