### PR TITLE
Successfully manage and sync ULN repositories

### DIFF
--- a/backend/common/suseLib.py
+++ b/backend/common/suseLib.py
@@ -628,7 +628,7 @@ def _useProxyFor(url):
     u = urlparse.urlsplit(url)
     # pylint can't see inside the SplitResult class
     # pylint: disable=E1103
-    if u.scheme == 'file':
+    if u.scheme == 'file' or not u.hostname:
         return False
     hostname = u.hostname.lower()
     if hostname in ["localhost", "127.0.0.1", "::1"]:

--- a/backend/common/suseLib.py
+++ b/backend/common/suseLib.py
@@ -112,6 +112,7 @@ class URL(object):
     def getURL(self, stripPw=False):
         """Return the full url as a string"""
         netloc = ""
+        path = self.path
         if self.username:
             netloc = self.username
         if self.password and not stripPw:
@@ -126,7 +127,13 @@ class URL(object):
         if self.port:
             netloc = '%s:%s' % (netloc, self.port)
 
-        return urlparse.urlunsplit((self.scheme, netloc, self.path,
+        # Default ULN channels URIs are like: uln:///ol7_x86_64_u8_base
+        # If not netloc, we fix the path to avoid getting url:/ol7_x86_64_u8_base
+        # as results from urlunsplit
+        if self.scheme == 'uln' and not netloc:
+            path = "//" + self.path
+
+        return urlparse.urlunsplit((self.scheme, netloc, path,
                                     self.query, self.fragment))
 
 

--- a/backend/satellite_tools/repo_plugins/uln_src.py
+++ b/backend/satellite_tools/repo_plugins/uln_src.py
@@ -34,6 +34,9 @@ class ContentSource(yum_ContentSource):
                  ca_cert_file=None, client_cert_file=None, client_key_file=None):
         if url[:6] != "uln://":
             raise RhnSyncException("url format error, url must start with uln://")
+        # Make sure baseurl ends with / and urljoin will work correctly
+        if url[-1] != '/':
+            url += '/'
         yum_ContentSource.__init__(self, url=url, name=name, insecure=insecure,
                                    interactive=interactive, yumsrc_conf=yumsrc_conf, org=org,
                                    channel_label=channel_label, no_mirrors=no_mirrors,

--- a/backend/satellite_tools/repo_plugins/uln_src.py
+++ b/backend/satellite_tools/repo_plugins/uln_src.py
@@ -49,11 +49,25 @@ class ContentSource(yum_ContentSource):
         self._uln_auth = ULNAuth()
         self.uln_token = self._uln_auth.authenticate(url)
         self.http_headers = {'X-ULN-Api-User-Key': self.uln_token}
-        hostname, label = self._uln_auth.get_hostname(url)
-        print(("The download URL is: " + self.url))
+        hostname, label = self._uln_auth.get_hostname(self.url)
+        self._load_proxy_settings(hostname)
+        print(("The download URL is: " + self._uln_auth.url + "/XMLRPC/GET-REQ/" + label))
         if self.proxy_url:
             print(("Trying proxy " + self.proxy_url))
 
     # pylint: disable=arguments-differ
     def setup_repo(self, repo, *args, **kwargs):
         yum_ContentSource.setup_repo(self, repo, *args, uln_repo=True, **kwargs)
+
+    # Get download parameters for threaded downloader
+    def set_download_parameters(self, params, relative_path, target_file, checksum_type=None,
+                                checksum_value=None, bytes_range=None):
+        yum_ContentSource.set_download_parameters(self,
+                                                  params=params,
+                                                  relative_path=relative_path,
+                                                  target_file=target_file,
+                                                  checksum_type=checksum_type,
+                                                  checksum_value=checksum_value,
+                                                  bytes_range=bytes_range)
+        hostname, label = self._uln_auth.get_hostname(self.url)
+        params['urls'] = [self._uln_auth.url + "/XMLRPC/GET-REQ/" + label]

--- a/backend/satellite_tools/repo_plugins/uln_src.py
+++ b/backend/satellite_tools/repo_plugins/uln_src.py
@@ -47,7 +47,6 @@ class ContentSource(yum_ContentSource):
         self.uln_token = self._uln_auth.authenticate(url)
         self.http_headers = {'X-ULN-Api-User-Key': self.uln_token}
         hostname, label = self._uln_auth.get_hostname(url)
-        self.url = self._uln_auth.url + "/XMLRPC/GET-REQ/" + label
         print(("The download URL is: " + self.url))
         if self.proxy_url:
             print(("Trying proxy " + self.proxy_url))

--- a/backend/satellite_tools/repo_plugins/yum_src.py
+++ b/backend/satellite_tools/repo_plugins/yum_src.py
@@ -580,7 +580,7 @@ class ContentSource:
         Setup repository and fetch metadata
         """
         self.zypposync = ZyppoSync(root=repo.root)
-        zypp_repo_url = self._prep_zypp_repo_url(self.url)
+        zypp_repo_url = self._prep_zypp_repo_url(self.url, uln_repo)
 
         mirrorlist = self._get_mirror_list(repo, self.url)
         if mirrorlist:
@@ -630,7 +630,7 @@ type=rpm-md
         rhnLog.log_clean(0, message)
         sys.stderr.write(str(message) + "\n")
 
-    def _prep_zypp_repo_url(self, url):
+    def _prep_zypp_repo_url(self, url, uln_repo):
         """
         Prepare the repository baseurl to use in the Zypper repo file.
         This will add the HTTP Proxy and Client certificate settings as part of
@@ -661,7 +661,7 @@ type=rpm-md
         if self.sslclientkey:
             query_params['ssl_clientkey'] = self.sslclientkey
         new_query = unquote(urlencode(query_params, doseq=True))
-        if self.authtoken:
+        if self.authtoken or uln_repo:
             ret_url = "{0}&{1}".format(url, new_query)
         else:
             ret_url = "{0}?{1}".format(url, new_query) if new_query else url

--- a/backend/satellite_tools/spacewalk-uln-resolver
+++ b/backend/satellite_tools/spacewalk-uln-resolver
@@ -39,8 +39,10 @@ class SpacewalkULNPlugin(Plugin):
             }
         except Exception as exc:
             self.answer("ERROR", {}, str(exc))
-        hostname, label = self._uln_auth.get_hostname(headers['url'])
+        hostname, label = self._uln_auth.get_hostname(headers.pop('url'))
         url = self._uln_auth.url + "/XMLRPC/GET-REQ/" + label
+        if headers:
+           url += "?{}".format(urllib.parse.urlencode(headers))
         self.answer("RESOLVEDURL", self.auth_headers, url)
 
 plugin = SpacewalkULNPlugin()

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Fix spacewalk-repo-sync to successfully manage and sync ULN repositories
 - fix errors in spacewalk-debug and align postgresql queries to new DB version
 - ISS: Differentiate packages with same nevra but different checksum in the same channel (bsc#1178195)
 - add 'allow_vendor_change' option to rhn clients for dist upgrades

--- a/java/code/src/com/redhat/rhn/manager/channel/repo/BaseRepoCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/repo/BaseRepoCommand.java
@@ -225,7 +225,7 @@ public abstract class BaseRepoCommand {
                 if (this.type.equals("uln")) {
                     // URL for ULN repositories, i.a. uln:///uln_channel_label, are not
                     // passing Java URL validation due unknown protocol. We fake the
-		    // protocol to "file" and run the validation for the rest of the URL.
+                    // protocol to "file" and run the validation for the rest of the URL.
                     final URI uri = new URI(this.url);
                     if (uri.getScheme().equals("uln")) {
                        u = new URI("file", uri.getSchemeSpecificPart(), uri.getFragment()).toURL();

--- a/java/code/src/com/redhat/rhn/manager/channel/repo/BaseRepoCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/repo/BaseRepoCommand.java
@@ -17,6 +17,8 @@
  */
 package com.redhat.rhn.manager.channel.repo;
 
+import org.apache.commons.validator.UrlValidator;
+
 import com.redhat.rhn.common.client.InvalidCertificateException;
 import com.redhat.rhn.domain.channel.ChannelFactory;
 import com.redhat.rhn.domain.channel.ContentSource;
@@ -30,7 +32,6 @@ import com.redhat.rhn.frontend.xmlrpc.channel.repo.InvalidRepoTypeException;
 import com.redhat.rhn.frontend.xmlrpc.channel.repo.InvalidRepoUrlException;
 import com.redhat.rhn.frontend.xmlrpc.channel.repo.InvalidRepoUrlInputException;
 
-import java.net.URL;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
@@ -219,11 +220,9 @@ public abstract class BaseRepoCommand {
         }
 
         if (this.url != null && this.type != null) {
-            final URL u;
-            try {
-                u = new URL(this.url);
-            }
-            catch (Exception e) {
+            String[] schemes = {"http", "https", "file", "ftp", "uln"};
+            UrlValidator urlValidator = new UrlValidator(schemes);
+            if (!urlValidator.isValid(this.url)) {
                 throw new InvalidRepoUrlInputException(url);
             }
             ContentSourceType cst = ChannelFactory.lookupContentSourceType(this.type);

--- a/java/code/src/com/redhat/rhn/manager/channel/repo/BaseRepoCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/repo/BaseRepoCommand.java
@@ -17,8 +17,6 @@
  */
 package com.redhat.rhn.manager.channel.repo;
 
-import org.apache.commons.validator.UrlValidator;
-
 import com.redhat.rhn.common.client.InvalidCertificateException;
 import com.redhat.rhn.domain.channel.ChannelFactory;
 import com.redhat.rhn.domain.channel.ContentSource;
@@ -32,6 +30,8 @@ import com.redhat.rhn.frontend.xmlrpc.channel.repo.InvalidRepoTypeException;
 import com.redhat.rhn.frontend.xmlrpc.channel.repo.InvalidRepoUrlException;
 import com.redhat.rhn.frontend.xmlrpc.channel.repo.InvalidRepoUrlInputException;
 
+import java.net.URL;
+import java.net.URI;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
@@ -220,9 +220,25 @@ public abstract class BaseRepoCommand {
         }
 
         if (this.url != null && this.type != null) {
-            String[] schemes = {"http", "https", "file", "ftp", "uln"};
-            UrlValidator urlValidator = new UrlValidator(schemes);
-            if (!urlValidator.isValid(this.url)) {
+            try {
+                final URL u;
+                if (this.type.equals("uln")) {
+                    // URL for ULN repositories, i.a. uln:///uln_channel_label, are not
+                    // passing Java URL validation due unknown protocol. We fake the
+		    // protocol to "file" and run the validation for the rest of the URL.
+                    final URI uri = new URI(this.url);
+                    if (uri.getScheme().equals("uln")) {
+                       u = new URI("file", uri.getSchemeSpecificPart(), uri.getFragment()).toURL();
+                    }
+                    else {
+                        throw new InvalidRepoUrlInputException(url);
+                    }
+                }
+                else {
+                    u = new URL(this.url);
+                }
+            }
+            catch (Exception e) {
                 throw new InvalidRepoUrlInputException(url);
             }
             ContentSourceType cst = ChannelFactory.lookupContentSourceType(this.type);

--- a/java/code/src/com/redhat/rhn/manager/channel/test/BaseRepoCommandTest.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/test/BaseRepoCommandTest.java
@@ -65,11 +65,11 @@ public class BaseRepoCommandTest extends RhnBaseTestCase {
         validUrlInput("http://another-one.de/example?v=10", "yum");
         validUrlInput("ftp://exampleABC.com", "yum");
 
-	// ULN - V A L I D
+        // ULN - V A L I D
         validUrlInput("uln://foo/example_label", "uln");
         validUrlInput("uln:///example_label", "uln");
 
-	// ULN - I N V A L I D
+        // ULN - I N V A L I D
         invalidUrlInput("", "uln");
         invalidUrlInput("example.com", "uln");
         invalidUrlInput("htp://some_test_url.com", "uln");

--- a/java/code/src/com/redhat/rhn/manager/channel/test/BaseRepoCommandTest.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/test/BaseRepoCommandTest.java
@@ -64,6 +64,8 @@ public class BaseRepoCommandTest extends RhnBaseTestCase {
         validUrlInput("https://another-one.de/example%20");
         validUrlInput("http://another-one.de/example?v=10");
         validUrlInput("ftp://exampleABC.com");
+        validUrlInput("uln:///example_label");
+        validUrlInput("uln://foo/example_label");
     }
 
     private void invalidUrlInput(String url) {

--- a/java/code/src/com/redhat/rhn/manager/channel/test/BaseRepoCommandTest.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/test/BaseRepoCommandTest.java
@@ -43,66 +43,74 @@ public class BaseRepoCommandTest extends RhnBaseTestCase {
         // Url must begin with a valid protocol (http, https, ftp, ...),
         //  end with a valid TLD and contain only valid characters
 
-        // I N V A L I D
-        invalidUrlInput("");
-        invalidUrlInput("example.com");
-        invalidUrlInput("htp://some_test_url.com");
-        invalidUrlInput("www.example.com");
+        // YUM - I N V A L I D
+        invalidUrlInput("", "yum");
+        invalidUrlInput("example.com", "yum");
+        invalidUrlInput("htp://some_test_url.com", "yum");
+        invalidUrlInput("www.example.com", "yum");
 
-        // V A L I D
-        validUrlInput("file:///srv/mirror");
-        validUrlInput("http://localhost");
-        validUrlInput("http://localhost:8080");
-        validUrlInput("http://localhost/pub");
-        validUrlInput("http://localhost.com.x/pub");
-        validUrlInput("http://www.example.com");
-        validUrlInput("http://www.example.co.uk");
-        validUrlInput("https://www3.example.com");
-        validUrlInput("https://test123.com");
-        validUrlInput("http://example.com");
-        validUrlInput("http://another-one.de/example");
-        validUrlInput("https://another-one.de/example%20");
-        validUrlInput("http://another-one.de/example?v=10");
-        validUrlInput("ftp://exampleABC.com");
-        validUrlInput("uln:///example_label");
-        validUrlInput("uln://foo/example_label");
+        // YUM - V A L I D
+        validUrlInput("file:///srv/mirror", "yum");
+        validUrlInput("http://localhost", "yum");
+        validUrlInput("http://localhost:8080", "yum");
+        validUrlInput("http://localhost/pub", "yum");
+        validUrlInput("http://localhost.com.x/pub", "yum");
+        validUrlInput("http://www.example.com", "yum");
+        validUrlInput("http://www.example.co.uk", "yum");
+        validUrlInput("https://www3.example.com", "yum");
+        validUrlInput("https://test123.com", "yum");
+        validUrlInput("http://example.com", "yum");
+        validUrlInput("http://another-one.de/example", "yum");
+        validUrlInput("https://another-one.de/example%20", "yum");
+        validUrlInput("http://another-one.de/example?v=10", "yum");
+        validUrlInput("ftp://exampleABC.com", "yum");
+
+	// ULN - V A L I D
+        validUrlInput("uln://foo/example_label", "uln");
+        validUrlInput("uln:///example_label", "uln");
+
+	// ULN - I N V A L I D
+        invalidUrlInput("", "uln");
+        invalidUrlInput("example.com", "uln");
+        invalidUrlInput("htp://some_test_url.com", "uln");
+        invalidUrlInput("www.example.com", "uln");
     }
 
-    private void invalidUrlInput(String url) {
+    private void invalidUrlInput(String url, String type) {
         // give it an invalid url
         ccc.setUrl(url);
         // give it a valid label
         ccc.setLabel("valid-label-name");
         // need to specify a type
-        ccc.setType("yum");
+        ccc.setType(type);
         // need to specify MetadataSigned
         ccc.setMetadataSigned(Boolean.FALSE);
 
         try {
             ccc.store();
-            fail("invalid url should have thrown error");
+            fail("invalid url should have thrown error: " + url);
         }
         catch (InvalidRepoUrlException e) {
-            fail("non duplicate url caused error");
+            fail("non duplicate url caused error: " + url);
         }
         catch (InvalidRepoUrlInputException expected) {
             // expected
         }
         catch (InvalidRepoLabelException e) {
-            fail("valid repo label caused error");
+            fail("valid repo label caused error: " + url);
         }
         catch (InvalidRepoTypeException e) {
-            fail("valid repo type caused error");
+            fail("valid repo type caused error: " + url);
         }
     }
 
-    private void validUrlInput(String url) {
+    private void validUrlInput(String url, String type) {
         // give it a valid url
         ccc.setUrl(url);
         // need to create unique label names.
         ccc.setLabel("valid-label-name-" + label_count++);
         // need to specify a type
-        ccc.setType("yum");
+        ccc.setType(type);
         // need to specify MetadataSigned
         ccc.setMetadataSigned(Boolean.FALSE);
 
@@ -110,16 +118,16 @@ public class BaseRepoCommandTest extends RhnBaseTestCase {
             ccc.store();
         }
         catch (InvalidRepoUrlException e) {
-            fail("non duplicate url caused error");
+            fail("non duplicate url caused error: " + url);
         }
         catch (InvalidRepoUrlInputException e) {
-            fail("valid repo url input caused error");
+            fail("valid repo url input caused error: " + url);
         }
         catch (InvalidRepoLabelException e) {
-            fail("valid repo label caused error");
+            fail("valid repo label caused error: " + url);
         }
         catch (InvalidRepoTypeException e) {
-            fail("valid repo type caused error");
+            fail("valid repo type caused error: " + url);
         }
     }
 }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Allow creating custom ULN repositories with uln:// urls
 - Change message "Minion is down" to be more accurate
 - Revert: Sync state modules when starting action chain execution (bsc#1177336)
 - Remove expiration date from ics files (bsc#1177892)


### PR DESCRIPTION
## What does this PR change?

This PR fixes broken ULN reposync plugin and also addresses other related ULN issues:

- Allow `spacewalk-repo-sync` to deal with `uln://` repositories URLs and successfully sync ULN repos.
- Successfully propagate HTTP proxy settings to dealing with ULN repos.
- Fix web UI and API to allow creating custom ULN repositories with `uln://` URLs.

Thanks a lot to @scomcd for the help on testing these changes against the real ULN network.

@scomcd I'll provide you some more notes at https://github.com/uyuni-project/uyuni/issues/2359 so you can give a test to the Python parts (reposync + http proxy). Thanks in advance! 

@parlt91 - Could you please also give a review to the Java changes? Thanks!

**I've marked this as [WIP] since I want to wait for a final feedback from @scomcd before merging**

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/2359

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"  
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
