### PR TITLE
Improve token checking

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/DownloadController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/DownloadController.java
@@ -32,6 +32,7 @@ import com.suse.utils.Opt;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
+import org.apache.log4j.Logger;
 import org.jose4j.jwt.JwtClaims;
 import org.jose4j.jwt.MalformedClaimException;
 import org.jose4j.jwt.consumer.InvalidJwtException;
@@ -60,6 +61,8 @@ import static spark.Spark.head;
  * Controller for the download endpoint serving packages and metadata to managed clients.
  */
 public class DownloadController {
+
+    private static Logger log = Logger.getLogger(DownloadController.class);
 
     private static final Key KEY = TokenBuilder.getKeyForSecret(
             TokenBuilder.getServerSecret().orElseThrow(
@@ -401,11 +404,13 @@ public class DownloadController {
         String header = request.headers("X-Mgr-Auth");
         header = StringUtils.isNotBlank(header) ? header : getTokenForDebian(request);
         if (queryParams.isEmpty() && StringUtils.isBlank(header)) {
+            log.info(String.format("Forbidden: You need a token to access %s", request.pathInfo()));
             halt(HttpStatus.SC_FORBIDDEN,
                  String.format("You need a token to access %s", request.pathInfo()));
         }
         if ((queryParams.size() > 1 && header == null) ||
                 (!queryParams.isEmpty() && header != null)) {
+            log.info("Bad Request: Only one token is accepted");
             halt(HttpStatus.SC_BAD_REQUEST, "Only one token is accepted");
         }
         if (!queryParams.isEmpty()) {
@@ -440,6 +445,7 @@ public class DownloadController {
     private static void validateToken(String token, String channel, String filename) {
         AccessTokenFactory.lookupByToken(token).ifPresent(obj -> {
             if (!obj.getValid()) {
+                log.info(String.format("Forbidden: invalid token to access %s", filename));
                 halt(HttpStatus.SC_FORBIDDEN, "This token is not valid");
             }
         });
@@ -451,20 +457,25 @@ public class DownloadController {
                     // new versions of getStringListClaimValue() return an empty list instead of null
                     .filter(l -> !l.isEmpty());
             if (Opt.fold(channelClaim, () -> false, channels -> !channels.contains(channel))) {
+                log.info(String.format("Forbidden: Token does not provide access to channel %s", channel));
                 halt(HttpStatus.SC_FORBIDDEN, "Token does not provide access to channel " + channel);
             }
 
             // enforce org claim
             Optional<Long> orgClaim = Optional.ofNullable(claims.getClaimValue("org", Long.class));
             Opt.consume(orgClaim, () -> {
+                log.info("Forbidden: Token does not specify the organization");
                 halt(HttpStatus.SC_BAD_REQUEST, "Token does not specify the organization");
             }, orgId -> {
                 if (!ChannelFactory.isAccessibleBy(channel, orgId)) {
-                    halt(HttpStatus.SC_FORBIDDEN, "Token does not provide access to channel %s" + channel);
+                    log.info(String.format("Forbidden: Token does not provide access to channel %s", channel));
+                    halt(HttpStatus.SC_FORBIDDEN, "Token does not provide access to channel " + channel);
                 }
             });
         }
         catch (InvalidJwtException | MalformedClaimException e) {
+            log.info(String.format("Forbidden: Token is not valid to access %s in %s: %s",
+                    filename, channel, e.getMessage()));
             halt(HttpStatus.SC_FORBIDDEN,
                  String.format("Token is not valid to access %s in %s: %s", filename, channel, e.getMessage()));
         }

--- a/java/code/src/log4j.properties
+++ b/java/code/src/log4j.properties
@@ -65,6 +65,7 @@ log4j.logger.org.directwebremoting.log.accessLog=EXCEPTION
 log4j.logger.com.redhat.rhn.frontend.action.LoginAction=INFO
 log4j.logger.com.redhat.rhn.frontend.action.LogoutAction=INFO
 log4j.logger.com.redhat.rhn.manager.content.ContentSyncManager=INFO
+log4j.logger.com.suse.manager.webui.controllers.DownloadController=INFO
 
 ## Frontend logs
 log4j.appender.FrontendLogControllerAppender=org.apache.log4j.RollingFileAppender

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- log token verify errors and check for expired tokens
 - show only kernel options in advanced autoinstallation page when working with
   a salt minion (bsc#1177767)
 - add new allowVendorChange flag for dist upgrades


### PR DESCRIPTION
## What does this PR change?

- Log errors on token verify.
- check for expired tokens (exceptional case only as we automatically renew them)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **debugging messages only**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/12949 https://github.com/SUSE/spacewalk/pull/12947

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
