### PR TITLE
Use correct eauth module and credentials for Salt SSH calls (bsc#1178319)

### DIFF
--- a/java/code/src/com/suse/manager/webui/services/impl/SaltSSHService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltSSHService.java
@@ -139,10 +139,10 @@ public class SaltSSHService {
             "services.salt-minion",
             "services.docker");
     private final String SALT_USER = "admin";
-    private final String SALT_PASSWORD = "";
-    private final AuthModule AUTH_MODULE = AuthModule.AUTO;
+    private final String SALT_PASSWORD = com.redhat.rhn.common.conf.Config.get().getString("server.secret_key");;
+    private final AuthModule AUTH_MODULE = AuthModule.FILE;
 
-    private final AuthMethod PW_AUTH = new AuthMethod(new PasswordAuth(SALT_USER, SALT_PASSWORD, AuthModule.AUTO));
+    private final AuthMethod PW_AUTH = new AuthMethod(new PasswordAuth(SALT_USER, SALT_PASSWORD, AuthModule.FILE));
 
     // Shared salt client instance
     private final SaltClient saltClient;

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Use correct eauth module and credentials for Salt SSH calls (bsc#1178319)
 - Enable validation of Content Lifecycle Management entities in the XMLRPC API (bsc#1177706)
 - Fix the order of the arguments in the XMLRPC API doc for contentmanagement.buildProject (bsc#1177704)
 - Remove the deprecated "satellite" API namespace


### PR DESCRIPTION
## What does this PR change?

This PR makes `SaltSSHService.java` to use the correct eauth module and credentials when dealing with the Salt API.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: already covered
- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/12963

- [x] **DONE**