### PR TITLE
Fix: don't translate spacecmd logging

### DIFF
--- a/spacecmd/po/Makevars
+++ b/spacecmd/po/Makevars
@@ -1,1 +1,1 @@
-XGETTEXT_OPTIONS = --keyword=_
+XGETTEXT_OPTIONS = --keyword=_ --keyword=_N

--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,5 @@
+- Fix: internal: workaround for future tee of logs translation
+
 -------------------------------------------------------------------
 Thu Dec 03 13:41:55 CET 2020 - jgonzalez@suse.com
 

--- a/spacecmd/src/bin/spacecmd
+++ b/spacecmd/src/bin/spacecmd
@@ -20,6 +20,7 @@
 #
 
 """ spacecmd - a command line interface to Spacewalk """
+from spacecmd.i18n import _N
 
 import gettext
 import logging
@@ -54,7 +55,6 @@ Type: 'help' for a list of commands
 
 _SYSTEM_CONF_FILE = '/etc/spacecmd.conf'
 
-
 def get_localhost_fqdn():
     """
     Get FQDN of the current machine.
@@ -71,7 +71,7 @@ def get_localhost_fqdn():
     except socket.gaierror as exc:
         logging.debug("Error while getting FQDN over the network: %s", str(exc))
     except Exception as exc:
-        logging.error(_("Unhandled exception occurred while getting FQDN:"), str(exc))
+        logging.error(_N("Unhandled exception occurred while getting FQDN:"), str(exc))
 
     return fqdn or socket.getfqdn()
 
@@ -153,7 +153,7 @@ if __name__ == '__main__':
     # don't automatically create config files passed via --config
     if shell.options.config:
         if not os.path.isfile(shell.options.config):
-            logging.error(_('Config file %s does not exist.'), shell.options.config)
+            logging.error(_N('Config file %s does not exist.'), shell.options.config)
             sys.exit(1)
     else:
     # create an empty configuration file if one's not present
@@ -170,7 +170,7 @@ if __name__ == '__main__':
                 handle.write('[spacecmd]\n')
                 handle.close()
             except IOError:
-                logging.error(_('Could not create %s'), user_conf_file)
+                logging.error(_N('Could not create %s'), user_conf_file)
 
     # load options from configuration files
     if shell.options.config:

--- a/spacecmd/src/spacecmd/activationkey.py
+++ b/spacecmd/src/spacecmd/activationkey.py
@@ -37,6 +37,7 @@ try:
     from xmlrpc import client as xmlrpclib
 except ImportError:
     import xmlrpclib
+from spacecmd.i18n import _N
 from spacecmd.utils import *
 
 translation = gettext.translation('spacecmd', fallback=True)
@@ -779,7 +780,7 @@ def do_activationkey_create(self, args):
                                                options.entitlements,
                                                options.universal)
 
-    logging.info(_('Created activation key %s') % new_key)
+    logging.info(_N('Created activation key %s') % new_key)
 
     return 0
 
@@ -810,7 +811,7 @@ def do_activationkey_delete(self, args):
                   (args, keys))
 
     if not keys:
-        logging.error(_("No keys matched argument %s") % args)
+        logging.error(_N("No keys matched argument %s") % args)
         return 1
 
     # Print the keys prior to the confimation
@@ -878,7 +879,7 @@ def do_activationkey_listsystems(self, args):
             self.client.activationkey.listActivatedSystems(self.session,
                                                            key)
     except xmlrpclib.Fault:
-        logging.warning(_('%s is not a valid activation key') % key)
+        logging.warning(_N('%s is not a valid activation key') % key)
         return 1
 
     systems = sorted([s.get('hostname') for s in systems])
@@ -927,7 +928,7 @@ def do_activationkey_details(self, args):
             # API returns 0/1 instead of boolean
             config_channel_deploy = config_channel_deploy == 1
         except xmlrpclib.Fault:
-            logging.warning(_('%s is not a valid activation key') % key)
+            logging.warning(_N('%s is not a valid activation key') % key)
             return
 
         groups = []
@@ -1128,7 +1129,7 @@ def do_activationkey_setusagelimit(self, args):
             usage_limit = int(args[0])
             logging.debug("Setting usage for key %s to %d" % (key, usage_limit))
         except ValueError:
-            logging.error(_("Couldn't convert argument %s to an integer") %
+            logging.error(_N("Couldn't convert argument %s to an integer") %
                           args[0])
             self.help_activationkey_setusagelimit()
             return 1
@@ -1210,7 +1211,7 @@ def complete_activationkey_export(self, text, line, beg, end):
 
 def export_activationkey_getdetails(self, key):
     # Get the key details
-    logging.info(_("Getting activation key details for %s" % key))
+    logging.info(_N("Getting activation key details for %s" % key))
     details = self.client.activationkey.getDetails(self.session, key)
 
     # Get the key config-channel data, add it to the existing details
@@ -1264,7 +1265,7 @@ def do_activationkey_export(self, args):
     if not args:
         if not filename:
             filename = "akey_all.json"
-        logging.info(_("Exporting ALL activation keys to %s") % filename)
+        logging.info(_N("Exporting ALL activation keys to %s") % filename)
         keys = self.do_activationkey_list('', True)
     else:
         # allow globbing of activationkey names
@@ -1273,7 +1274,7 @@ def do_activationkey_export(self, args):
                       (args, keys))
 
         if not keys:
-            logging.error(_("Invalid activation key passed"))
+            logging.error(_N("Invalid activation key passed"))
             return 1
 
         if not filename:
@@ -1288,7 +1289,7 @@ def do_activationkey_export(self, args):
     # Dump as a list of dict
     keydetails_list = []
     for k in keys:
-        logging.info(_("Exporting key %s to %s") % (k, filename))
+        logging.info(_N("Exporting key %s to %s") % (k, filename))
         keydetails_list.append(self.export_activationkey_getdetails(k))
 
     logging.debug("About to dump %d keys to %s" %
@@ -1302,7 +1303,7 @@ def do_activationkey_export(self, args):
             return 1
 
     if json_dump_to_file(keydetails_list, filename) != True:
-        logging.error(_("Failed to save exported keys to file: {}").format(filename))
+        logging.error(_N("Failed to save exported keys to file: {}").format(filename))
         return 1
 
     return 0
@@ -1321,7 +1322,7 @@ def do_activationkey_import(self, args):
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
-        logging.error(_("No filename passed"))
+        logging.error(_N("No filename passed"))
         self.help_activationkey_import()
         return 1
 
@@ -1330,12 +1331,12 @@ def do_activationkey_import(self, args):
         keydetails_list = json_read_from_file(filename)
 
         if not keydetails_list:
-            logging.error(_("Could not read json data from %s") % filename)
+            logging.error(_N("Could not read json data from %s") % filename)
             return 1
 
         for keydetails in keydetails_list:
             if self.import_activationkey_fromdetails(keydetails) != True:
-                logging.error(_("Failed to import key %s") %
+                logging.error(_N("Failed to import key %s") %
                               keydetails['key'])
                 return 1
 
@@ -1349,7 +1350,7 @@ def import_activationkey_fromdetails(self, keydetails):
     existing_keys = self.do_activationkey_list('', True)
 
     if keydetails['key'] in existing_keys:
-        logging.warning(_("%s already exists! Skipping!") % keydetails['key'])
+        logging.warning(_N("%s already exists! Skipping!") % keydetails['key'])
         return False
     else:
         # create the key, we need to drop the org prefix from the key name
@@ -1379,7 +1380,7 @@ def import_activationkey_fromdetails(self, keydetails):
                                                       keydetails['entitlements'],
                                                       keydetails['universal_default'])
         if not newkey:
-            logging.error(_("Failed to import key %s") %
+            logging.error(_N("Failed to import key %s") %
                           keyname)
             return False
 
@@ -1404,7 +1405,7 @@ def import_activationkey_fromdetails(self, keydetails):
         for grp in keydetails['server_groups']:
             grpdetails = self.client.systemgroup.getDetails(self.session, grp)
             if grpdetails is None:
-                logging.info(_("System group %s doesn't exist, creating") % grp)
+                logging.info(_N("System group %s doesn't exist, creating") % grp)
                 grpdetails = self.client.systemgroup.create(self.session, grp,
                                                             grp)
             gids.append(grpdetails.get('id'))
@@ -1469,16 +1470,16 @@ def do_activationkey_clone(self, args):
         options.clonename = prompt_user(_('Cloned Key:'), noblank=True)
     else:
         if not options.clonename and not options.regex:
-            logging.error(_("Error - must specify either -c or -x options!"))
+            logging.error(_N("Error - must specify either -c or -x options!"))
             self.help_activationkey_clone()
             return 1
 
     if options.clonename in allkeys:
-        logging.error(_("Key %s already exists") % options.clonename)
+        logging.error(_N("Key %s already exists") % options.clonename)
         return 1
 
     if not args:
-        logging.error(_("Error no activationkey to clone passed!"))
+        logging.error(_N("Error no activationkey to clone passed!"))
         self.help_activationkey_clone()
         return 1
 
@@ -1532,16 +1533,16 @@ def do_activationkey_clone(self, args):
 
                         new_child_channel_labels.append(newc)
                     else:
-                        logging.warning(_("Found child channel %s key %s, %s") %
+                        logging.warning(_N("Found child channel %s key %s, %s") %
                                         (c, keydetails['key'], newc) +
-                                        _(" does not exist, skipping!"))
+                                        _N(" does not exist, skipping!"))
 
                 logging.debug("Processed all child channels, " +
                               "new_child_channel_labels=%s" % new_child_channel_labels)
 
                 keydetails['child_channel_labels'] = new_child_channel_labels
             else:
-                logging.error(_("Regex-replacement results in new " +
+                logging.error(_N("Regex-replacement results in new " +
                               "base-channel %s which does not exist!") % newbasech)
 
             # Finally, any config-channels
@@ -1557,9 +1558,9 @@ def do_activationkey_clone(self, args):
 
                     new_config_channels.append(newcc)
                 else:
-                    logging.warning(_("Found config channel %s for key %s, %s ")
+                    logging.warning(_N("Found config channel %s for key %s, %s ")
                                     % (cc, keydetails['key'], newcc) +
-                                    _("does not exist, skipping!"))
+                                    _N("does not exist, skipping!"))
 
             logging.debug("Processed all config channels, " +
                           "new_config_channels = %s" % new_config_channels)
@@ -1577,11 +1578,11 @@ def do_activationkey_clone(self, args):
             else:
                 keydetails['key'] = options.clonename
 
-        logging.info("Cloning key %s as %s" % (ak, keydetails['key']))
+        logging.info(_N("Cloning key %s as %s") % (ak, keydetails['key']))
 
         # Finally : import the key from the modified keydetails dict
         if self.import_activationkey_fromdetails(keydetails) != True:
-            logging.error(_("Failed to clone %s to %s") %
+            logging.error(_N("Failed to clone %s to %s") %
                           (ak, keydetails['key']))
             return 1
 
@@ -1599,10 +1600,10 @@ def is_activationkey(self, name):
 
 def check_activationkey(self, name):
     if not name:
-        logging.error(_("no activationkey label given"))
+        logging.error(_N("no activationkey label given"))
         return False
     if not self.is_activationkey(name):
-        logging.error(_("invalid activationkey label ") + name)
+        logging.error(_N("invalid activationkey label ") + name)
         return False
     return True
 

--- a/spacecmd/src/spacecmd/api.py
+++ b/spacecmd/src/spacecmd/api.py
@@ -32,6 +32,7 @@ try:
     from xmlrpc import client as xmlrpclib
 except ImportError:
     import xmlrpclib
+from spacecmd.i18n import _N
 from spacecmd.utils import *
 
 translation = gettext.translation('spacecmd', fallback=True)
@@ -78,8 +79,8 @@ def do_api(self, args):
         try:
             output = open(options.output, "w")
         except IOError:
-            logging.warning(_("Could not open to write: ") + options.output)
-            logging.info(_("Fallback output to stdout"))
+            logging.warning(_N("Could not open to write: ") + options.output)
+            logging.info(_N("Fallback output to stdout"))
 
             output = sys.stdout
     else:
@@ -88,7 +89,7 @@ def do_api(self, args):
     api = getattr(self.client, api_name, None)
 
     if not callable(api):
-        logging.warning(_("No such API: ") + api_name)
+        logging.warning(_N("No such API: ") + api_name)
         return
 
     try:

--- a/spacecmd/src/spacecmd/configchannel.py
+++ b/spacecmd/src/spacecmd/configchannel.py
@@ -38,6 +38,7 @@ try:
     from xmlrpc import client as xmlrpclib
 except ImportError:
     import xmlrpclib
+from spacecmd.i18n import _N
 from spacecmd.utils import *
 
 translation = gettext.translation('spacecmd', fallback=True)
@@ -76,7 +77,7 @@ def complete_configchannel_listsystems(self, text, line, beg, end):
 
 def do_configchannel_listsystems(self, args):
     if not self.check_api_version('10.11'):
-        logging.warning(_("This version of the API doesn't support this method"))
+        logging.warning(_N("This version of the API doesn't support this method"))
         return 1
 
     arg_parser = get_argument_parser()
@@ -213,13 +214,13 @@ def do_configchannel_filedetails(self, args):
         try:
             revision = int(args[2])
         except (ValueError, IndexError):
-            logging.error(_("Invalid revision: %s"), args[2])
+            logging.error(_N("Invalid revision: %s"), args[2])
             return 1
 
     # the server return a null exception if an invalid file is passed
     valid_files = self.do_configchannel_listfiles(channel, True)
     if filename not in valid_files:
-        logging.warning(_('%s is not in this configuration channel') % filename)
+        logging.warning(_N('%s is not in this configuration channel') % filename)
         return 1
 
     if revision:
@@ -310,7 +311,7 @@ def do_configchannel_backup(self, args):
         if not os.path.isdir(outputpath_base):
             os.makedirs(outputpath_base)
     except OSError as exc:
-        logging.error(_('Could not create output directory: %s'), str(exc))
+        logging.error(_N('Could not create output directory: %s'), str(exc))
         return 1
 
     # the server return a null exception if an invalid file is passed
@@ -323,7 +324,7 @@ def do_configchannel_backup(self, args):
     try:
         fh = open(fh_path, 'w')
     except IOError as exc:
-        logging.error(_('Could not create "%s" file: %s'), fh_path, str(exc))
+        logging.error(_N('Could not create "%s" file: %s'), fh_path, str(exc))
         return 1
 
     for details in results:
@@ -445,11 +446,11 @@ def do_configchannel_create(self, args):
         if options.description == '':
             options.description = options.name
         if options.type not in ('normal', 'state'):
-            logging.error(_('Only [normal/state] values are acceptable for type'))
+            logging.error(_N('Only [normal/state] values are acceptable for type'))
             return 1
     else:
         if not options.name:
-            logging.error(_('A name is required'))
+            logging.error(_N('A name is required'))
             return 1
         if not options.label:
             options.label = options.name
@@ -458,7 +459,7 @@ def do_configchannel_create(self, args):
         if not options.type:
             options.type = 'normal'
         if options.type not in ('normal', 'state'):
-            logging.error(_('Only [normal/state] values are acceptable for --type parameter'))
+            logging.error(_N('Only [normal/state] values are acceptable for --type parameter'))
             return 1
 
     self.client.configchannel.create(self.session,
@@ -495,7 +496,7 @@ def do_configchannel_delete(self, args):
     logging.debug("configchannel_delete called with args %s, channels=%s" % (args, channels))
 
     if not channels:
-        logging.error(_("No channels matched argument(s): %s") % ", ".join(args))
+        logging.error(_N("No channels matched argument(s): %s") % ", ".join(args))
         return 1
 
     # Print the channels prior to the confirmation
@@ -590,7 +591,7 @@ def configfile_getinfo(self, args, options, file_info=None, interactive=False):
                 try:
                     options.revision = int(revision_input)
                 except ValueError:
-                    logging.warning(_('The revision must be an integer'))
+                    logging.warning(_N('The revision must be an integer'))
 
             if not options.directory:
                 if self.user_confirm(_('Read an existing file [y/N]:'),
@@ -613,7 +614,7 @@ def configfile_getinfo(self, args, options, file_info=None, interactive=False):
                     (contents, _ignore) = editor(template=template, delete=True)
     else:
         if not options.path:
-            logging.error(_('The path is required'))
+            logging.error(_N('The path is required'))
             return
 
         if not options.symlink and not options.directory:
@@ -627,11 +628,11 @@ def configfile_getinfo(self, args, options, file_info=None, interactive=False):
                 elif options.binary:
                     logging.debug("Binary selected")
             else:
-                logging.error(_('You must provide the file contents'))
+                logging.error(_N('You must provide the file contents'))
                 return
 
         if options.symlink and not options.target_path:
-            logging.error(_('You must provide the target path for a symlink'))
+            logging.error(_N('You must provide the target path for a symlink'))
             return
 
     # selinux_ctx can't be None
@@ -775,12 +776,12 @@ def do_configchannel_addfile(self, args, update_path=''):
                     break
                 else:
                     print('')
-                    logging.warning(_('%s is not a valid channel') %
+                    logging.warning(_N('%s is not a valid channel') %
                                     options.channel)
                     print('')
                     failures += 1
             if failures > 0:
-                logging.error(_("Unable to obtain a valid channel. Aborting."))
+                logging.error(_N("Unable to obtain a valid channel. Aborting."))
                 return 1
 
         if update_path:
@@ -802,12 +803,12 @@ def do_configchannel_addfile(self, args, update_path=''):
     file_info = self.configfile_getinfo(args, options, file_info, interactive)
 
     if not options.channel:
-        logging.error(_("No config channel specified!"))
+        logging.error(_N("No config channel specified!"))
         self.help_configchannel_addfile()
         return 1
 
     if not file_info:
-        logging.error(_("Error obtaining file info"))
+        logging.error(_N("Error obtaining file info"))
         self.help_configchannel_addfile()
         return 1
 
@@ -879,7 +880,7 @@ def do_configchannel_updateinitsls(self, args, update_path=''):
                     break
                 else:
                     print('')
-                    logging.warning('%s is not a valid channel' %
+                    logging.warning(_N('%s is not a valid channel') %
                                     options.channel)
                     print('')
         # check if this file already exists
@@ -889,7 +890,7 @@ def do_configchannel_updateinitsls(self, args, update_path=''):
                                                          options.channel,
                                                          [path])
         except xmlrpclib.Fault:
-            logging.error(_("No existing file information found for %s") %
+            logging.error(_N("No existing file information found for %s") %
                           options.path)
             return 1
         contents = file_info[0].get('contents')
@@ -910,7 +911,7 @@ def do_configchannel_updateinitsls(self, args, update_path=''):
         if options.file:
             contents = read_file(options.file)
         else:
-            logging.error(_('You must provide the file contents'))
+            logging.error(_N('You must provide the file contents'))
             return 1
 
     contents = base64.b64encode(contents.encode('utf8')).decode()
@@ -921,12 +922,12 @@ def do_configchannel_updateinitsls(self, args, update_path=''):
 
 
     if not options.channel:
-        logging.error(_("No config channel specified!"))
+        logging.error(_N("No config channel specified!"))
         self.help_configchannel_updateinitsls()
         return 1
 
     if not file_info:
-        logging.error(_("Error obtaining file info"))
+        logging.error(_N("Error obtaining file info"))
         self.help_configchannel_updateinitsls()
         return 1
     print(_('contents_enc64:           %s') % file_info['contents_enc64'])
@@ -1034,7 +1035,7 @@ def do_configchannel_verifyfile(self, args):
     system_ids = list(filter(None, (self.get_system_id(s) for s in systems)))
 
     if not system_ids:
-        logging.error(_('No valid system selected'))
+        logging.error(_N('No valid system selected'))
         return 1
     action_id = \
         self.client.configchannel.scheduleFileComparisons(self.session,
@@ -1042,7 +1043,7 @@ def do_configchannel_verifyfile(self, args):
                                                           path,
                                                           system_ids)
 
-    logging.info(_('Action ID: %i') % action_id)
+    logging.info(_N('Action ID: %i') % action_id)
 
     return 0
 
@@ -1067,7 +1068,7 @@ def complete_configchannel_export(self, text, line, beg, end):
 
 def export_configchannel_getdetails(self, channel):
     # Get the cc details
-    logging.info(_("Getting config channel details for %s") % channel)
+    logging.info(_N("Getting config channel details for %s") % channel)
     details = self.client.configchannel.getDetails(self.session, channel)
     files = self.client.configchannel.listFiles(self.session, channel)
     details['files'] = []
@@ -1087,7 +1088,7 @@ def export_configchannel_getdetails(self, channel):
             if pinfo:
                 fileinfo.append(pinfo[0])
         except xmlrpclib.Fault:
-            logging.error(_("Failed to get details for file %s from %s")
+            logging.error(_N("Failed to get details for file %s from %s")
                           % (p, channel))
     # Now we strip the datetime fields from the Info structs, as they
     # are not JSON serializable with the default encoder, and we don't
@@ -1133,11 +1134,11 @@ def export_configchannel_getdetails(self, channel):
             if not 'contents' in f:
                 if f['type'] != 'directory':
                     if not self.check_api_version('11.1'):
-                        logging.warning(_("File %s could not be exported ") % f['path'] +
-                                        _("with this API version(needs base64 encoding)"))
+                        logging.warning(_N("File %s could not be exported ") % f['path'] +
+                                        _N("with this API version(needs base64 encoding)"))
                     else:
-                        logging.info(_("File %s could not be exported as") % f['path'] +
-                                     _(" text...getting base64 encoded version"))
+                        logging.info(_N("File %s could not be exported as") % f['path'] +
+                                     _N(" text...getting base64 encoded version"))
                         b64f = self.client.configchannel.getEncodedFileRevision(
                             self.session, channel, f['path'], f['revision'])
                         f['contents'] = b64f['contents']
@@ -1160,7 +1161,7 @@ def do_configchannel_export(self, args):
 
     filename = ""
     if options.file is not None:
-        logging.debug(_("Passed filename '%s' to do_configchannel_export command."), options.file)
+        logging.debug("Passed filename '%s' to do_configchannel_export command.", options.file)
         filename = options.file
 
     # Get the list of ccs to export and sort out the filename if required
@@ -1168,14 +1169,14 @@ def do_configchannel_export(self, args):
     if not args:
         if not filename:
             filename = "cc_all.json"
-        logging.info(_("Exporting ALL config channels to %s"), filename)
+        logging.info(_N("Exporting ALL config channels to %s"), filename)
         ccs = self.do_configchannel_list('', True)
     else:
         # allow globbing of configchannel names
         ccs = filter_results(self.do_configchannel_list('', True), args)
         logging.debug("configchannel_export called with args %s, ccs=%s", args, ccs)
         if not ccs:
-            logging.error(_("Error, no valid config channel passed, "
+            logging.error(_N("Error, no valid config channel passed, "
                           "check name is  correct with spacecmd configchannel_list"))
             return 1
         if not filename:
@@ -1190,7 +1191,7 @@ def do_configchannel_export(self, args):
     # Dump as a list of dict
     ccdetails_list = []
     for c in ccs:
-        logging.info(_("Exporting cc %s to %s"), c, filename)
+        logging.info(_N("Exporting cc %s to %s"), c, filename)
         ccdetails_list.append(self.export_configchannel_getdetails(c))
 
     logging.debug("About to dump %d ccs to %s", len(ccdetails_list), filename)
@@ -1200,7 +1201,7 @@ def do_configchannel_export(self, args):
         if not self.options.yes and not self.user_confirm(_("File '{}' exists, confirm overwrite file? (y/n)").format(filename)):
             return 1
     if not json_dump_to_file(ccdetails_list, filename):
-        logging.error(_("Error saving exported config channels to file: %s"), filename)
+        logging.error(_N("Error saving exported config channels to file: %s"), filename)
         return 1
 
     return 0
@@ -1219,7 +1220,7 @@ def do_configchannel_import(self, args):
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
-        logging.error(_("Error, no filename passed"))
+        logging.error(_N("Error, no filename passed"))
         self.help_configchannel_import()
         return 1
 
@@ -1227,11 +1228,11 @@ def do_configchannel_import(self, args):
         logging.debug("Passed filename do_configchannel_import %s", filename)
         ccdetails_list = json_read_from_file(filename)
         if not ccdetails_list:
-            logging.error(_("Error, could not read json data from %s"), filename)
+            logging.error(_N("Error, could not read json data from %s"), filename)
             return 1
         for ccdetails in ccdetails_list:
             if not self.import_configchannel_fromdetails(ccdetails):
-                logging.error(_("Error importing configchannel %s"), ccdetails['name'])
+                logging.error(_N("Error importing configchannel %s"), ccdetails['name'])
 
     return 0
 
@@ -1243,12 +1244,12 @@ def import_configchannel_fromdetails(self, ccdetails):
     # First we check that an existing channel with the same name does not exist
     existing_ccs = self.do_configchannel_list('', True)
     if ccdetails['name'] in existing_ccs:
-        logging.warning(_("Config channel %s already exists! Skipping!") %
+        logging.warning(_N("Config channel %s already exists! Skipping!") %
                         ccdetails['name'])
         return False
     else:
         # create the cc, we need to drop the org prefix from the cc name
-        logging.info(_("Importing config channel  %s") % ccdetails['name'])
+        logging.info(_N("Importing config channel  %s") % ccdetails['name'])
 
         channeltype = 'normal'
         if 'configChannelType' in ccdetails:
@@ -1263,7 +1264,7 @@ def import_configchannel_fromdetails(self, ccdetails):
         for filedetails in ccdetails['files']:
             path = filedetails['path']
             del filedetails['path']
-            logging.info("Found %s %s for cc %s" %
+            logging.info(_N("Found %s %s for cc %s") %
                          (filedetails['type'], path, ccdetails['name']))
             ret = None
             if filedetails['type'] == 'symlink':
@@ -1293,7 +1294,7 @@ def import_configchannel_fromdetails(self, ccdetails):
                         logging.error(
                             _("Failed trying to import file %s (empty content)")
                             % path)
-                        logging.error(_("Older APIs can't export encoded files"))
+                        logging.error(_N("Older APIs can't export encoded files"))
                         continue
 
                     if not filedetails['contents_enc64']:
@@ -1316,7 +1317,7 @@ def import_configchannel_fromdetails(self, ccdetails):
                 logging.debug("Added file %s to %s" %
                               (ret['path'], ccdetails['name']))
             else:
-                logging.error(_("Error adding file %s to %s") %
+                logging.error(_N("Error adding file %s to %s") %
                               (filedetails['path'], ccdetails['label']))
                 continue
 
@@ -1356,7 +1357,7 @@ def do_configchannel_clone(self, args):
 
     if is_interactive(options):
         if not allccs:
-            logging.error(_("No config channels found"))
+            logging.error(_N("No config channels found"))
             return 1
         print('')
         print(_('Config Channels'))
@@ -1373,13 +1374,13 @@ def do_configchannel_clone(self, args):
         options.clonelabel = prompt_user(_('Clone label:'), noblank=True)
     else:
         if not options.clonelabel and not options.regex:
-            logging.error(_("Error - must specify either -c or -x options!"))
+            logging.error(_N("Error - must specify either -c or -x options!"))
             self.help_configchannel_clone()
         else:
             logging.debug("%s : %s", options.clonelabel, options.regex)
 
     if not args:
-        logging.error(_("Error no channel label passed!"))
+        logging.error(_N("Error no channel label passed!"))
         self.help_configchannel_clone()
         return 1
     logging.debug("Got args=%s %d", args, len(args))
@@ -1388,7 +1389,7 @@ def do_configchannel_clone(self, args):
     logging.debug("Filtered ccs %s", ccs)
 
     if not ccs:
-        logging.error(_("No suitable channels to clone has been found."))
+        logging.error(_N("No suitable channels to clone has been found."))
 
     for cc in ccs:
         logging.debug("Cloning %s" % cc)
@@ -1425,7 +1426,7 @@ def do_configchannel_clone(self, args):
 
         # Finally : import the cc from the modified ccdetails
         if not self.import_configchannel_fromdetails(ccdetails):
-            logging.error(_("Failed to clone %s to %s"), cc, ccdetails['label'])
+            logging.error(_N("Failed to clone %s to %s"), cc, ccdetails['label'])
 
     return 0
 
@@ -1441,10 +1442,10 @@ def is_configchannel(self, name):
 
 def check_configchannel(self, name):
     if not name:
-        logging.error(_("no configchannel given"))
+        logging.error(_N("no configchannel given"))
         return False
     if not self.is_configchannel(name):
-        logging.error(_("invalid configchannel label ") + name)
+        logging.error(_N("invalid configchannel label ") + name)
         return False
     return True
 
@@ -1562,7 +1563,7 @@ def do_configchannel_sync(self, args, doreturn=False):
     if not self.check_configchannel(target_channel):
         return 1
 
-    logging.info(_("syncing files from configchannel ") + source_channel + " to " + target_channel)
+    logging.info(_N("syncing files from configchannel ") + source_channel + " to " + target_channel)
 
     source_files = set(self.do_configchannel_listfiles(source_channel, doreturn=True))
     target_files = set(self.do_configchannel_listfiles(target_channel, doreturn=True))
@@ -1593,7 +1594,7 @@ def do_configchannel_sync(self, args, doreturn=False):
         print(_("files only in the target channel will be deleted"))
 
     if not (both or source_only or target_only):
-        logging.info(_("nothing to do"))
+        logging.info(_N("nothing to do"))
         return 1
 
     if not self.options.yes:
@@ -1649,7 +1650,7 @@ def do_configchannel_sync(self, args, doreturn=False):
                                                             target_data)
 
         else:
-            logging.warning(_("unknown file type ") + source_data.type)
+            logging.warning(_N("unknown file type ") + source_data.type)
 
     # removing all files from target channel that did not exist on source channel
     if target_only:

--- a/spacecmd/src/spacecmd/cryptokey.py
+++ b/spacecmd/src/spacecmd/cryptokey.py
@@ -31,6 +31,7 @@ try:
     from xmlrpc import client as xmlrpclib
 except ImportError:
     import xmlrpclib
+from spacecmd.i18n import _N
 from spacecmd.utils import *
 
 translation = gettext.translation('spacecmd', fallback=True)
@@ -72,15 +73,15 @@ def do_cryptokey_create(self, args):
             options.contents = editor(delete=True)
     else:
         if not options.type:
-            logging.error(_('The key type is required'))
+            logging.error(_N('The key type is required'))
             return 1
 
         if not options.description:
-            logging.error(_('A description is required'))
+            logging.error(_N('A description is required'))
             return 1
 
         if not options.file:
-            logging.error(_('A file containing the key is required'))
+            logging.error(_N('A file containing the key is required'))
             return 1
 
     # read the file the user specified
@@ -88,7 +89,7 @@ def do_cryptokey_create(self, args):
         options.contents = read_file(options.file)
 
     if not options.contents:
-        logging.error(_('No contents of the file'))
+        logging.error(_N('No contents of the file'))
         return 1
 
     # translate the key type to what the server expects
@@ -97,7 +98,7 @@ def do_cryptokey_create(self, args):
     elif re.match('S', options.type, re.I):
         options.type = 'SSL'
     else:
-        logging.error(_('Invalid key type'))
+        logging.error(_N('Invalid key type'))
         return 1
 
     self.client.kickstart.keys.create(self.session,
@@ -136,7 +137,7 @@ def do_cryptokey_delete(self, args):
                   (args, keys))
 
     if not keys:
-        logging.error(_("No keys matched argument %s") % args)
+        logging.error(_N("No keys matched argument %s") % args)
         return 1
 
     # Print the keys prior to the confirmation
@@ -194,7 +195,7 @@ def do_cryptokey_details(self, args):
                   (args, keys))
 
     if not keys:
-        logging.error(_("No keys matched argument %s") % args)
+        logging.error(_N("No keys matched argument %s") % args)
         return 1
 
     add_separator = False
@@ -204,7 +205,7 @@ def do_cryptokey_details(self, args):
             details = self.client.kickstart.keys.getDetails(self.session,
                                                             key)
         except xmlrpclib.Fault:
-            logging.warning(_('%s is not a valid crypto key') % key)
+            logging.warning(_N('%s is not a valid crypto key') % key)
             return 1
 
         if add_separator:

--- a/spacecmd/src/spacecmd/custominfo.py
+++ b/spacecmd/src/spacecmd/custominfo.py
@@ -27,6 +27,7 @@
 # pylint: disable=W0613
 
 import gettext
+from spacecmd.i18n import _N
 from spacecmd.utils import *
 
 translation = gettext.translation('spacecmd', fallback=True)
@@ -93,7 +94,7 @@ def do_custominfo_deletekey(self, args):
                   (args, keys))
 
     if not keys:
-        logging.error("No keys matched argument %s" % args)
+        logging.error(_N("No keys matched argument %s") % args)
         return 1
 
     # Print the keys prior to the confirmation
@@ -152,7 +153,7 @@ def do_custominfo_details(self, args):
         ", ".join(args), ", ".join(keys)))
 
     if not keys:
-        logging.error(_("No keys matched argument '{}'.").format(", ".join(args)))
+        logging.error(_N("No keys matched argument '{}'.").format(", ".join(args)))
         return 1
 
     add_separator = False

--- a/spacecmd/src/spacecmd/distribution.py
+++ b/spacecmd/src/spacecmd/distribution.py
@@ -30,6 +30,7 @@
 # pylint: disable=C0103
 
 import gettext
+from spacecmd.i18n import _N
 from spacecmd.utils import *
 
 translation = gettext.translation('spacecmd', fallback=True)
@@ -63,7 +64,7 @@ def do_distribution_create(self, args, update=False):
         if args:
             options.name = args[0]
         elif not options.name:
-            logging.error(_('The name of the distribution is required'))
+            logging.error(_N('The name of the distribution is required'))
             return 1
 
     if is_interactive(options):
@@ -83,7 +84,7 @@ def do_distribution_create(self, args, update=False):
             options.base_channel = prompt_user(_('Base Channel:'))
 
         if options.base_channel not in self.list_base_channels():
-            logging.warning(_('Invalid channel label'))
+            logging.warning(_N('Invalid channel label'))
             options.base_channel = ''
 
         install_types = \
@@ -102,23 +103,23 @@ def do_distribution_create(self, args, update=False):
             options.install_type = prompt_user(_('Install Type:'))
 
             if options.install_type not in install_types:
-                logging.warning(_('Invalid install type'))
+                logging.warning(_N('Invalid install type'))
                 options.install_type = ''
     else:
         if not options.name:
-            logging.error(_('A name is required'))
+            logging.error(_N('A name is required'))
             return 1
 
         if not options.path:
-            logging.error(_('A path is required'))
+            logging.error(_N('A path is required'))
             return 1
 
         if not options.base_channel:
-            logging.error(_('A base channel is required'))
+            logging.error(_N('A base channel is required'))
             return 1
 
         if not options.install_type:
-            logging.error(_('An install type is required'))
+            logging.error(_N('An install type is required'))
             return 1
 
     if update:
@@ -190,7 +191,7 @@ def do_distribution_delete(self, args):
                   (args, dists))
 
     if not dists:
-        logging.error(_("No distributions matched argument %s") % args)
+        logging.error(_N("No distributions matched argument %s") % args)
         return 1
 
     # Print the distributions prior to the confirmation
@@ -229,7 +230,7 @@ def do_distribution_details(self, args):
                   (args, dists))
 
     if not dists:
-        logging.error(_("No distributions matched argument %s") % args)
+        logging.error(_N("No distributions matched argument %s") % args)
         return 1
 
     add_separator = False

--- a/spacecmd/src/spacecmd/errata.py
+++ b/spacecmd/src/spacecmd/errata.py
@@ -37,6 +37,7 @@ try:
 except ImportError:
     import xmlrpclib
 
+from spacecmd.i18n import _N
 from spacecmd.utils import *
 
 translation = gettext.translation('spacecmd', fallback=True)
@@ -154,7 +155,7 @@ def do_errata_apply(self, args, only_systems=None):
     systems = sorted(list(set(systems)))
 
     if not systems:
-        logging.warning(_('No patches to apply'))
+        logging.warning(_N('No patches to apply'))
         return 1
 
     # a summary of which errata we're going to apply
@@ -193,7 +194,7 @@ def do_errata_apply(self, args, only_systems=None):
                                                    [erratum],
                                                    options.start_time)
 
-            logging.info('Scheduled %i system(s) for %s' %
+            logging.info(_N('Scheduled %i system(s) for %s') %
                          (len(to_apply[erratum]),
                           self.get_erratum_name(erratum)))
     else:
@@ -214,7 +215,7 @@ def do_errata_apply(self, args, only_systems=None):
                         break
 
             if not errata_to_apply:
-                logging.warning(_('No patches to schedule for %s') % system)
+                logging.warning(_N('No patches to schedule for %s') % system)
                 continue
 
             # this results in one action per erratum for each server
@@ -223,7 +224,7 @@ def do_errata_apply(self, args, only_systems=None):
                                                    errata_to_apply,
                                                    options.start_time)
 
-            logging.info(_('Scheduled %i patches for %s') %
+            logging.info(_N('Scheduled %i patches for %s') %
                          (len(errata_to_apply), system))
 
     return 0
@@ -386,7 +387,7 @@ def do_errata_details(self, args):
             channels = \
                 self.client.errata.applicableToChannels(self.session, erratum)
         except xmlrpclib.Fault:
-            logging.warning(_('%s is not a valid erratum') % erratum)
+            logging.warning(_N('%s is not a valid erratum') % erratum)
             continue
 
         if add_separator:
@@ -464,7 +465,7 @@ def do_errata_delete(self, args):
     errata = self.expand_errata(args)
 
     if not errata:
-        logging.warning(_('No patches to delete'))
+        logging.warning(_N('No patches to delete'))
         return 1
 
     print(_('Erratum            Channels'))
@@ -481,7 +482,7 @@ def do_errata_delete(self, args):
     for erratum in errata:
         self.client.errata.delete(self.session, erratum)
 
-    logging.info(_('Deleted %i patches') % len(errata))
+    logging.info(_N('Deleted %i patches') % len(errata))
 
     self.generate_errata_cache(True)
 
@@ -519,7 +520,7 @@ def do_errata_publish(self, args):
     channels = args[1:]
 
     if not errata:
-        logging.warning(_('No patches to publish'))
+        logging.warning(_N('No patches to publish'))
         return 1
 
     print('\n'.join(sorted(errata)))

--- a/spacecmd/src/spacecmd/group.py
+++ b/spacecmd/src/spacecmd/group.py
@@ -37,6 +37,8 @@ try:
     from xmlrpc import client as xmlrpclib
 except ImportError:
     import xmlrpclib
+
+from spacecmd.i18n import _N
 from spacecmd.utils import *
 
 translation = gettext.translation('spacecmd', fallback=True)
@@ -263,7 +265,7 @@ def do_group_backup(self, args):
         if not os.path.isdir(outputpath_base):
             os.makedirs(outputpath_base)
     except OSError:
-        logging.error(_('Could not create output directory: %s'), outputpath_base)
+        logging.error(_N('Could not create output directory: %s'), outputpath_base)
         return 1
 
     for group in groups:
@@ -326,21 +328,21 @@ def do_group_restore(self, args):
                 logging.debug("Found file %s" % inputdir + "/" + d_item)
                 files[d_item] = inputdir + "/" + d_item
     else:
-        logging.error(_("Restore dir %s does not exits or is not a directory") % inputdir)
+        logging.error(_N("Restore dir %s does not exits or is not a directory") % inputdir)
         return 1
 
     if not files:
-        logging.error(_("Restore dir %s has no restore items") % inputdir)
+        logging.error(_N("Restore dir %s has no restore items") % inputdir)
         return 1
 
     missing_groups = 0
     if groups and next(iter(groups)) != 'ALL':
         for group in groups:
             if group not in files:
-                logging.error(_("Group %s was not found in backup") % (group))
+                logging.error(_N("Group %s was not found in backup") % (group))
                 missing_groups += 1
     if missing_groups:
-        logging.error(_("Found %s missing groups, terminating"), missing_groups)
+        logging.error(_N("Found %s missing groups, terminating"), missing_groups)
         return 1
 
     for groupname in self.do_group_list('', True):
@@ -355,7 +357,7 @@ def do_group_restore(self, args):
         details = details.rstrip('\n')
 
         if groupname in current and current[groupname] == details:
-            logging.error(_("Group %s already restored") % groupname)
+            logging.error(_N("Group %s already restored") % groupname)
             continue
 
         elif groupname in current:
@@ -367,13 +369,13 @@ def do_group_restore(self, args):
                 userinput = prompt_user(_('Continue [y/N]:'))
 
                 if re.match('y', userinput, re.I):
-                    logging.info(_("Updating description for group: %s") % groupname)
+                    logging.info(_N("Updating description for group: %s") % groupname)
                     self.client.systemgroup.update(self.session, groupname, details)
             else:
-                logging.info(_("Updating description for group: %s") % groupname)
+                logging.info(_N("Updating description for group: %s") % groupname)
                 self.client.systemgroup.update(self.session, groupname, details)
         else:
-            logging.info(_("Creating new group %s") % groupname)
+            logging.info(_N("Creating new group %s") % groupname)
             self.client.systemgroup.create(self.session, groupname, details)
 
     return 0
@@ -423,7 +425,7 @@ def do_group_listsystems(self, args, doreturn=False):
         systems = self.client.systemgroup.listSystems(self.session, group)
         systems = [s.get('profile_name') for s in systems]
     except xmlrpclib.Fault:
-        logging.warning(_('%s is not a valid group') % group)
+        logging.warning(_N('%s is not a valid group') % group)
         return []
 
     if doreturn:
@@ -460,7 +462,7 @@ def do_group_details(self, args, short=False):
             details = self.client.systemgroup.getDetails(self.session, group)
             systems = [stm.get('profile_name') for stm in self.client.systemgroup.listSystems(self.session, group)]
         except xmlrpclib.Fault:
-            logging.warning(_('The group "%s" is invalid') % group)
+            logging.warning(_N('The group "%s" is invalid') % group)
             return 1
 
         if add_separator:

--- a/spacecmd/src/spacecmd/i18n.py
+++ b/spacecmd/src/spacecmd/i18n.py
@@ -1,0 +1,21 @@
+#
+# Licensed under the GNU General Public License Version 3
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Copyright (c) 2020 SUSE LLC
+
+def _N(message):
+    return message

--- a/spacecmd/src/spacecmd/kickstart.py
+++ b/spacecmd/src/spacecmd/kickstart.py
@@ -44,6 +44,8 @@ try:
     from xmlrpc import client as xmlrpclib
 except ImportError:
     import xmlrpclib
+
+from spacecmd.i18n import _N
 from spacecmd.utils import *
 
 translation = gettext.translation('spacecmd', fallback=True)
@@ -82,7 +84,7 @@ def do_kickstart_list(self, args, doreturn=False):
         if kickstarts:
             print(os.linesep.join(kickstarts))
         else:
-            logging.error(_("No kickstart profiles available"))
+            logging.error(_N("No kickstart profiles available"))
 
 ####################
 
@@ -139,23 +141,23 @@ def do_kickstart_create(self, args):
             if password1 == password2:
                 options.root_password = password1
             elif password1 == '':
-                logging.warning(_('Password must be at least 5 characters'))
+                logging.warning(_N('Password must be at least 5 characters'))
             else:
-                logging.warning(_("Passwords don't match"))
+                logging.warning(_N("Passwords don't match"))
     else:
         if not options.name:
-            logging.error(_('The Kickstart name is required'))
+            logging.error(_N('The Kickstart name is required'))
             return 1
 
         if not options.distribution:
-            logging.error(_('The distribution is required'))
+            logging.error(_N('The distribution is required'))
             return 1
 
         if not options.virt_type:
             options.virt_type = 'none'
 
         if not options.root_password:
-            logging.error(_('A root password is required'))
+            logging.error(_N('A root password is required'))
             return 1
 
     # leave this blank to use the default server
@@ -200,13 +202,13 @@ def do_kickstart_delete(self, args):
     logging.debug("Got labels to delete of %s" % labels)
 
     if not labels:
-        logging.error(_("No valid kickstart labels passed as arguments!"))
+        logging.error(_N("No valid kickstart labels passed as arguments!"))
         self.help_kickstart_delete()
         return 1
 
     mismatched = sorted(set(args).difference(set(all_labels)))
     if mismatched:
-        logging.error(_("The following kickstart labels are invalid:"),
+        logging.error(_N("The following kickstart labels are invalid:"),
                       ", ".join(mismatched))
         return 1
     else:
@@ -267,15 +269,15 @@ def kickstart_import_file(self, raw, args):
             options.distribution = prompt_user('Select:')
     else:
         if not options.name:
-            logging.error(_('The Kickstart name is required'))
+            logging.error(_N('The Kickstart name is required'))
             return
 
         if not options.distribution:
-            logging.error(_('The distribution is required'))
+            logging.error(_N('The distribution is required'))
             return
 
         if not options.file:
-            logging.error(_('A filename is required'))
+            logging.error(_N('A filename is required'))
             return
 
         if not options.virt_type:
@@ -350,7 +352,7 @@ def do_kickstart_details(self, args):
             break
 
     if not kickstart:
-        logging.warning(_('Invalid Kickstart profile'))
+        logging.warning(_N('Invalid Kickstart profile'))
         return
 
     act_keys = \
@@ -527,7 +529,7 @@ def kickstart_getcontents(self, profile):
             response = urlopen(url)
             kickstart = response.read()
         except HTTPError:
-            logging.error(_('Could not retrieve the Kickstart file'))
+            logging.error(_N('Could not retrieve the Kickstart file'))
 
     return kickstart
 
@@ -629,7 +631,7 @@ def do_kickstart_listcryptokeys(self, args, doreturn=False):
         if keys:
             print('\n'.join(keys))
         else:
-            logging.error(_("No crypto keys has been found"))
+            logging.error(_N("No crypto keys has been found"))
 
 ####################
 
@@ -1345,7 +1347,7 @@ def do_kickstart_addoption(self, args):
                                                          profile,
                                                          advanced)
     else:
-        logging.warning(_('%s needs to be set as a custom option') % key)
+        logging.warning(_N('%s needs to be set as a custom option') % key)
 
     return 0
 
@@ -1887,7 +1889,7 @@ def do_kickstart_listscripts(self, args):
     profile = args[0]
     scripts = self.client.kickstart.profile.listScripts(self.session, profile)
     if not scripts:
-        logging.error(_("No scripts has been found for profile '%s'"), profile)
+        logging.error(_N("No scripts has been found for profile '%s'"), profile)
     else:
         add_separator = False
         for script in scripts:
@@ -1977,15 +1979,15 @@ def do_kickstart_addscript(self, args):
             options.execution_time = 'post'
     else:
         if not options.profile:
-            logging.error(_('The Kickstart name is required'))
+            logging.error(_N('The Kickstart name is required'))
             return 1
 
         if not options.file:
-            logging.error(_('A filename is required'))
+            logging.error(_N('A filename is required'))
             return 1
 
         if not options.execution_time:
-            logging.error(_('The execution time is required'))
+            logging.error(_N('The execution time is required'))
             return 1
 
         if not options.chroot:
@@ -2055,7 +2057,7 @@ def do_kickstart_removescript(self, args):
         try:
             script_id = int(args[1])
         except ValueError:
-            logging.error(_('Invalid script ID'))
+            logging.error(_N('Invalid script ID'))
 
     # print(the scripts for the user to review)
     self.do_kickstart_listscripts(profile)
@@ -2068,7 +2070,7 @@ def do_kickstart_removescript(self, args):
             try:
                 script_id = int(userinput)
             except ValueError:
-                logging.error(_('Invalid script ID'))
+                logging.error(_N('Invalid script ID'))
 
     if not self.user_confirm(_('Remove this script [y/N]:')):
         return 1
@@ -2105,7 +2107,7 @@ def do_kickstart_clone(self, args):
 
     if is_interactive(options):
         if not profiles:
-            logging.error(_("No kickstart profiles available"))
+            logging.error(_N("No kickstart profiles available"))
             return 1
 
         print('')
@@ -2119,16 +2121,16 @@ def do_kickstart_clone(self, args):
     else:
 
         if not options.name:
-            logging.error(_('The Kickstart name is required'))
+            logging.error(_N('The Kickstart name is required'))
             return 1
 
         if not options.clonename:
-            logging.error(_('The Kickstart clone name is required'))
+            logging.error(_N('The Kickstart clone name is required'))
             return 1
 
     args.append(options.name)
     if not filter_results(profiles, args):
-        logging.error(_("Kickstart profile you've entered was not found"))
+        logging.error(_N("Kickstart profile you've entered was not found"))
         return 1
 
     self.client.kickstart.cloneProfile(self.session,
@@ -2268,7 +2270,7 @@ def do_kickstart_export(self, args):
     if not args:
         if not filename:
             filename = "ks_all.json"
-        logging.info(_("Exporting ALL kickstart profiles to %s") % filename)
+        logging.info(_N("Exporting ALL kickstart profiles to %s") % filename)
         profiles = self.do_kickstart_list('', True)
     else:
         # allow globbing of kickstart kickstart names
@@ -2276,7 +2278,7 @@ def do_kickstart_export(self, args):
         logging.debug("kickstart_export called with args %s, profiles=%s" %
                       (args, profiles))
         if not profiles:
-            logging.error(_("Error, no valid kickstart profile passed, " +
+            logging.error(_N("Error, no valid kickstart profile passed, " +
                           "check name is  correct with spacecmd kickstart_list"))
             return 1
         if not filename:
@@ -2296,7 +2298,7 @@ def do_kickstart_export(self, args):
     # Dump as a list of dict
     ksdetails_list = []
     for p in profiles:
-        logging.info(_("Exporting ks %s to %s") % (p, filename))
+        logging.info(_N("Exporting ks %s to %s") % (p, filename))
         ksdetails_list.append(self.export_kickstart_getdetails(p, kickstarts))
 
     logging.debug("About to dump %d ks profiles to %s" %
@@ -2307,7 +2309,7 @@ def do_kickstart_export(self, args):
                                  _("confirm overwrite file? (y/n)")):
             return 1
     if json_dump_to_file(ksdetails_list, filename) != True:
-        logging.error(_("Error saving exported kickstart profiles to file") %
+        logging.error(_N("Error saving exported kickstart profiles to file") %
                       filename)
         return 1
 
@@ -2327,7 +2329,7 @@ def do_kickstart_importjson(self, args):
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
-        logging.error(_("Error, no filename passed"))
+        logging.error(_N("Error, no filename passed"))
         self.help_kickstart_import()
         return 1
 
@@ -2335,11 +2337,11 @@ def do_kickstart_importjson(self, args):
         logging.debug("Passed filename do_kickstart_import %s" % filename)
         ksdetails_list = json_read_from_file(filename)
         if not ksdetails_list:
-            logging.error(_("Error, could not read json data from %s") % filename)
+            logging.error(_N("Error, could not read json data from %s") % filename)
             return 1
         for ksdetails in ksdetails_list:
             if self.import_kickstart_fromdetails(ksdetails) != True:
-                logging.error(_("Error importing kickstart %s") %
+                logging.error(_N("Error importing kickstart %s") %
                               ksdetails['name'])
 
     return 0
@@ -2352,11 +2354,11 @@ def import_kickstart_fromdetails(self, ksdetails):
     # First we check that an existing kickstart with the same name does not exist
     existing_profiles = self.do_kickstart_list('', True)
     if ksdetails['name'] in existing_profiles:
-        logging.error(_("ERROR : kickstart profile %s already exists! Skipping!")
+        logging.error(_N("ERROR : kickstart profile %s already exists! Skipping!")
                       % ksdetails['name'])
         return False
     # create the ks, we need to drop the org prefix from the ks name
-    logging.info(_("Found ks %s") % ksdetails['name'])
+    logging.info(_N("Found ks %s") % ksdetails['name'])
 
     # Create the kickstart
     # for adding new profiles, we require a root password.
@@ -2412,7 +2414,7 @@ def import_kickstart_fromdetails(self, ksdetails):
         if ret:
             logging.debug("Added %s script to profile" % script['script_type'])
         else:
-            logging.error(_("Error adding %s script") % script['script_type'])
+            logging.error(_N("Error adding %s script") % script['script_type'])
     # Specify ip ranges
     for iprange in ksdetails['ip_ranges']:
         if self.client.kickstart.profile.addIpRange(self.session,
@@ -2420,7 +2422,7 @@ def import_kickstart_fromdetails(self, ksdetails):
             logging.debug("added ip range %s-%s" %
                           iprange['min'], iprange['max'])
         else:
-            logging.warning(_("failed to add ip range %s-%s, continuing") %
+            logging.warning(_N("failed to add ip range %s-%s, continuing") %
                             iprange['min'], iprange['max'])
             continue
     # File preservations, only if the list exists
@@ -2434,9 +2436,9 @@ def import_kickstart_fromdetails(self, ksdetails):
                         self.session, ksdetails['label'], [fp]):
                     logging.debug("added file preservation '%s'" % fp)
                 else:
-                    logging.warning(_("failed to add file preservation %s, skipping") % fp)
+                    logging.warning(_N("failed to add file preservation %s, skipping") % fp)
             else:
-                logging.warning(_("file preservation list %s doesn't exist, skipping") % fp)
+                logging.warning(_N("file preservation list %s doesn't exist, skipping") % fp)
 
     # Now add activationkeys, only if they exist
     existing_act_keys = [k['key'] for k in
@@ -2447,7 +2449,7 @@ def import_kickstart_fromdetails(self, ksdetails):
             self.client.kickstart.profile.keys.addActivationKey(self.session,
                                                                 ksdetails['label'], akey)
         else:
-            logging.warning(_("Actvationkey %s does not exist on the ") % akey +
+            logging.warning(_N("Actvationkey %s does not exist on the ") % akey +
                             ("satellite, skipping"))
 
     # The GPG/SSL keys, only if they exist
@@ -2458,7 +2460,7 @@ def import_kickstart_fromdetails(self, ksdetails):
             self.client.kickstart.profile.system.addKeys(self.session,
                                                          ksdetails['label'], [key])
         else:
-            logging.warning(_("GPG/SSL key %s does not exist on the Spacewalk server, skipping") % key)
+            logging.warning(_N("GPG/SSL key %s does not exist on the Spacewalk server, skipping") % key)
 
     # The pre/post logging settings
     self.client.kickstart.profile.setLogging(self.session, ksdetails['label'],
@@ -2467,20 +2469,20 @@ def import_kickstart_fromdetails(self, ksdetails):
     # There are some frustrating ommisions from the API which means we can't
     # export/import some settings, so we post a warning that some manual
     # fixup may be required
-    logging.warning(_("Due to API ommissions, there are some settings which" +
+    logging.warning(_N("Due to API ommissions, there are some settings which" +
                     " cannot be imported, please check and fixup manually if necessary"))
-    logging.warning(_(" * Details->Preserve ks.cfg"))
-    logging.warning(_(" * Details->Comment"))
+    logging.warning(_N(" * Details->Preserve ks.cfg"))
+    logging.warning(_N(" * Details->Comment"))
     # Org default gets exported but no way to set it, so we can just show this
     # warning if they are trying to import an org_default profile
     if ksdetails['org_default']:
-        logging.warning(_(" * Details->Organization Default Profile"))
+        logging.warning(_N(" * Details->Organization Default Profile"))
     # No way to set the kernel options
-    logging.warning(_(" * Details->Kernel Options"))
+    logging.warning(_N(" * Details->Kernel Options"))
     # We can export Post kernel options (sort of, see above)
     # if they exist on import, flag a warning
     if 'post_kopts' in ksdetails:
-        logging.warning(_(" * Details->Post Kernel Options : %s") %
+        logging.warning(_N(" * Details->Post Kernel Options : %s") %
                         ksdetails['post_kopts'])
     return True
 
@@ -2496,10 +2498,10 @@ def is_kickstart(self, name):
 
 def check_kickstart(self, name):
     if not name:
-        logging.error(_("no kickstart label given"))
+        logging.error(_N("no kickstart label given"))
         return False
     if not self.is_kickstart(name):
-        logging.error(_("invalid kickstart label ") + name)
+        logging.error(_N("invalid kickstart label ") + name)
         return False
     return True
 
@@ -2593,13 +2595,13 @@ def do_kickstart_getupdatetype(self, args):
     logging.debug("Got labels to list the update type %s" % labels)
 
     if not labels:
-        logging.error(_("No valid kickstart labels passed as arguments!"))
+        logging.error(_N("No valid kickstart labels passed as arguments!"))
         self.help_kickstart_getupdatetype()
         return 1
 
     for label in labels:
         if not label in all_labels:
-            logging.error(_("kickstart label %s doesn't exist!") % label)
+            logging.error(_N("kickstart label %s doesn't exist!") % label)
             continue
 
         updatetype = self.client.kickstart.profile.getUpdateType(self.session, label)
@@ -2649,13 +2651,13 @@ def do_kickstart_setupdatetype(self, args):
     logging.debug("Got labels to set the update type %s" % labels)
 
     if not labels:
-        logging.error(_("No valid kickstart labels passed as arguments!"))
+        logging.error(_N("No valid kickstart labels passed as arguments!"))
         self.help_kickstart_setupdatetype()
         return 1
 
     for label in labels:
         if not label in all_labels:
-            logging.error(_("kickstart label %s doesn't exist!") % label)
+            logging.error(_N("kickstart label %s doesn't exist!") % label)
             continue
 
         self.client.kickstart.profile.setUpdateType(self.session, label, options.update_type)
@@ -2691,13 +2693,13 @@ def do_kickstart_getsoftwaredetails(self, args):
     logging.debug("Got labels to set the update type %s" % labels)
 
     if not labels:
-        logging.error(_("No valid kickstart labels passed as arguments!"))
+        logging.error(_N("No valid kickstart labels passed as arguments!"))
         self.help_kickstart_getsoftwaredetails()
         return 1
 
     for label in labels:
         if not label in all_labels:
-            logging.error(_("kickstart label %s doesn't exist!") % label)
+            logging.error(_N("kickstart label %s doesn't exist!") % label)
             continue
 
         software_details = self.client.kickstart.profile.software.getSoftwareDetails(self.session, label)

--- a/spacecmd/src/spacecmd/misc.py
+++ b/spacecmd/src/spacecmd/misc.py
@@ -45,6 +45,7 @@ try: # python 3
     from xmlrpc import client as xmlrpclib
 except ImportError: # python2
     import xmlrpclib
+from spacecmd.i18n import _N
 from spacecmd.utils import *
 
 translation = gettext.translation('spacecmd', fallback=True)
@@ -190,7 +191,7 @@ def do_get_session(self, args):
         print(self.session)
         return 0
     else:
-        logging.error(_('No session found'))
+        logging.error(_N('No session found'))
         return 1
 
 ####################
@@ -241,7 +242,7 @@ def do_login(self, args):
 
     # logout before logging in again
     if self.session:
-        logging.warning(_('You are already logged in'))
+        logging.warning(_N('You are already logged in'))
         return True
 
     # an argument passed to the function get precedence
@@ -253,7 +254,7 @@ def do_login(self, args):
 
     # bail out if not server was given
     if not server:
-        logging.warning(_('No server specified'))
+        logging.warning(_N('No server specified'))
         return False
 
     # load the server-specific configuration
@@ -298,7 +299,7 @@ def do_login(self, args):
             e = sys.exc_info()[0]
             logging.exception(e)
 
-        logging.error(_('Failed to connect to %s'), server_url)
+        logging.error(_N('Failed to connect to %s'), server_url)
         logging.debug("Error while connecting to the server %s: %s",
                       server_url, str(exc))
         self.client = None
@@ -306,7 +307,7 @@ def do_login(self, args):
 
     # ensure the server is recent enough
     if float(self.api_version) < self.MINIMUM_API_VERSION:
-        logging.error(_('API (%s) is too old (>= %s required)'),
+        logging.error(_N('API (%s) is too old (>= %s required)'),
                       self.api_version, self.MINIMUM_API_VERSION)
 
         self.client = None
@@ -336,7 +337,7 @@ def do_login(self, args):
 
             sessionfile.close()
         except IOError:
-            logging.error(_('Could not read %s'), session_file)
+            logging.error(_N('Could not read %s'), session_file)
 
     # check the cached credentials by doing an API call
     if self.session:
@@ -345,14 +346,14 @@ def do_login(self, args):
 
             self.client.user.listAssignableRoles(self.session)
         except xmlrpclib.Fault:
-            logging.warning(_('Cached credentials are invalid'))
+            logging.warning(_N('Cached credentials are invalid'))
             self.current_user = ''
             self.session = ''
 
     # attempt to login if we don't have a valid session yet
     if not self.session:
         if username:
-            logging.info(_('Spacewalk Username: %s'), username)
+            logging.info(_N('Spacewalk Username: %s'), username)
         else:
             username = prompt_user(_('Spacewalk Username:'), noblank=True)
 
@@ -371,7 +372,7 @@ def do_login(self, args):
         try:
             self.session = self.client.auth.login(username, password)
         except xmlrpclib.Fault as exc:
-            logging.error(_('Invalid credentials'))
+            logging.error(_N('Invalid credentials'))
             logging.debug("Login error: %s (%s)", exc.faultString, exc.faultCode)
             return False
         try:
@@ -389,7 +390,7 @@ def do_login(self, args):
             sessionfile.write(line)
             sessionfile.close()
         except IOError as exc:
-            logging.error(_('Could not write session file: %s'), str(exc))
+            logging.error(_N('Could not write session file: %s'), str(exc))
 
     # load the system/package/errata caches
     self.load_caches(server, username)
@@ -398,7 +399,7 @@ def do_login(self, args):
     self.current_user = username
     self.server = server
 
-    logging.info(_('Connected to %s as %s'), server_url, username)
+    logging.info(_N('Connected to %s as %s'), server_url, username)
 
     return True
 
@@ -433,7 +434,7 @@ def do_whoami(self, args):
         print(self.current_user)
         return 0
     else:
-        logging.warning(_("You are not logged in"))
+        logging.warning(_N("You are not logged in"))
         return 1
 
 ####################
@@ -449,7 +450,7 @@ def do_whoamitalkingto(self, args):
         print(self.server)
         return 0
     else:
-        logging.warning(_('Yourself'))
+        logging.warning(_N('Yourself'))
         return 1
 
 ####################
@@ -712,7 +713,7 @@ def load_caches(self, server, username):
         if not os.path.isdir(conf_dir):
             os.mkdir(conf_dir, int('0700', 8))
     except OSError:
-        logging.error(_('Could not create directory %s'), conf_dir)
+        logging.error(_N('Could not create directory %s'), conf_dir)
         return
 
     self.ssm_cache_file = os.path.join(conf_dir, 'ssm')
@@ -784,14 +785,14 @@ def get_system_id(self, name):
     if len(systems) == 1:
         return systems[0]
     elif not systems:
-        logging.warning(_("Can't find system ID for %s"), name)
+        logging.warning(_N("Can't find system ID for %s"), name)
         return 0
     else:
         if len(systems) == 2 and systems[0] == systems[1]:
             return systems[0]
-        logging.warning(_('Duplicate system profile names found!'))
-        logging.warning(_("Please reference systems by ID or resolve the"))
-        logging.warning(_("underlying issue with 'system_delete' or 'system_rename'"))
+        logging.warning(_N('Duplicate system profile names found!'))
+        logging.warning(_N("Please reference systems by ID or resolve the"))
+        logging.warning(_N("underlying issue with 'system_delete' or 'system_rename'"))
 
         id_list = '%s = ' % name
 
@@ -857,7 +858,7 @@ def expand_systems(self, args):
             if members:
                 systems.extend([re.escape(m) for m in members])
             else:
-                logging.warning(_('No systems in group %s'), item)
+                logging.warning(_N('No systems in group %s'), item)
         elif re.match('search:', item):
             query = item.split(':', 1)[1]
             results = self.do_system_search(query, True)
@@ -871,7 +872,7 @@ def expand_systems(self, args):
             if members:
                 systems.extend([re.escape(m) for m in members])
             else:
-                logging.warning(_('No systems subscribed to %s'), item)
+                logging.warning(_N('No systems subscribed to %s'), item)
         else:
             # translate system IDs that the user passes
             try:

--- a/spacecmd/src/spacecmd/org.py
+++ b/spacecmd/src/spacecmd/org.py
@@ -33,6 +33,7 @@ import gettext
 import logging
 from getpass import getpass
 from operator import itemgetter
+from spacecmd.i18n import _N
 from spacecmd.utils import *
 
 _PREFIXES = ['Dr.', 'Mr.', 'Miss', 'Mrs.', 'Ms.']
@@ -92,32 +93,32 @@ def do_org_create(self, args):
             if password1 == password2:
                 options.password = password1
             elif len(password1) < 5:
-                logging.warning(_('Password must be at least 5 characters'))
+                logging.warning(_N('Password must be at least 5 characters'))
             else:
-                logging.warning(_("Passwords don't match"))
+                logging.warning(_N("Passwords don't match"))
     else:
         if not options.org_name:
-            logging.error(_('An organization name is required'))
+            logging.error(_N('An organization name is required'))
             return 1
 
         if not options.username:
-            logging.error(_('A username is required'))
+            logging.error(_N('A username is required'))
             return 1
 
         if not options.first_name:
-            logging.error(_('A first name is required'))
+            logging.error(_N('A first name is required'))
             return 1
 
         if not options.last_name:
-            logging.error(_('A last name is required'))
+            logging.error(_N('A last name is required'))
             return 1
 
         if not options.email:
-            logging.error(_('An email address is required'))
+            logging.error(_N('An email address is required'))
             return 1
 
         if not options.password:
-            logging.error(_('A password is required'))
+            logging.error(_N('A password is required'))
             return 1
 
         if not options.pam:
@@ -165,7 +166,7 @@ def do_org_delete(self, args):
     name = args[0]
     org_id = self.get_org_id(name)
     if not org_id:
-        logging.warning(_("No organisation found for the name %s"), name)
+        logging.warning(_N("No organisation found for the name %s"), name)
         print(_("Organisation '{}' was not found").format(name))
         return 1
     elif self.user_confirm(_('Delete this organization [y/N]:')):
@@ -196,7 +197,7 @@ def do_org_rename(self, args):
     name, new_name = args
     org_id = self.get_org_id(name)
     if not org_id:
-        logging.warning(_("No organisation found for the name %s"), name)
+        logging.warning(_N("No organisation found for the name %s"), name)
         print(_("Organisation '{}' was not found").format(name))
         return 1
     else:
@@ -230,11 +231,11 @@ def do_org_addtrust(self, args):
     org_to_trust_id = self.get_org_id(trust_org)
 
     if your_org_id is None:
-        logging.warning(_("No organisation found for the name %s"), your_org)
+        logging.warning(_N("No organisation found for the name %s"), your_org)
         print(_("Organisation '{}' was not found").format(your_org))
         return 1
     elif org_to_trust_id is None:
-        logging.warning(_("No trust organisation found for the name %s"), trust_org)
+        logging.warning(_N("No trust organisation found for the name %s"), trust_org)
         print(_("Organisation '{}' to trust for, was not found").format(trust_org))
         return 1
     else:
@@ -266,11 +267,11 @@ def do_org_removetrust(self, args):
     your_org_id = self.get_org_id(your_org)
     trusted_org_id = self.get_org_id(trust_org)
     if your_org_id is None:
-        logging.warning(_("No organisation found for the name %s"), your_org)
+        logging.warning(_N("No organisation found for the name %s"), your_org)
         print(_("Organisation '{}' was not found").format(your_org))
         return 1
     elif trusted_org_id is None:
-        logging.warning(_("No trust organisation found for the name %s"), trust_org)
+        logging.warning(_N("No trust organisation found for the name %s"), trust_org)
         print(_("Organisation '{}' to trust for, was not found").format(trust_org))
         return 1
     else:
@@ -309,7 +310,7 @@ def do_org_trustdetails(self, args):
     trusted_org = args[0]
     org_id = self.get_org_id(trusted_org)
     if org_id is None:
-        logging.warning(_("No trusted organisation found for the name %s"), trusted_org)
+        logging.warning(_N("No trusted organisation found for the name %s"), trusted_org)
         print(_("Trusted organisation '{}' was not found").format(trusted_org))
         return 1
     else:
@@ -374,14 +375,14 @@ def do_org_listtrusts(self, args):
 
     org_id = self.get_org_id(args[0])
     if org_id is None:
-        logging.warning(_("No organisation found for the name %s"), args[0])
+        logging.warning(_N("No organisation found for the name %s"), args[0])
         print(_("Organisation '{}' was not found").format(args[0]))
         return 1
     else:
         trusts = self.client.org.trusts.listTrusts(self.session, org_id)
         if not trusts:
             print(_("No trust organisation has been found"))
-            logging.warning(_("No trust organisation has been found"))
+            logging.warning(_N("No trust organisation has been found"))
             return 1
         else:
             for trust in sorted(trusts, key=itemgetter('orgName')):
@@ -410,7 +411,7 @@ def do_org_listusers(self, args):
 
     org_id = self.get_org_id(args[0])
     if org_id is None:
-        logging.warning(_("No organisation found for the name %s"), args[0])
+        logging.warning(_N("No organisation found for the name %s"), args[0])
         print(_("Organisation '{}' was not found").format(args[0]))
         return 1
     else:

--- a/spacecmd/src/spacecmd/package.py
+++ b/spacecmd/src/spacecmd/package.py
@@ -34,6 +34,7 @@ try:
     from xmlrpc import client as xmlrpclib
 except ImportError:
     import xmlrpclib
+from spacecmd.i18n import _N
 from spacecmd.utils import *
 
 translation = gettext.translation('spacecmd', fallback=True)
@@ -65,7 +66,7 @@ def do_package_details(self, args):
         packages.extend(self.do_package_search(' '.join(args), True))
 
     if not packages:
-        logging.warning(_('No packages found'))
+        logging.warning(_N('No packages found'))
         return 1
 
     add_separator = False
@@ -78,7 +79,7 @@ def do_package_details(self, args):
         package_ids = self.get_package_id(package)
 
         if not package_ids:
-            logging.warning(_('%s is not a valid package') % package)
+            logging.warning(_N('%s is not a valid package') % package)
             continue
 
         for package_id in package_ids:
@@ -212,7 +213,7 @@ def do_package_remove(self, args):
             try:
                 self.client.packages.removePackage(self.session, package_id)
             except xmlrpclib.Fault:
-                logging.error(_('Failed to remove package ID %i') % package_id)
+                logging.error(_N('Failed to remove package ID %i') % package_id)
 
     # regenerate the package cache after removing these packages
     self.generate_package_cache(True)
@@ -253,7 +254,7 @@ def do_package_removeorphans(self, args):
 
     if not packages:
         print(_("No orphaned packages has been found"))
-        logging.warning(_('No orphaned packages'))
+        logging.warning(_N('No orphaned packages'))
         return 1
 
     if not self.user_confirm(_('Remove these packages [y/N]:')):
@@ -268,7 +269,7 @@ def do_package_removeorphans(self, args):
         try:
             self.client.packages.removePackage(self.session, package.get('id'))
         except xmlrpclib.Fault:
-            logging.error(_('Failed to remove package ID %i') % package.get('id'))
+            logging.error(_N('Failed to remove package ID %i') % package.get('id'))
             return 1
 
     return 0
@@ -299,7 +300,7 @@ def do_package_listinstalledsystems(self, args):
         packages.extend(self.do_package_search(package, True))
 
     if not packages:
-        logging.warning(_('No packages found'))
+        logging.warning(_N('No packages found'))
         return 1
 
     add_separator = False
@@ -348,7 +349,7 @@ def do_package_listerrata(self, args):
         packages.extend(self.do_package_search(' '.join(args), True))
 
     if not packages:
-        logging.warning(_('No packages found'))
+        logging.warning(_N('No packages found'))
         return 1
 
     add_separator = False
@@ -392,7 +393,7 @@ def do_package_listdependencies(self, args):
         packages.extend(self.do_package_search(' '.join(args), True))
 
     if not packages:
-        logging.warning(_('No packages found'))
+        logging.warning(_N('No packages found'))
         return 1
 
     add_separator = False
@@ -403,7 +404,7 @@ def do_package_listdependencies(self, args):
         add_separator = False
         for package_id in self.get_package_id(package):
             if not package_id:
-                logging.warning(_('%s is not a valid package') % package)
+                logging.warning(_N('%s is not a valid package') % package)
                 continue
 
             package_id = int(package_id)

--- a/spacecmd/src/spacecmd/repo.py
+++ b/spacecmd/src/spacecmd/repo.py
@@ -35,6 +35,7 @@ try:
     from xmlrpc import client as xmlrpclib
 except ImportError:
     import xmlrpclib
+from spacecmd.i18n import _N
 from spacecmd.utils import *
 
 translation = gettext.translation('spacecmd', fallback=True)
@@ -163,7 +164,7 @@ def do_repo_addfilters(self, args):
         repofilter = arg[1:]
 
         if not (flag == '+' or flag == '-'):
-            logging.error(_('Each filter must start with + or -'))
+            logging.error(_N('Each filter must start with + or -'))
             return 1
 
         self.client.channel.software.addRepoFilter(self.session,
@@ -200,7 +201,7 @@ def do_repo_removefilters(self, args):
         repofilter = arg[1:]
 
         if not (flag == '+' or flag == '-'):
-            logging.error(_('Each filter must start with + or -'))
+            logging.error(_N('Each filter must start with + or -'))
             return 1
 
         self.client.channel.software.removeRepoFilter(self.session,
@@ -239,7 +240,7 @@ def do_repo_setfilters(self, args):
         repofilter = arg[1:]
 
         if not (flag == '+' or flag == '-'):
-            logging.error(_('Each filter must start with + or -'))
+            logging.error(_N('Each filter must start with + or -'))
             return 1
 
         filters.append({'filter': repofilter, 'flag': flag})
@@ -313,7 +314,7 @@ def do_repo_delete(self, args):
             try:
                 self.client.channel.software.removeRepo(self.session, repo)
             except xmlrpclib.Fault:
-                logging.error(_('Failed to remove repo %s') % repo)
+                logging.error(_N('Failed to remove repo %s') % repo)
 
     return 0
 
@@ -354,11 +355,11 @@ def do_repo_create(self, args):
         options.key = prompt_user(_('SSL Client key:'))
     else:
         if not options.name:
-            logging.error(_('A name is required'))
+            logging.error(_N('A name is required'))
             return 1
 
         if not options.url:
-            logging.error(_('A URL is required'))
+            logging.error(_N('A URL is required'))
             return 1
 
         if not options.type:
@@ -401,7 +402,7 @@ def do_repo_rename(self, args):
         details = self.client.channel.software.getRepoDetails(self.session, args[0])
         oldname = details.get('id')
     except xmlrpclib.Fault:
-        logging.error(_('Could not find repo %s') % args[0])
+        logging.error(_N('Could not find repo %s') % args[0])
         return 1
 
     newname = args[1]
@@ -464,7 +465,7 @@ def do_repo_updatessl(self, args):
         options.key = prompt_user(_('SSL Client key:'))
     else:
         if not options.name:
-            logging.error(_('A name is required'))
+            logging.error(_N('A name is required'))
             return 1
 
     self.client.channel.software.updateRepoSsl(self.session,

--- a/spacecmd/src/spacecmd/report.py
+++ b/spacecmd/src/spacecmd/report.py
@@ -31,6 +31,7 @@
 
 import gettext
 from operator import itemgetter
+from spacecmd.i18n import _N
 from spacecmd.utils import *
 
 translation = gettext.translation('spacecmd', fallback=True)
@@ -198,7 +199,7 @@ def do_report_ipaddresses(self, args):
         systems = self.get_system_names()
 
     if not systems:
-        logging.warning(_('No systems selected'))
+        logging.warning(_N('No systems selected'))
         return 1
 
     report = {}
@@ -262,7 +263,7 @@ def do_report_kernels(self, args):
         systems = self.get_system_names()
 
     if not systems:
-        logging.warning(_('No systems selected'))
+        logging.warning(_N('No systems selected'))
         return 1
 
     report = {}

--- a/spacecmd/src/spacecmd/scap.py
+++ b/spacecmd/src/spacecmd/scap.py
@@ -31,6 +31,7 @@
 # pylint: disable=C0103
 
 import gettext
+from spacecmd.i18n import _N
 from spacecmd.utils import *
 
 translation = gettext.translation('spacecmd', fallback=True)
@@ -64,7 +65,7 @@ def do_scap_listxccdfscans(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning(_('No systems selected'))
+        logging.warning(_N('No systems selected'))
         return 1
 
     add_separator = False
@@ -150,7 +151,7 @@ def do_scap_getxccdfscandetails(self, args):
         add_separator = True
 
         if len(args) > 1:
-            print('XID: %s' % xid)
+            print(_('XID: %s') % xid)
             print('')
 
         xid = int(xid)
@@ -204,7 +205,7 @@ def do_scap_schedulexccdfscan(self, args):
         systems = self.expand_systems(args[2:])
 
     if not systems:
-        logging.warning(_('No systems selected'))
+        logging.warning(_N('No systems selected'))
         return 1
 
     for system in systems:

--- a/spacecmd/src/spacecmd/schedule.py
+++ b/spacecmd/src/spacecmd/schedule.py
@@ -36,6 +36,7 @@ try:
     from xmlrpc import client as xmlrpclib
 except ImportError:
     import xmlrpclib
+from spacecmd.i18n import _N
 from spacecmd.utils import *
 
 translation = gettext.translation('spacecmd', fallback=True)
@@ -155,7 +156,7 @@ def do_schedule_cancel(self, args):
     # cancel all actions
     if '.*' in args:
         if not self.user_confirm(_('Cancel all pending actions [y/N]:')):
-            logging.info(_("All pending actions left untouched"))
+            logging.info(_N("All pending actions left untouched"))
             return 1
 
         actions = self.client.schedule.listInProgressActions(self.session)
@@ -170,16 +171,16 @@ def do_schedule_cancel(self, args):
         try:
             actions.append(int(a))
         except ValueError:
-            logging.warning(_('"%s" is not a valid ID') % str(a))
+            logging.warning(_N('"%s" is not a valid ID') % str(a))
             failed_actions.append(a)
 
     if actions:
         self.client.schedule.cancelActions(self.session, actions)
         for a in actions:
-            logging.info(_('Canceled action: %i'), a)
+            logging.info(_N('Canceled action: %i'), a)
     if failed_actions:
         for action in failed_actions:
-            logging.info(_("Failed action: %s"), action)
+            logging.info(_N("Failed action: %s"), action)
 
     print(_('Canceled %i action(s)') % len(actions))
 
@@ -229,13 +230,13 @@ def do_schedule_reschedule(self, args):
                 if action_id in failed_actions:
                     to_reschedule.append(action_id)
                 else:
-                    logging.warning(_('"%i" is not a failed action') % action_id)
+                    logging.warning(_N('"%i" is not a failed action') % action_id)
             except ValueError:
-                logging.warning(_('"%s" is not a valid ID') % str(a))
+                logging.warning(_N('"%s" is not a valid ID') % str(a))
                 continue
 
     if not to_reschedule:
-        logging.warning(_('No failed actions to reschedule'))
+        logging.warning(_N('No failed actions to reschedule'))
         return 1
     else:
         self.client.schedule.rescheduleActions(self.session, to_reschedule, True)
@@ -265,7 +266,7 @@ def do_schedule_details(self, args):
     try:
         action_id = int(action_id)
     except ValueError:
-        logging.warning(_('The ID "%s" is invalid') % action_id)
+        logging.warning(_N('The ID "%s" is invalid') % action_id)
         return 1
 
     completed = self.client.schedule.listCompletedSystems(self.session, action_id)
@@ -304,7 +305,7 @@ def do_schedule_details(self, args):
             for s in pending:
                 print(s.get('server_name'))
     else:
-        logging.error(_('No action found with the ID "%s"') % action_id)
+        logging.error(_N('No action found with the ID "%s"') % action_id)
         return 1
 
     return 0
@@ -329,7 +330,7 @@ def do_schedule_getoutput(self, args):
     try:
         action_id = int(args[0])
     except ValueError:
-        logging.error(_('"%s" is not a valid action ID') % str(args[0]))
+        logging.error(_N('"%s" is not a valid action ID') % str(args[0]))
         return 1
 
     script_results = None
@@ -382,7 +383,7 @@ def do_schedule_getoutput(self, args):
                 print('------')
                 print(action.get('message'))
         else:
-            logging.error(_("No systems found"))
+            logging.error(_N("No systems found"))
             return 1
 
     return 0

--- a/spacecmd/src/spacecmd/shell.py
+++ b/spacecmd/src/spacecmd/shell.py
@@ -41,6 +41,7 @@ import re
 import shlex
 import sys
 from cmd import Cmd
+from spacecmd.i18n import _N
 from spacecmd.utils import *
 
 translation = gettext.translation('spacecmd', fallback=True)
@@ -117,11 +118,11 @@ class SpacewalkShell(Cmd):
                     atexit.register(readline.write_history_file,
                                     self.history_file)
                 except IOError:
-                    logging.error(_('Could not read history file'))
+                    logging.error(_N('Could not read history file'))
         # pylint: disable=W0702
         except Exception as exc:
             # pylint: disable=W0702
-            logging.error(_("Exception occurred: {}").format(exc))
+            logging.error(_N("Exception occurred: {}").format(exc))
             sys.exit(1)
 
     # handle shell exits and history substitution
@@ -185,7 +186,7 @@ class SpacewalkShell(Cmd):
             if line:
                 history_match = True
             else:
-                logging.warning(_('%s: event not found'), command)
+                logging.warning(_N('%s: event not found'), command)
                 return ''
 
         # attempt to find a numbered history item
@@ -224,7 +225,7 @@ class SpacewalkShell(Cmd):
             print(line)
             return line
         else:
-            logging.warning(_('%s: event not found'), command)
+            logging.warning(_N('%s: event not found'), command)
             return ''
 
     @staticmethod

--- a/spacecmd/src/spacecmd/snippet.py
+++ b/spacecmd/src/spacecmd/snippet.py
@@ -30,6 +30,7 @@
 # pylint: disable=C0103
 
 import gettext
+from spacecmd.i18n import _N
 from spacecmd.utils import *
 
 translation = gettext.translation('spacecmd', fallback=True)
@@ -87,7 +88,7 @@ def do_snippet_details(self, args):
                 break
 
         if not snippet:
-            logging.warning(_('%s is not a valid snippet') % name)
+            logging.warning(_N('%s is not a valid snippet') % name)
             continue
 
         if add_separator:
@@ -146,11 +147,11 @@ def do_snippet_create(self, args, update_name=''):
                                          delete=True)
     else:
         if not options.name:
-            logging.error(_('A name is required for the snippet'))
+            logging.error(_N('A name is required for the snippet'))
             return 1
 
         if not options.file:
-            logging.error(_('A file is required'))
+            logging.error(_N('A file is required'))
             return 1
 
     if options.file:

--- a/spacecmd/src/spacecmd/softwarechannel.py
+++ b/spacecmd/src/spacecmd/softwarechannel.py
@@ -43,6 +43,7 @@ try:
     from xmlrpc import client as xmlrpclib
 except ImportError:
     import xmlrpclib
+from spacecmd.i18n import _N
 from spacecmd.utils import *
 
 translation = gettext.translation('spacecmd', fallback=True)
@@ -440,13 +441,13 @@ def do_softwarechannel_setdetails(self, args):
         new_details['gpg_key_fp'] = options.gpg_fingerprint
 
     if not new_details:
-        logging.error(_('At least one attribute to set must be given'))
+        logging.error(_N('At least one attribute to set must be given'))
         return 1
 
     # allow globbing of software channel names
     channels = filter_results(self.do_softwarechannel_list('', True), args)
     if len(channels) < 1:
-        logging.info(_('No channels matching that label'))
+        logging.info(_N('No channels matching that label'))
         return 1
 
     # channel names must be unique, so if we are asked to set it,
@@ -458,7 +459,7 @@ def do_softwarechannel_setdetails(self, args):
     # also fails on same label.
     if new_details.get('name'):
         if len(channels) > 1:
-            logging.error(_('Setting same name for more than ' + \
+            logging.error(_N('Setting same name for more than ' + \
                           'one channel will fail'))
             return 1
         logging.debug('checking other channels for name "%s"' %
@@ -466,7 +467,7 @@ def do_softwarechannel_setdetails(self, args):
         for c in self.list_base_channels() + self.list_child_channels():
             cd = self.client.channel.software.getDetails(self.session, c)
             if cd.get('name') == new_details.get('name'):
-                logging.error(_('Name "%s" already in use by channel %s') %
+                logging.error(_N('Name "%s" already in use by channel %s') %
                               (cd.get('name'), cd.get('label')))
                 return 1
 
@@ -509,7 +510,7 @@ def do_softwarechannel_setdetails(self, args):
             details = self.client.channel.software.getDetails(self.session,
                                                               channel)
         except xmlrpclib.Fault as e:
-            logging.error(_('Could not get details for %s') % channel)
+            logging.error(_N('Could not get details for %s') % channel)
             logging.error(e)
             return 1
         channel_id = details.get('id')
@@ -521,10 +522,10 @@ def do_softwarechannel_setdetails(self, args):
                                                     new_details)
             num_changed += 1
         except xmlrpclib.Fault as e:
-            logging.error(_('Error while setting details for %s') % channel)
+            logging.error(_N('Error while setting details for %s') % channel)
             logging.error(e)
             return 1
-    logging.info(_('Channels changed: %d') % num_changed)
+    logging.info(_N('Channels changed: %d') % num_changed)
 
     return 0
 
@@ -653,7 +654,7 @@ def do_softwarechannel_listerrata(self, args):
 
     for channel in sorted(channels):
         if len(channels) > 1:
-            print('Channel: %s' % channel)
+            print(_('Channel: %s') % channel)
             print('')
 
         if begin_date and end_date:
@@ -843,10 +844,10 @@ def do_softwarechannel_update(self, args):
         options.disable_gpg_check = prompt_user(_('Disable GPG Check [yes/no]? '))
 
     if not options.label:
-        logging.error(_('A channel label is required to identify the channel'))
+        logging.error(_N('A channel label is required to identify the channel'))
         return 1
     if options.disable_gpg_check and options.disable_gpg_check not in ('yes','no'):
-        logging.error(_('Only [yes/no] values are acceptable for --disable_gpg_check'))
+        logging.error(_N('Only [yes/no] values are acceptable for --disable_gpg_check'))
         return 1
     details = {}
     if not vendor_channel:
@@ -1020,11 +1021,11 @@ def set_default_data(options):
 
 def validate_required_data(options):
     if not options.name:
-        logging.error(_('A channel name is required'))
+        logging.error(_N('A channel name is required'))
         return False
 
     if not options.label:
-        logging.error(_('A channel label is required'))
+        logging.error(_N('A channel label is required'))
         return False
 
     return True
@@ -1037,11 +1038,11 @@ def softwarechannel_check_existing(self, name, label):
     for c in self.list_base_channels() + self.list_child_channels():
         cd = self.client.channel.software.getDetails(self.session, c)
         if cd['name'] == name:
-            logging.error(_("Name %s already in use by channel %s") %
+            logging.error(_N("Name %s already in use by channel %s") %
                           (name, cd['label']))
             return True
         if cd['label'] == label:
-            logging.error(_("Label %s already in use by channel %s") %
+            logging.error(_N("Label %s already in use by channel %s") %
                           (label, cd['label']))
             return True
     return False
@@ -1114,15 +1115,15 @@ def do_softwarechannel_clone(self, args):
                               ignore_yes=True)
     else:
         if not options.source_channel:
-            logging.error(_('A source channel is required'))
+            logging.error(_N('A source channel is required'))
             return 1
 
         if not options.name and not options.regex:
-            logging.error(_('A channel name is required'))
+            logging.error(_N('A channel name is required'))
             return 1
 
         if not options.label and not options.regex:
-            logging.error(_('A channel label is required'))
+            logging.error(_N('A channel label is required'))
             return 1
 
         if not options.original_state:
@@ -1135,7 +1136,7 @@ def do_softwarechannel_clone(self, args):
                 options.name = newvalues['name']
 
     if options.disable_gpg_check and options.disable_gpg_check not in ('yes', 'no'):
-        logging.error(_('Only [yes/no] values are acceptable for --disable-gpg-check'))
+        logging.error(_N('Only [yes/no] values are acceptable for --disable-gpg-check'))
         return 1
     if self.softwarechannel_check_existing(options.name, options.label):
         return 1
@@ -1202,23 +1203,23 @@ def do_softwarechannel_clonetree(self, args):
             self.user_confirm(_('Original State (No Errata) [y/N]:'), ignore_yes=True)
     else:
         if not options.source_channel:
-            logging.error(_('A source channel is required'))
+            logging.error(_N('A source channel is required'))
             return 1
 
         if not options.prefix and not options.regex:
-            logging.error(_('A prefix or regex is required'))
+            logging.error(_N('A prefix or regex is required'))
             return 1
 
         if not options.original_state:
             options.original_state = False
 
     if options.disable_gpg_check and options.disable_gpg_check not in ('yes', 'no'):
-        logging.error(_('Only [yes/no] values are acceptable for --disable-gpg-check'))
+        logging.error(_N('Only [yes/no] values are acceptable for --disable-gpg-check'))
         return 1
 
     channels = [options.source_channel]
     if not options.source_channel in self.list_base_channels():
-        logging.error(_("Channel does not exist or is not a base channel!"))
+        logging.error(_N("Channel does not exist or is not a base channel!"))
         self.help_softwarechannel_clonetree()
         return 1
     logging.debug("--child mode specified, finding children of %s\n" % options.source_channel)
@@ -1245,7 +1246,7 @@ def do_softwarechannel_clonetree(self, args):
             name = options.prefix + srcdetails['name']
         else:
             # Shouldn't ever get here due to earlier checks
-            logging.error(_("called without prefix or regex option!"))
+            logging.error(_N("called without prefix or regex option!"))
             return 1
 
         # Catch label or name which already exists
@@ -1297,7 +1298,7 @@ def clone_channel(self, channel, options, details) :
 
     for key in to_remove:
         del details[key]
-    logging.info("Cloning %s as %s" % (channel, details['label']))
+    logging.info(_N("Cloning %s as %s") % (channel, details['label']))
     self.client.channel.software.clone(self.session,
                                        channel,
                                        details,
@@ -1371,7 +1372,7 @@ def do_softwarechannel_addpackages(self, args):
     # Take the first argument as the channel and validate it
     channel = args.pop(0)
     if not channel in self.do_softwarechannel_list('', True):
-        logging.error(_("%s is not a valid channel") % channel)
+        logging.error(_N("%s is not a valid channel") % channel)
         self.help_softwarechannel_addpackages()
         return 1
 
@@ -1386,7 +1387,7 @@ def do_softwarechannel_addpackages(self, args):
         package_ids += self.get_package_id(package)
 
     if not package_ids:
-        logging.warning(_('No packages to add'))
+        logging.warning(_N('No packages to add'))
         return 1
 
     print(_('Packages'))
@@ -1485,7 +1486,7 @@ def do_softwarechannel_removeerrata(self, args):
                 package_ids.append(package.get('id'))
 
     if not errata_details:
-        logging.warning(_('No patches to remove'))
+        logging.warning(_N('No patches to remove'))
         return 1
 
     print_errata_list(errata_details)
@@ -1570,7 +1571,7 @@ def do_softwarechannel_removepackages(self, args):
         package_ids += self.get_package_id(package)
 
     if not package_ids:
-        logging.warning(_('No packages to remove'))
+        logging.warning(_N('No packages to remove'))
         return 1
 
     print(_('Packages'))
@@ -1622,12 +1623,12 @@ def do_softwarechannel_adderratabydate(self, args):
     end_date = args[3]
 
     if not re.match(r'\d{8}', begin_date):
-        logging.error(_('%s is an invalid date') % begin_date)
+        logging.error(_N('%s is an invalid date') % begin_date)
         self.help_softwarechannel_adderratabydate()
         return 1
 
     if not re.match(r'\d{8}', end_date):
-        logging.error(_('%s is an invalid date') % end_date)
+        logging.error(_N('%s is an invalid date') % end_date)
         self.help_softwarechannel_adderratabydate()
         return 1
 
@@ -1640,14 +1641,14 @@ def do_softwarechannel_adderratabydate(self, args):
                                                 parse_time_input(end_date))
 
     if not errata:
-        logging.warning(_('No patches found between the given dates'))
+        logging.warning(_N('No patches found between the given dates'))
         return 1
 
     if options.publish:
         # Just publish the errata one-by-one, rather than calling
         # do_softwarechannel_adderrata which clones the errata
         for e in errata:
-            logging.info(_("Publishing errata %s to %s") %
+            logging.info(_N("Publishing errata %s to %s") %
                          (e.get('advisory_name'), dest_channel))
             self.client.errata.publish(self.session, e.get('advisory_name'),
                                        [dest_channel])
@@ -1693,12 +1694,12 @@ def do_softwarechannel_listerratabydate(self, args):
     end_date = args[2]
 
     if not re.match(r'\d{8}', begin_date):
-        logging.error(_('%s is an invalid date') % begin_date)
+        logging.error(_N('%s is an invalid date') % begin_date)
         self.help_softwarechannel_listerratabydate()
         return 1
 
     if not re.match(r'\d{8}', end_date):
-        logging.error(_('%s is an invalid date') % end_date)
+        logging.error(_N('%s is an invalid date') % end_date)
         self.help_softwarechannel_listerratabydate()
         return 1
 
@@ -1711,7 +1712,7 @@ def do_softwarechannel_listerratabydate(self, args):
                                                 parse_time_input(end_date))
 
     if not errata:
-        logging.warning(_('No errata found between the given dates'))
+        logging.warning(_N('No errata found between the given dates'))
         return 1
 
     print_errata_list(errata)
@@ -1753,12 +1754,12 @@ def do_softwarechannel_adderrata(self, args):
     allchannels = self.do_softwarechannel_list('', True)
     source_channel = args[0]
     if not source_channel in allchannels:
-        logging.error(_("source channel %s does not exist!") % source_channel)
+        logging.error(_N("source channel %s does not exist!") % source_channel)
         self.help_softwarechannel_adderrata()
         return 1
     dest_channel = args[1]
     if not dest_channel in allchannels:
-        logging.error(_("dest channel %s does not exist!") % dest_channel)
+        logging.error(_N("dest channel %s does not exist!") % dest_channel)
         self.help_softwarechannel_adderrata()
         return 1
     errata_wanted = self.expand_errata(args[2:])
@@ -1811,7 +1812,7 @@ def do_softwarechannel_adderrata(self, args):
                     package_ids.append(package.get('id'))
 
     if not errata:
-        logging.warning(_('No patch to add'))
+        logging.warning(_N('No patch to add'))
         return 1
 
     # show the user which errata will be added
@@ -1844,8 +1845,8 @@ def do_softwarechannel_adderrata(self, args):
             self.client.errata.cloneAsOriginal(self.session, dest_channel,
                                                [erratum])
         else:
-            logging.warning(_("Using the old errata.clone function"))
-            logging.warning(_("If you have base channels for multiple OS" +
+            logging.warning(_N("Using the old errata.clone function"))
+            logging.warning(_N("If you have base channels for multiple OS" +
                             " versions, check no unexpected packages have been added"))
             self.client.errata.clone(self.session, dest_channel, [erratum])
 
@@ -1991,7 +1992,7 @@ def do_softwarechannel_getorgaccesstree(self, args):
         channels = filter_results(self.list_base_channels(), args)
 
     if not channels:
-        logging.error(_("Channel does not exist or is not a base channel!"))
+        logging.error(_N("Channel does not exist or is not a base channel!"))
         self.help_softwarechannel_getorgaccesstree()
         return 1
 
@@ -2031,7 +2032,7 @@ def do_softwarechannel_setorgaccesstree(self, args):
     channels = filter_results(self.list_base_channels(), args)
 
     if not channels:
-        logging.error(_("Channel does not exist or is not a base channel!"))
+        logging.error(_N("Channel does not exist or is not a base channel!"))
         self.help_softwarechannel_setorgaccesstree()
         return 1
 
@@ -2110,10 +2111,10 @@ def is_softwarechannel(self, name):
 
 def check_softwarechannel(self, name):
     if not name:
-        logging.error(_("no softwarechannel label given"))
+        logging.error(_N("no softwarechannel label given"))
         return False
     if not self.is_softwarechannel(name):
-        logging.error(_("invalid softwarechannel label ") + name)
+        logging.error(_N("invalid softwarechannel label ") + name)
         return False
     return True
 
@@ -2290,7 +2291,7 @@ def do_softwarechannel_sync(self, args, deleteFromTarget=True):
         return 1
 
     command = "syncing" if deleteFromTarget else "merging"
-    logging.info(_("%s packages from softwarechannel %s to %s"),
+    logging.info(_N("%s packages from softwarechannel %s to %s"),
                  command, source_channel, target_channel)
 
     # use API call instead of spacecmd function
@@ -2309,7 +2310,7 @@ def do_softwarechannel_sync(self, args, deleteFromTarget=True):
         try:
             source_ids.add(package['id'])
         except KeyError:
-            logging.error(_("failed to read key id"))
+            logging.error(_N("failed to read key id"))
             continue
 
     target_ids = set()
@@ -2317,7 +2318,7 @@ def do_softwarechannel_sync(self, args, deleteFromTarget=True):
         try:
             target_ids.add(package['id'])
         except KeyError:
-            logging.error(_("failed to read key id"))
+            logging.error(_N("failed to read key id"))
             continue
     if not options.quiet:
         print(_("packages common in both channels:"))
@@ -2325,7 +2326,7 @@ def do_softwarechannel_sync(self, args, deleteFromTarget=True):
             print(self.get_package_name(i))
         print('')
     else:
-        logging.info(_("Omitting common packages in both specified channels"))
+        logging.info(_N("Omitting common packages in both specified channels"))
 
     # check for packages only in the source channel
     source_only = source_ids.difference(target_ids)
@@ -2417,8 +2418,8 @@ def do_softwarechannel_errata_sync(self, args):
     if not self.check_softwarechannel(target_channel):
         return 1
 
-    logging.info(_("syncing errata from softwarechannel ") + source_channel +
-                 _(" to ") + target_channel)
+    logging.info(_N("syncing errata from softwarechannel ") + source_channel +
+                 _N(" to ") + target_channel)
 
     source_errata = self.client.channel.software.listErrata(
         self.session, source_channel)
@@ -2431,7 +2432,7 @@ def do_softwarechannel_errata_sync(self, args):
         try:
             source_ids.add(erratum.get('advisory_name'))
         except KeyError:
-            logging.error(_("failed to read key id"))
+            logging.error(_N("failed to read key id"))
             continue
 
     target_ids = set()
@@ -2439,7 +2440,7 @@ def do_softwarechannel_errata_sync(self, args):
         try:
             target_ids.add(erratum.get('advisory_name'))
         except KeyError:
-            logging.error(_("failed to read key id"))
+            logging.error(_N("failed to read key id"))
             continue
 
     print(_("errata common in both channels:"))
@@ -2549,8 +2550,8 @@ def do_softwarechannel_errata_merge(self, args):
     if not self.check_softwarechannel(source_channel) or not self.check_softwarechannel(target_channel):
         return 1
 
-    logging.info(_("merging errata from softwarechannel ") + source_channel +
-                 _(" to ") + target_channel)
+    logging.info(_N("merging errata from softwarechannel ") + source_channel +
+                 _N(" to ") + target_channel)
 
     source_errata = self.client.channel.software.listErrata(
         self.session, source_channel)
@@ -2571,7 +2572,7 @@ def do_softwarechannel_errata_merge(self, args):
         try:
             source_ids.add(erratum.get('advisory_name'))
         except KeyError:
-            logging.error(_("failed to read key id"))
+            logging.error(_N("failed to read key id"))
             continue
 
     target_ids = set()
@@ -2579,7 +2580,7 @@ def do_softwarechannel_errata_merge(self, args):
         try:
             target_ids.add(erratum.get('advisory_name'))
         except KeyError:
-            logging.error(_("failed to read key id"))
+            logging.error(_N("failed to read key id"))
             continue
 
     # check for errata only in the source channel
@@ -2703,10 +2704,10 @@ def do_softwarechannel_setsyncschedule(self, args):
 
 
 def help_softwarechannel_removesyncschedule(self):
-    print('softwarechannel_removesyncschedule: ')
-    print('Removes the repo sync schedule for a software channel')
+    print(_('softwarechannel_removesyncschedule: '))
+    print(_('Removes the repo sync schedule for a software channel'))
     print('')
-    print('usage: softwarechannel_removesyncschedule <CHANNEL>')
+    print(_('usage: softwarechannel_removesyncschedule <CHANNEL>'))
 
 
 def complete_softwarechannel_removesyncschedule(self, text, line, beg, end):
@@ -2919,7 +2920,7 @@ def do_softwarechannel_mirrorpackages(self, args):
                     package_file, channel)
                 return 1
             except IOError:
-                logging.error(_("Could not fetch package %s from channel %s") %
+                logging.error(_N("Could not fetch package %s from channel %s") %
                               (package_file, channel))
                 return 1
 

--- a/spacecmd/src/spacecmd/ssm.py
+++ b/spacecmd/src/spacecmd/ssm.py
@@ -30,6 +30,7 @@
 # pylint: disable=C0103
 
 import gettext
+from spacecmd.i18n import _N
 from spacecmd.utils import *
 
 translation = gettext.translation('spacecmd', fallback=True)
@@ -52,7 +53,7 @@ def help_ssm(self):
     print('> ssm_add group:rhel5-x86_64')
     print('> ssm_intersect group:web-servers')
     print('')
-    print('Using the SSM:')
+    print(_('Using the SSM:'))
     print('> system_installpackage ssm zsh')
     print('> system_runscript ssm')
 
@@ -84,12 +85,12 @@ def do_ssm_add(self, args):
     systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning(_('No systems found'))
+        logging.warning(_N('No systems found'))
         return 1
 
     for system in systems:
         if system in self.ssm:
-            logging.warning(_('%s is already in the list') % system)
+            logging.warning(_N('%s is already in the list') % system)
             continue
         else:
             self.ssm[system] = self.get_system_id(system)
@@ -133,7 +134,7 @@ def do_ssm_intersect(self, args):
     systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning(_('No systems found'))
+        logging.warning(_N('No systems found'))
         return 1
 
     # tmp_ssm placeholder to gather systems that are both in original ssm
@@ -183,7 +184,7 @@ def do_ssm_remove(self, args):
     systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning(_('No systems found'))
+        logging.warning(_N('No systems found'))
         return 1
 
     for system in systems:

--- a/spacecmd/src/spacecmd/system.py
+++ b/spacecmd/src/spacecmd/system.py
@@ -38,6 +38,7 @@ except ImportError:
     import xmlrpclib
 from operator import itemgetter
 from xml.parsers.expat import ExpatError
+from spacecmd.i18n import _N
 from spacecmd.utils import *
 
 translation = gettext.translation('spacecmd', fallback=True)
@@ -210,7 +211,7 @@ def do_system_reboot(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning(_('No systems selected'))
+        logging.warning(_N('No systems selected'))
         return 1
 
     # get the start time option
@@ -275,14 +276,14 @@ def do_system_search(self, args, doreturn=False):
         try:
             (field, value) = query.split(':')
         except ValueError:
-            logging.error(_('Invalid query'))
+            logging.error(_N('Invalid query'))
             return []
     else:
         field = 'name'
         value = query
 
     if not value:
-        logging.warning(_('Invalid query'))
+        logging.warning(_N('Invalid query'))
         return []
 
     results = []
@@ -318,7 +319,7 @@ def do_system_search(self, args, doreturn=False):
         results = self.client.system.search.uuid(self.session, value)
         key = 'uuid'
     else:
-        logging.warning(_('Invalid search field'))
+        logging.warning(_N('Invalid search field'))
         return []
 
     systems = []
@@ -391,7 +392,7 @@ def do_system_runscript(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning(_('No systems selected'))
+        logging.warning(_N('No systems selected'))
         return 1
 
     if is_interactive(options):
@@ -411,7 +412,7 @@ def do_system_runscript(self, args):
             else:
                 options.timeout = 600
         except ValueError:
-            logging.error(_('Invalid timeout'))
+            logging.error(_N('Invalid timeout'))
             return 1
 
         options.start_time = prompt_user(_('Start Time [now]:'))
@@ -434,7 +435,7 @@ def do_system_runscript(self, args):
             keep_script_file = False
 
         if not script_contents:
-            logging.error(_('No script provided'))
+            logging.error(_N('No script provided'))
             return 1
     else:
         if not options.user:
@@ -453,7 +454,7 @@ def do_system_runscript(self, args):
             options.start_time = parse_time_input(options.start_time)
 
         if not options.file:
-            logging.error(_('A script file is required'))
+            logging.error(_N('A script file is required'))
             return 1
 
         script_contents = read_file(options.file)
@@ -506,7 +507,7 @@ def do_system_runscript(self, args):
                                                              options.start_time)
 
 
-        logging.info(_('Action ID: %i') % action_id)
+        logging.info(_N('Action ID: %i') % action_id)
         scheduled = len(system_ids)
     else:
         # older versions of the API require each system to be
@@ -526,21 +527,21 @@ def do_system_runscript(self, args):
                                                          script_contents,
                                                          options.start_time)
 
-                logging.info(_('Action ID: %i') % action_id)
+                logging.info(_N('Action ID: %i') % action_id)
                 scheduled += 1
             except xmlrpclib.Fault as detail:
                 logging.debug(detail)
-                logging.error(_('Failed to schedule %s') % system)
+                logging.error(_N('Failed to schedule %s') % system)
                 return 1
 
-    logging.info(_('Scheduled: %i system(s)') % scheduled)
+    logging.info(_N('Scheduled: %i system(s)') % scheduled)
 
     # don't delete a pre-existing script that the user provided
     if not keep_script_file:
         try:
             os.remove(options.file)
         except OSError:
-            logging.error(_('Could not remove %s') % options.file)
+            logging.error(_N('Could not remove %s') % options.file)
             return 1
 
     return 0
@@ -576,7 +577,7 @@ def do_system_listhardware(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning(_('No systems selected'))
+        logging.warning(_N('No systems selected'))
         return 1
 
     for system in sorted(systems):
@@ -740,7 +741,7 @@ def do_system_installpackage(self, args):
         systems = self.expand_systems(args.pop(0))
 
     if not systems:
-        logging.warning(_('No systems selected'))
+        logging.warning(_N('No systems selected'))
         return 1
 
     packages_to_install = args
@@ -789,7 +790,7 @@ def do_system_installpackage(self, args):
                     jobs[system_id].append(package.get('id'))
 
     if not jobs:
-        logging.warning(_('No packages to install'))
+        logging.warning(_N('No packages to install'))
         return 1
 
     add_separator = False
@@ -813,7 +814,7 @@ def do_system_installpackage(self, args):
     if warnings:
         print('')
     for system_id in warnings:
-        logging.warning(_('%s does not have access to all requested packages') %
+        logging.warning(_N('%s does not have access to all requested packages') %
                         self.get_system_name(system_id))
 
     print('')
@@ -832,9 +833,9 @@ def do_system_installpackage(self, args):
 
             scheduled += 1
         except xmlrpclib.Fault:
-            logging.error(_('Failed to schedule %s') % self.get_system_name(system_id))
+            logging.error(_N('Failed to schedule %s') % self.get_system_name(system_id))
 
-    logging.info(_('Scheduled %i system(s)') % scheduled)
+    logging.info(_N('Scheduled %i system(s)') % scheduled)
 
     return 0
 
@@ -895,7 +896,7 @@ def do_system_removepackage(self, args):
         systems = self.expand_systems(args.pop(0))
 
     if not systems:
-        logging.warning(_('No systems selected'))
+        logging.warning(_N('No systems selected'))
         return 1
 
     package_list = args
@@ -956,12 +957,12 @@ def do_system_removepackage(self, args):
                                                                  jobs[system],
                                                                  options.start_time)
 
-            logging.info(_('Action ID: %i') % action_id)
+            logging.info(_N('Action ID: %i') % action_id)
             scheduled += 1
         except xmlrpclib.Fault:
-            logging.error(_('Failed to schedule %s') % system)
+            logging.error(_N('Failed to schedule %s') % system)
 
-    logging.info(_('Scheduled %i system(s)') % scheduled)
+    logging.info(_N('Scheduled %i system(s)') % scheduled)
 
     return 0
 
@@ -1030,7 +1031,7 @@ def do_system_upgradepackage(self, args):
         systems = self.expand_systems(args.pop(0))
 
     if not systems:
-        logging.warning(_('No systems selected'))
+        logging.warning(_N('No systems selected'))
         return 1
 
     # make a dictionary of each system and the package IDs to install
@@ -1048,7 +1049,7 @@ def do_system_upgradepackage(self, args):
             package_ids = [p.get('to_package_id') for p in packages]
             jobs[system] = package_ids
         else:
-            logging.warning(_('No upgrades available for %s') % system)
+            logging.warning(_N('No upgrades available for %s') % system)
 
     if not jobs:
         return 1
@@ -1071,7 +1072,7 @@ def do_system_upgradepackage(self, args):
             if name:
                 package_names.append(name)
             else:
-                logging.error(_("Couldn't get name for package %i") % package)
+                logging.error(_N("Couldn't get name for package %i") % package)
 
         print('\n'.join(sorted(package_names)))
 
@@ -1093,9 +1094,9 @@ def do_system_upgradepackage(self, args):
 
             scheduled += 1
         except xmlrpclib.Fault:
-            logging.error(_('Failed to schedule %s') % system)
+            logging.error(_N('Failed to schedule %s') % system)
 
-    logging.info(_('Scheduled %i system(s)') % scheduled)
+    logging.info(_N('Scheduled %i system(s)') % scheduled)
 
     return 0
 
@@ -1131,7 +1132,7 @@ def do_system_listupgrades(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning(_('No systems selected'))
+        logging.warning(_N('No systems selected'))
         return 1
 
     for system in sorted(systems):
@@ -1144,7 +1145,7 @@ def do_system_listupgrades(self, args):
                                                             system_id)
 
         if not packages:
-            logging.warning(_('No upgrades available for %s') % system)
+            logging.warning(_N('No upgrades available for %s') % system)
             continue
 
         if add_separator:
@@ -1201,7 +1202,7 @@ def do_system_listinstalledpackages(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning(_('No systems selected'))
+        logging.warning(_N('No systems selected'))
         return 1
 
     for system in sorted(systems):
@@ -1256,7 +1257,7 @@ def do_system_listconfigchannels(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning(_('No systems selected'))
+        logging.warning(_N('No systems selected'))
         return 1
 
     for system in sorted(systems):
@@ -1269,13 +1270,13 @@ def do_system_listconfigchannels(self, args):
         add_separator = True
 
         if len(systems) > 1:
-            print('System: %s' % system)
+            print(_('System: %s') % system)
 
         try:
             channels = self.client.system.config.listChannels(self.session,
                                                               system_id)
         except xmlrpclib.Fault:
-            logging.warning(_('%s does not support configuration channels') %
+            logging.warning(_N('%s does not support configuration channels') %
                             system)
             continue
 
@@ -1355,7 +1356,7 @@ def do_system_listconfigfiles(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning(_('No systems selected'))
+        logging.warning(_N('No systems selected'))
         return 1
 
     for system in sorted(systems):
@@ -1378,7 +1379,7 @@ def do_system_listconfigfiles(self, args):
             files += self.client.system.config.listFiles(self.session,
                                                          system_id, 1)
         except xmlrpclib.Fault:
-            logging.warning(_('%s does not support configuration channels') %
+            logging.warning(_N('%s does not support configuration channels') %
                             system)
             continue
 
@@ -1401,7 +1402,7 @@ def do_system_listconfigfiles(self, args):
                     toprint.append(f)
 
             else:
-                logging.error("Error, unexpected channel type label %s" %
+                logging.error(_N("Error, unexpected channel type label %s") %
                               f['channel_type']['label'])
                 return 1
 
@@ -1484,7 +1485,7 @@ def do_system_addconfigfile(self, args, update_path=''):
                     break
                 else:
                     print('')
-                    logging.warning(_('%s is not a valid system') %
+                    logging.warning(_N('%s is not a valid system') %
                                     options.system)
                     print('')
 
@@ -1510,12 +1511,12 @@ def do_system_addconfigfile(self, args, update_path=''):
     elif options.sandbox:
         logging.debug("Selected system-sandbox")
     else:
-        logging.error(_("Must choose system-sandbox or locally-managed option"))
+        logging.error(_N("Must choose system-sandbox or locally-managed option"))
         self.help_system_addconfigfile()
         return 1
 
     if not options.system:
-        logging.error("Must provide system")
+        logging.error(_N("Must provide system"))
         self.help_system_addconfigfile()
         return 1
 
@@ -1588,7 +1589,7 @@ def do_system_addconfigchannels(self, args):
         systems = self.expand_systems(args.pop(0))
 
     if not systems:
-        logging.warning(_('No systems selected'))
+        logging.warning(_N('No systems selected'))
         return 1
 
     channels = args
@@ -1651,7 +1652,7 @@ def do_system_removeconfigchannels(self, args):
         systems = self.expand_systems(args.pop(0))
 
     if not systems:
-        logging.warning(_('No systems selected'))
+        logging.warning(_N('No systems selected'))
         return 1
 
     channels = args
@@ -1694,7 +1695,7 @@ def do_system_setconfigchannelorder(self, args):
         systems = self.expand_systems(args.pop(0))
 
     if not systems:
-        logging.warning(_('No systems selected'))
+        logging.warning(_N('No systems selected'))
         return 1
 
     # get the current configuration channels from the first system
@@ -1774,7 +1775,7 @@ def do_system_deployconfigfiles(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning(_('No systems selected'))
+        logging.warning(_N('No systems selected'))
         return 1
 
     print('')
@@ -1794,7 +1795,7 @@ def do_system_deployconfigfiles(self, args):
                                         system_ids,
                                         options.start_time)
 
-    logging.info(_('Scheduled deployment for %i system(s)') % len(system_ids))
+    logging.info(_N('Scheduled deployment for %i system(s)') % len(system_ids))
 
     return 0
 
@@ -1847,7 +1848,7 @@ def do_system_delete(self, args):
         system_ids.append(system_id)
 
     if not system_ids:
-        logging.warning(_('No systems to delete'))
+        logging.warning(_N('No systems to delete'))
         return 1
 
     # make the column the right size
@@ -1870,7 +1871,7 @@ def do_system_delete(self, args):
     logging.debug("System names to IDs: %s", systems)
 
     self.client.system.deleteSystems(self.session, system_ids, options.cleanuptype)
-    logging.info(_('%i system(s) scheduled for removal'), len(system_ids))
+    logging.info(_N('%i system(s) scheduled for removal'), len(system_ids))
 
     # regenerate the system name cache
     self.generate_system_cache(True, delay=1)
@@ -1916,7 +1917,7 @@ def do_system_lock(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning(_('No systems selected'))
+        logging.warning(_N('No systems selected'))
         return 1
 
     for system in sorted(systems):
@@ -1958,7 +1959,7 @@ def do_system_unlock(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning(_('No systems selected'))
+        logging.warning(_N('No systems selected'))
         return 1
 
     for system in sorted(systems):
@@ -2046,7 +2047,7 @@ def do_system_listcustomvalues(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning(_('No systems selected'))
+        logging.warning(_N('No systems selected'))
         return 1
 
     add_separator = False
@@ -2113,7 +2114,7 @@ def do_system_addcustomvalue(self, args):
         systems = self.expand_systems(args[2:])
 
     if not systems:
-        logging.warning(_('No systems selected'))
+        logging.warning(_N('No systems selected'))
         return 1
 
     for system in systems:
@@ -2195,7 +2196,7 @@ def do_system_removecustomvalues(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning(_('No systems selected'))
+        logging.warning(_N('No systems selected'))
         return 1
 
     keys = args[1:]
@@ -2250,7 +2251,7 @@ def do_system_addnote(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning(_('No systems selected'))
+        logging.warning(_N('No systems selected'))
         return 1
 
     if is_interactive(options):
@@ -2260,11 +2261,11 @@ def do_system_addnote(self, args):
         options.body = prompt_user(message, noblank=True, multiline=True)
     else:
         if not options.subject:
-            logging.error(_('A subject is required'))
+            logging.error(_N('A subject is required'))
             return 1
 
         if not options.body:
-            logging.error(_('A body is required'))
+            logging.error(_N('A body is required'))
             return 1
 
     for system in systems:
@@ -2310,13 +2311,13 @@ def do_system_deletenotes(self, args):
         systems = self.expand_systems(args.pop(0))
 
     if not systems:
-        logging.warning(_('No systems selected'))
+        logging.warning(_N('No systems selected'))
         return 1
 
     note_ids = args
 
     if not args:
-        logging.warning(_('No notes to delete'))
+        logging.warning(_N('No notes to delete'))
         return
 
     for system in systems:
@@ -2331,7 +2332,7 @@ def do_system_deletenotes(self, args):
                 try:
                     note_id = int(note_id)
                 except ValueError:
-                    logging.warning('%s is not a valid note ID' % note_id)
+                    logging.warning(_N('%s is not a valid note ID') % note_id)
                     continue
 
                 # deleteNote does not throw an exception
@@ -2369,7 +2370,7 @@ def do_system_listnotes(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning(_('No systems selected'))
+        logging.warning(_N('No systems selected'))
         return 1
 
     add_separator = False
@@ -2427,7 +2428,7 @@ def do_system_listfqdns(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning(_('No systems selected'))
+        logging.warning(_N('No systems selected'))
         return 1
 
     add_separator = False
@@ -2486,7 +2487,7 @@ def do_system_setbasechannel(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning(_('No systems selected'))
+        logging.warning(_N('No systems selected'))
         return 1
 
     add_separator = False
@@ -2553,7 +2554,7 @@ def do_system_schedulechangechannels(self, args):
         return 1
 
     if not options.base:
-        logging.error(_('A base channel is required'))
+        logging.error(_N('A base channel is required'))
         return 1
 
     # use the systems listed in the SSM
@@ -2563,7 +2564,7 @@ def do_system_schedulechangechannels(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning(_('No systems selected'))
+        logging.warning(_N('No systems selected'))
         return 1
 
     if not options.start_time:
@@ -2644,7 +2645,7 @@ def do_system_listbasechannel(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning(_('No systems selected'))
+        logging.warning(_N('No systems selected'))
         return 1
 
     for system in sorted(systems):
@@ -2699,7 +2700,7 @@ def do_system_listchildchannels(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning(_('No systems selected'))
+        logging.warning(_N('No systems selected'))
         return 1
 
     for system in sorted(systems):
@@ -2952,7 +2953,7 @@ def do_system_details(self, args, short=False):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning(_('No systems selected'))
+        logging.warning(_N('No systems selected'))
         return 1
 
     for system in sorted(systems):
@@ -3105,7 +3106,7 @@ def do_system_listerrata(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning(_('No systems selected'))
+        logging.warning(_N('No systems selected'))
         return 1
 
     for system in sorted(systems):
@@ -3174,7 +3175,7 @@ def do_system_applyerrata(self, args):
         systems = self.expand_systems(args.pop(0))
 
     if not systems:
-        logging.warning(_('No systems selected'))
+        logging.warning(_N('No systems selected'))
         return 1
 
     # allow globbing and searching of errata
@@ -3220,7 +3221,7 @@ def do_system_listevents(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning(_('No systems selected'))
+        logging.warning(_N('No systems selected'))
         return 1
 
     add_separator = False
@@ -3279,7 +3280,7 @@ def do_system_listentitlements(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning(_('No systems selected'))
+        logging.warning(_N('No systems selected'))
         return 1
 
     for system in sorted(systems):
@@ -3343,7 +3344,7 @@ def do_system_addentitlements(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning(_('No systems selected'))
+        logging.warning(_N('No systems selected'))
         return 1
 
     for system in systems:
@@ -3399,7 +3400,7 @@ def do_system_removeentitlement(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning(_('No systems selected'))
+        logging.warning(_N('No systems selected'))
         return 1
 
     for system in systems:
@@ -3473,7 +3474,7 @@ def do_system_deletepackageprofile(self, args):
             profile_id = profile.get('id')
 
     if not profile_id:
-        logging.warning(_('%s is not a valid profile') % label)
+        logging.warning(_N('%s is not a valid profile') % label)
         return 1
 
     self.client.system.deletePackageProfile(self.session, profile_id)
@@ -3519,11 +3520,11 @@ def do_system_createpackageprofile(self, args):
         options.description = prompt_user(_('Description:'), multiline=True)
     else:
         if not options.name:
-            logging.error(_('A profile name is required'))
+            logging.error(_N('A profile name is required'))
             return 1
 
         if not options.description:
-            logging.error(_('A profile description is required'))
+            logging.error(_N('A profile description is required'))
             return 1
 
     self.client.system.createPackageProfile(self.session,
@@ -3531,7 +3532,7 @@ def do_system_createpackageprofile(self, args):
                                             options.name,
                                             options.description)
 
-    logging.info(_("Created package profile '%s'") % options.name)
+    logging.info(_N("Created package profile '%s'") % options.name)
 
     return 0
 
@@ -3574,7 +3575,7 @@ def do_system_comparepackageprofile(self, args):
         systems = self.expand_systems(args[:-1])
 
     if not systems:
-        logging.warning(_('No systems selected'))
+        logging.warning(_N('No systems selected'))
         return 1
 
     profile = args[-1]
@@ -3726,8 +3727,8 @@ def filter_latest_packages(pkglist, version_key='version',
             p['arch'] = re.sub('AMD64', 'x86_64', p['arch'])
             tuplekey = p['name'], p['arch']
         else:
-            logging.error(_("Failed to filter package list, package %s") % p
-                          + _("found with no arch or arch_label"))
+            logging.error(_N("Failed to filter package list, package %s") % p
+                          + _N("found with no arch or arch_label"))
             return None
         if not tuplekey in latest:
             latest[tuplekey] = p
@@ -3852,7 +3853,7 @@ def do_system_comparewithchannel(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning(_('No systems selected'))
+        logging.warning(_N('No systems selected'))
         return 1
 
     channel_latest = {}
@@ -3877,7 +3878,7 @@ def do_system_comparewithchannel(self, args):
             allch = self.client.channel.listSoftwareChannels(self.session)
             allch_labels = [c['label'] for c in allch]
             if not options.channel in allch_labels:
-                logging.error(_("Specified channel does not exist"))
+                logging.error(_N("Specified channel does not exist"))
                 self.help_system_comparewithchannel()
                 return
             channels = [options.channel]
@@ -3888,9 +3889,9 @@ def do_system_comparewithchannel(self, args):
             basech = self.client.system.getSubscribedBaseChannel(self.session,
                                                                  system_id)
             if not basech:
-                logging.error(_("system %s is not subscribed to any channel!")
+                logging.error(_N("system %s is not subscribed to any channel!")
                               % system)
-                logging.error(_("Please subscribe to a channel, or specify a" +
+                logging.error(_N("Please subscribe to a channel, or specify a" +
                               "channel to compare with"))
                 return 1
             logging.debug("base channel %s for %s" % (basech['name'], system))
@@ -3995,7 +3996,7 @@ def do_system_schedulehardwarerefresh(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning(_('No systems selected'))
+        logging.warning(_N('No systems selected'))
         return 1
 
     for system in systems:
@@ -4057,7 +4058,7 @@ def do_system_schedulepackagerefresh(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning(_('No systems selected'))
+        logging.warning(_N('No systems selected'))
         return 1
 
     for system in systems:
@@ -4105,7 +4106,7 @@ def do_system_show_packageversion(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning(_('No systems selected'))
+        logging.warning(_N('No systems selected'))
         return 1
 
     print(_("Package\tVersion\tRelease\tEpoch\tArch\tSystem"))
@@ -4163,7 +4164,7 @@ def do_system_setcontactmethod(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning(_('No systems selected'))
+        logging.warning(_N('No systems selected'))
         return 1
 
     for system in sorted(systems):
@@ -4221,7 +4222,7 @@ def do_system_scheduleapplyconfigchannels(self, args):
         systems = self.expand_systems(args)
 
     if not systems:
-        logging.warning(_('No systems selected'))
+        logging.warning(_N('No systems selected'))
         return 1
 
     print('')
@@ -4279,7 +4280,7 @@ def do_system_listmigrationtargets(self, args):
             print(_('WARN: Cannot find system ') + str(system))
             continue
 
-        print('System ' + str(system))
+        print(_('System ') + str(system))
         tgts = self.client.system.listMigrationTargets(self.session, system_id)
 
         if not tgts:
@@ -4345,7 +4346,7 @@ def do_system_schedulespmigration(self, args):
     for system in sorted(systems):
         system_id = self.get_system_id(system)
         if not system_id:
-            logging.warning(_('Cannot find system ') + str(system) + _('. Skipping it.'))
+            logging.warning(_N('Cannot find system ') + str(system) + _('. Skipping it.'))
             continue
 
         print(_('Scheduling Service Pack migration for system ') + str(system))
@@ -4355,6 +4356,6 @@ def do_system_schedulespmigration(self, args):
                     child_channels, options.dry_run, options.start_time)
             print(_('Scheduled action ID: ') + str(result))
         except xmlrpclib.Fault as detail:
-            logging.error(_('Failed to schedule %s') % detail)
+            logging.error(_N('Failed to schedule %s') % detail)
 
 ####################

--- a/spacecmd/src/spacecmd/user.py
+++ b/spacecmd/src/spacecmd/user.py
@@ -37,6 +37,7 @@ try:
     from xmlrpc import client as xmlrpclib
 except ImportError:
     import xmlrpclib
+from spacecmd.i18n import _N
 from spacecmd.utils import *
 
 translation = gettext.translation('spacecmd', fallback=True)
@@ -87,28 +88,28 @@ def do_user_create(self, args):
             if password1 == password2:
                 options.password = password1
             elif password1 == '':
-                logging.warning(_('Password must be at least 5 characters'))
+                logging.warning(_N('Password must be at least 5 characters'))
             else:
-                logging.warning(_("Passwords don't match"))
+                logging.warning(_N("Passwords don't match"))
     else:
         if not options.username:
-            logging.error(_('A username is required'))
+            logging.error(_N('A username is required'))
             return 1
 
         if not options.first_name:
-            logging.error(_('A first name is required'))
+            logging.error(_N('A first name is required'))
             return 1
 
         if not options.last_name:
-            logging.error(_('A last name is required'))
+            logging.error(_N('A last name is required'))
             return 1
 
         if not options.email:
-            logging.error(_('An email address is required'))
+            logging.error(_N('An email address is required'))
             return 1
 
         if not options.password and not options.pam:
-            logging.error(_('A password is required'))
+            logging.error(_N('A password is required'))
             return 1
 
         if options.pam:
@@ -116,7 +117,7 @@ def do_user_create(self, args):
             # API requires a non-None password even though it's not used
             # when PAM is enabled
             if options.password:
-                logging.warning(_("Note: password was ignored due to PAM mode"))
+                logging.warning(_N("Note: password was ignored due to PAM mode"))
             options.password = ""
         else:
             options.pam = 0
@@ -249,7 +250,7 @@ def do_user_listavailableroles(self, args, doreturn=False):
         if roles:
             print('\n'.join(sorted(roles)))
         else:
-            logging.error(_("No roles has been found"))
+            logging.error(_N("No roles has been found"))
 
 ####################
 
@@ -357,8 +358,8 @@ def do_user_details(self, args):
                 self.client.user.listDefaultSystemGroups(self.session,
                                                          user)
         except xmlrpclib.Fault as exc:
-            logging.warning(_('%s is not a valid user') % user)
-            logging.debug(_("Error '{}' while getting data about user '{}': {}").format(
+            logging.warning(_N('%s is not a valid user') % user)
+            logging.debug("Error '{}' while getting data about user '{}': {}".format(
                 exc.faultCode, user, exc.faultString))
             continue
 

--- a/spacecmd/src/spacecmd/utils.py
+++ b/spacecmd/src/spacecmd/utils.py
@@ -60,6 +60,7 @@ except ImportError:
 import rpm
 
 from spacecmd.argumentparser import SpacecmdArgumentParser
+from spacecmd.i18n import _N
 
 __EDITORS = ['vim', 'vi', "emacs", 'nano']
 
@@ -130,13 +131,13 @@ def load_cache(cachefile):
             # So we catch this error and remove the corrupt partial file
             # If you don't do this then spacecmd will fail with an unhandled
             # exception until the partial file is manually removed
-            logging.warning(_("Loading cache file %s failed"), cachefile)
-            logging.warning(_("Cache generation was probably interrupted," +
+            logging.warning(_N("Loading cache file %s failed"), cachefile)
+            logging.warning(_N("Cache generation was probably interrupted," +
                             "removing corrupt %s"), cachefile)
             logging.debug(str(exc))
             os.remove(cachefile)
         except IOError:
-            logging.error(_("Couldn't load cache from %s"), cachefile)
+            logging.error(_N("Couldn't load cache from %s"), cachefile)
 
         if isinstance(data, (list, dict)):
             if 'expire' in data:
@@ -157,7 +158,7 @@ def save_cache(cachefile, data, expire=None):
         pickle.dump(data, output, pickle.HIGHEST_PROTOCOL)
         output.close()
     except IOError:
-        logging.error(_("Couldn't write to %s"), cachefile)
+        logging.error(_N("Couldn't write to %s"), cachefile)
 
     if 'expire' in data:
         del data['expire']
@@ -202,7 +203,7 @@ def editor(template='', delete=False):
             handle.write(template)
             handle.close()
         except IOError as exc:
-            logging.warning(_('Could not open the temporary file'))
+            logging.warning(_N('Could not open the temporary file'))
             logging.error(str(exc))
             return
 
@@ -222,12 +223,12 @@ def editor(template='', delete=False):
                 success = True
                 break
             else:
-                logging.error(_('Editor "%s" exited with code %i'), editor_cmd, exit_code)
+                logging.error(_N('Editor "%s" exited with code %i'), editor_cmd, exit_code)
         except OSError as exc:
-            logging.error(_("General failure running editor: %s"), str(exc))
+            logging.error(_N("General failure running editor: %s"), str(exc))
 
     if not success:
-        logging.error(_('No editors found'))
+        logging.error(_N('No editors found'))
         return ''
 
     if os.path.isfile(file_name) and exit_code == 0:
@@ -242,11 +243,11 @@ def editor(template='', delete=False):
                     os.remove(file_name)
                     file_name = ''
                 except OSError:
-                    logging.error(_('Could not remove %s'), file_name)
+                    logging.error(_N('Could not remove %s'), file_name)
 
             return contents, file_name
         except IOError:
-            logging.error(_('Could not read %s'), file_name)
+            logging.error(_N('Could not read %s'), file_name)
             return [], ''
 
 
@@ -364,7 +365,7 @@ def parse_time_input(userinput=''):
     if timestamp:
         return xmlrpclib.DateTime(timestamp.timetuple())
 
-    logging.error(_('Invalid time provided'))
+    logging.error(_N('Invalid time provided'))
     return
 
 
@@ -452,7 +453,7 @@ def print_errata_list(errata):
         elif re.match('product enhancement', erratum.get('advisory_type'), re.I):
             rhea.append(erratum)
         else:
-            logging.warning('%s is an unknown errata type',
+            logging.warning(_N('%s is an unknown errata type'),
                             erratum.get('advisory_name'))
             continue
 
@@ -507,7 +508,7 @@ def config_channel_order(all_channels=None, new_channels=None):
             channel = prompt_user(_('Channel:'))
 
             if channel not in all_channels:
-                logging.warning(_('Invalid channel'))
+                logging.warning(_N('Invalid channel'))
                 continue
 
             try:
@@ -518,16 +519,16 @@ def config_channel_order(all_channels=None, new_channels=None):
 
                 new_channels.insert(rank - 1, channel)
             except IndexError:
-                logging.warning(_('Invalid rank'))
+                logging.warning(_N('Invalid rank'))
                 continue
             except ValueError:
-                logging.warning(_('Invalid rank'))
+                logging.warning(_N('Invalid rank'))
                 continue
         elif re.match('r', action, re.I):
             channel = prompt_user(_('Channel:'))
 
             if channel not in all_channels:
-                logging.warning(_('Invalid channel'))
+                logging.warning(_N('Invalid channel'))
                 continue
 
             new_channels.remove(channel)
@@ -557,7 +558,7 @@ def list_locales():
                 for subitem in os.listdir(path):
                     zones.append(os.path.join(item, subitem))
             except IOError:
-                logging.error(_('Could not read %s'), path)
+                logging.error(_N('Could not read %s'), path)
         else:
             zones.append(item)
 
@@ -687,14 +688,14 @@ def json_dump_to_file(obj, filename):
 
     out = False
     if json_data is None:
-        logging.error(_("Could not generate json data object!"))
+        logging.error(_N("Could not generate json data object!"))
     else:
         try:
             with open(filename, 'w') as fdh:
                 fdh.write(json_data)
             out = True
         except IOError as exc:
-            logging.error(_("Could not open file %s for writing: %s"), filename, str(exc))
+            logging.error(_N("Could not open file %s for writing: %s"), filename, str(exc))
 
     return out
 
@@ -705,11 +706,11 @@ def json_read_from_file(filename):
         with open(filename) as fhd:
             data = json.loads(fhd.read())
     except IOError as exc:
-        logging.error(_("Could not open file %s for reading: %s"), filename, str(exc))
+        logging.error(_N("Could not open file %s for reading: %s"), filename, str(exc))
     except ValueError as exc:
-        logging.error(_("Could not parse JSON data from %s: %s"), filename, str(exc))
+        logging.error(_N("Could not parse JSON data from %s: %s"), filename, str(exc))
     except Exception as exc:
-        logging.error(_("Error processing file %s: %s"), filename, str(exc))
+        logging.error(_N("Error processing file %s: %s"), filename, str(exc))
 
     return data
 
@@ -737,7 +738,7 @@ def get_string_diff_dicts(string1, string2, sep="-"):
     replace2 = {}
 
     if string1 == string2:
-        logging.info(_("Skipping usage of common strings: both strings are equal"))
+        logging.info(_N("Skipping usage of common strings: both strings are equal"))
         return [None, None]
     substrings1 = deque(string1.split(sep))
     substrings2 = deque(string2.split(sep))
@@ -753,7 +754,7 @@ def get_string_diff_dicts(string1, string2, sep="-"):
             replace1['(^|-)' + sub1 + '(-|$)'] = r'\1' + "DIFF(" + sub1 + "|" + sub2 + ")" + r'\2'
             replace2['(^|-)' + sub2 + '(-|$)'] = r'\1' + "DIFF(" + sub1 + "|" + sub2 + ")" + r'\2'
     if substrings1 or substrings2:
-        logging.info(_("Skipping usage of common strings: number of substrings differ"))
+        logging.info(_N("Skipping usage of common strings: number of substrings differ"))
         return [None, None]
     return [replace1, replace2]
 


### PR DESCRIPTION
## What does this PR change?

Make use of new `_N` method for spacecmd's `logging.*` messages.
The `_N` method is returning the same string passed as argument

## GUI diff

No difference.

## Documentation
- No documentation needed: internal strings

## Test coverage
- No tests: already present

## Links

Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
