### PR TITLE
Allow specifying both name and label of new Content Environment (bsc#1176411)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -8946,7 +8946,7 @@ Alternatively, you will want to download &lt;strong&gt;Incremental Channel Conte
         <source>Label must not exceed 16 characters</source>
       </trans-unit>
       <trans-unit id="contentmanagement.environment_name_too_long" xml:space="preserve">
-        <source>Label must not exceed 128 characters</source>
+        <source>Name must not exceed 128 characters</source>
       </trans-unit>
       <trans-unit id="contentmanagement.filter_exists" xml:space="preserve">
         <source>Filter name already exists</source>

--- a/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment-form.js
+++ b/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment-form.js
@@ -33,6 +33,15 @@ const EnvironmentForm = (props: Props) =>
       </div>
       <div className="row">
         <Text
+          name="label"
+          label={t("Label")}
+          labelClass="col-md-3"
+          divClass="col-md-8"
+          disabled={props.editing}
+        />
+      </div>
+      <div className="row">
+        <Text
           name="description"
           label={t("Description")}
           labelClass="col-md-3"

--- a/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment-view.js
+++ b/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment-view.js
@@ -36,6 +36,10 @@ const EnvironmentView = React.memo((props: Props) => {
   return (
     <React.Fragment>
       <dl className="row">
+        <dt className="col-xs-3">{t('Label')}:</dt>
+        <dd className="col-xs-9">{props.environment.label}</dd>
+      </dl>
+      <dl className="row">
         <dt className="col-xs-3">{t('Description')}:</dt>
         <dd className="col-xs-9">{props.environment.description}</dd>
       </dl>

--- a/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment.utils.js
+++ b/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment.utils.js
@@ -2,8 +2,10 @@ export function mapAddEnvironmentRequest(environment, environments, projectId) {
   let environmentRequest = {
     ...environment,
     projectLabel: projectId,
-    label: environment.name
+    label: environment.label,
+    name: environment.name
   }
+
 
   if (!environmentRequest.predecessorLabel) {
     const lastEnvironment = environments[environments.length - 1]

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,5 @@
+- Allow specifying both name and label of new Content Environment (bsc#1176411)
+
 -------------------------------------------------------------------
 Wed Nov 25 12:26:38 CET 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
When creating a Content Environment in the web UI, we display 'Name'
field, that we use as both name and label of the new Environment, which
lead to confusion.

Fixed by displaying text inputs for both 'Name' and 'Label'.


## GUI diff

Before:
![ss-before](https://user-images.githubusercontent.com/1412268/100326618-781d0880-2fca-11eb-99a9-64b0dbaf8d97.png)

After:
![ss-after](https://user-images.githubusercontent.com/1412268/100326630-7c492600-2fca-11eb-8dd5-73d285fd32bb.png)

- [x] **DONE**

## Documentation
https://github.com/uyuni-project/uyuni-docs/pull/699
- [x] **DONE**

## Test coverage
- no tests

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/12448

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"