### PR TITLE
 Fix: reinspecting a container image (bsc#1177092)

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/ImageBuildController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/ImageBuildController.java
@@ -48,12 +48,6 @@ import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.manager.rhnpackage.PackageManager;
 import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
-
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParseException;
-import com.google.gson.JsonPrimitive;
 import com.suse.manager.gatherer.GathererRunner;
 import com.suse.manager.kubernetes.KubernetesManager;
 import com.suse.manager.model.gatherer.GathererModule;
@@ -64,10 +58,15 @@ import com.suse.manager.webui.controllers.utils.ImagesUtil;
 import com.suse.manager.webui.errors.NotFoundException;
 import com.suse.manager.webui.utils.MinionActionUtils;
 import com.suse.manager.webui.utils.ViewHelper;
-import com.suse.manager.webui.utils.gson.ScheduledRequestJson;
 import com.suse.manager.webui.utils.gson.ImageInfoJson;
 import com.suse.manager.webui.utils.gson.ResultJson;
+import com.suse.manager.webui.utils.gson.ScheduledRequestJson;
 
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
 import org.apache.log4j.Logger;
@@ -442,6 +441,7 @@ public class ImageBuildController {
         try {
             inspectRequest = new GsonBuilder()
                     .registerTypeAdapter(LocalDateTime.class, new LocalDateTimeISOAdapter())
+                    .registerTypeAdapterFactory(new OptionalTypeAdapterFactory())
                     .create().fromJson(req.body(), InspectRequest.class);
         }
         catch (JsonParseException e) {
@@ -486,6 +486,7 @@ public class ImageBuildController {
         try {
             data = new GsonBuilder()
                     .registerTypeAdapter(LocalDateTime.class, new LocalDateTimeISOAdapter())
+                    .registerTypeAdapterFactory(new OptionalTypeAdapterFactory())
                     .create().fromJson(req.body(), ImportRequest.class);
         }
         catch (JsonParseException e) {

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix: reinspecting a container image (bsc#1177092)
 - add power management xmlrpc api
 - allow nightly ISS sync to also cover custom channels
 - Include build id in boot image local path


### PR DESCRIPTION
## What does this PR change?

Fix: reinspecting a container image (bsc#1177092)
Regression of uyuni-project/uyuni#2108

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: bugfix

- [X] **DONE**

## Test coverage
- No tests: bugfix

- [X] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/12604

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
