### PR TITLE
Separate executor for ssh minion actions to allow parallel execution (bsc#1173199)

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/TaskomaticApi.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/TaskomaticApi.java
@@ -29,12 +29,14 @@ import com.redhat.rhn.domain.org.Org;
 import com.redhat.rhn.domain.org.OrgFactory;
 import com.redhat.rhn.domain.recurringactions.RecurringAction;
 import com.redhat.rhn.domain.role.RoleFactory;
+import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.taskomatic.domain.TaskoSchedule;
 import com.redhat.rhn.taskomatic.task.RepoSyncTask;
 
 import com.suse.manager.utils.MinionServerUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 
 import java.net.MalformedURLException;
@@ -104,6 +106,26 @@ public class TaskomaticApi {
             return false;
         }
     }
+
+    /**
+     * Schedule a single ssh minion action.
+     * @param actionIn the action
+     * @param sshMinion the Salt ssh minion
+     * @throws TaskomaticApiException if there was an error
+     */
+    public void scheduleSSHActionExecution(Action actionIn, MinionServer sshMinion)
+            throws TaskomaticApiException {
+        Map scheduleParams = new HashMap();
+        scheduleParams.put("action_id", Long.toString(actionIn.getId()));
+        scheduleParams.put("ssh_minion_id", sshMinion.getMinionId());
+        invoke("tasko.scheduleSingleSatBunchRun",
+                "ssh-minion-action-executor-bunch",
+                StringUtils.substring(
+                        "ssh-minion-action-executor-" + actionIn.getId() + "-" + sshMinion.getId(), 0, 50),
+                scheduleParams,
+                new Date());
+    }
+
 
     /**
      * Schedule a single reposync

--- a/java/code/src/com/redhat/rhn/taskomatic/task/SSHMinionActionExecutor.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/SSHMinionActionExecutor.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.taskomatic.task;
+
+import com.redhat.rhn.GlobalInstanceHolder;
+import com.redhat.rhn.domain.action.Action;
+import com.redhat.rhn.domain.action.ActionFactory;
+import com.redhat.rhn.domain.server.MinionServer;
+import com.redhat.rhn.domain.server.MinionServerFactory;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+
+import java.util.Optional;
+
+/**
+ * Execute actions via salt-ssh.
+ */
+public class SSHMinionActionExecutor extends RhnJavaJob {
+
+    /**
+     * @param context the job execution context
+     * @see org.quartz.Job#execute(JobExecutionContext)
+     */
+    @Override
+    public void execute(JobExecutionContext context) throws JobExecutionException {
+        long actionId = context.getJobDetail()
+                .getJobDataMap().getLongValueFromString("action_id");
+        String sshMinionId = context.getJobDetail().getJobDataMap().getString("ssh_minion_id");
+        Optional<MinionServer> sshMinionOpt = MinionServerFactory.findByMinionId(sshMinionId);
+        if (sshMinionId.isEmpty()) {
+            log.error("SSH Minion " + sshMinionId + " not found. Aborting execution of action " + actionId);
+            return;
+        }
+        Action action = ActionFactory.lookupById(actionId);
+        if (action == null) {
+            log.error("Action not found: " + actionId);
+            return;
+        }
+        log.info("Executing action: " + actionId + " on ssh minion: " + sshMinionId);
+        GlobalInstanceHolder.SALT_SERVER_ACTION_SERVICE.executeSSHAction(action, sshMinionOpt.get());
+    }
+}

--- a/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
+++ b/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
@@ -70,6 +70,7 @@ import com.suse.manager.clusters.ClusterManager;
 import com.suse.manager.utils.SaltKeyUtils;
 import com.suse.manager.utils.SaltUtils;
 import com.suse.manager.virtualization.test.TestVirtManager;
+import com.suse.manager.webui.controllers.utils.ContactMethodUtil;
 import com.suse.manager.webui.services.SaltActionChainGeneratorService;
 import com.suse.manager.webui.services.SaltServerActionService;
 import com.suse.manager.webui.services.iface.SaltApi;
@@ -79,11 +80,13 @@ import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.manager.webui.utils.SaltModuleRun;
 import com.suse.manager.webui.utils.SaltState;
 import com.suse.manager.webui.utils.SaltSystemReboot;
+import com.suse.salt.netapi.calls.LocalAsyncResult;
 import com.suse.salt.netapi.calls.LocalCall;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
+import com.suse.salt.netapi.datatypes.target.Target;
 import org.jmock.Expectations;
 import org.jmock.imposters.ByteBuddyClassImposteriser;
 
@@ -110,8 +113,8 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
 
     private MinionServer minion;
     private SaltServerActionService saltServerActionService;
-    private SystemSummary sshPushSystemMock;
     private SystemEntitlementManager systemEntitlementManager;
+    private TaskomaticApi taskomaticMock;
 
     @Override
     public void setUp() throws Exception {
@@ -139,7 +142,8 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
                         serverGroupManager)
         );
 
-        sshPushSystemMock = mock(SystemSummary.class);
+        taskomaticMock = mock(TaskomaticApi.class);
+        saltServerActionService.setTaskomaticApi(taskomaticMock);
     }
 
     private SaltServerActionService createSaltServerActionService(SystemQuery systemQuery, SaltApi saltApi) {
@@ -454,7 +458,6 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
         };
 
         saltServerActionService.setSaltActionChainGeneratorService(generatorService);
-        TaskomaticApi taskomaticMock = mock(TaskomaticApi.class);
         ActionChainFactory.setTaskomaticApi(taskomaticMock);
 
         MinionServer minion1 = MinionServerFactoryTest.createTestMinionServer(user);
@@ -645,10 +648,23 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
 
     private ServerAction createChildServerAction(Action action, ActionStatus status,
                                                  long remainingTries) throws Exception {
-        ServerAction serverAction = ActionFactoryTest.createServerAction(minion, action);
+        return createChildServerAction(action, status, minion, remainingTries);
+    }
+
+    private ServerAction createChildServerAction(Action action, ActionStatus status,
+                                                 MinionServer minionIn,
+                                                 long remainingTries) throws Exception {
+        ServerAction serverAction = ActionFactoryTest.createServerAction(minionIn, action);
         serverAction.setStatus(status);
         serverAction.setRemainingTries(remainingTries);
-        action.setServerActions(Collections.singleton(serverAction));
+        if (action.getServerActions() == null) {
+            Set set = new HashSet();
+            set.add(serverAction);
+            action.setServerActions(set);
+        }
+        else {
+            action.getServerActions().add(serverAction);
+        }
         return serverAction;
     }
 
@@ -833,6 +849,33 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
         assertEquals(STATUS_QUEUED, serverAction.getStatus());
         assertEquals(Long.valueOf(5L), serverAction.getRemainingTries());
         assertEquals(0, counter.get());
+    }
+
+    public void testExectueSSHAction() throws Exception {
+        MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
+        MinionServer sshMinion = MinionServerFactoryTest.createTestMinionServer(user);
+        sshMinion.setContactMethod(ServerFactory.findContactMethodByLabel(ContactMethodUtil.SSH_PUSH));
+        Action action = ActionFactoryTest.createAction(user, ActionFactory.TYPE_REBOOT);
+        createChildServerAction(action, STATUS_QUEUED, sshMinion,5L);
+        createChildServerAction(action, STATUS_QUEUED, minion,5L);
+        HibernateFactory.getSession().flush();
+
+        SaltService saltServiceMock = mock(SaltService.class);
+        SaltServerActionService saltServerActionService = createSaltServerActionService(saltServiceMock, saltServiceMock);
+        saltServerActionService.setTaskomaticApi(taskomaticMock);
+        context().checking(new Expectations() { {
+            oneOf(taskomaticMock).scheduleSSHActionExecution(action, sshMinion);
+            oneOf(saltServiceMock).callAsync(with(any(LocalCall.class)), with(any(Target.class)), with(any(Optional.class)));
+            LocalAsyncResult<?> result = new LocalAsyncResult() {
+                public List<String> getMinions() {
+                    return Arrays.asList(minion.getMinionId());
+                }
+            };
+            will(returnValue(Optional.of(result)));
+        } });
+
+        saltServerActionService.execute(action, false, false, Optional.empty());
+
     }
 
     private void assertActionWillBeRetried() throws Exception {

--- a/java/conf/rhn_java.conf
+++ b/java/conf/rhn_java.conf
@@ -232,3 +232,6 @@ java.http_socket_timeout = 300
 # option to allow third-party scripts to change vendor information, but please note any channel in this list, once this
 # option is enabled, cannot be supported by the vendor. Please check the documentation for more information.
 #java.allow_adding_patches_via_api = centos6-x86_64,centos7-x86_64,centos8-x86_64
+
+# Maximum number of actions targetting Salt SSH minions executing at the same time
+taskomatic.com.redhat.rhn.taskomatic.task.SSHMinionActionExecutor.parallel_threads = 20

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Execute Salt SSH actions in parallel (bsc#1173199)
 - Enable to switch to multiple webUI theme
 - Hotfix the modular RPMs release comparison
 - enable redfish power management by default

--- a/schema/spacewalk/common/data/rhnTaskoBunch.sql
+++ b/schema/spacewalk/common/data/rhnTaskoBunch.sql
@@ -111,4 +111,7 @@ INSERT INTO rhnTaskoBunch (id, name, description, org_bunch)
 INSERT INTO RhnTaskoBunch (id, name, description, org_bunch)
    VALUES (sequence_nextval('rhn_tasko_bunch_id_seq'), 'recurring-state-apply-bunch', 'Applies salt state to minion/group/org', null);
 
+INSERT INTO rhnTaskoBunch (id, name, description, org_bunch)
+   VALUES (sequence_nextval('rhn_tasko_bunch_id_seq'), 'ssh-minion-action-executor-bunch', 'Execute actions on SSH Minions', null);
+
 commit;

--- a/schema/spacewalk/common/data/rhnTaskoTask.sql
+++ b/schema/spacewalk/common/data/rhnTaskoTask.sql
@@ -113,4 +113,7 @@ INSERT INTO rhnTaskoTask (id, name, class)
 INSERT INTO rhnTaskoTask (id, name, class)
    VALUES (sequence_nextval('rhn_tasko_task_id_seq'), 'recurring-state-apply', 'com.redhat.rhn.taskomatic.task.RecurringStateApplyJob');
 
+INSERT INTO rhnTaskoTask (id, name, class)
+   VALUES (sequence_nextval('rhn_tasko_task_id_seq'), 'ssh-minion-action-executor', 'com.redhat.rhn.taskomatic.task.SSHMinionActionExecutor');
+
 commit;

--- a/schema/spacewalk/common/data/rhnTaskoTemplate.sql
+++ b/schema/spacewalk/common/data/rhnTaskoTemplate.sql
@@ -245,4 +245,11 @@ INSERT INTO rhnTaskoTemplate (id, bunch_id, task_id, ordering, start_if)
                         0,
                         null);
 
+INSERT INTO rhnTaskoTemplate (id, bunch_id, task_id, ordering, start_if)
+            VALUES (sequence_nextval('rhn_tasko_template_id_seq'),
+                        (SELECT id FROM rhnTaskoBunch WHERE name='ssh-minion-action-executor-bunch'),
+                        (SELECT id FROM rhnTaskoTask WHERE name='ssh-minion-action-executor'),
+                        0,
+                        null);
+
 commit;

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- Execute Salt SSH actions in parallel (bsc#1173199)
 - Hotfix the modular RPMs release comparison
 - show info message when applying schema upgrade
 - Fix: handle version comparison corner cases in Ubuntu packages

--- a/schema/spacewalk/upgrade/susemanager-schema-4.2.2-to-susemanager-schema-4.2.3/200-minionSSHActionExecutor.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.2.2-to-susemanager-schema-4.2.3/200-minionSSHActionExecutor.sql
@@ -1,0 +1,21 @@
+INSERT INTO rhnTaskoBunch (id, name, description, org_bunch)
+SELECT sequence_nextval('rhn_tasko_bunch_id_seq'), 'ssh-minion-action-executor-bunch', 'Execute actions on SSH Minions', null
+WHERE NOT EXISTS (
+    SELECT 1 FROM rhnTaskoBunch WHERE name='ssh-minion-action-executor-bunch'
+);
+
+INSERT INTO rhnTaskoTask (id, name, class)
+SELECT sequence_nextval('rhn_tasko_task_id_seq'), 'ssh-minion-action-executor', 'com.redhat.rhn.taskomatic.task.SSHMinionActionExecutor'
+WHERE NOT EXISTS (
+    SELECT 1 FROM rhnTaskoTask WHERE name='ssh-minion-action-executor'
+);
+
+INSERT INTO rhnTaskoTemplate (id, bunch_id, task_id, ordering, start_if)
+SELECT sequence_nextval('rhn_tasko_template_id_seq'),
+        (SELECT id FROM rhnTaskoBunch WHERE name='ssh-minion-action-executor-bunch'),
+        (SELECT id FROM rhnTaskoTask WHERE name='ssh-minion-action-executor'),
+        0,
+        null
+WHERE NOT EXISTS (
+    SELECT 1 FROM rhnTaskoTemplate WHERE bunch_id=(SELECT id FROM rhnTaskoBunch WHERE name='ssh-minion-action-executor-bunch')
+);


### PR DESCRIPTION
## What does this PR change?

Port of https://github.com/SUSE/spacewalk/pull/12522

Use a separate taskomatic job to execute actions on SSH minions. The normal MinionActionExecutor will schedule the SSH actions as separate jobs.
The number of concurrent SSH executions can be controlled using the configuration parameter `taskomatic.com.redhat.rhn.taskomatic.task.SSHMinionActionExecutor.parallel_threads` (default 1).
The total number of Taskomatic worker threads must also be increased: `org.quartz.threadPool.threadCount=20 + <parallel ssh threads>`

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- uyuni-project/uyuni-docs#612

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Tracks SUSE/spacewalk#12522

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
