### PR TITLE
Change message "Minion is down" to be more accurate

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/BatchStartedEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/BatchStartedEventMessageAction.java
@@ -89,7 +89,7 @@ public class BatchStartedEventMessageAction implements MessageAction {
         if (LOG.isDebugEnabled()) {
             LOG.debug("Marking server action as failed for server: " + minionId);
         }
-        sa.fail("Minion is down");
+        sa.fail("Minion is down or could not be contacted.");
         ActionFactory.save(sa);
     }
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Change message "Minion is down" to be more accurate
 - Revert: Sync state modules when starting action chain execution (bsc#1177336)
 - Remove expiration date from ics files (bsc#1177892)
 - Localize documentation links


### PR DESCRIPTION
## What does this PR change?

"Minion is down" message is misleading. The minion could indeed be turned off, but it could also be any other kind of network problem.

Change it to "Minion is down or cannot be contacted." like in other parts of Uyuni

## Test coverage
- No tests: I did a grep and it should not break the test suite

## Links

Ports:
* 4.1: SUSE/spacewalk#13104
* 4.0: SUSE/spacewalk#13103

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed
