### PR TITLE
Testsuite: Use an xml available in the centos minion

### DIFF
--- a/testsuite/features/secondary/min_centos_openscap_audit.feature
+++ b/testsuite/features/secondary/min_centos_openscap_audit.feature
@@ -19,7 +19,7 @@ Feature: openSCAP audit of CentOS Salt minion
     When I follow "Audit" in the content area
     And I follow "Schedule" in the content area
     And I enter "--profile standard" as "params"
-    And I enter "/usr/share/xml/scap/ssg/content/ssg-centos7-xccdf.xml" as "path"
+    And I enter "/usr/share/xml/scap/ssg/content/ssg-rhel7-xccdf.xml" as "path"
     And I click on "Schedule"
     Then I should see a "XCCDF scan has been scheduled" text
     And I wait at most 500 seconds until event "OpenSCAP xccdf scanning" is completed


### PR DESCRIPTION
## What does this PR change?
Use an XML that is available in the CentOS minion for the openscap scan.

## Links
### Ports
- Manager-4.0:  https://github.com/SUSE/spacewalk/pull/13121
- Manager-4.1: https://github.com/SUSE/spacewalk/pull/13120
## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)
