### PR TITLE
Pick safest auth method offered by HTTP proxy

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -35,9 +35,9 @@ Then(/^it should be possible to reach the test packages$/) do
 end
 
 Then(/^it should be possible to use the HTTP proxy$/) do
-  url = 'http://www.suse.com'
+  url = 'https://www.suse.com'
   proxy = "suma:P4$$word@#{$server_http_proxy}"
-  $server.run("curl --insecure --proxy '#{proxy}' --location '#{url}' --output /dev/null")
+  $server.run("curl --insecure --proxy '#{proxy}' --proxy-anyauth --location '#{url}' --output /dev/null")
 end
 
 Then(/^it should be possible to reach the build sources$/) do


### PR DESCRIPTION
## What does this PR change?

When the proxy was offering NTLM authentication, the sanity check was still passing, even though NTLM authentication was broken there. This is because:

   "Basic is the default authentication method curl uses with proxies."

This PR tries to make curl pick strongest auth method as explained in the RFC.

See SUSE/spacewalk#12940 .


## Links

* 4.1:
* 4.0:


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
