### PR TITLE
Move internal registry to registry.mgr.prv.suse.net

### DIFF
--- a/testsuite/features/profiles/Makefile
+++ b/testsuite/features/profiles/Makefile
@@ -9,8 +9,8 @@ REGISTRY_PLACEHOLDER_AUTH   = portus.mgr.suse.de:5000
 ENVIRONMENTS                = internal_nue internal_prv
 REG_REPLACEMENT_NUE_NOAUTH  = registry.mgr.suse.de
 REG_REPLACEMENT_NUE_AUTH    = portus.mgr.suse.de:5000
-REG_REPLACEMENT_PRV_NOAUTH  = minima-mirror.mgr.prv.suse.net
-REG_REPLACEMENT_PRV_AUTH    = minima-mirror.mgr.prv.suse.net:5000
+REG_REPLACEMENT_PRV_NOAUTH  = registry.mgr.prv.suse.net
+REG_REPLACEMENT_PRV_AUTH    = registry.mgr.prv.suse.net:5000
 
 update: $(ENVIRONMENTS)
 

--- a/testsuite/features/profiles/internal_prv/Docker/Dockerfile
+++ b/testsuite/features/profiles/internal_prv/Docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM minima-mirror.mgr.prv.suse.net/toaster-sles12sp3-products
+FROM registry.mgr.prv.suse.net/toaster-sles12sp3-products
 MAINTAINER Admin User "noemail@example.com"
 
 ARG repo

--- a/testsuite/features/profiles/internal_prv/Docker/authprofile/Dockerfile
+++ b/testsuite/features/profiles/internal_prv/Docker/authprofile/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION               1.0.0
 
-FROM minima-mirror.mgr.prv.suse.net:5000/cucutest/suma-head-testsuite
+FROM registry.mgr.prv.suse.net:5000/cucutest/suma-head-testsuite
 MAINTAINER Michael Calmer "mc@suse.com"
 
 ARG repo

--- a/testsuite/features/profiles/internal_prv/Docker/serverhost/Dockerfile
+++ b/testsuite/features/profiles/internal_prv/Docker/serverhost/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION               1.0.0
 
-FROM minima-mirror.mgr.prv.suse.net/suma-head-testsuite
+FROM registry.mgr.prv.suse.net/suma-head-testsuite
 MAINTAINER Michael Calmer "mc@suse.com"
 
 ARG repo


### PR DESCRIPTION
## What does this PR change?

We are moving the internal docker registry to a new vm

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed: internal infrastructure

- [ ] **DONE**

## Test coverage
- No tests: we need to see that tests still pass

- [ ] **DONE**

## Links

Fixes #
Tracks # https://github.com/SUSE/spacewalk/issues/13060

- [ ] **DONE**

## Changelogs

- [X] No changelog needed



## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
