### PR TITLE
Only update the kickstart path in cobbler if necessary (bsc#1175216)

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerProfileSyncCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerProfileSyncCommand.java
@@ -15,6 +15,7 @@
 
 package com.redhat.rhn.manager.kickstart.cobbler;
 
+import java.nio.file.Path;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -22,6 +23,7 @@ import java.util.Map;
 
 import org.apache.log4j.Logger;
 
+import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.validator.ValidatorError;
 import com.redhat.rhn.domain.kickstart.KickstartData;
 import com.redhat.rhn.domain.kickstart.KickstartFactory;
@@ -151,25 +153,35 @@ public class CobblerProfileSyncCommand extends CobblerCommand {
         }
 
         //Now re-set the filename in case someone set it incorrectly
-        try {
-        String handle = (String) invokeXMLRPC("get_profile_handle",
-                cobblerProfile.get("name"), xmlRpcToken);
-        invokeXMLRPC("modify_profile", handle, "kickstart", profile.buildCobblerFileName(),
-                xmlRpcToken);
-        invokeXMLRPC("save_profile", handle, xmlRpcToken);
+        Path kickstartPath = Path.of(
+                ConfigDefaults.get().getKickstartConfigDir(),
+                cobblerProfile.get("kickstart").toString()
+        );
+        String cobblerKickstartFileName = profile.buildCobblerFileName();
+        if (!Path.of(cobblerKickstartFileName).equals(kickstartPath)) {
+            try {
+                log.info(String.format("Updating cobbler profile, setting 'kickstart' to: %s",
+                        cobblerKickstartFileName));
+                String handle = (String) invokeXMLRPC("get_profile_handle",
+                        cobblerProfile.get("name"), xmlRpcToken);
+                invokeXMLRPC("modify_profile", handle, "kickstart", cobblerKickstartFileName,
+                        xmlRpcToken);
 
-        //Lets update the modified date just to make sure
-        profile.setModified(new Date());
-        }
-        catch (RuntimeException re) {
-            if (re.getCause() instanceof XmlRpcFault) {
-                XmlRpcFault xrf = (XmlRpcFault)re.getCause();
-                if (xrf.getMessage().contains("unknown profile name")) {
-                    log.error("Cobbler doesn't know about this profile any more!");
-                }
+                invokeXMLRPC("save_profile", handle, xmlRpcToken);
+
+                //Lets update the modified date just to make sure
+                profile.setModified(new Date());
             }
-            else {
-                throw re;
+            catch (RuntimeException re) {
+                if (re.getCause() instanceof XmlRpcFault) {
+                    XmlRpcFault xrf = (XmlRpcFault)re.getCause();
+                    if (xrf.getMessage().contains("unknown profile name")) {
+                        log.error("Cobbler doesn't know about this profile any more!");
+                    }
+                }
+                else {
+                    throw re;
+                }
             }
         }
     }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/CobblerSyncTask.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/CobblerSyncTask.java
@@ -39,7 +39,7 @@ import redstone.xmlrpc.XmlRpcFault;
 
 /**
  * CobblerSyncTask
- * synces cobbler
+ * syncs cobbler
  */
 public class CobblerSyncTask extends RhnJavaJob {
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Only update the kickstart path in cobbler if necessary (bsc#1175216)
 - enhance config channel API with list assigned groups
 - enhance server group API with config channel and formula
   access methods


### PR DESCRIPTION
## What does this PR change?

The `CobblerSyncTask` calls `CobblerProfileSyncCommand`, which in turn modifies the kickstart path attribute in the cobbler profile.

This results in a full sync, which might be slow on bigger setups.

Fixed by updating the attribute only if necessary (cobbler value differs from the one in Uyuni database).

## Minor TODO
- [ ] Adjust the javadoc: mention that java -> cobbler sync can cause full sync in `CobblerSyncTask`

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bugfix

- [x] **DONE**

## Test coverage
- No tests: no tests in this area

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/12174

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"