### PR TITLE
Let SUSE Manager know openSCAP packages are installed

### DIFF
--- a/testsuite/features/secondary/min_salt_openscap_audit.feature
+++ b/testsuite/features/secondary/min_salt_openscap_audit.feature
@@ -7,8 +7,13 @@ Feature: OpenSCAP audit of Salt minion
   I want to run an OpenSCAP scan on it
 
   Scenario: Install the OpenSCAP packages on the SLE minion
+    Given I am on the Systems overview page of this "sle_minion"
     When I enable repository "os_pool_repo os_update_repo" on this "sle_minion"
     And I install OpenSCAP dependencies on "sle_minion"
+    And I follow "Software" in the content area
+    And I click on "Update Package List"
+    And I follow "Events" in the content area
+    And I wait until I do not see "Package List Refresh scheduled by admin" text, refreshing the page
 
   Scenario: Schedule an OpenSCAP audit job on the SLE minion
     Given I disable IPv6 forwarding on all interfaces of the SLE minion


### PR DESCRIPTION
## What does this PR change?

Forgotten port from 4.1. See https://github.com/SUSE/spacewalk/pull/13197/files#diff-1f77b3883b9418ea4417282aa5e9cdfcc96ecbfda94ce7eff59259b9c357744a .

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
