### PR TITLE
Fix openSCAP results

### DIFF
--- a/testsuite/features/qam/init_clients/ceos6_client.feature
+++ b/testsuite/features/qam/init_clients/ceos6_client.feature
@@ -13,7 +13,7 @@ Feature: Be able to register a CentOS 6 traditional client and do some basic ope
     And I enable repository "SLE-Manager-Tools-RES-6-x86_64" on this "ceos6_client"
     And I enable repository "CentOS-Base" on this "ceos6_client"
     And I install the traditional stack utils on "ceos6_client"
-    And I install OpenSCAP centos dependencies on "ceos6_client"
+    And I install OpenSCAP dependencies on "ceos6_client"
     And I register "ceos6_client" as traditional client with activation key "1-ceos6_client_key"
     And I run "mgr-actions-control --enable-all" on "ceos6_client"
     And I wait until onboarding is completed for "ceos6_client"

--- a/testsuite/features/qam/init_clients/ceos7_client.feature
+++ b/testsuite/features/qam/init_clients/ceos7_client.feature
@@ -10,7 +10,8 @@ Feature: Be able to register a CentOS 7 traditional client and do some basic ope
   Scenario: Prepare a CentOS 7 traditional client
     When I bootstrap traditional client "ceos7_client" using bootstrap script with activation key "1-ceos7_client_key" from the proxy
     And I install the traditional stack utils on "ceos7_client"
-    And I install OpenSCAP centos dependencies on "ceos7_client"
+    And I install OpenSCAP dependencies on "ceos7_client"
+    And I fix CentOS 7 OpenSCAP files on "ceos7_client"
     And I run "mgr-actions-control --enable-all" on "ceos7_client"
     And I wait until onboarding is completed for "ceos7_client"
 

--- a/testsuite/features/secondary/min_centos_openscap_audit.feature
+++ b/testsuite/features/secondary/min_centos_openscap_audit.feature
@@ -50,3 +50,31 @@ Feature: openSCAP audit of CentOS Salt minion
     When I enter "pass" as the filtered XCCDF result type
     And I click on the filter button
     Then I should see a "rpm_verify_permissions" link
+
+@centos_minion
+  Scenario: Cleanup: remove audit scans retention period from CentOS minion
+    Given I am on the Organizations page
+    When I follow "SUSE Test" in the content area
+    And I follow "Configuration" in the content area
+    And I enter "0" as "scap_retention_period"
+    And I click on "Update Organization"
+    Then I should see a "Organization SUSE Test was successfully updated." text
+
+@centos_minion
+  Scenario: Cleanup: delete audit results from CentOS minion
+    Given I am on the Systems overview page of this "ceos_minion"
+    When I follow "Audit" in the content area
+    And I follow "List Scans" in the content area
+    And I click on "Select All"
+    And I click on "Remove Selected Scans"
+    And I click on "Confirm"
+    Then I should see a " SCAP Scan(s) deleted. 0 SCAP Scan(s) retained" text
+
+@centos_minion
+  Scenario: Cleanup: restore audit scans retention period on CentOS minion
+    Given I am on the Organizations page
+    When I follow "SUSE Test" in the content area
+    And I follow "Configuration" in the content area
+    And I enter "90" as "scap_retention_period"
+    And I click on "Update Organization"
+    Then I should see a "Organization SUSE Test was successfully updated." text

--- a/testsuite/features/secondary/min_centos_openscap_audit.feature
+++ b/testsuite/features/secondary/min_centos_openscap_audit.feature
@@ -47,5 +47,6 @@ Feature: openSCAP audit of CentOS Salt minion
     Then I should see a "Details of XCCDF Scan" text
     And I should see a "RHEL-7" text
     And I should see a "XCCDF Rule Results" text
-    And I should see a "pass" text
-    And I should see a "rpm_" link
+    When I enter "pass" as the filtered XCCDF result type
+    And I click on the filter button
+    Then I should see a "rpm_verify_permissions" link

--- a/testsuite/features/secondary/min_centos_openscap_audit.feature
+++ b/testsuite/features/secondary/min_centos_openscap_audit.feature
@@ -1,20 +1,19 @@
 # Copyright (c) 2017-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-Feature: openSCAP audit of CentOS Salt minion
+Feature: OpenSCAP audit of CentOS Salt minion
   In order to audit a CentOS Salt minion
   As an authorized user
-  I want to run an openSCAP scan on it
+  I want to run an OpenSCAP scan on it
 
 @centos_minion
-  Scenario: Prepare the CentOS minion
-    Given I am authorized
-    When I enable SUSE Manager tools repositories on "ceos_minion"
-    And I enable repository "CentOS-Base" on this "ceos_minion"
-    And I install OpenSCAP centos dependencies on "ceos_minion"
+  Scenario: Install the OpenSCAP packages on the CentOS minion
+    When I enable repository "CentOS-Base" on this "ceos_minion"
+    And I install OpenSCAP dependencies on "ceos_minion"
+    And I fix CentOS 7 OpenSCAP files on "ceos_minion"
 
 @centos_minion
-  Scenario: Schedule an OpenSCAP audit job for the CentOS minion
+  Scenario: Schedule an OpenSCAP audit job on the CentOS minion
     Given I am on the Systems overview page of this "ceos_minion"
     When I follow "Audit" in the content area
     And I follow "Schedule" in the content area
@@ -78,3 +77,8 @@ Feature: openSCAP audit of CentOS Salt minion
     And I enter "90" as "scap_retention_period"
     And I click on "Update Organization"
     Then I should see a "Organization SUSE Test was successfully updated." text
+
+@centos_minion
+  Scenario: Cleanup: remove the OpenSCAP packages from the CentOS minion
+    When I remove OpenSCAP dependencies from "ceos_minion"
+    And I disable repository "CentOS-Base" on this "ceos_minion"

--- a/testsuite/features/secondary/min_salt_openscap_audit.feature
+++ b/testsuite/features/secondary/min_salt_openscap_audit.feature
@@ -19,13 +19,14 @@ Feature: openSCAP audit of Salt minion
 
   Scenario: Check results of the audit job on the minion
     Given I am on the Systems overview page of this "sle_minion"
-    And I follow "Audit" in the content area
-    When I follow "xccdf_org.open-scap_testresult_Default"
+    When I follow "Audit" in the content area
+    And I follow "xccdf_org.open-scap_testresult_Default"
     Then I should see a "Details of XCCDF Scan" text
     And I should see a "Default" text
     And I should see a "XCCDF Rule Results" text
-    And I should see a "pass" text or "notapplicable" text
-    And I should see a "rule-" link
+    When I enter "pass" as the filtered XCCDF result type
+    And I click on the filter button
+    Then I should see a "rule-pwd-warnage" link
 
   Scenario: Create a second, almost identical, audit job
     Given I enable IPv6 forwarding on all interfaces of the SLE minion

--- a/testsuite/features/secondary/min_salt_openscap_audit.feature
+++ b/testsuite/features/secondary/min_salt_openscap_audit.feature
@@ -1,12 +1,16 @@
 # Copyright (c) 2017-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-Feature: openSCAP audit of Salt minion
+Feature: OpenSCAP audit of Salt minion
   In order to audit a Salt minion
   As an authorized user
-  I want to run an openSCAP scan on it
+  I want to run an OpenSCAP scan on it
 
-  Scenario: Schedule an audit job on the minion
+  Scenario: Install the OpenSCAP packages on the SLE minion
+    When I enable repository "os_pool_repo os_update_repo" on this "sle_minion"
+    And I install OpenSCAP dependencies on "sle_minion"
+
+  Scenario: Schedule an OpenSCAP audit job on the SLE minion
     Given I disable IPv6 forwarding on all interfaces of the SLE minion
     When I am on the Systems overview page of this "sle_minion"
     And I follow "Audit" in the content area
@@ -73,3 +77,7 @@ Feature: openSCAP audit of Salt minion
     And I enter "90" as "scap_retention_period"
     And I click on "Update Organization"
     Then I should see a "Organization SUSE Test was successfully updated." text
+
+  Scenario: Cleanup: remove the OpenSCAP packages from the SLE minion
+    When I remove OpenSCAP dependencies from "sle_minion"
+    And I disable repository "os_pool_repo os_update_repo" on this "sle_minion"

--- a/testsuite/features/secondary/min_salt_openscap_audit.feature
+++ b/testsuite/features/secondary/min_salt_openscap_audit.feature
@@ -8,10 +8,10 @@ Feature: openSCAP audit of Salt minion
 
   Scenario: Schedule an audit job on the minion
     Given I disable IPv6 forwarding on all interfaces of the SLE minion
-    And I am on the Systems overview page of this "sle_minion"
+    When I am on the Systems overview page of this "sle_minion"
     And I follow "Audit" in the content area
     And I follow "Schedule" in the content area
-    When I enter "--profile Default" as "params"
+    And I enter "--profile Default" as "params"
     And I enter "/usr/share/openscap/scap-yast2sec-xccdf.xml" as "path"
     And I click on "Schedule"
     Then I should see a "XCCDF scan has been scheduled" text
@@ -30,46 +30,46 @@ Feature: openSCAP audit of Salt minion
 
   Scenario: Create a second, almost identical, audit job
     Given I enable IPv6 forwarding on all interfaces of the SLE minion
-    And I am on the Systems overview page of this "sle_minion"
+    When I am on the Systems overview page of this "sle_minion"
     And I follow "Audit" in the content area
     And I follow "Schedule" in the content area
-    When I enter "--profile Default" as "params"
+    And I enter "--profile Default" as "params"
     And I enter "/usr/share/openscap/scap-yast2sec-xccdf.xml" as "path"
     And I click on "Schedule"
     Then I should see a "XCCDF scan has been scheduled" text
-    And I wait for the openSCAP audit to finish
+    When I wait for the OpenSCAP audit to finish
     And I disable IPv6 forwarding on all interfaces of the SLE minion
 
   Scenario: Compare audit results
     Given I am on the Systems overview page of this "sle_minion"
-    And I follow "Audit" in the content area
+    When I follow "Audit" in the content area
     And I follow "List Scans" in the content area
-    When I click on "Select All"
+    And I click on "Select All"
     And I click on "Compare Selected Scans"
     Then I should see a "XCCDF Rule Results" text
     And I should see a "rule-sysctl-ipv6-all-forward" text
 
-  Scenario: Remove audit scans retention period
+  Scenario: Cleanup: remove audit scans retention period
     Given I am on the Organizations page
-    And I follow "SUSE Test" in the content area
+    When I follow "SUSE Test" in the content area
     And I follow "Configuration" in the content area
-    When I enter "0" as "scap_retention_period"
+    And I enter "0" as "scap_retention_period"
     And I click on "Update Organization"
     Then I should see a "Organization SUSE Test was successfully updated." text
 
-  Scenario: Delete audit results
+  Scenario: Cleanup: delete audit results
     Given I am on the Systems overview page of this "sle_minion"
-    And I follow "Audit" in the content area
+    When I follow "Audit" in the content area
     And I follow "List Scans" in the content area
-    When I click on "Select All"
+    And I click on "Select All"
     And I click on "Remove Selected Scans"
     And I click on "Confirm"
     Then I should see a "2 SCAP Scan(s) deleted. 0 SCAP Scan(s) retained" text
 
   Scenario: Cleanup: restore audit scans retention period
     Given I am on the Organizations page
-    And I follow "SUSE Test" in the content area
+    When I follow "SUSE Test" in the content area
     And I follow "Configuration" in the content area
-    When I enter "90" as "scap_retention_period"
+    And I enter "90" as "scap_retention_period"
     And I click on "Update Organization"
     Then I should see a "Organization SUSE Test was successfully updated." text

--- a/testsuite/features/secondary/min_ubuntu_openscap_audit.feature
+++ b/testsuite/features/secondary/min_ubuntu_openscap_audit.feature
@@ -1,13 +1,23 @@
 # Copyright (c) 2017-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-Feature: openSCAP audit of Ubuntu Salt minion
+Feature: OpenSCAP audit of Ubuntu Salt minion
   In order to audit an Ubuntu Salt minion
   As an authorized user
-  I want to run an openSCAP scan on it
+  I want to run an OpenSCAP scan on it
 
 @ubuntu_minion
-  Scenario: Schedule an OpenSCAP audit job for the Ubuntu minion
+  Scenario: Install the OpenSCAP packages on the Ubuntu minion
+    Given I am on the Systems overview page of this "ubuntu_minion"
+    When I enable universe repositories on "ubuntu_minion"
+    And I install OpenSCAP dependencies on "ubuntu_minion"
+    And I follow "Software" in the content area
+    And I click on "Update Package List"
+    And I follow "Events" in the content area
+    And I wait until I do not see "Package List Refresh scheduled by admin" text, refreshing the page
+
+@ubuntu_minion
+  Scenario: Schedule an OpenSCAP audit job on the Ubuntu minion
     Given I am on the Systems overview page of this "ubuntu_minion"
     When I follow "Audit" in the content area
     And I follow "Schedule" in the content area
@@ -71,3 +81,8 @@ Feature: openSCAP audit of Ubuntu Salt minion
     And I enter "90" as "scap_retention_period"
     And I click on "Update Organization"
     Then I should see a "Organization SUSE Test was successfully updated." text
+
+@ubuntu_minion
+  Scenario: Cleanup: remove the OpenSCAP packages from the Ubuntu minion
+    When I remove OpenSCAP dependencies from "ubuntu_minion"
+    When I disable universe repositories on "ubuntu_minion"

--- a/testsuite/features/secondary/min_ubuntu_openscap_audit.feature
+++ b/testsuite/features/secondary/min_ubuntu_openscap_audit.feature
@@ -43,3 +43,31 @@ Feature: openSCAP audit of Ubuntu Salt minion
     And I click on the filter button
     # TODO: make at least one rule pass on Ubuntu
     Then I should see a "report.html" link
+
+@ubuntu_minion
+  Scenario: Cleanup: remove audit scans retention period from Ubuntu minion
+    Given I am on the Organizations page
+    When I follow "SUSE Test" in the content area
+    And I follow "Configuration" in the content area
+    And I enter "0" as "scap_retention_period"
+    And I click on "Update Organization"
+    Then I should see a "Organization SUSE Test was successfully updated." text
+
+@ubuntu_minion
+  Scenario: Cleanup: delete audit results from Ubuntu minion
+    Given I am on the Systems overview page of this "ubuntu_minion"
+    When I follow "Audit" in the content area
+    And I follow "List Scans" in the content area
+    And I click on "Select All"
+    And I click on "Remove Selected Scans"
+    And I click on "Confirm"
+    Then I should see a " SCAP Scan(s) deleted. 0 SCAP Scan(s) retained" text
+
+@ubuntu_minion
+  Scenario: Cleanup: restore audit scans retention period on Ubuntu minion
+    Given I am on the Organizations page
+    When I follow "SUSE Test" in the content area
+    And I follow "Configuration" in the content area
+    And I enter "90" as "scap_retention_period"
+    And I click on "Update Organization"
+    Then I should see a "Organization SUSE Test was successfully updated." text

--- a/testsuite/features/secondary/min_ubuntu_openscap_audit.feature
+++ b/testsuite/features/secondary/min_ubuntu_openscap_audit.feature
@@ -39,6 +39,7 @@ Feature: openSCAP audit of Ubuntu Salt minion
     Then I should see a "Details of XCCDF Scan" text
     And I should see a "Ubuntu" text
     And I should see a "XCCDF Rule Results" text
-    And I should see a "pass" text or "notapplicable" text
-    And I should see a "report.html" link
-    And I should see a "results.xml" link
+    When I enter "pass" as the filtered XCCDF result type
+    And I click on the filter button
+    # TODO: make at least one rule pass on Ubuntu
+    Then I should see a "report.html" link

--- a/testsuite/features/secondary/trad_centos_client.feature
+++ b/testsuite/features/secondary/trad_centos_client.feature
@@ -25,7 +25,8 @@ Feature: Be able to register a CentOS 7 traditional client and do some basic ope
     When I enable SUSE Manager tools repositories on "ceos_client"
     And I enable repository "CentOS-Base" on this "ceos_client"
     And I install the traditional stack utils on "ceos_client"
-    And I install OpenSCAP centos dependencies on "ceos_client"
+    And I install OpenSCAP dependencies on "ceos_client"
+    And I fix CentOS 7 OpenSCAP files on "ceos_client"
     And I register "ceos_client" as traditional client
     And I run "rhn-actions-control --enable-all" on "ceos_client"
 
@@ -104,7 +105,9 @@ Feature: Be able to register a CentOS 7 traditional client and do some basic ope
 @centos_minion
   Scenario: Cleanup: delete the installed rpms on CentOS 7 traditional client
     When I remove the traditional stack utils from "ceos_client"
-    And I remove OpenSCAP centos dependencies from "ceos_client"
+    And I remove OpenSCAP dependencies from "ceos_client"
+    And I disable SUSE Manager tools repositories on "ceos_client"
+    And I disable repository "CentOS-Base" on this "ceos_client"
 
 @centos_minion
   Scenario: Cleanup: bootstrap a CentOS minion after traditional client tests

--- a/testsuite/features/secondary/trad_centos_client.feature
+++ b/testsuite/features/secondary/trad_centos_client.feature
@@ -79,8 +79,9 @@ Feature: Be able to register a CentOS 7 traditional client and do some basic ope
     Then I should see a "Details of XCCDF Scan" text
     And I should see a "RHEL-7" text
     And I should see a "XCCDF Rule Results" text
-    And I should see a "pass" text
-    And I should see a "rpm_verify_hashes" link
+    When I enter "pass" as the filtered XCCDF result type
+    And I click on the filter button
+    Then I should see a "ensure_redhat_gpgkey_installed" link
 
 @centos_minion
   Scenario: Schedule some actions on the CentOS 7 traditional client

--- a/testsuite/features/secondary/trad_migrate_to_minion.feature
+++ b/testsuite/features/secondary/trad_migrate_to_minion.feature
@@ -95,7 +95,6 @@ Feature: Migrate a traditional client into a Salt minion
   Scenario: Cleanup: register minion again as traditional client
     When I enable SUSE Manager tools repositories on "sle_client"
     And I install the traditional stack utils on "sle_client"
-    And I install OpenSCAP traditional dependencies on "sle_client"
     And I remove package "salt-minion" from this "sle_client"
     And I bootstrap traditional client "sle_client" using bootstrap script with activation key "1-SUSE-DEV-x86_64" from the proxy
     Then I should see "sle_client" via spacecmd

--- a/testsuite/features/secondary/trad_migrate_to_sshminion.feature
+++ b/testsuite/features/secondary/trad_migrate_to_sshminion.feature
@@ -118,7 +118,6 @@ Feature: Migrate a traditional client into a Salt SSH minion
   Scenario: Cleanup: register SSH minion again as traditional client
     When I enable SUSE Manager tools repositories on "sle_client"
     And I install the traditional stack utils on "sle_client"
-    And I install OpenSCAP traditional dependencies on "sle_client"
     And I bootstrap traditional client "sle_client" using bootstrap script with activation key "1-SUSE-DEV-x86_64" from the proxy
     Then I should see "sle_client" via spacecmd
 

--- a/testsuite/features/secondary/trad_openscap_audit.feature
+++ b/testsuite/features/secondary/trad_openscap_audit.feature
@@ -23,8 +23,9 @@ Feature: openSCAP audit of traditional client
     Then I should see a "Details of XCCDF Scan" text
     And I should see a "Default" text
     And I should see a "XCCDF Rule Results" text
-    And I should see a "pass" text or "notapplicable" text
-    And I should see a "rule-" link
+    When I enter "pass" as the filtered XCCDF result type
+    And I click on the filter button
+    Then I should see a "rule-pwd-warnage" link
 
   Scenario: Cleanup: remove audit scans retention period from traditional client
     Given I am on the Organizations page

--- a/testsuite/features/secondary/trad_openscap_audit.feature
+++ b/testsuite/features/secondary/trad_openscap_audit.feature
@@ -1,12 +1,17 @@
 # Copyright (c) 2015-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-Feature: openSCAP audit of traditional client
+Feature: OpenSCAP audit of traditional client
   In order to audit a traditional client
   As an authorized user
-  I want to run an openSCAP scan on it
+  I want to run an OpenSCAP scan on it
 
-  Scenario: Schedule an audit job using the SUSE profile
+  Scenario: Install the OpenSCAP packages on the traditional client
+    When I enable repository "os_pool_repo os_update_repo" on this "sle_client"
+    And I enable SUSE Manager tools repositories on "sle_client"
+    And I install OpenSCAP dependencies on "sle_client"
+
+  Scenario: Schedule an OpenSCAP audit job on the traditional client using SUSE profile
     Given I am on the Systems overview page of this "sle_client"
     When I follow "Audit" in the content area
     And I follow "Schedule" in the content area
@@ -51,3 +56,8 @@ Feature: openSCAP audit of traditional client
     And I enter "90" as "scap_retention_period"
     And I click on "Update Organization"
     Then I should see a "Organization SUSE Test was successfully updated." text
+
+  Scenario: Cleanup: remove the OpenSCAP packages from the traditional client
+    When I remove OpenSCAP dependencies from "sle_client"
+    And I disable SUSE Manager tools repositories on "sle_client"
+    And I disable repository "os_pool_repo os_update_repo" on this "sle_client"

--- a/testsuite/features/secondary/trad_openscap_audit.feature
+++ b/testsuite/features/secondary/trad_openscap_audit.feature
@@ -35,16 +35,16 @@ Feature: openSCAP audit of traditional client
     And I click on "Update Organization"
     Then I should see a "Organization SUSE Test was successfully updated." text
 
-  Scenario: Delete audit results from traditional client
+  Scenario: Cleanup: delete audit results from traditional client
     Given I am on the Systems overview page of this "sle_client"
     When I follow "Audit" in the content area
     And I follow "List Scans" in the content area
     And I click on "Select All"
     And I click on "Remove Selected Scans"
     And I click on "Confirm"
-    Then I should see a "deleted. 0 SCAP Scan(s) retained" text
+    Then I should see a " SCAP Scan(s) deleted. 0 SCAP Scan(s) retained" text
 
-  Scenario: Restore audit scans retention period on traditional client
+  Scenario: Cleanup: restore audit scans retention period on traditional client
     Given I am on the Organizations page
     When I follow "SUSE Test" in the content area
     And I follow "Configuration" in the content area

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -659,7 +659,7 @@ When(/^I enable IPv6 forwarding on all interfaces of the SLE minion$/) do
   $minion.run('sysctl net.ipv6.conf.all.forwarding=1')
 end
 
-When(/^I wait for the openSCAP audit to finish$/) do
+When(/^I wait for the OpenSCAP audit to finish$/) do
   host = $server.full_hostname
   @sle_id = retrieve_server_id($minion.full_hostname)
   @cli = XMLRPC::Client.new2('http://' + host + '/rpc/api')

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -771,17 +771,30 @@ When(/^I remove pattern "([^"]*)" from this "([^"]*)"$/) do |pattern, host|
 end
 
 When(/^I (install|remove) the traditional stack utils (on|from) "([^"]*)"$/) do |action, where, host|
-  step %(I #{action} packages "#{TRADITIONAL_STACK_RPMS}" #{where} this "#{host}")
+  pkgs = 'spacewalk-client-tools spacewalk-check spacewalk-client-setup mgr-daemon mgr-osad mgr-cfg-actions'
+  step %(I #{action} packages "#{pkgs}" #{where} this "#{host}")
 end
 
-When(/^I (install|remove) OpenSCAP (traditional|salt|centos) dependencies (on|from) "([^"]*)"$/) do |action, client_type, where, host|
-  if client_type == 'traditional'
-    step %(I #{action} packages "#{OPEN_SCAP_TRAD_DEPS}" #{where} this "#{host}")
-  elsif client_type == 'salt'
-    step %(I #{action} packages "#{OPEN_SCAP_SALT_DEPS}" #{where} this "#{host}")
-  else
-    step %(I #{action} packages "#{OPEN_SCAP_CENTOS_DEPS}" #{where} this "#{host}")
+When(/^I (install|remove) OpenSCAP dependencies (on|from) "([^"]*)"$/) do |action, where, host|
+  node = get_target(host)
+  os_version, os_family = get_os_version(node)
+  if os_family =~ /^opensuse/ || os_family =~ /^sles/
+    pkgs = 'openscap-utils openscap-content'
+  elsif os_family =~ /^centos/
+    pkgs = 'openscap-utils scap-security-guide'
+  elsif os_family =~ /^ubuntu/
+    pkgs = 'libopenscap8 ssg-debderived'
   end
+  pkgs += ' spacewalk-oscap' if host.include? 'client'
+  step %(I #{action} packages "#{pkgs}" #{where} this "#{host}")
+end
+
+# On CentOS 7, OpenSCAP files are for RedHat and need a small adaptation for CentOS
+When(/^I fix CentOS 7 OpenSCAP files on "([^"]*)"$/) do |host|
+  node = get_target(host)
+  script = '/<\/rear-matter>/a  <platform idref="cpe:/o:centos:centos:7"/>'
+  file = "/usr/share/xml/scap/ssg/content/ssg-rhel7-xccdf.xml"
+  node.run("sed -i '#{script}' #{file}")
 end
 
 When(/^I install package(?:s)? "([^"]*)" on this "([^"]*)"((?: without error control)?)$/) do |package, host, error_control|

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -729,6 +729,32 @@ When(/^I enable SUSE Manager tools repositories on "([^"]*)"$/) do |host|
   end
 end
 
+When(/^I disable SUSE Manager tools repositories on "([^"]*)"$/) do |host|
+  node = get_target(host)
+  os_version, os_family = get_os_version(node)
+  if os_family =~ /^opensuse/ || os_family =~ /^sles/
+    repos, _code = node.run('zypper lr | grep "tools" | cut -d"|" -f2')
+    node.run("zypper mr --disable #{repos.gsub(/\s/, ' ')}")
+  elsif os_family =~ /^centos/
+    repos, _code = node.run('yum repolist enabled 2>/dev/null | grep "tools" | cut -d" " -f1')
+    repos.gsub(/\s/, ' ').split.each do |repo|
+      node.run("sed -i 's/enabled=.*/enabled=0/g' /etc/yum.repos.d/#{repo}.repo")
+    end
+  end
+end
+
+When(/^I enable universe repositories on "([^"]*)"$/) do |host|
+  node = get_target(host)
+  node.run("sed -i '/^#\\s*deb http:\\/\\/archive.ubuntu.com\\/ubuntu .* universe/ s/^#\\s*deb /deb /' /etc/apt/sources.list")
+  node.run("apt-get update")
+end
+
+When(/^I disable universe repositories on "([^"]*)"$/) do |host|
+  node = get_target(host)
+  node.run("sed -i '/^deb http:\\/\\/archive.ubuntu.com\\/ubuntu .* universe/ s/^deb /# deb /' /etc/apt/sources.list")
+  node.run("apt-get update")
+end
+
 When(/^I enable repositories before installing Docker$/) do
   os_version, os_family = get_os_version($build_host)
 

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -241,6 +241,10 @@ When(/^I enter "([^"]*)" as the filtered product description$/) do |input|
   find("input[name='product-description-filter']").set(input)
 end
 
+When(/^I enter "([^"]*)" as the filtered XCCDF result type$/) do |input|
+  find("input[placeholder='Filter by Result: ']").set(input)
+end
+
 # Salt formulas
 When(/^I manually install the "([^"]*)" formula on the server$/) do |package|
   $server.run("zypper --non-interactive install --force #{package}-formula")

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -197,12 +197,3 @@ PKGARCH_BY_CLIENT = { 'proxy' => 'x86_64',
                       'ubuntu1804_minion' => 'x86_64',
                       'ubuntu2004_ssh_minion' => 'x86_64',
                       'ubuntu2004_minion' => 'x86_64' }.freeze
-
-TRADITIONAL_STACK_RPMS = 'spacewalk-client-tools spacewalk-check spacewalk-client-setup '\
-                         'mgr-daemon mgr-osad mgr-cfg-actions'.freeze
-
-OPEN_SCAP_CENTOS_DEPS = 'spacewalk-oscap scap-security-guide'.freeze
-
-OPEN_SCAP_TRAD_DEPS = 'spacewalk-oscap'.freeze
-
-OPEN_SCAP_SALT_DEPS = 'openscap-utils openscap-content scap-security-guide'.freeze


### PR DESCRIPTION
## What does this PR change?

The result of the openSCAP audit may list many not applicable rules. They make the test for passing rules difficult as they may start on page 2. This PR uses the filter button to focus on the passing rules.

Now we will install all needed packages from the test suite, instead of a mixture of sumaform and the test suite (see uyuni-project/sumaform#801). This PR adapts.

The list of packages to install for openSCAP tests was wrong, For example, the CentOS traditional client is both a CentOS client and a traditional client. Constant package lists were not fit for this, this PR computes the list dynamically.

This PR also cleans up the generated reports, the installed packages and the enabled repositories at the end to make these tests idempotent.


## Links

Ports:
* 4.1: SUSE/spacewalk#13187 SUSE/spacewalk#13189 SUSE/spacewalk#13195 SUSE/spacewalk#13197
* 4.0: SUSE/spacewalk#13188 SUSE/spacewalk#13190 SUSE/spacewalk#13194 SUSE/spacewalk#13196


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
