### PR TITLE
Fix the activation key handling from kickstart profile (bsc#1178647)

### DIFF
--- a/java/conf/cobbler/snippets/minion_script
+++ b/java/conf/cobbler/snippets/minion_script
@@ -5,22 +5,43 @@
         <![CDATA[
 cat <<EOF >"/etc/salt/minion.d/susemanager.conf"
 master: $redhat_management_server
+server_id_use_crc: adler32
+enable_legacy_startup_events: False
+enable_fqdns_grains: False
+mine_enabled: False
 
 EOF
-#if $varExists('registration_key') or $varExists('redhat_management_key')
+#set activation_keys = ""
+#set management_key  = ""
+#if $varExists('registration_key')
+   #set activation_keys = $registration_key
+#end if
+
+#if $varExists('redhat_management_key')
+   #set management_key = $redhat_management_key.split(",",1)[0]
+#end if
+
+#if not $activation_keys and $management_key
+  #set keys= $redhat_management_key.split(",",1)
+  #if len(keys) > 1
+     #set activation_keys = $keys[1]
+  #end if
+#end if
+
+#if $activation_keys or $management_key
 cat <<EOF >>"/etc/salt/minion.d/susemanager.conf"
 grains:
     susemanager:
 EOF
 #end if
-#if $varExists('redhat_management_key')
+#if $management_key
 cat <<EOF >>"/etc/salt/minion.d/susemanager.conf"
-        management_key: "$redhat_management_key"
+        management_key: "$management_key"
 EOF
 #end if
-#if $varExists('registration_key')
+#if $activation_keys
 cat <<EOF >>"/etc/salt/minion.d/susemanager.conf"
-        activation_key: "$registration_key"
+        activation_key: "$activation_keys"
 EOF
 #end if
 

--- a/java/conf/cobbler/snippets/redhat_register_using_salt
+++ b/java/conf/cobbler/snippets/redhat_register_using_salt
@@ -7,20 +7,37 @@ enable_fqdns_grains: False
 mine_enabled: False
 
 EOF
-#if $varExists('registration_key') or $varExists('redhat_management_key')
+#set activation_keys = ""
+#set management_key  = ""
+#if $varExists('registration_key')
+   #set activation_keys = $registration_key
+#end if
+
+#if $varExists('redhat_management_key')
+   #set management_key = $redhat_management_key.split(",",1)[0]
+#end if
+
+#if not $activation_keys and $management_key
+  #set keys= $redhat_management_key.split(",",1)
+  #if len(keys) > 1
+     #set activation_keys = $keys[1]
+  #end if
+#end if
+
+#if $activation_keys or $management_key
 cat <<EOF >>"/etc/salt/minion.d/susemanager.conf"
 grains:
     susemanager:
 EOF
 #end if
-#if $varExists('redhat_management_key')
+#if $management_key
 cat <<EOF >>"/etc/salt/minion.d/susemanager.conf"
-        management_key: "$redhat_management_key"
+        management_key: "$management_key"
 EOF
 #end if
-#if $varExists('registration_key')
+#if $activation_keys
 cat <<EOF >>"/etc/salt/minion.d/susemanager.conf"
-        activation_key: "$registration_key"
+        activation_key: "$activation_keys"
 EOF
 #end if
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix the activation key handling from kickstart profile (bsc#1178647)
 - Ignore docker network ifaces in the system duplicates list
 - Fix incorrect password autocompletions (bsc#1148357)
 - add translation strings for newly added countries and timezones (jsc#PM-2081)


### PR DESCRIPTION
## What does this PR change?

Port of https://github.com/SUSE/spacewalk/pull/13087

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test" 
- [ ] Re-run test "backend_unittests_pgsql" (Test skipped, there are no changes to test)
- [x] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"  
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"