### PR TITLE
[Port] QAM: Change the fqdn of the QAM Mirror (#13139)

### DIFF
--- a/testsuite/features/qam/add_custom_repositories/add_ceos6_repositories.feature
+++ b/testsuite/features/qam/add_custom_repositories/add_ceos6_repositories.feature
@@ -5,7 +5,7 @@
 Feature: Adding the CentOS 6 distribution custom repositories
 
   Scenario: Download the iso of CentOS 6 DVD and mount it on the server
-    When I mount as "centos-6-iso" the ISO from "http://schnell.suse.de/CentOS/CentOS-6.5-x86_64-binDVD.iso" in the server
+    When I mount as "centos-6-iso" the ISO from "http://minima-mirror-qam.mgr.prv.suse.net/pub/centos/6.10/isos/x86_64/CentOS-6.10-x86_64-bin-DVD1.iso" in the server
 
   Scenario: Add a child channel for CentOS 6 DVD repositories
     Given I am authorized as "admin" with password "admin"

--- a/testsuite/features/qam/add_custom_repositories/add_ceos7_repositories.feature
+++ b/testsuite/features/qam/add_custom_repositories/add_ceos7_repositories.feature
@@ -5,7 +5,7 @@
 Feature: Adding the CentOS 7 distribution custom repositories
 
   Scenario: Download the iso of CentOS 7 DVD and mount it on the server
-    When I mount as "centos-7-iso" the ISO from "http://schnell.suse.de/CentOS/CentOS-7.0-1406-x86_64-Minimal.iso" in the server
+    When I mount as "centos-7-iso" the ISO from "http://minima-mirror-qam.mgr.prv.suse.net/pub/centos/7/isos/x86_64/CentOS-7-x86_64-DVD-2003.iso" in the server
 
   Scenario: Add a child channel for CentOS 7 DVD repositories
     Given I am authorized as "admin" with password "admin"


### PR DESCRIPTION
## What does this PR change?

When we changed our internal qam mirror fqdn, we missed to update the testsuite code.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
 - Manager-4.1 https://github.com/SUSE/spacewalk/pull/13139

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
