### PR TITLE
Maintain list of synced images in pillar

### DIFF
--- a/java/code/src/com/suse/manager/reactor/SaltReactor.java
+++ b/java/code/src/com/suse/manager/reactor/SaltReactor.java
@@ -42,6 +42,8 @@ import com.suse.manager.reactor.messaging.LibvirtEnginePoolRefreshMessage;
 import com.suse.manager.reactor.messaging.MinionStartEventDatabaseMessage;
 import com.suse.manager.reactor.messaging.MinionStartEventMessage;
 import com.suse.manager.reactor.messaging.MinionStartEventMessageAction;
+import com.suse.manager.reactor.messaging.ImageSyncedEventMessage;
+import com.suse.manager.reactor.messaging.ImageSyncedEventMessageAction;
 import com.suse.manager.utils.SaltUtils;
 import com.suse.manager.virtualization.VirtManagerSalt;
 import com.suse.manager.webui.services.SaltServerActionService;
@@ -60,6 +62,7 @@ import com.suse.manager.reactor.messaging.VirtpollerBeaconEventMessage;
 import com.suse.manager.reactor.messaging.VirtpollerBeaconEventMessageAction;
 import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.manager.webui.utils.salt.custom.ImageDeployedEvent;
+import com.suse.manager.webui.utils.salt.custom.ImageSyncedEvent;
 import com.suse.manager.webui.utils.salt.custom.SystemIdGenerateEvent;
 import com.suse.manager.webui.utils.salt.custom.VirtpollerData;
 import com.suse.salt.netapi.datatypes.Event;
@@ -149,6 +152,8 @@ public class SaltReactor {
                 LibvirtEngineNetworkLifecycleMessage.class);
         MessageQueue.registerAction(new BatchStartedEventMessageAction(),
                 BatchStartedEventMessage.class);
+        MessageQueue.registerAction(new ImageSyncedEventMessageAction(),
+                ImageSyncedEventMessage.class);
 
         MessageQueue.publish(new RefreshGeneratedSaltFilesEventMessage());
 
@@ -192,10 +197,11 @@ public class SaltReactor {
                BatchStartedEvent.parse(event).map(this::eventToMessages).orElseGet(() ->
                SystemIdGenerateEvent.parse(event).map(this::eventToMessages).orElseGet(() ->
                ImageDeployedEvent.parse(event).map(this::eventToMessages).orElseGet(() ->
+               ImageSyncedEvent.parse(event).map(this::eventToMessages).orElseGet(() ->
                EngineEvent.parse(event).map(this::eventToMessages).orElseGet(() ->
                BeaconEvent.parse(event).map(this::eventToMessages).orElse(
                empty()
-        )))))));
+        ))))))));
     }
 
     /**
@@ -229,6 +235,16 @@ public class SaltReactor {
      */
     private Stream<EventMessage> eventToMessages(ImageDeployedEvent imageDeployedEvent) {
         return of(new ImageDeployedEventMessage(imageDeployedEvent));
+    }
+
+    /**
+     * Trigger ImageSynced events.
+     *
+     * @param imageSyncedEvent image deployed event
+     * @return event handler runnable
+     */
+    private Stream<EventMessage> eventToMessages(ImageSyncedEvent imageSyncedEvent) {
+        return of(new ImageSyncedEventMessage(imageSyncedEvent));
     }
 
     /**

--- a/java/code/src/com/suse/manager/reactor/messaging/ImageSyncedEventMessage.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/ImageSyncedEventMessage.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.suse.manager.reactor.messaging;
+
+import com.redhat.rhn.common.messaging.EventMessage;
+import com.suse.manager.webui.utils.salt.custom.ImageSyncedEvent;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+/**
+ * Carrier of the image synced event.
+ */
+public class ImageSyncedEventMessage implements EventMessage {
+
+    private ImageSyncedEvent imageSyncedEvent;
+
+    /**
+     * Standard constructor.
+     *
+     * @param imageSyncedEventIn - 'image synced' event
+     */
+    public ImageSyncedEventMessage(ImageSyncedEvent imageSyncedEventIn) {
+        this.imageSyncedEvent = imageSyncedEventIn;
+    }
+
+    /**
+     * Gets the 'image synced' event.
+     *
+     * @return ImageSyncedEvent
+     */
+    public ImageSyncedEvent getImageSyncedEvent() {
+        return imageSyncedEvent;
+    }
+
+    @Override
+    public String toText() {
+        return toString();
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .append("ImageSyncedEvent", imageSyncedEvent)
+                .toString();
+    }
+
+    @Override
+    public Long getUserId() {
+        return null;
+    }
+}

--- a/java/code/src/com/suse/manager/reactor/messaging/ImageSyncedEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/ImageSyncedEventMessageAction.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.suse.manager.reactor.messaging;
+
+import com.redhat.rhn.common.messaging.EventMessage;
+import com.redhat.rhn.common.messaging.MessageAction;
+import com.redhat.rhn.domain.server.ServerGroupFactory;
+import com.redhat.rhn.domain.server.ManagedServerGroup;
+import com.redhat.rhn.domain.server.MinionServer;
+import com.redhat.rhn.domain.server.MinionServerFactory;
+import com.suse.manager.webui.services.SaltStateGeneratorService;
+import com.suse.manager.webui.utils.salt.custom.ImageSyncedEvent;
+import org.apache.log4j.Logger;
+
+import java.util.Optional;
+
+/**
+ * Logic responsible for reacting to 'image synced' event.
+ */
+public class ImageSyncedEventMessageAction implements MessageAction {
+
+    private static final Logger LOG = Logger.getLogger(ImageSyncedEventMessageAction.class);
+
+
+    @Override
+    public void execute(EventMessage msg) {
+        ImageSyncedEvent imageSyncedEvent = ((ImageSyncedEventMessage) msg).getImageSyncedEvent();
+
+        String minionId = imageSyncedEvent.getMinionId();
+
+        Optional<MinionServer> minionOpt = MinionServerFactory.findByMinionId(minionId);
+        minionOpt.ifPresent(minion -> {
+            ManagedServerGroup branchGroup = ServerGroupFactory.lookupByNameAndOrg(imageSyncedEvent.getBranch(),
+                minion.getOrg());
+
+            if (!minion.getGroups().contains(branchGroup)) {
+                LOG.error("Branch server " + minionId + " is not in group " + imageSyncedEvent.getBranch());
+                return;
+            }
+
+            String action = imageSyncedEvent.getAction();
+            if (action.equals("add")) {
+                SaltStateGeneratorService.INSTANCE.createImageSyncedPillar(branchGroup,
+                    imageSyncedEvent.getImageName(), imageSyncedEvent.getImageVersion());
+            }
+            else if (action.equals("remove")) {
+                SaltStateGeneratorService.INSTANCE.removeImageSyncedPillar(branchGroup,
+                    imageSyncedEvent.getImageName(), imageSyncedEvent.getImageVersion());
+            }
+            else {
+                LOG.warn("Unknown image_synced action: " + action);
+            }
+        });
+    }
+
+    @Override
+    public boolean canRunConcurrently() {
+        return true;
+    }
+}

--- a/java/code/src/com/suse/manager/reactor/messaging/test/ImageSyncedEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/ImageSyncedEventMessageActionTest.java
@@ -1,0 +1,89 @@
+package com.suse.manager.reactor.messaging.test;
+
+import static java.util.Arrays.asList;
+
+import static com.suse.manager.webui.services.SaltConstants.PILLAR_IMAGE_DATA_FILE_EXT;
+import static com.suse.manager.webui.services.SaltConstants.SUMA_PILLAR_IMAGES_DATA_PATH;
+
+import com.redhat.rhn.common.messaging.EventMessage;
+import com.redhat.rhn.domain.action.Action;
+import com.redhat.rhn.domain.server.ManagedServerGroup;
+import com.redhat.rhn.domain.server.MinionServer;
+import com.redhat.rhn.domain.server.ServerFactory;
+import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
+import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
+import com.redhat.rhn.testing.ServerGroupTestUtils;
+import com.redhat.rhn.testing.TestUtils;
+
+import com.suse.manager.reactor.messaging.ImageSyncedEventMessage;
+import com.suse.manager.reactor.messaging.ImageSyncedEventMessageAction;
+import com.suse.manager.webui.utils.salt.custom.ImageSyncedEvent;
+import com.suse.salt.netapi.datatypes.Event;
+import com.suse.salt.netapi.parser.JsonParser;
+
+import com.google.gson.reflect.TypeToken;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+
+/**
+ * Test for {@link ImageDeployedEvent}
+ */
+public class ImageSyncedEventMessageActionTest extends JMockBaseTestCaseWithUser {
+    // Fixed test parameters
+    private MinionServer testMinion;
+    private ManagedServerGroup testGroup1, testGroup2;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        // setup a minion
+        testMinion = MinionServerFactoryTest.createTestMinionServer(user);
+        testMinion.setServerArch(ServerFactory.lookupServerArchByLabel("x86_64-redhat-linux"));
+
+        testGroup1 = ServerGroupTestUtils.createManaged(user);
+        testGroup2 = ServerGroupTestUtils.createManaged(user);
+        testMinion.addGroup(testGroup1);
+        testMinion.addGroup(testGroup2);
+    }
+
+    /**
+     * Happy path scenario: machine_id grain is present.
+     * In this case we test that at the end of the Action, the minion has correct channels
+     * (based on its product) assigned.
+     */
+    public void testImageSyncedPillarCreated() throws Exception {
+        JsonParser<Event> jsonParser = new JsonParser<>(new TypeToken<Event>() {});
+        Event event = jsonParser.parse(
+        "{                                                       " +
+        "    'tag': 'suse/manager/image_synced',                 " +
+        "    'data': {                                           " +
+        "        'id': '" + testMinion.getMinionId() + "',       " +
+        "        'cmd': '_minion_event',                         " +
+        "        'pretag': None,                                 " +
+        "        'data': {                                       " +
+        "            'branch': '" + testGroup1.getName() + "',   " +
+        "            'action': 'add',                            " +
+        "            'image_name': 'ImageTest',                  " +
+        "            'image_version': '7.0.0'                    " +
+        "        }                                               " +
+        "    }                                                   " +
+        "}");
+
+        Optional<ImageSyncedEvent> imageSyncedEventOpt = ImageSyncedEvent.parse(event);
+        assertTrue(imageSyncedEventOpt.isPresent());
+        assertEquals("add", imageSyncedEventOpt.get().getAction());
+        EventMessage message = new ImageSyncedEventMessage(imageSyncedEventOpt.get());
+        ImageSyncedEventMessageAction action = new ImageSyncedEventMessageAction();
+        action.execute(message);
+        
+        Path filePath = tmpSaltRoot.resolve(SUMA_PILLAR_IMAGES_DATA_PATH)
+            .resolve("group" + testGroup1.getId().toString())
+            .resolve("ImageTest-7.0.0." + PILLAR_IMAGE_DATA_FILE_EXT);
+
+        assertTrue(Files.exists(filePath));
+        Files.deleteIfExists(filePath);
+    }
+}

--- a/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
@@ -1690,7 +1690,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         doTestKiwiImageInspect(server, "my-kiwi-image", profile, (info) -> {
             assertNotNull(info.getInspectAction().getId());
             assertEquals(286, info.getPackages().size());
-            File generatedPillar = new File("/srv/susemanager/pillar_data/images/image-POS_Image_JeOS6.x86_64-6.0.0-build24.sls");
+            File generatedPillar = new File("/srv/susemanager/pillar_data/images/org" + user.getOrg().getId() + "/image-POS_Image_JeOS6.x86_64-6.0.0-build24.sls");
 
             assertTrue(generatedPillar.exists());
             Map<String, Object> map;

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -67,6 +67,7 @@ import com.redhat.rhn.domain.image.OSImageStoreUtils;
 import com.redhat.rhn.domain.notification.NotificationMessage;
 import com.redhat.rhn.domain.notification.UserNotificationFactory;
 import com.redhat.rhn.domain.notification.types.StateApplyFailed;
+import com.redhat.rhn.domain.org.Org;
 import com.redhat.rhn.domain.product.SUSEProduct;
 import com.redhat.rhn.domain.product.SUSEProductFactory;
 import com.redhat.rhn.domain.product.Tuple2;
@@ -1311,10 +1312,10 @@ public class SaltUtils {
                         Optional.of(pkg.getRelease()), pkg.getVersion(), Optional.of(instantNow),
                         Optional.of(pkg.getArch()), imageInfo));
                 if ("pxe".equals(ret.getImage().getType())) {
-                    String storeDirectory = OSImageStoreUtils.getOSImageStoreURIForOrg(
-                            serverAction.getParentAction().getOrg());
+                    Org org = serverAction.getParentAction().getOrg();
+                    String storeDirectory = OSImageStoreUtils.getOSImageStoreURIForOrg(org);
                     SaltStateGeneratorService.INSTANCE.generateOSImagePillar(ret.getImage(), ret.getBundle(),
-                            ret.getBootImage(), storeDirectory);
+                            ret.getBootImage(), storeDirectory, org);
                 }
             }
             else {

--- a/java/code/src/com/suse/manager/webui/services/SaltStateGeneratorService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltStateGeneratorService.java
@@ -80,9 +80,10 @@ public enum SaltStateGeneratorService {
      * @param bundle the OS image bundle resulting image from an inspection
      * @param bootImage the OS image boot image resulting image from an inspection
      * @param urlBase the OS Image store URL
+     * @param org the OS Image organization
      */
     public void generateOSImagePillar(OSImageInspectSlsResult.Image image, OSImageInspectSlsResult.Bundle bundle,
-                                      OSImageInspectSlsResult.BootImage bootImage, String urlBase) {
+                                      OSImageInspectSlsResult.BootImage bootImage, String urlBase, Org org) {
         try {
             SaltPillar pillar = new SaltPillar();
             String name = image.getName();
@@ -105,9 +106,16 @@ public enum SaltStateGeneratorService {
                 }
             }
 
-            Path filePath = Paths.get(SUMA_PILLAR_IMAGES_DATA_PATH).resolve(
+            Path dirPath = Paths.get(SUMA_PILLAR_IMAGES_DATA_PATH).resolve(
+                    "org" + org.getId().toString()
+            );
+            Path filePath = dirPath.resolve(
                     getImagePillarFileName(bundle)
             );
+
+            if (!dirPath.toFile().exists()) {
+                dirPath.toFile().mkdirs();
+            }
 
             SaltStateGenerator saltStateGenerator = new SaltStateGenerator(filePath.toFile());
             saltStateGenerator.generate(pillar);

--- a/java/code/src/com/suse/manager/webui/services/SaltStateGeneratorService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltStateGeneratorService.java
@@ -194,6 +194,67 @@ public enum SaltStateGeneratorService {
     }
 
     /**
+     * Generate OS Image specific pillar for Branch group, containing synced flag
+     * @param branch the ServerGroup for which the pillar is created
+     * @param name the OS image name
+     * @param version the OS image version
+     */
+    public void createImageSyncedPillar(ServerGroup branch, String name, String version) {
+
+        try {
+            SaltPillar pillar = new SaltPillar();
+            Map<String, Object> imagePillarDetails = Collections.singletonMap("synced", true);
+            Map<String, Object> imagePillarBase = Collections.singletonMap(version, imagePillarDetails);
+            Map<String, Object> imagePillar = Collections.singletonMap(name, imagePillarBase);
+
+            pillar.add("images", imagePillar);
+
+            Path dirPath = Paths.get(SUMA_PILLAR_IMAGES_DATA_PATH).resolve(
+                    "group" + branch.getId().toString()
+            );
+
+            Path filePath = dirPath.resolve(
+                    name.replace('.', '-') + "-" + version + "." + PILLAR_IMAGE_DATA_FILE_EXT
+            );
+
+            if (!dirPath.toFile().exists()) {
+                dirPath.toFile().mkdirs();
+            }
+
+            SaltStateGenerator saltStateGenerator = new SaltStateGenerator(filePath.toFile());
+            saltStateGenerator.generate(pillar);
+        }
+        catch (IOException e) {
+            LOG.error(e.getMessage(), e);
+        }
+
+    }
+
+    /**
+     * Remove OS Image specific pillar for Branch group
+     * @param branch the ServerGroup
+     * @param name the OS image name
+     * @param version the OS image version
+     */
+    public void removeImageSyncedPillar(ServerGroup branch, String name, String version) {
+        try {
+            Path dirPath = Paths.get(SUMA_PILLAR_IMAGES_DATA_PATH).resolve(
+                    "group" + branch.getId().toString()
+            );
+
+            Path filePath = dirPath.resolve(
+                    name.replace('.', '-') + "-" + version + "." + PILLAR_IMAGE_DATA_FILE_EXT
+            );
+
+            Files.deleteIfExists(filePath);
+        }
+        catch (IOException e) {
+            LOG.error(e.getMessage(), e);
+        }
+    }
+
+
+    /**
      * Remove the config channel assignments for minion server.
      * @param minion the minion server
      */

--- a/java/code/src/com/suse/manager/webui/utils/salt/custom/ImageSyncedEvent.java
+++ b/java/code/src/com/suse/manager/webui/utils/salt/custom/ImageSyncedEvent.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.webui.utils.salt.custom;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.reflect.TypeToken;
+import com.suse.salt.netapi.datatypes.Event;
+import com.suse.salt.netapi.parser.JsonParser;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+
+/**
+ * Represents an event fired when a minion connects to the salt master
+ */
+public class ImageSyncedEvent {
+
+    private static final Pattern PATTERN = Pattern.compile("^suse/manager/image_synced");
+
+    private static final Gson GSON = JsonParser.GSON;
+
+    private final String minionId;
+    private final JsonElement data;
+
+    /**
+     * Creates a new ImageSyncedEvent
+     * @param minionId the id of the minion sending the event
+     * @param data data containing more information about this event
+     */
+    private ImageSyncedEvent(String minionIdIn, JsonElement dataIn) {
+        this.minionId = minionIdIn;
+        this.data = dataIn;
+    }
+
+    /**
+     * The id of the minion that started
+     *
+     * @return the minion id
+     */
+    public String getMinionId() {
+        return minionId;
+    }
+
+    public String getAction() {
+        return data.getAsJsonObject().get("data").getAsJsonObject().get("action").getAsString();
+    }
+
+    public String getBranch() {
+        return data.getAsJsonObject().get("data").getAsJsonObject().get("branch").getAsString();
+    }
+
+    public String getImageName() {
+        return data.getAsJsonObject().get("data").getAsJsonObject().get("image_name").getAsString();
+    }
+
+    public String getImageVersion() {
+        return data.getAsJsonObject().get("data").getAsJsonObject().get("image_version").getAsString();
+    }
+
+    /**
+     * Return the event data parsed into the given type.
+     * @param type type token to parse data
+     * @param <R> type to parse the data into
+     * @return the event data
+     */
+    public <R> R getData(TypeToken<R> type) {
+        return GSON.fromJson(data, type.getType());
+    }
+
+    /**
+     * Return event data as Map
+     * @return event data as map
+     */
+    public Map<String, Object> getData() {
+        TypeToken<Map<String, Object>> typeToken = new TypeToken<Map<String, Object>>() { };
+        return getData(typeToken);
+    }
+
+    /**
+     * Utility method to parse e generic event to a more specific one
+     * @param event the generic event to parse
+     * @return an option containing the parsed value or non if it could not be parsed
+     */
+    public static Optional<ImageSyncedEvent> parse(Event event) {
+        Matcher matcher = PATTERN.matcher(event.getTag());
+        if (matcher.matches()) {
+            ImageSyncedEvent result = new ImageSyncedEvent(
+                (String) event.getData().get("id"),
+                event.getData(JsonElement.class)
+            );
+            return Optional.of(result);
+        }
+        else {
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .append("minionId", minionId)
+                .append("data", data)
+                .toString();
+    }
+
+}

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Make image pillar visible only in buildhost organization
+- Maintain list of synced images in pillar
 - Remove hostname from /var/lib/salt/.ssh/known_hosts when deleting system (bsc#1176159)
 - log token verify errors and check for expired tokens
 - show only kernel options in advanced autoinstallation page when working with

--- a/susemanager-utils/susemanager-sls/modules/engines/mgr_events.py
+++ b/susemanager-utils/susemanager-sls/modules/engines/mgr_events.py
@@ -126,6 +126,7 @@ class Responder:
             fnmatch.fnmatch(tag, "salt/engines/*"),
             fnmatch.fnmatch(tag, "salt/batch/*/start"),
             fnmatch.fnmatch(tag, "suse/manager/image_deployed"),
+            fnmatch.fnmatch(tag, "suse/manager/image_synced"),
             fnmatch.fnmatch(tag, "suse/systemid/generate")
         ]) and not self._is_salt_mine_event(tag, data) and not self._is_presence_ping(tag, data):
             queue = 0

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Handle group- and org-specific image pillars
 - Remove hostname from /var/lib/salt/.ssh/known_hosts when deleting system (bsc#1176159)
 - Fix grub2 autoinstall kernel path (bsc#1178060)
 - use require in reboot trigger (bsc#1177767)


### PR DESCRIPTION
## What does this PR change?

This adds functionality for adding and removing "synced" flag for each image in each branch, based on salt events emitted by image-sync formula.
It also limits visibility of image pillars to buildhost org only.

## GUI diff

No difference.


## Documentation
- No documentation needed.

## Test coverage

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/10577 and https://github.com/SUSE/spacewalk/issues/12388

Depends on https://github.com/uyuni-project/retail/pull/67

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
