### PR TITLE
Fix mgr daemon remove with selinux

### DIFF
--- a/client/rhel/mgr-daemon/mgr-daemon.changes
+++ b/client/rhel/mgr-daemon/mgr-daemon.changes
@@ -1,3 +1,5 @@
+- fix removal of mgr-deamon with selinux enabled (bsc#1177928)
+
 -------------------------------------------------------------------
 Mon Sep 21 11:59:11 CEST 2020 - jgonzalez@suse.com
 

--- a/client/rhel/mgr-daemon/mgr-daemon.spec
+++ b/client/rhel/mgr-daemon/mgr-daemon.spec
@@ -258,14 +258,14 @@ fi
 %{insserv_cleanup}
 %endif
 %else
-if [ "$1" -ge "1" ]; then
-    %if 0%{?fedora} || 0%{?rhel} >= 7
+%if 0%{?fedora} || 0%{?rhel} >= 7
     %systemd_postun_with_restart rhnsd.timer
     %systemd_postun_with_restart spacewalk-update-status.service
-    %else
+%else
+if [ "$1" -ge "1" ]; then
     service rhnsd condrestart >/dev/null 2>&1 || :
-    %endif
 fi
+%endif
 %endif
 %endif
 


### PR DESCRIPTION
## What does this PR change?

With selinux set to enforcing removing of mgr-daemon confuses systemd.
A daemon reload is required which was prevented by a check for package was updated.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal only**

- [x] **DONE**

## Test coverage
- No tests: **already covered**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/12823
Tracks https://github.com/SUSE/spacewalk/pull/12833

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
