### PR TITLE
Add Ubuntu 20.04 for QAM

### DIFF
--- a/testsuite/features/qam/add_custom_repositories/add_ubuntu2004_repositories.feature
+++ b/testsuite/features/qam/add_custom_repositories/add_ubuntu2004_repositories.feature
@@ -1,0 +1,91 @@
+# Copyright (c) 2020 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+@ubuntu2004_minion
+Feature: Adding the Ubuntu 20.04 distribution custom repositories
+
+  Scenario: Add a child channel for Ubuntu Focal main repositories
+    Given I am authorized as "admin" with password "admin"
+    When I follow the left menu "Software > Manage > Channels"
+    And I follow "Create Channel"
+    When I enter "Custom Channel for ubuntu-focal-main" as "Channel Name"
+    And I enter "ubuntu-focal-main" as "Channel Label"
+    And I select the parent channel for the "ubuntu2004_minion" from "Parent Channel"
+    And I enter "Custom channel" as "Channel Summary"
+    And I click on "Create Channel"
+    Then I should see a "Channel Custom Channel for ubuntu-focal-main created" text
+
+  Scenario: Add a child channel for Ubuntu Focal main updates repositories
+    Given I am authorized as "admin" with password "admin"
+    When I follow the left menu "Software > Manage > Channels"
+    And I follow "Create Channel"
+    When I enter "Custom Channel for ubuntu-focal-main-updates" as "Channel Name"
+    And I enter "ubuntu-focal-main-updates" as "Channel Label"
+    And I select the parent channel for the "ubuntu2004_minion" from "Parent Channel"
+    And I enter "Custom channel" as "Channel Summary"
+    And I click on "Create Channel"
+    Then I should see a "Channel Custom Channel for ubuntu-focal-main-updates created" text
+
+  Scenario: Add the Ubuntu Focal main repositories
+    Given I am authorized as "admin" with password "admin"
+    When I follow the left menu "Software > Manage > Repositories"
+    And I follow "Create Repository"
+    And I enter "ubuntu-focal-main" as "label"
+    And I enter "http://archive.ubuntu.com/ubuntu/dists/focal/main/binary-amd64/" as "url"
+    And I select "deb" from "contenttype"
+    And I click on "Create Repository"
+    Then I should see a "Repository created successfully" text
+    And I should see "metadataSigned" as checked
+
+  Scenario: Add the Ubuntu Focal main updates repositories
+    Given I am authorized as "admin" with password "admin"
+    When I follow the left menu "Software > Manage > Repositories"
+    And I follow "Create Repository"
+    And I enter "ubuntu-focal-main-updates" as "label"
+    And I enter "http://archive.ubuntu.com/ubuntu/dists/focal-updates/main/binary-amd64/" as "url"
+    And I select "deb" from "contenttype"
+    And I click on "Create Repository"
+    Then I should see a "Repository created successfully" text
+    And I should see "metadataSigned" as checked
+
+  Scenario: Add the repository to the custom channel for ubuntu-focal-main
+    Given I am authorized as "admin" with password "admin"
+    When I follow the left menu "Software > Manage > Channels"
+    And I follow "Custom Channel for ubuntu-focal-main"
+    And I follow "Repositories" in the content area
+    And I select the "ubuntu-focal-main" repo
+    And I click on "Save Repositories"
+    Then I should see a "repository information was successfully updated" text
+
+  Scenario: Add the repository to the custom channel for ubuntu-focal-main-updates
+    Given I am authorized as "admin" with password "admin"
+    When I follow the left menu "Software > Manage > Channels"
+    And I follow "Custom Channel for ubuntu-focal-main-updates"
+    And I follow "Repositories" in the content area
+    And I select the "ubuntu-focal-main-updates" repo
+    And I click on "Save Repositories"
+    Then I should see a "repository information was successfully updated" text
+
+  Scenario: Synchronize the repository in the custom channel for ubuntu-focal-main
+    Given I am authorized as "admin" with password "admin"
+    When I follow the left menu "Software > Manage > Channels"
+    And I follow "Custom Channel for ubuntu-focal-main"
+    And I follow "Repositories" in the content area
+    And I follow "Sync"
+    And I click on "Sync Now"
+    Then I should see a "Repository sync scheduled" text
+
+  Scenario: Synchronize the repository in the custom channel for ubuntu-focal-main-updates
+    Given I am authorized as "admin" with password "admin"
+    When I follow the left menu "Software > Manage > Channels"
+    And I follow "Custom Channel for ubuntu-focal-main-updates"
+    And I follow "Repositories" in the content area
+    And I follow "Sync"
+    And I click on "Sync Now"
+    Then I should see a "Repository sync scheduled" text
+
+  Scenario: The custom channel for ubuntu-focal-main has been synced
+    When I wait until the channel "ubuntu-focal-main" has been synced
+
+  Scenario: The custom channel for ubuntu-focal-main-updates has been synced
+    When I wait until the channel "ubuntu-focal-main-updates" has been synced

--- a/testsuite/features/qam/init_clients/ubuntu2004_minion.feature
+++ b/testsuite/features/qam/init_clients/ubuntu2004_minion.feature
@@ -1,0 +1,38 @@
+# Copyright (c) 2020 SUSE LLC
+# Licensed under the terms of the MIT license.
+#
+#  1) bootstrap a new Ubuntu minion
+#  2) subscribe it to a base channel for testing
+
+@ubuntu2004_minion
+Feature: Bootstrap a Ubuntu 20.04 minion and do some basic operations on it
+
+  Scenario: Bootstrap a Ubuntu 20.04 minion
+    Given I am authorized
+    When I go to the bootstrapping page
+    Then I should see a "Bootstrap Minions" text
+    And I enter the hostname of "ubuntu2004_minion" as "hostname"
+    And I enter "linux" as "password"
+    And I select "1-ubuntu2004_minion_key" from "activationKeys"
+    And I select the hostname of "proxy" from "proxies"
+    And I click on "Bootstrap"
+    Then I wait until I see "Successfully bootstrapped host!" text
+    And I wait until onboarding is completed for "ubuntu2004_minion"
+
+@proxy
+  Scenario: Check connection from Ubuntu 20.04 minion to proxy
+    Given I am on the Systems overview page of this "ubuntu2004_minion"
+    When I follow "Details" in the content area
+    And I follow "Connection" in the content area
+    Then I should see "proxy" short hostname
+
+@proxy
+  Scenario: Check registration on proxy of Ubuntu 20.04 minion
+    Given I am on the Systems overview page of this "proxy"
+    When I follow "Details" in the content area
+    And I follow "Proxy" in the content area
+    Then I should see "ubuntu2004_minion" hostname
+
+  Scenario: Check events history for failures on Ubuntu 20.04 minion
+    Given I am on the Systems overview page of this "ubuntu2004_minion"
+    Then I check for failed events on history event page

--- a/testsuite/features/qam/init_clients/ubuntu2004_ssh_minion.feature
+++ b/testsuite/features/qam/init_clients/ubuntu2004_ssh_minion.feature
@@ -1,0 +1,24 @@
+# Copyright (c) 2020 SUSE LLC
+# Licensed under the terms of the MIT license.
+#
+#  1) bootstrap a new Ubuntu minion via salt-ssh
+#  2) subscribe it to a base channel for testing
+
+@ubuntu2004_ssh_minion
+Feature: Bootstrap a SSH-managed Ubuntu 20.04 minion and do some basic operations on it
+
+  Scenario: Bootstrap a SSH-managed Ubuntu 20.04 minion
+    Given I am authorized
+    When I go to the bootstrapping page
+    Then I should see a "Bootstrap Minions" text
+    When I check "manageWithSSH"
+    And I select "1-ubuntu2004_ssh_minion_key" from "activationKeys"
+    And I enter the hostname of "ubuntu2004_ssh_minion" as "hostname"
+    And I enter "linux" as "password"
+    And I click on "Bootstrap"
+    Then I wait until I see "Successfully bootstrapped host!" text
+    And I wait until onboarding is completed for "ubuntu2004_ssh_minion"
+
+  Scenario: Check events history for failures on SSH-managed Ubuntu 20.04 minion
+    Given I am on the Systems overview page of this "ubuntu2004_ssh_minion"
+    Then I check for failed events on history event page

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -120,6 +120,8 @@ PACKAGE_BY_CLIENT = { 'ceos_minion' => 'ant',
                       'ubuntu1604_ssh_minion' => 'bison',
                       'ubuntu1804_minion' => 'bison',
                       'ubuntu1804_ssh_minion' => 'bison',
+                      'ubuntu2004_minion' => 'bison',
+                      'ubuntu2004_ssh_minion' => 'bison',
                       'sle11sp4_ssh_minion' => 'bison',
                       'sle11sp4_minion' => 'bison',
                       'sle11sp4_client' => 'bison',
@@ -160,7 +162,9 @@ CHANNEL_BY_CLIENT = { 'proxy' => 'SLES15-SP2-Pool',
                       'ubuntu1604_ssh_minion' => 'ubuntu-16.04-pool',
                       'ubuntu1604_minion' => 'ubuntu-16.04-pool',
                       'ubuntu1804_ssh_minion' => 'ubuntu-18.04-pool',
-                      'ubuntu1804_minion' => 'ubuntu-18.04-pool' }.freeze
+                      'ubuntu1804_minion' => 'ubuntu-18.04-pool',
+                      'ubuntu2004_ssh_minion' => 'ubuntu-20.04-pool',
+                      'ubuntu2004_minion' => 'ubuntu-20.04-pool' }.freeze
 
 PKGARCH_BY_CLIENT = { 'proxy' => 'x86_64',
                       'sle_client' => 'x86_64',
@@ -190,7 +194,9 @@ PKGARCH_BY_CLIENT = { 'proxy' => 'x86_64',
                       'ubuntu1604_ssh_minion' => 'x86_64',
                       'ubuntu1604_minion' => 'x86_64',
                       'ubuntu1804_ssh_minion' => 'x86_64',
-                      'ubuntu1804_minion' => 'x86_64' }.freeze
+                      'ubuntu1804_minion' => 'x86_64',
+                      'ubuntu2004_ssh_minion' => 'x86_64',
+                      'ubuntu2004_minion' => 'x86_64' }.freeze
 
 SPACEWALK_UTILS_RPMS = 'spacewalk-client-tools spacewalk-check spacewalk-client-setup'\
                        'mgr-daemon mgr-osad mgr-cfg-actions spacewalk-oscap scap-security-guide'.freeze

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -190,6 +190,14 @@ Before('@ubuntu1804_ssh_minion') do
   skip_this_scenario unless $ubuntu1804_ssh_minion
 end
 
+Before('@ubuntu2004_minion') do
+  skip_this_scenario unless $ubuntu2004_minion
+end
+
+Before('@ubuntu2004_ssh_minion') do
+  skip_this_scenario unless $ubuntu2004_ssh_minion
+end
+
 Before('@sle11sp4_ssh_minion') do
   skip_this_scenario unless $sle11sp4_ssh_minion
 end

--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -56,6 +56,8 @@ if $qam_test
   $ubuntu1604_ssh_minion = twopence_init("ssh:#{ENV['UBUNTU1604_SSHMINION']}") if ENV['UBUNTU1604_SSHMINION']
   $ubuntu1804_minion = twopence_init("ssh:#{ENV['UBUNTU1804_MINION']}") if ENV['UBUNTU1804_MINION']
   $ubuntu1804_ssh_minion = twopence_init("ssh:#{ENV['UBUNTU1804_SSHMINION']}") if ENV['UBUNTU1804_SSHMINION']
+  $ubuntu2004_minion = twopence_init("ssh:#{ENV['UBUNTU2004_MINION']}") if ENV['UBUNTU2004_MINION']
+  $ubuntu2004_ssh_minion = twopence_init("ssh:#{ENV['UBUNTU2004_SSHMINION']}") if ENV['UBUNTU2004_SSHMINION']
   # As we share core features for QAM and QA environments, we share also those vm twopence objects
   $minion = $sle12sp4_minion
   $ssh_minion = $sle12sp4_ssh_minion
@@ -70,6 +72,7 @@ if $qam_test
             $ceos7_minion, $ceos7_ssh_minion, $ceos7_client,
             $ubuntu1604_ssh_minion, $ubuntu1604_minion,
             $ubuntu1804_ssh_minion, $ubuntu1804_minion,
+            $ubuntu2004_ssh_minion, $ubuntu2004_minion,
             $client, $minion, $ceos_minion, $ubuntu_minion, $ssh_minion]
 else
   # Define twopence objects for QA environment
@@ -219,6 +222,8 @@ $node_by_host = { 'server'                => $server,
                   'ubuntu1604_ssh_minion' => $ubuntu1604_ssh_minion,
                   'ubuntu1804_minion'     => $ubuntu1804_minion,
                   'ubuntu1804_ssh_minion' => $ubuntu1804_ssh_minion,
+                  'ubuntu2004_minion'     => $ubuntu2004_minion,
+                  'ubuntu2004_ssh_minion' => $ubuntu2004_ssh_minion,
                   'sle11sp4_ssh_minion'   => $sle11sp4_ssh_minion,
                   'sle11sp4_minion'       => $sle11sp4_minion,
                   'sle11sp4_client'       => $sle11sp4_client,

--- a/testsuite/run_sets/qam_add_custom_repositories.yml
+++ b/testsuite/run_sets/qam_add_custom_repositories.yml
@@ -7,6 +7,7 @@
 
 - features/qam/add_custom_repositories/add_ubuntu1604_repositories.feature
 - features/qam/add_custom_repositories/add_ubuntu1804_repositories.feature
+- features/qam/add_custom_repositories/add_ubuntu2004_repositories.feature
 - features/qam/add_custom_repositories/add_ceos6_repositories.feature
 - features/qam/add_custom_repositories/add_ceos7_repositories.feature
 - features/qam/add_custom_repositories/add_ceos8_repositories.feature

--- a/testsuite/run_sets/qam_init_clients.yml
+++ b/testsuite/run_sets/qam_init_clients.yml
@@ -31,5 +31,7 @@
 - features/qam/init_clients/ubuntu1604_ssh_minion.feature
 - features/qam/init_clients/ubuntu1804_minion.feature
 - features/qam/init_clients/ubuntu1804_ssh_minion.feature
+- features/qam/init_clients/ubuntu2004_minion.feature
+- features/qam/init_clients/ubuntu2004_ssh_minion.feature
 
 ## QAM Init Clients END ###


### PR DESCRIPTION
## What does this PR change?

This PR adds running of Ubuntu 20.04 to QAM test suite.


## Links

Fixes SUSE/spacewalk#12765.

Ports:
* 4.1: SUSE/spacewalk#12787
* 4.0: SUSE/spacewalk#12788
* 3.2: no QAM

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
