### PR TITLE
Uyunify missing translations

### DIFF
--- a/backend/common/rhnException.py
+++ b/backend/common/rhnException.py
@@ -132,7 +132,7 @@ on this system."),
      does not already exists on the server
      """),
     55: _("""
-     The --force rhnpush option is disabled on this server.
+     The --force mgrpush option is disabled on this server.
      Please contact your SUSE Manager administrator for more help.
      """),
 

--- a/backend/satellite_tools/messages.py
+++ b/backend/satellite_tools/messages.py
@@ -48,14 +48,6 @@ ERROR: There was a problem communicating with the ISS Master.
        Error message: %s
 """)
 
-sat_iss_not_available = _("""
-ERROR: There was a problem communicating with the ISS Master.
-       If the master satellite is older than v5.3, it does not have ISS capability.
-       Otherwise, depending on the specific error details, please review your
-       configuration, basic network connectivity, and/or name resolution, and try again.
-       Error message: %s
-""")
-
 parent_channel_error = _("""
 ERROR: a child-channel cannot be synced without its parent being synced as
        well. A parent needs to be either (a) previously synced or (b) synced

--- a/backend/satellite_tools/satsync.py
+++ b/backend/satellite_tools/satsync.py
@@ -684,7 +684,7 @@ class Syncer:
 
         # print out the relevant channel tree
         # 3/6/06 wregglej 183213 Don't print out the end-of-service message if
-        # satellite-sync is running with the --mount-point (-m) option. If it
+        # mgr-inter-sync is running with the --mount-point (-m) option. If it
         # did, it would incorrectly list channels as end-of-service if they had been
         # synced already but aren't in the channel dump.
         self._printChannelTree(doEOSYN=doEOSYN)
@@ -2200,14 +2200,14 @@ def processCommandline():
     optionsTable = [
         Option('--batch-size',          action='store',
                help=_('DEBUG ONLY: max. batch-size for XML/database-import processing (1..%s).'
-                      + '"man satellite-sync" for more information.') % SequenceServer.NEVER_MORE_THAN),
+                      + '"man mgr-inter-sync" for more information.') % SequenceServer.NEVER_MORE_THAN),
         Option('--ca-cert',             action='store',
                help=_('alternative SSL CA Cert (fullpath to cert file)')),
         Option('-c', '--channel',             action='append',
                help=_('process data for this channel only')),
         Option('--consider-full',       action='store_true',
                help=_('disk dump will be considered to be a full export; '
-                      'see "man satellite-sync" for more information.')),
+                      'see "man mgr-inter-sync" for more information.')),
         Option('--include-custom-channels',       action='store_true',
                help=_('existing custom channels will also be synced (unless -c is used)')),
         Option('--debug-level',         action='store',
@@ -2251,7 +2251,7 @@ def processCommandline():
         Option('-s', '--server',        action='store',
                help=_('alternative server with which to connect (hostname)')),
         Option('--step',                action='store',
-               help=_('synchronize to this step (man satellite-sync for more info)')),
+               help=_('synchronize to this step (man mgr-inter-sync for more info)')),
         Option('--sync-to-temp',        action='store_true',
                help=_('write complete data to tempfile before streaming to remainder of app')),
         Option('--systemid',            action='store',

--- a/backend/server/rhnChannel.py
+++ b/backend/server/rhnChannel.py
@@ -1998,11 +1998,6 @@ def guess_channels_for_server(server, user_id=None, none_ok=0,
             'www_activation': ''
         }
 
-        if CFG.REFER_TO_WWW:
-            error_strings['www_activation'] = _("\nIf you have a "
-                                                "registration number, please register with it first at "
-                                                "http://www.redhat.com/apps/activate/ and then try again.\n\n")
-
         raise_with_tb(rhnFault(19, msg % error_strings), sys.exc_info()[2])
     except BaseChannelDeniedError:
         if none_ok:
@@ -2272,17 +2267,6 @@ def subscribe_to_tools_channel(server_id):
 #
 # bretm 02/07/2007 -- when we have better old-client documentation, probably
 # will be safe to get rid of all this crap
-
-h_invalid_channel_title = _("System Registered but Inactive")
-h_invalid_channel_message = _("""
-Invalid Architecture and OS release combination (%s, %s).
-Your system has been registered, but will not receive updates
-because it is not subscribed to a channel. If you have not yet
-activated your product for service, please visit our website at:
-
-     http://www.redhat.com/apps/activate/
-
-...to activate your product.""")
 
 s_invalid_channel_title = _("System Registered but Inactive")
 s_invalid_channel_message = _("""

--- a/client/rhel/spacewalk-client-tools/rhn_register.desktop.in
+++ b/client/rhel/spacewalk-client-tools/rhn_register.desktop.in
@@ -1,8 +1,8 @@
 [Desktop Entry]
 Encoding=UTF-8
 _Name=RHN Registration
-_GenericName=Register for software updates from Spacewalk/Red Hat Satellite/Red Hat Network Classic
-_Comment=Register to Spacewalk/Red Hat Satellite/Red Hat Network Classic.
+_GenericName=Register for software updates from Spacewalk/Uyuni/SUSE Manager
+_Comment=Register to Spacewalk/Uyuni/SUSE Manager
 Exec=rhn_register
 Icon=up2date
 Terminal=false

--- a/client/rhel/spacewalk-client-tools/src/up2date_client/rhnregGui.py
+++ b/client/rhel/spacewalk-client-tools/src/up2date_client/rhnregGui.py
@@ -323,8 +323,8 @@ class ChooseServerPage:
             log.log_exception(*sys.exc_info())
             protocol, host, path, parameters, query, fragmentIdentifier = urlparse.urlparse(config.getServerlURL()[0])
             dialog = messageWindow.BulletedOkDialog(_("Cannot contact selected server"))
-            dialog.add_text(_("We could not contact the Satellite or Proxy "
-                              "at '%s.'") % host)
+            dialog.add_text(_("We could not contact the {PRODUCT_NAME} or Proxy "
+                              "at '{HOST}'.").format(PRODUCT_NAME=rhnreg_constants.PRODUCT_NAME, HOST=host))
             dialog.add_bullet(_("Double-check the location - is '%s' "
                                 "correct? If not, you can correct it and "
                                 "try again.") % host)
@@ -1323,7 +1323,7 @@ def unexpectedError(message, exc_info=None):
     logFile = cfg['logFile'] or '/var/log/up2date'
     message = message + "\n" + (_("This error shouldn't have happened. If you'd "
                                  "like to help us improve this program, please "
-                                 "file a bug at bugzilla.redhat.com. Including "
+                                 "file a bug at bugzilla.suse.com. Including "
                                  "the relevant parts of '%s' would be very "
                                  "helpful. Thanks!") % logFile)
     errorWindow(message)

--- a/spacecmd/src/spacecmd/api.py
+++ b/spacecmd/src/spacecmd/api.py
@@ -41,7 +41,7 @@ except AttributeError:
     _ = translation.gettext
 
 def help_api(self):
-    print(_('api: call RHN API with arguments directly'))
+    print(_('api: call server API with arguments directly'))
     print(_('''usage: api [options] API_STRING)
 
 options:

--- a/spacecmd/src/spacecmd/kickstart.py
+++ b/spacecmd/src/spacecmd/kickstart.py
@@ -2458,8 +2458,7 @@ def import_kickstart_fromdetails(self, ksdetails):
             self.client.kickstart.profile.system.addKeys(self.session,
                                                          ksdetails['label'], [key])
         else:
-            logging.warning(_("GPG/SSL key %s does not exist on the ") % key +
-                            _("satellite, skipping"))
+            logging.warning(_("GPG/SSL key %s does not exist on the Spacewalk server, skipping") % key)
 
     # The pre/post logging settings
     self.client.kickstart.profile.setLogging(self.session, ksdetails['label'],

--- a/spacecmd/src/spacecmd/package.py
+++ b/spacecmd/src/spacecmd/package.py
@@ -175,7 +175,7 @@ def do_package_search(self, args, doreturn=False):
 
 
 def help_package_remove(self):
-    print(_('package_remove: Remove a package from Satellite'))
+    print(_('package_remove: Remove a package from Spacewalk'))
     print(_('usage: package_remove PACKAGE ...'))
 
 


### PR DESCRIPTION
Some strings escaped my attention in the first round.


Used the following command to find the occurences in the POT files:

`git grep -i '^[^#].*\(satellite\|redhat\|red hat\|rhn\)' \*.pot`

There are still some string occurences, that don't pass the above grep, but I
believe they shouldn't appear in the UI/they would need some refactoring to be
removed.

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"