### PR TITLE
Generalize the message for reactivation keys

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -21615,7 +21615,7 @@ The Tree Path, Base Channel, and Installer Generation should always match. This 
         </context-group>
       </trans-unit>
       <trans-unit id="sdc.details.activation.summary" xml:space="preserve">
-        <source>With a system profile specific activation key, this system can be re-registered using the 'rhnreg_ks' command-line utility.  The system will be re-registered with the same id, history, groups, and channels (unless the system's base channel changes).</source>
+        <source>With a system profile specific activation key, this system can be re-registered with the same id, history, groups, and channels (unless the system's base channel changes).</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/systems/details/Activation.do</context>
         </context-group>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Generalize the reactivation key message (bsc#1178483)
+
 -------------------------------------------------------------------
 Thu Dec 03 13:45:57 CET 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Change the message for reactivation key so that it's valid for both traditional and salt clients.

If the user needs more information about the reactivation keys, they refer to the detailed documentation, that is available under the info icon.

## GUI diff

Before:
![before](https://user-images.githubusercontent.com/1412268/100716875-9499b600-33b9-11eb-88b1-6bcc8faa5db8.png)

After (text change):
![after](https://user-images.githubusercontent.com/1412268/100716876-96fc1000-33b9-11eb-801e-4e9ab79004bb.png)

- [x] **DONE**

## Documentation
https://github.com/uyuni-project/uyuni-docs/pull/712

- [x] **DONE**

## Test coverage
- No tests: just changed a message

- [x] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/13068

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"