### PR TITLE
[Port] QAM: Fix parent channel on Ubuntu 16 custom channels (#13143)

### DIFF
--- a/testsuite/features/qam/add_custom_repositories/add_ubuntu1604_repositories.feature
+++ b/testsuite/features/qam/add_custom_repositories/add_ubuntu1604_repositories.feature
@@ -10,7 +10,7 @@ Feature: Adding the Ubuntu 16.04 distribution custom repositories
     And I follow "Create Channel"
     When I enter "Custom Channel for ubuntu-xenial-main" as "Channel Name"
     And I enter "ubuntu-xenial-main" as "Channel Label"
-    And I select the parent channel for the "ubuntu1804_minion" from "Parent Channel"
+    And I select the parent channel for the "ubuntu1604_minion" from "Parent Channel"
     And I enter "Custom channel" as "Channel Summary"
     And I click on "Create Channel"
     Then I should see a "Channel Custom Channel for ubuntu-xenial-main created" text
@@ -21,7 +21,7 @@ Feature: Adding the Ubuntu 16.04 distribution custom repositories
     And I follow "Create Channel"
     When I enter "Custom Channel for ubuntu-xenial-main-updates" as "Channel Name"
     And I enter "ubuntu-xenial-main-updates" as "Channel Label"
-    And I select the parent channel for the "ubuntu1804_minion" from "Parent Channel"
+    And I select the parent channel for the "ubuntu1604_minion" from "Parent Channel"
     And I enter "Custom channel" as "Channel Summary"
     And I click on "Create Channel"
     Then I should see a "Channel Custom Channel for ubuntu-xenial-main-updates created" text


### PR DESCRIPTION
## What does this PR change?

Fix parent channel on Ubuntu 16 custom channels

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
 - Manager-4.1 https://github.com/SUSE/spacewalk/pull/13143

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
