### PR TITLE
Support debian  add product data

### DIFF
--- a/susemanager-sync-data/additional_products.json
+++ b/susemanager-sync-data/additional_products.json
@@ -1,5 +1,119 @@
 [
     {
+        "id" : -20,
+        "name" : "Debian 10",
+        "identifier" : "Debian-Client",
+        "former_identifier" : "",
+        "version" : "10",
+        "release_type" : null,
+        "arch" : "amd64",
+        "friendly_name" : "Debian 10",
+        "product_class" : "SLE-M-T",
+        "cpe" : null,
+        "free" : false,
+        "description" : null,
+        "release_stage" : "alpha",
+        "eula_url" : "",
+        "product_type" : "base",
+        "offline_predecessor_ids" : [
+        ],
+        "online_predecessor_ids" : [
+        ],
+        "shortname" : null,
+        "recommended" : false,
+        "extensions" : [
+        ],
+        "repositories" : [
+            {
+                "id" : -217,
+                "url" : "http://deb.debian.org/debian/dists/buster/main/binary-amd64/",
+                "name" : "debian-10-pool",
+                "distro_target" : "amd64",
+                "description" : "Debian 10 (buster) pool for amd64",
+                "enabled" : true,
+                "autorefresh" : false,
+                "installer_updates" : false
+            },
+            {
+                "id" : -218,
+                "url" : "http://deb.debian.org/debian/dists/buster-updates/main/binary-amd64/",
+                "name" : "debian-10-main-updates",
+                "distro_target" : "amd64",
+                "description" : "Debian 10 (buster) AMD64 Main Updates",
+                "enabled" : true,
+                "autorefresh" : false,
+                "installer_updates" : false
+            },
+            {
+                "id" : -219,
+                "url" : "http://security-cdn.debian.org/debian-security/dists/buster/updates/main/binary-amd64/",
+                "name" : "debian-10-main-security",
+                "distro_target" : "amd64",
+                "description" : "Debian 10 (buster) AMD64 Main Security",
+                "enabled" : false,
+                "autorefresh" : false,
+                "installer_updates" : false
+            }
+        ]
+    },
+    {
+        "id" : -19,
+        "name" : "Debian 9",
+        "identifier" : "Debian-Client",
+        "former_identifier" : "",
+        "version" : "9",
+        "release_type" : null,
+        "arch" : "amd64",
+        "friendly_name" : "Debian 9",
+        "product_class" : "SLE-M-T",
+        "cpe" : null,
+        "free" : false,
+        "description" : null,
+        "release_stage" : "alpha",
+        "eula_url" : "",
+        "product_type" : "base",
+        "offline_predecessor_ids" : [
+        ],
+        "online_predecessor_ids" : [
+        ],
+        "shortname" : null,
+        "recommended" : false,
+        "extensions" : [
+        ],
+        "repositories" : [
+            {
+                "id" : -214,
+                "url" : "http://deb.debian.org/debian/dists/stretch/main/binary-amd64/",
+                "name" : "debian-9-pool",
+                "distro_target" : "amd64",
+                "description" : "Debian 9 (stretch) pool for amd64",
+                "enabled" : true,
+                "autorefresh" : false,
+                "installer_updates" : false
+            },
+            {
+                "id" : -215,
+                "url" : "http://deb.debian.org/debian/dists/stretch-updates/main/binary-amd64/",
+                "name" : "debian-9-main-updates",
+                "distro_target" : "amd64",
+                "description" : "Debian 9 (stretch) AMD64 Main Updates",
+                "enabled" : true,
+                "autorefresh" : false,
+                "installer_updates" : false
+            },
+            {
+                "id" : -216,
+                "url" : "http://security-cdn.debian.org/debian-security/dists/stretch/updates/main/binary-amd64/",
+                "name" : "debian-9-main-security",
+                "distro_target" : "amd64",
+                "description" : "Debian 9 (stretch) AMD64 Main Security",
+                "enabled" : false,
+                "autorefresh" : false,
+                "installer_updates" : false
+            }
+        ]
+    },
+    {
         "id" : -18,
         "name" : "Ubuntu 20.04",
         "identifier" : "Ubuntu-Client",

--- a/susemanager-sync-data/susemanager-sync-data.changes
+++ b/susemanager-sync-data/susemanager-sync-data.changes
@@ -1,3 +1,5 @@
+- add product definitions for Debain 9 AMD64 and Debian 10 AMD64
+
 -------------------------------------------------------------------
 Wed Nov 25 12:33:21 CET 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Add product definitions for Debian 9 AMD64 and Debian 10 AMD64

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **Issue already exists**

- [x] **DONE**

## Test coverage
- No tests: **just data**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/12497
Tracks https://github.com/SUSE/spacewalk/pull/13181

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
