### PR TITLE
QA: New step to select/deselect products depending if it's Uyuni or S…

### DIFF
--- a/testsuite/features/reposync/srv_sync_products.feature
+++ b/testsuite/features/reposync/srv_sync_products.feature
@@ -70,6 +70,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     When I open the sub-list of the product "Basesystem Module 15 SP2 x86_64"
     Then I should see that the "Server Applications Module 15 SP2 x86_64" product is "recommended"
     When I select "SUSE Linux Enterprise Server 15 SP2 x86_64" as a product
+    And I deselect "SUSE Manager Tools 15 x86_64 (BETA)" as a SUSE Manager product
     And I deselect "Server Applications Module 15 SP2 x86_64" as a product
     And I click the Add Product button
     And I wait until I see "SUSE Linux Enterprise Server 15 SP2 x86_64" product has been added

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -462,6 +462,12 @@ When(/^I (deselect|select) "([^\"]*)" as a product$/) do |select, product|
   raise "xpath: #{xpath} not found" unless find(:xpath, xpath).set(select == "select")
 end
 
+When(/^I (deselect|select) "([^\"]*)" as a (SUSE Manager|Uyuni) product$/) do |select, product, product_version|
+  if $product == product_version
+    step %(I #{select} "#{product}" as a product)
+  end
+end
+
 When(/^I wait until the tree item "([^"]+)" has no sub-list$/) do |item|
   repeat_until_timeout(message: "could still find a sub list for tree item #{item}") do
     xpath = "//span[contains(text(), '#{item}')]/ancestor::div[contains(@class, 'product-details-wrapper')]/div/i[contains(@class, 'fa-angle-')]"


### PR DESCRIPTION
## What does this PR change?

This PR offers a new step definition that check if the product running is a Uyuni or a SUSE Manager instance, depending on it, will select/deselect a specified product from the Setup Wizard list.

This aims to fix an issue with the Beta Tools, which are shown in the list for our Head CI, but not into the Uyuni CI.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports required for:
- Manager-4.1
- Manager-4.0

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
