### PR TITLE
[Port] QAM: Fix extraction of logs from old clients not having /etc/os-relea…

### DIFF
--- a/testsuite/.rubocop_todo.yml
+++ b/testsuite/.rubocop_todo.yml
@@ -362,10 +362,7 @@ Style/DateTime:
 # Offense count: 4
 # Cop supports --auto-correct.
 Style/DisableCopsWithinSourceCodeDirective:
-  Exclude:
-    - 'features/step_definitions/common_steps.rb'
-    - 'features/step_definitions/command_steps.rb'
-    - 'features/step_definitions/salt_steps.rb'
+  Enabled: false
 
 # Offense count: 129
 # Configuration parameters: RequireForNonPublicMethods.

--- a/testsuite/features/support/client_stack.rb
+++ b/testsuite/features/support/client_stack.rb
@@ -64,22 +64,28 @@ end
 
 # Extract the OS version and OS family
 # We get these data decoding the values in '/etc/os-release'
+# rubocop:disable Metrics/AbcSize
 def get_os_version(node)
-  os_family_raw, _code = node.run('grep "^ID=" /etc/os-release')
-  os_family = os_family_raw.strip.split('=')[1]
-  return nil, nil if os_family.nil?
-  os_family.delete! '"'
-
-  os_version_raw, _code = node.run('grep "^VERSION_ID=" /etc/os-release')
-  os_version = os_version_raw.strip.split('=')[1]
-  return nil, nil if os_version.nil?
-  os_version.delete! '"'
-
-  # on SLES, we need to replace the dot with '-SP'
-  os_version.gsub!(/\./, '-SP') if os_family =~ /^sles/
-
-  [os_version, os_family]
+  os_family_raw, code = node.run('grep "^ID=" /etc/os-release', false)
+  if code.zero?
+    os_family = os_family_raw.strip.split('=')[1]
+    return nil, nil if os_family.nil?
+    os_family.delete! '"'
+    os_version_raw, _code = node.run('grep "^VERSION_ID=" /etc/os-release')
+    os_version = os_version_raw.strip.split('=')[1]
+    return nil, nil if os_version.nil?
+    os_version.delete! '"'
+    # on SLES, we need to replace the dot with '-SP'
+    os_version.gsub!(/\./, '-SP') if os_family =~ /^sles/
+    [os_version, os_family]
+  else
+    # The only node that we handle which doesn't support 'os-release' file is Centos 6
+    _os_family_raw, code = node.run('test -f /etc/centos-release', false)
+    return nil, nil unless code.zero?
+    ['6', 'centos']
+  end
 end
+# rubocop:enable Metrics/AbcSize
 
 def sle11family?(node)
   _out, code = node.run('pidof systemd', false)


### PR DESCRIPTION
## What does this PR change?

On this PR we treat differently the way to obtain family and version from a CentOS6 node. After analyzing all the current supported nodes in our test suite, we noticed that only CentOS6 has not `/etc/os-release` file. Instead, it has a different file with a different format.

We decided that while we don't integrate other distros not supporting `/etc/os-release`, as it is a unique case, as soon as we notice it exist a file `/etc/centos-release` we can set the values for family and version to `centos` and `6`.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
 - Manager-4.1 https://github.com/SUSE/spacewalk/pull/13134

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
