### PR TITLE
[Port] QAM: Fix creation of MU repositories (#13141)

### DIFF
--- a/testsuite/features/qam/add_custom_repositories/add_mu_repository.template
+++ b/testsuite/features/qam/add_custom_repositories/add_mu_repository.template
@@ -17,8 +17,7 @@ Feature: Adding a Maintenance Update custom channel and the custom repositories 
 
   Scenario: Add the Maintenance update repositories for <client>
     Given I am authorized as "admin" with password "admin"
-    When I follow the left menu "Software > Manage > Repositories"
-    And I create the MU repositories for "<client>"
+    When I create the MU repositories for "<client>"
 
   Scenario: Add the custom repositories to the custom channel for <client>
     Given I am authorized as "admin" with password "admin"

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -1179,14 +1179,15 @@ When(/^I create the MU repositories for "([^"]*)"$/) do |client|
       puts "The MU repository #{unique_repo_name} was already created, we will reuse it."
     else
       steps %(
-      When I follow "Create Repository"
-      And I enter "#{unique_repo_name}" as "label"
-      And I enter "#{repo_url.strip}" as "url"
-      And I select "#{client.include?('ubuntu') ? 'deb' : 'yum'}" from "contenttype"
-      And I click on "Create Repository"
-      Then I should see a "Repository created successfully" text
-      And I should see "metadataSigned" as checked
-    )
+        When I follow the left menu "Software > Manage > Repositories"
+        And I follow "Create Repository"
+        And I enter "#{unique_repo_name}" as "label"
+        And I enter "#{repo_url.strip}" as "url"
+        And I select "#{client.include?('ubuntu') ? 'deb' : 'yum'}" from "contenttype"
+        And I click on "Create Repository"
+        Then I should see a "Repository created successfully" text
+        And I should see "metadataSigned" as checked
+      )
     end
   end
 end


### PR DESCRIPTION
## What does this PR change?

Fix creation of MU repositories. We were missing a step in the loop, to go back to the Repositories page.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needes

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
 - Manager-4.1 https://github.com/SUSE/spacewalk/pull/13141

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
