### PR TITLE
Fix 'module not found' exception handling in mgr-libmod (bsc#1179257)

### DIFF
--- a/susemanager-utils/mgr-libmod/mgr-libmod.changes
+++ b/susemanager-utils/mgr-libmod/mgr-libmod.changes
@@ -1,3 +1,5 @@
+- Fix 'module not found' exception handling (bsc#1179257)
+
 -------------------------------------------------------------------
 Fri Sep 18 11:08:02 CEST 2020 - jgonzalez@suse.com
 

--- a/susemanager-utils/mgr-libmod/mgrlibmod/mllib.py
+++ b/susemanager-utils/mgr-libmod/mgrlibmod/mllib.py
@@ -148,12 +148,12 @@ class MLLibmodProc:
 
     def get_default_stream(self, name: str):
         if self._mod_index is None:
-            raise mlerrcode.MlModuleNotFound("Unable to access module index when resolving default stream")
+            raise mlerrcode.MlGeneralException("Module index not found")
 
         module = self._mod_index.get_module(name)
 
         if not module:
-            raise mlerrcode.MlModuleNotFound("Module {} not found".format(name))
+            raise mlerrcode.MlModuleNotFound("Module {} not found".format(name)).set_data("streams", [mltypes.MLStreamType(name, "").to_obj()])
 
         defaults = module.get_defaults()
         if defaults:
@@ -183,7 +183,7 @@ class MLLibmodProc:
 
     def get_rpm_blacklist(self):
         if self._mod_index is None:
-            raise mlerrcode.MlModuleNotFound("No module index has been found")
+            raise mlerrcode.MlGeneralException("No module index has been found")
 
         enabled_packages: Set = set()
         for stream in self._enabled_stream_modules.values():
@@ -411,7 +411,7 @@ class MLLibmodAPI:
                 else:
                     self._proc.pick_default_stream(s_type=s_type)
             except mlerrcode.MlModuleNotFound as e:
-                not_found += e.data["streams"]
+                not_found.extend(e.data["streams"])
 
         if not_found:
             raise mlerrcode.MlModuleNotFound("Module not found").set_data("streams", not_found)


### PR DESCRIPTION
`MlModuleNotFound` exception is expected to have a list of stream objects as additional data with the key `"streams"`. If the key is missing in the data, the exception cannot be handled correctly. This PR makes sure that the `MlModuleNotFound` exception always has this data.

## Links

https://bugzilla.suse.com/1179257
Fixes https://github.com/uyuni-project/uyuni/issues/2906

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
