### PR TITLE
Fix: make spacecmd build on Debian

### DIFF
--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,4 @@
+- Fix: make spacecmd build on Debian
 - Python3 fixes for errata in spacecmd (bsc#1169664)
 - Added support for i18n of user-facing strings
 - Python3 fix for sorted usage (bsc#1167907)

--- a/spacecmd/spacecmd.spec
+++ b/spacecmd/spacecmd.spec
@@ -61,6 +61,11 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
 %endif
 
+%if %{_vendor} == "debbuild"
+BuildRequires:  gettext
+BuildRequires:  intltool
+%endif
+
 %if 0%{?pylint_check}
 %if 0%{?build_py3}
 BuildRequires:  spacewalk-python3-pylint


### PR DESCRIPTION
## What does this PR change?

Fix spacecmd on debian

## GUI diff

No difference.

## Documentation
- No documentation needed: spec

## Test coverage
- No tests: spec

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
