### PR TITLE
Run nosetests for satellite_tools unit tests with verbose output

### DIFF
--- a/backend/test/docker-backend-tools-tests.sh
+++ b/backend/test/docker-backend-tools-tests.sh
@@ -2,4 +2,4 @@
 
 touch /etc/rhn/rhn.conf
 mkdir -p /manager/backend/reports
-nosetests --with-xunit --xunit-file /manager/backend/reports/satellite_tools_tests.xml -s /manager/backend/satellite_tools/test/unit/
+nosetests -v --with-xunit --xunit-file /manager/backend/reports/satellite_tools_tests.xml -s /manager/backend/satellite_tools/test/unit/


### PR DESCRIPTION
## What does this PR change?

This PR adds `-v` to nosetests execution in order to get a detailed output and names of satetille tools unit tests execution:

Before this  PR:

```console
......10:26:28 Channel Label does not exist.
.........10:26:28 Could not figure out which credentials to use for this URL: http://example.com/?credentials=bad_creds_with_underscore
...10:26:28 Could not figure out which credentials to use for this URL: http://example.com/?credentials=testcreds
..................10:26:28 ======================================
10:26:28 | Channel: chann_1
10:26:28 ======================================
10:26:28 Sync of channel started.
10:26:28 ======================================
10:26:28 | Channel: chann_2
10:26:28 ======================================
10:26:28 Sync of channel started.
10:26:28 Total time: 0:00:00
..chgrp: cannot access '/var/log/rhn/reposync/channel-label.log': No such file or directory
.chgrp: cannot access '/var/log/rhn/reposync/channel-label.log': No such file or directory
10:26:28 Sync completed.
.chgrp: cannot access '/var/log/rhn/reposync/channel-label.log': No such file or directory
.chgrp: cannot access '/var/log/rhn/reposync/channel-label.log': No such file or directory
.10:26:28 Unhandled error occurred: error msg
10:26:28 ChannelException: error msg
.10:26:28 Unhandled error occurred: error msg
10:26:28 RepoMDError: error msg
...........
----------------------------------------------------------------------
Ran 54 tests in 0.278s

OK
```

After this PR:

```console
test_associate_package (backend.satellite_tools.test.unit.test_reposync.RepoSyncTest) ... ok
test_bad_repo_type (backend.satellite_tools.test.unit.test_reposync.RepoSyncTest) ... ok
test_get_compat_arches (backend.satellite_tools.test.unit.test_reposync.RepoSyncTest) ... ok
test_get_errata_advisories_but_no_channels (backend.satellite_tools.test.unit.test_reposync.RepoSyncTest) ... ok
test_get_errata_no_advisories_found (backend.satellite_tools.test.unit.test_reposync.RepoSyncTest) ... ok
test_get_errata_success (backend.satellite_tools.test.unit.test_reposync.RepoSyncTest) ... ok
test_init_bad_channel (backend.satellite_tools.test.unit.test_reposync.RepoSyncTest) ... 10:27:11 Channel Label does not exist.
ok
test_init_channel (backend.satellite_tools.test.unit.test_reposync.RepoSyncTest) ... ok
Init rhnLog successfully ... ok
test_init_succeeds_with_correct_attributes (backend.satellite_tools.test.unit.test_reposync.RepoSyncTest) ... ok
test_init_with_custom_flags (backend.satellite_tools.test.unit.test_reposync.RepoSyncTest) ... ok
test_init_with_custom_url (backend.satellite_tools.test.unit.test_reposync.RepoSyncTest) ... ok
Test generates empty metadata via taskomatic and quits ... ok
Test for _is_old_suse_style ... ok
test_send_error_mail (backend.satellite_tools.test.unit.test_reposync.RepoSyncTest) ... ok
test_set_repo_credentials_bad_credentials (backend.satellite_tools.test.unit.test_reposync.RepoSyncTest) ... 10:27:11 Could not figure out which credentials to use for this URL: http://example.com/?credentials=bad_creds_with_underscore
ok
test_set_repo_credentials_no_credentials (backend.satellite_tools.test.unit.test_reposync.RepoSyncTest) ... ok
test_set_repo_credentials_number_credentials (backend.satellite_tools.test.unit.test_reposync.RepoSyncTest) ... ok
test_set_repo_credentials_old_default_credentials_bad (backend.satellite_tools.test.unit.test_reposync.RepoSyncTest) ... 10:27:11 Could not figure out which credentials to use for this URL: http://example.com/?credentials=testcreds
ok
test_sync_raises_channel_timeout (backend.satellite_tools.test.unit.test_reposync.RepoSyncTest) ... ok
test_sync_raises_unexpected_error (backend.satellite_tools.test.unit.test_reposync.RepoSyncTest) ... ok
test_sync_success_no_regen (backend.satellite_tools.test.unit.test_reposync.RepoSyncTest) ... ok
test_sync_success_regen (backend.satellite_tools.test.unit.test_reposync.RepoSyncTest) ... ok
Test for _to_db_date ... ok
test_update_bugs (backend.satellite_tools.test.unit.test_reposync.RepoSyncTest) ... ok
test_update_cves (backend.satellite_tools.test.unit.test_reposync.RepoSyncTest) ... ok
test_update_cves_with_description (backend.satellite_tools.test.unit.test_reposync.RepoSyncTest) ... ok
test_update_keywords_both_false (backend.satellite_tools.test.unit.test_reposync.RepoSyncTest) ... ok
test_update_keywords_reboot (backend.satellite_tools.test.unit.test_reposync.RepoSyncTest) ... ok
test_update_keywords_restart (backend.satellite_tools.test.unit.test_reposync.RepoSyncTest) ... ok
test_update_keywords_restart_and_reboot (backend.satellite_tools.test.unit.test_reposync.RepoSyncTest) ... ok
test_updates_process_packages_checksum_not_found (backend.satellite_tools.test.unit.test_reposync.RepoSyncTest) ... ok
test_updates_process_packages_checksum_not_found_but_not_available (backend.satellite_tools.test.unit.test_reposync.RepoSyncTest) ... ok
test_updates_process_packages_checksum_not_found_no_epoch (backend.satellite_tools.test.unit.test_reposync.RepoSyncTest) ... ok
test_updates_process_packages_returns_the_right_values (backend.satellite_tools.test.unit.test_reposync.RepoSyncTest) ... ok
test_updates_process_packages_simple (backend.satellite_tools.test.unit.test_reposync.RepoSyncTest) ... ok
test_config_parameter_channel_as_list (backend.satellite_tools.test.unit.test_reposync.RunScriptTest) ... 10:27:11 ======================================
10:27:11 | Channel: chann_1
10:27:11 ======================================
10:27:11 Sync of channel started.
10:27:11 ======================================
10:27:11 | Channel: chann_2
10:27:11 ======================================
10:27:11 Sync of channel started.
10:27:11 Total time: 0:00:00
ok
test_config_parameter_channel_not_list (backend.satellite_tools.test.unit.test_reposync.RunScriptTest) ... ok
test__url_with_repo_credentials (backend.satellite_tools.test.unit.test_reposync.SyncTest) ... chgrp: cannot access '/var/log/rhn/reposync/channel-label.log': No such file or directory
ok
test_pass_multiple_urls_params (backend.satellite_tools.test.unit.test_reposync.SyncTest) ... chgrp: cannot access '/var/log/rhn/reposync/channel-label.log': No such file or directory
10:27:11 Sync completed.
ok
test_rhnSQL_should_return_source_urls_as_list (backend.satellite_tools.test.unit.test_reposync.SyncTest) ... chgrp: cannot access '/var/log/rhn/reposync/channel-label.log': No such file or directory
ok
test_set_repo_credentials_with_multiple_urls (backend.satellite_tools.test.unit.test_reposync.SyncTest) ... chgrp: cannot access '/var/log/rhn/reposync/channel-label.log': No such file or directory
ok
Test rasising all the different exceptions when syncing ... 10:27:11 Unhandled error occurred: error msg
10:27:11 ChannelException: error msg
ok
Test rasising all the different exceptions when syncing ... 10:27:11 Unhandled error occurred: error msg
10:27:11 RepoMDError: error msg
ok
Authenticate ULN, getting its token. ... ok
Test credentials ULN configuration readable. ... ok
Test credentials ULN ... ok
Test credentials ULN was not found ... ok
Test partial credentials ULN found ... ok
Test credentials ULN configuration exists. ... ok
Test ULN uri inserts a custom hostname, if specified. ... ok
Test ULN uri inserts a default hostname, if not specified. ... ok
Test ULN uri raises an exception if protocol is not ULN. ... ok
test_content_source_init (backend.satellite_tools.test.unit.test_yum_src.YumSrcTest) ... ok

----------------------------------------------------------------------
XML: /manager/backend/reports/satellite_tools_tests.xml
----------------------------------------------------------------------
Ran 54 tests in 0.193s

OK
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **test fix**
- [x] **DONE**

## Test coverage
- No tests: **test fix**
- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
