### PR TITLE
salt-secrets-config: make check more robust (bsc#1177435)

### DIFF
--- a/spacewalk/admin/salt-secrets-config.py
+++ b/spacewalk/admin/salt-secrets-config.py
@@ -54,7 +54,7 @@ if not os.path.isdir("/etc/salt/pki/api"):
     os.chown("/etc/salt/pki/api", pwd.getpwnam("salt").pw_uid, grp.getgrnam("salt").gr_gid)
     os.chmod("/etc/salt/pki/api", 0o750)
 
-if (not os.path.isfile("/etc/salt/pki/api/salt-api.crt")) or (not os.path.isfile("/etc/salt/pki/api/salt-api.crt")):
+if (not all([os.path.isfile(f) for f in ["/etc/salt/pki/api/salt-api.crt", "/etc/pki/trust/anchors/salt-api.crt", "/etc/salt/pki/api/salt-api.key"]])):
     os.system("openssl req -newkey rsa:4096 -x509 -sha256 -days 3650 -nodes -out /etc/salt/pki/api/salt-api.crt -keyout /etc/salt/pki/api/salt-api.key -subj '/CN=localhost'")
     os.chown("/etc/salt/pki/api/salt-api.crt", pwd.getpwnam("salt").pw_uid, grp.getgrnam("salt").gr_gid)
     os.chmod("/etc/salt/pki/api/salt-api.crt", 0o600)

--- a/spacewalk/admin/spacewalk-admin.changes
+++ b/spacewalk/admin/spacewalk-admin.changes
@@ -1,3 +1,5 @@
+- prevent javax.net.ssl.SSLHandshakeException after upgrading from
+  SUSE Manager 3.2 (bsc#1177435)
 - show info message when applying schema upgrade
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

It prevents a stack trace when the Salt API certificate is removed from the trust anchors directory (which happens when migrating from 3.2 straight to 4.1)

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **we do not test migrations automatically**

- [x] **DONE**

## Links

Fixes https://bugzilla.suse.com/1177435
Tracks https://github.com/SUSE/spacewalk/pull/12729

- [x] **DONE**


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
