### PR TITLE
use velocity from Leap

### DIFF
--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -92,7 +92,7 @@
         <dependency org="suse" name="xalan-j2-serializer" rev="2.7.2" />
         <dependency org="suse" name="xerces-j2" rev="2.12.0" />
         <dependency org="suse" name="xmlsec" rev="2.0.7" />
-        <dependency org="suse" name="velocity" rev="1.5" />
+        <dependency org="suse" name="velocity" rev="1.7" />
 
         <!-- Uncommend commons-lang only to generate the apidocs using manager-build.xml -->
         <!-- <dependency org="suse" name="commons-lang" rev="2.6" /> -->

--- a/java/buildconf/ivy/obs-maven-config.yaml
+++ b/java/buildconf/ivy/obs-maven-config.yaml
@@ -257,7 +257,7 @@ artifacts:
     package: apache-commons-lang
     repository: Leap
   - artifact: velocity
-    repository: Uyuni_Other
+    repository: Leap
 
   - artifact: jasper
     package: tomcat-lib


### PR DESCRIPTION
## What does this PR change?

obs-to-maven use now velocity from Leap.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **for devel only**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
