### PR TITLE
Testsuite: Do not assume SLE-Manager-Tools15-Updates channel is present

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -551,7 +551,6 @@ Then(/^the SLE15SP2 base products should be added$/) do
   raise unless output[:stdout].include? '[I] SLE-Product-SLES15-SP2-Pool for x86_64 SUSE Linux Enterprise Server 15 SP2 x86_64 [sle-product-sles15-sp2-pool-x86_64]'
   raise unless output[:stdout].include? '[I] SLE-Module-Basesystem15-SP2-Updates for x86_64 Basesystem Module 15 SP2 x86_64 [sle-module-basesystem15-sp2-updates-x86_64]'
   raise unless output[:stdout].include? '[ ] SLE-Module-Server-Applications15-SP2-Pool for x86_64 Server Applications Module 15 SP2 x86_64 [sle-module-server-applications15-sp2-pool-x86_64]'
-  raise unless output[:stdout].include? '[I] SLE-Manager-Tools15-Updates for x86_64 SUSE Manager Tools 15 x86_64 [sle-manager-tools15-updates-x86_64-sp2]'
 end
 
 When(/^I click the channel list of product "(.*?)"$/) do |product|


### PR DESCRIPTION
## What does this PR change?
This channel is not present in the Uyuni case.


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)
