### PR TITLE
Remove salt cleanup when unregistering

### DIFF
--- a/testsuite/features/secondary/min_activationkey.feature
+++ b/testsuite/features/secondary/min_activationkey.feature
@@ -9,7 +9,6 @@ Feature: Bootstrap a Salt minion via the GUI with an activation key
     Then I should see a "Confirm System Profile Deletion" text
     When I click on "Delete Profile"
     And I wait until I see "has been deleted" text
-    And I clean up the minion's cache on "sle_minion"
     Then "sle_minion" should not be registered
 
   Scenario: Create a configuration channel for the activation key

--- a/testsuite/features/secondary/min_bootstrap_negative.feature
+++ b/testsuite/features/secondary/min_bootstrap_negative.feature
@@ -26,7 +26,6 @@ Feature: Negative tests for bootstrapping normal minions
     Then I should see a "Confirm System Profile Deletion" text
     When I click on "Delete Profile"
     And I wait until I see "has been deleted" text
-    And I clean up the minion's cache on "sle_minion"
     Then "sle_minion" should not be registered
 
   Scenario: Bootstrap a SLES minion with wrong hostname

--- a/testsuite/features/secondary/min_bootstrap_script.feature
+++ b/testsuite/features/secondary/min_bootstrap_script.feature
@@ -15,7 +15,6 @@ Feature: Register a Salt minion via Bootstrap-script
     Then I should see a "Confirm System Profile Deletion" text
     When I click on "Delete Profile"
     And I wait until I see "has been deleted" text
-    And I clean up the minion's cache on "sle_minion"
     Then "sle_minion" should not be registered
 
   Scenario: Bootstrap the minion using the script

--- a/testsuite/features/secondary/min_bootstrap_ssh_key.feature
+++ b/testsuite/features/secondary/min_bootstrap_ssh_key.feature
@@ -9,7 +9,6 @@ Feature: Bootstrap a Salt minion via the GUI using SSH key
     Then I should see a "Confirm System Profile Deletion" text
     When I click on "Delete Profile"
     And I wait until I see "has been deleted" text
-    And I clean up the minion's cache on "sle_minion"
     Then "sle_minion" should not be registered
 
   Scenario: Prepare the minion for SSH key authentication

--- a/testsuite/features/secondary/min_bootstrap_xmlrpc.feature
+++ b/testsuite/features/secondary/min_bootstrap_xmlrpc.feature
@@ -9,7 +9,6 @@ Feature: Register a Salt minion via XML-RPC API
     Then I should see a "Confirm System Profile Deletion" text
     When I click on "Delete Profile"
     And I wait until I see "has been deleted" text
-    And I clean up the minion's cache on "sle_minion"
     Then "sle_minion" should not be registered
 
   Scenario: Bootstrap a SLES minion via XML-RPC

--- a/testsuite/features/secondary/min_salt_mgrcompat_state.feature
+++ b/testsuite/features/secondary/min_salt_mgrcompat_state.feature
@@ -30,7 +30,6 @@ Feature: Verify that Salt mgrcompat state works when the new module.run syntax i
     Then I should see a "Confirm System Profile Deletion" text
     When I click on "Delete Profile"
     And I wait until I see "has been deleted" text
-    And I clean up the minion's cache on "sle_minion"
     Then "sle_minion" should not be registered
 
   Scenario: Enable new module.run syntax on the minion and perform registration
@@ -74,7 +73,6 @@ Feature: Verify that Salt mgrcompat state works when the new module.run syntax i
     Then I should see a "Confirm System Profile Deletion" text
     When I click on "Delete Profile"
     And I wait until I see "has been deleted" text
-    And I clean up the minion's cache on "sle_minion"
     Then "sle_minion" should not be registered
 
   Scenario: Cleanup: bootstrap again the minion after mgrcompat tests

--- a/testsuite/features/secondary/min_ssh_tunnel.feature
+++ b/testsuite/features/secondary/min_ssh_tunnel.feature
@@ -9,7 +9,6 @@ Feature: Register a salt system to be managed via SSH tunnel
     Then I should see a "Confirm System Profile Deletion" text
     When I click on "Delete Profile"
     And I wait until I see "has been deleted" text
-    And I clean up the minion's cache on "sle_minion"
     Then "sle_minion" should not be registered
 
   Scenario: Register this minion for push via SSH tunnel

--- a/testsuite/features/secondary/minssh_bootstrap_xmlrpc.feature
+++ b/testsuite/features/secondary/minssh_bootstrap_xmlrpc.feature
@@ -10,7 +10,6 @@ Feature: Register a salt-ssh system via XML-RPC
     Then I should see a "Confirm System Profile Deletion" text
     When I click on "Delete Profile"
     And I wait until I see "has been deleted" text
-    And I clean up the minion's cache on "ssh_minion"
     Then "ssh_minion" should not be registered
 
 @ssh_minion

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -678,22 +678,6 @@ When(/^I enter "([^"]*)" password$/) do |host|
   step %(I enter "#{ENV['VIRTHOST_XEN_PASSWORD']}" as "password") if host == "xen_server"
 end
 
-# TODO: Ideally we should do a full cleanup of the minion
-#       But we can't do that as we don't have products synced, so it will fail installing salt and sal-minion
-#       Instead we inject those packages when deploying through sumaform and we can't remove them.
-#       If someday we have synced products, we can proceed to run a full cleanup
-When(/^I clean up the minion's cache on "([^"]*)"$/) do |minion|
-  raise "#{minion} is not a salt minion" unless minion.include? 'minion'
-  node = get_target(minion)
-  if %w[sle_minion sle_ssh_tunnel_minion].include?(minion)
-    node.run('rcsalt-minion stop')
-    node.run('rm -Rf /var/cache/salt/minion')
-  elsif %w[ceos_minion ceos_ssh_minion ubuntu_minion ubuntu_ssh_minion].include?(minion)
-    node.run('systemctl stop salt-minion')
-    node.run('rm -Rf /var/cache/salt/minion')
-  end
-end
-
 When(/^I perform a full salt minion cleanup on "([^"]*)"$/) do |host|
   node = get_target(host)
   if host.include? 'ceos'


### PR DESCRIPTION
## What does this PR change?

This PR removes code that has been added long ago to deal with problem of unaccepted Salt keys reappearing all the time.

Such keys appear on SUSE Manager server with deleted minions when:
* `salt-minion` service is restarted on the minion
* the minion reboots

The proper fix to this problem is to fix the issue in the product: 

  https://bugzilla.suse.com/show_bug.cgi?id=1179288

This PR has been tested with success on 4.1 branch:

   https://ci.suse.de/view/Manager/view/Manager-4.1/job/manager-4.1-cucumber-NUE/205/parameters/


## Links

Ports:
* 4.0: SUSE/spacewalk#13265
* 4.1: SUSE/spacewalk#13263


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
