### PR TITLE
Do not raise TypeError when changing base channel during trad registration (bsc#1178704)

### DIFF
--- a/backend/server/rhnChannel.py
+++ b/backend/server/rhnChannel.py
@@ -1891,6 +1891,13 @@ class LiteServer:
     def get_suse_products(self):
         return self.suse_products
 
+    def add_suse_products(self, suse_products):
+        log_debug(1, suse_products)
+        if isinstance(suse_products, dict):
+            self.suse_products = suse_products['products']
+        elif isinstance(suse_products, list):
+            self.suse_products = suse_products
+
     def __repr__(self):
         dict = {}
         for attr in self._attributes:

--- a/backend/server/rhnServer/server_class.py
+++ b/backend/server/rhnServer/server_class.py
@@ -216,7 +216,7 @@ class Server(ServerWrapper):
         s.release = new_rel
         s.arch = self.archname
         if suse_products:
-            s.suse_products = suse_products
+            s.add_suse_products(suse_products)
         # Let get_server_channels deal with the errors and raise rhnFault
         target_channels = rhnChannel.guess_channels_for_server(s, none_ok=True)
         if target_channels:

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,5 @@
+- Do not raise TypeError when processing SUSE products (bsc#1178704)
+
 -------------------------------------------------------------------
 Wed Nov 25 12:19:21 CET 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue happening during a re-registration of a traditional client, caused by a wrong handling of "suse products" by `server.change_base_channel` function. We know that this happens on the context of re-registering a SUSE Manager Proxy that was previously 3.2 and now is 4.1.

```console
Exception Handler Information
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/spacewalk/server/apacheRequest.py", line 135, in call_function
    response = func(*params)
  File "/usr/share/rhn/server/handlers/xmlrpc/registration.py", line 528, in new_system
    architecture, data)
  File "/usr/share/rhn/server/handlers/xmlrpc/registration.py", line 324, in create_system
    newserv.change_base_channel(release, suse_products=suse_products) 
  File "/usr/lib/python3.6/site-packages/spacewalk/server/rhnServer/server_class.py", line 221, in change_base_channel
    target_channels = rhnChannel.guess_channels_for_server(s, none_ok=True)
  File "/usr/lib/python3.6/site-packages/spacewalk/server/rhnChannel.py", line 1974, in guess_channels_for_server
    suse_channels = guess_suse_channels_for_server(server, server.org_id, user_id, raise_exceptions)
  File "/usr/lib/python3.6/site-packages/spacewalk/server/rhnChannel.py", line 1910, in guess_suse_channels_for_server
    if product['baseproduct'] == 'Y':
TypeError: string indices must be integers
```

It seems that some of the latest changes we introduced on the structure and way of handling `server.suse_products` could be causing this issue:

```pprint
server/rhnChannel.guess_channels_for_server(<LiteServer instance at 140481237063664: attributes={'id': 1000011650, 'org_id': 1, 'release': '4.1', 'arch': 'x86_64', 'suse_products': {'guid': 'c38af82bb2bb4f6ab366cd273c7fff75', 'secret': '6d374b2ad0a24a4bb1ca29a610a6636a', 'ostarget': 'sle-15-x86_64', 'products': [{'name': 'SUSE-Manager-Proxy', 'version': '4.1', 'release': '0', 'arch': 'x86_64', 'baseproduct': 'Y'}, {'name': 'sle-module-basesystem', 'version': '15.2', 'release': '0', 'arch': 'x86_64', 'baseproduct': 'N'}, {'name': 'sle-module-server-applications', 'version': '15.2', 'release': '0', 'arch': 'x86_64', 'baseproduct': 'N'}, {'name': 'sle-module-python2', 'version': '15.2', 'release': '0', 'arch': 'x86_64', 'baseproduct': 'N'}, {'name': 'sle-module-web-scripting', 'version': '15.2', 'release': '0', 'arch': 'x86_64', 'baseproduct': 'N'}, {'name': 'sle-module-suse-manager-proxy', 'version': '4.1', 'release': '0', 'arch': 'x86_64', 'baseproduct': 'N'}]}}>,)
```

As we can see above, in this context, `suse_products` is not a list of dicts, but just the old dict which we would need to resolve accesing the `products` attribute where the actual content is stored.

This PR ensure we call `server.add_suse_products` to properly parse and set the suse products regardless if this is a dict or a list of dicts.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- No tests: **bugfix**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/13094

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
