### PR TITLE
Testsuite: do not try to disable a missing product

### DIFF
--- a/testsuite/features/reposync/srv_sync_products.feature
+++ b/testsuite/features/reposync/srv_sync_products.feature
@@ -70,7 +70,6 @@ Feature: Synchronize products in the products page of the Setup Wizard
     When I open the sub-list of the product "Basesystem Module 15 SP2 x86_64"
     Then I should see that the "Server Applications Module 15 SP2 x86_64" product is "recommended"
     When I select "SUSE Linux Enterprise Server 15 SP2 x86_64" as a product
-    And I deselect "SUSE Manager Tools 15 x86_64 (BETA)" as a product
     And I deselect "Server Applications Module 15 SP2 x86_64" as a product
     And I click the Add Product button
     And I wait until I see "SUSE Linux Enterprise Server 15 SP2 x86_64" product has been added


### PR DESCRIPTION
## What does this PR change?
Do not try to disable SUSE Manager beta client tools.
Uyuni has its own client tools; head only uses beta tools during
beta testing.



## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


