### PR TITLE
Debian bootstrap repo data

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -1220,12 +1220,12 @@ DATA = {
         'TYPE' : 'deb'
     },
     'debian9-amd64' : {
-        'BASECHANNEL' : 'debian-9-pool-amd64', 'PKGLIST' : PKGLISTDEBIAN9,
+        'PDID' : [-19, 2208], 'BETAPDID' : [2209], 'PKGLIST' : PKGLISTDEBIAN9,
         'DEST' : '/srv/www/htdocs/pub/repositories/debian/9/bootstrap/',
         'TYPE' : 'deb'
     },
     'debian10-amd64' : {
-        'BASECHANNEL' : 'debian-10-pool-amd64', 'PKGLIST' : PKGLISTDEBIAN10,
+        'PDID' : [-20, 2210], 'BETAPDID' : [2211], 'PKGLIST' : PKGLISTDEBIAN10,
         'DEST' : '/srv/www/htdocs/pub/repositories/debian/10/bootstrap/',
         'TYPE' : 'deb'
     },

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- Use product IDs for Debian 9 and 10 SUSE Manager bootstrap repo data
 - Added RHEL/CentOS Java alternatives options.
 - Create PostgreSQL Datadir should it not exist.
 

--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -1871,35 +1871,6 @@ checksum = sha256
 base_channels = ubuntu-20.04-pool-amd64-uyuni
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/Ubuntu2004-Uyuni-Client-Tools/xUbuntu_20.04/
 
-[debian-9-pool-amd64]
-label    = debian-9-pool-amd64
-checksum = sha256
-archs    = amd64-deb
-repo_type = deb
-name     = Debian 9 (stretch) pool for amd64
-gpgkey_url =
-gpgkey_id =
-gpgkey_fingerprint =
-repo_url = http://deb.debian.org/debian/dists/stretch/main/binary-amd64/
-
-[debian-9-amd64-main-updates]
-label    = debian-9-amd64-main-updates
-name     = Debian 9 (stretch) AMD64 Main Updates
-archs    = amd64-deb
-repo_type = deb
-checksum = sha256
-base_channels = debian-9-pool-amd64
-repo_url = http://deb.debian.org/debian/dists/stretch-updates/main/binary-amd64/
-
-[debian-9-amd64-main-security]
-label    = debian-9-amd64-main-security
-name     = Debian 9 (stretch) AMD64 Main Security
-archs    = amd64-deb
-repo_type = deb
-checksum = sha256
-base_channels = debian-9-pool-amd64
-repo_url = http://security-cdn.debian.org/debian-security/dists/stretch/updates/main/binary-amd64/
-
 [debian-9-pool-amd64-uyuni]
 label    = debian-9-pool-amd64-uyuni
 checksum = sha256
@@ -1946,35 +1917,6 @@ repo_type = deb
 checksum = sha256
 base_channels = debian-9-pool-amd64-uyuni
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/Debian9-Uyuni-Client-Tools/Debian_9/
-
-[debian-10-pool-amd64]
-label    = debian-10-pool-amd64
-checksum = sha256
-archs    = amd64-deb
-repo_type = deb
-name     = Debian 10 (buster) pool for amd64
-gpgkey_url =
-gpgkey_id =
-gpgkey_fingerprint =
-repo_url = http://deb.debian.org/debian/dists/buster/main/binary-amd64/
-
-[debian-10-amd64-main-updates]
-label    = debian-10-amd64-main-updates
-name     = Debian 10 (buster) AMD64 Main Updates
-archs    = amd64-deb
-repo_type = deb
-checksum = sha256
-base_channels = debian-10-pool-amd64
-repo_url = http://deb.debian.org/debian/dists/buster-updates/main/binary-amd64/
-
-[debian-10-amd64-main-security]
-label    = debian-10-amd64-main-security
-name     = Debian 10 (buster) AMD64 Main Security
-archs    = amd64-deb
-repo_type = deb
-checksum = sha256
-base_channels = debian-10-pool-amd64
-repo_url = http://security-cdn.debian.org/debian-security/dists/buster/updates/main/binary-amd64/
 
 [debian-10-pool-amd64-uyuni]
 label    = debian-10-pool-amd64-uyuni

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,5 @@
+- Remove Debian 9 and 10 channels for SUSE Manager, now provided by SCC data
+
 -------------------------------------------------------------------
 Wed Nov 25 12:25:22 CET 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Debian 9 and Debian 10 got official product IDs and this PR change now the bootstrap repo metadata to use them.
Port of https://github.com/SUSE/spacewalk/pull/13295

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- General Documentation issue exists for Debian 9/10

- [x] **DONE**

## Test coverage
- No tests: **already covered**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/13295

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
