### PR TITLE
Testsuite: Use the right JeOS image

### DIFF
--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -39,9 +39,7 @@ end
 # determine image for PXE boot tests
 def compute_image_filename
   case ENV['PXEBOOT_IMAGE']
-  when nil
-    'Kiwi/POS_Image-JeOS6_head'
-  when 'sles15sp2', 'sles15sp2o'
+  when 'sles15sp2', 'sles15sp2o', 'sles15sp3o'
     'Kiwi/POS_Image-JeOS7_head'
   when 'sles15sp1', 'sles15sp1o'
     raise 'This is not supported image version.'
@@ -52,9 +50,7 @@ end
 
 def compute_image_name
   case ENV['PXEBOOT_IMAGE']
-  when nil
-    'POS_Image_JeOS6_head'
-  when 'sles15sp2', 'sles15sp2o'
+  when 'sles15sp2', 'sles15sp2o', 'sles15sp3o'
     'POS_Image_JeOS7_head'
   when 'sles15sp1', 'sles15sp1o'
     raise 'This is not supported image version.'


### PR DESCRIPTION
## What does this PR change?

Now, head uses sles15sp3o; update code to pick up the right JeOS image for head.
- testsuite/features/support/commonlib.rb:
Consider 'sles15sp3o' in the `case` expression.
Delete unneeded nil-check.



## Links
- Manager-4.0: https://github.com/SUSE/spacewalk/pull/13204
- Manager-4.1: https://github.com/SUSE/spacewalk/pull/13203

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)
