### PR TITLE
QAM: Prepare repo name, when coming from a mirror

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -1154,9 +1154,9 @@ end
 
 When(/^I create the MU repository for (salt|traditional) "([^"]*)" if necessary$/) do |client_type, client|
   client.sub! 'ssh_minion', 'minion' # Both minion and ssh_minion uses the same repositories
-  url = $mu_repositories[client][client_type].strip
-  tmp = url.delete_prefix "http://download.suse.de/ibs/SUSE:/Maintenance:/"
-  repo_name = tmp.delete_prefix "http://minima-mirror-qam.mgr.prv.suse.net/ibs/SUSE:/Maintenance:/"
+  repo_name = url = $mu_repositories[client][client_type].strip
+  repo_name.delete_prefix! "http://download.suse.de/ibs/SUSE:/Maintenance:/"
+  repo_name.delete_prefix! "http://minima-mirror-qam.mgr.prv.suse.net/ibs/SUSE:/Maintenance:/"
   if repository_exist? repo_name
     puts "The MU repository #{repo_name} was already created, we will reuse it."
   else
@@ -1174,9 +1174,9 @@ end
 
 When(/^I select the MU repository name for (salt|traditional) "([^"]*)" from the list$/) do |client_type, client|
   client.sub! 'ssh_minion', 'minion' # Both minion and ssh_minion uses the same repositories
-  url = $mu_repositories[client][client_type].strip
-  tmp = url.delete_prefix "http://download.suse.de/ibs/SUSE:/Maintenance:/"
-  repo_name = tmp.delete_prefix "http://minima-mirror-qam.mgr.prv.suse.net/ibs/SUSE:/Maintenance:/"
+  repo_name = url = $mu_repositories[client][client_type].strip
+  repo_name.delete_prefix! "http://download.suse.de/ibs/SUSE:/Maintenance:/"
+  repo_name.delete_prefix! "http://minima-mirror-qam.mgr.prv.suse.net/ibs/SUSE:/Maintenance:/"
   step %(I check "#{repo_name}" in the list)
 end
 

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -1155,7 +1155,8 @@ end
 When(/^I create the MU repository for (salt|traditional) "([^"]*)" if necessary$/) do |client_type, client|
   client.sub! 'ssh_minion', 'minion' # Both minion and ssh_minion uses the same repositories
   url = $mu_repositories[client][client_type].strip
-  repo_name = url.delete_prefix "http://download.suse.de/ibs/SUSE:/Maintenance:/"
+  tmp = url.delete_prefix "http://download.suse.de/ibs/SUSE:/Maintenance:/"
+  repo_name = tmp.delete_prefix "http://minima-mirror-qam.mgr.prv.suse.net/ibs/SUSE:/Maintenance:/"
   if repository_exist? repo_name
     puts "The MU repository #{repo_name} was already created, we will reuse it."
   else
@@ -1174,7 +1175,8 @@ end
 When(/^I select the MU repository name for (salt|traditional) "([^"]*)" from the list$/) do |client_type, client|
   client.sub! 'ssh_minion', 'minion' # Both minion and ssh_minion uses the same repositories
   url = $mu_repositories[client][client_type].strip
-  repo_name = url.delete_prefix "http://download.suse.de/ibs/SUSE:/Maintenance:/"
+  tmp = url.delete_prefix "http://download.suse.de/ibs/SUSE:/Maintenance:/"
+  repo_name = tmp.delete_prefix "http://minima-mirror-qam.mgr.prv.suse.net/ibs/SUSE:/Maintenance:/"
   step %(I check "#{repo_name}" in the list)
 end
 


### PR DESCRIPTION
## What does this PR change?

Support for QAM mirror as MU Repo URL

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
 - Manager-4.0 https://github.com/SUSE/spacewalk/pull/12854
 - Manager-4.1  https://github.com/SUSE/spacewalk/pull/12855

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
