### PR TITLE
Testsuite: Drop unicode \xHH from stdout

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -824,10 +824,10 @@ And(/^I register "([^*]*)" as traditional client with activation key "([^*]*)"$/
     node.run('yum install wget', true, 600, 'root')
   end
   command1 = "wget --no-check-certificate -O /usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT http://#{$server.ip}/pub/RHN-ORG-TRUSTED-SSL-CERT"
-  # Dump the string before print it; this prevent from unescaped special chars in the output (they might break Cucumber formatters).
-  puts node.run(command1, true, 500, 'root').to_s.dump
+  # Replace unicode chars \xHH with ? in the output (otherwise, they might break Cucumber formatters).
+  puts node.run(command1, true, 500, 'root').to_s.gsub(/(\\x\h+){1,}/, '?')
   command2 = "rhnreg_ks --force --serverUrl=#{registration_url} --sslCACert=/usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT --activationkey=#{key}"
-  puts node.run(command2, true, 500, 'root').to_s.dump
+  puts node.run(command2, true, 500, 'root').to_s.gsub(/(\\x\h+){1,}/, '?')
 end
 
 When(/^I wait until onboarding is completed for "([^"]*)"$/) do |host|


### PR DESCRIPTION
## What does this PR change?
Remove unicode expressions like \xHH from the stdout.

Escaping the initial slash is not enough: the Cucumber formatter
still find them and it crashes.

- testsuite/features/step_definitions/common_steps.rb:
Replace unicode \xHH with ?.


## Links
https://github.com/SUSE/spacewalk/issues/12739
Continuation of https://github.com/uyuni-project/uyuni/pull/2732

### Ports:
- Manager-4.0: https://github.com/SUSE/spacewalk/pull/12815
- Manager-4.1: https://github.com/SUSE/spacewalk/pull/12816

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)
