### PR TITLE
ssl-cert-check: Added RHEL to the Python 3 build.

### DIFF
--- a/projects/ssl-cert-check/spacewalk-ssl-cert-check.changes
+++ b/projects/ssl-cert-check/spacewalk-ssl-cert-check.changes
@@ -1,3 +1,5 @@
+- Added RHEL to the Python 3 build.
+
 -------------------------------------------------------------------
 Fri Sep 18 11:46:06 CEST 2020 - jgonzalez@suse.com
 

--- a/projects/ssl-cert-check/spacewalk-ssl-cert-check.spec
+++ b/projects/ssl-cert-check/spacewalk-ssl-cert-check.spec
@@ -16,7 +16,7 @@
 # Please submit bugfixes or comments via https://bugs.opensuse.org/
 #
 
-%if 0%{?suse_version} > 1320
+%if 0%{?suse_version} > 1320 || 0%{?rhel}
 %global build_py3 1
 %endif
 
@@ -69,16 +69,30 @@ install -m755 ssl-cert-check $RPM_BUILD_ROOT/%{_bindir}/ssl-cert-check
 install -m644 ssl-cert-check.8 $RPM_BUILD_ROOT%{_mandir}/man8/
 
 %pre
+%if !0%{?rhel}
 %service_add_pre %{name}.timer
+%endif
 
 %post
+%if 0%{?rhel}
+%systemd_post %{name}.timer
+%else
 %service_add_post %{name}.timer
+%endif
 
 %preun
+%if 0%{?rhel}
+%systemd_preun %{name}.timer
+%else
 %service_del_preun %{name}.timer
+%endif
 
 %postun
+%if 0%{?rhel}
+%systemd_preun %{name}.timer
+%else
 %service_del_postun %{name}.timer
+%endif
 
 %files
 %defattr(-,root,root,-)


### PR DESCRIPTION
## What does this PR change?

Modified SPEC file to work with RHEL8.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: No functional changes.

- [X] **DONE**

## Test coverage
- No tests: Tested during automatic build
Tested successful build on CentOS 7+ and LEAP 15.2

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
