### PR TITLE
QAM: Refactor to handle multiple repositories per client

### DIFF
--- a/testsuite/features/qam/add_custom_repositories/add_mu_repository.template
+++ b/testsuite/features/qam/add_custom_repositories/add_mu_repository.template
@@ -2,7 +2,7 @@
 # Licensed under the terms of the MIT license.
 
 @<client>
-Feature: Adding a Maintenance Update custom channel and repository for <client>
+Feature: Adding a Maintenance Update custom channel and the custom repositories for <client>
 
   Scenario: Add a child channel for <client>
     Given I am authorized as "admin" with password "admin"
@@ -15,21 +15,21 @@ Feature: Adding a Maintenance Update custom channel and repository for <client>
     And I click on "Create Channel"
     Then I should see a "Channel Custom Channel for <client> created" text
 
-  Scenario: Add the Maintenance update repository for <client>
+  Scenario: Add the Maintenance update repositories for <client>
     Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Software > Manage > Repositories"
-    And I create the MU repository for <type> "<client>" if necessary
+    And I create the MU repositories for "<client>"
 
-  Scenario: Add the repository to the custom channel for <client>
+  Scenario: Add the custom repositories to the custom channel for <client>
     Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Software > Manage > Channels"
     And I follow "Custom Channel for <client>"
     And I follow "Repositories" in the content area
-    And I select the MU repository name for <type> "<client>" from the list
+    And I select the MU repositories for "<client>" from the list
     And I click on "Save Repositories"
     Then I should see a "repository information was successfully updated" text
 
-  Scenario: Synchronize the repository in the custom channel for <client>
+  Scenario: Synchronize the repositories in the custom channel for <client>
     Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Software > Manage > Channels"
     And I follow "Custom Channel for <client>"

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -1157,32 +1157,32 @@ Then(/^I should see a list item with text "([^"]*)" and a (success|failing|warni
   find(:xpath, item_xpath)
 end
 
-When(/^I create the MU repository for (salt|traditional) "([^"]*)" if necessary$/) do |client_type, client|
-  client.sub! 'ssh_minion', 'minion' # Both minion and ssh_minion uses the same repositories
-  repo_name = url = $mu_repositories[client][client_type].strip
-  repo_name.delete_prefix! "http://download.suse.de/ibs/SUSE:/Maintenance:/"
-  repo_name.delete_prefix! "http://minima-mirror-qam.mgr.prv.suse.net/ibs/SUSE:/Maintenance:/"
-  if repository_exist? repo_name
-    puts "The MU repository #{repo_name} was already created, we will reuse it."
-  else
-    steps %(
+When(/^I create the MU repositories for "([^"]*)"$/) do |client|
+  repo_list = $mu_repositories[client]
+  repo_list.each do |_repo_name, repo_url|
+    unique_repo_name = generate_repository_name(repo_url)
+    if repository_exist? unique_repo_name
+      puts "The MU repository #{unique_repo_name} was already created, we will reuse it."
+    else
+      steps %(
       When I follow "Create Repository"
-      And I enter "#{repo_name}" as "label"
-      And I enter "#{url}" as "url"
+      And I enter "#{unique_repo_name}" as "label"
+      And I enter "#{repo_url.strip}" as "url"
       And I select "#{client.include?('ubuntu') ? 'deb' : 'yum'}" from "contenttype"
       And I click on "Create Repository"
       Then I should see a "Repository created successfully" text
       And I should see "metadataSigned" as checked
     )
+    end
   end
 end
 
-When(/^I select the MU repository name for (salt|traditional) "([^"]*)" from the list$/) do |client_type, client|
-  client.sub! 'ssh_minion', 'minion' # Both minion and ssh_minion uses the same repositories
-  repo_name = url = $mu_repositories[client][client_type].strip
-  repo_name.delete_prefix! "http://download.suse.de/ibs/SUSE:/Maintenance:/"
-  repo_name.delete_prefix! "http://minima-mirror-qam.mgr.prv.suse.net/ibs/SUSE:/Maintenance:/"
-  step %(I check "#{repo_name}" in the list)
+When(/^I select the MU repositories for "([^"]*)" from the list$/) do |client|
+  repo_list = $mu_repositories[client]
+  repo_list.each do |_repo_name, repo_url|
+    unique_repo_name = generate_repository_name(repo_url)
+    step %(I check "#{unique_repo_name}" in the list)
+  end
 end
 
 # content lifecycle steps

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -221,3 +221,10 @@ def repository_exist?(repo)
   repo_list = repo_xmlrpc.repo_list
   repo_list.include? repo
 end
+
+def generate_repository_name(repo_url)
+  repo_name = repo_url.strip
+  repo_name.delete_prefix! 'http://download.suse.de/ibs/SUSE:/Maintenance:/'
+  repo_name.delete_prefix! 'http://minima-mirror-qam.mgr.prv.suse.net/ibs/SUSE:/Maintenance:/'
+  repo_name
+end


### PR DESCRIPTION
## What does this PR change?

Refactor to handle multiple repositories per client.

Related card: https://github.com/SUSE/spacewalk/issues/13016

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
Manager-4.1
Manager-4.0

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
