### PR TITLE
Reposync add timeout config

### DIFF
--- a/backend/rhn-conf/rhn_server_satellite.conf
+++ b/backend/rhn-conf/rhn_server_satellite.conf
@@ -36,7 +36,11 @@ cdn_root = https://cdn.redhat.com
 # override candlepin server API
 # https://subscription.rhsm.redhat.com/subscription/consumers/
 candlepin_server_api = 
-reposync_download_threads = 5
 
 # alternative sender of email reports from satellite-sync/cdn-sync/spacewalk-repo-sync
 default_mail_from =
+
+# reposync defaults
+reposync_download_threads = 5
+reposync_timeout = 300
+reposync_minrate = 1000

--- a/backend/satellite_tools/download.py
+++ b/backend/satellite_tools/download.py
@@ -138,12 +138,6 @@ class PyCurlFileObjectThread(PyCurlFileObject):
                 self.parent.first_in_queue_done = True
                 self.parent.first_in_queue_lock.release()
 
-    def _set_opts(self, opts=None):
-        if not opts:
-            opts = {}
-        PyCurlFileObject._set_opts(self, opts=opts)
-        self.curl_obj.setopt(pycurl.FORBID_REUSE, 0) # pylint: disable=E1101
-
 
 class FailedDownloadError(Exception):
     pass
@@ -205,11 +199,21 @@ class DownloadThread(Thread):
                                    checksum=params['checksum']):
                 return True
 
-        opts = URLGrabberOptions(ssl_ca_cert=params['ssl_ca_cert'], ssl_cert=params['ssl_client_cert'],
-                                 ssl_key=params['ssl_client_key'], range=params['bytes_range'],
-                                 proxy=params['proxy'], username=params['proxy_username'],
-                                 password=params['proxy_password'], proxies=params['proxies'],
-                                 http_headers=tuple(params['http_headers'].items()))
+        opts = URLGrabberOptions(
+            ssl_ca_cert=params["ssl_ca_cert"],
+            ssl_cert=params["ssl_client_cert"],
+            ssl_key=params["ssl_client_key"],
+            range=params["bytes_range"],
+            proxy=params["proxy"],
+            username=params["proxy_username"],
+            password=params["proxy_password"],
+            proxies=params["proxies"],
+            http_headers=tuple(params["http_headers"].items()),
+            timeout=params["timeout"],
+            minrate=params["minrate"],
+            keepalive=True,
+        )
+
         mirrors = len(params['urls'])
         for retry in range(max(self.parent.retries, mirrors)):
             fo = None
@@ -278,16 +282,31 @@ class ThreadedDownloader:
     def __init__(self, retries=3, log_obj=None, force=False):
         self.queues = {}
         comp = CFG.getComponent()
-        initCFG('server.satellite')
+        initCFG("server.satellite")
         try:
             self.threads = int(CFG.REPOSYNC_DOWNLOAD_THREADS)
         except ValueError:
-            initCFG(comp)
-            raise ValueError("Number of threads expected, found: '%s'" % CFG.REPOSYNC_DOWNLOAD_THREADS)
-        else:
-            initCFG(comp)
+            raise ValueError(
+                "Number of threads expected, found: '%s'" % CFG.REPOSYNC_DOWNLOAD_THREADS
+            )
+        try:
+            self.timeout = int(CFG.REPOSYNC_TIMEOUT)
+        except ValueError:
+            raise ValueError(
+                "Timeout in seconds expected, found: '%s'" % CFG.REPOSYNC_TIMEOUT
+            )
+        try:
+            self.minrate = int(CFG.REPOSYNC_MINRATE)
+        except ValueError:
+            raise ValueError(
+                "Minimal transfer rate in bytes pre second expected, found: '%s'"
+                % CFG.REPOSYNC_MINRATE
+            )
+
         if self.threads < 1:
             raise ValueError("Invalid number of threads: %d" % self.threads)
+
+        initCFG(comp)
         self.retries = retries
         self.log_obj = log_obj
         self.force = force
@@ -318,6 +337,8 @@ class ThreadedDownloader:
             if ssl_set not in self.queues:
                 self.queues[ssl_set] = Queue()
             queue = self.queues[ssl_set]
+            params["timeout"] = self.timeout
+            params["minrate"] = self.minrate
             queue.put(params)
 
     def run(self):

--- a/backend/satellite_tools/download.py
+++ b/backend/satellite_tools/download.py
@@ -115,7 +115,7 @@ class PyCurlFileObjectThread(PyCurlFileObject):
         (url, parts) = opts.urlparser.parse(url, opts)
         (scheme, host, path, parm, query, frag) = parts
         opts.find_proxy(url, scheme)
-        PyCurlFileObject.__init__(self, str(url), filename, opts)
+        super().__init__(str(url), filename, opts)
 
     def _do_open(self):
         self.curl_obj = self.curl_cache
@@ -132,7 +132,7 @@ class PyCurlFileObjectThread(PyCurlFileObject):
             if self.parent.first_in_queue_done:
                 self.parent.first_in_queue_lock.release()
         try:
-            PyCurlFileObject._do_perform(self)
+            super()._do_perform()
         finally:
             if not self.parent.first_in_queue_done:
                 self.parent.first_in_queue_done = True
@@ -145,7 +145,7 @@ class FailedDownloadError(Exception):
 
 class DownloadThread(Thread):
     def __init__(self, parent, queue):
-        Thread.__init__(self)
+        super().__init__()
         self.parent = parent
         self.queue = queue
         # pylint: disable=E1101

--- a/backend/satellite_tools/repo_plugins/deb_src.py
+++ b/backend/satellite_tools/repo_plugins/deb_src.py
@@ -283,6 +283,18 @@ class ContentSource:
         (_scheme, _netloc, _path, query, _fragid) = urlparse.urlsplit(url)
         if query:
             self.authtoken = query
+
+        # configure network connection
+        try:
+            # bytes per second
+            self.minrate = int(CFG.REPOSYNC_MINRATE)
+        except ValueError:
+            self.minrate = 1000
+        try:
+            # seconds
+            self.timeout = int(CFG.REPOSYNC_TIMEOUT)
+        except ValueError:
+            self.timeout = 300
         initCFG(comp)
 
     def get_md_checksum_type(self):
@@ -437,6 +449,8 @@ class ContentSource:
         params['proxy_username'] = self.proxy_user
         params['proxy_password'] = self.proxy_pass
         params['http_headers'] = self.repo.http_headers
+        params["timeout"] = self.timeout
+        params["minrate"] = self.minrate
         # Older urlgrabber compatibility
         params['proxies'] = get_proxies(self.repo.proxy, self.repo.proxy_username,
                                         self.repo.proxy_password)

--- a/backend/satellite_tools/repo_plugins/yum_src.py
+++ b/backend/satellite_tools/repo_plugins/yum_src.py
@@ -466,6 +466,18 @@ class ContentSource:
         self.num_excluded = 0
         self.gpgkey_autotrust = None
         self.groupsfile = None
+
+        # configure network connection
+        try:
+            # bytes per second
+            self.minrate = int(CFG.REPOSYNC_MINRATE)
+        except ValueError:
+            self.minrate = 1000
+        try:
+            # seconds
+            self.timeout = int(CFG.REPOSYNC_TIMEOUT)
+        except ValueError:
+            self.timeout = 300
         # set config component back to original
         initCFG(comp)
 
@@ -1159,6 +1171,8 @@ type=rpm-md
         params['proxy_username'] = self.proxy_user
         params['proxy_password'] = self.proxy_pass
         params['http_headers'] = self.http_headers
+        params["timeout"] = self.timeout
+        params["minrate"] = self.minrate
         # Older urlgrabber compatibility
         params['proxies'] = get_proxies(self.proxy_url, self.proxy_user, self.proxy_pass)
 

--- a/backend/satellite_tools/test/unit/test_download.py
+++ b/backend/satellite_tools/test/unit/test_download.py
@@ -1,0 +1,50 @@
+#!/usr/bin/python3
+#
+# Copyright (c) 2021 SUSE LLC
+#
+# This software is licensed to you under the GNU General Public License,
+# version 2 (GPLv2). There is NO WARRANTY for this software, express or
+# implied, including the implied warranties of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+# along with this software; if not, see
+# http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+
+from mock import Mock, patch
+
+from spacewalk.satellite_tools.download import ThreadedDownloader, pycurl
+
+
+class NoKeyErrorsDict(dict):
+    """Like a dict that is only accessed by .get(key)"""
+
+    def __getitem__(self, key):
+        return super().get(key)
+
+
+# this initCFG also operates on spacewalk.common.rhnConfig.CFG
+@patch("spacewalk.satellite_tools.download.initCFG", Mock())
+@patch("spacewalk.satellite_tools.download.log", Mock())  # no logging
+@patch("urlgrabber.grabber.PyCurlFileObject._do_grab", Mock())  # no downloads
+@patch("urlgrabber.grabber.PyCurlFileObject.close", Mock())  # no need to close files
+@patch("spacewalk.satellite_tools.download.os.path.isfile", Mock(return_value=False))
+def test_reposync_timeout_minrate_are_passed_to_curl():
+    # only provide needed params with dummy data, the rest is "None"
+    params = NoKeyErrorsDict({"http_headers": dict(), "urls": ["http://example.com"]})
+
+    CFG = Mock()
+    CFG.REPOSYNC_TIMEOUT = 42
+    CFG.REPOSYNC_MINRATE = 42
+    CFG.REPOSYNC_DOWNLOAD_THREADS = 42 # Throws ValueError if not defined
+
+    curl_spy = Mock()
+
+    with patch(
+        "spacewalk.satellite_tools.download.pycurl.Curl", Mock(return_value=curl_spy)
+    ), patch("spacewalk.satellite_tools.download.CFG", CFG):
+
+        td = ThreadedDownloader(force=True)
+        td.add(params)
+        td.run()
+
+        curl_spy.setopt.assert_any_call(pycurl.LOW_SPEED_LIMIT, 42)
+        curl_spy.setopt.assert_any_call(pycurl.LOW_SPEED_TIME, 42)

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Add minrate/timeout configuration values for downloading DEB/RPM packages
 - add allow vendor change with patching via rhnstack 
 - Fixed kickstart tree permissions to a+r.
 - Avoid race condition due multiple reposync import threads (bsc#1183151)


### PR DESCRIPTION
## What does this PR change?

Add a configuration value for setting the minimal transfer rate and a timeout period. If the transfer speed falls under the minimal transfer rate for the timeout duration, the download is aborted. 

I've reused the variable names (`minrate`, `timeout`) from [ulrgrabber](http://urlgrabber.baseurl.org/). They are passed through to PyCurl, therefore it is also an option to use libCurl's names (`LOW_SPEED_TIME`, `LOW_SPEED_LIMIT`). I find the urlgrabber ones a little bit nicer, but I don't mind either way.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- Documentation issue was created: 
- PR: https://github.com/uyuni-project/uyuni-docs/pull/816

- [ ] **DONE**

## Test coverage
- No tests: Don't know how this can be tested in a meaningful way. Ideas welcome.
- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/12635


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
