### PR TITLE
Path has changed on Ubuntu 20.04

### DIFF
--- a/testsuite/features/secondary/min_ubuntu_openscap_audit.feature
+++ b/testsuite/features/secondary/min_ubuntu_openscap_audit.feature
@@ -12,7 +12,7 @@ Feature: openSCAP audit of Ubuntu Salt minion
     When I follow "Audit" in the content area
     And I follow "Schedule" in the content area
     And I enter "--profile common" as "params"
-    And I enter "/usr/share/scap-security-guide/ssg-ubuntu1604-xccdf.xml" as "path"
+    And I enter "/usr/share/xml/scap/ssg/content/ssg-ubuntu1604-xccdf.xml" as "path"
     And I click on "Schedule"
     Then I should see a "XCCDF scan has been scheduled" text
     And I wait at most 500 seconds until event "OpenSCAP xccdf scanning" is completed


### PR DESCRIPTION
## What does this PR change?

This PR adapts openscap definitions path for Ubuntu 20.04.

To be noted: we still use 16.04 data (see issue SUSE/spacewalk#12860 for details).

See also SUSE/susemanager-ci#148 for the infrastructure part.

## Links

Ports:
* 4.1: SUSE/spacewalk#12861
* 4.0: SUSE/spacewalk#12862


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
