### PR TITLE
Testsuite: prevent special chars in the output xml files

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1432,5 +1432,5 @@ When(/^I apply "([^"]*)" local salt state on "([^"]*)"$/) do |state, host|
   remote_file = '/usr/share/susemanager/salt/' + state + '.sls'
   return_code = file_inject(node, source, remote_file)
   raise 'File injection failed' unless return_code.zero?
-  node.run('salt-call --local --file-root=/usr/share/susemanager/salt --module-dirs=/usr/share/susemanager/salt/ --log-level=info --retcode-passthrough --force-color state.apply ' + state)
+  node.run('salt-call --local --file-root=/usr/share/susemanager/salt --module-dirs=/usr/share/susemanager/salt/ --log-level=info --retcode-passthrough state.apply ' + state)
 end


### PR DESCRIPTION
## What does this PR change?
Prevent special chars in the output xml files.

Otherwise, they break the `minidom` parser and the CI won't send
the mail with the results.
- testsuite/features/step_definitions/command_steps.rb:
Do not pass `--force-color` option to the `salt-call`.


## Links
### Ports
- Manager-4.1: https://github.com/SUSE/spacewalk/pull/13225

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)
