### PR TITLE
uyuni configuration state cucumber test bug

### DIFF
--- a/testsuite/features/upload_files/salt/teardown_users_configuration.sls
+++ b/testsuite/features/upload_files/salt/teardown_users_configuration.sls
@@ -24,6 +24,7 @@ user2_absent:
 
 delete_obsolete_activation_key:
     uyuni.activation_key_absent:
-        - name: 1-my-suse
+        - name: my-suse
         - org_admin_user: admin
         - org_admin_password: admin
+


### PR DESCRIPTION
Signed-off-by: Ricardo Mateus <rmateus@suse.com>

## What does this PR change?

correct the teardown state apply on cucumber test which had the wrong activation key name.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: correct cucumber test

- [X] **DONE**

## Test coverage
- No tests: correct cucumber test

- [X] **DONE**

## Links

Fixes #
Tracks # Backport to manager 4.1

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
