### PR TITLE
spacewalk-setup-jabberd: Updated SPEC and manage_database.

### DIFF
--- a/spacewalk/spacewalk-setup-jabberd/include/manage_database
+++ b/spacewalk/spacewalk-setup-jabberd/include/manage_database
@@ -3,6 +3,9 @@
 XSLPROC="xsltproc"
 SQLITE="sqlite3"
 STP_QUERY="/etc/jabberd/scripts/db-setup.sqlite"
+if [ -f "$STP_QUERY" ]; then
+    STP_QUERY="/usr/share/jabberd/db-setup.sqlite"
+fi
 
 # How to parse sm.xml config
 read -r -d '' SM_PARSE <<XML
@@ -98,7 +101,7 @@ if [ -s ${DB_FILE[1]} ]; then
 fi
 
 # Create the database
-rcjabberd stop
+service jabberd stop
 echo "Daemon stopped"
 
 $SQLITE ${DB_FILE[1]} < $STP_QUERY 2>&1>/dev/null
@@ -106,7 +109,7 @@ chown jabber:jabber ${DB_FILE[1]}
 chmod 640 ${DB_FILE[1]}
 
 if [ $START_DAEMON -eq 1 ]; then
-    rcjabberd start
+    service jabberd start
     echo "Daemon started"
 fi
 

--- a/spacewalk/spacewalk-setup-jabberd/spacewalk-setup-jabberd.changes
+++ b/spacewalk/spacewalk-setup-jabberd/spacewalk-setup-jabberd.changes
@@ -1,3 +1,6 @@
+- Generalised manage_database.
+- Updated SPEC to work on RHEL.
+
 -------------------------------------------------------------------
 Fri Sep 18 11:43:47 CEST 2020 - jgonzalez@suse.com
 

--- a/spacewalk/spacewalk-setup-jabberd/spacewalk-setup-jabberd.spec
+++ b/spacewalk/spacewalk-setup-jabberd/spacewalk-setup-jabberd.spec
@@ -26,14 +26,10 @@ Group:          Applications/System
 Url:            https://github.com/uyuni-project/uyuni
 Source0:        https://github.com/spacewalkproject/spacewalk/archive/%{name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
-PreReq:         sqlite3
-%if 0%{?fedora} && 0%{?fedora} > 26
-BuildRequires:  perl-interpreter
-%else
+PreReq:         (sqlite3 or sqlite < 4)
 BuildRequires:  perl
-%endif
 BuildRequires:  jabberd
-BuildRequires:  sqlite3
+BuildRequires:  (sqlite3 or sqlite < 4)
 BuildRequires:  perl(ExtUtils::MakeMaker)
 BuildArch:      noarch
 %if 0%{?fedora} && 0%{?fedora} > 26
@@ -41,10 +37,9 @@ Requires:       perl-interpreter
 %else
 Requires:       perl
 %endif
-%if 0%{?suse_version}
 Requires:       jabberd-sqlite
-%endif
 Requires(post): libxslt-tools
+Requires(post): jabberd
 
 %description
 Script, which sets up Jabberd for Spacewalk. Used during installation of


### PR DESCRIPTION
## What does this PR change?

- Updated SPEC to work on RHEL.
- Generalised manage_database (to work with RHEL)

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: No functional change.

- [X] **DONE**

## Test coverage
- No tests: Tested during automatic build.
Tested build successful on CentOS8, LEAP 15.2, Fedora 31-33
Fedora Rawhide fails. (Also CentOS <= 7)

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
