### PR TITLE
ISS: Differentiate packages with same nevra but different checksum (bsc#1178195)

### DIFF
--- a/backend/satellite_tools/satsync.py
+++ b/backend/satellite_tools/satsync.py
@@ -1884,7 +1884,7 @@ class Syncer:
         # pylint: disable=W0631
         return "%*.*f %s" % (int_len, fract_len, fuzzy, unit)
 
-    def _get_package_stream(self, channel, package_id, nvrea, sources):
+    def _get_package_stream(self, channel, package_id, nvrea, sources, checksum):
         """ returns (filepath, stream), so in the case of a "wire source",
             the return value is, of course, (None, stream)
         """
@@ -1904,11 +1904,11 @@ class Syncer:
 
         # Wire stream
         if CFG.ISS_PARENT:
-            stream = self.xmlDataServer.getRpm(nvrea, channel)
+            stream = self.xmlDataServer.getRpm(nvrea, channel, checksum)
         else:
             rpmServer = xmlWireSource.RPCGetWireSource(self.systemid, self.sslYN,
                                                        self.xml_dump_version)
-            stream = rpmServer.getPackageStream(channel, nvrea)
+            stream = rpmServer.getPackageStream(channel, nvrea, checksum)
 
         return (None, stream)
 
@@ -2006,7 +2006,7 @@ class ThreadDownload(threading.Thread):
                 self.lock.acquire()
                 try:
                     rpmFile, stream = self.syncer._get_package_stream(self.channel,
-                                                                      package_id, nvrea, self.sources)
+                                                                      package_id, nvrea, self.sources, checksum)
                 except:
                     self.lock.release()
                     raise

--- a/backend/satellite_tools/xmlWireSource.py
+++ b/backend/satellite_tools/xmlWireSource.py
@@ -288,7 +288,7 @@ class MetadataWireSource(BaseWireSource):
         return self._openSocketStream("dump.get_modules",
                                       (self.systemid, channel))
 
-    def getRpm(self, nvrea, channel):
+    def getRpm(self, nvrea, channel, checksum):
         release = nvrea[2]
         epoch = nvrea[3]
         if epoch:
@@ -297,7 +297,7 @@ class MetadataWireSource(BaseWireSource):
                                             nvrea[4])
         self._prepare()
         return self._openSocketStream("dump.get_rpm",
-                                      (self.systemid, package_name, channel))
+                                      (self.systemid, package_name, channel, checksum))
 
     def getKickstartFile(self, ks_label, relative_path):
         self._prepare()
@@ -488,14 +488,14 @@ class RPCGetWireSource(BaseWireSource):
                 return ret
         raise Exception("Failed after multiple attempts!")
 
-    def getPackageStream(self, channel, nvrea):
+    def getPackageStream(self, channel, nvrea, checksum):
         release = nvrea[2]
         epoch = nvrea[3]
         if epoch:
             release = "%s:%s" % (release, epoch)
         package_name = "%s-%s-%s.%s.rpm" % (nvrea[0], nvrea[1], release,
                                             nvrea[4])
-        return self._rpc_call("getPackage", (channel, package_name))
+        return self._rpc_call("getPackage", (channel, package_name, checksum))
 
     def getKickstartFileStream(self, channel, ks_tree_label, relative_path):
         return self._rpc_call("getKickstartFile", (channel, ks_tree_label,

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- ISS: Differentiate packages with same nevra but different checksum in the same channel (bsc#1178195)
 - add 'allow_vendor_change' option to rhn clients for dist upgrades
 - Re-enables possibility to use local repos with repo-sync (bsc#1175607)
 - prevent IntegrityError during mgr-inter-sync execution (bsc#1177235)


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue when running `mgr-inter-sync` to sync a channel in which there are packages that have the same NEVRA (name-epoch-version-release-arch) but have different checksum.

Currently, when this situation happens, `mgr-inter-sync` produces errors when downloading the packages:

```console
# mgr-inter-sync -c suse-packagehub-12-sp5-standard-pool-x86_64
[...]
15:38:08 Error: file /var/spacewalk/packages/NULL/00b/ColPack-devel/1.0.9-2.1/x86_64/00b5bbc2d48aa83001b2716333a3110e802eeeaf203070ef48c8aefc0a3b825e/ColPack-devel-1.0.9-2.1.x86_64.rpm has wrong size. Expected 33830 bytes, got 33828 bytes
15:38:08     Fetch unsuccessful: ColPack-devel-1.0.9-2.1.x86_64.rpm
15:38:08 Error: file /var/spacewalk/packages/NULL/f37/hdf/4.2.11-2.1/x86_64/f376f495863322d151c81379c0278262637097f9cba301fd3567921c782c6558/hdf-4.2.11-2.1.x86_64.rpm has wrong size. Expected 237319 bytes, got 234526 bytes
15:38:09     Fetch unsuccessful: hdf-4.2.11-2.1.x86_64.rpm
15:38:09 Error: file /var/spacewalk/packages/NULL/90b/hdf-devel/4.2.11-2.1/x86_64/90b52bfe4ad503ee5e36ce168f52eed03b9234b1ea76ead702b4f1ac6615a687/hdf-devel-4.2.11-2.1.x86_64.rpm has wrong size. Expected 98280 bytes, got 98124 bytes
[...]
```

This PR makes ISS to not only identify channel packages using NEVRA but also taking care of checking the checksum to uniquely identify an RPM package/file.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**
- [x] **DONE**

## Test coverage
- No tests: **bugfix**
- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/12898

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
