### PR TITLE
Fix docker registry URL at Provo

### DIFF
--- a/testsuite/features/profiles/Makefile
+++ b/testsuite/features/profiles/Makefile
@@ -9,8 +9,8 @@ REGISTRY_PLACEHOLDER_AUTH   = portus.mgr.suse.de:5000
 ENVIRONMENTS                = internal_nue internal_prv
 REG_REPLACEMENT_NUE_NOAUTH  = registry.mgr.suse.de
 REG_REPLACEMENT_NUE_AUTH    = portus.mgr.suse.de:5000
-REG_REPLACEMENT_PRV_NOAUTH  = minima-mirror.prv.suse.net
-REG_REPLACEMENT_PRV_AUTH    = minima-mirror.prv.suse.net:5000
+REG_REPLACEMENT_PRV_NOAUTH  = minima-mirror.mgr.prv.suse.net
+REG_REPLACEMENT_PRV_AUTH    = minima-mirror.mgr.prv.suse.net:5000
 
 update: $(ENVIRONMENTS)
 

--- a/testsuite/features/profiles/internal_prv/Docker/Dockerfile
+++ b/testsuite/features/profiles/internal_prv/Docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM minima-mirror.prv.suse.net/toaster-sles12sp3-products
+FROM minima-mirror.mgr.prv.suse.net/toaster-sles12sp3-products
 MAINTAINER Admin User "noemail@example.com"
 
 ARG repo

--- a/testsuite/features/profiles/internal_prv/Docker/authprofile/Dockerfile
+++ b/testsuite/features/profiles/internal_prv/Docker/authprofile/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION               1.0.0
 
-FROM minima-mirror.prv.suse.net:5000/cucutest/suma-head-testsuite
+FROM minima-mirror.mgr.prv.suse.net:5000/cucutest/suma-head-testsuite
 MAINTAINER Michael Calmer "mc@suse.com"
 
 ARG repo

--- a/testsuite/features/profiles/internal_prv/Docker/serverhost/Dockerfile
+++ b/testsuite/features/profiles/internal_prv/Docker/serverhost/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION               1.0.0
 
-FROM minima-mirror.prv.suse.net/suma-head-testsuite
+FROM minima-mirror.mgr.prv.suse.net/suma-head-testsuite
 MAINTAINER Michael Calmer "mc@suse.com"
 
 ARG repo


### PR DESCRIPTION
## What does this PR change?
Update the Docker profile used at Provo to use the new network: minima-mirror.mgr.prv.suse.net

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)
