### PR TITLE
Perl term completion

### DIFF
--- a/spec-tree/perl-Term-Completion/perl-Term-Completion.spec
+++ b/spec-tree/perl-Term-Completion/perl-Term-Completion.spec
@@ -1,7 +1,8 @@
 Name:       perl-Term-Completion 
 Version:    1.00
-Release:    9%{?dist}.5
+Release:    9%{?dist}.6
 License:    GPL+ or Artistic 
+Group:      Development/Libraries
 Summary:    Read one line of user input, with convenience functions 
 Source:     https://search.cpan.org/CPAN/authors/id/M/MA/MAREKR/Term-Completion-%{version}.tar.gz 
 Url:        https://search.cpan.org/dist/Term-Completion
@@ -25,7 +26,7 @@ BuildRequires: perl(Term::ReadKey) >= 2.3
 BuildRequires: perl(Term::Size)
 BuildRequires: perl(Test::More)
 BuildRequires: perl(warnings)
-
+Provides:      perl(Term::Completion::Path)
 Patch0:    space-handling.patch
 
 %{?perl_default_filter}
@@ -67,8 +68,14 @@ make test
 %{_mandir}/man3/*.3*
 
 %changelog
+* Thu Nov 05 2020 Stefan Bluhm <stefan.bluhm@clacee.eu> 1.00-9.6
+- Added explicit perl(Term::Completion::Path) provision.
+
 * Fri Feb 21 2020 Stefan Bluhm <stefan.bluhm@clacee.eu> 1.00-9.5
 - Updated source URLs to https.
+
+* Sat Feb 10 2018 mcalmer <mcalmer@suse.com> 1.00-9.4
+- Revert removed Group from specfile
 
 * Fri Feb 09 2018 Michael Mraka <michael.mraka@redhat.com> 1.00-9.4
 - removed Group from specfile

--- a/spec-tree/perl-Term-Completion/perl-Term-Completion.spec
+++ b/spec-tree/perl-Term-Completion/perl-Term-Completion.spec
@@ -1,11 +1,10 @@
 Name:       perl-Term-Completion 
 Version:    1.00
-Release:    9%{?dist}.4
+Release:    9%{?dist}.5
 License:    GPL+ or Artistic 
-Group:      Development/Libraries
 Summary:    Read one line of user input, with convenience functions 
-Source:     http://search.cpan.org/CPAN/authors/id/M/MA/MAREKR/Term-Completion-%{version}.tar.gz 
-Url:        http://search.cpan.org/dist/Term-Completion
+Source:     https://search.cpan.org/CPAN/authors/id/M/MA/MAREKR/Term-Completion-%{version}.tar.gz 
+Url:        https://search.cpan.org/dist/Term-Completion
 Requires:   perl(:MODULE_COMPAT_%(eval "`perl -V:version`"; echo $version))
 BuildArch:  noarch
 %if 0%{?fedora} && 0%{?fedora} > 26
@@ -68,6 +67,9 @@ make test
 %{_mandir}/man3/*.3*
 
 %changelog
+* Fri Feb 21 2020 Stefan Bluhm <stefan.bluhm@clacee.eu> 1.00-9.5
+- Updated source URLs to https.
+
 * Fri Feb 09 2018 Michael Mraka <michael.mraka@redhat.com> 1.00-9.4
 - removed Group from specfile
 


### PR DESCRIPTION
## What does this PR change?

- Added latest Spacewalk Project changes (updates URLs to https)
- Added explicit perl(Term::Completion::Path) provision. 
- Re-added and documented chagnes from 2018-02-10.

## GUI diff

No difference.

Before:

After:

- [X] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [X] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
