### PR TITLE
Testsuite: scroll up to help Selenimum driver to find the button

### DIFF
--- a/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
+++ b/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
@@ -63,6 +63,7 @@ Feature: PXE boot a Retail terminal
     And I enter the hostname of "proxy" in third CNAME name field
     # direct zone tf.local:
     #   (Avahi does not cross networks, so we need to cheat by serving tf.local)
+    And I scroll to the top of the page
     And I press "Add Item" in available zones section
     And I enter "tf.local" in third available zone name field
     And I enter "master/db.tf.local" in third file name field


### PR DESCRIPTION
## What does this PR change?

Fix unclickable button error at proxy_retail_pxeboot_and_mass_import.feature
This error seems related to the recent update of the chromedriver
(See https://stackoverflow.com/questions/62003082/elementnotinteractableexception-element-not-interactable-element-has-zero-size#answer-62137766)

## Links

### Ports
- Manager-4.0: https://github.com/SUSE/spacewalk/pull/13186
- Manager-4.1: https://github.com/SUSE/spacewalk/pull/13185

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

