### PR TITLE
Remove hostname from /var/lib/salt/.ssh/known_hosts when deleting system (bsc#1176159)

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -738,7 +738,7 @@ public class SystemManager extends BaseManager {
 
     private static void removeSaltSSHKnownHosts(Server server) {
         Optional<MgrUtilRunner.RemoveKnowHostResult> result =
-                saltServiceInstance.removeSaltSSHKnownHost(server.getHostname());
+                saltApi.removeSaltSSHKnownHost(server.getHostname());
         boolean removed = result.map(r -> "removed".equals(r.getStatus())).orElse(false);
         if (!removed) {
             log.warn("Hostname " + server.getHostname() + " could not be removed from " +

--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -114,6 +114,7 @@ import com.suse.manager.webui.services.SaltStateGeneratorService;
 import com.suse.manager.webui.services.StateRevisionService;
 import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.impl.SaltService;
+import com.suse.manager.webui.services.impl.runner.MgrUtilRunner;
 import com.suse.utils.Opt;
 
 import org.apache.commons.lang3.RandomStringUtils;
@@ -721,6 +722,11 @@ public class SystemManager extends BaseManager {
         });
 
 
+        // clean known_hosts
+        if (server.asMinionServer().isPresent()) {
+            removeSaltSSHKnownHosts(server);
+        }
+
         // remove server itself
         ServerFactory.delete(server);
 
@@ -728,6 +734,16 @@ public class SystemManager extends BaseManager {
             saltApi.deleteKey(minion.getMinionId());
             SaltStateGeneratorService.INSTANCE.removeServer(minion);
         });
+    }
+
+    private static void removeSaltSSHKnownHosts(Server server) {
+        Optional<MgrUtilRunner.RemoveKnowHostResult> result =
+                saltServiceInstance.removeSaltSSHKnownHost(server.getHostname());
+        boolean removed = result.map(r -> "removed".equals(r.getStatus())).orElse(false);
+        if (!removed) {
+            log.warn("Hostname " + server.getHostname() + " could not be removed from " +
+                    "/var/lib/salt/.ssh/known_hosts: " + result.map(r -> r.getComment()).orElse(""));
+        }
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerMockTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerMockTest.java
@@ -23,31 +23,30 @@ import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
 import com.redhat.rhn.domain.user.User;
-import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.manager.kickstart.cobbler.CobblerXMLRPCHelper;
 import com.redhat.rhn.manager.kickstart.cobbler.test.MockXMLRPCInvoker;
-
+import com.redhat.rhn.manager.system.SystemManager;
+import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
 import com.redhat.rhn.testing.TestUtils;
-import com.redhat.rhn.testing.RhnJmockBaseTestCase;
 import com.redhat.rhn.testing.UserTestUtils;
-
 import com.suse.manager.webui.services.impl.SaltService;
-
+import com.suse.manager.webui.services.impl.runner.MgrUtilRunner;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.cobbler.test.MockConnection;
 import org.jmock.Expectations;
 import org.jmock.imposters.ByteBuddyClassImposteriser;
 
 import java.util.Collections;
+import java.util.Optional;
 
 
 /**
  * SystemManagerMockTest
  */
-public class SystemManagerMockTest extends RhnJmockBaseTestCase {
+public class SystemManagerMockTest extends JMockBaseTestCaseWithUser {
 
     @Override
-    protected void setUp() throws Exception {
+    public void setUp() throws Exception {
         super.setUp();
         Config.get().setString(CobblerXMLRPCHelper.class.getName(),
                 MockXMLRPCInvoker.class.getName());
@@ -83,6 +82,8 @@ public class SystemManagerMockTest extends RhnJmockBaseTestCase {
 
         context().checking(new Expectations() {{
             allowing(saltServiceMock).deleteKey(testMinionServer.getMinionId());
+            allowing(saltServiceMock).removeSaltSSHKnownHost(testMinionServer.getHostname());
+            will(returnValue(Optional.of(new MgrUtilRunner.RemoveKnowHostResult("removed", ""))));
         }});
 
         SystemManager.mockSaltService(saltServiceMock);

--- a/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
@@ -116,6 +116,7 @@ import com.suse.manager.webui.controllers.utils.ContactMethodUtil;
 import com.suse.manager.webui.services.iface.*;
 import com.suse.manager.webui.services.impl.SaltService;
 
+import com.suse.manager.webui.services.impl.runner.MgrUtilRunner;
 import com.suse.manager.webui.services.test.TestSaltApi;
 import com.suse.manager.webui.services.test.TestSystemQuery;
 import org.apache.commons.io.FileUtils;
@@ -293,6 +294,8 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
 
         context().checking(new Expectations() {{
             allowing(saltServiceMock).deleteKey(minionId);
+            allowing(saltServiceMock).removeSaltSSHKnownHost(minion.getHostname());
+            will(returnValue(Optional.of(new MgrUtilRunner.RemoveKnowHostResult("removed", ""))));
         }});
         SystemManager.deleteServer(user, minion.getId());
 
@@ -314,6 +317,8 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
 
         context().checking(new Expectations() {{
             allowing(saltServiceMock).deleteKey(minionId);
+            allowing(saltServiceMock).removeSaltSSHKnownHost(minion.getHostname());
+            will(returnValue(Optional.of(new MgrUtilRunner.RemoveKnowHostResult("removed", ""))));
         }});
         SystemManager.deleteServer(user, minion.getId());
 

--- a/java/code/src/com/suse/manager/webui/services/iface/SaltApi.java
+++ b/java/code/src/com/suse/manager/webui/services/iface/SaltApi.java
@@ -151,6 +151,13 @@ public interface SaltApi {
                                                        String outputfile);
 
     /**
+     * Removes a hostname from the Salt ~/.ssh/known_hosts file.
+     * @param hostname the hostname to remote
+     * @return the result of the runner call
+     */
+    Optional<MgrUtilRunner.RemoveKnowHostResult> removeSaltSSHKnownHost(String hostname);
+
+    /**
      * Call 'saltutil.sync_grains' to sync the grains to the target minion(s).
      * @param minionList minion list
      */

--- a/java/code/src/com/suse/manager/webui/services/iface/SystemQuery.java
+++ b/java/code/src/com/suse/manager/webui/services/iface/SystemQuery.java
@@ -20,6 +20,7 @@ import com.suse.manager.webui.services.impl.runner.MgrUtilRunner;
 import com.suse.salt.netapi.calls.LocalCall;
 import com.suse.salt.netapi.calls.modules.Zypper;
 import com.suse.salt.netapi.exception.SaltException;
+import com.suse.manager.webui.services.impl.runner.MgrUtilRunner;
 
 import java.util.List;
 import java.util.Map;
@@ -47,6 +48,13 @@ public interface SystemQuery {
      */
     Optional<Map<String, Map<String, Object>>> listClusterNodes(MinionServer managementNode,
                                                                 ClusterProviderParameters clusterProviderParameters);
+    /**
+     * Removes a hostname from the Salt ~/.ssh/known_hosts file.
+     * @param hostname the hostname to remote
+     * @return the result of the runner call
+     */
+    Optional<MgrUtilRunner.RemoveKnowHostResult> removeSaltSSHKnownHost(String hostname);
+
 
     /**
      * Send notification about a system id to be generated.

--- a/java/code/src/com/suse/manager/webui/services/iface/SystemQuery.java
+++ b/java/code/src/com/suse/manager/webui/services/iface/SystemQuery.java
@@ -20,7 +20,6 @@ import com.suse.manager.webui.services.impl.runner.MgrUtilRunner;
 import com.suse.salt.netapi.calls.LocalCall;
 import com.suse.salt.netapi.calls.modules.Zypper;
 import com.suse.salt.netapi.exception.SaltException;
-import com.suse.manager.webui.services.impl.runner.MgrUtilRunner;
 
 import java.util.List;
 import java.util.Map;
@@ -48,13 +47,6 @@ public interface SystemQuery {
      */
     Optional<Map<String, Map<String, Object>>> listClusterNodes(MinionServer managementNode,
                                                                 ClusterProviderParameters clusterProviderParameters);
-    /**
-     * Removes a hostname from the Salt ~/.ssh/known_hosts file.
-     * @param hostname the hostname to remote
-     * @return the result of the runner call
-     */
-    Optional<MgrUtilRunner.RemoveKnowHostResult> removeSaltSSHKnownHost(String hostname);
-
 
     /**
      * Send notification about a system id to be generated.

--- a/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
@@ -1151,6 +1151,15 @@ public class SaltService implements SystemQuery, SaltApi {
     /**
      * {@inheritDoc}
      */
+    public Optional<MgrUtilRunner.RemoveKnowHostResult> removeSaltSSHKnownHost(String hostname) {
+        RunnerCall<MgrUtilRunner.RemoveKnowHostResult> call = MgrUtilRunner.removeSSHKnowHost("salt", hostname);
+        return callSync(call);
+    }
+
+
+    /**
+     * {@inheritDoc}
+     */
     public Optional<MgrUtilRunner.ExecResult> deleteRejectedKey(String minionId) {
         RunnerCall<MgrUtilRunner.ExecResult> call = MgrUtilRunner.deleteRejectedKey(minionId);
         return callSync(call);

--- a/java/code/src/com/suse/manager/webui/services/impl/runner/MgrUtilRunner.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/runner/MgrUtilRunner.java
@@ -75,6 +75,48 @@ public class MgrUtilRunner {
     }
 
     /**
+     * Result of removing a hostname from the ~/.ssh/known_hosts file
+     */
+    public static class RemoveKnowHostResult {
+
+        @SerializedName("status")
+        private String status;
+
+        @SerializedName("comment")
+        private String comment;
+
+        /**
+         * Constructor.
+         */
+        public RemoveKnowHostResult() {
+        }
+
+        /**
+         * Only needed for unit tests.
+         * @param statusIn status
+         * @param commentIn comment
+         */
+        public RemoveKnowHostResult(String statusIn, String commentIn) {
+            this.status = statusIn;
+            this.comment = commentIn;
+        }
+
+        /**
+         * @return status to get
+         */
+        public String getStatus() {
+            return status;
+        }
+
+        /**
+         * @return comment to get
+         */
+        public String getComment() {
+            return comment;
+        }
+    }
+
+    /**
      * Remove a Salt key from the "Rejected Keys" category.
      * @param minionId the minionId to look for in "Rejected Keys"
      * @return the execution result
@@ -99,6 +141,22 @@ public class MgrUtilRunner {
         RunnerCall<ExecResult> call =
                 new RunnerCall<>("mgrutil.ssh_keygen", Optional.of(args),
                         new TypeToken<ExecResult>() { });
+        return call;
+    }
+
+    /**
+     * Removes a hostname from a user's ~/.ssh/known_hosts file.
+     * @param user the user for which to remove the hostname
+     * @param hostname hotname to remove
+     * @return the execution result
+     */
+    public static RunnerCall<RemoveKnowHostResult> removeSSHKnowHost(String user, String hostname) {
+        Map<String, Object> args = new LinkedHashMap<>();
+        args.put("user", user);
+        args.put("hostname", hostname);
+        RunnerCall<RemoveKnowHostResult> call =
+                new RunnerCall<>("mgrutil.remove_ssh_known_host", Optional.of(args),
+                        new TypeToken<RemoveKnowHostResult>() { });
         return call;
     }
 

--- a/java/code/src/com/suse/manager/webui/services/test/TestSaltApi.java
+++ b/java/code/src/com/suse/manager/webui/services/test/TestSaltApi.java
@@ -90,6 +90,11 @@ public class TestSaltApi implements SaltApi {
     }
 
     @Override
+    public Optional<MgrUtilRunner.RemoveKnowHostResult> removeSaltSSHKnownHost(String hostname) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public void syncGrains(MinionList minionList) {
         throw new UnsupportedOperationException();
     }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Remove hostname from /var/lib/salt/.ssh/known_hosts when deleting system (bsc#1176159)
 - show only kernel options in advanced autoinstallation page when working with
   a salt minion (bsc#1177767)
 - add new allowVendorChange flag for dist upgrades

--- a/susemanager-utils/susemanager-sls/modules/runners/mgrutil.py
+++ b/susemanager-utils/susemanager-sls/modules/runners/mgrutil.py
@@ -68,6 +68,9 @@ def chain_ssh_cmd(hosts=None, clientkey=None, proxykey=None, user="root", option
             out.write(ret["stdout"])
     return ret
 
+def remove_ssh_known_host(user, hostname):
+    return __salt__['salt.cmd']('ssh.rm_known_host', user, hostname)
+
 
 def _cmd(cmd):
     p = Popen(cmd, stdout=PIPE, stderr=PIPE)

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Remove hostname from /var/lib/salt/.ssh/known_hosts when deleting system (bsc#1176159)
 - Fix grub2 autoinstall kernel path (bsc#1178060)
 - use require in reboot trigger (bsc#1177767)
 - add pillar option to get allowVendorChange option during dist upgrade


### PR DESCRIPTION
## What does this PR change?

Port of https://github.com/SUSE/spacewalk/pull/12428

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bugfix

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/2233
Tracks https://github.com/SUSE/spacewalk/pull/12428

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
