### PR TITLE
Add requests module to salt-thin

### DIFF
--- a/spacewalk/setup/salt/susemanager.conf
+++ b/spacewalk/setup/salt/susemanager.conf
@@ -82,7 +82,8 @@ timeout: 120
 gather_job_timeout: 120
 
 # Ensure that certifi is part of the thin
-thin_extra_mods: certifi
+# Add requests module to salt thin
+thin_extra_mods: certifi,requests
 
 # Location for storing temporary roster files
 rosters:

--- a/spacewalk/setup/spacewalk-setup.changes
+++ b/spacewalk/setup/spacewalk-setup.changes
@@ -1,3 +1,4 @@
+- add requests module to salt-thin
 - add sock_pool_size setting by default for better performance
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Prevents backtraces on `salt-ssh` minions using `salt-thin` in DEBUG logging level.
```
2020-11-03 10:40:16,571 [salt.loader      :1668][DEBUG   ][2451] Failed to import module vsphere:
Traceback (most recent call last):
  File "/var/tmp/.root_52ffee_salt/pyall/salt/loader.py", line 1658, in _load_module
    mod = imp.load_module(mod_namespace, fn_, fpath, desc)
  File "/usr/lib64/python3.4/imp.py", line 235, in load_module
    return load_source(name, filename, file)
  File "/usr/lib64/python3.4/imp.py", line 171, in load_source
    module = methods.load()
  File "<frozen importlib._bootstrap>", line 1220, in load
  File "<frozen importlib._bootstrap>", line 1200, in _load_unlocked
  File "<frozen importlib._bootstrap>", line 1129, in _exec
  File "<frozen importlib._bootstrap>", line 1471, in exec_module
  File "<frozen importlib._bootstrap>", line 321, in _call_with_frames_removed
  File "/var/tmp/.root_52ffee_salt/pyall/salt/modules/vsphere.py", line 201, in <module>
    import salt.utils.pbm
  File "/var/tmp/.root_52ffee_salt/pyall/salt/utils/pbm.py", line 46, in <module>
    import salt.utils.vmware
  File "/var/tmp/.root_52ffee_salt/pyall/salt/utils/vmware.py", line 82, in <module>
    import requests
ImportError: No module named 'requests'
```

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
- No tests: already covered

## Links

Tracks https://github.com/SUSE/spacewalk/pull/13027

## Changelogs

- add requests module to salt-thin

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "spacecmd_unittests"
