### PR TITLE
[Port] QAM: Remove workaroung dmidecode in SLES nodes (#13146)

### DIFF
--- a/testsuite/features/qam/init_clients/sle11sp4_ssh_minion.feature
+++ b/testsuite/features/qam/init_clients/sle11sp4_ssh_minion.feature
@@ -28,10 +28,6 @@ Feature: Bootstrap a SLES 11 SP4 Salt SSH Minion
     Given I am on the Systems overview page of this "sle11sp4_ssh_minion"
     When I remove package "sle-manager-tools-release" from highstate
 
-# WORKAROUD for bsc#1178328
-  Scenario: Install dmidecode package to avoid a Hardware Refresh issue in SLES 11 SP4 SSH minion
-    And I install package "dmidecode" on this "sle11sp4_ssh_minion"
-
 @proxy
   Scenario: Check connection from SLES 11 SP4 SSH minion to proxy
     Given I am on the Systems overview page of this "sle11sp4_ssh_minion"

--- a/testsuite/features/qam/init_clients/sle12sp4_ssh_minion.feature
+++ b/testsuite/features/qam/init_clients/sle12sp4_ssh_minion.feature
@@ -28,10 +28,6 @@ Feature: Bootstrap a SLES 12 SP4 Salt SSH Minion
     Given I am on the Systems overview page of this "sle12sp4_ssh_minion"
     When I remove package "sle-manager-tools-release" from highstate
 
-# WORKAROUD for bsc#1178328
-  Scenario: Install dmidecode package to avoid a Hardware Refresh issue in SLES 12 SP4 SSH minion
-    And I install package "dmidecode" on this "sle12sp4_ssh_minion"
-
 @proxy
   Scenario: Check connection from SLES 12 SP4 SSH minion to proxy
     Given I am on the Systems overview page of this "sle12sp4_ssh_minion"

--- a/testsuite/features/qam/init_clients/sle15_ssh_minion.feature
+++ b/testsuite/features/qam/init_clients/sle15_ssh_minion.feature
@@ -28,10 +28,6 @@ Feature: Bootstrap a SLES 15 Salt SSH Minion
     Given I am on the Systems overview page of this "sle15_ssh_minion"
     When I remove package "sle-manager-tools-release" from highstate
 
-# WORKAROUD for bsc#1178328
-  Scenario: Install dmidecode package to avoid a Hardware Refresh issue in SLES 15 SSH minion
-    And I install package "dmidecode" on this "sle15_ssh_minion"
-
 @proxy
   Scenario: Check connection from SLES 15 SSH minion to proxy
     Given I am on the Systems overview page of this "sle15_ssh_minion"

--- a/testsuite/features/qam/init_clients/sle15sp1_ssh_minion.feature
+++ b/testsuite/features/qam/init_clients/sle15sp1_ssh_minion.feature
@@ -28,10 +28,6 @@ Feature: Bootstrap a SLES 15 SP1 Salt SSH Minion
     Given I am on the Systems overview page of this "sle15sp1_ssh_minion"
     When I remove package "sle-manager-tools-release" from highstate
 
-# WORKAROUD for bsc#1178328
-  Scenario: Install dmidecode package to avoid a Hardware Refresh issue in SLES 15 SP1 SSH minion
-    And I install package "dmidecode" on this "sle15sp1_ssh_minion"
-
 @proxy
   Scenario: Check connection from SLES 15 SP1 SSH minion to proxy
     Given I am on the Systems overview page of this "sle15sp1_ssh_minion"


### PR DESCRIPTION
## What does this PR change?

Remove workaroung dmidecode in SLES nodes

Related to : https://github.com/SUSE/spacewalk/issues/12775

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [ ] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
 - Manager-4.1 https://github.com/SUSE/spacewalk/pull/13146

- [x] **DONE**


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
