### PR TITLE
QA: Re-adding unexpectedAlertBehaviour into our chromedriver options

### DIFF
--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -53,6 +53,7 @@ MultiTest.disable_autorun
 Capybara.register_driver(:headless_chrome) do |app|
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
     chromeOptions: { args: %w[headless no-sandbox disable-dev-shm-usage disable-gpu window-size=2048,2048, js-flags=--max_old_space_size=2048] },
+    unexpectedAlertBehaviour: 'accept',
     unhandledPromptBehavior: 'accept'
   )
 


### PR DESCRIPTION
## What does this PR change?

Based on the answer written here https://stackoverflow.com/questions/57700388/how-to-set-unexpectedalertbehaviour-in-selenium-python as when reloading a page we were experiencing an unexpected alert which wasn't caught, I changed one option to another into the chromedriver options.

On this PR, we will instead include both, as apparently in some cases the previous option was functional.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

Need ports:
 - Manager-4.0 https://github.com/SUSE/spacewalk/pull/12662
 - Manager-4.1 https://github.com/SUSE/spacewalk/pull/12798

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
