### PR TITLE
suseRegisterInfo: Added RHEL support

### DIFF
--- a/suseRegisterInfo/suseRegisterInfo.changes
+++ b/suseRegisterInfo/suseRegisterInfo.changes
@@ -1,3 +1,5 @@
+- Adapted for RHEL build.
+
 -------------------------------------------------------------------
 Fri Sep 18 11:50:05 CEST 2020 - jgonzalez@suse.com
 

--- a/suseRegisterInfo/suseRegisterInfo.spec
+++ b/suseRegisterInfo/suseRegisterInfo.spec
@@ -15,7 +15,7 @@
 # Please submit bugfixes or comments via https://bugs.opensuse.org/
 #
 
-%if 0%{?fedora} || 0%{?suse_version} > 1320 || 0%{?rhel}
+%if 0%{?fedora} || 0%{?suse_version} > 1320 || 0%{?rhel} >= 8
 %global build_py3   1
 %global default_py3 1
 %endif

--- a/suseRegisterInfo/suseRegisterInfo.spec
+++ b/suseRegisterInfo/suseRegisterInfo.spec
@@ -15,13 +15,13 @@
 # Please submit bugfixes or comments via https://bugs.opensuse.org/
 #
 
-
-%{!?python_sitelib: %global python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")}
-%if 0%{?fedora} || 0%{?suse_version} > 1320
+%if 0%{?fedora} || 0%{?suse_version} > 1320 || 0%{?rhel}
 %global build_py3   1
 %global default_py3 1
 %endif
 
+%global __python /usr/bin/python2
+%{!?python_sitelib: %global python_sitelib %(%{__python} -c "from distutils.sysconfig import get_python_lib; print get_python_lib()")}
 %define pythonX %{?default_py3:python3}%{!?default_py3:python2}
 
 Name:           suseRegisterInfo
@@ -54,8 +54,13 @@ for a registration
 Summary:        Python 2 specific files for %{name}
 Group:          Productivity/Other
 Requires:       %{name} = %{version}-%{release}
+%if 0%{?rhel} >=8
+Requires:       python2
+BuildRequires:  python2-devel
+%else
 Requires:       python
 BuildRequires:  python-devel
+%endif
 
 %description -n python2-%{name}
 Python 2 specific files for %{name}.


### PR DESCRIPTION
## What does this PR change?

Adapted for RHEL builds.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: No functional changes.

- [X] **DONE**

## Test coverage
- No tests: Tested during auto-build process.
Build tested successfully on CentOS 7+, Fedora 31+, LEAP 15.2

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
