### PR TITLE
Set sock_pool_size master option by default

### DIFF
--- a/spacewalk/setup/salt/susemanager.conf
+++ b/spacewalk/setup/salt/susemanager.conf
@@ -73,6 +73,9 @@ ext_pillar:
 # verifying the master is up, worker_threads may need to be increased
 worker_threads: 8
 
+# Use several sockets to handle multiple concurrent API calls from Java components
+sock_pool_size: 30
+
 # Wait for slow minions, or long running operations, longer. Default is 15s in total.
 # Raise the timeout after 4 minutes.
 timeout: 120

--- a/spacewalk/setup/spacewalk-setup.changes
+++ b/spacewalk/setup/spacewalk-setup.changes
@@ -1,3 +1,5 @@
+- add sock_pool_size setting by default for better performance
+
 -------------------------------------------------------------------
 Fri Sep 18 12:34:52 CEST 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

From: https://docs.saltstack.com/en/3001/ref/configuration/master.html#sock-pool-size

"sock_pool_size

Default: 1

To avoid blocking waiting while writing a data to a socket, we support
socket pool for Salt applications. For example, a job with a large
number of target host list can cause long period blocking waiting. The
option is used by ZMQ and TCP transports, and the other transport
methods don't need the socket pool by definition. Most of Salt tools,
including CLI, are enough to use a single bucket of socket pool. On the
other hands, it is highly recommended to set the size of socket pool
larger than 1 for other Salt applications, especially Salt API, which
must write data to socket concurrently."

This PR introduces this parameter by default, as we use the Salt API extensively and concurrently, this should result in better performance.

## GUI diff

No difference.
- [x] **DONE**

## Documentation
- No documentation needed: **internal change only**
- [x] **DONE**

## Test coverage
- No tests: **abundantly covered already**

- [x] **DONE**

## Links

Fixes #
Tracks https://github.com/SUSE/spacewalk/pull/12845

- [x] **DONE**


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
