### PR TITLE
Fix truncate messages

### DIFF
--- a/java/code/src/com/suse/manager/webui/websocket/RemoteMinionCommands.java
+++ b/java/code/src/com/suse/manager/webui/websocket/RemoteMinionCommands.java
@@ -342,15 +342,11 @@ public class RemoteMinionCommands {
                             details.append(command);
                             details.append("</pre> returned:<pre>");
                             int maxLength = 4000 - details.length() - 6;
-                            String output;
-                            if (result.length() > maxLength) {
+                            String output = result;
+                            int truncate = StringUtil.htmlifyText(output).length() - maxLength;
+                            if (truncate > 0) {
                                 // command output too large, truncate it to fit in the db
-                                output = StringUtils
-                                        .substring(result, 0, maxLength - 3) +
-                                        "...";
-                            }
-                            else {
-                                output = result;
+                                output = StringUtils.substring(output, 0, maxLength - truncate - 3) + "...";
                             }
                             details.append(StringUtil.htmlifyText(output));
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- calculate size to truncate a history message based on the htmlified version (bsc#1178503)
 - Sync state modules when starting action chain execution (bsc#1177336)
 - Fix repo url of AppStream in generated RHEL/Centos 8 kickstart file (bsc#1175739)
 - Enable validation of Content Lifecycle Management entities in the XMLRPC API (bsc#1177706)


### PR DESCRIPTION
## What does this PR change?

When `htmlify()` does replacements, it will typically add more characters as it remove.
So we need to calculate the number of characters to truncate based on the HTML version of the message.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: 

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/13033
Tracks https://github.com/SUSE/spacewalk/pull/13035 https://github.com/SUSE/spacewalk/pull/13036

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
