### PR TITLE
Replace unicode quotes at stdout with single quotes

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -824,9 +824,10 @@ And(/^I register "([^*]*)" as traditional client with activation key "([^*]*)"$/
     node.run('yum install wget', true, 600, 'root')
   end
   command1 = "wget --no-check-certificate -O /usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT http://#{$server.ip}/pub/RHN-ORG-TRUSTED-SSL-CERT"
-  puts node.run(command1, true, 500, 'root').to_s
+  # Dump the string before print it; this prevent from unescaped special chars in the output (they might break Cucumber formatters).
+  puts node.run(command1, true, 500, 'root').to_s.dump
   command2 = "rhnreg_ks --force --serverUrl=#{registration_url} --sslCACert=/usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT --activationkey=#{key}"
-  puts node.run(command2, true, 500, 'root').to_s
+  puts node.run(command2, true, 500, 'root').to_s.dump
 end
 
 When(/^I wait until onboarding is completed for "([^"]*)"$/) do |host|


### PR DESCRIPTION
## What does this PR change?
Having these quotes in the output break some Cucumber formatters; when
this happen, the testsuite reporter is not created, and no e-mail is
sent.
- testsuite/features/step_definitions/common_steps.rb



## Links
https://github.com/SUSE/spacewalk/issues/12739
Continuation of  https://github.com/uyuni-project/uyuni/pull/2724
### Ports
- Manager-4.1: https://github.com/SUSE/spacewalk/pull/12813
- Manager-4.0: https://github.com/SUSE/spacewalk/pull/12814

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)
