### PR TITLE
Allow vendor change during dist upgrades

### DIFF
--- a/backend/server/action/distupgrade.py
+++ b/backend/server/action/distupgrade.py
@@ -22,7 +22,7 @@ from spacewalk.server.rhnLib import InvalidAction, ShadowAction
 __rhnexport__ = ['upgrade']
 
 _query_dup_data = rhnSQL.Statement("""
-    SELECT id, dry_run, full_update
+    SELECT id, dry_run, allow_vendor_change, full_update
       FROM rhnActionDup
      WHERE action_id = :action_id
 """)
@@ -100,6 +100,7 @@ def upgrade(serverId, actionId, dry_run=0):
             "full_update"         : (row['full_update'] == 'Y'),
             "change_product"      : do_change,
             "products"            : sle10_products,
+            "allow_vendor_change" : (row['allow_vendor_change'] == 'Y'),
             "dry_run"             : (row['dry_run'] == 'Y') }
         return (params)
 
@@ -125,6 +126,7 @@ def upgrade(serverId, actionId, dry_run=0):
         "full_update"         : (row['full_update'] == 'Y'),
         "change_product"      : do_change,
         "products"            : sle10_products,
+        "allow_vendor_change" : (row['allow_vendor_change'] == 'Y'),
         "dry_run"             : (row['dry_run'] == 'Y') }
     return (params)
 

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- add 'allow_vendor_change' option to rhn clients for dist upgrades
 - Re-enables possibility to use local repos with repo-sync (bsc#1175607)
 - prevent IntegrityError during mgr-inter-sync execution (bsc#1177235)
 

--- a/java/code/src/com/redhat/rhn/domain/action/dup/DistUpgradeActionDetails.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/dup/DistUpgradeActionDetails.hbm.xml
@@ -26,6 +26,7 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
       <one-to-many class="com.redhat.rhn.domain.action.dup.DistUpgradeChannelTask" />
     </set>
     <property name="dryRun" column="dry_run" type="yes_no" />
+    <property name="allowVendorChange" column="allow_vendor_change" type="yes_no" />
     <property name="fullUpdate" column="full_update" type="yes_no" />
   </class>
 </hibernate-mapping>

--- a/java/code/src/com/redhat/rhn/domain/action/dup/DistUpgradeActionDetails.java
+++ b/java/code/src/com/redhat/rhn/domain/action/dup/DistUpgradeActionDetails.java
@@ -72,12 +72,16 @@ public class DistUpgradeActionDetails extends ActionChild {
      * Set if vendor changed allowed or not.
      * @param allowVendorChangeIn boolean
      */
-    public void setAllowVendorChange(boolean allowVendorChangeIn) { this.allowVendorChange = allowVendorChangeIn; }
+    public void setAllowVendorChange(boolean allowVendorChangeIn) {
+        this.allowVendorChange = allowVendorChangeIn;
+    }
 
     /**
      * @return the allowVendorChange as boolean
      */
-    public boolean isAllowVendorChange() { return allowVendorChange; }
+    public boolean isAllowVendorChange() {
+        return allowVendorChange;
+    }
 
     /**
      * @return the fullUpdate

--- a/java/code/src/com/redhat/rhn/domain/action/dup/DistUpgradeActionDetails.java
+++ b/java/code/src/com/redhat/rhn/domain/action/dup/DistUpgradeActionDetails.java
@@ -27,6 +27,7 @@ public class DistUpgradeActionDetails extends ActionChild {
 
     private Long id;
     private boolean dryRun;
+    private boolean allowVendorChange;
     private boolean fullUpdate;
 
     // Set of tasks to perform on single channels
@@ -66,6 +67,17 @@ public class DistUpgradeActionDetails extends ActionChild {
     public void setDryRun(boolean dryRunIn) {
         this.dryRun = dryRunIn;
     }
+
+    /**
+     * Set if vendor changed allowed or not.
+     * @param allowVendorChangeIn boolean
+     */
+    public void setAllowVendorChange(boolean allowVendorChangeIn) { this.allowVendorChange = allowVendorChangeIn; }
+
+    /**
+     * @return the allowVendorChange as boolean
+     */
+    public boolean isAllowVendorChange() { return allowVendorChange; }
 
     /**
      * @return the fullUpdate

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/SPMigrationAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/SPMigrationAction.java
@@ -31,6 +31,7 @@ import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.log4j.Logger;
 import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionForward;
@@ -193,9 +194,7 @@ public class SPMigrationAction extends RhnAction {
             targetAddonProducts = (Long[]) form.get(ADDON_PRODUCTS);
             targetBaseChannel = (Long) form.get(BASE_CHANNEL);
             targetChildChannels = (Long[]) form.get(CHILD_CHANNELS);
-            if (form.get(ALLOW_VENDOR_CHANGE) != null) {
-                allowVendorChange = true;
-            }
+            allowVendorChange = BooleanUtils.isTrue((Boolean)form.get(ALLOW_VENDOR_CHANGE));
 
             // Get additional flags
             if (dispatch.equals(LocalizationService.getInstance().getMessage(DISPATCH_DRYRUN))) {

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/SPMigrationAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/SPMigrationAction.java
@@ -193,7 +193,7 @@ public class SPMigrationAction extends RhnAction {
             targetAddonProducts = (Long[]) form.get(ADDON_PRODUCTS);
             targetBaseChannel = (Long) form.get(BASE_CHANNEL);
             targetChildChannels = (Long[]) form.get(CHILD_CHANNELS);
-            if(form.get(ALLOW_VENDOR_CHANGE) != null) {
+            if (form.get(ALLOW_VENDOR_CHANGE) != null) {
                 allowVendorChange = true;
             }
 

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/SPMigrationAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/SPMigrationAction.java
@@ -97,6 +97,7 @@ public class SPMigrationAction extends RhnAction {
     private static final String BASE_CHANNEL = "baseChannel";
     private static final String CHILD_CHANNELS = "childChannels";
     private static final String TARGET_PRODUCT_SELECTED = "targetProductSelected";
+    private static final String ALLOW_VENDOR_CHANGE = "allowVendorChange";
 
     // Message keys
     private static final String DISPATCH_DRYRUN = "spmigration.jsp.confirm.submit.dry-run";
@@ -178,6 +179,8 @@ public class SPMigrationAction extends RhnAction {
         boolean dryRun = false;
         boolean goBack = false;
         boolean targetProductSelectedEmpty = false;
+        boolean allowVendorChange = false;
+
         String targetProductSelected = request.getParameter(TARGET_PRODUCT_SELECTED);
 
         // Read form parameters if dispatching
@@ -190,6 +193,9 @@ public class SPMigrationAction extends RhnAction {
             targetAddonProducts = (Long[]) form.get(ADDON_PRODUCTS);
             targetBaseChannel = (Long) form.get(BASE_CHANNEL);
             targetChildChannels = (Long[]) form.get(CHILD_CHANNELS);
+            if(form.get(ALLOW_VENDOR_CHANGE) != null) {
+                allowVendorChange = true;
+            }
 
             // Get additional flags
             if (dispatch.equals(LocalizationService.getInstance().getMessage(DISPATCH_DRYRUN))) {
@@ -294,6 +300,7 @@ public class SPMigrationAction extends RhnAction {
             request.setAttribute(TARGET_PRODUCTS, targetProductSet);
             request.setAttribute(BASE_PRODUCT, targetProductSet.getBaseProduct());
             request.setAttribute(ADDON_PRODUCTS, targetProductSet.getAddonProducts());
+            request.setAttribute(ALLOW_VENDOR_CHANGE, allowVendorChange);
             // Put channel data
             Channel baseChannel = ChannelFactory.lookupByIdAndUser(targetBaseChannel, ctx.getCurrentUser());
             request.setAttribute(BASE_CHANNEL, baseChannel);
@@ -320,7 +327,7 @@ public class SPMigrationAction extends RhnAction {
             Date earliest = getStrutsDelegate().readScheduleDate(form, "date",
                     DatePicker.YEAR_RANGE_POSITIVE);
             Long actionID = DistUpgradeManager.scheduleDistUpgrade(ctx.getCurrentUser(),
-                    server, targetProductSet, channelIDs, dryRun, earliest);
+                    server, targetProductSet, channelIDs, dryRun, allowVendorChange, earliest);
 
             // Display a message to the user
             String product = targetProductSet.getBaseProduct().getFriendlyName();

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -25069,6 +25069,9 @@ given channel.</source>
       <trans-unit id="spmigration.jsp.target.submit" xml:space="preserve">
         <source>Select Channels</source>
       </trans-unit>
+      <trans-unit id="spmigration.jsp.allow.vendor.change">
+        <source>Allow Vendor Change</source>
+      </trans-unit>
       <trans-unit id="spmigration.jsp.error.targetProductSelectedEmpty" xml:space="preserve">
         <source>Please select one target product to migrate</source>
       </trans-unit>

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -6692,6 +6692,43 @@ public class SystemHandler extends BaseHandler {
         return returnList;
     }
 
+
+    /**
+     * Schedule a Service Pack migration for a system. This call is the recommended and
+     * supported way of migrating a system to the next Service Pack.
+     *
+     * This call automatically select the nearest possible migration target.
+     *
+     * It will automatically find all mandatory product channels below a given
+     * target base channel and subscribe the system accordingly. Any additional
+     * optional channels can be subscribed by providing their labels.
+     *
+     * @param loggedInUser the currently logged in user
+     * @param sid ID of the server
+     * @param baseChannelLabel label of the target base channel
+     * @param optionalChildChannels labels of optional child channels to subscribe
+     * @param dryRun set to true to perform a dry run
+     * @param earliest earliest occurrence of the migration
+     * @return action id, exception thrown otherwise
+     *
+     * @xmlrpc.doc Schedule a Service Pack migration for a system. This call is the
+     * recommended and supported way of migrating a system to the next Service Pack. It will
+     * automatically find all mandatory product channels below a given target base channel
+     * and subscribe the system accordingly. Any additional optional channels can be
+     * subscribed by providing their labels.
+     * @xmlrpc.param #param("string", "sessionKey")
+     * @xmlrpc.param #param("int", "serverId")
+     * @xmlrpc.param #param("string", "baseChannelLabel")
+     * @xmlrpc.param #array_single("string", "optionalChildChannels")
+     * @xmlrpc.param #param("boolean", "dryRun")
+     * @xmlrpc.param #param("dateTime.iso8601", "earliest")
+     * @xmlrpc.returntype #param_desc("int", "actionId", "The action id of the scheduled action")
+     */
+    public Long scheduleSPMigration(User loggedInUser, Integer sid, String baseChannelLabel,
+                                    List<String> optionalChildChannels, boolean dryRun, Date earliest) {
+        return scheduleSPMigration(loggedInUser, sid, baseChannelLabel, optionalChildChannels, dryRun, false, earliest);
+    }
+
     /**
      * Schedule a Service Pack migration for a system. This call is the recommended and
      * supported way of migrating a system to the next Service Pack.
@@ -6728,6 +6765,45 @@ public class SystemHandler extends BaseHandler {
             List<String> optionalChildChannels, boolean dryRun, boolean allowVendorChange, Date earliest) {
         return scheduleSPMigration(loggedInUser, sid, null, baseChannelLabel,
                 optionalChildChannels, dryRun, allowVendorChange, earliest);
+    }
+
+
+    /**
+     * Schedule a Service Pack migration for a system. This call is the recommended and
+     * supported way of migrating a system to the next Service Pack. It will automatically
+     * find all mandatory product channels below a given target base channel and subscribe
+     * the system accordingly. Any additional optional channels can be subscribed by
+     * providing their labels.
+     *
+     * @param loggedInUser the currently logged in user
+     * @param sid ID of the server
+     * @param targetIdent identifier for the selected migration
+     *                    target ({@link #listMigrationTargets})
+     * @param baseChannelLabel label of the target base channel
+     * @param optionalChildChannels labels of optional child channels to subscribe
+     * @param dryRun set to true to perform a dry run
+     * @param earliest earliest occurrence of the migration
+     * @return action id, exception thrown otherwise
+     *
+     * @xmlrpc.doc Schedule a Service Pack migration for a system. This call is the
+     * recommended and supported way of migrating a system to the next Service Pack. It will
+     * automatically find all mandatory product channels below a given target base channel
+     * and subscribe the system accordingly. Any additional optional channels can be
+     * subscribed by providing their labels.
+     * @xmlrpc.param #param("string", "sessionKey")
+     * @xmlrpc.param #param("int", "serverId")
+     * @xmlrpc.param #param("string", "targetIdent")
+     * @xmlrpc.param #param("string", "baseChannelLabel")
+     * @xmlrpc.param #array_single("string", "optionalChildChannels")
+     * @xmlrpc.param #param("boolean", "dryRun")
+     * @xmlrpc.param #param("dateTime.iso8601",  "earliest")
+     * @xmlrpc.returntype #param_desc("int", "actionId", "The action id of the scheduled action")
+     */
+    public Long scheduleSPMigration(User loggedInUser, Integer sid, String targetIdent,
+                                    String baseChannelLabel, List<String> optionalChildChannels, boolean dryRun,
+                                    Date earliest) {
+        return scheduleSPMigration(loggedInUser, sid, targetIdent, baseChannelLabel, optionalChildChannels, dryRun,
+                false, earliest);
     }
 
     /**
@@ -6872,6 +6948,39 @@ public class SystemHandler extends BaseHandler {
         // We didn't find target products if we are still here
         throw new FaultException(-1, "servicePackMigrationNoTarget",
                 "No target found for SP migration");
+    }
+
+    /**
+     * Schedule a dist upgrade for a system. This call takes a list of channel labels that
+     * the system will be subscribed to before performing the dist upgrade.
+     *
+     * Note: You can seriously damage your system with this call, use it only if you really
+     * know what you are doing! Make sure that the list of channel labels is complete and
+     * in any case do a dry run before scheduling an actual dist upgrade.
+     *
+     * @param loggedInUser the currently logged in user
+     * @param sid ID of the server
+     * @param channels labels of channels to subscribe to
+     * @param dryRun set to true to perform a dry run
+     * @param earliest earliest occurrence of the migration
+     * @return action id, exception thrown otherwise
+     *
+     * @xmlrpc.doc Schedule a dist upgrade for a system. This call takes a list of channel
+     * labels that the system will be subscribed to before performing the dist upgrade.
+     * Note: You can seriously damage your system with this call, use it only if you really
+     * know what you are doing! Make sure that the list of channel labels is complete and in
+     * any case do a dry run before scheduling an actual dist upgrade.
+     * @xmlrpc.param #param("string", "sessionKey")
+     * @xmlrpc.param #param("int", "serverId")
+     * @xmlrpc.param #array_single("string", "channels")
+     * @xmlrpc.param #param("boolean", "dryRun")
+     * @xmlrpc.param #param("dateTime.iso8601",  "earliest")
+     * @xmlrpc.returntype #param("int", "actionId", "The action id of the scheduled action")
+     */
+    public Long scheduleDistUpgrade(User loggedInUser, Integer sid, List<String> channels,
+                                    boolean dryRun, Date earliest) {
+        // for older calls that don't use vendor change
+        return scheduleDistUpgrade(loggedInUser, sid, channels, dryRun, false, earliest);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -6720,13 +6720,14 @@ public class SystemHandler extends BaseHandler {
      * @xmlrpc.param #param("string", "baseChannelLabel")
      * @xmlrpc.param #array_single("string", "optionalChildChannels")
      * @xmlrpc.param #param("boolean", "dryRun")
-     * @xmlrpc.param #param("dateTime.iso8601",  "earliest")
+     * @xmlrpc.param #param("boolean", "allowVendorChange")
+     * @xmlrpc.param #param("dateTime.iso8601", "earliest")
      * @xmlrpc.returntype #param_desc("int", "actionId", "The action id of the scheduled action")
      */
     public Long scheduleSPMigration(User loggedInUser, Integer sid, String baseChannelLabel,
-            List<String> optionalChildChannels, boolean dryRun, Date earliest) {
+            List<String> optionalChildChannels, boolean dryRun, boolean allowVendorChange, Date earliest) {
         return scheduleSPMigration(loggedInUser, sid, null, baseChannelLabel,
-                optionalChildChannels, dryRun, earliest);
+                optionalChildChannels, dryRun, allowVendorChange, earliest);
     }
 
     /**
@@ -6757,12 +6758,13 @@ public class SystemHandler extends BaseHandler {
      * @xmlrpc.param #param("string", "baseChannelLabel")
      * @xmlrpc.param #array_single("string", "optionalChildChannels")
      * @xmlrpc.param #param("boolean", "dryRun")
+     * @xmlrpc.param #param("boolean", "allowVendorChange")
      * @xmlrpc.param #param("dateTime.iso8601",  "earliest")
      * @xmlrpc.returntype #param_desc("int", "actionId", "The action id of the scheduled action")
      */
     public Long scheduleSPMigration(User loggedInUser, Integer sid, String targetIdent,
             String baseChannelLabel, List<String> optionalChildChannels, boolean dryRun,
-            Date earliest) {
+            boolean allowVendorChange, Date earliest) {
         // Perform checks on the server
         Server server = null;
         try {
@@ -6848,7 +6850,7 @@ public class SystemHandler extends BaseHandler {
                         channelIDs.add(channel.getId());
                     }
                     return DistUpgradeManager.scheduleDistUpgrade(loggedInUser, server,
-                            targetProducts, channelIDs, dryRun, earliest);
+                            targetProducts, channelIDs, dryRun, allowVendorChange, earliest);
                 }
 
                 // Consider alternatives (cloned channel trees)
@@ -6858,7 +6860,7 @@ public class SystemHandler extends BaseHandler {
                     if (clonedBaseChannel.getLabel().equals(baseChannelLabel)) {
                         channelIDs.addAll(alternatives.get(clonedBaseChannel));
                         return DistUpgradeManager.scheduleDistUpgrade(loggedInUser, server,
-                                targetProducts, channelIDs, dryRun, earliest);
+                                targetProducts, channelIDs, dryRun, allowVendorChange, earliest);
                     }
                 }
             }
@@ -6896,11 +6898,12 @@ public class SystemHandler extends BaseHandler {
      * @xmlrpc.param #param("int", "serverId")
      * @xmlrpc.param #array_single("string", "channels")
      * @xmlrpc.param #param("boolean", "dryRun")
+     * @xmlrpc.param #param("boolean", "allowVendorChange")
      * @xmlrpc.param #param("dateTime.iso8601",  "earliest")
      * @xmlrpc.returntype #param("int", "actionId", "The action id of the scheduled action")
      */
     public Long scheduleDistUpgrade(User loggedInUser, Integer sid, List<String> channels,
-            boolean dryRun, Date earliest) {
+            boolean dryRun, boolean allowVendorChange, Date earliest) {
         // Lookup the server and perform some checks
         Server server = null;
         try {
@@ -6915,7 +6918,7 @@ public class SystemHandler extends BaseHandler {
         try {
             channelIDs = DistUpgradeManager.performChannelChecks(channels, loggedInUser);
             return DistUpgradeManager.scheduleDistUpgrade(loggedInUser, server, null,
-                    channelIDs, dryRun, earliest);
+                    channelIDs, dryRun, allowVendorChange, earliest);
         }
         catch (DistUpgradeException e) {
             throw new FaultException(-1, "distUpgradeChannelError", e.getMessage());

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -6744,6 +6744,7 @@ public class SystemHandler extends BaseHandler {
      * @param baseChannelLabel label of the target base channel
      * @param optionalChildChannels labels of optional child channels to subscribe
      * @param dryRun set to true to perform a dry run
+     * @param allowVendorChange set to true to allow vendor change
      * @param earliest earliest occurrence of the migration
      * @return action id, exception thrown otherwise
      *
@@ -6820,6 +6821,7 @@ public class SystemHandler extends BaseHandler {
      * @param baseChannelLabel label of the target base channel
      * @param optionalChildChannels labels of optional child channels to subscribe
      * @param dryRun set to true to perform a dry run
+     * @param allowVendorChange set to true to allow vendor change
      * @param earliest earliest occurrence of the migration
      * @return action id, exception thrown otherwise
      *
@@ -6995,6 +6997,7 @@ public class SystemHandler extends BaseHandler {
      * @param sid ID of the server
      * @param channels labels of channels to subscribe to
      * @param dryRun set to true to perform a dry run
+     * @param allowVendorChange set to true to allow vendor change
      * @param earliest earliest occurrence of the migration
      * @return action id, exception thrown otherwise
      *

--- a/java/code/src/com/redhat/rhn/manager/distupgrade/DistUpgradeManager.java
+++ b/java/code/src/com/redhat/rhn/manager/distupgrade/DistUpgradeManager.java
@@ -623,6 +623,7 @@ public class DistUpgradeManager extends BaseManager {
      * @param targetSet set of target products (base product and addons)
      * @param channelIDs IDs of all channels to subscribe
      * @param dryRun perform a dry run
+     * @param allowVendorChange allow vendor change during dist upgrade
      * @param earliest earliest schedule date
      * @return the action ID
      * @throws TaskomaticApiException if there was a Taskomatic error
@@ -630,7 +631,7 @@ public class DistUpgradeManager extends BaseManager {
      */
     public static Long scheduleDistUpgrade(User user, Server server,
             SUSEProductSet targetSet, Collection<Long> channelIDs,
-            boolean dryRun, Date earliest) throws TaskomaticApiException {
+            boolean dryRun, boolean allowVendorChange, Date earliest) throws TaskomaticApiException {
         // Create action details
         DistUpgradeActionDetails details = new DistUpgradeActionDetails();
 
@@ -676,6 +677,7 @@ public class DistUpgradeManager extends BaseManager {
 
         // Set additional attributes
         details.setDryRun(dryRun);
+        details.setAllowVendorChange(allowVendorChange);
         details.setFullUpdate(true);
 
         // Return the ID of the scheduled action

--- a/java/code/src/com/redhat/rhn/manager/distupgrade/test/DistUpgradeManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/distupgrade/test/DistUpgradeManagerTest.java
@@ -606,7 +606,7 @@ public class DistUpgradeManagerTest extends BaseTestCaseWithUser {
         channelIDs.add(channel2.getId());
         Date scheduleDate = new Date();
         Long actionID = DistUpgradeManager.scheduleDistUpgrade(
-                user, server, targetSet, channelIDs, true, scheduleDate);
+                user, server, targetSet, channelIDs, true, false, scheduleDate);
 
         // Get the scheduled action and check the contents
         DistUpgradeAction action = (DistUpgradeAction) ActionFactory.lookupById(actionID);
@@ -617,6 +617,7 @@ public class DistUpgradeManagerTest extends BaseTestCaseWithUser {
         assertEquals(server, serverActions.iterator().next().getServer());
         DistUpgradeActionDetails details = action.getDetails();
         assertTrue(details.isDryRun());
+        assertFalse(details.isAllowVendorChange());
 
         // Check product upgrade
         Set<SUSEProductUpgrade> upgrades = details.getProductUpgrades();

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -1520,7 +1520,7 @@ public class SaltServerActionService {
         Map<String, Object> distupgrade = new HashMap<>();
         susemanager.put("distupgrade", distupgrade);
         distupgrade.put("dryrun", action.getDetails().isDryRun());
-        distupgrade.put("allowVendorChange", !action.getDetails().isAllowVendorChange());
+        distupgrade.put("allowVendorChange", action.getDetails().isAllowVendorChange());
         distupgrade.put("channels", subbed.stream()
                 .sorted()
                 .map(c -> "susemanager:" + c.getLabel())

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -1520,6 +1520,7 @@ public class SaltServerActionService {
         Map<String, Object> distupgrade = new HashMap<>();
         susemanager.put("distupgrade", distupgrade);
         distupgrade.put("dryrun", action.getDetails().isDryRun());
+        distupgrade.put("allowVendorChange", !action.getDetails().isAllowVendorChange());
         distupgrade.put("channels", subbed.stream()
                 .sorted()
                 .map(c -> "susemanager:" + c.getLabel())

--- a/java/code/webapp/WEB-INF/pages/systems/spmigration/channel-details.jspf
+++ b/java/code/webapp/WEB-INF/pages/systems/spmigration/channel-details.jspf
@@ -42,11 +42,6 @@
                 <c:set var="disabledChannel" scope="page" value="alt=\"enabled\"" />
               </c:otherwise>
             </c:choose>
-
-            <li>
-              <input ${disabledChannel} name="child_channel" value="${channel.id}" type="checkbox" id="unchecked" />
-              <a href="/rhn/channels/ChannelDetail.do?cid=${channel.id}"><c:out value="${channel.name}" /></a>
-            </li>
           </c:if>
         </c:forEach>
         <c:if test="${empty optionalChannels}">

--- a/java/code/webapp/WEB-INF/pages/systems/spmigration/channel-details.jspf
+++ b/java/code/webapp/WEB-INF/pages/systems/spmigration/channel-details.jspf
@@ -42,6 +42,11 @@
                 <c:set var="disabledChannel" scope="page" value="alt=\"enabled\"" />
               </c:otherwise>
             </c:choose>
+
+            <li>
+              <input ${disabledChannel} name="child_channel" value="${channel.id}" type="checkbox" id="unchecked" />
+              <a href="/rhn/channels/ChannelDetail.do?cid=${channel.id}"><c:out value="${channel.name}" /></a>
+            </li>
           </c:if>
         </c:forEach>
         <c:if test="${empty optionalChannels}">
@@ -50,10 +55,6 @@
           </li>
         </c:if>
       </ul>
-    </li>
-    <li>
-      <input  name="allowVendorChange" value="true" type="checkbox" id="unchecked" />
-      <bean:message key="spmigration.jsp.allow.vendor.change" />
     </li>
   </ul>
 

--- a/java/code/webapp/WEB-INF/pages/systems/spmigration/channel-details.jspf
+++ b/java/code/webapp/WEB-INF/pages/systems/spmigration/channel-details.jspf
@@ -56,6 +56,10 @@
         </c:if>
       </ul>
     </li>
+    <li>
+      <input  name="allowVendorChange" value="true" type="checkbox" id="unchecked" />
+      <bean:message key="spmigration.jsp.allow.vendor.change" />
+    </li>
   </ul>
 
 </div>

--- a/java/code/webapp/WEB-INF/pages/systems/spmigration/spmigration-confirm.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/spmigration/spmigration-confirm.jsp
@@ -91,6 +91,8 @@
     <c:forEach items="${childChannels}" var="current">
       <html:hidden property="childChannels" value="${current.id}" />
     </c:forEach>
+    <html:hidden property="allowVendorChange" value="${allowVendorChange}" />
+
     <html:hidden property="targetProductSelected"
         value="${targetProducts.serializedProductIDs}" />
     <html:hidden property="step" value="confirm" />

--- a/java/code/webapp/WEB-INF/pages/systems/spmigration/spmigration-setup.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/spmigration/spmigration-setup.jsp
@@ -98,6 +98,16 @@
                 </div>
             </div>
             <div class="form-group">
+                <label class="col-sm-2 control-label">
+                    <bean:message key="spmigration.jsp.allow.vendor.change" />
+                </label>
+                <ul class="form-control-static products-list">
+                    <li>
+                        <input  name="allowVendorChange" type="checkbox" />
+                    </li>
+               </ul>
+            </div>
+            <div class="form-group">
                 <div class="col-sm-offset-2 col-sm-10">
                     <button type="submit" name="dispatch"
                         class="btn btn-success" id="submitButton"
@@ -107,6 +117,7 @@
                     </button>
                 </div>
             </div>
+
             <html:hidden property="baseProduct"
                 value="${targetProducts.baseProduct.id}" />
             <c:forEach items="${targetProducts.addonProducts}" var="current">

--- a/java/code/webapp/WEB-INF/struts-config.xml
+++ b/java/code/webapp/WEB-INF/struts-config.xml
@@ -1080,6 +1080,7 @@
       <form-property name="addonProducts" type="java.lang.Long[]" />
       <form-property name="baseChannel" type="java.lang.Long" />
       <form-property name="childChannels" type="java.lang.Long[]" />
+      <form-property name="allowVendorChange" type="java.lang.Boolean" />
       <form-property name="submitted" type="java.lang.Boolean" />
       <!-- Date picker fields -->
       <form-property name="schedule_type" type="java.lang.String" />

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- add new allowVendorChange flag for dist upgrades
 - Take pool and volume from Salt virt.vm_info for files and blocks disks (bsc#1175987)
 - Create VM on a Salt host using a cobbler profile
 - Show cluster upgrade plan in the upgrade UI

--- a/schema/spacewalk/common/tables/rhnActionDup.sql
+++ b/schema/spacewalk/common/tables/rhnActionDup.sql
@@ -27,6 +27,10 @@ CREATE TABLE rhnActionDup
                             DEFAULT ('Y') NOT NULL
                             CONSTRAINT rhn_actiondup_fu_ck
                                 CHECK (full_update in ('Y','N')),
+    allow_vendor_change CHAR(1)
+                            DEFAULT ('N') NOT NULL
+                            CONSTRAINT rhn_actiondup_avc_ck
+                                CHECK (allow_vendor_change in ('Y','N')),
     created   TIMESTAMPTZ
                   DEFAULT (current_timestamp) NOT NULL,
     modified  TIMESTAMPTZ

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- add new column to rhnactiondup table for allowVendorChange flag
 - Add cobbler-related fields in VM Creation action table
 - Execute Salt SSH actions in parallel (bsc#1173199)
 - Hotfix the modular RPMs release comparison

--- a/schema/spacewalk/upgrade/susemanager-schema-4.1.9-to-susemanager-schema-4.1.10/001-rhnActionDup-add-alllow-vendor-change.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.1.9-to-susemanager-schema-4.1.10/001-rhnActionDup-add-alllow-vendor-change.sql
@@ -1,0 +1,6 @@
+ALTER TABLE rhnActionDup DROP CONSTRAINT IF EXISTS rhn_actiondup_avc_ck;
+ALTER TABLE rhnActionDup
+  ADD COLUMN IF NOT EXISTS allow_vendor_change CHAR(1)
+  DEFAULT ('N') NOT NULL
+  CONSTRAINT rhn_actiondup_avc_ck
+  CHECK (allow_vendor_change in ('Y','N'));

--- a/schema/spacewalk/upgrade/susemanager-schema-4.2.2-to-susemanager-schema-4.2.3/001-rhnActionDup-add-alllow-vendor-change.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.2.2-to-susemanager-schema-4.2.3/001-rhnActionDup-add-alllow-vendor-change.sql
@@ -1,3 +1,5 @@
 ALTER TABLE rhnActionDup
-  ADD COLUMN allow_vendor_change CHAR(1) DEFAULT 'N';  
-
+  ADD COLUMN allow_vendor_change CHAR(1)
+  DEFAULT ('N') NOT NULL
+  CONSTRAINT rhn_actiondup_avc_ck
+  CHECK (allow_vendor_change in ('Y','N'));

--- a/schema/spacewalk/upgrade/susemanager-schema-4.2.2-to-susemanager-schema-4.2.3/001-rhnActionDup-add-alllow-vendor-change.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.2.2-to-susemanager-schema-4.2.3/001-rhnActionDup-add-alllow-vendor-change.sql
@@ -1,0 +1,3 @@
+ALTER TABLE rhnActionDup
+  ADD COLUMN allow_vendor_change CHAR(1) DEFAULT 'N';  
+

--- a/schema/spacewalk/upgrade/susemanager-schema-4.2.2-to-susemanager-schema-4.2.3/001-rhnActionDup-add-alllow-vendor-change.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.2.2-to-susemanager-schema-4.2.3/001-rhnActionDup-add-alllow-vendor-change.sql
@@ -1,5 +1,6 @@
+ALTER TABLE rhnActionDup DROP CONSTRAINT IF EXISTS rhn_actiondup_avc_ck;
 ALTER TABLE rhnActionDup
-  ADD COLUMN allow_vendor_change CHAR(1)
+  ADD COLUMN IF NOT EXISTS allow_vendor_change CHAR(1)
   DEFAULT ('N') NOT NULL
   CONSTRAINT rhn_actiondup_avc_ck
   CHECK (allow_vendor_change in ('Y','N'));

--- a/susemanager-utils/susemanager-sls/salt/distupgrade/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/distupgrade/init.sls
@@ -5,7 +5,7 @@ spmigration:
     - dist_upgrade: True
     - dryrun: {{ salt['pillar.get']('susemanager:distupgrade:dryrun', False) }}
 {% if grains['osrelease_info'][0] >= 12 %}
-    - novendorchange: True
+    - novendorchange: {{ not salt['pillar.get']('susemanager:distupgrade:allowVendorChange', False) }}
 {% else %}
     - fromrepo: {{ salt['pillar.get']('susemanager:distupgrade:channels', []) }}
 {% endif %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- add pillar option to get allowVendorChange option during dist upgrade
 - Change VM creation state to handle installation from kernel, PXE or CDROM
 - States and metadata for showing the cluster upgrade plan in the UI
 - Fix action chain resuming when patches updating salt-minion don't cause service to be


### PR DESCRIPTION
## What does this PR change?
This is a port of spacewalk pr 12584
Spacewalk issue #11331 


This adds support for allow vendor change during dist upgrades.  You can now enable vendor change in the UI during a single action, or via the api.  

Also hangs on this: https://github.com/openSUSE/zypp-plugin-spacewalk/pull/43 (merged)
and this: https://github.com/saltstack/salt/pull/58560#pullrequestreview-497272067  (merged)
or this: https://github.com/openSUSE/salt/pull/284

## GUI diff

Before:

After:
![image](https://user-images.githubusercontent.com/729087/94927085-18224e00-04c2-11eb-9e20-0a30c44b4e89.png)


- [ ] **DONE**

## Documentation
- https://github.com/uyuni-project/uyuni-docs/issues/571

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**



- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql" 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
