### PR TITLE
Testsuite: Refactor cleanup step for salt minions

### DIFF
--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -720,14 +720,10 @@ When(/^I enter "([^"]*)" password$/) do |host|
 end
 
 And(/^I cleanup minion "([^"]*)"$/) do |minion|
+  raise "#{minion} is not a salt minion" unless minion.include? 'minion'
   node = get_target(minion)
-  if %w[sle_minion sle_ssh_tunnel_minion].include?(minion)
-    node.run('rcsalt-minion stop')
-    node.run('rm -Rf /var/cache/salt/minion')
-  elsif %w[ceos_minion ceos_ssh_minion ubuntu_minion ubuntu_ssh_minion].include?(minion)
-    node.run('systemctl stop salt-minion')
-    node.run('rm -Rf /var/cache/salt/minion')
-  end
+  node.run('systemctl stop salt-minion')
+  node.run('rm -Rf /var/cache/salt/minion')
 end
 
 When(/^I install a salt pillar top file for "([^"]*)" with target "([^"]*)" on the server$/) do |file, host|


### PR DESCRIPTION
## What does this PR change?
Refactor cleanup step for salt minions.
We use `systemd` in all our salt minions, thus no need to use `rcsalt-minion` for SUSE minions
and `systemd` for the rest. 

## Links
- Manager-4.0: 
- Manager-4.1: 

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)
