### PR TITLE
Correct profile for openSCAP

### DIFF
--- a/testsuite/features/secondary/min_ubuntu_openscap_audit.feature
+++ b/testsuite/features/secondary/min_ubuntu_openscap_audit.feature
@@ -11,7 +11,7 @@ Feature: openSCAP audit of Ubuntu Salt minion
     Given I am on the Systems overview page of this "ubuntu_minion"
     When I follow "Audit" in the content area
     And I follow "Schedule" in the content area
-    And I enter "--profile common" as "params"
+    And I enter "--profile standard" as "params"
     And I enter "/usr/share/xml/scap/ssg/content/ssg-ubuntu1604-xccdf.xml" as "path"
     And I click on "Schedule"
     Then I should see a "XCCDF scan has been scheduled" text


### PR DESCRIPTION
## What does this PR change?

Fix openSCAP on Ubuntu 20.04.

```
root@suma-41-min-ubuntu2004:~# oscap info /usr/share/xml/scap/ssg/content/ssg-ubuntu1604-xccdf.xml
Document type: XCCDF Checklist
Checklist version: 1.1
Imported: 2018-07-26T16:58:28
Status: draft
Generated: 2018-07-26
Resolved: true
Profiles:
	Title: Profile for ANSSI DAT-NT28 Restrictive Level
		Id: anssi_np_nt28_restrictive
	Title: Standard System Security Profile for Ubuntu 16
		Id: standard
	Title: Profile for ANSSI DAT-NT28 High (Enforced) Level
		Id: anssi_np_nt28_high
	Title: Profile for ANSSI DAT-NT28 Minimal Level
		Id: anssi_np_nt28_minimal
	Title: Profile for ANSSI DAT-NT28 Average (Intermediate) Level
		Id: anssi_np_nt28_average
Referenced check files:
	ssg-ubuntu1604-oval.xml
		system: http://oval.mitre.org/XMLSchema/oval-definitions-5
	ssg-ubuntu1604-ocil.xml
		system: http://scap.nist.gov/schema/ocil/2
```


## Links

Ports:
* 4.1: SUSE/spacewalk#12865
* 4.0: SUSE/spacewalk#12866


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
