### PR TITLE
Internationalization of dnf-plugin-spacewalk

### DIFF
--- a/client/rhel/dnf-plugin-spacewalk/po/Makefile
+++ b/client/rhel/dnf-plugin-spacewalk/po/Makefile
@@ -1,0 +1,176 @@
+# Makefile for program source directory in GNU NLS utilities package.
+# Copyright (C) 1995-1997, 2000, 2001 by Ulrich Drepper <drepper@gnu.ai.mit.edu>
+#
+# This file file be copied and used freely without restrictions.  It can
+# be used in projects which are not available under the GNU Public License
+# but which still want to provide support for the GNU gettext functionality.
+# Please note that the actual code is *not* freely available.
+#
+#  Modified by Yukihiro Nakai <ynakai@redhat.com> to use pygettext.py
+#  Modified by Yukihiro Nakai <ynakai@redhat.com> to use libglade-xgettext
+#
+
+PACKAGE = dnf-plugin-spacewalk
+VERSION = $(shell awk '/Version:/ { print $$2 }' ../dnf-plugin-spacewalk.spec)
+
+# These two variables depend on the location of this directory.
+subdir = po
+top_builddir = ..
+
+SHELL = /bin/sh
+
+
+srcdir = .
+top_srcdir = ..
+
+PREFIX ?=
+prefix = /usr
+exec_prefix = $(PREFIX)${prefix}
+datadir = $(PREFIX)${prefix}/share
+localedir = $(datadir)/locale
+gettextsrcdir = $(datadir)/gettext/po
+
+INSTALL = /usr/bin/install -c
+INSTALL_DATA = ${INSTALL} -m 644
+
+GMSGFMT = /usr/bin/msgfmt
+MSGFMT = /usr/bin/msgfmt
+MSGMERGE = /usr/bin/intltool-update -x --gettext-package=$(PACKAGE) --dist
+
+INCLUDES = -I.. -I$(top_srcdir)/intl
+
+POFILES = $(shell ls *.po)
+GMOFILES = $(patsubst %.po,%.gmo,$(POFILES))
+
+DISTFILES = ChangeLog POTFILES.in $(PACKAGE).pot $(POFILES) $(GMOFILES)
+
+POTFILES = \
+	$(wildcard ../*.py) \
+	$(wildcard ../actions/*.py)
+
+CATALOGS = $(GMOFILES)
+
+.SUFFIXES:
+.SUFFIXES: .po .pox .gmo .mo
+
+.po.pox:
+	$(MAKE) $(PACKAGE).pot
+	$(MSGMERGE) $< $(srcdir)/$(PACKAGE).pot -o $*.pox
+
+.po.mo:
+	$(MSGFMT) -o $@ $<
+
+.po.gmo:
+	file=$(srcdir)/`echo $* | sed 's,.*/,,'`.gmo \
+	  && rm -f $$file && $(GMSGFMT) --statistics -o $$file $<
+
+all: all-yes
+
+all-yes: $(CATALOGS)
+all-no:
+
+# Note: Target 'all' must not depend on target '$(srcdir)/$(PACKAGE).pot',
+# otherwise packages like GCC can not be built if only parts of the source
+# have been downloaded.
+
+POTFILES.in:
+	echo "[encoding: UTF-8]" > $@
+	for file in $(POTFILES); do \
+	  echo "$${file#../}" ; \
+	done >> $@
+
+$(srcdir)/$(PACKAGE).pot: $(POTFILES) POTFILES.in
+	/usr/bin/intltool-update --gettext-package=$(PACKAGE) --pot
+	rm -f POTFILES.in
+
+install: install-exec install-data
+install-exec:
+install-data: install-data-yes
+install-data-no: all
+install-data-yes: all
+	mkdir -p $(DESTDIR)$(datadir)
+	@catalogs='$(CATALOGS)'; \
+	for cat in $$catalogs; do \
+	  cat=`basename $$cat`; \
+	  lang=`echo $$cat | sed 's/\.gmo$$//'`; \
+	  dir=$(localedir)/$$lang/LC_MESSAGES; \
+	  mkdir -p $(DESTDIR)$$dir; \
+	  if test -r $$cat; then \
+	    $(INSTALL_DATA) $$cat $(DESTDIR)$$dir/$(PACKAGE).mo; \
+	    echo "installing $$cat as $(DESTDIR)$$dir/$(PACKAGE).mo"; \
+	  else \
+	    $(INSTALL_DATA) $(srcdir)/$$cat $(DESTDIR)$$dir/$(PACKAGE).mo; \
+	    echo "installing $(srcdir)/$$cat as" \
+		 "$(DESTDIR)$$dir/$(PACKAGE).mo"; \
+	  fi; \
+	done
+
+# Define this as empty until I found a useful application.
+installcheck:
+
+uninstall:
+	catalogs='$(CATALOGS)'; \
+	for cat in $$catalogs; do \
+	  cat=`basename $$cat`; \
+	  lang=`echo $$cat | sed 's/\.gmo$$//'`; \
+	  rm -f $(DESTDIR)$(localedir)/$$lang/LC_MESSAGES/$(PACKAGE).mo; \
+	done
+
+check: all
+
+dvi info tags TAGS ID:
+
+mostlyclean:
+	rm -f core core.* *.pox $(PACKAGE).po *.new.po POTFILES.in
+	rm -fr *.o
+
+clean: mostlyclean
+	rm -f *.gmo
+
+distclean: clean
+	rm -f POTFILES *.mo
+
+maintainer-clean: distclean
+	@echo "This command is intended for maintainers to use;"
+	@echo "it deletes files that may require special tools to rebuild."
+	rm -f $(GMOFILES)
+
+distdir = $(top_builddir)/$(PACKAGE)-$(VERSION)/$(subdir)
+dist distdir:
+	$(MAKE) update-po
+	@$(MAKE) dist2
+# This is a separate target because 'update-po' must be executed before.
+dist2: $(DISTFILES)
+	dists="$(DISTFILES)"; \
+	for file in $$dists; do \
+	  if test -f $$file; then dir=.; else dir=$(srcdir); fi; \
+	  cp -p $$dir/$$file $(distdir); \
+	done
+
+update-po: Makefile POTFILES.in $(PACKAGE).pot
+	$(MAKE) $(PACKAGE).pot
+	if test "$(PACKAGE)" = "gettext"; then PATH=`pwd`/../src:$$PATH; fi; \
+	cd $(srcdir); \
+	catalogs='$(GMOFILES)'; \
+	for cat in $$catalogs; do \
+	  cat=`basename $$cat`; \
+	  lang=`echo $$cat | sed 's/\.gmo$$//'`; \
+	  echo "$$lang:"; \
+	  cp $$lang.po $$lang.old.po; \
+	  if $(MSGMERGE) $$lang; then \
+	    rm -f $$lang.old.po ; \
+	  else \
+	    echo "msgmerge for $$cat failed!"; \
+	    mv $$lang.old.po $$lang.po ; \
+	  fi; \
+	done
+	$(MAKE) update-gmo
+
+update-gmo: Makefile $(GMOFILES)
+	@:
+
+Makefile:
+
+# Tell versions [3.59,3.63) of GNU make not to export all variables.
+# Otherwise a system limit (for SysV at least) may be exceeded.
+.NOEXPORT:

--- a/client/rhel/dnf-plugin-spacewalk/po/Makevars
+++ b/client/rhel/dnf-plugin-spacewalk/po/Makevars
@@ -1,0 +1,1 @@
+XGETTEXT_OPTIONS = --keyword=_

--- a/client/rhel/dnf-plugin-spacewalk/po/dnf-plugin-spacewalk.pot
+++ b/client/rhel/dnf-plugin-spacewalk/po/dnf-plugin-spacewalk.pot
@@ -1,0 +1,71 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-11-05 13:12+0100\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../spacewalk.py:41
+msgid "Spacewalk based repositories will be disabled."
+msgstr ""
+
+#: ../spacewalk.py:42
+msgid "Spacewalk channel support will be disabled."
+msgstr ""
+
+#: ../spacewalk.py:43
+msgid "There was an error communicating with Spacewalk server."
+msgstr ""
+
+#: ../spacewalk.py:44
+msgid "This system is not registered with Spacewalk server."
+msgstr ""
+
+#: ../spacewalk.py:45
+msgid "This system is not subscribed to any channels."
+msgstr ""
+
+#: ../spacewalk.py:46
+msgid "SystemId could not be acquired."
+msgstr ""
+
+#: ../spacewalk.py:47
+msgid "You can use rhn_register to register."
+msgstr ""
+
+#: ../spacewalk.py:48
+msgid "This system is receiving updates from Spacewalk server."
+msgstr ""
+
+#: ../spacewalk.py:49
+#, python-format
+msgid ""
+"For security reasons packages from Spacewalk based repositories can be "
+"verified only with locally installed gpg keys. GPG key '%s' has been "
+"rejected."
+msgstr ""
+
+#: ../spacewalk.py:50
+msgid "Package profile information could not be sent."
+msgstr ""
+
+#: ../spacewalk.py:51
+#, python-format
+msgid "Missing required login information for Spacewalk: %s"
+msgstr ""
+
+#: ../spacewalk.py:52
+msgid "Spacewalk plugin has to be run under with the root privileges."
+msgstr ""


### PR DESCRIPTION
## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: i18n

- [x] **DONE**

## Test coverage
- No tests: i18n

- [x] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/12328

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"