### PR TITLE
Sync state modules when starting action chain execution (bsc#1177336)

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/JobReturnEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/JobReturnEventMessageAction.java
@@ -41,6 +41,9 @@ import com.suse.utils.Json;
 import org.apache.log4j.Logger;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -148,11 +151,24 @@ public class JobReturnEventMessageAction implements MessageAction {
                 throw e;
             }
 
+            Optional<StateApplyResult<Ret<JsonElement>>> result = Optional.ofNullable(
+                    actionChainResult.get("mgrcompat_|-start_action_chain_|-mgractionchains.start_|-module_run"));
+            var entries = result.map(r -> r.getChanges())
+                    .map(c -> c.getRet())
+                    .map(r -> r.getAsJsonObject())
+                    .map(o -> o.entrySet())
+                    .map(set -> set.stream()
+                            .collect(Collectors.toMap(e -> e.getKey(),
+                                    e -> (StateApplyResult<Ret<JsonElement>>)Json.GSON.fromJson(e.getValue(),
+                                            new TypeToken<StateApplyResult<Ret<JsonElement>>>() { }.getType())
+                                    )))
+                    .orElse(Collections.emptyMap());
+
             saltServerActionService.handleActionChainResult(jobReturnEvent.getMinionId(),
                     jobReturnEvent.getJobId(),
                     jobReturnEvent.getData().getRetcode(),
                     jobReturnEvent.getData().isSuccess(),
-                    actionChainResult,
+                    entries,
                     stateResult -> false);
 
             boolean packageRefreshNeeded = actionChainResult.entrySet().stream()
@@ -198,7 +214,6 @@ public class JobReturnEventMessageAction implements MessageAction {
             }
         }
     }
-
 
     /**
      * This method does two things

--- a/java/code/src/com/suse/manager/reactor/messaging/JobReturnEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/JobReturnEventMessageAction.java
@@ -42,8 +42,6 @@ import org.apache.log4j.Logger;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Date;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;

--- a/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
@@ -19,6 +19,8 @@ import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.common.messaging.MessageQueue;
 import com.redhat.rhn.domain.action.Action;
+import com.redhat.rhn.domain.action.ActionChain;
+import com.redhat.rhn.domain.action.ActionChainFactory;
 import com.redhat.rhn.domain.action.ActionFactory;
 import com.redhat.rhn.domain.action.channel.SubscribeChannelsAction;
 import com.redhat.rhn.domain.action.cluster.BaseClusterModifyNodesAction;
@@ -2031,6 +2033,60 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 "-rwxr-xr-x  1 root root 1636 Sep 12 17:07 netcat.py\n" +
                 "drwxr-xr-x 14 root root 4096 Jul 25  2017 salt\n",
                 new String(scriptResult.getOutput()));
+    }
+
+    public void testActionChainSaltErrorResponse() throws Exception {
+        TaskomaticApi taskomaticMock = mock(TaskomaticApi.class);
+        ActionManager.setTaskomaticApi(taskomaticMock);
+        ActionChainFactory.setTaskomaticApi(taskomaticMock);
+        context().checking(new Expectations() { {
+            oneOf(taskomaticMock).scheduleActionChainExecution(with(any(ActionChain.class)));
+        } });
+
+        MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
+        SystemManager.giveCapability(minion.getId(), SystemManager.CAP_SCRIPT_RUN, 1L);
+
+        Date earliestAction = new Date();
+
+        String label = TestUtils.randomString();
+        ActionChain actionChain = ActionChainFactory.createActionChain(label, user);
+
+        ApplyStatesAction applyState = (ApplyStatesAction)ActionChainManager
+                .scheduleApplyStates(user, Arrays.asList(minion.getId()), Optional.of(false), earliestAction, actionChain)
+                .stream().findFirst().get();
+
+        ScriptActionDetails sad = ActionFactory
+                .createScriptActionDetails("root", "root", 10L, "#!/bin/csh\necho hello");
+        ScriptRunAction runScript = (ScriptRunAction)ActionChainManager
+                .scheduleScriptRuns(user, Arrays.asList(minion.getId()), "test", sad, earliestAction, actionChain)
+                .stream().findFirst().get();
+
+        ActionChainFactory.schedule(actionChain, earliestAction);
+
+        HibernateFactory.getSession().flush();
+        HibernateFactory.getSession().clear();
+
+        Map<String, String> placeholders = new HashMap<>();
+        placeholders.put("${minion-id}", minion.getMinionId());
+
+        Optional<JobReturnEvent> event = JobReturnEvent.parse(
+                getJobReturnEvent("action.chain.salt.error.json", 0,
+                        placeholders));
+        JobReturnEventMessage message = new JobReturnEventMessage(event.get());
+
+        // Process the event message
+        JobReturnEventMessageAction messageAction = new JobReturnEventMessageAction(saltServerActionService, saltUtils);
+        messageAction.execute(message);
+
+        applyState = (ApplyStatesAction)ActionFactory.lookupById(applyState.getId());
+        ServerAction saApplyState = applyState.getServerActions().stream().findFirst().get();
+
+        assertEquals(ActionFactory.STATUS_QUEUED, saApplyState.getStatus());
+
+        Action runScriptAction = ActionFactory.lookupById(runScript.getId());
+        ServerAction saScript = runScriptAction.getServerActions().stream().findFirst().get();
+
+        assertEquals(ActionFactory.STATUS_QUEUED, saScript.getStatus());
     }
 
     public void testActionChainPackageRefreshNeeded() throws Exception {

--- a/java/code/src/com/suse/manager/reactor/messaging/test/action.chain.one.chunk.json
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/action.chain.one.chunk.json
@@ -2,169 +2,186 @@
   "tag": "salt/job/20180301231955542441/ret/${minion-id}",
   "data": {
     "fun_args": [
-      "41"
+      {
+        "mods": [
+          "actionchains.start"
+        ],
+        "pillar": {
+          "action_chain_id": 140
+        },
+        "queue": true
+      }
     ],
     "jid": "20180301231955542441",
     "return": {
-      "mgrcompat_|-mgr_actionchain_140_action_${action2-id}_chunk_1_|-state.apply_|-module_run": {
-        "comment": "Module function state.apply executed",
-        "name": "state.apply",
-        "start_time": "23:19:57.135700",
-        "result": true,
-        "duration": 214.369,
+      "mgrcompat_|-start_action_chain_|-mgractionchains.start_|-module_run": {
+        "__id__": "start_action_chain",
         "__run_num__": 1,
+        "__sls__": "actionchains.start",
         "changes": {
           "ret": {
-            "cmd_|-remote_command_|-remote_command_|-script": {
-              "comment": "Command 'remote_command' run",
-              "name": "remote_command",
-              "start_time": "23:19:57.220170",
+            "mgrcompat_|-mgr_actionchain_140_action_${action2-id}_chunk_1_|-state.apply_|-module_run": {
+              "comment": "Module function state.apply executed",
+              "name": "state.apply",
+              "start_time": "23:19:57.135700",
               "result": true,
-              "duration": 127.67,
+              "duration": 214.369,
+              "__run_num__": 1,
+              "changes": {
+                "ret": {
+                  "cmd_|-remote_command_|-remote_command_|-script": {
+                    "comment": "Command 'remote_command' run",
+                    "name": "remote_command",
+                    "start_time": "23:19:57.220170",
+                    "result": true,
+                    "duration": 127.67,
+                    "__run_num__": 0,
+                    "changes": {
+                      "pid": 2141,
+                      "retcode": 0,
+                      "stderr": "",
+                      "stdout": "total 12\ndrwxr-xr-x  2 root root 4096 Sep 21  2014 bin\n-rwxr-xr-x  1 root root 1636 Sep 12 17:07 netcat.py\ndrwxr-xr-x 14 root root 4096 Jul 25  2017 salt"
+                    },
+                    "__id__": "remote_command"
+                  }
+                }
+              },
+              "__id__": "suma_action_255"
+            },
+            "mgrcompat_|-mgr_actionchain_140_action_${action1-id}_chunk_1_|-state.apply_|-module_run": {
+              "comment": "Module function state.apply executed",
+              "name": "state.apply",
+              "start_time": "23:19:55.827744",
+              "result": true,
+              "duration": 1307.219,
               "__run_num__": 0,
               "changes": {
-                "pid": 2141,
-                "retcode": 0,
-                "stderr": "",
-                "stdout": "total 12\ndrwxr-xr-x  2 root root 4096 Sep 21  2014 bin\n-rwxr-xr-x  1 root root 1636 Sep 12 17:07 netcat.py\ndrwxr-xr-x 14 root root 4096 Jul 25  2017 salt"
+                "ret": {
+                  "service_|-disable_osad_|-osad_|-dead": {
+                    "comment": "The named service osad is not available",
+                    "name": "osad",
+                    "start_time": "23:19:57.070140",
+                    "result": true,
+                    "duration": 9.38,
+                    "__run_num__": 8,
+                    "changes": {},
+                    "__id__": "disable_osad"
+                  },
+                  "cmd_|-update-ca-certificates_|-/usr/sbin/update-ca-certificates_|-run": {
+                    "comment": "State was not run because none of the onchanges reqs changed",
+                    "__run_num__": 2,
+                    "__sls__": "certs",
+                    "changes": {},
+                    "result": true
+                  },
+                  "file_|-mgrchannels_repo_|-/etc/zypp/repos.d/susemanager:channels.repo_|-managed": {
+                    "comment": "File /etc/zypp/repos.d/susemanager:channels.repo is in the correct state",
+                    "pchanges": {},
+                    "name": "/etc/zypp/repos.d/susemanager:channels.repo",
+                    "start_time": "23:19:56.694611",
+                    "result": true,
+                    "duration": 38.241,
+                    "__run_num__": 0,
+                    "changes": {},
+                    "__id__": "mgrchannels_repo"
+                  },
+                  "service_|-disable_spacewalk-update-status_|-spacewalk-update-status_|-dead": {
+                    "comment": "The named service spacewalk-update-status is not available",
+                    "name": "spacewalk-update-status",
+                    "start_time": "23:19:57.060776",
+                    "result": true,
+                    "duration": 8.98,
+                    "__run_num__": 7,
+                    "changes": {},
+                    "__id__": "disable_spacewalk-update-status"
+                  },
+                  "service_|-disable_spacewalksd_|-rhnsd_|-dead": {
+                    "comment": "The named service rhnsd is not available",
+                    "name": "rhnsd",
+                    "start_time": "23:19:57.046074",
+                    "result": true,
+                    "duration": 14.314,
+                    "__run_num__": 6,
+                    "changes": {},
+                    "__id__": "disable_spacewalksd"
+                  },
+                  "file_|-/etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT_|-/etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT_|-managed": {
+                    "comment": "File /etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT is in the correct state",
+                    "pchanges": {},
+                    "name": "/etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT",
+                    "start_time": "23:19:56.733280",
+                    "result": true,
+                    "duration": 17.96,
+                    "__run_num__": 1,
+                    "changes": {},
+                    "__id__": "/etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT"
+                  },
+                  "service_|-mgr_salt_minion_|-salt-minion_|-running": {
+                    "comment": "The service salt-minion is already running",
+                    "name": "salt-minion",
+                    "start_time": "23:19:57.109934",
+                    "result": true,
+                    "duration": 23.152,
+                    "__run_num__": 12,
+                    "changes": {},
+                    "__id__": "mgr_salt_minion"
+                  },
+                  "pkg_|-remove_traditional_stack_|-remove_traditional_stack_|-removed": {
+                    "comment": "All specified packages are already absent",
+                    "name": "remove_traditional_stack",
+                    "start_time": "23:19:57.079898",
+                    "result": true,
+                    "duration": 13.824,
+                    "__run_num__": 9,
+                    "changes": {},
+                    "__id__": "remove_traditional_stack"
+                  },
+                  "pkg_|-pkg_removed_|-pkg_removed_|-removed": {
+                    "comment": "All specified packages are already absent",
+                    "name": "pkg_removed",
+                    "start_time": "23:19:56.901769",
+                    "result": true,
+                    "duration": 141.871,
+                    "__run_num__": 4,
+                    "changes": {},
+                    "__id__": "pkg_removed"
+                  },
+                  "pkg_|-mgr_salt_minion_|-salt-minion_|-installed": {
+                    "comment": "Package salt-minion is already installed",
+                    "name": "salt-minion",
+                    "start_time": "23:19:57.096235",
+                    "result": true,
+                    "duration": 13.059,
+                    "__run_num__": 11,
+                    "changes": {},
+                    "__id__": "mgr_salt_minion"
+                  },
+                  "pkg_|-pkg_installed_|-pkg_installed_|-installed": {
+                    "comment": "No packages to install provided",
+                    "name": "pkg_installed",
+                    "start_time": "23:19:56.900107",
+                    "result": true,
+                    "duration": 1.27,
+                    "__run_num__": 3,
+                    "changes": {},
+                    "__id__": "pkg_installed"
+                  },
+                  "pkg_|-pkg_latest_|-pkg_latest_|-latest": {
+                    "comment": "No packages to install provided",
+                    "name": "pkg_latest",
+                    "start_time": "23:19:57.044121",
+                    "result": true,
+                    "duration": 1.031,
+                    "__run_num__": 5,
+                    "changes": {},
+                    "__id__": "pkg_latest"
+                  }
+                }
               },
-              "__id__": "remote_command"
+              "__id__": "suma_action_254"
             }
           }
-        },
-        "__id__": "suma_action_255"
-      },
-      "mgrcompat_|-mgr_actionchain_140_action_${action1-id}_chunk_1_|-state.apply_|-module_run": {
-        "comment": "Module function state.apply executed",
-        "name": "state.apply",
-        "start_time": "23:19:55.827744",
-        "result": true,
-        "duration": 1307.219,
-        "__run_num__": 0,
-        "changes": {
-          "ret": {
-            "service_|-disable_osad_|-osad_|-dead": {
-              "comment": "The named service osad is not available",
-              "name": "osad",
-              "start_time": "23:19:57.070140",
-              "result": true,
-              "duration": 9.38,
-              "__run_num__": 8,
-              "changes": {},
-              "__id__": "disable_osad"
-            },
-            "cmd_|-update-ca-certificates_|-/usr/sbin/update-ca-certificates_|-run": {
-              "comment": "State was not run because none of the onchanges reqs changed",
-              "__run_num__": 2,
-              "__sls__": "certs",
-              "changes": {},
-              "result": true
-            },
-            "file_|-mgrchannels_repo_|-/etc/zypp/repos.d/susemanager:channels.repo_|-managed": {
-              "comment": "File /etc/zypp/repos.d/susemanager:channels.repo is in the correct state",
-              "pchanges": {},
-              "name": "/etc/zypp/repos.d/susemanager:channels.repo",
-              "start_time": "23:19:56.694611",
-              "result": true,
-              "duration": 38.241,
-              "__run_num__": 0,
-              "changes": {},
-              "__id__": "mgrchannels_repo"
-            },
-            "service_|-disable_spacewalk-update-status_|-spacewalk-update-status_|-dead": {
-              "comment": "The named service spacewalk-update-status is not available",
-              "name": "spacewalk-update-status",
-              "start_time": "23:19:57.060776",
-              "result": true,
-              "duration": 8.98,
-              "__run_num__": 7,
-              "changes": {},
-              "__id__": "disable_spacewalk-update-status"
-            },
-            "service_|-disable_spacewalksd_|-rhnsd_|-dead": {
-              "comment": "The named service rhnsd is not available",
-              "name": "rhnsd",
-              "start_time": "23:19:57.046074",
-              "result": true,
-              "duration": 14.314,
-              "__run_num__": 6,
-              "changes": {},
-              "__id__": "disable_spacewalksd"
-            },
-            "file_|-/etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT_|-/etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT_|-managed": {
-              "comment": "File /etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT is in the correct state",
-              "pchanges": {},
-              "name": "/etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT",
-              "start_time": "23:19:56.733280",
-              "result": true,
-              "duration": 17.96,
-              "__run_num__": 1,
-              "changes": {},
-              "__id__": "/etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT"
-            },
-            "service_|-mgr_salt_minion_|-salt-minion_|-running": {
-              "comment": "The service salt-minion is already running",
-              "name": "salt-minion",
-              "start_time": "23:19:57.109934",
-              "result": true,
-              "duration": 23.152,
-              "__run_num__": 12,
-              "changes": {},
-              "__id__": "mgr_salt_minion"
-            },
-            "pkg_|-remove_traditional_stack_|-remove_traditional_stack_|-removed": {
-              "comment": "All specified packages are already absent",
-              "name": "remove_traditional_stack",
-              "start_time": "23:19:57.079898",
-              "result": true,
-              "duration": 13.824,
-              "__run_num__": 9,
-              "changes": {},
-              "__id__": "remove_traditional_stack"
-            },
-            "pkg_|-pkg_removed_|-pkg_removed_|-removed": {
-              "comment": "All specified packages are already absent",
-              "name": "pkg_removed",
-              "start_time": "23:19:56.901769",
-              "result": true,
-              "duration": 141.871,
-              "__run_num__": 4,
-              "changes": {},
-              "__id__": "pkg_removed"
-            },
-            "pkg_|-mgr_salt_minion_|-salt-minion_|-installed": {
-              "comment": "Package salt-minion is already installed",
-              "name": "salt-minion",
-              "start_time": "23:19:57.096235",
-              "result": true,
-              "duration": 13.059,
-              "__run_num__": 11,
-              "changes": {},
-              "__id__": "mgr_salt_minion"
-            },
-            "pkg_|-pkg_installed_|-pkg_installed_|-installed": {
-              "comment": "No packages to install provided",
-              "name": "pkg_installed",
-              "start_time": "23:19:56.900107",
-              "result": true,
-              "duration": 1.27,
-              "__run_num__": 3,
-              "changes": {},
-              "__id__": "pkg_installed"
-            },
-            "pkg_|-pkg_latest_|-pkg_latest_|-latest": {
-              "comment": "No packages to install provided",
-              "name": "pkg_latest",
-              "start_time": "23:19:57.044121",
-              "result": true,
-              "duration": 1.031,
-              "__run_num__": 5,
-              "changes": {},
-              "__id__": "pkg_latest"
-            }
-          }
-        },
-        "__id__": "suma_action_254"
+        }
       }
     },
     "retcode": 0,

--- a/java/code/src/com/suse/manager/reactor/messaging/test/action.chain.salt.error.json
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/action.chain.salt.error.json
@@ -1,0 +1,44 @@
+{
+  "tag": "salt/job/20201021085859521120/ret/${minion-id}",
+  "data": {
+    "_stamp": "2020-10-21T08:59:01.049784",
+    "cmd": "_return",
+    "fun": "state.apply",
+    "fun_args": [
+      {
+        "mods": [
+          "actionchains.start"
+        ],
+        "pillar": {
+          "action_chain_id": 28
+        },
+        "queue": true
+      }
+    ],
+    "id": "dev-min-sles12sp4.lan",
+    "jid": "20201021085859521120",
+    "metadata": {
+      "batch-mode": true,
+      "suma-action-chain": true,
+      "suma-action-id": 0,
+      "suma-force-pkg-list-refresh": false,
+      "suma-minion-startup": false
+    },
+    "out": "highstate",
+    "retcode": 2,
+    "return": {
+      "mgrcompat_|-start_action_chain_|-mgractionchains.start_|-module_run": {
+        "__id__": "start_action_chain",
+        "__run_num__": 0,
+        "__sls__": "actionchains.start",
+        "changes": {},
+        "comment": "Module function mgractionchains.start is not available",
+        "duration": 1036.51,
+        "name": "mgractionchains.start",
+        "result": false,
+        "start_time": "10:59:00.006331"
+      }
+    },
+    "success": false
+  }
+}

--- a/java/code/src/com/suse/manager/webui/services/SaltActionChainGeneratorService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltActionChainGeneratorService.java
@@ -374,8 +374,10 @@ public class SaltActionChainGeneratorService {
             Path targetDir = getTargetDir();
             Path targetFilePath = Paths.get(targetDir.toString(),
                     getActionChainSLSFileName(actionChainId, new MinionSummary(minionServer), chunk));
-            // Add specified SLS chunk file to remove list
-            deleteSlsAndRefs(targetDir, targetFilePath);
+            if (Files.exists(targetFilePath)) {
+                // Add specified SLS chunk file to remove list
+                deleteSlsAndRefs(targetDir, targetFilePath);
+            }
 
             if (actionChainFailed) {
                 // Add also next SLS chunks because the Action Chain failed and these

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -125,7 +125,6 @@ import com.suse.manager.webui.utils.DownloadTokenBuilder;
 import com.suse.manager.webui.utils.SaltModuleRun;
 import com.suse.manager.webui.utils.SaltState;
 import com.suse.manager.webui.utils.SaltSystemReboot;
-import com.suse.manager.webui.utils.salt.custom.MgrActionChains;
 import com.suse.manager.webui.utils.salt.custom.ClusterOperationsSlsResult;
 import com.suse.manager.webui.utils.salt.custom.ScheduleMetadata;
 import com.suse.salt.netapi.calls.LocalCall;
@@ -551,8 +550,12 @@ public class SaltServerActionService {
      */
     private void startActionChainExecution(ActionChain actionChain, Set<MinionSummary> targetMinions) {
         // prepare the start action chain call
+        Map<String, Object> pillar = new HashMap<>();
+        pillar.put("action_chain_id", actionChain.getId());
+
         Map<Boolean, ? extends Collection<MinionSummary>> results =
-                callAsyncActionChainStart(MgrActionChains.start(actionChain.getId()), targetMinions);
+                callAsyncActionChainStart(State.apply(Arrays.asList("actionchains.start"),
+                        Optional.of(pillar)), targetMinions);
 
         results.get(false).forEach(minionSummary -> {
             LOG.warn("Failed to schedule action chain for minion: " +
@@ -2458,7 +2461,7 @@ public class SaltServerActionService {
         Long retActionChainId = null;
         boolean actionChainFailed = false;
         List<Long> failedActionIds = new ArrayList<>();
-        for (Map.Entry<String, StateApplyResult<Ret<JsonElement>>> entry : actionChainResult.entrySet()) {
+        for (var entry : actionChainResult.entrySet()) {
             String key = entry.getKey();
             StateApplyResult<Ret<JsonElement>> actionStateApply = entry.getValue();
 
@@ -2478,17 +2481,30 @@ public class SaltServerActionService {
                     // don't stop handling the result entries if there's a failed action
                     // the result entries are not returned in order
                 }
-                handleAction(actionId,
-                        minionId,
-                        actionStateApply.isResult() ? 0 : -1,
-                        actionStateApply.isResult(),
-                        jobId,
-                        actionStateApply.getChanges().getRet(),
-                        actionStateApply.getName());
+                try {
+                    handleAction(actionId,
+                            minionId,
+                            actionStateApply.isResult() ? 0 : -1,
+                            actionStateApply.isResult(),
+                            jobId,
+                            actionStateApply.getChanges().getRet(),
+                            actionStateApply.getName());
+                }
+                catch (Exception e) {
+                    LOG.error("Error handling result of action " + actionId + " for minion " + minionId, e);
+                    actionChainFailed = true;
+                    failedActionIds.add(actionId);
+                }
             }
             else if (!key.contains("schedule_next_chunk")) {
                 LOG.warn("Could not find action id in action chain state key: " + key);
             }
+        }
+        if (actionChainResult.isEmpty()) {
+            // if there are no entries we have no way of knowing which actions belonged to this action chain
+            // and set them to failed because the action chain is already gone from the db at this point
+            LOG.error("No action results found in response for minion " + minionId +
+                    ". Some actions will remain in pending.");
         }
 
         if (retActionChainId != null) {

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Sync state modules when starting action chain execution (bsc#1177336)
 - Fix repo url of AppStream in generated RHEL/Centos 8 kickstart file (bsc#1175739)
 - Enable validation of Content Lifecycle Management entities in the XMLRPC API (bsc#1177706)
 - Fix the order of the arguments in the XMLRPC API doc for contentmanagement.buildProject (bsc#1177704)

--- a/susemanager-utils/susemanager-sls/salt/actionchains/start.sls
+++ b/susemanager-utils/susemanager-sls/salt/actionchains/start.sls
@@ -1,0 +1,13 @@
+start_action_chain:
+    mgrcompat.module_run:
+    -  name: mgractionchains.start
+    -  actionchain_id: {{ pillar['action_chain_id']}}
+    - require:
+{%- if grains.get('__suse_reserved_saltutil_states_support', False) %}
+      - saltutil: sync_states
+{%- else %}
+      - mgrcompat: sync_states
+{%- endif %}
+
+include:
+  - util.syncstates

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Sync state modules when starting action chain execution (bsc#1177336)
 - Handle group- and org-specific image pillars
 - Remove hostname from /var/lib/salt/.ssh/known_hosts when deleting system (bsc#1176159)
 - Fix grub2 autoinstall kernel path (bsc#1178060)


### PR DESCRIPTION
## What does this PR change?

Port of https://github.com/SUSE/spacewalk/pull/12827

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bugfix

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
