### PR TITLE
Do not serialize null objects in formula data

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/formula/FormulaFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/formula/FormulaFactory.java
@@ -111,7 +111,6 @@ public class FormulaFactory {
                         }
                     }
                 })
-            .serializeNulls()
             .create();
     private static final Yaml YAML = new Yaml(new SafeConstructor());
 


### PR DESCRIPTION
## What does this PR change?

Null objects do not have their representation in XmlRpc serializer.
Because formula data is used both by Gson and XmlRpc serializers we
should use the same behavior in both of them and do not serialize null
objects.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: change is transparent to users.

- [x] **DONE**

## Test coverage
- No tests: existing test cover relevant cases.

- [x] **DONE**

## Links

Fixes # https://github.com/SUSE/spacewalk/issues/12579

- [x] **DONE**

## Changelogs

- [x] No changelog needed

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
