### PR TITLE
QA: Rescue from Capybara::ModalNotFound (#12899)

### DIFF
--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -234,8 +234,12 @@ end
 #
 # Click on a button and confirm in alert box
 When(/^I click on "([^"]*)" and confirm$/) do |text|
-  accept_alert do
-    step %(I click on "#{text}")
+  begin
+    accept_alert do
+      step %(I click on "#{text}")
+    end
+  rescue Capybara::ModalNotFound
+    # ignored
   end
 end
 


### PR DESCRIPTION
## What does this PR change?

This PR rescue the Capybara:ModalNotFound exception (which is used to raise problems in both cases: alert messages and modal dialogs) when we expect an alert message to be confirmed but it is not shown.
This issue starts to happen when added a new option in the Chrome driver, to automatically accept unhandled alert messages, as when we reload the page, it is randomly showing an alert and we couldn't catch it properly. So, adding this option it is also auto-accepting the unique alert message implementation in our product, which is expected when we are cleaning values from a formula. Ideally this alert message should be converted to a modal dialog, so we can distinguish the alert messages and auto-accept them, and the modal dialogs and accept them manually. https://github.com/uyuni-project/uyuni/issues/2768

### How to distinguish modal dialogs and alert messages?

The main difference is that a modal dialog is HTML code embedded inside the page and an alert message is a system window, that is handled differently and can be triggered via javascript but also related to some browser issues.

**Alert message example:**
![image](https://user-images.githubusercontent.com/2827771/97416478-c88b4280-1906-11eb-8e1c-d62a389f25a6.png)

**Modal dialog example:**
![image](https://user-images.githubusercontent.com/2827771/97417296-c970a400-1907-11eb-86c7-cb02c9bfa80c.png)


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

Ports:
 - Manager-4.0 https://github.com/SUSE/spacewalk/pull/12901
 - Manager-4.1 https://github.com/SUSE/spacewalk/pull/12899

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
