### PR TITLE
Get rid of traditional stack package installation if we are not in a traditional client

### DIFF
--- a/testsuite/features/qam/init_clients/ceos6_client.feature
+++ b/testsuite/features/qam/init_clients/ceos6_client.feature
@@ -9,7 +9,8 @@ Feature: Be able to register a CentOS 6 traditional client and do some basic ope
     When I enable repository "Devel_Galaxy_Manager_4.0_RES-Manager-Tools-6-x86_64" on this "ceos6_client"
     And I enable repository "SLE-Manager-Tools-RES-6-x86_64" on this "ceos6_client"
     And I enable repository "CentOS-Base" on this "ceos6_client"
-    And I install all spacewalk client utils on "ceos6_client"
+    And I install the traditional stack utils on "ceos6_client"
+    And I install OpenSCAP traditional dependencies on "ceos6_client"
     And I register "ceos6_client" as traditional client with activation key "1-ceos6_client_key"
     And I run "mgr-actions-control --enable-all" on "ceos6_client"
     And I wait until onboarding is completed for "ceos6_client"
@@ -33,7 +34,7 @@ Feature: Be able to register a CentOS 6 traditional client and do some basic ope
     When I follow "Audit" in the content area
     And I follow "Schedule" in the content area
     And I enter "--profile standard" as "params"
-    And I enter "/usr/share/xml/scap/ssg/content/ssg-centos7-xccdf.xml" as "path"
+    And I enter "/usr/share/xml/scap/ssg/content/ssg-centos6-xccdf.xml" as "path"
     And I click on "Schedule"
     And I run "rhn_check -vvv" on "ceos6_client"
     Then I should see a "XCCDF scan has been scheduled" text
@@ -44,7 +45,7 @@ Feature: Be able to register a CentOS 6 traditional client and do some basic ope
     When I follow "Audit" in the content area
     And I follow "xccdf_org.open-scap_testresult_standard"
     Then I should see a "Details of XCCDF Scan" text
-    And I should see a "RHEL-7" text
+    And I should see a "RHEL-6" text
     And I should see a "XCCDF Rule Results" text
     And I should see a "pass" text
     And I should see a "service_" link

--- a/testsuite/features/qam/init_clients/ceos6_minion.feature
+++ b/testsuite/features/qam/init_clients/ceos6_minion.feature
@@ -33,10 +33,6 @@ Feature: Bootstrap a CentOS 6 minion and do some basic operations on it
     And I follow "Proxy" in the content area
     Then I should see "ceos6_minion" hostname
 
-  Scenario: Prepare a CentOS 6 minion
-    Given I am authorized
-    And I install all spacewalk client utils on "ceos6_minion"
-
-  Scenario: Check events history for failures on CentOS 6 minion
+  Scenario: Check events history for failures on CentOS 6 Salt minion
     Given I am on the Systems overview page of this "ceos6_minion"
     Then I check for failed events on history event page

--- a/testsuite/features/qam/init_clients/ceos6_ssh_minion.feature
+++ b/testsuite/features/qam/init_clients/ceos6_ssh_minion.feature
@@ -34,10 +34,6 @@ Feature: Bootstrap a SSH-managed CentOS 6 minion and do some basic operations on
     And I follow "Proxy" in the content area
     Then I should see "ceos6_ssh_minion" hostname
 
-  Scenario: Prepare a SSH-managed CentOS 6 minion
-    Given I am authorized
-    And I install all spacewalk client utils on "ceos6_ssh_minion"
-
-  Scenario: Check events history for failures on SSH-managed CentOS 6 minion
+  Scenario: Check events history for failures on CentOS 6 Salt SSH minion
     Given I am on the Systems overview page of this "ceos6_ssh_minion"
     Then I check for failed events on history event page

--- a/testsuite/features/qam/init_clients/ceos7_client.feature
+++ b/testsuite/features/qam/init_clients/ceos7_client.feature
@@ -6,7 +6,8 @@ Feature: Be able to register a CentOS 7 traditional client and do some basic ope
 
   Scenario: Prepare a CentOS 7 traditional client
     When I bootstrap traditional client "ceos7_client" using bootstrap script with activation key "1-ceos7_client_key" from the proxy
-    And I install all spacewalk client utils on "ceos7_client"
+    And I install the traditional stack utils on "ceos7_client"
+    And I install OpenSCAP traditional dependencies on "ceos7_client"
     And I run "mgr-actions-control --enable-all" on "ceos7_client"
     And I wait until onboarding is completed for "ceos7_client"
 

--- a/testsuite/features/qam/init_clients/ceos7_minion.feature
+++ b/testsuite/features/qam/init_clients/ceos7_minion.feature
@@ -33,10 +33,6 @@ Feature: Bootstrap a CentOS 7 minion and do some basic operations on it
     And I follow "Proxy" in the content area
     Then I should see "ceos7_minion" hostname
 
-  Scenario: Prepare a CentOS 7 minion
-    Given I am authorized
-    And I install all spacewalk client utils on "ceos7_minion"
-
-  Scenario: Check events history for failures on CentOS 7 minion
+  Scenario: Check events history for failures on CentOS 7 Salt minion
     Given I am on the Systems overview page of this "ceos7_minion"
     Then I check for failed events on history event page

--- a/testsuite/features/qam/init_clients/ceos7_ssh_minion.feature
+++ b/testsuite/features/qam/init_clients/ceos7_ssh_minion.feature
@@ -34,10 +34,6 @@ Feature: Bootstrap a SSH-managed CentOS 7 minion and do some basic operations on
     And I follow "Proxy" in the content area
     Then I should see "ceos7_ssh_minion" hostname
 
-  Scenario: Prepare a SSH-managed CentOS 7 minion
-    Given I am authorized
-    And I install all spacewalk client utils on "ceos7_ssh_minion"
-
-  Scenario: Check events history for failures on SSH-managed CentOS 7 minion
+  Scenario: Check events history for failures on CentOS 7 Salt SSH minion
     Given I am on the Systems overview page of this "ceos7_ssh_minion"
     Then I check for failed events on history event page

--- a/testsuite/features/qam/init_clients/ceos8_minion.feature
+++ b/testsuite/features/qam/init_clients/ceos8_minion.feature
@@ -33,10 +33,6 @@ Feature: Bootstrap a CentOS 8 Salt minion
     And I follow "Proxy" in the content area
     Then I should see "ceos8_minion" hostname
 
-  Scenario: Prepare a CentOS 8 Salt minion
-    Given I am authorized
-    And I install all spacewalk client utils on "ceos8_minion"
-
   Scenario: Check events history for failures on CentOS 8 Salt minion
     Given I am on the Systems overview page of this "ceos8_minion"
     Then I check for failed events on history event page

--- a/testsuite/features/qam/init_clients/ceos8_ssh_minion.feature
+++ b/testsuite/features/qam/init_clients/ceos8_ssh_minion.feature
@@ -34,10 +34,6 @@ Feature: Bootstrap a CentOS 8 Salt SSH minion
     And I follow "Proxy" in the content area
     Then I should see "ceos8_ssh_minion" hostname
 
-  Scenario: Prepare a CentOS 8 Salt SSH minion
-    Given I am authorized
-    And I install all spacewalk client utils on "ceos8_ssh_minion"
-
   Scenario: Check events history for failures on CentOS 8 Salt SSH minion
     Given I am on the Systems overview page of this "ceos8_ssh_minion"
     Then I check for failed events on history event page

--- a/testsuite/features/secondary/min_centos_openscap_audit.feature
+++ b/testsuite/features/secondary/min_centos_openscap_audit.feature
@@ -10,10 +10,8 @@ Feature: openSCAP audit of CentOS Salt minion
   Scenario: Prepare the CentOS minion
     Given I am authorized
     When I enable SUSE Manager tools repositories on "ceos_minion"
-    And  I enable repository "CentOS-Base" on this "ceos_minion"
-    And  I install package "hwdata m2crypto wget" on this "ceos_minion"
-    And  I install package "spacewalk-client-tools spacewalk-check spacewalk-client-setup mgr-daemon mgr-osad mgr-cfg-actions" on this "ceos_minion"
-    And  I install package "spacewalk-oscap scap-security-guide" on this "ceos_minion"
+    And I enable repository "CentOS-Base" on this "ceos_minion"
+    And I install OpenSCAP salt dependencies on "ceos_minion"
 
 @centos_minion
   Scenario: Schedule an OpenSCAP audit job for the CentOS minion

--- a/testsuite/features/secondary/trad_centos_client.feature
+++ b/testsuite/features/secondary/trad_centos_client.feature
@@ -24,9 +24,8 @@ Feature: Be able to register a CentOS 7 traditional client and do some basic ope
     Given I am authorized
     When I enable SUSE Manager tools repositories on "ceos_client"
     And I enable repository "CentOS-Base" on this "ceos_client"
-    And I install package "hwdata m2crypto wget" on this "ceos_client"
-    And I install package "spacewalk-client-tools spacewalk-check spacewalk-client-setup mgr-daemon mgr-osad mgr-cfg-actions" on this "ceos_client"
-    And I install package "spacewalk-oscap scap-security-guide" on this "ceos_client"
+    And I install the traditional stack utils on "ceos_client"
+    And I install OpenSCAP traditional dependencies on "ceos_client"
     And I register "ceos_client" as traditional client
     And I run "rhn-actions-control --enable-all" on "ceos_client"
 
@@ -100,6 +99,11 @@ Feature: Be able to register a CentOS 7 traditional client and do some basic ope
     When I click on "Delete Profile"
     And I wait until I see "has been deleted." text
     Then "ceos_client" should not be registered
+
+@centos_minion
+  Scenario: Cleanup: delete the installed rpms on CentOS 7 traditional client
+    When I remove the traditional stack utils from "ceos_client"
+    And I remove OpenSCAP salt dependencies from "ceos_client"
 
 @centos_minion
   Scenario: Cleanup: bootstrap a CentOS minion after traditional client tests

--- a/testsuite/features/secondary/trad_migrate_to_minion.feature
+++ b/testsuite/features/secondary/trad_migrate_to_minion.feature
@@ -94,7 +94,8 @@ Feature: Migrate a traditional client into a Salt minion
 
   Scenario: Cleanup: register minion again as traditional client
     When I enable SUSE Manager tools repositories on "sle_client"
-    And I install package "spacewalk-client-setup spacewalk-oscap mgr-cfg-actions" on this "sle_client"
+    And I install the traditional stack utils on "sle_client"
+    And I install OpenSCAP traditional dependencies on "sle_client"
     And I remove package "salt-minion" from this "sle_client"
     And I bootstrap traditional client "sle_client" using bootstrap script with activation key "1-SUSE-DEV-x86_64" from the proxy
     Then I should see "sle_client" via spacecmd

--- a/testsuite/features/secondary/trad_migrate_to_sshminion.feature
+++ b/testsuite/features/secondary/trad_migrate_to_sshminion.feature
@@ -117,7 +117,8 @@ Feature: Migrate a traditional client into a Salt SSH minion
 
   Scenario: Cleanup: register SSH minion again as traditional client
     When I enable SUSE Manager tools repositories on "sle_client"
-    And I install package "spacewalk-client-setup spacewalk-oscap mgr-cfg-actions" on this "sle_client"
+    And I install the traditional stack utils on "sle_client"
+    And I install OpenSCAP traditional dependencies on "sle_client"
     And I bootstrap traditional client "sle_client" using bootstrap script with activation key "1-SUSE-DEV-x86_64" from the proxy
     Then I should see "sle_client" via spacecmd
 

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -768,8 +768,16 @@ When(/^I remove pattern "([^"]*)" from this "([^"]*)"$/) do |pattern, host|
   node.run(cmd, true, DEFAULT_TIMEOUT, 'root', [0, 100, 101, 102, 103, 104, 106])
 end
 
-When(/^I install all spacewalk client utils on "([^"]*)"$/) do |host|
-  step %(I install packages "#{SPACEWALK_UTILS_RPMS}" on this "#{host}")
+When(/^I (install|remove) the traditional stack utils (on|from) "([^"]*)"$/) do |action, where, host|
+  step %(I #{action} packages "#{TRADITIONAL_STACK_RPMS}" #{where} this "#{host}")
+end
+
+When(/^I (install|remove) OpenSCAP (traditional|salt) dependencies (on|from) "([^"]*)"$/) do |action, client_type, where, host|
+  if client_type == 'traditional'
+    step %(I #{action} packages "#{OPEN_SCAP_TRAD_DEPS}" #{where} this "#{host}")
+  else
+    step %(I #{action} packages "#{OPEN_SCAP_SALT_DEPS}" #{where} this "#{host}")
+  end
 end
 
 When(/^I install package(?:s)? "([^"]*)" on this "([^"]*)"((?: without error control)?)$/) do |package, host, error_control|

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -198,5 +198,9 @@ PKGARCH_BY_CLIENT = { 'proxy' => 'x86_64',
                       'ubuntu2004_ssh_minion' => 'x86_64',
                       'ubuntu2004_minion' => 'x86_64' }.freeze
 
-SPACEWALK_UTILS_RPMS = 'spacewalk-client-tools spacewalk-check spacewalk-client-setup'\
-                       'mgr-daemon mgr-osad mgr-cfg-actions spacewalk-oscap scap-security-guide'.freeze
+TRADITIONAL_STACK_RPMS = 'spacewalk-client-tools spacewalk-check spacewalk-client-setup'\
+                         'mgr-daemon mgr-osad mgr-cfg-actions'.freeze
+
+OPEN_SCAP_TRAD_DEPS = 'spacewalk-oscap scap-security-guide'.freeze
+
+OPEN_SCAP_SALT_DEPS = 'openscap-utils openscap-content scap-security-guide'.freeze


### PR DESCRIPTION
## What does this PR change?

Get rid of traditional stack package installation if we are not in a traditional client. It applies to CI testsuite and also to QAM Testsuite.

Note: I remove `m2crypto` and `hwdata` as OpenSCAP dependencies to install, because it must be part of the dependencies for spacewalk-oscap to be installed automatically by zypper/yum.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed 

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
