### PR TITLE
QA: Fixing a mistake on the list of rpms

### DIFF
--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -198,7 +198,7 @@ PKGARCH_BY_CLIENT = { 'proxy' => 'x86_64',
                       'ubuntu2004_ssh_minion' => 'x86_64',
                       'ubuntu2004_minion' => 'x86_64' }.freeze
 
-TRADITIONAL_STACK_RPMS = 'spacewalk-client-tools spacewalk-check spacewalk-client-setup'\
+TRADITIONAL_STACK_RPMS = 'spacewalk-client-tools spacewalk-check spacewalk-client-setup '\
                          'mgr-daemon mgr-osad mgr-cfg-actions'.freeze
 
 OPEN_SCAP_CENTOS_DEPS = 'spacewalk-oscap scap-security-guide'.freeze


### PR DESCRIPTION
## What does this PR change?

Fixing a mistake on the list of rpms. Missing white space.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:

 - Manager-4.1 https://github.com/SUSE/spacewalk/pull/12857
 - Manager-4.0 https://github.com/SUSE/spacewalk/pull/13005

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
