### PR TITLE
Enforce to create bootstrap repo

### DIFF
--- a/susemanager/src/mgr-create-bootstrap-repo
+++ b/susemanager/src/mgr-create-bootstrap-repo
@@ -63,6 +63,37 @@ SELECT label
    AND org_id IS NOT NULL
 """;
 
+_sql_find_pkgs_all = """
+SELECT distinct
+       pkg.id AS id,
+       pn.name || '-' || evr_t_as_vre_simple(pevr.evr) || '.' || pa.label AS nvrea,
+       pa.label AS arch,
+       pkg.path
+   FROM rhnPackage pkg
+   JOIN rhnPackageArch pa ON pkg.package_arch_id = pa.id
+   JOIN rhnPackageName pn ON pkg.name_id = pn.id
+   JOIN rhnPackageEVR pevr ON pkg.evr_id = pevr.id
+   JOIN rhnChannelPackage CP ON CP.package_id = pkg.id
+   JOIN rhnChannel c ON CP.channel_id = c.id
+   JOIN (
+          SELECT I_C.*
+            FROM suseProducts I_SP
+            JOIN suseProductChannel I_PC ON I_SP.id = I_PC.product_id
+            JOIN rhnChannel I_C ON I_PC.channel_id = I_C.id
+           WHERE  I_SP.product_id IN ( %s )
+           UNION
+           SELECT *
+             FROM rhnChannel
+            WHERE org_id IS NOT NULL
+              AND parent_channel IN (
+                                     SELECT pc.id
+                                       FROM rhnChannel pc
+                                      WHERE pc.label = :parentchannel)
+        ) spc ON spc.id = c.id
+  WHERE pn.name = :pkgname
+ORDER BY pkg.id
+"""
+
 _sql_find_pkgs = """
 SELECT distinct
         pkg.id AS id,
@@ -250,6 +281,8 @@ def cli():
                       help='when used in conjuction with --create, deletes the target repository before creating it (default)')
     parser.add_option('--no-flush', action='store_true', dest='noflush',
                       help='when used in conjuction with --create, prevent deletion of the target repository before creating it')
+    parser.add_option('--force', action='store_true', dest='force',
+                      help='Force creation even when not all required channels are available')
     parser.add_option('', '--with-custom-channels', action='store_true', dest='usecustomchannels',
                       help='Take custom channels into account when searching for newest package versions')
     parser.add_option('', '--with-parent-channel', action="store", dest='parentchannel',
@@ -334,7 +367,7 @@ def find_custom_parent_channel_labels():
     return [x['label'] for x in rhnSQL.fetchall_dict(h) or []]
 
 
-def list_labels(mgr_bootstrap_data, do_print=True):
+def list_labels(mgr_bootstrap_data, force=False, do_print=True):
     """
     Create list of labels and return a structure of them for the menu.
 
@@ -346,7 +379,8 @@ def list_labels(mgr_bootstrap_data, do_print=True):
     label_index = 1
     for label in sorted(mgr_bootstrap_data.DATA.keys()):
         if ('PDID' in mgr_bootstrap_data.DATA[label] and mgr_bootstrap_data.DATA[label]['PDID'] and
-            all(elem in synced_products for elem in mgr_bootstrap_data.DATA[label]['PDID'])):
+            (all(elem in synced_products for elem in mgr_bootstrap_data.DATA[label]['PDID']) or
+                (force and any(elem in synced_products for elem in mgr_bootstrap_data.DATA[label]['PDID'])))):
 
             if do_print:
                 print("{0}. {1}".format(label_index, label))
@@ -442,8 +476,10 @@ def create_repo(label, options, mgr_bootstrap_data, additional=[]):
     else:
         log("Creating bootstrap repo for {0}".format(label))
 
-    if pdids:
+    if pdids and not options.force:
         h = rhnSQL.prepare(rhnSQL.Statement(_sql_find_pkgs % (pdids)))
+    elif pdids and options.force:
+        h = rhnSQL.prepare(rhnSQL.Statement(_sql_find_pkgs_all % (pdids)))
     else:
         h = rhnSQL.prepare(rhnSQL.Statement(_sql_find_pkgs_custom ))
     packagelist = mgr_bootstrap_data.DATA[label]['PKGLIST']
@@ -660,7 +696,7 @@ def main():
     if opts.auto:
         r = generate_all(opts, mgr_bootstrap_data, additional=args)
     elif opts.interactive:
-        label_map = list_labels(mgr_bootstrap_data)
+        label_map = list_labels(mgr_bootstrap_data, force=opts.force)
         if not label_map:
             log("No products available")
             sys.exit(0)
@@ -689,7 +725,7 @@ def main():
                     os.rename(destdir, destdirold)
         r = create_repo(elabel, opts, mgr_bootstrap_data, additional=args)
     elif opts.list:
-        list_labels(mgr_bootstrap_data)
+        list_labels(mgr_bootstrap_data, force=opts.force)
     elif opts.create:
         if opts.create not in mgr_bootstrap_data.DATA:
             log_error("'%s' not found" % opts.create)

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,5 @@
+- add --force to mgr-create-bootstrap-repo to enforce generation
+  even when some products are not synchronized
 - Bootstrap repository definitions for CentOS7 and 8 for ppc64le
 - create bootstrap repo should not flush by default (bsc#1175843)
 - improve detection of base channels for products (bsc#1177478)


### PR DESCRIPTION
## What does this PR change?

Add --force to mgr-create-bootstrap-repo to enforce generation even when some products are not synchronized.

Case:

When a Product goes EOL, SUSE provide for some Long Term Support Service (LTSS) a customer need to pay for.
Not every customer has it.

But some packages are maintained in service pack independent repositories and the required dependencies may
only be available in the LTSS repositories.

Problem:

- We need to add the LTSS product to products required to generate the bootstrap repos. Customers who do not have LTSS do not have access to it.
- Packages which are available only in LTSS now will always cause errors when generating bootstrap repos
- Customers who do not have LTSS, cannot see the item anymore as LTSS is now mandatory. New Bootstrap repos cannot be created.

Solution:

- As soon as a product goes out of regular support and got a LTSS product, we add that product id to the bootstrap data file
- This will hide this target for all customer who do not have LTSS
- As we changed the default for the `flush`option to **False**, existing bootstrap repos will stay and can still be used. They will not get updates anymore which makes sense, as the products do not see updates anymore.

In case a customer must regenerate such a bootstrap repo:
- new customer want to onboard outdated clients with the goal to update to a supported version
- customers who lost the old bootstrap repo for whatever reason
we provide a `--force` option.

With `--force` we change the algorithm in the following way:
- we take what we can get. A not available products will not cause an abort of the bootstrap repo generation. But at least one product must be available
- we copy **all versions** of the packages into the bootstrap repo, not only the latest. With this we should get an installable selection without dependency conflicts

zypper would install the newest installable version. Having newer versions of packages in the repo which result in dependency conflicts would not hurt.


## GUI diff

No difference.

- [x] **DONE**

## Documentation

- https://github.com/SUSE/spacewalk/issues/12786

- [x] **DONE**

## Test coverage
- No tests: **manual**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/11949
Tracks https://github.com/SUSE/spacewalk/pull/12844 https://github.com/SUSE/spacewalk/pull/12848

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
