### PR TITLE
Correct link name

### DIFF
--- a/testsuite/features/secondary/min_ubuntu_openscap_audit.feature
+++ b/testsuite/features/secondary/min_ubuntu_openscap_audit.feature
@@ -35,7 +35,7 @@ Feature: openSCAP audit of Ubuntu Salt minion
   Scenario: Check the results of the OpenSCAP scan on the Ubuntu minion
     Given I am on the Systems overview page of this "ubuntu_minion"
     When I follow "Audit" in the content area
-    And I follow "xccdf_org.open-scap_testresult_common"
+    And I follow "xccdf_org.open-scap_testresult_standard"
     Then I should see a "Details of XCCDF Scan" text
     And I should see a "Ubuntu" text
     And I should see a "XCCDF Rule Results" text


### PR DESCRIPTION
## What does this PR change?

Fix Ubuntu 20.04 openscap test


## Links

Ports:
* 4.1: SUSE/spacewalk#/12867
* 4.0: SUSE/spacewalk#/12868


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
