### PR TITLE
Enable ppc64le for CentOS7 and CentOS8

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -352,8 +352,11 @@ RES7 = [
     "mgr-daemon|spacewalksd",
     "suseRegisterInfo",
     "python2-suseRegisterInfo",
-    "python2-hwdata",
-    "dmidecode",
+    "python2-hwdata"
+]
+
+RES7_X86 = [
+    "dmidecode"
 ]
 
 RES8 = [
@@ -373,13 +376,16 @@ RES8 = [
     "python3-requests",
     "openpgm",
     "zeromq",
-    "dmidecode",
     "python3-urllib3",
     "python3-idna",
     "python3-chardet",
     "python3-pysocks",
     "python3-pytz",
     "python3-setuptools"
+]
+
+RES8_X86 = [
+    "dmidecode"
 ]
 
 PKGLIST15_SALT = [
@@ -914,7 +920,7 @@ DATA = {
         'DEST' : '/srv/www/htdocs/pub/repositories/res/6/bootstrap/'
     },
     'RES7-x86_64' : {
-        'PDID' : [1251], 'BETAPDID' : [2065], 'PKGLIST' : RES7,
+        'PDID' : [1251], 'BETAPDID' : [2065], 'PKGLIST' : RES7 + RES7_X86,
         'DEST' : '/srv/www/htdocs/pub/repositories/res/7/bootstrap/'
     },
     'SLE-12-SP2-aarch64' : {
@@ -1142,11 +1148,11 @@ DATA = {
         'DEST' : '/srv/www/htdocs/pub/repositories/centos/6/bootstrap/'
     },
     'centos-7-x86_64' : {
-        'PDID' : [-12, 1683], 'BETAPDID' : [2065], 'PKGLIST' : RES7,
+        'PDID' : [-12, 1683], 'BETAPDID' : [2065], 'PKGLIST' : RES7 + RES7_X86,
         'DEST' : '/srv/www/htdocs/pub/repositories/centos/7/bootstrap/'
     },
     'centos-8-x86_64' : {
-        'PDID' : [-13, 2007], 'BETAPDID' : [2066], 'PKGLIST' : RES8,
+        'PDID' : [-13, 2007], 'BETAPDID' : [2066], 'PKGLIST' : RES8 + RES8_X86,
         'DEST' : '/srv/www/htdocs/pub/repositories/centos/8/bootstrap/'
     },
     'centos-6-x86_64-uyuni' : {
@@ -1154,11 +1160,19 @@ DATA = {
         'DEST' : '/srv/www/htdocs/pub/repositories/centos/6/bootstrap/'
     },
     'centos-7-x86_64-uyuni' : {
-        'BASECHANNEL' : 'centos7-x86_64', 'PKGLIST' : RES7,
+        'BASECHANNEL' : 'centos7-x86_64', 'PKGLIST' : RES7 + RES7_X86,
+        'DEST' : '/srv/www/htdocs/pub/repositories/centos/7/bootstrap/'
+    },
+    'centos-7-ppc64le-uyuni' : {
+        'BASECHANNEL' : 'centos7-ppc64le', 'PKGLIST' : RES7,
         'DEST' : '/srv/www/htdocs/pub/repositories/centos/7/bootstrap/'
     },
     'centos-8-x86_64-uyuni' : {
-        'BASECHANNEL' : 'centos8-x86_64', 'PKGLIST' : RES8,
+        'BASECHANNEL' : 'centos8-x86_64', 'PKGLIST' : RES8 + RES8_X86,
+        'DEST' : '/srv/www/htdocs/pub/repositories/centos/8/bootstrap/'
+    },
+    'centos-8-ppc64le-uyuni' : {
+        'BASECHANNEL' : 'centos8-ppc64le', 'PKGLIST' : RES8,
         'DEST' : '/srv/www/htdocs/pub/repositories/centos/8/bootstrap/'
     },
     'oracle-6-x86_64' : {
@@ -1166,11 +1180,11 @@ DATA = {
         'DEST' : '/srv/www/htdocs/pub/repositories/oracle/6/bootstrap/'
     },
     'oracle-7-x86_64' : {
-        'PDID' : [-14, 1683], 'BETAPDID' : [2065], 'PKGLIST' : RES7,
+        'PDID' : [-14, 1683], 'BETAPDID' : [2065], 'PKGLIST' : RES7 + RES7_X86,
         'DEST' : '/srv/www/htdocs/pub/repositories/oracle/7/bootstrap/'
     },
     'oracle-8-x86_64' : {
-        'PDID' : [-17, 2007], 'BETAPDID' : [2066], 'PKGLIST' : RES8,
+        'PDID' : [-17, 2007], 'BETAPDID' : [2066], 'PKGLIST' : RES8 + RES8_X86,
         'DEST' : '/srv/www/htdocs/pub/repositories/oracle/8/bootstrap/'
     },
     'oracle-6-x86_64-uyuni' : {
@@ -1178,11 +1192,11 @@ DATA = {
         'DEST' : '/srv/www/htdocs/pub/repositories/oracle/6/bootstrap/'
     },
     'oracle-7-x86_64-uyuni' : {
-        'BASECHANNEL' : 'oraclelinux7-x86_64', 'PKGLIST' : RES7,
+        'BASECHANNEL' : 'oraclelinux7-x86_64', 'PKGLIST' : RES7 + RES7_X86,
         'DEST' : '/srv/www/htdocs/pub/repositories/oracle/7/bootstrap/'
     },
     'oracle-8-x86_64-uyuni' : {
-        'BASECHANNEL' : 'oraclelinux8-x86_64', 'PKGLIST' : RES8,
+        'BASECHANNEL' : 'oraclelinux8-x86_64', 'PKGLIST' : RES8 + RES8_X86,
         'DEST' : '/srv/www/htdocs/pub/repositories/oracle/8/bootstrap/'
     },
     'RHEL6-x86_64' : {
@@ -1194,15 +1208,15 @@ DATA = {
         'DEST' : '/srv/www/htdocs/pub/repositories/res/6/bootstrap/'
     },
     'RHEL7-x86_64' : {
-        'PDID' : [-7, 1683], 'BETAPDID' : [2065], 'PKGLIST' : RES7,
+        'PDID' : [-7, 1683], 'BETAPDID' : [2065], 'PKGLIST' : RES7 + RES7_X86,
         'DEST' : '/srv/www/htdocs/pub/repositories/res/7/bootstrap/'
     },
     'SLE-ES8-x86_64' : {
-        'PDID' : [-8, 1921, 2007], 'BETAPDID' : [2066], 'PKGLIST' : RES8,
+        'PDID' : [-8, 1921, 2007], 'BETAPDID' : [2066], 'PKGLIST' : RES8 + RES8_X86,
         'DEST' : '/srv/www/htdocs/pub/repositories/res/8/bootstrap/'
     },
     'RHEL8-x86_64' : {
-        'PDID' : [-8, 2007], 'BETAPDID' : [2066], 'PKGLIST' : RES8,
+        'PDID' : [-8, 2007], 'BETAPDID' : [2066], 'PKGLIST' : RES8 + RES8_X86,
         'DEST' : '/srv/www/htdocs/pub/repositories/res/8/bootstrap/'
     },
     'ubuntu-16.04-amd64' : {

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- Bootstrap repository definitions for CentOS7 and 8 for ppc64le
 - create bootstrap repo should not flush by default (bsc#1175843)
 - improve detection of base channels for products (bsc#1177478)
 - Add LTSS PIDs for SLE12SP1, SLE12SP2, SLE12SP3 and SLE12SP4 to

--- a/utils/spacewalk-common-channels
+++ b/utils/spacewalk-common-channels
@@ -49,6 +49,7 @@ CHANNEL_ARCH = {
     'x86_64':       'channel-x86_64',
     'ppc':          'channel-ppc',
     'ppc64':        'channel-ppc64',
+    'ppc64le':      'channel-ppc64le',
     'amd64-deb':    'channel-amd64-deb',
     'ia32-deb':     'channel-ia32-deb',
     'ia64-deb':     'channel-ia64-deb',

--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -151,7 +151,7 @@ base_channels = fedora30-%(arch)s
 yumrepo_url = https://mirrors.fedoraproject.org/metalink?repo=updates-released-debug-f30&arch=%(arch)s
 
 [centos8]
-archs    = x86_64
+archs    = x86_64, ppc64le
 name     = CentOS 8 (%(arch)s)
 gpgkey_url = http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-Official
 gpgkey_id = 8483C65D
@@ -161,49 +161,49 @@ dist_map_release = 8
 
 [centos8-appstream]
 label    = %(base_channel)s-appstream
-archs    = x86_64
+archs    = x86_64, ppc64le
 name     = CentOS 8 AppStream (%(arch)s)
 base_channels = centos8-%(arch)s
 repo_url = http://mirrorlist.centos.org/?release=8&arch=%(arch)s&repo=AppStream&infra=stock
 
 [centos8-centosplus]
 label    = %(base_channel)s-centosplus
-archs    = x86_64
+archs    = x86_64, ppc64le
 name     = CentOS 8 Plus (%(arch)s)
 base_channels = centos8-%(arch)s
 repo_url = http://mirrorlist.centos.org/?release=8&arch=%(arch)s&repo=centosplus&infra=stock
 
 [centos8-cr]
 label    = %(base_channel)s-cr
-archs    = x86_64
+archs    = x86_64, ppc64le
 name     = CentOS 8 CR (%(arch)s)
 base_channels = centos8-%(arch)s
 repo_url = http://mirrorlist.centos.org/?release=8&arch=%(arch)s&repo=cr&infra=stock
 
 [centos8-extras]
 label    = %(base_channel)s-extras
-archs    = x86_64
+archs    = x86_64, ppc64le
 name     = CentOS 8 Extras (%(arch)s)
 base_channels = centos8-%(arch)s
 repo_url = http://mirrorlist.centos.org/?release=8&arch=%(arch)s&repo=extras&infra=stock
 
 [centos8-fasttrack]
 label    = %(base_channel)s-fasttrack
-archs    = x86_64
+archs    = x86_64, ppc64le
 name     = CentOS 8 FastTrack (%(arch)s)
 base_channels = centos8-%(arch)s
 repo_url = http://mirrorlist.centos.org/?release=8&arch=%(arch)s&repo=fasttrack&infra=stock
 
 [centos8-powertools]
 label    = %(base_channel)s-powertools
-archs    = x86_64
+archs    = x86_64, ppc64le
 name     = CentOS 8 PowerTools (%(arch)s)
 base_channels = centos8-%(arch)s
 repo_url = http://mirrorlist.centos.org/?release=8&arch=%(arch)s&repo=PowerTools&infra=stock
 
 [centos8-uyuni-client]
 name     = Uyuni Client Tools for %(base_channel_name)s
-archs    = %(_x86_archs)s
+archs    = %(_x86_archs)s, ppc64le
 base_channels = centos8-%(arch)s
 gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS8-Uyuni-Client-Tools/CentOS_8/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
@@ -212,7 +212,7 @@ repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/
 
 [centos8-uyuni-client-devel]
 name     = Uyuni Client Tools for %(base_channel_name)s (Development)
-archs    = %(_x86_archs)s
+archs    = %(_x86_archs)s, ppc64le
 base_channels = centos8-%(arch)s
 gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/CentOS8-Uyuni-Client-Tools/CentOS_8/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
@@ -222,7 +222,7 @@ repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/
 [epel8]
 label    = epel8-%(base_channel)s
 name     = EPEL 8 for %(base_channel_name)s
-archs    = x86_64
+archs    = x86_64, ppc64le
 base_channels = centos8-%(arch)s
 gpgkey_url = http://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8
 gpgkey_id = 2F86D6A1
@@ -299,7 +299,7 @@ gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/CentOS8-Uyuni-Client-Tools/CentOS_8/
 
 [centos7]
-archs    = x86_64
+archs    = x86_64, ppc64le
 name     = CentOS 7 (%(arch)s)
 gpgkey_url = http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-7
 gpgkey_id = F4A80EB5
@@ -316,7 +316,7 @@ repo_url = http://mirror.centos.org/centos-7/7/atomic/%(arch)s
 
 [centos7-centosplus]
 label    = %(base_channel)s-centosplus
-archs    = x86_64
+archs    = x86_64, ppc64le
 name     = CentOS 7 Plus (%(arch)s)
 base_channels = centos7-%(arch)s
 repo_url = http://mirrorlist.centos.org/?release=7&arch=%(arch)s&repo=centosplus
@@ -330,21 +330,21 @@ repo_url = http://mirror.centos.org/centos-7/7/cloud/%(arch)s
 
 [centos7-cr]
 label    = %(base_channel)s-cr
-archs    = x86_64
+archs    = x86_64, ppc64le
 name     = CentOS 7 CR (%(arch)s)
 base_channels = centos7-%(arch)s
 repo_url = http://mirrorlist.centos.org/?release=7&arch=%(arch)s&repo=cr
 
 [centos7-extras]
 label    = %(base_channel)s-extras
-archs    = x86_64
+archs    = x86_64, ppc64le
 name     = CentOS 7 Extras (%(arch)s)
 base_channels = centos7-%(arch)s
 repo_url = http://mirrorlist.centos.org/?release=7&arch=%(arch)s&repo=extras
 
 [centos7-fasttrack]
 label    = %(base_channel)s-fasttrack
-archs    = x86_64
+archs    = x86_64, ppc64le
 name     = CentOS 7 FastTrack (%(arch)s)
 base_channels = centos7-%(arch)s
 repo_url = http://mirrorlist.centos.org/?release=7&arch=%(arch)s&repo=fasttrack
@@ -386,7 +386,7 @@ repo_url = http://mirror.centos.org/centos-7/7/storage/%(arch)s
 
 [centos7-updates]
 label    = %(base_channel)s-updates
-archs    = x86_64
+archs    = x86_64, ppc64le
 name     = CentOS 7 Updates (%(arch)s)
 base_channels = centos7-%(arch)s
 repo_url = http://mirrorlist.centos.org/?release=7&arch=%(arch)s&repo=updates
@@ -400,7 +400,7 @@ repo_url = http://mirror.centos.org/centos-7/7/virt/%(arch)s
 
 [centos7-uyuni-client]
 name     = Uyuni Client Tools for %(base_channel_name)s
-archs    = %(_x86_archs)s
+archs    = %(_x86_archs)s, ppc64le
 base_channels = centos7-%(arch)s
 gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS7-Uyuni-Client-Tools/CentOS_7/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
@@ -409,7 +409,7 @@ repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/
 
 [centos7-uyuni-client-devel]
 name     = Uyuni Client Tools for %(base_channel_name)s (Development)
-archs    = %(_x86_archs)s
+archs    = %(_x86_archs)s, ppc64le
 base_channels = centos7-%(arch)s
 gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/CentOS7-Uyuni-Client-Tools/CentOS_7/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
@@ -419,7 +419,7 @@ repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/
 [epel7]
 label    = epel7-%(base_channel)s
 name     = EPEL 7 for %(base_channel_name)s
-archs    = x86_64, ppc64
+archs    = x86_64, ppc64, ppc64le
 base_channels = centos7-%(arch)s scientific7-%(arch)s
 gpgkey_url = http://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
 gpgkey_id = 352C64E5

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,5 @@
+- Enable ppc64le for CentOS7 and CentOS8
+
 -------------------------------------------------------------------
 Fri Sep 18 12:17:53 CEST 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Enable ppc64le for CentOS7 and CentOS8:

- Add the channels to `spacewalk-common-channels`
- Create the bootstrap repository definitions

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- Documentation issue was created: https://github.com/uyuni-project/uyuni-docs/pull/625

- [x] **DONE**

## Test coverage
- No tests: Not automated, we only support automation for x86_64 for now.

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/12504
FIxes https://github.com/SUSE/spacewalk/issues/12505

Partially addresses https://github.com/SUSE/spacewalk/issues/12506

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
