### PR TITLE
Fix sp migration on iss slave

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/product/test/SUSEProductTestUtils.java
+++ b/java/code/src/com/redhat/rhn/domain/product/test/SUSEProductTestUtils.java
@@ -305,6 +305,7 @@ public class SUSEProductTestUtils extends HibernateFactory {
         Channel channel = ChannelTestUtils.createBaseChannel(admin);
         channel.setChannelArch(channelArch);
         channel.setName("Channel for " + product.getFriendlyName());
+        channel.setOrg(null);
         channel = TestUtils.saveAndReload(channel);
         SUSEProductTestUtils.createTestSUSEProductChannel(channel, product, true);
         return channel;
@@ -316,6 +317,7 @@ public class SUSEProductTestUtils extends HibernateFactory {
         channel.setChannelArch(channelArch);
         channel.setParentChannel(baseChannel);
         channel.setName("Channel for " + product.getFriendlyName());
+        channel.setOrg(null);
         channel = TestUtils.saveAndReload(channel);
         SUSEProductTestUtils.createTestSUSEProductChannel(channel, product, true);
         return channel;

--- a/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -29,6 +29,7 @@ import com.redhat.rhn.domain.channel.PublicChannelFamily;
 import com.redhat.rhn.domain.common.ManagerInfoFactory;
 import com.redhat.rhn.domain.credentials.Credentials;
 import com.redhat.rhn.domain.credentials.CredentialsFactory;
+import com.redhat.rhn.domain.iss.IssFactory;
 import com.redhat.rhn.domain.product.MgrSyncChannelDto;
 import com.redhat.rhn.domain.product.ProductType;
 import com.redhat.rhn.domain.product.ReleaseStage;
@@ -1728,6 +1729,8 @@ public class ContentSyncManager {
     /**
      * Check if all mandatory repositories of product for the given root are accessible.
      * No recursive checking if bases are accessible too.
+     * For ISS Slave we cannot check if the channel would be available on the master.
+     * In this case we also return true
      * @param product the product to check
      * @param root the root we check for
      * @return true in case of all mandatory repos could be mirrored, otherwise false
@@ -1741,12 +1744,15 @@ public class ContentSyncManager {
                 .filter(e -> e.isMandatory())
                 .allMatch(entry -> {
                     boolean isPublic = entry.getProduct().getChannelFamily().isPublic();
-                    boolean isMirrorable = entry.getRepository().isAccessible();
+                    boolean isISSSlave = IssFactory.getCurrentMaster() != null;
+                    boolean isMirrorable = false;
+                    if (!isISSSlave) {
+                        isMirrorable = entry.getRepository().isAccessible();
+                    }
                     log.debug(product.getFriendlyName() + " - " + entry.getChannelLabel() +
-                            " isPublic: " + isPublic + " isMirrorable: " + isMirrorable);
-                    return  isPublic &&
-                            // isMirrorable
-                            isMirrorable;
+                            " isPublic: " + isPublic + " isMirrorable: " + isMirrorable +
+                            " isISSSlave: " + isISSSlave);
+                    return  isPublic && (isMirrorable || isISSSlave);
                 }
              );
     }

--- a/java/code/src/com/redhat/rhn/manager/distupgrade/test/DistUpgradeManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/distupgrade/test/DistUpgradeManagerTest.java
@@ -31,6 +31,8 @@ import com.redhat.rhn.domain.channel.ChannelFamily;
 import com.redhat.rhn.domain.channel.ChannelProduct;
 import com.redhat.rhn.domain.channel.test.ChannelFactoryTest;
 import com.redhat.rhn.domain.credentials.Credentials;
+import com.redhat.rhn.domain.iss.IssFactory;
+import com.redhat.rhn.domain.iss.IssMaster;
 import com.redhat.rhn.domain.product.ReleaseStage;
 import com.redhat.rhn.domain.product.SUSEProduct;
 import com.redhat.rhn.domain.product.SUSEProductChannel;
@@ -266,6 +268,131 @@ public class DistUpgradeManagerTest extends BaseTestCaseWithUser {
 
         SCCRepository addon = SUSEProductTestUtils.createSCCRepository();
         SUSEProductTestUtils.createSCCRepositoryTokenAuth(sccc, addon);
+
+        SUSEProductSCCRepository spsca = new SUSEProductSCCRepository();
+        spsca.setProduct(targetAddonProduct);
+        spsca.setRootProduct(targetBaseProduct);
+        spsca.setRepository(addon);
+        spsca.setChannelLabel(targetAddonChannel.getLabel());
+        spsca.setParentChannelLabel(targetBaseChannel.getLabel());
+        spsca.setChannelName(targetBaseChannel.getLabel());
+        spsca.setMandatory(true);
+        spsca = TestUtils.saveAndReload(spsca);
+
+        // Verify that target products are returned correctly
+
+        ChannelArch arch = ChannelFactory.findArchByLabel("channel-x86_64");
+        List<SUSEProductSet> targetProductSets = DistUpgradeManager.getTargetProductSets(Optional.of(sourceProducts), arch, user);
+
+        targetProductSets = DistUpgradeManager.removeIncompatibleTargets(Optional.of(sourceProducts), targetProductSets, Optional.empty());
+
+        assertNotNull(targetProductSets);
+        assertEquals(2, targetProductSets.size());
+
+        for (SUSEProductSet target : targetProductSets) {
+            if (target.getBaseProduct().getId() == sourceBaseProduct.getId()) {
+                List<SUSEProduct> addonProducts = target.getAddonProducts();
+                assertEquals(1, addonProducts.size());
+                assertEquals(targetAddonProduct, addonProducts.get(0));
+            }
+            else if (target.getBaseProduct().getId() == targetBaseProduct.getId()) {
+                List<SUSEProduct> addonProducts = target.getAddonProducts();
+                assertEquals(1, addonProducts.size());
+                assertEquals(targetAddonProduct, addonProducts.get(0));
+            }
+            else {
+                fail("unexpected product " + target.getBaseProduct());
+            }
+        }
+    }
+
+    /**
+     * Test getTargetProductSets(): target products are actually found (base + addon).
+     * @throws Exception if anything goes wrong
+     */
+    public void testGetTargetProductSetsOnISSSlave() throws Exception {
+        // setup a Slave by defining its master
+        IssMaster master = new IssMaster();
+        master.setLabel("dummy-master");
+        master.makeDefaultMaster();
+        IssFactory.save(master);
+
+        Credentials sccc = SUSEProductTestUtils.createSCCCredentials("dummy", user);
+        // Setup source products
+        ChannelFamily family = createTestChannelFamily();
+        SUSEProduct sourceBaseProduct = SUSEProductTestUtils.createTestSUSEProduct(family);
+        Channel sourceBaseChannel = SUSEProductTestUtils.createBaseChannelForBaseProduct(sourceBaseProduct, user);
+
+        List<SUSEProduct> sourceAddons = new ArrayList<>();
+        SUSEProduct sourceAddonProduct = SUSEProductTestUtils.createTestSUSEProduct(family);
+        Channel sourceChildChannel = SUSEProductTestUtils.createChildChannelsForProduct(sourceAddonProduct, sourceBaseChannel, user);
+        SUSEProductExtension e = new SUSEProductExtension(sourceBaseProduct, sourceAddonProduct, sourceBaseProduct, false);
+        TestUtils.saveAndReload(e);
+
+        sourceAddons.add(sourceAddonProduct);
+        SUSEProductSet sourceProducts = new SUSEProductSet(sourceBaseProduct, sourceAddons);
+
+        SCCRepository sbase = SUSEProductTestUtils.createSCCRepository();
+
+        SUSEProductSCCRepository sspsc = new SUSEProductSCCRepository();
+        sspsc.setProduct(sourceBaseProduct);
+        sspsc.setRootProduct(sourceBaseProduct);
+        sspsc.setRepository(sbase);
+        sspsc.setChannelLabel(sourceBaseChannel.getLabel());
+        sspsc.setParentChannelLabel(sourceBaseChannel.getLabel());
+        sspsc.setChannelName(sourceBaseChannel.getLabel());
+        sspsc.setMandatory(true);
+        sspsc = TestUtils.saveAndReload(sspsc);
+
+        SCCRepository saddon = SUSEProductTestUtils.createSCCRepository();
+
+        SUSEProductSCCRepository sspsca = new SUSEProductSCCRepository();
+        sspsca.setProduct(sourceAddonProduct);
+        sspsca.setRootProduct(sourceBaseProduct);
+        sspsca.setRepository(saddon);
+        sspsca.setChannelLabel(sourceChildChannel.getLabel());
+        sspsca.setParentChannelLabel(sourceBaseChannel.getLabel());
+        sspsca.setChannelName(sourceBaseChannel.getLabel());
+        sspsca.setMandatory(true);
+        sspsca = TestUtils.saveAndReload(sspsca);
+
+        // Setup migration target product + upgrade path
+        SUSEProduct targetBaseProduct = SUSEProductTestUtils.createTestSUSEProduct(family);
+        Channel targetBaseChannel = SUSEProductTestUtils.createBaseChannelForBaseProduct(targetBaseProduct, user);
+        SUSEProductChannel pcbase = new SUSEProductChannel();
+        pcbase.setChannel(targetBaseChannel);
+        pcbase.setProduct(targetBaseProduct);
+        pcbase.setMandatory(true);
+        SUSEProductFactory.save(pcbase);
+        sourceBaseProduct.setUpgrades(Collections.singleton(targetBaseProduct));
+
+        // Setup target addon product + upgrade path
+        SUSEProduct targetAddonProduct = SUSEProductTestUtils.createTestSUSEProduct(family);
+        Channel targetAddonChannel = SUSEProductTestUtils.createChildChannelsForProduct(targetAddonProduct, targetBaseChannel, user);
+        SUSEProductChannel pcaddon = new SUSEProductChannel();
+        pcaddon.setChannel(targetAddonChannel);
+        pcaddon.setProduct(targetAddonProduct);
+        pcaddon.setMandatory(true);
+        SUSEProductFactory.save(pcaddon);
+        sourceAddonProduct.setUpgrades(Collections.singleton(targetAddonProduct));
+        SUSEProductExtension e2 = new SUSEProductExtension(sourceBaseProduct, targetAddonProduct, sourceBaseProduct, false);
+        SUSEProductExtension e3 = new SUSEProductExtension(targetBaseProduct, targetAddonProduct, targetBaseProduct, false);
+        TestUtils.saveAndReload(e2);
+        TestUtils.saveAndReload(e3);
+
+        SCCRepository base = SUSEProductTestUtils.createSCCRepository();
+
+        SUSEProductSCCRepository spsc = new SUSEProductSCCRepository();
+        spsc.setProduct(targetBaseProduct);
+        spsc.setRootProduct(targetBaseProduct);
+        spsc.setRepository(base);
+        spsc.setChannelLabel(targetBaseChannel.getLabel());
+        spsc.setParentChannelLabel(targetBaseChannel.getLabel());
+        spsc.setChannelName(targetBaseChannel.getLabel());
+        spsc.setMandatory(true);
+        spsc = TestUtils.saveAndReload(spsc);
+
+        SCCRepository addon = SUSEProductTestUtils.createSCCRepository();
 
         SUSEProductSCCRepository spsca = new SUSEProductSCCRepository();
         spsca.setProduct(targetAddonProduct);

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- fix check for available products on ISS Slaves (bsc#1177184)
 - XMLRPC: Report architecture label in the list of installed packages (bsc#1176898)
 - get media.1/products for cloned channels (bsc#1178303)
 - calculate size to truncate a history message based on the htmlified version (bsc#1178503)


### PR DESCRIPTION
## What does this PR change?

When doing a SP Migration we call `isProductAvailable()` . This method check if the customer has subscriptions for
a possible target product. In case he has, but it is just not synced, we show can show him the target and he
can sync the missing channels from SCC.

But in case of an ISS Slave this check hide all target products as we do not sync `sccRepositoryAuth` data to the slave.

This PR disable the isMirrorable test when we are on an ISS Slave.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **should now work like documented**

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Port of https://github.com/SUSE/spacewalk/pull/13047

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
