### PR TITLE
spacewalk-search: Added RHEL8 build support

### DIFF
--- a/search-server/spacewalk-search/spacewalk-search.changes
+++ b/search-server/spacewalk-search/spacewalk-search.changes
@@ -1,3 +1,5 @@
+- Added RHEL8 build support.
+
 -------------------------------------------------------------------
 Wed Nov 25 12:24:19 CET 2020 - jgonzalez@suse.com
 

--- a/search-server/spacewalk-search/spacewalk-search.spec
+++ b/search-server/spacewalk-search/spacewalk-search.spec
@@ -18,8 +18,10 @@
 
 %if 0%{?suse_version}
 %define java_version   11
+%global apache_group www
 %else
 %define java_version   1:11
+%global apache_group apache
 %endif
 
 Name:           spacewalk-search
@@ -50,7 +52,7 @@ BuildRequires:  doc-indexes
 BuildRequires:  hadoop
 BuildRequires:  jakarta-commons-httpclient
 BuildRequires:  jakarta-oro
-BuildRequires:  java-devel >= %{java_version}
+BuildRequires:  (java-devel >= %{java_version} or java-11-openjdk-devel)
 BuildRequires:  javapackages-tools
 BuildRequires:  junit
 BuildRequires:  lucene == 2.4.1
@@ -62,6 +64,9 @@ BuildRequires:  redstone-xmlrpc
 BuildRequires:  simple-core
 BuildRequires:  slf4j
 BuildRequires:  systemd
+%if 0%{?rhel}
+BuildRequires:  systemd-rpm-macros
+%endif
 BuildRequires:  uyuni-base-common
 BuildRequires:  zip
 Requires(pre):  doc-indexes
@@ -85,16 +90,8 @@ Requires:       quartz >= 2.0
 Requires:       redstone-xmlrpc
 Requires:       simple-core
 Obsoletes:      rhn-search < 5.3.0
-%if 0%{?fedora} || 0%{?rhel} >=7
-Requires:       mchange-commons
-%endif
-%if 0%{?fedora} >= 21 || 0%{?sle_version} >= 150200
-Requires:       log4j12
-BuildRequires:  log4j12
-%else
-Requires:       log4j
-BuildRequires:  log4j
-%endif
+Requires:       (log4j or log4j12)
+BuildRequires:  (log4j or log4j12)
 
 %description
 This package contains the code for the Full Text Search Server for
@@ -104,6 +101,9 @@ Spacewalk Server.
 %setup -n %{name}-%{version}
 
 %install
+%if 0%{?rhel}
+export JAVA_HOME=/usr/lib/jvm/java-11-openjdk/
+%endif
 rm -fr ${RPM_BUILD_ROOT}
 ant -Djar.version=%{version} install
 install -d -m 755 $RPM_BUILD_ROOT%{_prefix}/share/rhn/config-defaults
@@ -136,16 +136,30 @@ mkdir -p  $RPM_BUILD_ROOT/%{_sbindir}/
 ln -sf service $RPM_BUILD_ROOT/%{_sbindir}/rcrhn-search
 
 %post
+%if 0%{?rhel}
+%systemd_post rhn-search.service
+%else
 %service_add_post rhn-search.service
+%endif
 
 %preun
+%if 0%{?rhel}
+%systemd_preun rhn-search.service
+%else
 %service_del_preun rhn-search.service
+%endif
 
 %postun
+%if 0%{?rhel}
+%systemd_preun rhn-search.service
+%else
 %service_del_postun rhn-search.service
+%endif
 
 %pre
+%if !0%{?rhel}
 %service_add_pre rhn-search.service
+%endif
 
 %files
 %defattr(644,root,root,755)
@@ -165,7 +179,11 @@ ln -sf service $RPM_BUILD_ROOT/%{_sbindir}/rcrhn-search
 %dir /usr/share/rhn
 %dir /usr/share/rhn/search
 %dir /usr/share/rhn/search/lib
-%attr(770,root,www) %dir /var/log/rhn
+%if 0%{?rhel}
+%dir %{_var}/log/rhn
+%else
+%attr(770,root,%{apache_group}) %dir %{_var}/log/rhn
+%endif
 %{_sbindir}/rcrhn-search
 
 %changelog


### PR DESCRIPTION
## What does this PR change?

- Added RHEL8 build support.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: No functional changes.

- [X] **DONE**

## Test coverage
- No tests: Tested by automatic build.

Build tested successfully on CentOS 8 and LEAP 15.2

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
