### PR TITLE
QAM: Clean up the VMs deployed using sumaform (#12999)

### DIFF
--- a/testsuite/features/qam/init_clients/ceos6_client.feature
+++ b/testsuite/features/qam/init_clients/ceos6_client.feature
@@ -4,6 +4,9 @@
 @ceos6_client
 Feature: Be able to register a CentOS 6 traditional client and do some basic operations on it
 
+  Scenario: Clean up sumaform leftovers on a CentOS 6 traditional client
+    When I perform a full salt minion cleanup on "ceos6_client"
+
   Scenario: Prepare a CentOS 6 traditional client
     Given I am authorized
     When I enable repository "Devel_Galaxy_Manager_4.0_RES-Manager-Tools-6-x86_64" on this "ceos6_client"

--- a/testsuite/features/qam/init_clients/ceos6_minion.feature
+++ b/testsuite/features/qam/init_clients/ceos6_minion.feature
@@ -5,9 +5,12 @@
 #  2) subscribe it to a base channel for testing
 
 @ceos6_minion
-Feature: Bootstrap a CentOS 6 minion and do some basic operations on it
+Feature: Bootstrap a CentOS 6 Salt minion
 
-  Scenario: Bootstrap a CentOS 6 minion
+  Scenario: Clean up sumaform leftovers on a CentOS 6 Salt minion
+    When I perform a full salt minion cleanup on "ceos6_minion"
+
+  Scenario: Bootstrap a CentOS 6 Salt minion
     Given I am authorized
     When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text

--- a/testsuite/features/qam/init_clients/ceos6_ssh_minion.feature
+++ b/testsuite/features/qam/init_clients/ceos6_ssh_minion.feature
@@ -5,9 +5,12 @@
 #  2) subscribe it to a base channel for testing
 
 @ceos6_ssh_minion
-Feature: Bootstrap a SSH-managed CentOS 6 minion and do some basic operations on it
+Feature: Bootstrap a CentOS 6 Salt SSH minion
 
-  Scenario: Bootstrap a SSH-managed CentOS 6 minion
+  Scenario: Clean up sumaform leftovers on a CentOS 6 Salt SSH minion
+    When I perform a full salt minion cleanup on "ceos6_ssh_minion"
+
+  Scenario: Bootstrap a CentOS 6 Salt SSH minion
     Given I am authorized
     When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
@@ -21,14 +24,14 @@ Feature: Bootstrap a SSH-managed CentOS 6 minion and do some basic operations on
     And I wait until onboarding is completed for "ceos6_ssh_minion"
 
 @proxy
-  Scenario: Check connection from SSH-managed CentOS 6 minion to proxy
+  Scenario: Check connection from CentOS 6 Salt SSH minion to proxy
     Given I am on the Systems overview page of this "ceos6_ssh_minion"
     When I follow "Details" in the content area
     And I follow "Connection" in the content area
     Then I should see "proxy" short hostname
 
 @proxy
-  Scenario: Check registration on proxy of SSH-managed CentOS 6 minion
+  Scenario: Check registration on proxy of CentOS 6 Salt SSH minion
     Given I am on the Systems overview page of this "proxy"
     When I follow "Details" in the content area
     And I follow "Proxy" in the content area

--- a/testsuite/features/qam/init_clients/ceos7_client.feature
+++ b/testsuite/features/qam/init_clients/ceos7_client.feature
@@ -4,6 +4,9 @@
 @ceos7_client
 Feature: Be able to register a CentOS 7 traditional client and do some basic operations on it
 
+  Scenario: Clean up sumaform leftovers on a CentOS 7 traditional client
+    When I perform a full salt minion cleanup on "ceos7_client"
+
   Scenario: Prepare a CentOS 7 traditional client
     When I bootstrap traditional client "ceos7_client" using bootstrap script with activation key "1-ceos7_client_key" from the proxy
     And I install the traditional stack utils on "ceos7_client"

--- a/testsuite/features/qam/init_clients/ceos7_minion.feature
+++ b/testsuite/features/qam/init_clients/ceos7_minion.feature
@@ -5,9 +5,12 @@
 #  2) subscribe it to a base channel for testing
 
 @ceos7_minion
-Feature: Bootstrap a CentOS 7 minion and do some basic operations on it
+Feature: Bootstrap a CentOS 7 Salt minion
 
-  Scenario: Bootstrap a CentOS 7 minion
+  Scenario: Clean up sumaform leftovers on a  CentOS 7 Salt minion
+    When I perform a full salt minion cleanup on "ceos7_minion"
+
+  Scenario: Bootstrap a CentOS 7 Salt minion
     Given I am authorized
     When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
@@ -20,14 +23,14 @@ Feature: Bootstrap a CentOS 7 minion and do some basic operations on it
     And I wait until onboarding is completed for "ceos7_minion"
 
 @proxy
-  Scenario: Check connection from CentOS 7 minion to proxy
+  Scenario: Check connection from CentOS 7 Salt minion to proxy
     Given I am on the Systems overview page of this "ceos7_minion"
     When I follow "Details" in the content area
     And I follow "Connection" in the content area
     Then I should see "proxy" short hostname
 
 @proxy
-  Scenario: Check registration on proxy of CentOS 7 minion
+  Scenario: Check registration on proxy of CentOS 7 Salt minion
     Given I am on the Systems overview page of this "proxy"
     When I follow "Details" in the content area
     And I follow "Proxy" in the content area

--- a/testsuite/features/qam/init_clients/ceos7_ssh_minion.feature
+++ b/testsuite/features/qam/init_clients/ceos7_ssh_minion.feature
@@ -5,9 +5,12 @@
 #  2) subscribe it to a base channel for testing
 
 @ceos7_ssh_minion
-Feature: Bootstrap a SSH-managed CentOS 7 minion and do some basic operations on it
+Feature: Bootstrap a CentOS 7 Salt SSH minion
 
-  Scenario: Bootstrap a SSH-managed CentOS 7 minion
+  Scenario: Clean up sumaform leftovers on a CentOS 7 Salt SSH minion
+    When I perform a full salt minion cleanup on "ceos7_ssh_minion"
+
+  Scenario: Bootstrap a CentOS 7 Salt SSH minion
     Given I am authorized
     When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
@@ -21,14 +24,14 @@ Feature: Bootstrap a SSH-managed CentOS 7 minion and do some basic operations on
     And I wait until onboarding is completed for "ceos7_ssh_minion"
 
 @proxy
-  Scenario: Check connection from SSH-managed CentOS 7 minion to proxy
+  Scenario: Check connection from CentOS 7 Salt SSH minion to proxy
     Given I am on the Systems overview page of this "ceos7_ssh_minion"
     When I follow "Details" in the content area
     And I follow "Connection" in the content area
     Then I should see "proxy" short hostname
 
 @proxy
-  Scenario: Check registration on proxy of SSH-managed CentOS 7 minion
+  Scenario: Check registration on proxy of CentOS 7 Salt SSH minion
     Given I am on the Systems overview page of this "proxy"
     When I follow "Details" in the content area
     And I follow "Proxy" in the content area

--- a/testsuite/features/qam/init_clients/ceos8_minion.feature
+++ b/testsuite/features/qam/init_clients/ceos8_minion.feature
@@ -7,6 +7,9 @@
 @ceos8_minion
 Feature: Bootstrap a CentOS 8 Salt minion
 
+  Scenario: Clean up sumaform leftovers on a CentOS 8 Salt minion
+    When I perform a full salt minion cleanup on "ceos8_minion"
+
   Scenario: Bootstrap a CentOS 8 Salt minion
     Given I am authorized
     When I go to the bootstrapping page

--- a/testsuite/features/qam/init_clients/ceos8_ssh_minion.feature
+++ b/testsuite/features/qam/init_clients/ceos8_ssh_minion.feature
@@ -7,6 +7,9 @@
 @ceos8_ssh_minion
 Feature: Bootstrap a CentOS 8 Salt SSH minion
 
+  Scenario: Clean up sumaform leftovers on a CentOS 8 Salt SSH minion
+    When I perform a full salt minion cleanup on "ceos8_ssh_minion"
+
   Scenario: Bootstrap a CentOS 8 Salt SSH minion
     Given I am authorized
     When I go to the bootstrapping page

--- a/testsuite/features/qam/init_clients/proxy.feature
+++ b/testsuite/features/qam/init_clients/proxy.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 SUSE LLC
+# Copyright (c) 2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # The scenarios in this feature are skipped if there is no proxy
@@ -10,6 +10,9 @@ Feature: Setup SUSE Manager proxy
   In order to use a proxy with the SUSE manager server
   As the system administrator
   I want to register the proxy to the server
+
+  Scenario: Clean up sumaform leftovers on a SUSE Manager proxy
+    When I perform a full salt minion cleanup on "proxy"
 
   Scenario: Bootstrap the proxy as a Salt minion
     Given I am authorized

--- a/testsuite/features/qam/init_clients/sle11sp4_client.feature
+++ b/testsuite/features/qam/init_clients/sle11sp4_client.feature
@@ -1,19 +1,23 @@
-# Copyright (c) 2015 SUSE LLC
+# Copyright (c) 2017-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @sle11sp4_client
-Feature: Register a sle11sp4 traditional client
-  In order to register a traditional client to the SUSE Manager server
-  As the root user
-  I want to call rhnreg_ks
+Feature: Bootstrap a SLES 11 SP4 traditional client
 
-  Scenario: Register a sle11sp4 traditional client
-    When I register "sle11sp4_client" as traditional client with activation key "1-sle11sp4_client_key"
+  Scenario: Clean up sumaform leftovers on a SLES 11 SP4 traditional client
+    When I perform a full salt minion cleanup on "sle11sp4_client"
+
+  Scenario: Register a SLES 11 SP4 traditional client
+    When I bootstrap traditional client "sle11sp4_client" using bootstrap script with activation key "1-sle11sp4_client_key" from the proxy
+    And I install package "spacewalk-client-setup spacewalk-oscap mgr-cfg-actions" on this "sle11sp4_client"
     And I run "mgr-actions-control --enable-all" on "sle11sp4_client"
     Then I should see "sle11sp4_client" via spacecmd
-    And I wait until onboarding is completed for "sle11sp4_client"
 
-  Scenario: Check registration values of sle11sp4 traditional
+  Scenario: The onboarding of SLES 11 SP4 traditional client is completed
+    Given I am authorized
+    Then I wait until onboarding is completed for "sle11sp4_client"
+
+  Scenario: Check registration values of SLES 11 SP4 traditional
     Given I update the profile of "sle11sp4_client"
     When I am on the Systems overview page of this "sle11sp4_client"
     And I wait until I see "Software Updates Available" text or "System is up to date" text
@@ -26,14 +30,14 @@ Feature: Register a sle11sp4 traditional client
     And I should see a "OS: sles-release" text
 
 @proxy
-  Scenario: Check connection from sle11sp4 traditional to proxy
+  Scenario: Check connection from SLES 11 SP4 traditional to proxy
     Given I am on the Systems overview page of this "sle11sp4_client"
     When I follow "Details" in the content area
     And I follow "Connection" in the content area
     Then I should see "proxy" short hostname
 
 @proxy
-  Scenario: Check registration on proxy of sle11sp4 traditional
+  Scenario: Check registration on proxy of SLES 11 SP4 traditional
     Given I am on the Systems overview page of this "proxy"
     When I follow "Details" in the content area
     And I follow "Proxy" in the content area

--- a/testsuite/features/qam/init_clients/sle11sp4_minion.feature
+++ b/testsuite/features/qam/init_clients/sle11sp4_minion.feature
@@ -4,6 +4,9 @@
 @sle11sp4_minion
 Feature: Be able to bootstrap a sle11sp4 Salt minion via the GUI
 
+  Scenario: Clean up sumaform leftovers on a SLES 11 SP4 Salt minion
+    When I perform a full salt minion cleanup on "sle11sp4_minion"
+
   Scenario: Create the bootstrap repository for a Salt client
     Given I am authorized
     And I create the "x86_64" bootstrap repository for "sle11sp4_minion" on the server

--- a/testsuite/features/qam/init_clients/sle11sp4_ssh_minion.feature
+++ b/testsuite/features/qam/init_clients/sle11sp4_ssh_minion.feature
@@ -2,10 +2,12 @@
 # Licensed under the terms of the MIT license.
 
 @sle11sp4_ssh_minion
-Feature: Be able to bootstrap a sle11sp4 Salt host managed via salt-ssh
+Feature: Bootstrap a SLES 11 SP4 Salt SSH Minion
 
-@ssh_minion
-  Scenario: Bootstrap a sle11sp4 system managed via salt-ssh
+  Scenario: Clean up sumaform leftovers on a SLES 11 SP4 Salt SSH Minion
+    When I perform a full salt minion cleanup on "sle11sp4_ssh_minion"
+
+  Scenario: Bootstrap a SLES 11 SP4 system managed via salt-ssh
     Given I am authorized
     And I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
@@ -22,29 +24,29 @@ Feature: Be able to bootstrap a sle11sp4 Salt host managed via salt-ssh
 # Package 'sle-manager-tools-release' is automatically installed during bootstrap and
 # stays installed after removal of channel containing it. So it is not possible to update it.
 # Package needs to be removed from highstate to avoid failure when updating it.
-@ssh_minion
-  Scenario: Remove sle-manager-tools-release from state after sle11sp4 bootstrap
+  Scenario: Remove sle-manager-tools-release from state after SLES 11 SP4 bootstrap
     Given I am on the Systems overview page of this "sle11sp4_ssh_minion"
     When I remove package "sle-manager-tools-release" from highstate
 
+# WORKAROUD for bsc#1178328
+  Scenario: Install dmidecode package to avoid a Hardware Refresh issue in SLES 11 SP4 SSH minion
+    And I install package "dmidecode" on this "sle11sp4_ssh_minion"
+
 @proxy
-@ssh_minion
-  Scenario: Check connection from sle11sp4 SSH minion to proxy
+  Scenario: Check connection from SLES 11 SP4 SSH minion to proxy
     Given I am on the Systems overview page of this "sle11sp4_ssh_minion"
     When I follow "Details" in the content area
     And I follow "Connection" in the content area
     Then I should see "proxy" short hostname
 
 @proxy
-@ssh_minion
-  Scenario: Check registration on proxy of sle11sp4 SSH minion
+  Scenario: Check registration on proxy of SLES 11 SP4 SSH minion
     Given I am on the Systems overview page of this "proxy"
     When I follow "Details" in the content area
     And I follow "Proxy" in the content area
     Then I should see "sle11sp4_ssh_minion" hostname
 
-@ssh_minion
-  Scenario: Schedule errata refresh to reflect channel assignment on sle11sp4 SSH minion
+  Scenario: Schedule errata refresh to reflect channel assignment on SLES 11 SP4 SSH minion
     Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Admin > Task Schedules"
     And I follow "errata-cache-default"
@@ -53,7 +55,6 @@ Feature: Be able to bootstrap a sle11sp4 Salt host managed via salt-ssh
     Then I should see a "bunch was scheduled" text
     And I wait until the table contains "FINISHED" or "SKIPPED" followed by "FINISHED" in its first rows
 
-@ssh_minion
-  Scenario: Check events history for failures on sle11sp4 SSH minion
+  Scenario: Check events history for failures on SLES 11 SP4 SSH minion
     Given I am on the Systems overview page of this "sle11sp4_ssh_minion"
     Then I check for failed events on history event page

--- a/testsuite/features/qam/init_clients/sle12sp4_client.feature
+++ b/testsuite/features/qam/init_clients/sle12sp4_client.feature
@@ -2,18 +2,22 @@
 # Licensed under the terms of the MIT license.
 
 @sle12sp4_client
-Feature: Register a sle12sp4 traditional client
-  In order to register a traditional client to the SUSE Manager server
-  As the root user
-  I want to call rhnreg_ks
+Feature: Bootstrap a SLES 12 SP4 traditional client
 
-  Scenario: Register a sle12sp4 traditional client
-    When I register "sle12sp4_client" as traditional client with activation key "1-sle12sp4_client_key"
+  Scenario: Clean up sumaform leftovers on a SLES 12 SP4 traditional client
+    When I perform a full salt minion cleanup on "sle12sp4_client"
+
+  Scenario: Register a SLES 12 SP4 traditional client
+    When I bootstrap traditional client "sle12sp4_client" using bootstrap script with activation key "1-sle12sp4_client_key" from the proxy
+    And I install package "spacewalk-client-setup spacewalk-oscap mgr-cfg-actions" on this "sle12sp4_client"
     And I run "mgr-actions-control --enable-all" on "sle12sp4_client"
     Then I should see "sle12sp4_client" via spacecmd
-    And I wait until onboarding is completed for "sle12sp4_client"
 
-  Scenario: Check registration values of sle12sp4 traditional client
+  Scenario: The onboarding of SLES 12 SP4 traditional client is completed
+    Given I am authorized
+    Then I wait until onboarding is completed for "sle12sp4_client"
+
+  Scenario: Check registration values of SLES 12 SP4 traditional client
     Given I update the profile of "sle12sp4_client"
     When I am on the Systems overview page of this "sle12sp4_client"
     And I wait until I see "Software Updates Available" text or "System is up to date" text
@@ -26,14 +30,14 @@ Feature: Register a sle12sp4 traditional client
     And I should see a "OS: sles-release" text
 
 @proxy
-  Scenario: Check connection from sle12sp4 traditional to proxy
+  Scenario: Check connection from SLES 12 SP4 traditional to proxy
     Given I am on the Systems overview page of this "sle12sp4_client"
     When I follow "Details" in the content area
     And I follow "Connection" in the content area
     Then I should see "proxy" short hostname
 
 @proxy
-  Scenario: Check registration on proxy of sle12sp4 traditional
+  Scenario: Check registration on proxy of SLES 12 SP4 traditional
     Given I am on the Systems overview page of this "proxy"
     When I follow "Details" in the content area
     And I follow "Proxy" in the content area

--- a/testsuite/features/qam/init_clients/sle12sp4_minion.feature
+++ b/testsuite/features/qam/init_clients/sle12sp4_minion.feature
@@ -4,6 +4,9 @@
 @sle12sp4_minion
 Feature: Be able to bootstrap a sle12sp4 Salt minion via the GUI
 
+  Scenario: Clean up sumaform leftovers on a SLES 12 SP4 Salt minion
+    When I perform a full salt minion cleanup on "sle12sp4_minion"
+
   Scenario: Create the bootstrap repository for a Salt client
     Given I am authorized
     And I create the "x86_64" bootstrap repository for "sle12sp4_minion" on the server

--- a/testsuite/features/qam/init_clients/sle12sp4_ssh_minion.feature
+++ b/testsuite/features/qam/init_clients/sle12sp4_ssh_minion.feature
@@ -2,10 +2,12 @@
 # Licensed under the terms of the MIT license.
 
 @sle12sp4_ssh_minion
-Feature: Be able to bootstrap a sle12sp4 Salt host managed via salt-ssh
+Feature: Bootstrap a SLES 12 SP4 Salt SSH Minion
 
-@ssh_minion
-  Scenario: Bootstrap a sle12sp4 system managed via salt-ssh
+  Scenario: Clean up sumaform leftovers on a SLES 12 SP4 Salt SSH Minion
+    When I perform a full salt minion cleanup on "sle12sp4_ssh_minion"
+
+  Scenario: Bootstrap a SLES 12 SP4 system managed via salt-ssh
     Given I am authorized
     And I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
@@ -22,29 +24,29 @@ Feature: Be able to bootstrap a sle12sp4 Salt host managed via salt-ssh
 # Package 'sle-manager-tools-release' is automatically installed during bootstrap and
 # stays installed after removal of channel containing it. So it is not possible to update it.
 # Package needs to be removed from highstate to avoid failure when updating it.
-@ssh_minion
-  Scenario: Remove sle-manager-tools-release from state after sle12sp4 bootstrap
+  Scenario: Remove sle-manager-tools-release from state after SLES 12 SP4 bootstrap
     Given I am on the Systems overview page of this "sle12sp4_ssh_minion"
     When I remove package "sle-manager-tools-release" from highstate
 
+# WORKAROUD for bsc#1178328
+  Scenario: Install dmidecode package to avoid a Hardware Refresh issue in SLES 12 SP4 SSH minion
+    And I install package "dmidecode" on this "sle12sp4_ssh_minion"
+
 @proxy
-@ssh_minion
-  Scenario: Check connection from sle12sp4 SSH minion to proxy
+  Scenario: Check connection from SLES 12 SP4 SSH minion to proxy
     Given I am on the Systems overview page of this "sle12sp4_ssh_minion"
     When I follow "Details" in the content area
     And I follow "Connection" in the content area
     Then I should see "proxy" short hostname
 
 @proxy
-@ssh_minion
-  Scenario: Check registration on proxy of sle12sp4 SSH minion
+  Scenario: Check registration on proxy of SLES 12 SP4 SSH minion
     Given I am on the Systems overview page of this "proxy"
     When I follow "Details" in the content area
     And I follow "Proxy" in the content area
     Then I should see "sle12sp4_ssh_minion" hostname
 
-@ssh_minion
-  Scenario: Schedule errata refresh to reflect channel assignment on sle12sp4 SSH minion
+  Scenario: Schedule errata refresh to reflect channel assignment on SLES 12 SP4 SSH minion
     Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Admin > Task Schedules"
     And I follow "errata-cache-default"
@@ -53,7 +55,6 @@ Feature: Be able to bootstrap a sle12sp4 Salt host managed via salt-ssh
     Then I should see a "bunch was scheduled" text
     And I wait until the table contains "FINISHED" or "SKIPPED" followed by "FINISHED" in its first rows
 
-@ssh_minion
-  Scenario: Check events history for failures on sle12sp4 SSH minion
+  Scenario: Check events history for failures on SLES 12 SP4 SSH minion
     Given I am on the Systems overview page of this "sle12sp4_ssh_minion"
     Then I check for failed events on history event page

--- a/testsuite/features/qam/init_clients/sle15_client.feature
+++ b/testsuite/features/qam/init_clients/sle15_client.feature
@@ -2,18 +2,22 @@
 # Licensed under the terms of the MIT license.
 
 @sle15_client
-Feature: Register a sle15 traditional client
-  In order to register a traditional client to the SUSE Manager server
-  As the root user
-  I want to call rhnreg_ks
+Feature: Bootstrap a SLES 15 traditional client
 
-  Scenario: Register a traditional client
-    When I register "sle15_client" as traditional client with activation key "1-sle15_client_key"
+  Scenario: Clean up sumaform leftovers on a SLES 15 traditional client
+    When I perform a full salt minion cleanup on "sle15_client"
+
+  Scenario: Register a SLES 15 traditional client
+    When I bootstrap traditional client "sle15_client" using bootstrap script with activation key "1-sle15_client_key" from the proxy
+    And I install package "spacewalk-client-setup spacewalk-oscap mgr-cfg-actions" on this "sle15_client"
     And I run "mgr-actions-control --enable-all" on "sle15_client"
     Then I should see "sle15_client" via spacecmd
-    And I wait until onboarding is completed for "sle15_client"
 
-  Scenario: Check registration values
+  Scenario: The onboarding of SLES 15 traditional client is completed
+    Given I am authorized
+    Then I wait until onboarding is completed for "sle15_client"
+
+  Scenario: Check registration values of SLES 15 traditional client
     Given I update the profile of "sle15_client"
     When I am on the Systems overview page of this "sle15_client"
     And I wait until I see "Software Updates Available" text or "System is up to date" text
@@ -26,20 +30,20 @@ Feature: Register a sle15 traditional client
     And I should see a "OS: sles-release" text
 
 @proxy
-  Scenario: Check connection from traditional to proxy
+  Scenario: Check connection from SLES 15 traditional to proxy
     Given I am on the Systems overview page of this "sle15_client"
     When I follow "Details" in the content area
     And I follow "Connection" in the content area
     Then I should see "proxy" short hostname
 
 @proxy
-  Scenario: Check registration on proxy of traditional
+  Scenario: Check registration on proxy of SLES 15 traditional
     Given I am on the Systems overview page of this "proxy"
     When I follow "Details" in the content area
     And I follow "Proxy" in the content area
     Then I should see "sle15_client" hostname
 
-  Scenario: Check tab links "Software" => "Patches"
+  Scenario: Check tab links "Software" => "Patches" of SLES 15 traditional
     Given I am on the Systems overview page of this "sle15_client"
     When I follow "Software" in the content area
     And I follow "Patches" in the content area

--- a/testsuite/features/qam/init_clients/sle15_minion.feature
+++ b/testsuite/features/qam/init_clients/sle15_minion.feature
@@ -2,13 +2,16 @@
 # Licensed under the terms of the MIT license.
 
 @sle15_minion
-Feature: Be able to bootstrap a sle15 Salt minion via the GUI
+Feature: Be able to bootstrap a SLES 15 Salt minion
+
+  Scenario: Clean up sumaform leftovers on a SLES 15 Salt minion
+    When I perform a full salt minion cleanup on "sle15_minion"
 
   Scenario: Create the bootstrap repository for a Salt client
     Given I am authorized
     And I create the "x86_64" bootstrap repository for "sle15_minion" on the server
 
-  Scenario: Bootstrap a sle15 minion
+  Scenario: Bootstrap a SLES 15 minion
     Given I am authorized
     When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
@@ -22,34 +25,34 @@ Feature: Be able to bootstrap a sle15 Salt minion via the GUI
     And I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "sle15_minion"
 
-  Scenario: Check the new bootstrapped sle15 minion in System Overview page
+  Scenario: Check the new bootstrapped SLES 15 minion in System Overview page
     Given I am authorized
     And I go to the minion onboarding page
     Then I should see a "accepted" text
     And the Salt master can reach "sle15_minion"
 
 @proxy
-  Scenario: Check connection from sle15 minion to proxy
+  Scenario: Check connection from SLES 15 minion to proxy
     Given I am on the Systems overview page of this "sle15_minion"
     When I follow "Details" in the content area
     And I follow "Connection" in the content area
     Then I should see "proxy" short hostname
 
 @proxy
-  Scenario: Check registration on proxy of sle15 minion
+  Scenario: Check registration on proxy of SLES 15 minion
     Given I am on the Systems overview page of this "proxy"
     When I follow "Details" in the content area
     And I follow "Proxy" in the content area
     Then I should see "sle15_minion" hostname
 
   # bsc#1085436 - Apache returns 403 Forbidden after a zypper refresh on minion
-  Scenario: Check the new channel is working
+  Scenario: Check the new channel for SLES 15 minion is working
     When I refresh the metadata for "sle15_minion"
 
-  Scenario: Detect latest Salt changes on the sle15 minion
+  Scenario: Detect latest Salt changes on the SLES 15 minion
     When I query latest Salt changes on "sle15_minion"
 
-  Scenario: Run a remote command on normal sle15 minion
+  Scenario: Run a remote command on normal SLES 15 minion
     Given I am authorized as "testing" with password "testing"
     When I follow the left menu "Salt > Remote Commands"
     Then I should see a "Remote Commands" text in the content area
@@ -62,10 +65,10 @@ Feature: Be able to bootstrap a sle15 Salt minion via the GUI
     And I expand the results for "sle15_minion"
     Then I should see "/tmp: sticky, directory" in the command output for "sle15_minion"
 
-  Scenario: Check spacecmd system ID of bootstrapped sle15 minion
+  Scenario: Check spacecmd system ID of bootstrapped SLES 15 minion
     Given I am on the Systems overview page of this "sle15_minion"
     Then I run spacecmd listevents for "sle15_minion"
 
-  Scenario: Check events history for failures on sle15 minion
+  Scenario: Check events history for failures on SLES 15 minion
     Given I am on the Systems overview page of this "sle15_minion"
     Then I check for failed events on history event page

--- a/testsuite/features/qam/init_clients/sle15_ssh_minion.feature
+++ b/testsuite/features/qam/init_clients/sle15_ssh_minion.feature
@@ -2,9 +2,12 @@
 # Licensed under the terms of the MIT license.
 
 @sle15_ssh_minion
-Feature: Be able to bootstrap a sle15 Salt host managed via salt-ssh
+Feature: Bootstrap a SLES 15 Salt SSH Minion
 
-  Scenario: Bootstrap a sle15 system managed via salt-ssh
+  Scenario: Clean up sumaform leftovers on a SLES 15 Salt SSH Minion
+    When I perform a full salt minion cleanup on "sle15_ssh_minion"
+
+  Scenario: Bootstrap a SLES 15 system managed via salt-ssh
     Given I am authorized
     And I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
@@ -21,25 +24,29 @@ Feature: Be able to bootstrap a sle15 Salt host managed via salt-ssh
   # Package 'sle-manager-tools-release' is automatically installed during bootstrap and
   # stays installed after removal of channel containing it. So it is not possible to update it.
   # Package needs to be removed from highstate to avoid failure when updating it.
-  Scenario: Remove sle-manager-tools-release from state after sle15 bootstrap
+  Scenario: Remove sle-manager-tools-release from state after SLES 15 bootstrap
     Given I am on the Systems overview page of this "sle15_ssh_minion"
     When I remove package "sle-manager-tools-release" from highstate
 
+# WORKAROUD for bsc#1178328
+  Scenario: Install dmidecode package to avoid a Hardware Refresh issue in SLES 15 SSH minion
+    And I install package "dmidecode" on this "sle15_ssh_minion"
+
 @proxy
-  Scenario: Check connection from sle15 SSH minion to proxy
+  Scenario: Check connection from SLES 15 SSH minion to proxy
     Given I am on the Systems overview page of this "sle15_ssh_minion"
     When I follow "Details" in the content area
     And I follow "Connection" in the content area
     Then I should see "proxy" short hostname
 
 @proxy
-  Scenario: Check registration on proxy of sle15 SSH minion
+  Scenario: Check registration on proxy of SLES 15 SSH minion
     Given I am on the Systems overview page of this "proxy"
     When I follow "Details" in the content area
     And I follow "Proxy" in the content area
     Then I should see "sle15_ssh_minion" hostname
 
-  Scenario: Schedule errata refresh to reflect channel assignment on sle15 SSH minion
+  Scenario: Schedule errata refresh to reflect channel assignment on SLES 15 SSH minion
     Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Admin > Task Schedules"
     And I follow "errata-cache-default"
@@ -48,6 +55,6 @@ Feature: Be able to bootstrap a sle15 Salt host managed via salt-ssh
     Then I should see a "bunch was scheduled" text
     And I wait until the table contains "FINISHED" or "SKIPPED" followed by "FINISHED" in its first rows
 
-  Scenario: Check events history for failures on sle15 SSH minion
+  Scenario: Check events history for failures on SLES 15 SSH minion
     Given I am on the Systems overview page of this "sle15_ssh_minion"
     Then I check for failed events on history event page

--- a/testsuite/features/qam/init_clients/sle15sp1_client.feature
+++ b/testsuite/features/qam/init_clients/sle15sp1_client.feature
@@ -2,18 +2,22 @@
 # Licensed under the terms of the MIT license.
 
 @sle15sp1_client
-Feature: Register a sle15sp1 traditional client
-  In order to register a traditional client to the SUSE Manager server
-  As the root user
-  I want to call rhnreg_ks
+Feature: Bootstrap a SLES 15 SP1 traditional client
 
-  Scenario: Register a sle15sp1 traditional client
-    When I register "sle15sp1_client" as traditional client with activation key "1-sle15sp1_client_key"
+  Scenario: Clean up sumaform leftovers on a SLES 15 SP1 traditional client
+    When I perform a full salt minion cleanup on "sle15sp1_client"
+
+  Scenario: Register a SLES 15 SP1 traditional client
+    When I bootstrap traditional client "sle15sp1_client" using bootstrap script with activation key "1-sle15sp1_client_key" from the proxy
+    And I install package "spacewalk-client-setup spacewalk-oscap mgr-cfg-actions" on this "sle15sp1_client"
     And I run "mgr-actions-control --enable-all" on "sle15sp1_client"
     Then I should see "sle15sp1_client" via spacecmd
-    And I wait until onboarding is completed for "sle15sp1_client"
 
-  Scenario: Check registration values of sle15sp1 traditional
+  Scenario: The onboarding of SLES 15 SP1 traditional client is completed
+    Given I am authorized
+    Then I wait until onboarding is completed for "sle15sp1_client"
+
+  Scenario: Check registration values of SLES 15 SP1 traditional
     Given I update the profile of "sle15sp1_client"
     When I am on the Systems overview page of this "sle15sp1_client"
     And I wait until I see "Software Updates Available" text or "System is up to date" text
@@ -26,20 +30,20 @@ Feature: Register a sle15sp1 traditional client
     And I should see a "OS: sles-release" text
 
 @proxy
-  Scenario: Check connection from sle15sp1 traditional to proxy
+  Scenario: Check connection from SLES 15 SP1 traditional to proxy
     Given I am on the Systems overview page of this "sle15sp1_client"
     When I follow "Details" in the content area
     And I follow "Connection" in the content area
     Then I should see "proxy" short hostname
 
 @proxy
-  Scenario: Check registration on proxy of sle15sp1 traditional
+  Scenario: Check registration on proxy of SLES 15 SP1 traditional
     Given I am on the Systems overview page of this "proxy"
     When I follow "Details" in the content area
     And I follow "Proxy" in the content area
     Then I should see "sle15sp1_client" hostname
 
-  Scenario: Check tab links "Software" => "Patches" for sle15sp1 traditional
+  Scenario: Check tab links "Software" => "Patches" for SLES 15 SP1 traditional
     Given I am on the Systems overview page of this "sle15sp1_client"
     When I follow "Software" in the content area
     And I follow "Patches" in the content area

--- a/testsuite/features/qam/init_clients/sle15sp1_minion.feature
+++ b/testsuite/features/qam/init_clients/sle15sp1_minion.feature
@@ -2,13 +2,16 @@
 # Licensed under the terms of the MIT license.
 
 @sle15sp1_minion
-Feature: Be able to bootstrap a sle15sp1 Salt minion via the GUI
+Feature: Be able to bootstrap a SLES 15 SP1 Salt minion
+
+  Scenario: Clean up sumaform leftovers on a SLES 15 SP1 Salt minion
+    When I perform a full salt minion cleanup on "sle15sp1_minion"
 
   Scenario: Create the bootstrap repository for a Salt client
     Given I am authorized
     And I create the "x86_64" bootstrap repository for "sle15sp1_minion" on the server
 
-  Scenario: Bootstrap a sle15sp1 minion
+  Scenario: Bootstrap a SLES 15 SP1 minion
     Given I am authorized
     When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
@@ -22,37 +25,37 @@ Feature: Be able to bootstrap a sle15sp1 Salt minion via the GUI
     And I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "sle15sp1_minion"
 
-  Scenario: Check the new bootstrapped sle15sp1 minion in System Overview page
+  Scenario: Check the new bootstrapped SLES 15 SP1 minion in System Overview page
     Given I am authorized
     And I go to the minion onboarding page
     Then I should see a "accepted" text
     And the Salt master can reach "sle15sp1_minion"
 
 @proxy
-  Scenario: Check connection from sle15sp1 minion to proxy
+  Scenario: Check connection from SLES 15 SP1 minion to proxy
     Given I am on the Systems overview page of this "sle15sp1_minion"
     When I follow "Details" in the content area
     And I follow "Connection" in the content area
     Then I should see "proxy" short hostname
 
 @proxy
-  Scenario: Check registration on proxy of sle15sp1 minion
+  Scenario: Check registration on proxy of SLES 15 SP1 minion
     Given I am on the Systems overview page of this "proxy"
     When I follow "Details" in the content area
     And I follow "Proxy" in the content area
     Then I should see "sle15sp1_minion" hostname
 
   # bsc#1085436 - Apache returns 403 Forbidden after a zypper refresh on minion
-  Scenario: Check the new channel is working
+  Scenario: Check the new channel for SLES 15 SP1 minion is working
     When I refresh the metadata for "sle15sp1_minion"
 
-  Scenario: Detect latest Salt changes on the sle15sp1 minion
+  Scenario: Detect latest Salt changes on the SLES 15 SP1 minion
     When I query latest Salt changes on "sle15sp1_minion"
 
-  Scenario: Check spacecmd system ID of bootstrapped sle15sp1 minion
+  Scenario: Check spacecmd system ID of bootstrapped SLES 15 SP1 minion
     Given I am on the Systems overview page of this "sle15sp1_minion"
     Then I run spacecmd listevents for "sle15sp1_minion"
 
-  Scenario: Check events history for failures on sle15sp1 minion
+  Scenario: Check events history for failures on SLES 15 SP1 minion
     Given I am on the Systems overview page of this "sle15sp1_minion"
     Then I check for failed events on history event page

--- a/testsuite/features/qam/init_clients/sle15sp1_ssh_minion.feature
+++ b/testsuite/features/qam/init_clients/sle15sp1_ssh_minion.feature
@@ -2,9 +2,12 @@
 # Licensed under the terms of the MIT license.
 
 @sle15sp1_ssh_minion
-Feature: Be able to bootstrap a sle15sp1 Salt host managed via salt-ssh
+Feature: Bootstrap a SLES 15 SP1 Salt SSH Minion
 
-  Scenario: Bootstrap a sle15sp1 system managed via salt-ssh
+  Scenario: Clean up sumaform leftovers on a SLES 15 SP1 Salt SSH Minion
+    When I perform a full salt minion cleanup on "sle15sp1_ssh_minion"
+
+  Scenario: Bootstrap a SLES 15 SP1 system managed via salt-ssh
     Given I am authorized
     And I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
@@ -21,25 +24,29 @@ Feature: Be able to bootstrap a sle15sp1 Salt host managed via salt-ssh
   # Package 'sle-manager-tools-release' is automatically installed during bootstrap and
   # stays installed after removal of channel containing it. So it is not possible to update it.
   # Package needs to be removed from highstate to avoid failure when updating it.
-  Scenario: Remove sle-manager-tools-release from state after sle15sp1 bootstrap
+  Scenario: Remove sle-manager-tools-release from state after SLES 15 SP1 bootstrap
     Given I am on the Systems overview page of this "sle15sp1_ssh_minion"
     When I remove package "sle-manager-tools-release" from highstate
 
+# WORKAROUD for bsc#1178328
+  Scenario: Install dmidecode package to avoid a Hardware Refresh issue in SLES 15 SP1 SSH minion
+    And I install package "dmidecode" on this "sle15sp1_ssh_minion"
+
 @proxy
-  Scenario: Check connection from sle15sp1 SSH minion to proxy
+  Scenario: Check connection from SLES 15 SP1 SSH minion to proxy
     Given I am on the Systems overview page of this "sle15sp1_ssh_minion"
     When I follow "Details" in the content area
     And I follow "Connection" in the content area
     Then I should see "proxy" short hostname
 
 @proxy
-  Scenario: Check registration on proxy of sle15sp1 SSH minion
+  Scenario: Check registration on proxy of SLES 15 SP1 SSH minion
     Given I am on the Systems overview page of this "proxy"
     When I follow "Details" in the content area
     And I follow "Proxy" in the content area
     Then I should see "sle15sp1_ssh_minion" hostname
 
-  Scenario: Schedule errata refresh to reflect channel assignment on sle15sp1 SSH minion
+  Scenario: Schedule errata refresh to reflect channel assignment on SLES 15 SP1 SSH minion
     Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Admin > Task Schedules"
     And I follow "errata-cache-default"
@@ -48,6 +55,6 @@ Feature: Be able to bootstrap a sle15sp1 Salt host managed via salt-ssh
     Then I should see a "bunch was scheduled" text
     And I wait until the table contains "FINISHED" or "SKIPPED" followed by "FINISHED" in its first rows
 
-  Scenario: Check events history for failures on sle15sp1 SSH minion
+  Scenario: Check events history for failures on SLES 15 SP1 SSH minion
     Given I am on the Systems overview page of this "sle15sp1_ssh_minion"
     Then I check for failed events on history event page

--- a/testsuite/features/qam/init_clients/ubuntu1604_minion.feature
+++ b/testsuite/features/qam/init_clients/ubuntu1604_minion.feature
@@ -7,6 +7,9 @@
 @ubuntu1604_minion
 Feature: Bootstrap a Ubuntu 16.04 minion and do some basic operations on it
 
+  Scenario: Clean up sumaform leftovers on a Ubuntu 16.04 Salt minion
+    When I perform a full salt minion cleanup on "ubuntu1604_minion"
+
   Scenario: Bootstrap a Ubuntu 16.04 minion
     Given I am authorized
     When I go to the bootstrapping page

--- a/testsuite/features/qam/init_clients/ubuntu1604_ssh_minion.feature
+++ b/testsuite/features/qam/init_clients/ubuntu1604_ssh_minion.feature
@@ -7,6 +7,9 @@
 @ubuntu1604_ssh_minion
 Feature: Bootstrap a SSH-managed Ubuntu 16.04 minion and do some basic operations on it
 
+  Scenario: Clean up sumaform leftovers on a Ubuntu 16.04 Salt SSH minion
+    When I perform a full salt minion cleanup on "ubuntu1604_ssh_minion"
+
   Scenario: Bootstrap a SSH-managed Ubuntu 16.04 minion
     Given I am authorized
     When I go to the bootstrapping page

--- a/testsuite/features/qam/init_clients/ubuntu1804_minion.feature
+++ b/testsuite/features/qam/init_clients/ubuntu1804_minion.feature
@@ -7,6 +7,9 @@
 @ubuntu1804_minion
 Feature: Bootstrap a Ubuntu 18.04 minion and do some basic operations on it
 
+  Scenario: Clean up sumaform leftovers on a Ubuntu 18.04 Salt minion
+    When I perform a full salt minion cleanup on "ubuntu1804_minion"
+
   Scenario: Bootstrap a Ubuntu 18.04 minion
     Given I am authorized
     When I go to the bootstrapping page

--- a/testsuite/features/qam/init_clients/ubuntu1804_ssh_minion.feature
+++ b/testsuite/features/qam/init_clients/ubuntu1804_ssh_minion.feature
@@ -7,6 +7,9 @@
 @ubuntu1804_ssh_minion
 Feature: Bootstrap a SSH-managed Ubuntu 18.04 minion and do some basic operations on it
 
+  Scenario: Clean up sumaform leftovers on a 18.04 Salt SSH Minion
+    When I perform a full salt minion cleanup on "ubuntu1804_ssh_minion"
+
   Scenario: Bootstrap a SSH-managed Ubuntu 18.04 minion
     Given I am authorized
     When I go to the bootstrapping page

--- a/testsuite/features/qam/init_clients/ubuntu2004_minion.feature
+++ b/testsuite/features/qam/init_clients/ubuntu2004_minion.feature
@@ -5,7 +5,10 @@
 #  2) subscribe it to a base channel for testing
 
 @ubuntu2004_minion
-Feature: Bootstrap a Ubuntu 20.04 minion and do some basic operations on it
+Feature: Bootstrap a Ubuntu 20.04 Salt minion
+
+  Scenario: Clean up sumaform leftovers on a Ubuntu 20.04 minion
+    When I perform a full salt minion cleanup on "ubuntu2004_minion"
 
   Scenario: Bootstrap a Ubuntu 20.04 minion
     Given I am authorized

--- a/testsuite/features/qam/init_clients/ubuntu2004_ssh_minion.feature
+++ b/testsuite/features/qam/init_clients/ubuntu2004_ssh_minion.feature
@@ -5,7 +5,10 @@
 #  2) subscribe it to a base channel for testing
 
 @ubuntu2004_ssh_minion
-Feature: Bootstrap a SSH-managed Ubuntu 20.04 minion and do some basic operations on it
+Feature: Bootstrap a Ubuntu 20.04 Salt SSH Minion
+
+  Scenario: Clean up sumaform leftovers on a Ubuntu 20.04 Salt SSH Minion
+    When I perform a full salt minion cleanup on "ubuntu2004_ssh_minion"
 
   Scenario: Bootstrap a SSH-managed Ubuntu 20.04 minion
     Given I am authorized

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -719,28 +719,27 @@ When(/^I enter "([^"]*)" password$/) do |host|
   step %(I enter "#{ENV['VIRTHOST_XEN_PASSWORD']}" as "password") if host == "xen_server"
 end
 
-And(/^I clean up the minion's cache on "([^"]*)"$/) do |minion|
+# TODO: Ideally we should do a full cleanup of the minion
+#       But we can't do that as we don't have products synced, so it will fail installing salt and sal-minion
+#       Instead we inject those packages when deploying through sumaform and we can't remove them.
+#       If someday we have synced products, we can proceed to run a full cleanup
+When(/^I clean up the minion's cache on "([^"]*)"$/) do |minion|
   raise "#{minion} is not a salt minion" unless minion.include? 'minion'
   node = get_target(minion)
   node.run_until_ok('systemctl stop salt-minion')
   node.run('rm -Rf /var/cache/salt/minion')
-  # TODO: Ideally we should remove /etc/salt/* /var/run/salt/* /var/log/salt/* and salt and salt-minion packages
-  #       But we can't do that as we don't have products synced, so it will fail installing salt and sal-minion
-  #       Instead we inject those packages when deploying through sumaform and we can't remove them.
-  #       If someday we have synced products, we can proceed to run a full cleanup:
-  #
-  # And(/^I perform a full salt minion cleanup on "([^"]*)"$/) do |minion|
-  #   raise "#{minion} is not a salt minion" unless minion.include? 'minion'
-  #   node = get_target(minion)
-  #   if minion.include? 'ceos'
-  #     node.run('yum -y remove salt salt-minion')
-  #   elsif minion.include? 'ubuntu'
-  #     node.run('apt-get --assume-yes remove salt salt-minion')
-  #   else
-  #     node.run('zypper --non-interactive remove -y salt salt-minion')
-  #   end
-  #   node.run('rm -Rf /var/cache/salt/minion /var/run/salt /var/log/salt /etc/salt')
-  # end
+end
+
+When(/^I perform a full salt minion cleanup on "([^"]*)"$/) do |host|
+  node = get_target(host)
+  if host.include? 'ceos'
+    node.run('yum -y remove salt salt-minion')
+  elsif host.include? 'ubuntu'
+    node.run('apt-get --assume-yes remove salt salt-minion')
+  else
+    node.run('zypper --non-interactive remove -y salt salt-minion')
+  end
+  node.run('rm -Rf /var/cache/salt/minion /var/run/salt /var/log/salt /etc/salt')
 end
 
 When(/^I install a salt pillar top file for "([^"]*)" with target "([^"]*)" on the server$/) do |file, host|


### PR DESCRIPTION
## What does this PR change?

This PR creates a new step definition to clean up all the related of salt and salt-minion from a VM.
We want this to remove possible conflicting packages when a VM is deployed using sumaform.
For now, we can only use it in QAM bootstraps, as is the only environment where we have synced repositories that provides the necessary packages for salt and salt-minion, once they are removed.

WARN: It might be that we need to clean more stuff let by sumaform. For now only cleanning salt and salt-minion.

Related card https://github.com/SUSE/spacewalk/issues/11332

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
