### PR TITLE
Testsuite: Also use an available xml for trad/qam centos tests

### DIFF
--- a/testsuite/features/qam/init_clients/ceos7_client.feature
+++ b/testsuite/features/qam/init_clients/ceos7_client.feature
@@ -33,7 +33,7 @@ Feature: Be able to register a CentOS 7 traditional client and do some basic ope
     When I follow "Audit" in the content area
     And I follow "Schedule" in the content area
     And I enter "--profile standard" as "params"
-    And I enter "/usr/share/xml/scap/ssg/content/ssg-centos7-xccdf.xml" as "path"
+    And I enter "/usr/share/xml/scap/ssg/content/ssg-rhel7-xccdf.xml" as "path"
     And I click on "Schedule"
     And I run "rhn_check -vvv" on "ceos7_client"
     Then I should see a "XCCDF scan has been scheduled" text

--- a/testsuite/features/secondary/trad_centos_client.feature
+++ b/testsuite/features/secondary/trad_centos_client.feature
@@ -65,7 +65,7 @@ Feature: Be able to register a CentOS 7 traditional client and do some basic ope
     When I follow "Audit" in the content area
     And I follow "Schedule" in the content area
     And I enter "--profile standard" as "params"
-    And I enter "/usr/share/xml/scap/ssg/content/ssg-centos7-xccdf.xml" as "path"
+    And I enter "/usr/share/xml/scap/ssg/content/ssg-rhel7-xccdf.xml" as "path"
     And I click on "Schedule"
     And I run "rhn_check -vvv" on "ceos_client"
     Then I should see a "XCCDF scan has been scheduled" text


### PR DESCRIPTION
## What does this PR change?
Also use an available xml for trad/qam centos tests

- testsuite/features/secondary/trad_centos_client.feature
- testsuite/features/qam/init_clients/ceos7_client.feature

## Links
No ports needed
It completes: https://github.com/uyuni-project/uyuni/pull/2848

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

