### PR TITLE
Perl mail rfc822 address: Integrated Spacewalk Project changes.

### DIFF
--- a/spec-tree/perl-Mail-RFC822-Address/perl-Mail-RFC822-Address.spec
+++ b/spec-tree/perl-Mail-RFC822-Address/perl-Mail-RFC822-Address.spec
@@ -4,7 +4,9 @@ Version: 0.3
 Release: 17%{?dist}
 Summary: Mail-RFC822-Address Perl module
 License: distributable
+Group: Development/Libraries
 URL: http://search.cpan.org/search?mode=module&query=Mail%3a%3aRFC822%3a%3aAddress
+BuildRoot: %{_tmppath}/%{name}-root
 Buildarch: noarch
 %if 0%{?fedora} && 0%{?fedora} > 26
 BuildRequires:	perl-interpreter
@@ -68,6 +70,10 @@ fi
 * Mon May 25 2020 Stefan Bluhm <stefan.bluhm@clacee.eu> 0.3-16
 - Added source URL
 - Comment to build on RHEL8
+
+* Sat Feb 10 2018 mcalmer <mcalmer@suse.com> 0.3-15
+- revert removed Group from specfile
+- revert removed BuildRoot from specfiles
 
 * Fri Feb 09 2018 Michael Mraka <michael.mraka@redhat.com> 0.3-15
 - remove install/clean section initial cleanup

--- a/spec-tree/perl-Mail-RFC822-Address/perl-Mail-RFC822-Address.spec
+++ b/spec-tree/perl-Mail-RFC822-Address/perl-Mail-RFC822-Address.spec
@@ -1,12 +1,10 @@
 %{!?perlgen:%global perlgen 5.8}
 Name: perl-Mail-RFC822-Address
 Version: 0.3
-Release: 15%{?dist}
+Release: 17%{?dist}
 Summary: Mail-RFC822-Address Perl module
 License: distributable
-Group: Development/Libraries
 URL: http://search.cpan.org/search?mode=module&query=Mail%3a%3aRFC822%3a%3aAddress
-BuildRoot: %{_tmppath}/%{name}-root
 Buildarch: noarch
 %if 0%{?fedora} && 0%{?fedora} > 26
 BuildRequires:	perl-interpreter
@@ -19,10 +17,7 @@ BuildRequires:  perl(Data::Dumper)
 %endif
 
 
-Requires: %(perl -MConfig -le 'if (defined $Config{useithreads}) { print "perl(:WITH_ITHREADS)" } else { print "perl(:WITHOUT_ITHREADS)" }')
-Requires: %(perl -MConfig -le 'if (defined $Config{usethreads}) { print "perl(:WITH_THREADS)" } else { print "perl(:WITHOUT_THREADS)" }')
-Requires: %(perl -MConfig -le 'if (defined $Config{uselargefiles}) { print "perl(:WITH_LARGEFILES)" } else { print "perl(:WITHOUT_LARGEFILES)" }')
-Source0: Mail-RFC822-Address-0.3.tar.gz
+Source0:  https://cpan.metacpan.org/authors/id/P/PD/PDWARREN/Mail-RFC822-Address-0.3.tar.gz
 
 %description
 Mail-RFC822-Address Perl module
@@ -66,6 +61,14 @@ fi
 %files -f Mail-RFC822-Address-%{version}-filelist
 
 %changelog
+* Mon May 25 2020 Michael Mraka <michael.mraka@redhat.com> 0.3-17
+- removed unnecessary dynamic requires to make it build on Fedora/RHEL without
+  preinstalled perl
+
+* Mon May 25 2020 Stefan Bluhm <stefan.bluhm@clacee.eu> 0.3-16
+- Added source URL
+- Comment to build on RHEL8
+
 * Fri Feb 09 2018 Michael Mraka <michael.mraka@redhat.com> 0.3-15
 - remove install/clean section initial cleanup
 - removed Group from specfile


### PR DESCRIPTION
## What does this PR change?

- Added latest Spacewalk Project changes for perl-Mail-RFC822-Address. (Updated source URL and removed per Perl build requirement).
- Re-added and documented reverted changes from 2018-02-10.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [X] **DONE**

## Test coverage
- No tests: Automatic test on build.

- [X] **DONE**

## Links

Upstream # https://github.com/spacewalkproject/spacewalk/tree/master/spec-tree/perl-Mail-RFC822-Address

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
