### PR TITLE
Fix loading indicator for tables using SimpleDataProvider

### DIFF
--- a/web/html/src/components/table/Table.test.js
+++ b/web/html/src/components/table/Table.test.js
@@ -117,4 +117,28 @@ describe("Table component", () => {
       })
     ).not.toBe(null);
   });
+
+  test("loading indicator for tables using SimpleDataProvider", async () => {
+    const data = [{value: "Value 0"}];
+
+    const { rerender } = render(
+      <Table {...baseProps} loading={true} />
+    );
+
+    // Check if loading indicator appears
+    expect(screen.queryByText(baseProps.loadingText)).not.toBe(null);
+
+    rerender(
+      <Table {...baseProps} data={data} loading={false} >
+        <Column columnKey="value" cell={item => item.value} />
+      </Table>
+    );
+    await waitForElementToBeRemoved(() =>
+      screen.queryByText(baseProps.loadingText)
+    );
+
+    // Check if loading indicator disappears and data is displayed
+    expect(screen.queryByText(baseProps.loadingText)).toBe(null);
+    expect(screen.queryByText(data[0].value)).not.toBe(null);
+  });
 });

--- a/web/html/src/components/table/TableDataHandler.js
+++ b/web/html/src/components/table/TableDataHandler.js
@@ -56,6 +56,8 @@ type Props = {
   selectedItems?: Array<any>,
   /** The message which is shown when there are no rows to display */
   emptyText?: string,
+  /** Indicate whether the data is loading (only effective for tables using SimpleDataProvider) */
+  loading?: boolean,
   /** The message which is shown when the data is loading */
   loadingText?: string,
   /** Children node in the table */
@@ -111,7 +113,7 @@ export class TableDataHandler extends React.Component<Props, State> {
       }, {});
 
       return new SimpleDataProvider(data, this.props.identifier,
-        this.props.searchField && this.props.searchField.props.filter, comparators);
+        this.props.searchField && this.props.searchField.props.filter, comparators, this.props.loading);
     }
     else if (typeof data === "string") {
       return new AsyncDataProvider(data);

--- a/web/html/src/utils/data-providers/simple-data-provider.js
+++ b/web/html/src/utils/data-providers/simple-data-provider.js
@@ -9,17 +9,24 @@ export default class SimpleDataProvider {
   identifier: (row: any) => any;
   filter: ?(row: any, criteria: string) => boolean;
   comparators: ?{[string]: Comparator};
+  loading: ?boolean;
 
   constructor(data: Array<any>, identifier: (row: any) => any,
       filter?: (row: any, criteria: string) => boolean,
-      comparators?: {[string]: Comparator}) {
+      comparators?: {[string]: Comparator}, loading?: boolean) {
     this.data = data;
     this.identifier = identifier;
     this.filter = filter;
     this.comparators = comparators;
+    this.loading = loading;
   }
 
   get(callback: (promise: Promise<PagedData>) => any, pageControl?: PageControl): void {
+    // Only proceed if loading has finished
+    if (this.loading) {
+      return;
+    }
+
     let data = this.data;
     let total = data.length;
 

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Fix loading indicator for tables using SimpleDataProvider (bsc#1177756)
 - Required NodeJS version upgraded to 10
 - Fix incorrect password autocompletions (bsc#1148357)
 - Fix mandatory channels JS API to finish loading in case of error (bsc#1178839)


### PR DESCRIPTION
## What does this PR change?

Fix loading indicator for tables using `SimpleDataProvider`

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: Fix

- [x] **DONE**

## Test coverage

- No tests: Fix

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/12799

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
