### PR TITLE
Fix py3 proxy package manager

### DIFF
--- a/proxy/proxy/pm/rhn_package_manager.py
+++ b/proxy/proxy/pm/rhn_package_manager.py
@@ -63,7 +63,7 @@ PREFIX = 'rhn'
 def main():
     # Initialize a command-line processing object with a table of options
     optionsTable = [
-        Option('-v', '--verbose',   action='count',      help='Increase verbosity'),
+        Option('-v', '--verbose',   action='count',      help='Increase verbosity', default=1),
         Option('-d', '--dir',       action='store',      help='Process packages from this directory'),
         Option('-L', '--cache-locally', action='store_true',
                help='Locally cache packages so that Proxy will not ever need to '

--- a/proxy/proxy/pm/rhn_package_manager.py
+++ b/proxy/proxy/pm/rhn_package_manager.py
@@ -221,7 +221,7 @@ class UploadClass(uploadLib.UploadClass):
         for hash_dir in uploadLib.listdir(os.path.join(export_dir, "rpms")):
             for rpm in uploadLib.listdir(hash_dir):
                 # rpm name minus '.rpm'
-                if os.path.basename(rpm)[:-4] in package_set:
+                if str.encode(os.path.basename(rpm)[:-4]) in package_set:
                     self.files.append(rpm)
 
     def setServer(self):

--- a/proxy/proxy/spacewalk-proxy.changes
+++ b/proxy/proxy/spacewalk-proxy.changes
@@ -1,3 +1,5 @@
+- fix package manager string compare - python3 porting issue
+
 -------------------------------------------------------------------
 Fri Sep 18 12:17:21 CEST 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

During python3 porting we overlooked a compare of string with bytes.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/2473
Tracks

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
