### PR TITLE
use the license macro to mark the LICENSE in the package

### DIFF
--- a/spacewalk/admin/spacewalk-admin.changes
+++ b/spacewalk/admin/spacewalk-admin.changes
@@ -1,3 +1,5 @@
+- use the license macro to mark the LICENSE in the package so that
+  when installing without docs, it **does** install the LICENSE file
 - prevent javax.net.ssl.SSLHandshakeException after upgrading from
   SUSE Manager 3.2 (bsc#1177435)
 - show info message when applying schema upgrade

--- a/spacewalk/admin/spacewalk-admin.spec
+++ b/spacewalk/admin/spacewalk-admin.spec
@@ -93,7 +93,7 @@ fi
 
 
 %files
-%doc LICENSE
+%license LICENSE
 %dir %{rhnroot}
 %{_sbindir}/spacewalk-startup-helper
 %{_sbindir}/spacewalk-service


### PR DESCRIPTION
## What does this PR change?

When installing without docs, it **does** install the LICENSE

## GUI diff

No difference.

Before:

`rpm -qpL spacewalk-admin-*.rpm`
returns nothing


After:

`rpm -qpL spackwalk-admin-*.rpm`
returns
`/usr/share/licenses/spacewalk-admin/LICENSE`

Tested with a local checkout of https://build.opensuse.org/package/show/systemsmanagement:Uyuni:Master/spacewalk-admin, applying the same change and then running the command within opensuse/leap:15.2 docker container.


- [ ] **DONE**

## Documentation
- No documentation needed: This is an implementation detail, no impact on the user


- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes #12923


- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
