### PR TITLE
Fix optional no such elem exception

### DIFF
--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -2140,9 +2140,10 @@ public class SaltServerActionService {
 
             ScheduleMetadata metadata = ScheduleMetadata.getMetadataForRegularMinionActions(
                     isStagingJob, forcePackageListRefresh, actionIn.getId());
-            List<String> results = saltApi
-                    .callAsync(call, new MinionList(minionIds), Optional.of(metadata))
-                    .get().getMinions();
+            List<String> results = Opt.fold(
+                    saltApi.callAsync(call, new MinionList(minionIds), Optional.of(metadata)),
+                    () -> new ArrayList<String>(),
+                    l -> l.getMinions());
 
             result = minionSummaries.stream().collect(Collectors
                     .partitioningBy(minionId -> results.contains(minionId.getMinionId())));


### PR DESCRIPTION
## What does this PR change?

Found the following in the logs:

```
2020-11-08 10:38:48,557 [DefaultQuartzScheduler_Worker-2] INFO  com.redhat.rhn.taskomatic.task.MinionActionExecutor - Executing action: 381
2020-11-08 10:38:48,653 [DefaultQuartzScheduler_Worker-2] ERROR com.redhat.rhn.taskomatic.task.MinionActionExecutor - Executing a task threw an exception: java.util.NoSuchElementException
2020-11-08 10:38:48,653 [DefaultQuartzScheduler_Worker-2] ERROR com.redhat.rhn.taskomatic.task.MinionActionExecutor - Message: No value present
2020-11-08 10:38:48,653 [DefaultQuartzScheduler_Worker-2] ERROR com.redhat.rhn.taskomatic.task.MinionActionExecutor - Cause: null
2020-11-08 10:38:48,653 [DefaultQuartzScheduler_Worker-2] ERROR com.redhat.rhn.taskomatic.task.MinionActionExecutor - Stack trace:java.util.NoSuchElementException: No value present
        at java.base/java.util.Optional.get(Optional.java:148)
        at com.suse.manager.webui.services.SaltServerActionService.execute(SaltServerActionService.java:2145)
        at com.suse.manager.webui.services.SaltServerActionService.executeForRegularMinions(SaltServerActionService.java:528)
        at com.suse.manager.webui.services.SaltServerActionService.execute(SaltServerActionService.java:489)
        at com.redhat.rhn.taskomatic.task.MinionActionExecutor.execute(MinionActionExecutor.java:125)
        at com.redhat.rhn.taskomatic.task.RhnJavaJob.execute(RhnJavaJob.java:88)
        at com.redhat.rhn.taskomatic.TaskoJob.execute(TaskoJob.java:199)
        at org.quartz.core.JobRunShell.run(JobRunShell.java:202)
        at org.quartz.simpl.SimpleThreadPool$WorkerThread.run(SimpleThreadPool.java:573)
```

This prevent to try to get a value when there is none.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **already covered**

- [x] **DONE**

## Links

Tracks

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
