### PR TITLE
Sanity tests for new location of Docker profiles

### DIFF
--- a/testsuite/features/core/allcli_sanity.feature
+++ b/testsuite/features/core/allcli_sanity.feature
@@ -66,8 +66,7 @@ Feature: Sanity checks
   Scenario: The external resources can be reached
     Then it should be possible to reach the test packages
     And it should be possible to reach the build sources
-    And it should be possible to reach the container profiles
-    And it should be possible to reach the test suite profiles
+    And it should be possible to reach the Docker profiles
 
 @server_http_proxy
   Scenario: The HTTP proxy is working

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -50,18 +50,11 @@ Then(/^it should be possible to reach the build sources$/) do
   end
 end
 
-Then(/^it should be possible to reach the container profiles$/) do
-  if $product == 'Uyuni'
-    # TODO: move that resource to next location ("test suite profiles")
-    STDERR.puts 'Sanity check not implemented, move resource to external network first'
-  else
-    url = 'https://gitlab.suse.de/galaxy/suse-manager-containers/blob/master/test-profile/Dockerfile'
-    $server.run("curl --insecure --location #{url} --output /dev/null")
-  end
-end
-
-Then(/^it should be possible to reach the test suite profiles$/) do
-  url = 'https://github.com/uyuni-project/uyuni/blob/master/testsuite/features/profiles/Docker/Dockerfile'
+Then(/^it should be possible to reach the Docker profiles$/) do
+  git_profiles = ENV['GITPROFILES']
+  url = git_profiles.sub(/github\.com/, "raw.githubusercontent.com")
+                    .sub(/\.git#:/, "/master/")
+                    .sub(/$/, "/Docker/Dockerfile")
   $server.run("curl --insecure --location #{url} --output /dev/null")
 end
 


### PR DESCRIPTION
## What does this PR change?

Use new locations for Docker profiles after refactoring by @mcalmer (internal NUE, internal PRV, ..).

## Links

Fixes #13148

Ports:
* 4.0: SUSE/spacewalk#13157
* 4.1: SUSE/spacewalk#13156

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
