### PR TITLE
Remove java checkstyle from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -48,7 +48,6 @@ If you need to re-run a test, please mark the related checkbox, it will be unche
 
 - [ ] Re-run test "changelog_test"
 - [ ] Re-run test "backend_unittests_pgsql"
-- [ ] Re-run test "java_lint_checkstyle"
 - [ ] Re-run test "java_pgsql_tests"
 - [ ] Re-run test "schema_migration_test_oracle"
 - [ ] Re-run test "schema_migration_test_pgsql"


### PR DESCRIPTION
## What does this PR change?

Remove java checkstyle from PR template. Java checkstyle is now in github actions.

## GUI diff

No difference.

Before:

See the option in the PR template

```
- [ ] Re-run test "java_lint_checkstyle"
```

After:

You should not see the option in the PR template

- [X] **DONE**

## Documentation
- No documentation needed: This is for CI

- [X] **DONE**

## Test coverage
- No tests: this actually removes a test

- [X] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/12892

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed




## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
