### PR TITLE
Be able to select API when building packages locally

### DIFF
--- a/rel-eng/build-packages-local-obs.sh
+++ b/rel-eng/build-packages-local-obs.sh
@@ -1,7 +1,8 @@
 #!/bin/bash -e
 SCRIPT=$(basename ${0})
 BASE_DIR=$(dirname "${0}")
-OSC="osc -A https://api.suse.de"
+OSC_API="https://api.suse.de"
+OSC="osc -A $OSC_API"
 # List of packages that won't be built in any case
 EXCLUDED_PACKAGES=(heirloom-pkgtools oracle-server-admin oracle-server-scripts rhnclient smartpm jabberd-selinux oracle-rhnsat-selinux oracle-selinux oracle-xe-selinux spacewalk-monitoring-selinux spacewalk-proxy-selinux spacewalk-selinux cx_Oracle apt-spacewalk perl-DBD-Oracle spacewalk-jpp-workaround)
 
@@ -35,6 +36,8 @@ Optional:
   --force                    Continue even if there are uncommited changes.
                              Can be a problem if such changes affect the
                              packages you intend to build.
+  --osc_api=<API URL>        Build Service API. For example, https://api.opensuse.org.
+                             If not specified, default is $OSC_API
 
 EOF
 }
@@ -81,7 +84,7 @@ check_repo () {
 check_requirements;
 
 # read the options
-ARGS=$(getopt -o h --long help,no_revert,force,packages:,osc_project_wc:,repository: -n "${SCRIPT}" -- "$@")
+ARGS=$(getopt -o h --long help,no_revert,force,packages:,osc_project_wc:,repository:,osc_api: -n "${SCRIPT}" -- "$@")
 if [ $? -ne 0 ];
 then
   print_incorrect_syntax
@@ -96,6 +99,7 @@ while true ; do
     --repository)     REPOSITORY="${2}"; shift 2;;
     --no_revert)      REVERT="FALSE"; shift 1;;
     --force)          FORCE="TRUE"; shift 1;;
+    --osc_api)        OSC_API="${2}"; OSC="osc -A $OSC_API";shift 2;;
     --) shift ; break ;;
     *) print_incorrect_syntax; exit 1;;
   esac


### PR DESCRIPTION
## Maintenance Update status

N/A

## What does this PR change?

Adds an optional parameter to the package build local script so that we can build packages that are in build.opensuse.org.

## GUI diff

Before:
When calling `./build-packages-local-obs.sh -h`
there was no osc_api argument

After:
When calling `./build-packages-local-obs.sh -h`
you should see the optional argument osc_api

Before:
When calling

```
mkdir /tmp/obs
cd /tmp/obs
osc checkout systems:management:Uyuni:Master spacewalk-admin
cd -
./build-packages-local-obs.sh --osc_project_wc=/tmp/obs/systemsmanagement:Uyuni:Master --repository=openSUSE_Leap_15.2 --packages=spacewalk-admin --osc_api=https://build.opensuse.org
```

you should see an error

after:

same command, but no error and the package is built in /tmp/....



- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: This is a helper script for building packages, I don't think there is tests for this.

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/13065

Relevant branches (GitHub automatic links expected below):
 - Uyuni

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
