### PR TITLE
spacewalk-cert-tools: Added RHEL8 build and simplified SPEC file.

### DIFF
--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,6 @@
+- Added RHEL8 build support.
+- SPEC file house keeping.
+
 -------------------------------------------------------------------
 Wed Nov 25 12:20:25 CET 2020 - jgonzalez@suse.com
 

--- a/spacewalk/certs-tools/spacewalk-certs-tools.spec
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.spec
@@ -86,7 +86,6 @@ Spacewalk.
 %package -n python2-%{name}
 Summary:        Spacewalk SSL Key/Cert Tool
 Group:          Applications/Internet
-BuildRequires:  (python or python2)
 Requires:       %{name} = %{version}-%{release}
 Requires:       python2-rhn-client-tools
 Requires:       python2-uyuni-common-libs


### PR DESCRIPTION
## What does this PR change?

Added RHEL8 build support.
Minor simplification of the SPEC file.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: No functional change.

- [X] **DONE**

## Test coverage
- No tests: Tested during automated build.

Tested the build successfully on CentOS 8, Fedora 31+, LEAP 15.2

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
