### PR TITLE
Testsuite: Fix srv_content_lifecycle tests

### DIFF
--- a/testsuite/features/secondary/srv_content_lifecycle.feature
+++ b/testsuite/features/secondary/srv_content_lifecycle.feature
@@ -93,9 +93,8 @@ Feature: Content lifecycle
     Then I should see a "Version 1 history" text
     When I enter "test version message 1" as "message"
     And I click the environment build button
-    And I wait until I see "Version 1 successfully built into dev_name" text
-    Then I should see a "Version 1: test version message 1" text
-    And I wait at most 600 seconds until I see "Built" text
+    And I wait until I see "Version 1: test version message 1" text in the environment "dev_name"
+    And I wait at most 600 seconds until I see "Built" text in the environment "dev_name"
 
 @susemanager
   Scenario: Build the sources in the project for SUSE Manager
@@ -107,9 +106,8 @@ Feature: Content lifecycle
     Then I should see a "Version 1 history" text
     When I enter "test version message 1" as "message"
     And I click the environment build button
-    And I wait until I see "Version 1 successfully built into dev_name" text
-    Then I should see a "Version 1: test version message 1" text
-    And I wait at most 600 seconds until I see "Built" text
+    And I wait until I see "Version 1: test version message 1" text in the environment "dev_name"
+    And I wait at most 600 seconds until I see "Built" text in the environment "dev_name"
 
   Scenario: Promote promote the sources in the project
     Given I am authorized as "admin" with password "admin"
@@ -121,11 +119,13 @@ Feature: Content lifecycle
     Then I should see a "qa_desc" text in the environment "qa_name"
     And I should see a "not built" text in the environment "qa_name"
     When I click promote from Development to QA
+    Then I should see a "Version 1: test version message 1" text
     And I click on "Promote environment" in "Promote version 1 into qa_name" modal
-    Then I wait until I see "Version 1: test version message 1" text in the environment "qa_name"
+    Then I wait until I see "Built" text in the environment "qa_name"
     When I click promote from QA to Production
+    Then I should see a "Version 1: test version message 1" text
     And I click on "Promote environment" in "Promote version 1 into prod_name" modal
-    Then I wait until I see "Version 1: test version message 1" text in the environment "prod_name"
+    Then I wait until I see "Built" text in the environment "prod_name"
 
   Scenario: Add new sources and promote again
     Given I am authorized as "admin" with password "admin"
@@ -142,13 +142,16 @@ Feature: Content lifecycle
     Then I wait until I see "Version 2 history" text
     When I enter "test version message 2" as "message"
     And I click the environment build button
-    Then I wait until I see "Version 2: test version message 2" text
+    Then I wait until I see "Version 2: test version message 2" text in the environment "dev_name"
+    And I wait until I see "Built" text in the environment "dev_name"
     When I click promote from Development to QA
+    Then I should see a "Version 2: test version message 2" text
     And I click on "Promote environment" in "Promote version 2 into qa_name" modal
-    Then I wait until I see "Version 2: test version message 2" text in the environment "qa_name"
+    Then I wait until I see "Built" text in the environment "qa_name"
     When I click promote from QA to Production
+    Then I should see a "Version 2: test version message 2" text
     And I click on "Promote environment" in "Promote version 2 into prod_name" modal
-    Then I wait until I see "Version 2: test version message 2" text in the environment "prod_name"
+    Then I wait until I see "Built" text in the environment "prod_name"
 
   Scenario: Clean up the Content Lifecycle Management feature
     Given I am authorized as "admin" with password "admin"

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -1187,20 +1187,26 @@ end
 
 # content lifecycle steps
 When(/^I click the environment build button$/) do
-  raise "Click on environment build failed" unless find(:xpath, '//*[@id="cm-build-modal-save-button"]').click
+  raise 'Click on environment build failed' unless find_button('cm-build-modal-save-button', disabled: false, wait: DEFAULT_TIMEOUT).click
 end
 
 When(/^I click promote from Development to QA$/) do
-  raise "Click on promote from Development failed" unless find(:xpath, '//*[@id="dev_name-promote-modal-link"]').click
+  raise 'Click on promote from Development failed' unless find_button('dev_name-promote-modal-link', disabled: false, wait: DEFAULT_TIMEOUT).click
 end
 
 When(/^I click promote from QA to Production$/) do
-  raise "Click on promote from QA failed" unless find(:xpath, '//*[@id="qa_name-promote-modal-link"]').click
+  raise 'Click on promote from QA failed' unless find_button('qa_name-promote-modal-link', disabled: false, wait: DEFAULT_TIMEOUT).click
 end
 
 Then(/^I should see a "([^"]*)" text in the environment "([^"]*)"$/) do |text, env|
   within(:xpath, "//h3[text()='#{env}']/../..") do
     raise "Text \"#{text}\" not found" unless has_content?(text)
+  end
+end
+
+When(/^I wait at most (\d+) seconds until I see "([^"]*)" text in the environment "([^"]*)"$/) do |seconds, text, env|
+  within(:xpath, "//h3[text()='#{env}']/../..") do
+    step %(I wait at most #{seconds} seconds until I see "#{text}" text)
   end
 end
 


### PR DESCRIPTION
## What does this PR change?
Fix errors at srv_content_lifecycle tests about unclickable buttons.

Search for the text messages in the specific environment where
they appear.
Wait until a target button is enabled before to click it.

- testsuite/features/secondary/srv_content_lifecycle.feature:
Ensure we search for the expected text in the right environment.

- testsuite/features/step_definitions/common_steps.rb:
Add step to wait a custom number of seconds until a target string
shows up in the target envitonment.


## Links
### Ports:
- Manager-4.1: https://github.com/SUSE/spacewalk/pull/13168
- Manager-4.0: https://github.com/SUSE/spacewalk/pull/13167

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)
