### PR TITLE
Get mediaproducts for cloned channels

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/common/DownloadFile.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/common/DownloadFile.java
@@ -26,6 +26,7 @@ import com.redhat.rhn.domain.action.script.ScriptResult;
 import com.redhat.rhn.domain.action.script.ScriptRunAction;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.channel.ChannelFactory;
+import com.redhat.rhn.domain.channel.MediaProducts;
 import com.redhat.rhn.domain.common.CommonFactory;
 import com.redhat.rhn.domain.common.TinyUrl;
 import com.redhat.rhn.domain.kickstart.KickstartFactory;
@@ -75,6 +76,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -641,10 +643,16 @@ public class DownloadFile extends DownloadAction {
                 }
                 else if (tree.getKernelOptions() != null &&
                          tree.getKernelOptions().contains("useonlinerepo") &&
-                         path.endsWith("/media.1/products") &&
-                         tree.getChannel().getMediaProducts() != null) {
-                    diskPath = Config.get().getString(ConfigDefaults.MOUNT_POINT) +
-                        "/" + tree.getChannel().getMediaProducts().getRelativeFilename();
+                         path.endsWith("/media.1/products")) {
+                    MediaProducts mediaProducts = Optional.ofNullable(tree.getChannel().getMediaProducts())
+                            .orElse(ChannelManager.getOriginalChannel(tree.getChannel()).getMediaProducts());
+                    if (mediaProducts != null) {
+                        diskPath = Config.get().getString(ConfigDefaults.MOUNT_POINT) +
+                                "/" + mediaProducts.getRelativeFilename();
+                    }
+                    else {
+                        diskPath = kickstartMount + "/" + tree.getBasePath() + path;
+                    }
                 }
                 else {
                     diskPath = kickstartMount + "/" + tree.getBasePath() + path;

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- get media.1/products for cloned channels (bsc#1178303)
 - calculate size to truncate a history message based on the htmlified version (bsc#1178503)
 - Sync state modules when starting action chain execution (bsc#1177336)
 - Fix repo url of AppStream in generated RHEL/Centos 8 kickstart file (bsc#1175739)


### PR DESCRIPTION
## What does this PR change?

Port of https://github.com/SUSE/spacewalk/pull/12965

For autoinstalling a SUSE system we need the media.1/products file. This is synced for vendor channels but not copied when we create clones of the channels.

When performing an autoinstallation and the channel does not have a media product, we should check the original channel .
If none it has it, we fallback to the linked media.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **already covered**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
