### PR TITLE
Fix mandatory channels JS API to finish loading in case of error (bsc#1178839)

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/product/SUSEProductFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/product/SUSEProductFactory.java
@@ -40,6 +40,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -278,7 +279,8 @@ public class SUSEProductFactory extends HibernateFactory {
             Channel baseChannel = Optional.ofNullable(channel.getParentChannel()).orElse(channel);
 
             SUSEProductChannel baseProductChannel = findSyncProductChannelByLabel(baseChannel.getLabel())
-                    .orElseThrow(() -> new IllegalStateException("No product channel found for " + baseChannel));
+                    .orElseThrow(() -> new NoSuchElementException("No product channel found for " + baseChannel +
+                            " of " + channel));
             Stream<SUSEProductChannel> suseProductChannelStream = findSyncedMandatoryChannels(
                         suseProductChannel.getProduct(),
                         baseProductChannel.getProduct(),

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Update exception message in findSyncedMandatoryChannels
+
 -------------------------------------------------------------------
 Wed Nov 25 12:22:07 CET 2020 - jgonzalez@suse.com
 

--- a/web/html/src/core/channels/api/use-mandatory-channels-api.js
+++ b/web/html/src/core/channels/api/use-mandatory-channels-api.js
@@ -55,12 +55,10 @@ const useMandatoryChannelsApi = () : UseMandatoryChannelsApiReturnType => {
           setMandatoryChannelsRaw(allTheNewMandatoryChannelsData);
           setRequiredChannels(dependencies.requiredChannels);
           setRequiredByChannels(dependencies.requiredByChannels);
-          setIsDependencyDataLoaded(true);
-        })
-        .catch((jqXHR: Object, arg: string = '') => {
+        }).catch((jqXHR: Object, arg: string = '') => {
           const msg = Network.responseErrorMessage(jqXHR, (status, msg) => msgMap[msg] ? t(msgMap[msg], arg) : null);
           setMessages(messages.concat(msg))
-        });
+        }).finally(() => setIsDependencyDataLoaded(true));
     } else {
       setIsDependencyDataLoaded(true);
     }

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Fix mandatory channels JS API to finish loading in case of error (bsc#1178839)
 - Allow specifying both name and label of new Content Environment (bsc#1176411)
 
 -------------------------------------------------------------------


### PR DESCRIPTION
CLM "add sources" panel is stuck with "Loading" when the mandatory channels API returns an error. This should not prevent users from working with CLM. This change fixes the API to go out of loading state when the request finishes with any result.

https://bugzilla.suse.com/1178839

Port of https://github.com/SUSE/spacewalk/pull/13150

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
