### PR TITLE
Fix modular data handling for cloned channels

### DIFF
--- a/backend/satellite_tools/reposync.py
+++ b/backend/satellite_tools/reposync.py
@@ -20,6 +20,7 @@ import shutil
 import socket
 import subprocess
 import sys
+import tempfile
 import time
 import traceback
 import base64
@@ -739,6 +740,17 @@ class RepoSync(object):
             elif notices_type == 'patches':
                 self.upload_patches(notices)
 
+    @staticmethod
+    def _getDecompressedFileChecksum(abspath, hashtype):
+        src = fileutils.decompress_open(abspath)
+        tmp = tempfile.TemporaryFile('w')
+        shutil.copyfileobj(src, tmp)
+        tmp.flush()
+        result = getFileChecksum(hashtype, fd=tmp.fileno())
+        tmp.close()
+        src.close()
+        return result
+
     def copy_metadata_file(self, plug, filename, comps_type, relative_dir):
         old_checksum = None
         db_timestamp = datetime.fromtimestamp(0.0, utc)
@@ -753,6 +765,12 @@ class RepoSync(object):
         if comps_type == 'comps' and not re.match('comps.xml(' + "|".join(compressed_suffixes) + ')*', basename):
             log(0, "  Renaming non-standard filename %s to %s." % (basename, 'comps' + basename[basename.find('.'):]))
             basename = 'comps' + basename[basename.find('.'):]
+        elif comps_type == 'modules' and re.match('modules.yaml(' + "|".join(compressed_suffixes) + ')*', basename):
+            # decompress only for getting the checksum
+            checksum = self._getDecompressedFileChecksum(filename, 'sha256')
+            basename = checksum + "-" + basename
+            log(0, "Including the checksum in the modules file name: %s" % basename)
+
         relativepath = os.path.join(relativedir, basename)
         abspath = os.path.join(absdir, basename)
         for suffix in compressed_suffixes:

--- a/backend/satellite_tools/reposync.py
+++ b/backend/satellite_tools/reposync.py
@@ -769,7 +769,7 @@ class RepoSync(object):
             # decompress only for getting the checksum
             checksum = self._getDecompressedFileChecksum(filename, 'sha256')
             basename = checksum + "-" + basename
-            log(0, "Including the checksum in the modules file name: %s" % basename)
+            log(0, "  Including the checksum in the modules file name: %s" % basename)
 
         relativepath = os.path.join(relativedir, basename)
         abspath = os.path.join(absdir, basename)

--- a/backend/satellite_tools/reposync.py
+++ b/backend/satellite_tools/reposync.py
@@ -741,7 +741,7 @@ class RepoSync(object):
                 self.upload_patches(notices)
 
     @staticmethod
-    def _getDecompressedFileChecksum(abspath, hashtype):
+    def _get_decompressed_file_checksum(abspath, hashtype):
         src = fileutils.decompress_open(abspath)
         tmp = tempfile.TemporaryFile('w')
         shutil.copyfileobj(src, tmp)
@@ -767,7 +767,7 @@ class RepoSync(object):
             basename = 'comps' + basename[basename.find('.'):]
         elif comps_type == 'modules' and re.match('modules.yaml(' + "|".join(compressed_suffixes) + ')*', basename):
             # decompress only for getting the checksum
-            checksum = self._getDecompressedFileChecksum(filename, 'sha256')
+            checksum = self._get_decompressed_file_checksum(filename, 'sha256')
             basename = checksum + "-" + basename
             log(0, "  Including the checksum in the modules file name: %s" % basename)
 

--- a/backend/satellite_tools/reposync.py
+++ b/backend/satellite_tools/reposync.py
@@ -742,14 +742,10 @@ class RepoSync(object):
 
     @staticmethod
     def _get_decompressed_file_checksum(abspath, hashtype):
-        src = fileutils.decompress_open(abspath)
-        tmp = tempfile.TemporaryFile('w')
-        shutil.copyfileobj(src, tmp)
-        tmp.flush()
-        result = getFileChecksum(hashtype, fd=tmp.fileno())
-        tmp.close()
-        src.close()
-        return result
+        with fileutils.decompress_open(abspath) as src, tempfile.TemporaryFile('w') as tmp:
+            shutil.copyfileobj(src, tmp)
+            tmp.flush()
+            return getFileChecksum(hashtype, fd=tmp.fileno())
 
     def copy_metadata_file(self, plug, filename, comps_type, relative_dir):
         old_checksum = None

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Reposync: Fix modular data handling for cloned channels (bsc#1177508)
 - Added dnf plugin to reposync.
 - Drop Transfer-Encoding header from proxy respone to fix error response messages (bsc#1176906)
 - Prevent tracebacks on missing mail configuration (bsc#1179990)

--- a/java/code/src/com/redhat/rhn/domain/channel/Channel.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/Channel.java
@@ -224,6 +224,15 @@ public class Channel extends BaseDomainHelper implements Comparable<Channel> {
     }
 
     /**
+     * Sets modules data from given channel.
+     *
+     * @param from the Channel
+     */
+    public void cloneModulesFrom(Channel from) {
+        ChannelFactory.cloneModulesMetadata(from, this);
+    }
+
+    /**
      * @return Returns the Modules.
      */
     public Modules getModules() {

--- a/java/code/src/com/redhat/rhn/domain/channel/ChannelFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/ChannelFactory.java
@@ -1372,4 +1372,26 @@ public class ChannelFactory extends HibernateFactory {
         var m = ModeFactory.getCallableMode("Channel_queries", "analyze_channel_packages");
         m.execute(new HashMap<>(), new HashMap<>());
     }
+
+    /**
+     * Sets channel modules data from given channel.
+     *
+     * @param from the Channel
+     */
+    public static void cloneModulesMetadata(Channel from, Channel to) {
+        if (!from.isModular()) {
+            if (to.isModular()) {
+                HibernateFactory.getSession().delete(to.getModules());
+                to.setModules(null);
+            }
+        }
+        else {
+            if (!to.isModular()) {
+                Modules modules = new Modules();
+                modules.setChannel(to);
+                to.setModules(modules);
+            }
+            to.getModules().setRelativeFilename(from.getModules().getRelativeFilename());
+        }
+    }
 }

--- a/java/code/src/com/redhat/rhn/domain/channel/ChannelFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/ChannelFactory.java
@@ -1376,7 +1376,8 @@ public class ChannelFactory extends HibernateFactory {
     /**
      * Sets channel modules data from given channel.
      *
-     * @param from the Channel
+     * @param from the source Channel
+     * @param to  the target Channel
      */
     public static void cloneModulesMetadata(Channel from, Channel to) {
         if (!from.isModular()) {

--- a/java/code/src/com/redhat/rhn/domain/channel/RepoMetadata.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/channel/RepoMetadata.hbm.xml
@@ -5,7 +5,6 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
 
 <hibernate-mapping>
     <class name="com.redhat.rhn.domain.channel.RepoMetadata"
-           mutable="false"
            table="rhnChannelComps"
            discriminator-value="-1">
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandler.java
@@ -2330,7 +2330,7 @@ public class ChannelSoftwareHandler extends BaseHandler {
      */
     public Object[] mergePackages(User loggedInUser, String mergeFromLabel,
             String mergeToLabel) {
-        return mergePackages(loggedInUser,mergeFromLabel, mergeToLabel, false);
+        return mergePackages(loggedInUser, mergeFromLabel, mergeToLabel, false);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/software/ChannelSoftwareHandler.java
@@ -2330,6 +2330,32 @@ public class ChannelSoftwareHandler extends BaseHandler {
      */
     public Object[] mergePackages(User loggedInUser, String mergeFromLabel,
             String mergeToLabel) {
+        return mergePackages(loggedInUser,mergeFromLabel, mergeToLabel, false);
+    }
+
+    /**
+     * Merge a channel's packages into another channel.
+     * @param loggedInUser The current user
+     * @param mergeFromLabel the label of the channel to pull the packages from
+     * @param mergeToLabel the label of the channel to push packages into
+     * @param alignModules whether to align RHEL >= 8 modular data
+     * @return A list of packages that were merged.
+     *
+     * @xmlrpc.doc Merges all packages from one channel into another
+     * @xmlrpc.param #session_key()
+     * @xmlrpc.param #param_desc("string", "mergeFromLabel", "the label of the
+     *          channel to pull packages from")
+     * @xmlrpc.param #param_desc("string", "mergeToLabel", "the label to push the
+     *              packages into")
+     * @xmlrpc.param #param_desc("boolean", "alignModules", "align modular data of the target channel
+     *              to the source channel (RHEL8 and higher)")
+     * @xmlrpc.returntype
+     *      #array_begin()
+     *          $PackageSerializer
+     *      #array_end()
+     */
+    public Object[] mergePackages(User loggedInUser, String mergeFromLabel,
+            String mergeToLabel, boolean alignModules) {
 
         Channel mergeFrom = lookupChannelByLabel(loggedInUser, mergeFromLabel);
         Channel mergeTo = lookupChannelByLabel(loggedInUser, mergeToLabel);
@@ -2352,6 +2378,10 @@ public class ChannelSoftwareHandler extends BaseHandler {
         mergeTo.getPackages().addAll(differentPackages);
         ChannelFactory.save(mergeTo);
         ChannelManager.refreshWithNewestPackages(mergeTo, "java::mergePackages");
+
+        if (alignModules) {
+            mergeTo.cloneModulesFrom(mergeFrom);
+        }
 
         List<Long> cids = new ArrayList<Long>();
         cids.add(mergeTo.getId());

--- a/java/code/src/com/redhat/rhn/manager/channel/CloneChannelCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/CloneChannelCommand.java
@@ -117,6 +117,8 @@ public class CloneChannelCommand extends CreateChannelCommand {
         ChannelFactory.save(c);
         c = (ClonedChannel) ChannelFactory.reload(c);
 
+        c.cloneModulesFrom(original);
+
         // This ends up being a mode query call so need to save first to get channel id
         c.setGloballySubscribable(globallySubscribable, user.getOrg());
 

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
@@ -913,16 +913,11 @@ public class ContentManager {
      * @param tgt the target {@link Channel}
      * @param user the user
      */
-    public void alignEnvironmentTargetSync(Collection<ContentFilter> filters, Channel src, Channel tgt,
-            User user) {
-        // align packages and the cache (rhnServerNeededCache)
-        List<PackageFilter> packageFilters = filters.stream()
-                .flatMap(f -> stream((Optional<PackageFilter>) f.asPackageFilter()))
-                .collect(toList());
-        List<ErrataFilter> errataFilters = filters.stream()
-                .flatMap(f -> stream((Optional<ErrataFilter>) f.asErrataFilter()))
-                .collect(toList());
+    public void alignEnvironmentTargetSync(Collection<ContentFilter> filters, Channel src, Channel tgt, User user) {
+        List<PackageFilter> packageFilters = extractFiltersOfType(filters, PackageFilter.class);
+        List<ErrataFilter> errataFilters = extractFiltersOfType(filters, ErrataFilter.class);
 
+        // align packages and the cache (rhnServerNeededCache)
         alignPackages(src, tgt, packageFilters);
 
         // align errata and the cache (rhnServerNeededCache)
@@ -938,6 +933,15 @@ public class ContentManager {
         tgt.setLastModified(new Date());
         HibernateFactory.getSession().saveOrUpdate(tgt);
         ChannelManager.queueChannelChange(tgt.getLabel(), "java::alignChannel", "Channel aligned");
+    }
+
+    // helper for extracting certain filter types
+    // it's not optimal to run this method multiple times for same collection of filters, but at least it's clear
+    private static <T> List<T> extractFiltersOfType(Collection<ContentFilter> filters, Class<T> type) {
+        return filters.stream()
+                .filter(f -> type.isAssignableFrom(f.getClass()))
+                .map(f -> (T) f)
+                .collect(toList());
     }
 
     private void alignPackages(Channel srcChannel, Channel tgtChannel, Collection<PackageFilter> filters) {

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/test/ContentManagerChannelAlignmentTest.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/test/ContentManagerChannelAlignmentTest.java
@@ -22,7 +22,6 @@ import static com.redhat.rhn.domain.contentmgmt.ContentFilter.Rule.DENY;
 import static com.redhat.rhn.domain.role.RoleFactory.ORG_ADMIN;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singleton;
-import static java.util.Optional.empty;
 import static java.util.Optional.of;
 import static java.util.stream.Collectors.toSet;
 
@@ -30,7 +29,6 @@ import com.redhat.rhn.common.db.datasource.DataResult;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.channel.ChannelFactory;
-import com.redhat.rhn.domain.channel.Modules;
 import com.redhat.rhn.domain.channel.test.ChannelFactoryTest;
 import com.redhat.rhn.domain.contentmgmt.ContentFilter;
 import com.redhat.rhn.domain.contentmgmt.FilterCriteria;

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/test/ContentManagerChannelAlignmentTest.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/test/ContentManagerChannelAlignmentTest.java
@@ -22,6 +22,7 @@ import static com.redhat.rhn.domain.contentmgmt.ContentFilter.Rule.DENY;
 import static com.redhat.rhn.domain.role.RoleFactory.ORG_ADMIN;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singleton;
+import static java.util.Optional.empty;
 import static java.util.Optional.of;
 import static java.util.stream.Collectors.toSet;
 
@@ -29,6 +30,7 @@ import com.redhat.rhn.common.db.datasource.DataResult;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.channel.ChannelFactory;
+import com.redhat.rhn.domain.channel.Modules;
 import com.redhat.rhn.domain.channel.test.ChannelFactoryTest;
 import com.redhat.rhn.domain.contentmgmt.ContentFilter;
 import com.redhat.rhn.domain.contentmgmt.FilterCriteria;

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/test/ContentManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/test/ContentManagerTest.java
@@ -31,6 +31,7 @@ import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.common.security.PermissionException;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.channel.ChannelFactory;
+import com.redhat.rhn.domain.channel.Modules;
 import com.redhat.rhn.domain.channel.test.ChannelFactoryTest;
 import com.redhat.rhn.domain.contentmgmt.ContentEnvironment;
 import com.redhat.rhn.domain.contentmgmt.ContentFilter;
@@ -921,6 +922,7 @@ public class ContentManagerTest extends JMockBaseTestCaseWithUser {
         // Assert that the target channel is also modular
         Channel targetChannel = env.getTargets().get(0).asSoftwareTarget().get().getChannel();
         assertTrue(targetChannel.isModular());
+        assertEquals(channel.getModules().getRelativeFilename(), targetChannel.getModules().getRelativeFilename());
         assertEquals(channel.getPackageCount(), targetChannel.getPackageCount());
     }
 
@@ -1587,6 +1589,120 @@ public class ContentManagerTest extends JMockBaseTestCaseWithUser {
             fail("No ContentManagementException expected");
         }
         getFirstTarget(env5).setStatus(Status.BUILT); // revert
+    }
+
+    /**
+     * Tests that building a project with a non-modular source strips the data in the existing target
+     *
+     * @throws Exception
+     */
+    public void testModularDataAlignmentNoModulesSource() throws Exception {
+        var cp = new ContentProject("cplabel", "cpname", "cpdesc", user.getOrg());
+        ContentProjectFactory.save(cp);
+        var env = contentManager.createEnvironment(cp.getLabel(), empty(), "fst", "first env", "desc", false, user);
+
+        var channel = createPopulatedChannel();
+        contentManager.attachSource("cplabel", SW_CHANNEL, channel.getLabel(), empty(), user);
+
+        // we already have a modular target cloned from the past
+        var alreadyExistingTgt = createChannelInEnvironment(env, of(channel.getLabel()));
+        Modules modules = new Modules();
+        modules.setRelativeFilename("srcfilename");
+        modules.setChannel(alreadyExistingTgt);
+        alreadyExistingTgt.setModules(modules);
+        env.addTarget(new SoftwareEnvironmentTarget(env, alreadyExistingTgt));
+
+        contentManager.buildProject("cplabel", empty(), false, user);
+
+        // building project with unmodular source should reset the modular data in corresponding target
+        assertFalse(env.getTargets().get(0).asSoftwareTarget().get().getChannel().isModular());
+    }
+
+    /**
+     * Checks that building with a modular filter strips metadata of already existing target
+     *
+     * @throws Exception
+     */
+    public void testModularFiltersStripTargetModules() throws Exception {
+        var cp = new ContentProject("cplabel", "cpname", "cpdesc", user.getOrg());
+        ContentProjectFactory.save(cp);
+        var env = contentManager.createEnvironment(cp.getLabel(), empty(), "fst", "first env", "desc", false, user);
+
+        FilterCriteria criteria = new FilterCriteria(Matcher.EQUALS, "module_stream", "postgresql:10");
+        ContentFilter filter = contentManager.createFilter("my-filter-1", Rule.ALLOW, EntityType.MODULE, criteria, user);
+        contentManager.attachFilter("cplabel", filter.getId(), user);
+
+        var channel = MockModulemdApi.createModularTestChannel(user);
+        contentManager.attachSource("cplabel", SW_CHANNEL, channel.getLabel(), empty(), user);
+
+        var alreadyExistingTgt = createChannelInEnvironment(env, of(channel.getLabel()));
+        Modules modules = new Modules();
+        modules.setRelativeFilename("srcfilename");
+        modules.setChannel(alreadyExistingTgt);
+        alreadyExistingTgt.setModules(modules);
+        env.addTarget(new SoftwareEnvironmentTarget(env, alreadyExistingTgt));
+
+        // both source and current target have modular metadata...
+        contentManager.buildProject("cplabel", empty(), false, user);
+
+        // ...but presence of a filter strips it away
+        assertFalse(env.getTargets().get(0).asSoftwareTarget().get().getChannel().isModular());
+    }
+
+    /**
+     * Tests consisting of multiple steps verifying that modules metadata is aligned throughout multiple builds
+     * @throws Exception
+     */
+    public void testModularDataAlignment() throws Exception {
+        var cp = new ContentProject("cplabel", "cpname", "cpdesc", user.getOrg());
+        ContentProjectFactory.save(cp);
+        var env = contentManager.createEnvironment(cp.getLabel(), empty(), "fst", "first env", "desc", false, user);
+
+        // verify that a non-modular source results in an non-modular target
+        var channel = createPopulatedChannel();
+        contentManager.attachSource("cplabel", SW_CHANNEL, channel.getLabel(), empty(), user);
+        contentManager.buildProject("cplabel", empty(), false, user);
+        assertFalse(env.getTargets().get(0).asSoftwareTarget().get().getChannel().isModular());
+
+        // verify that a modular source results in a modular target
+        Modules modules = new Modules();
+        modules.setRelativeFilename("srcfilename");
+        modules.setChannel(channel);
+        channel.setModules(modules);
+        contentManager.buildProject("cplabel", empty(), false, user);
+        var tgtChannel = env.getTargets().get(0).asSoftwareTarget().get().getChannel();
+        assertTrue(tgtChannel.isModular());
+        assertEquals("srcfilename",  tgtChannel.getModules().getRelativeFilename());
+
+        // verify that a non-modular source strips the modular data
+        HibernateFactory.getSession().delete(channel.getModules());
+        channel.setModules(null);
+        contentManager.buildProject("cplabel", empty(), false, user);
+        assertFalse(env.getTargets().get(0).asSoftwareTarget().get().getChannel().isModular());
+    }
+
+    /**
+     * Test that the modular data is propagated in the promote operation, too.
+     *
+     * @throws Exception
+     */
+    public void testModularDataAlignmentPromote() throws Exception {
+        Channel channel = MockModulemdApi.createModularTestChannel(user);
+
+        ContentProject cp = new ContentProject("cplabel", "cpname", "cpdesc", user.getOrg());
+        ContentProjectFactory.save(cp);
+        ContentEnvironment fst = contentManager.createEnvironment(cp.getLabel(), empty(), "fst", "first env", "desc", false, user);
+        ContentEnvironment snd = contentManager.createEnvironment(cp.getLabel(), of("fst"), "snd", "second env", "desc", false, user);
+
+        contentManager.attachSource("cplabel", SW_CHANNEL, channel.getLabel(), empty(), user);
+        contentManager.buildProject("cplabel", empty(), false, user);
+        contentManager.promoteProject("cplabel", "fst", false, user);
+
+        String relativeFilename = channel.getModules().getRelativeFilename();
+        Channel fstTgt = fst.getTargets().get(0).asSoftwareTarget().get().getChannel();
+        Channel sndTgt = snd.getTargets().get(0).asSoftwareTarget().get().getChannel();
+        assertEquals(relativeFilename, fstTgt.getModules().getRelativeFilename());
+        assertEquals(relativeFilename, sndTgt.getModules().getRelativeFilename());
     }
 
     private void assertBuildFails(String projectLabel) {

--- a/java/code/src/com/redhat/rhn/taskomatic/task/ModularDataCleanup.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/ModularDataCleanup.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.taskomatic.task;
+
+import com.redhat.rhn.common.conf.Config;
+import com.redhat.rhn.common.conf.ConfigDefaults;
+import com.redhat.rhn.common.hibernate.HibernateFactory;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.filefilter.SuffixFileFilter;
+import org.apache.commons.io.filefilter.TrueFileFilter;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Clean up unused channel modular data files (modules.yaml).
+ */
+public class ModularDataCleanup extends RhnJavaJob {
+
+    private static final String MOUNT_POINT_PATH = Config.get().getString(ConfigDefaults.MOUNT_POINT);
+    private static final String MODULES_REL_PATH = "rhn/modules";
+
+    @Override
+    public void execute(JobExecutionContext jobExecutionContext) throws JobExecutionException {
+        Set<String> usedModularDataPaths = HibernateFactory.getSession()
+                .createQuery("SELECT DISTINCT(m.relativeFilename) FROM Modules m", String.class)
+                .stream()
+                .collect(Collectors.toSet());
+        Set<Path> usedModularDataAbsolutePaths = usedModularDataPaths.stream()
+                .map(relPath -> Path.of(MOUNT_POINT_PATH, relPath))
+                .collect(Collectors.toSet());
+        Collection<File> modularDataFiles = FileUtils.listFiles(
+                Path.of(MOUNT_POINT_PATH, MODULES_REL_PATH).toFile(),
+                new SuffixFileFilter("modules.yaml"),
+                TrueFileFilter.TRUE);
+
+        List<Path> unusedModularPaths = modularDataFiles
+                .stream()
+                .map(file -> file.toPath())
+                .filter(path -> !usedModularDataAbsolutePaths.contains(path))
+                .collect(Collectors.toList());
+
+        logCleaning(unusedModularPaths);
+        unusedModularPaths.forEach(path -> path.toFile().delete());
+    }
+
+    private void logCleaning(List<Path> unusedModularPaths) {
+        if (unusedModularPaths.size() > 0) {
+            log.info(String.format("Cleaning %d unused modular data files", unusedModularPaths.size()));
+            if (log.isDebugEnabled()) {
+                log.debug("Cleaning: " +
+                        unusedModularPaths.stream().map(p -> p.toString()).collect(Collectors.joining(", ")));
+            }
+        }
+    }
+}

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix modular data handling for cloned channels (bsc#1177508)
 - Fix: login gets an ISE when SSO is enabled (bsc#1181048)
 - Content Lifecycle Management input validation errors are now displayed at the field-level instead of a popup
 - Add an API endpoint to allow/disallow scheduling irrelevant patches (bsc#1180757)

--- a/schema/spacewalk/common/data/rhnTaskoTask.sql
+++ b/schema/spacewalk/common/data/rhnTaskoTask.sql
@@ -117,6 +117,6 @@ INSERT INTO rhnTaskoTask (id, name, class)
    VALUES (sequence_nextval('rhn_tasko_task_id_seq'), 'ssh-minion-action-executor', 'com.redhat.rhn.taskomatic.task.SSHMinionActionExecutor');
 
 INSERT INTO rhnTaskoTask (id, name, class)
-   VALUES (sequence_nextval('rhn_tasko_task_id_seq'), 'channel-modular-data-cleaunp', 'com.redhat.rhn.taskomatic.task.ModularDataCleanup');
+   VALUES (sequence_nextval('rhn_tasko_task_id_seq'), 'channel-modular-data-cleanup', 'com.redhat.rhn.taskomatic.task.ModularDataCleanup');
 
 commit;

--- a/schema/spacewalk/common/data/rhnTaskoTask.sql
+++ b/schema/spacewalk/common/data/rhnTaskoTask.sql
@@ -116,4 +116,7 @@ INSERT INTO rhnTaskoTask (id, name, class)
 INSERT INTO rhnTaskoTask (id, name, class)
    VALUES (sequence_nextval('rhn_tasko_task_id_seq'), 'ssh-minion-action-executor', 'com.redhat.rhn.taskomatic.task.SSHMinionActionExecutor');
 
+INSERT INTO rhnTaskoTask (id, name, class)
+   VALUES (sequence_nextval('rhn_tasko_task_id_seq'), 'channel-modular-data-cleaunp', 'com.redhat.rhn.taskomatic.task.ModularDataCleanup');
+
 commit;

--- a/schema/spacewalk/common/data/rhnTaskoTemplate.sql
+++ b/schema/spacewalk/common/data/rhnTaskoTemplate.sql
@@ -255,7 +255,7 @@ INSERT INTO rhnTaskoTemplate (id, bunch_id, task_id, ordering, start_if)
 INSERT INTO rhnTaskoTemplate (id, bunch_id, task_id, ordering, start_if)
             VALUES (sequence_nextval('rhn_tasko_template_id_seq'),
                         (SELECT id FROM rhnTaskoBunch WHERE name='cleanup-data-bunch'),
-                        (SELECT id FROM rhnTaskoTask WHERE name='channel-modular-data-cleaunp'),
+                        (SELECT id FROM rhnTaskoTask WHERE name='channel-modular-data-cleanup'),
                         1,
                         null);
 

--- a/schema/spacewalk/common/data/rhnTaskoTemplate.sql
+++ b/schema/spacewalk/common/data/rhnTaskoTemplate.sql
@@ -252,4 +252,11 @@ INSERT INTO rhnTaskoTemplate (id, bunch_id, task_id, ordering, start_if)
                         0,
                         null);
 
+INSERT INTO rhnTaskoTemplate (id, bunch_id, task_id, ordering, start_if)
+            VALUES (sequence_nextval('rhn_tasko_template_id_seq'),
+                        (SELECT id FROM rhnTaskoBunch WHERE name='cleanup-data-bunch'),
+                        (SELECT id FROM rhnTaskoTask WHERE name='channel-modular-data-cleaunp'),
+                        1,
+                        null);
+
 commit;

--- a/schema/spacewalk/upgrade/susemanager-schema-4.2.2-to-susemanager-schema-4.2.3/210-channel-modular-data-cleaunp-job.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.2.2-to-susemanager-schema-4.2.3/210-channel-modular-data-cleaunp-job.sql
@@ -1,16 +1,16 @@
 INSERT INTO rhnTaskoTask (id, name, class)
-SELECT sequence_nextval('rhn_tasko_task_id_seq'), 'channel-modular-data-cleaunp', 'com.redhat.rhn.taskomatic.task.ModularDataCleanup'
-WHERE NOT EXISTS (SELECT 1 FROM rhnTaskoTask WHERE name='channel-modular-data-cleaunp');
+SELECT sequence_nextval('rhn_tasko_task_id_seq'), 'channel-modular-data-cleanup', 'com.redhat.rhn.taskomatic.task.ModularDataCleanup'
+WHERE NOT EXISTS (SELECT 1 FROM rhnTaskoTask WHERE name='channel-modular-data-cleanup');
 
 INSERT INTO rhnTaskoTemplate (id, bunch_id, task_id, ordering, start_if)
 SELECT sequence_nextval('rhn_tasko_template_id_seq'),
     (SELECT id FROM rhnTaskoBunch WHERE name='cleanup-data-bunch'),
-    (SELECT id FROM rhnTaskoTask WHERE name='channel-modular-data-cleaunp'),
+    (SELECT id FROM rhnTaskoTask WHERE name='channel-modular-data-cleanup'),
     1,
     null
 WHERE NOT EXISTS (
     SELECT 1 FROM rhnTaskoTemplate
     WHERE bunch_id = (SELECT id FROM rhnTaskoBunch WHERE name = 'cleanup-data-bunch')
-      AND task_id = (SELECT id FROM rhnTaskoTask WHERE name = 'channel-modular-data-cleaunp')
+      AND task_id = (SELECT id FROM rhnTaskoTask WHERE name = 'channel-modular-data-cleanup')
       AND ordering = 1
 );

--- a/schema/spacewalk/upgrade/susemanager-schema-4.2.2-to-susemanager-schema-4.2.3/210-channel-modular-data-cleaunp-job.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.2.2-to-susemanager-schema-4.2.3/210-channel-modular-data-cleaunp-job.sql
@@ -1,0 +1,16 @@
+INSERT INTO rhnTaskoTask (id, name, class)
+SELECT sequence_nextval('rhn_tasko_task_id_seq'), 'channel-modular-data-cleaunp', 'com.redhat.rhn.taskomatic.task.ModularDataCleanup'
+WHERE NOT EXISTS (SELECT 1 FROM rhnTaskoTask WHERE name='channel-modular-data-cleaunp');
+
+INSERT INTO rhnTaskoTemplate (id, bunch_id, task_id, ordering, start_if)
+SELECT sequence_nextval('rhn_tasko_template_id_seq'),
+    (SELECT id FROM rhnTaskoBunch WHERE name='cleanup-data-bunch'),
+    (SELECT id FROM rhnTaskoTask WHERE name='channel-modular-data-cleaunp'),
+    1,
+    null
+WHERE NOT EXISTS (
+    SELECT 1 FROM rhnTaskoTemplate
+    WHERE bunch_id = (SELECT id FROM rhnTaskoBunch WHERE name = 'cleanup-data-bunch')
+      AND task_id = (SELECT id FROM rhnTaskoTask WHERE name = 'channel-modular-data-cleaunp')
+      AND ordering = 1
+);

--- a/utils/spacewalk-manage-channel-lifecycle
+++ b/utils/spacewalk-manage-channel-lifecycle
@@ -284,7 +284,7 @@ def merge_channels(source_label, dest_label) -> None:
     if not options.dry_run:
         # merge the packages from one channel into another
         try:
-            packages = client.channel.software.mergePackages(session, source_label, dest_label)
+            packages = client.channel.software.mergePackages(session, source_label, dest_label, True)
             logging.info('Added %i packages', len(packages))
         except xmlrpclib.Fault as e:
             if options.debug:

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,4 @@
+- Fix modular data handling for cloned channels (bsc#1177508)
 - spacewalk-common-channels: Update CentOS6 URLs to use vault.centos.org
 - spacewalk-common-channels: re-use repositories when different channels
   use the same one


### PR DESCRIPTION
The modular metadata (`modules.yaml`) is shared between cloned channels: Whenever we clone a channel, we skip cloning the metadata and instead serve it from the original when requested from clients (`DownloadFile`, `DownloadController`).

With this approach, the following scenario is problematic:
- we sync a vendor channel `A`
- we clone it into `B`
- next day, the vendor channel `A` receives new modular metadata, so we update it
- when a client requests modular metadata for the *clone* `B`, it gets metadata for `A`
- this is a problem since:
  - the new modular information doesn't need to be correct for the clone
  - (and mainly) the checksum of the `modules.yaml` in the `repomd.xml` of `B` is not matching the new `modules.yaml`, thus leading to `dnf` errors

The fix is in 2 places:
- reposync: when syncing `modules.yaml` from a RHEL modular channel, we prepend the the checksum to the file name when saving the file on the disk (`/var/spacewalk/rhn/modules`). This allows co-existence of multiple `modules.yaml`, which can be referenced from the Uyuni channels.
- java code:
  - cloning channel also clones the modular metadata
  - CLM operations (build/promote) also keep the modular metadata in correct state

## Review
Commit-by-commit (there are some `todo`s in the intermediate commits, but these can be ignored).

## New additions
- cleanup job
`ModularDataCleanup.java` is part of the `cleanup-data-bunch` and takes care of removing stale `modules.yaml` files

- fix `spacewalk-manage-lifecycle`
This tool was also broken. For promoting channels in the "environments", `mergePackages` endpoint is used. This does not align the modules. Resolved by introducing a new API endpoint with the possibility to align the repodata.

- reposync tests:
none added. I tried to write some, but the idea of testing the `copy_metadata_file` behavior didn't fit the rest of the `reposync` test. If test are needed, I'd need some help.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bugfix

- [x] **DONE**

## Test coverage
- Unit tests were added


- [x] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/12718

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"