### PR TITLE
Improve updating ca trust store

### DIFF
--- a/spacewalk/certs-tools/rhn_bootstrap_strings.py
+++ b/spacewalk/certs-tools/rhn_bootstrap_strings.py
@@ -801,7 +801,7 @@ if [ $USING_SSL -eq 1 ] ; then
     fi
 
     function updateCertificates() {
-        if [ -d /etc/pki/ca-trust/source/anchors ]; then
+        if [ -d /etc/pki/ca-trust/source/anchors  -a -x /usr/bin/update-ca-trust ]; then
             TRUST_DIR=/etc/pki/ca-trust/source/anchors
         elif [ -d /etc/pki/trust/anchors/ -a -x /usr/sbin/update-ca-certificates ]; then
             # SLE 12

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,4 @@
+- improve check for correct CA trust store directory (bsc#1176417)
 - Add option --notty to spacewalk-ssh-push-init
 
 -------------------------------------------------------------------

--- a/spacewalk/certs-tools/update-ca-cert-trust.sh
+++ b/spacewalk/certs-tools/update-ca-cert-trust.sh
@@ -24,7 +24,7 @@ CERT_DIR=/usr/share/rhn
 CERT_FILE=RHN-ORG-TRUSTED-SSL-CERT
 TRUST_DIR=/etc/pki/ca-trust/source/anchors
 UPDATE_TRUST_CMD="/usr/bin/update-ca-trust extract"
-if [ -d /etc/pki/ca-trust/source/anchors ]; then
+if [ -d /etc/pki/ca-trust/source/anchors -a -x /usr/bin/update-ca-trust ]; then
     TRUST_DIR=/etc/pki/ca-trust/source/anchors
 elif [ -d /etc/pki/trust/anchors/ -a -x /usr/sbin/update-ca-certificates ]; then
     # SLE 12


### PR DESCRIPTION
## What does this PR change?

Case: a user had installed CA certificates under the RedHat path on a SUSE system. This caused the scripts to call the wrong tool and do not create the tust store correctly.

This PR improve the detection of the correct directory and tool to call.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **should now behave like expected**

- [x] **DONE**

## Test coverage
- No tests: **manual**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/12632
Tracks https://github.com/SUSE/spacewalk/pull/13073 https://github.com/SUSE/spacewalk/pull/13074

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests" (Test skipped, there are no changes to test)
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
