### PR TITLE
Added hostname field in system-history report

### DIFF
--- a/reporting/reports/data/system-history
+++ b/reporting/reports/data/system-history
@@ -10,6 +10,7 @@ description:
 columns:
 
 	server_id:i	System identifier
+	hostname	hostname
 	event_id:i	Event id
 	time		Time of event
 	status		Status of the event
@@ -23,9 +24,10 @@ multival_columns:
 
 sql:
 
-	select server_id, event_id, time, status, event, event_data
+	select server_id, hostname, event_id, time, status, event, event_data
 	from (
 		select rhnserveraction.server_id,
+			rhnserver.hostname,
 			rhnserveraction.action_id as event_id,
 			to_char(rhnserveraction.completion_time, 'YYYY-MM-DD HH24:MI:SS') as time,
 			rhnactionstatus.name as status,
@@ -52,6 +54,8 @@ sql:
 				end as event_data
 		from rhnserveraction left outer join rhnactionerrataupdate
 			on rhnserveraction.action_id = rhnactionerrataupdate.action_id
+			left outer join rhnserver 
+				on rhnserveraction.server_id = rhnserver.id
 			left outer join rhnactionpackage
 				on rhnserveraction.action_id = rhnactionpackage.action_id
 				left outer join rhnpackagename
@@ -76,9 +80,10 @@ sql:
 			and rhnaction.action_type = rhnactiontype.id
 			and rhnserveraction.status = rhnactionstatus.id
 		union all
-		select rhnserverhistory.server_id,
+		select rhnserverhistory.server_id, 
+			rhnserver.hostname,
 			rhnserverhistory.id,
-			to_char(greatest(created, modified), 'YYYY-MM-DD HH24:MI:SS'),
+			to_char(greatest(rhnserverhistory.created, rhnserverhistory.modified), 'YYYY-MM-DD HH24:MI:SS'),
 			'Done',
 			case when rhnserverhistory.summary like 'subscribed to channel %' then 'Subscribed to channel'
 				when rhnserverhistory.summary like 'unsubscribed from channel %' then 'Unsubscribed from channel'
@@ -89,7 +94,7 @@ sql:
 				when summary like 'unsubscribed from channel %' then details
 				when summary like 'Updated system release %' then substr(summary, 24)
 			end
-		from rhnserverhistory
+		from rhnserverhistory left outer join rhnserver on rhnserverhistory.server_id = rhnserver.id
 	) X
 	-- where placeholder
 	order by server_id, time, event_id

--- a/reporting/reports/data/system-history
+++ b/reporting/reports/data/system-history
@@ -54,7 +54,7 @@ sql:
 				end as event_data
 		from rhnserveraction left outer join rhnactionerrataupdate
 			on rhnserveraction.action_id = rhnactionerrataupdate.action_id
-			left outer join rhnserver 
+			inner join rhnserver 
 				on rhnserveraction.server_id = rhnserver.id
 			left outer join rhnactionpackage
 				on rhnserveraction.action_id = rhnactionpackage.action_id
@@ -94,7 +94,7 @@ sql:
 				when summary like 'unsubscribed from channel %' then details
 				when summary like 'Updated system release %' then substr(summary, 24)
 			end
-		from rhnserverhistory left outer join rhnserver on rhnserverhistory.server_id = rhnserver.id
+		from rhnserverhistory inner join rhnserver on rhnserverhistory.server_id = rhnserver.id
 	) X
 	-- where placeholder
 	order by server_id, time, event_id

--- a/reporting/spacewalk-reports.changes
+++ b/reporting/spacewalk-reports.changes
@@ -1,3 +1,5 @@
+- Added hostname field to system-history report
+
 -------------------------------------------------------------------
 Fri Sep 18 11:41:39 CEST 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

**It adds "hostname" field to the report**

## GUI diff

One more column in the output of `spacewalk-report`

- [x] **DONE**

## Documentation
- No documentation needed: **reports are not described at column detail**

- [x] **DONE**

## Test coverage
- No tests: **no test infra for spacewalk-report at this time**

- [x] **DONE**

## Links

None
- [x] **DONE**


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
