### PR TITLE
Add helper Salt state to create a big VM

### DIFF
--- a/susemanager-utils/susemanager-sls/src/states/virthelper.py
+++ b/susemanager-utils/susemanager-sls/src/states/virthelper.py
@@ -1,0 +1,125 @@
+'''
+Virtualization helper states
+'''
+
+import logging
+import itertools
+
+log = logging.getLogger(__name__)
+
+__virtualname__ = 'virthelper'
+
+def __virtual__():
+    if "virt.node_info" not in __salt__:
+        return (False, "virt module could not be loaded")
+    return __virtualname__
+
+def single_vm(name,
+              disks=None,
+              interfaces=None,
+              graphics=None,
+              boot_dev=None,
+              boot=None,
+              serials=None,
+              consoles=None,
+              stop_on_reboot=False,
+              utc_clock=True):
+    '''
+    Create a big VM with guests CPU mapped to the host CPU topology.
+
+    name
+        the name of the virtual machine
+    '''
+    caps = __salt__['virt.capabilities']()
+    cells = caps['host']['topology']['cells']
+    cpus = [cell['cpus'] for cell in cells]
+    cpus = [cpu for sublist in cpus for cpu in sublist]
+
+    cpu_topology = {
+        'sockets': len({c['socket_id'] for c in cpus}),
+        'cores': len({c['core_id'] for c in cpus}),
+        'threads': {
+            len(list(g))
+            for k, g
+            in itertools.groupby(cpus, lambda c: '{}-{}'.format(c['socket_id'], c['core_id']))
+        }.pop()
+    }
+
+    node_info = __salt__['virt.node_info']()
+    vm_memory = int(node_info['phymemory'] * 0.9)
+
+    numa = {
+        c['id']: {
+            'cpus': ','.join([str(cpu['id']) for cpu in c['cpus']]),
+            'memory': c['memory'],
+            'distances': c['distances'],
+        }
+        for c
+        in cells
+    }
+    log.debug(numa)
+
+    # Call the virt.defined state
+    return __states__['virt.defined'](
+        name=name,
+        cpu={
+            'placement': 'static',
+            'maximum': cpu_topology['sockets'] * cpu_topology["cores"] * cpu_topology['threads'],
+            'topology': cpu_topology,
+            'mode': 'host-passthrough',
+            'check': 'none',
+            'features': {
+                'rdtscp': 'require',
+                'invtsc': 'require',
+                'x2apic': 'require',
+            },
+            'tuning': {
+                'vcpupin': {cpu['id']: cpu['siblings'] for cpu in cpus},
+            },
+            'numa': {
+                c['id']: {
+                    'cpus': ','.join([str(cpu['id']) for cpu in c['cpus']]),
+                    'memory': str(vm_memory / len(cells)) + ' MiB',
+                    'distances': c['distances'],
+                }
+                for c
+                in cells
+            },
+        },
+        numatune={
+            'memory': {
+                'mode': 'strict',
+                'nodeset': ','.join([str(cell['id']) for cell in cells]),
+            },
+            'memnodes': {
+                cell['id']: {'mode': 'strict', 'nodeset': cell['id']}
+                for cell
+                in cells
+            },
+        },
+        mem={
+            'boot': str(vm_memory) + ' MiB',
+            'current': str(vm_memory) + ' MiB',
+            'nosharepages': True,
+            'hugepages': [{'size': '1g'}],
+        },
+        update=True,
+        hypervisor_features={'kvm-hint-dedicated': True},
+        clock={
+            'utc': utc_clock,
+            'timers': {
+                'rtc': {'tickpolicy': 'catchup'},
+                'pit': {'tickpolicy': 'catchup'},
+                'hpet': {'present': False},
+            },
+        },
+        seed=False,
+        disks=disks,
+        interfaces=interfaces,
+        graphics=graphics,
+        boot_dev=boot_dev,
+        boot=boot,
+        serials=serials,
+        consoles=consoles,
+        stop_on_reboot=stop_on_reboot,
+    )

--- a/susemanager-utils/susemanager-sls/src/tests/test_state_virthelper.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_state_virthelper.py
@@ -1,0 +1,186 @@
+'''
+Author: cbosdonnat@suse.com
+'''
+
+from mock import MagicMock, patch, call
+
+from ..states import virthelper
+from . import mockery
+mockery.setup_environment()
+
+# Mock globals
+virthelper.log = MagicMock()
+virthelper.__salt__ = {}
+virthelper.__states__ = {}
+
+def test_single_vm():
+    '''
+    Test the virthelper.single_vm() state
+    '''
+    caps = {
+        "host": {
+            "topology": {
+                "cells": [
+                    {
+                        "id": 0,
+                        "memory": "905532 KiB",
+                        "distances": {"0": 10, "1": 20, "2": 20, "3": 20},
+                        "cpus": [
+                            {"id": 0, "socket_id": 0, "core_id": 0, "siblings": "0-1"},
+                            {"id": 1, "socket_id": 0, "core_id": 0, "siblings": "0-1"},
+                            {"id": 2, "socket_id": 0, "core_id": 1, "siblings": "2-3"},
+                            {"id": 3, "socket_id": 0, "core_id": 1, "siblings": "2-3"}
+                        ]
+                    },
+                    {
+                        "id": 1,
+                        "memory": "909096 KiB",
+                        "distances": {"0": 20, "1": 10, "2": 20, "3": 20},
+                        "cpus": [
+                            {"id": 4, "socket_id": 1, "core_id": 0, "siblings": "4-5"},
+                            {"id": 5, "socket_id": 1, "core_id": 0, "siblings": "4-5"},
+                            {"id": 6, "socket_id": 1, "core_id": 1, "siblings": "6-7"},
+                            {"id": 7, "socket_id": 1, "core_id": 1, "siblings": "6-7"}
+                        ]
+                    },
+                    {
+                        "id": 2,
+                        "memory": "908072 KiB",
+                        "distances": {"0": 20, "1": 20, "2": 10, "3": 20},
+                        "cpus": [
+                            {"id": 8, "socket_id": 2, "core_id": 0, "siblings": "8-9"},
+                            {"id": 9, "socket_id": 2, "core_id": 0, "siblings": "8-9"},
+                            {"id": 10, "socket_id": 2, "core_id": 1, "siblings": "10-11"},
+                            {"id": 11, "socket_id": 2, "core_id": 1, "siblings": "10-11"}
+                        ]
+                    },
+                    {
+                        "id": 3,
+                        "memory": "808460 KiB",
+                        "distances": {"0": 20, "1": 20, "2": 20, "3": 10},
+                        "cpus": [
+                            {"id": 12, "socket_id": 3, "core_id": 0, "siblings": "12-13"},
+                            {"id": 13, "socket_id": 3, "core_id": 0, "siblings": "12-13"},
+                            {"id": 14, "socket_id": 3, "core_id": 1, "siblings": "14-15"},
+                            {"id": 15, "socket_id": 3, "core_id": 1, "siblings": "14-15"}
+                        ]
+                    }
+                ]
+            }
+        }
+    }
+
+    with patch.dict(virthelper.__salt__, {
+        'virt.capabilities': MagicMock(return_value=caps),
+        'virt.node_info': MagicMock(return_value={'phymemory': 3448}),
+    }):
+        expected_result = {"name": "testvm", "changes":{}, "result": True}
+        defined_mock = MagicMock(return_value=expected_result)
+        with patch.dict(virthelper.__states__, {'virt.defined': defined_mock}):
+            result = virthelper.single_vm(
+                "testvm",
+                disks=[{"name": "system", "pool": "default", "source_file": "system_disk.qcow2"}],
+                interfaces=[{"name": "eth0", "type": "default", "source": "default"}],
+                graphics={"type": "vnc"},
+                boot_dev="network hd",
+                boot={"efi": True},
+                serials=[{"type": "pty"}],
+                consoles=[{"type": "pty"}],
+                stop_on_reboot=True,
+                utc_clock=False,
+            )
+            assert expected_result == result
+
+            calls = [
+                call(
+                    name="testvm",
+                    cpu={
+                        'placement': 'static',
+                        'maximum': 16,
+                        'topology': {"sockets": 4, "cores": 2, "threads": 2},
+                        'mode': 'host-passthrough',
+                        'check': 'none',
+                        'features': {'rdtscp': 'require', 'invtsc': 'require', 'x2apic': 'require'},
+                        'tuning': {
+                            'vcpupin': {
+                                0: "0-1",
+                                1: "0-1",
+                                2: "2-3",
+                                3: "2-3",
+                                4: "4-5",
+                                5: "4-5",
+                                6: "6-7",
+                                7: "6-7",
+                                8: "8-9",
+                                9: "8-9",
+                                10: "10-11",
+                                11: "10-11",
+                                12: "12-13",
+                                13: "12-13",
+                                14: "14-15",
+                                15: "14-15",
+                            },
+                        },
+                        'numa': {
+                            0: {
+                                'cpus': '0,1,2,3',
+                                'memory': '775.75 MiB',
+                                'distances': {"0": 10, "1": 20, "2": 20, "3": 20},
+                            },
+                            1: {
+                                'cpus': '4,5,6,7',
+                                'memory': '775.75 MiB',
+                                'distances': {"0": 20, "1": 10, "2": 20, "3": 20},
+                            },
+                            2: {
+                                'cpus': '8,9,10,11',
+                                'memory': '775.75 MiB',
+                                'distances': {"0": 20, "1": 20, "2": 10, "3": 20},
+                            },
+                            3: {
+                                'cpus': '12,13,14,15',
+                                'memory': '775.75 MiB',
+                                'distances': {"0": 20, "1": 20, "2": 20, "3": 10},
+                            },
+                        },
+                    },
+                    numatune={
+                        'memory': {
+                            'mode': 'strict',
+                            'nodeset': '0,1,2,3',
+                        },
+                        'memnodes': {
+                            0: {'mode': 'strict', 'nodeset': 0},
+                            1: {'mode': 'strict', 'nodeset': 1},
+                            2: {'mode': 'strict', 'nodeset': 2},
+                            3: {'mode': 'strict', 'nodeset': 3},
+                        },
+                    },
+                    update=True,
+                    hypervisor_features={'kvm-hint-dedicated': True},
+                    mem={
+                        "boot": "3103 MiB",
+                        "current": "3103 MiB",
+                        "nosharepages": True,
+                        'hugepages': [{'size': '1g'}],
+                    },
+                    clock={
+                        "utc": False,
+                        "timers": {
+                            "rtc": {"tickpolicy": "catchup"},
+                            "pit": {"tickpolicy": "catchup"},
+                            "hpet": {"present": False},
+                        }
+                    },
+                    seed=False,
+                    disks=[{"name": "system", "pool": "default", "source_file": "system_disk.qcow2"}],
+                    interfaces=[{"name": "eth0", "type": "default", "source": "default"}],
+                    graphics={"type": "vnc"},
+                    boot_dev="network hd",
+                    boot={"efi": True},
+                    serials=[{"type": "pty"}],
+                    consoles=[{"type": "pty"}],
+                    stop_on_reboot=True,
+                )
+            ]
+            defined_mock.assert_has_calls(calls)

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Add virthelper state to create one big VM on a virtual host
 - Revert: Sync state modules when starting action chain execution (bsc#1177336)
 - Sync state modules when starting action chain execution (bsc#1177336)
 - Handle group- and org-specific image pillars


### PR DESCRIPTION
## What does this PR change?

In order to create a virtual machine that is performance optimized and
eats almost all the virtual host resources, the virtual CPUs need to be
pinned, the vCPU topology need to match the physical one, same for the
NUMA configuration.

All these can be boring to type, and the more CPUs there are on the
virtual host, the worst it is. This adds a helper state that computes it
for the user.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: Documentation will be needed once a UI for this state will be added (in another PR)

- [X] **DONE**

## Test coverage
- Unit tests were added

- [X] **DONE**

## Links

Required Salt PRs:

- [ ] https://github.com/saltstack/salt/pull/58196
- [ ] https://github.com/saltstack/salt/pull/59007

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
