### PR TITLE
Add dnf-plugin-spacewalk Spanish gettext catalog

### DIFF
--- a/client/rhel/dnf-plugin-spacewalk/po/es.po
+++ b/client/rhel/dnf-plugin-spacewalk/po/es.po
@@ -1,0 +1,71 @@
+# Spanish translations for PACKAGE package.
+# Copyright (C) 2020 THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# Automatically generated, 2020.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-11-05 13:12+0100\n"
+"PO-Revision-Date: 2020-11-05 13:12+0100\n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=ASCII\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: ../spacewalk.py:41
+msgid "Spacewalk based repositories will be disabled."
+msgstr ""
+
+#: ../spacewalk.py:42
+msgid "Spacewalk channel support will be disabled."
+msgstr ""
+
+#: ../spacewalk.py:43
+msgid "There was an error communicating with Spacewalk server."
+msgstr ""
+
+#: ../spacewalk.py:44
+msgid "This system is not registered with Spacewalk server."
+msgstr ""
+
+#: ../spacewalk.py:45
+msgid "This system is not subscribed to any channels."
+msgstr ""
+
+#: ../spacewalk.py:46
+msgid "SystemId could not be acquired."
+msgstr ""
+
+#: ../spacewalk.py:47
+msgid "You can use rhn_register to register."
+msgstr ""
+
+#: ../spacewalk.py:48
+msgid "This system is receiving updates from Spacewalk server."
+msgstr ""
+
+#: ../spacewalk.py:49
+#, python-format
+msgid ""
+"For security reasons packages from Spacewalk based repositories can be "
+"verified only with locally installed gpg keys. GPG key '%s' has been "
+"rejected."
+msgstr ""
+
+#: ../spacewalk.py:50
+msgid "Package profile information could not be sent."
+msgstr ""
+
+#: ../spacewalk.py:51
+#, python-format
+msgid "Missing required login information for Spacewalk: %s"
+msgstr ""
+
+#: ../spacewalk.py:52
+msgid "Spacewalk plugin has to be run under with the root privileges."
+msgstr ""


### PR DESCRIPTION
## What does this PR change?

WebLate will not allow me to create the component unless there is at least one .po file for one translation. Weird.

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed:

- [x] **DONE**

## Test coverage
- No tests are needed

- [x] **DONE**

## Links

Fixes spacewalk #12238

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
