### PR TITLE
Report resolved module dependencies on CLM project UI

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/modulemd/Module.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/modulemd/Module.java
@@ -37,6 +37,14 @@ public class Module {
         this.stream = streamIn;
     }
 
+    /**
+     * Initialize a new Module instance
+     * @param moduleInfo the module information retrieved from the ModulemdApi
+     */
+    public Module(ModuleInfo moduleInfo) {
+        this(moduleInfo.getName(), moduleInfo.getStream());
+    }
+
     public String getName() {
         return name;
     }

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/modulemd/ModuleInfo.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/modulemd/ModuleInfo.java
@@ -16,7 +16,7 @@
 package com.redhat.rhn.domain.contentmgmt.modulemd;
 
 /**
- * Holds details for a unique AppStream module entry
+ * Detailed information on a unique AppStream module entry
  */
 public class ModuleInfo {
 
@@ -25,6 +25,23 @@ public class ModuleInfo {
     private String version;
     private String context;
     private String arch;
+
+    /**
+     * All args constructor
+     *
+     * @param nameIn the module name
+     * @param streamIn the stream name
+     * @param versionIn the stream version
+     * @param contextIn the stream context hash value
+     * @param archIn the architecture
+     */
+    public ModuleInfo(String nameIn, String streamIn, String versionIn, String contextIn, String archIn) {
+        name = nameIn;
+        stream = streamIn;
+        version = versionIn;
+        context = contextIn;
+        arch = archIn;
+    }
 
     public String getName() {
         return name;

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/validation/ModularDependencyValidator.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/validation/ModularDependencyValidator.java
@@ -24,6 +24,7 @@ import com.redhat.rhn.domain.contentmgmt.modulemd.Module;
 import com.redhat.rhn.domain.contentmgmt.modulemd.ModuleNotFoundException;
 import com.redhat.rhn.domain.contentmgmt.modulemd.ModulemdApi;
 import com.redhat.rhn.manager.contentmgmt.DependencyResolutionException;
+import com.redhat.rhn.manager.contentmgmt.DependencyResolutionResult;
 import com.redhat.rhn.manager.contentmgmt.DependencyResolver;
 
 import java.util.ArrayList;
@@ -32,6 +33,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import static com.redhat.rhn.domain.contentmgmt.validation.ContentValidationMessage.TYPE_ERROR;
+import static com.redhat.rhn.domain.contentmgmt.validation.ContentValidationMessage.TYPE_INFO;
 
 /**
  * Validates resolution of modular dependencies in a content project
@@ -75,7 +77,13 @@ public class ModularDependencyValidator implements ContentValidator {
 
         List<ContentValidationMessage> messages = new ArrayList<>();
         try {
-            resolver.resolveFilters(project.getActiveFilters());
+            DependencyResolutionResult result = resolver.resolveFilters(project.getActiveFilters());
+
+            // Add a message with the list of resolved modules
+            String selectedModules =
+                    result.getModules().stream().map(Module::getFullName).collect(Collectors.joining(", "));
+            messages.add(ContentValidationMessage.contentFiltersMessage(
+                    loc.getMessage("contentmanagement.validation.selectedmodules", selectedModules), TYPE_INFO));
         }
         catch (DependencyResolutionException e) {
             if (e.getCause() instanceof ModuleNotFoundException) {

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/validation/test/ModularDependencyValidatorTest.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/validation/test/ModularDependencyValidatorTest.java
@@ -19,6 +19,7 @@ import com.redhat.rhn.domain.contentmgmt.validation.ModularDependencyValidator;
 import com.redhat.rhn.manager.contentmgmt.test.MockModulemdApi;
 
 import static com.redhat.rhn.domain.contentmgmt.validation.ContentValidationMessage.TYPE_ERROR;
+import static com.redhat.rhn.domain.contentmgmt.validation.ContentValidationMessage.TYPE_INFO;
 
 public class ModularDependencyValidatorTest extends ContentValidatorTestBase {
 
@@ -49,7 +50,8 @@ public class ModularDependencyValidatorTest extends ContentValidatorTestBase {
     public void testMatchingFilter() throws Exception {
         attachModularSource();
         attachModularFilter();
-        assertTrue(validator.validate(project).isEmpty());
+        // There should be no ERR/WARN messages
+        assertTrue(validator.validate(project).stream().allMatch(m -> TYPE_INFO.equals(m.getType())));
     }
 
     public void testNonMatchingFilter() throws Exception {

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -8885,6 +8885,12 @@ Alternatively, you will want to download &lt;strong&gt;Incremental Channel Conte
       <trans-unit id="clusters.nav.add" xml:space="preserve">
         <source>Add</source>
       </trans-unit>
+      <trans-unit id="contentmanagement.validation.selectedmodules">
+        <source>The following module streams will be enabled: {0}</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">com.redhat.rhn.domain.contentmgmt.validation.ModularDependencyValidator</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="contentmanagement.validation.modulenotfound" xml:space="preserve">
         <source>Module '{0}' not found.</source>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
@@ -729,11 +729,11 @@ public class ContentManager {
         // Resolve filters for dependencies
         try {
             DependencyResolver resolver = new DependencyResolver(env.getContentProject(), this.modulemdApi);
-            List<ContentFilter> resolvedFilters = resolver.resolveFilters(filters);
+            DependencyResolutionResult result = resolver.resolveFilters(filters);
 
             // align the contents
             newSrcTgtPairs.forEach(srcTgt ->
-                    alignEnvironmentTarget(srcTgt.getLeft(), srcTgt.getRight(), resolvedFilters, async, user));
+                    alignEnvironmentTarget(srcTgt.getLeft(), srcTgt.getRight(), result.getFilters(), async, user));
         }
         catch (DependencyResolutionException e) {
             // Build shouldn't be allowed if dependency resolution fails

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/DependencyResolutionResult.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/DependencyResolutionResult.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2020 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.manager.contentmgmt;
+
+import com.redhat.rhn.domain.contentmgmt.ContentFilter;
+import com.redhat.rhn.domain.contentmgmt.modulemd.Module;
+
+import java.util.List;
+
+/**
+ * Class to report the result of a modular dependency resolution
+ *
+ * Modular dependency resolution involves discovery of additional dependent modules and mutating a set of module filters
+ * into resolved package filters on-the-go. An instance of this class stores information on this process.
+ */
+public class DependencyResolutionResult {
+    private List<ContentFilter> filters;
+    private List<Module> modules;
+
+    /**
+     * Create an instance with a list of filters and a list of modules
+     * @param filtersIn the filter list
+     * @param modulesIn the module list
+     */
+    public DependencyResolutionResult(List<ContentFilter> filtersIn, List<Module> modulesIn) {
+        this.filters = filtersIn;
+        this.modules = modulesIn;
+    }
+
+    public List<ContentFilter> getFilters() {
+        return filters;
+    }
+
+    public List<Module> getModules() {
+        return modules;
+    }
+}

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/test/MockModulemdApi.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/test/MockModulemdApi.java
@@ -23,6 +23,7 @@ import com.redhat.rhn.domain.channel.Modules;
 import com.redhat.rhn.domain.channel.test.ChannelFactoryTest;
 import com.redhat.rhn.domain.contentmgmt.modulemd.ConflictingStreamsException;
 import com.redhat.rhn.domain.contentmgmt.modulemd.Module;
+import com.redhat.rhn.domain.contentmgmt.modulemd.ModuleInfo;
 import com.redhat.rhn.domain.contentmgmt.modulemd.ModuleNotFoundException;
 import com.redhat.rhn.domain.contentmgmt.modulemd.ModulePackagesResponse;
 import com.redhat.rhn.domain.contentmgmt.modulemd.ModuleStreams;
@@ -106,7 +107,11 @@ public class MockModulemdApi extends ModulemdApi {
             }
         }
 
-        return new ModulePackagesResponse(getRpmApis(selectedModules), getPackages(selectedModules), null);
+        return new ModulePackagesResponse(getRpmApis(selectedModules), getPackages(selectedModules),
+                selectedModules.stream()
+                        .map(m -> new ModuleInfo(m.getName(), m.getStream(), "1000000001", "6789abcd", "x86_64"))
+                        .collect(Collectors.toList())
+        );
     }
 
     /**

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Report resolved module dependencies on CLM project details page
 - Allow creating custom ULN repositories with uln:// urls
 - Change message "Minion is down" to be more accurate
 - Revert: Sync state modules when starting action chain execution (bsc#1177336)

--- a/web/html/src/manager/content-management/list-filters/list-filters.js
+++ b/web/html/src/manager/content-management/list-filters/list-filters.js
@@ -34,7 +34,7 @@ const ListFilters = (props: Props) => {
   }, [])
 
   const searchData = (row, criteria) => {
-    const keysToSearch = ['name'];
+    const keysToSearch = ['filter_name'];
     if (criteria) {
       return keysToSearch.map(key => row[key]).join().toLowerCase().includes(criteria.toLowerCase());
     }
@@ -67,7 +67,7 @@ const ListFilters = (props: Props) => {
         searchField={(
           <SearchField
             filter={searchData}
-            placeholder={t('Filter by any value')}
+            placeholder={t('Filter by name')}
           />
         )}
       >

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Fix the search panel in CLM filters page
 - Localize documentation links
 - Don't allow selecting spice for Xen PV and PVH guests
 - Allow creating a VM on Salt host using a cobbler profile


### PR DESCRIPTION
In the current implementation, there is no indication of whether additional modules are enabled as dependencies. This PR adds a message to the filters pane on the CLM project page to display the actual list of enabled modules, including any dependencies.

Port of: https://github.com/SUSE/spacewalk/pull/13037

## GUI diff

Before:
![clm-module-msg-before](https://user-images.githubusercontent.com/1103552/98392721-a016ed00-2058-11eb-8919-d9b4c6f692cc.png)

After:
![clm-module-msg-after](https://user-images.githubusercontent.com/1103552/98392718-9f7e5680-2058-11eb-8782-eec54580f33a.png)

## Documentation
- No documentation needed: no change in functionality

## Test coverage
- Unit tests were added

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
