### PR TITLE
Fix: sync before start action chains (bsc#1177336) 

### DIFF
--- a/susemanager-utils/susemanager-sls/src/modules/mgractionchains.py
+++ b/susemanager-utils/susemanager-sls/src/modules/mgractionchains.py
@@ -122,6 +122,11 @@ def start(actionchain_id):
     target_sls = _calculate_sls(actionchain_id, __grains__['machine_id'], 1)
     log.debug("Starting execution of SUSE Manager Action Chains ID "
               "'{0}' -> Target SLS: {1}".format(actionchain_id, target_sls))
+    try:
+        __salt__['saltutil.sync_states']()
+        __salt__['saltutil.sync_modules']()
+    except Exception as exc:
+        log.error("There was an error while syncing custom states and execution modules")
     ret = __salt__['state.sls'](target_sls, queue=True)
     if isinstance(ret, list):
         raise CommandExecutionError(ret)
@@ -186,5 +191,3 @@ def clean():
     '''
     _read_next_ac_chunk()
     return {"success": True}
-
-

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Fix: sync before start action chains (bsc#1177336)
 - Revert: Sync state modules when starting action chain execution (bsc#1177336)
 - Sync state modules when starting action chain execution (bsc#1177336)
 - Handle group- and org-specific image pillars


### PR DESCRIPTION
## What does this PR change?

Calls saltutil.sync_{modules,states} before starting action chains

## GUI diff

No difference.

- [X] **DONE**

## Test coverage
- No tests: already tested
- [X] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/12682

- [X] **DONE**

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
