### PR TITLE
Prevent from unescaped special chars in the stdout

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -824,9 +824,9 @@ And(/^I register "([^*]*)" as traditional client with activation key "([^*]*)"$/
     node.run('yum install wget', true, 600, 'root')
   end
   command1 = "wget --no-check-certificate -O /usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT http://#{$server.ip}/pub/RHN-ORG-TRUSTED-SSL-CERT"
-  puts node.run(command1, true, 500, 'root')
+  puts node.run(command1, true, 500, 'root').to_s
   command2 = "rhnreg_ks --force --serverUrl=#{registration_url} --sslCACert=/usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT --activationkey=#{key}"
-  puts node.run(command2, true, 500, 'root')
+  puts node.run(command2, true, 500, 'root').to_s
 end
 
 When(/^I wait until onboarding is completed for "([^"]*)"$/) do |host|


### PR DESCRIPTION
## What does this PR change?
When the command output contains non-ascii Unicode characters and we
give to `puts` an array `arr = [cmd_output, cmd_ret_code]`, then
Cucumber might be not able to dump the json file.

Instead of arr use arr.to_s as `puts` argument (spacewalk#12739).
- testsuite/features/step_definitions/common_steps.rb:
Give to `puts` the string representation of the array.


## Links
https://github.com/SUSE/spacewalk/issues/12739
### Ports
- Manager-4.1: https://github.com/SUSE/spacewalk/pull/12784
- Manager-4.0: https://github.com/SUSE/spacewalk/pull/12783


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)
