### PR TITLE
QA: Refactor extraction of logs to support QAM clients

### DIFF
--- a/testsuite/features/finishing/allcli_debug.feature
+++ b/testsuite/features/finishing/allcli_debug.feature
@@ -3,38 +3,5 @@
 
 Feature: Debug the clients after the testsuite has run
 
-@proxy
-  Scenario: Get client logs for proxy
-    When I get logfiles from "proxy"
-
-@sle_client
-  Scenario: Get client logs for traditional client
-    When I get logfiles from "sle_client"
-
-@sle_minion
-  Scenario: Get client logs for minion
-    When I get logfiles from "sle_minion"
-
-@centos_minion
-  Scenario: Get client logs for CentOS SSH minion
-    When I get logfiles from "ceos_minion"
-
-@ubuntu_minion
-  Scenario: Get client logs for Ubuntu SSH minion
-    When I get logfiles from "ubuntu_minion"
-
-@ssh_minion
-  Scenario: Get client logs for SSH minion
-    When I get logfiles from "ssh_minion"
-
-@virthost_kvm
-  Scenario: Get client logs for KVM virtualization host
-    When I get logfiles from "kvm_server"
-
-@virthost_xen
-  Scenario: Get client logs for Xen virtualization host
-    When I get logfiles from "xen_server"
-
-@buildhost
-  Scenario: Get client logs for build host
-    When I get logfiles from "build_host"
+  Scenario: Extract the logs from all our clients
+    When I extract the log files from all our active nodes

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -324,16 +324,12 @@ When(/^I execute spacewalk-debug on the server$/) do
   raise "Download debug file failed" unless code.zero?
 end
 
-Then(/^I get logfiles from "([^"]*)"$/) do |target|
-  node = get_target(target)
-  os_version, os_family = get_os_version(node)
-  if os_family =~ /^opensuse/
-    node.run('zypper mr --enable os_pool_repo os_update_repo && zypper --non-interactive install tar')
+When(/^I extract the log files from all our active nodes$/) do
+  $nodes.each do |node|
+    next if node.nil?
+
+    extract_logs_from_node(node)
   end
-  node.run("journalctl > /var/log/messages && (tar cfvJP /tmp/#{target}-logs.tar.xz /var/log/ || [[ $? -eq 1 ]])")
-  `mkdir logs` unless Dir.exist?('logs')
-  code = file_extract(node, "/tmp/#{target}-logs.tar.xz", "logs/#{target}-logs.tar.xz")
-  raise "Download log archive failed" unless code.zero?
 end
 
 Then(/^the susemanager repo file should exist on the "([^"]*)"$/) do |host|

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -228,3 +228,17 @@ def generate_repository_name(repo_url)
   repo_name.delete_prefix! 'http://minima-mirror-qam.mgr.prv.suse.net/ibs/SUSE:/Maintenance:/'
   repo_name
 end
+
+def extract_logs_from_node(node)
+  _os_version, os_family = get_os_version(node)
+  if os_family =~ /^opensuse/
+    node.run('zypper mr --enable os_pool_repo os_update_repo') unless $qam_test
+    node.run('zypper --non-interactive install tar')
+    node.run('zypper mr --disable os_pool_repo os_update_repo') unless $qam_test
+  end
+  node.run('journalctl > /var/log/messages', false) # Some clients might not support systemd
+  node.run("tar cfvJP /tmp/#{node.full_hostname}-logs.tar.xz /var/log/ || [[ $? -eq 1 ]]")
+  `mkdir logs` unless Dir.exist?('logs')
+  code = file_extract(node, "/tmp/#{node.full_hostname}-logs.tar.xz", "logs/#{node.full_hostname}-logs.tar.xz")
+  raise 'Download log archive failed' unless code.zero?
+end

--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -30,7 +30,7 @@ $server = twopence_init("ssh:#{ENV['SERVER']}")
 $kvm_server = twopence_init("ssh:#{ENV['VIRTHOST_KVM_URL']}") if ENV['VIRTHOST_KVM_URL'] && ENV['VIRTHOST_KVM_PASSWORD']
 $xen_server = twopence_init("ssh:#{ENV['VIRTHOST_XEN_URL']}") if ENV['VIRTHOST_XEN_URL'] && ENV['VIRTHOST_XEN_PASSWORD']
 
-nodes = [$server, $proxy, $kvm_server, $xen_server]
+$nodes = [$server, $proxy, $kvm_server, $xen_server]
 
 if $qam_test
   # Define twopence objects for QAM environment
@@ -64,16 +64,16 @@ if $qam_test
   $client = $sle12sp4_client
   $ceos_minion = $ceos6_ssh_minion
   $ubuntu_minion = $ubuntu1804_minion
-  nodes += [$sle11sp4_minion, $sle11sp4_ssh_minion, $sle11sp4_client,
-            $sle12sp4_minion, $sle12sp4_ssh_minion, $sle12sp4_client,
-            $sle15_minion, $sle15_ssh_minion, $sle15_client,
-            $sle15sp1_minion, $sle15sp1_ssh_minion, $sle15sp1_client,
-            $ceos6_minion, $ceos6_ssh_minion, $ceos6_client,
-            $ceos7_minion, $ceos7_ssh_minion, $ceos7_client,
-            $ubuntu1604_ssh_minion, $ubuntu1604_minion,
-            $ubuntu1804_ssh_minion, $ubuntu1804_minion,
-            $ubuntu2004_ssh_minion, $ubuntu2004_minion,
-            $client, $minion, $ceos_minion, $ubuntu_minion, $ssh_minion]
+  $nodes += [$sle11sp4_minion, $sle11sp4_ssh_minion, $sle11sp4_client,
+             $sle12sp4_minion, $sle12sp4_ssh_minion, $sle12sp4_client,
+             $sle15_minion, $sle15_ssh_minion, $sle15_client,
+             $sle15sp1_minion, $sle15sp1_ssh_minion, $sle15sp1_client,
+             $ceos6_minion, $ceos6_ssh_minion, $ceos6_client,
+             $ceos7_minion, $ceos7_ssh_minion, $ceos7_client,
+             $ubuntu1604_ssh_minion, $ubuntu1604_minion,
+             $ubuntu1804_ssh_minion, $ubuntu1804_minion,
+             $ubuntu2004_ssh_minion, $ubuntu2004_minion,
+             $client, $minion, $ceos_minion, $ubuntu_minion, $ssh_minion]
 else
   # Define twopence objects for QA environment
   $minion = twopence_init("ssh:#{ENV['MINION']}") if ENV['MINION']
@@ -82,19 +82,19 @@ else
   $client = twopence_init("ssh:#{ENV['CLIENT']}") if ENV['CLIENT']
   $ceos_minion = twopence_init("ssh:#{ENV['CENTOSMINION']}") if ENV['CENTOSMINION']
   $ubuntu_minion = twopence_init("ssh:#{ENV['UBUNTUMINION']}") if ENV['UBUNTUMINION']
-  nodes += [$client, $minion, $build_host, $ceos_minion, $ubuntu_minion, $ssh_minion]
+  $nodes += [$client, $minion, $build_host, $ceos_minion, $ubuntu_minion, $ssh_minion]
 end
 
 # Lavanda library module extension
 # Look at support/lavanda.rb for more details
-nodes.each do |node|
+$nodes.each do |node|
   next if node.nil?
 
   node.extend(LavandaBasic)
 end
 
 # Initialize hostname
-nodes.each do |node|
+$nodes.each do |node|
   next if node.nil?
 
   hostname, _local, _remote, code = node.test_and_store_results_together('hostname', 'root', 500)
@@ -111,7 +111,7 @@ nodes.each do |node|
 end
 
 # Initialize IP address or domain name
-nodes.each do |node|
+$nodes.each do |node|
   next if node.nil?
 
   node.init_ip(node.full_hostname)


### PR DESCRIPTION
## What does this PR change?

Small refactor to extract logs from all the active nodes in our testsuite. In that way, we fix the current failure on the QAM test suite at the same time that we don't need to worry if we add more clients to the list of nodes.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
