### PR TITLE
Salt autoinst advanced options

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -19302,19 +19302,19 @@ the &lt;a href="/rhn/kickstart/ActivationKeysList.do?ksid={0}"&gt;Activation Key
       </trans-unit>
       <!--KS schedule pages -->
       <trans-unit id="kickstart.schedule.heading4.jsp">
-          <source>Advanced Kickstart Configuration</source>
+          <source>Advanced Autoinstallation Configuration</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/details/kickstart/ScheduleWizard.do</context>
         </context-group>
         </trans-unit>
         <trans-unit id="kickstart.schedule.kernel.options.distro">
-          <source>As specified by Kickstart Distribution</source>
+          <source>As specified by the Distribution</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/details/kickstart/ScheduleWizard.do</context>
         </context-group>
         </trans-unit>
         <trans-unit id="kickstart.schedule.kernel.options.profile">
-          <source>As specified by Kickstart Profile</source>
+          <source>As specified by the Profile</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/details/kickstart/ScheduleWizard.do</context>
         </context-group>

--- a/java/code/webapp/WEB-INF/pages/common/fragments/kickstart/schedule/advanced.jspf
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/kickstart/schedule/advanced.jspf
@@ -64,6 +64,7 @@
         <html:hidden property="guestName" />
         <html:hidden property="proxyHost" />
 
+        <rhn:require acl="system_has_management_entitlement()">
         <div class="panel panel-default">
             <div class="panel-heading"><h4><bean:message key="kickstart.schedule.heading4.jsp" /></h4></div>
             <div class="panel-body">
@@ -81,6 +82,15 @@
         <c:if test="${empty regularKS}">
             <%@ include file="/WEB-INF/pages/common/fragments/kickstart/schedule/virt-options.jspf"%>
         </c:if>
+        </rhn:require>
+        <rhn:require acl="system_has_salt_entitlement()">
+        <div class="panel panel-default">
+            <div class="panel-heading"><h4><bean:message key="kickstart.schedule.heading4.jsp" /></h4></div>
+            <div class="panel-body">
+                <%@ include file="/WEB-INF/pages/common/fragments/kickstart/schedule/kernel-options.jspf"%>
+            </div>
+        </div>
+        </rhn:require>
 
         <div class="panel">
             <div class="row">

--- a/java/code/webapp/WEB-INF/pages/common/fragments/kickstart/schedule/kernel-options.jspf
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/kickstart/schedule/kernel-options.jspf
@@ -73,9 +73,6 @@
         <html:text styleId="kernelParamsId" property="kernelParams" onkeydown="return blockEnter(event)" styleClass="form-control"
             disabled="${form.kernelParamsType ne &quot;custom&quot;}"
         />
-        <rhn:tooltip>
-            <bean:message key="kickstart.schedule.kernel.options.custom.tip" arg0="${rhn:localize('Custom')}" />
-        </rhn:tooltip>
     </div>
 </div>
 
@@ -139,8 +136,5 @@
         <html:text styleId="postKernelParamsId" property="postKernelParams" onkeydown="return blockEnter(event)" styleClass="form-control"
             disabled="${form.postKernelParamsType ne &quot;custom&quot;}"
         />
-        <rhn:tooltip>
-            <bean:message key="kickstart.schedule.kernel.options.custom.tip" arg0="${rhn:localize('Custom')}" />
-        </rhn:tooltip>
     </div>
 </div>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- show only kernel options in advanced autoinstallation page when working with
+  a salt minion (bsc#1177767)
 - add new allowVendorChange flag for dist upgrades
 - Take pool and volume from Salt virt.vm_info for files and blocks disks (bsc#1175987)
 - Create VM on a Salt host using a cobbler profile


### PR DESCRIPTION
## What does this PR change?

The advanced page for autoinstallation provide the special settings which only work with tranditional clients.
For salt we do not have the mapping of cobbler network device settings to special kernel options.
If this is needed, the user can provide directly the required options into the kernel options field.

This PR show only the Kernel Options fields when the system is a salt client.

## GUI diff

Before:
![image](https://user-images.githubusercontent.com/1038917/97463439-09537d80-1940-11eb-96b0-cb27861d72f3.png)

After:
![image](https://user-images.githubusercontent.com/1038917/97467380-6bae7d00-1944-11eb-9b46-72bb31aed77e.png)

- [x] **DONE**

## Documentation
- https://github.com/SUSE/spacewalk/issues/12915

- [x] **DONE**

## Test coverage
- No tests: **already covered**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/12802
Tracks https://github.com/SUSE/spacewalk/pull/12929

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
