### PR TITLE
Run the checkstyle workflow on all PRs

### DIFF
--- a/.github/workflows/java-checkstyle.yml
+++ b/.github/workflows/java-checkstyle.yml
@@ -1,6 +1,11 @@
 name: Java checkstyle
 
 on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'java/**.java' 
   pull_request:
     paths:
       - 'java/**.java'

--- a/.github/workflows/java-checkstyle.yml
+++ b/.github/workflows/java-checkstyle.yml
@@ -1,11 +1,7 @@
 name: Java checkstyle
 
 on:
-  # Limit this workflow to push events on the master branch, encrypted secrets
-  # cannot currently be used from actions triggered by PRs created from a fork.
-  push:
-    branches:
-      - master
+  pull_request:
     paths:
       - 'java/**.java'
 


### PR DESCRIPTION
## What does this PR change?

This patch reverts commit 4552dc2b5cb62071e29aa6756e61c8a2f424055e: As `obs-to-maven` does no longer rely on `osc`, we can go back to run this workflow for each PR, and it should even work for PRs created from forks. Additionally it would run after changes to `*.java` files are pushed to master, i.e. after a PR is merged that contains Java code.

If this proves to be working fine it should be a full replacement of the Jenkins checkstyle job that could then be disabled in a subsequent step.

## GUI diff

No difference.

- [X] **DONE**

## Documentation

- No documentation needed, only CI is affected.

- [X] **DONE**

## Test coverage

- No tests needed, only CI is affected.

- [X] **DONE**

## Links

No links for this PR.

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below).

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
