### PR TITLE
QA: Make sure we stop salt-minion service on clean-up

### DIFF
--- a/testsuite/features/secondary/min_activationkey.feature
+++ b/testsuite/features/secondary/min_activationkey.feature
@@ -9,7 +9,7 @@ Feature: Bootstrap a Salt minion via the GUI with an activation key
     Then I should see a "Confirm System Profile Deletion" text
     When I click on "Delete Profile"
     And I wait until I see "has been deleted" text
-    And I cleanup minion "sle_minion"
+    And I clean up the minion's cache on "sle_minion"
     Then "sle_minion" should not be registered
 
   Scenario: Create a configuration channel for the activation key

--- a/testsuite/features/secondary/min_bootstrap_negative.feature
+++ b/testsuite/features/secondary/min_bootstrap_negative.feature
@@ -26,7 +26,7 @@ Feature: Negative tests for bootstrapping normal minions
     Then I should see a "Confirm System Profile Deletion" text
     When I click on "Delete Profile"
     And I wait until I see "has been deleted" text
-    And I cleanup minion "sle_minion"
+    And I clean up the minion's cache on "sle_minion"
     Then "sle_minion" should not be registered
 
   Scenario: Bootstrap a SLES minion with wrong hostname

--- a/testsuite/features/secondary/min_bootstrap_script.feature
+++ b/testsuite/features/secondary/min_bootstrap_script.feature
@@ -15,7 +15,7 @@ Feature: Register a Salt minion via Bootstrap-script
     Then I should see a "Confirm System Profile Deletion" text
     When I click on "Delete Profile"
     And I wait until I see "has been deleted" text
-    And I cleanup minion "sle_minion"
+    And I clean up the minion's cache on "sle_minion"
     Then "sle_minion" should not be registered
 
   Scenario: Bootstrap the minion using the script

--- a/testsuite/features/secondary/min_bootstrap_ssh_key.feature
+++ b/testsuite/features/secondary/min_bootstrap_ssh_key.feature
@@ -9,7 +9,7 @@ Feature: Bootstrap a Salt minion via the GUI using SSH key
     Then I should see a "Confirm System Profile Deletion" text
     When I click on "Delete Profile"
     And I wait until I see "has been deleted" text
-    And I cleanup minion "sle_minion"
+    And I clean up the minion's cache on "sle_minion"
     Then "sle_minion" should not be registered
 
   Scenario: Prepare the minion for SSH key authentication

--- a/testsuite/features/secondary/min_bootstrap_xmlrpc.feature
+++ b/testsuite/features/secondary/min_bootstrap_xmlrpc.feature
@@ -9,7 +9,7 @@ Feature: Register a Salt minion via XML-RPC API
     Then I should see a "Confirm System Profile Deletion" text
     When I click on "Delete Profile"
     And I wait until I see "has been deleted" text
-    And I cleanup minion "sle_minion"
+    And I clean up the minion's cache on "sle_minion"
     Then "sle_minion" should not be registered
 
   Scenario: Bootstrap a SLES minion via XML-RPC

--- a/testsuite/features/secondary/min_salt_mgrcompat_state.feature
+++ b/testsuite/features/secondary/min_salt_mgrcompat_state.feature
@@ -30,7 +30,7 @@ Feature: Verify that Salt mgrcompat state works when the new module.run syntax i
     Then I should see a "Confirm System Profile Deletion" text
     When I click on "Delete Profile"
     And I wait until I see "has been deleted" text
-    And I cleanup minion "sle_minion"
+    And I clean up the minion's cache on "sle_minion"
     Then "sle_minion" should not be registered
 
   Scenario: Enable new module.run syntax on the minion and perform registration
@@ -74,7 +74,7 @@ Feature: Verify that Salt mgrcompat state works when the new module.run syntax i
     Then I should see a "Confirm System Profile Deletion" text
     When I click on "Delete Profile"
     And I wait until I see "has been deleted" text
-    And I cleanup minion "sle_minion"
+    And I clean up the minion's cache on "sle_minion"
     Then "sle_minion" should not be registered
 
   Scenario: Cleanup: bootstrap again the minion after mgrcompat tests

--- a/testsuite/features/secondary/min_ssh_tunnel.feature
+++ b/testsuite/features/secondary/min_ssh_tunnel.feature
@@ -9,7 +9,7 @@ Feature: Register a salt system to be managed via SSH tunnel
     Then I should see a "Confirm System Profile Deletion" text
     When I click on "Delete Profile"
     And I wait until I see "has been deleted" text
-    And I cleanup minion "sle_ssh_tunnel_minion"
+    And I clean up the minion's cache on "sle_ssh_tunnel_minion"
     Then "sle_ssh_tunnel_minion" should not be registered
 
   Scenario: Register this minion for push via SSH tunnel

--- a/testsuite/features/secondary/minssh_bootstrap_xmlrpc.feature
+++ b/testsuite/features/secondary/minssh_bootstrap_xmlrpc.feature
@@ -10,7 +10,7 @@ Feature: Register a salt-ssh system via XML-RPC
     Then I should see a "Confirm System Profile Deletion" text
     When I click on "Delete Profile"
     And I wait until I see "has been deleted" text
-    And I cleanup minion "ssh_minion"
+    And I clean up the minion's cache on "ssh_minion"
     Then "ssh_minion" should not be registered
 
 @ssh_minion

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -719,11 +719,28 @@ When(/^I enter "([^"]*)" password$/) do |host|
   step %(I enter "#{ENV['VIRTHOST_XEN_PASSWORD']}" as "password") if host == "xen_server"
 end
 
-And(/^I cleanup minion "([^"]*)"$/) do |minion|
+And(/^I clean up the minion's cache on "([^"]*)"$/) do |minion|
   raise "#{minion} is not a salt minion" unless minion.include? 'minion'
   node = get_target(minion)
-  node.run('systemctl stop salt-minion')
+  node.run_until_ok('systemctl stop salt-minion')
   node.run('rm -Rf /var/cache/salt/minion')
+  # TODO: Ideally we should remove /etc/salt/* /var/run/salt/* /var/log/salt/* and salt and salt-minion packages
+  #       But we can't do that as we don't have products synced, so it will fail installing salt and sal-minion
+  #       Instead we inject those packages when deploying through sumaform and we can't remove them.
+  #       If someday we have synced products, we can proceed to run a full cleanup:
+  #
+  # And(/^I perform a full salt minion cleanup on "([^"]*)"$/) do |minion|
+  #   raise "#{minion} is not a salt minion" unless minion.include? 'minion'
+  #   node = get_target(minion)
+  #   if minion.include? 'ceos'
+  #     node.run('yum -y remove salt salt-minion')
+  #   elsif minion.include? 'ubuntu'
+  #     node.run('apt-get --assume-yes remove salt salt-minion')
+  #   else
+  #     node.run('zypper --non-interactive remove -y salt salt-minion')
+  #   end
+  #   node.run('rm -Rf /var/cache/salt/minion /var/run/salt /var/log/salt /etc/salt')
+  # end
 end
 
 When(/^I install a salt pillar top file for "([^"]*)" with target "([^"]*)" on the server$/) do |file, host|


### PR DESCRIPTION
## What does this PR change?

Recently we updated our step definition to clean up minion's content, once we deleted the system from SUSE Manager.
We simplified it by using the `systemctl` command to stop the salt-minion service in all kinds of minions, while before we were using a different command for SLE minions. This change, cause a problem in our tests, as sometimes on SLE clients we stopped the service at the same time that SUMA was acting on it. In order to fix it, I changed the `run` command to another command that retries several times until it gives a successful result. Also, this step only removes the information from the cache, so it needs a rename to don't cause confusion. By the way, I use the verb "clean up" instead of the noun "cleanup" as it was before.

In addition, I would like to keep (commented) a TODO which explains better the reason why we are only cleaning the cache of the minion (so it doesn't try to connect to master again) instead of perform a full clean-up where we can uninstall the salt and salt-minion packages. I'm offering in the TODO description the step definition that we can use in case we unblock the reason why we can't use it ;)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.1
- Manager-4.0

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
