### PR TITLE
Ignore docker network interfaces when reporting list of systems duplicated by IP address

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
@@ -1859,6 +1859,7 @@ SELECT 1
                     rhnServerNetAddress4 sa4_2 on sa4_2.interface_id = ni2.id
                         where USP2.user_id = :uid and
                                 sa4_2.address not in(%s) and NI2.name not like 'vnet%' and NI2.name not like 'virbr%'
+                                and NI2.name not like 'docker%'
                                 group by sa4_2.address having count(distinct NI2.server_id) > 1) SUMM on SUMM.address = sa4.address
         where USP.user_id = :uid
     </query>
@@ -1901,7 +1902,7 @@ SELECT 1
                       rhnservernetaddress6 sa6_2 on sa6_2.interface_id = ni2.id
                 where usp2.user_id = :uid and
                       sa6_2.address not in(%s) and
-                      ni2.name not like 'vnet%' and ni2.name not like 'virbr%'
+                      ni2.name not like 'vnet%' and ni2.name not like 'virbr%' and NI2.name not like 'docker%'
                                 group by sa6_2.address, sa6_2.scope
                having count(distinct ni2.server_id) > 1) summ on summ.address = sa6.address and summ.scope = sa6.scope
          where usp.user_id = :uid

--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
@@ -1858,8 +1858,8 @@ SELECT 1
                     rhnUserServerPerms USP2 on NI2.server_id = USP2.server_id inner join
                     rhnServerNetAddress4 sa4_2 on sa4_2.interface_id = ni2.id
                         where USP2.user_id = :uid and
-                                sa4_2.address not in(%s) and NI2.name not like 'vnet%' and NI2.name not like 'virbr%'
-                                and NI2.name not like 'docker%'
+                                sa4_2.address not in(%s) and NI2.name not like 'vnet%' and NI2.name not like 'virbr%' and
+                                NI2.name not like 'docker%'
                                 group by sa4_2.address having count(distinct NI2.server_id) > 1) SUMM on SUMM.address = sa4.address
         where USP.user_id = :uid
     </query>
@@ -1902,7 +1902,8 @@ SELECT 1
                       rhnservernetaddress6 sa6_2 on sa6_2.interface_id = ni2.id
                 where usp2.user_id = :uid and
                       sa6_2.address not in(%s) and
-                      ni2.name not like 'vnet%' and ni2.name not like 'virbr%' and NI2.name not like 'docker%'
+                      ni2.name not like 'vnet%' and ni2.name not like 'virbr%' and
+                      ni2.name not like 'docker%'
                                 group by sa6_2.address, sa6_2.scope
                having count(distinct ni2.server_id) > 1) summ on summ.address = sa6.address and summ.scope = sa6.scope
          where usp.user_id = :uid

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Ignore docker network ifaces in the system duplicates list
 - Fix incorrect password autocompletions (bsc#1148357)
 - add translation strings for newly added countries and timezones (jsc#PM-2081)
 - Update exception message in findSyncedMandatoryChannels


### PR DESCRIPTION
## What does this PR change?

When listing system duplicates by ip address, we don't take docker interfaces in account.
We already handle libvirt interfaces (like `virbrX`) and this PR extends this mechanism to docker interfaces.

## GUI diff

(No UI change, only the dupes are not reported).

- [x] **DONE**

## Documentation
- No documentation needed: bugfix

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/2703
Tracks https://github.com/SUSE/spacewalk/issues/12930

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"