### PR TITLE
Quote the proxy settings to be used by Zypper (bsc#1179087)

### DIFF
--- a/backend/satellite_tools/repo_plugins/yum_src.py
+++ b/backend/satellite_tools/repo_plugins/yum_src.py
@@ -641,11 +641,11 @@ type=rpm-md
         ret_url = None
         query_params = {}
         if self.proxy_hostname:
-            query_params['proxy'] = self.proxy_hostname
+            query_params['proxy'] = quote(self.proxy_hostname)
         if self.proxy_user:
-            query_params['proxyuser'] = self.proxy_user
+            query_params['proxyuser'] = quote(self.proxy_user)
         if self.proxy_pass:
-            query_params['proxypass'] = self.proxy_pass
+            query_params['proxypass'] = quote(self.proxy_pass)
         if self.sslcacert:
             # Since Zypper only accepts CAPATH, we need to split the certificates bundle
             # and run "c_rehash" on our custom CAPATH

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Quote the proxy settings to be used by Zypper (bsc#1179087)
 - Do not raise TypeError when processing SUSE products (bsc#1178704)
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

This PR "quotes" the proxy settings when building the URL that is going to be used by Zypper when dealing with RPM repositories in `spacewalk-repo-sync` in order to avoid issues when proxy settings contains specials characters, i.a. `%` or `&`.

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- No tests: **bugfix**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/13200

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
