### PR TITLE
Testsuite: add workaround for issue at IPMI functions test

### DIFF
--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -53,6 +53,9 @@ MultiTest.disable_autorun
 
 # register chromedriver headless mode
 Capybara.register_driver(:headless_chrome) do |app|
+  client = Selenium::WebDriver::Remote::Http::Default.new
+  # WORKAROUND failure at Scenario: Test IPMI functions: increase from 60 s to 180 s
+  client.read_timeout = 180
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
     chromeOptions: { args: %w[headless no-sandbox disable-dev-shm-usage disable-gpu window-size=2048,2048, js-flags=--max_old_space_size=2048] },
     unexpectedAlertBehaviour: 'accept',
@@ -62,7 +65,8 @@ Capybara.register_driver(:headless_chrome) do |app|
   Capybara::Selenium::Driver.new(
     app,
     browser: :chrome,
-    desired_capabilities: capabilities
+    desired_capabilities: capabilities,
+    http_client: client
   )
 end
 


### PR DESCRIPTION
## What does this PR change?
Temporary increase from 60 s to 180 s read_timeout for http requests.

This test is failing at head and uyuni; at these two branches the
power management functions are taking longer than expected
(~ 100 s the reboot).

- testsuite/features/support/env.rb


## Links
This workaround is only needed for Uyuni and head.
https://github.com/SUSE/spacewalk/issues/12928

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)
