### PR TITLE
Testsuite: Use different user for testsuite HTTP proxy

### DIFF
--- a/testsuite/features/core/first_settings.feature
+++ b/testsuite/features/core/first_settings.feature
@@ -82,8 +82,8 @@ Feature: Very first settings
     And I should see a "HTTP Proxy Username" text
     And I should see a "HTTP Proxy Password" text
     When I enter the address of the HTTP proxy as "HTTP Proxy Hostname"
-    And I enter "suma" as "HTTP Proxy Username"
-    And I enter "P4$$word" as "HTTP Proxy Password"
+    And I enter "suma2" as "HTTP Proxy Username"
+    And I enter "P4$$wordWith%and&" as "HTTP Proxy Password"
     And I click on "Save and Verify"
     Then HTTP proxy verification should have succeeded
 

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -36,7 +36,7 @@ end
 
 Then(/^it should be possible to use the HTTP proxy$/) do
   url = 'https://www.suse.com'
-  proxy = "suma:P4$$word@#{$server_http_proxy}"
+  proxy = "suma2:P4$$wordWith%and&@#{$server_http_proxy}"
   $server.run("curl --insecure --proxy '#{proxy}' --proxy-anyauth --location '#{url}' --output /dev/null")
 end
 


### PR DESCRIPTION
## What does this PR change?

This PR changes the testsuite to use different credentials for the configured HTTP Proxy in order to test that proxy passwords with special characters like `%` or `&` are properly pass to Zypper.

This requires https://github.com/uyuni-project/uyuni/pull/2918 to be merged.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **testsuite changes**

- [x] **DONE**

## Test coverage
- No tests: **testsuite changes**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
