### PR TITLE
Helper to create new DB migration file in right directory

### DIFF
--- a/schema/spacewalk/Makefile
+++ b/schema/spacewalk/Makefile
@@ -2,9 +2,10 @@ include ../../rel-eng/Makefile
 
 TOP      := .
 SPECFILE := $(firstword $(wildcard *.spec))
-NAME     := $(shell rpm -q --qf '%{name}\n' --specfile $(SPECFILE))
-VERSION  := $(shell rpm -q --qf '%{version}\n' --specfile $(SPECFILE))
-RELEASE  := $(shell rpm -q --qf '%{release}\n' --specfile $(SPECFILE))
+NAME     := $(shell rpm -q --qf '%{name}\n' --specfile $(SPECFILE) | head -n1)
+VERSION  := $(shell rpm -q --qf '%{version}\n' --specfile $(SPECFILE) | head -n1)
+RELEASE  := $(shell rpm -q --qf '%{release}\n' --specfile $(SPECFILE) | head -n1)
+NEXTVERSION := $(shell echo $(VERSION) | awk '{ pre=post=$$0; gsub("[0-9]+$$","",pre); gsub(".*\\.","",post); print pre post+1; }')
 
 spacewalk-clean satellite-clean : FORCE
 	$(MAKE) -f $(TOP)/Makefile.schema clean
@@ -13,3 +14,12 @@ spacewalk-release satellite-release : FORCE
 	$(MAKE) -f $(TOP)/Makefile.schema SCHEMA=$(NAME) VERSION=$(VERSION) RELEASE=$(RELEASE) all
 
 FORCE :
+
+newmigration:
+	@mkdir -p upgrade/$(NAME)-$(VERSION)-to-$(NAME)-$(NEXTVERSION)
+	@if [ -e upgrade/$(NAME)-$(VERSION)-to-$(NAME)-$(NEXTVERSION)/new.sql ]; then \
+		echo "Please rename first upgrade/$(NAME)-$(VERSION)-to-$(NAME)-$(NEXTVERSION)/new.sql"; \
+		exit 1; \
+	fi
+	@touch upgrade/$(NAME)-$(VERSION)-to-$(NAME)-$(NEXTVERSION)/new.sql
+	@echo "New migration file at upgrade/$(NAME)-$(VERSION)-to-$(NAME)-$(NEXTVERSION)/new.sql"


### PR DESCRIPTION
## What does this PR change?

In which directory I need to create a new DB schema migration file?

Answer:

```
$> cd schema/spacewalk/
$> make newmigration 
New migration file at upgrade/susemanager-schema-4.2.2-to-susemanager-schema-4.2.3/new.sql
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal tooling**

- [x] **DONE**

## Test coverage
- No tests: **internal tooling**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
