### PR TITLE
QA: On bind formula we don't need dnssec settings anymore

### DIFF
--- a/testsuite/features/core/proxy_branch_network.feature
+++ b/testsuite/features/core/proxy_branch_network.feature
@@ -92,12 +92,6 @@ Feature: Setup SUSE Manager for Retail branch network
     And I press "Add Item" in config options section
     And I enter "empty-zones-enable" in first option field
     And I enter "no" in first value field
-    And I press "Add Item" in config options section
-    And I enter "dnssec-enable" in second option field
-    And I enter "no" in second value field
-    And I press "Add Item" in config options section
-    And I enter "dnssec-validation" in third option field
-    And I enter "no" in third value field
     And I enter "example.org" in first configured zone name field
     And I press "Add Item" in configured zones section
     And I enter the local zone name in second configured zone name field


### PR DESCRIPTION
## What does this PR change?

As we fixed on the product side, we don't need to configure manually, on the bind formula, the settings for dnssec-validation.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
Manager-4.0 https://github.com/SUSE/spacewalk/pull/12843
Manager-4.1 https://github.com/SUSE/spacewalk/pull/12842

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
