### PR TITLE
Fix repo url of AppStream in generated RHEL/Centos 8 kickstart file (bsc#1175739) 

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/kickstart/RepoInfo.java
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/RepoInfo.java
@@ -121,7 +121,7 @@ public class RepoInfo {
         String repourl = helper.getRepoUrl(this);
         if (name.equals("AppStream")) {
             /* RHEL 8 AppStream */
-            repourl = helper.getKickstartMediaUrl().replace("baseos", "appstream");
+            repourl = String.format("%s%s%s", repourl, repourl.endsWith("/") ? "" : "/", name);
         }
         return String.format("repo --name=%s --baseurl=%s", name,
                                     repourl);

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix repo url of AppStream in generated RHEL/Centos 8 kickstart file (bsc#1175739)
 - Enable validation of Content Lifecycle Management entities in the XMLRPC API (bsc#1177706)
 - Fix the order of the arguments in the XMLRPC API doc for contentmanagement.buildProject (bsc#1177704)
 - Remove the deprecated "satellite" API namespace


### PR DESCRIPTION
## What does this PR change?

Port of https://github.com/SUSE/spacewalk/pull/12335

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bugfix

- [x] **DONE**

## Test coverage
- No tests: **add explanation**

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"  
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
