### PR TITLE
Move changelog entry from susemaneger-sls to uyuni-cluster-provider

### DIFF
--- a/susemanager-utils/cluster-providers/caasp/uyuni-cluster-provider-caasp/uyuni-cluster-provider-caasp.changes
+++ b/susemanager-utils/cluster-providers/caasp/uyuni-cluster-provider-caasp/uyuni-cluster-provider-caasp.changes
@@ -1,3 +1,5 @@
+- States and metadata for showing the cluster upgrade plan in the UI
+
 -------------------------------------------------------------------
 Fri Sep 18 11:59:39 CEST 2020 - jgonzalez@suse.com
 

--- a/susemanager-utils/cluster-providers/caasp/uyuni-cluster-provider-caasp/uyuni-cluster-provider-caasp.changes
+++ b/susemanager-utils/cluster-providers/caasp/uyuni-cluster-provider-caasp/uyuni-cluster-provider-caasp.changes
@@ -1,4 +1,4 @@
-- States and metadata for showing the cluster upgrade plan in the UI
+- Show the cluster upgrade plan in the UI
 
 -------------------------------------------------------------------
 Fri Sep 18 11:59:39 CEST 2020 - jgonzalez@suse.com

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,6 +1,5 @@
 - add pillar option to get allowVendorChange option during dist upgrade
 - Change VM creation state to handle installation from kernel, PXE or CDROM
-- States and metadata for showing the cluster upgrade plan in the UI
 - Fix action chain resuming when patches updating salt-minion don't cause service to be
   restarted (bsc#1144447)
 - Make grub2 autoinstall kernel path relative to the boot partition root (bsc#1175876)


### PR DESCRIPTION
## What does this PR change?

Move changelog entry from susemaneger-sls to uyuni-cluster-provider

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: not needed

- [x] **DONE**

## Test coverage
- No tests: not needed

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
