### PR TITLE
Fix incorrect import

### DIFF
--- a/web/html/src/utils/test-utils/setup.js
+++ b/web/html/src/utils/test-utils/setup.js
@@ -1,5 +1,5 @@
 import "../../manager/polyfills.js";
-import jQuery from "jQuery";
+import jQuery from "jquery";
 
 // Allows us to mock and test the existing network layer easily
 global.jQuery = jQuery;


### PR DESCRIPTION
## What does this PR change?

Fix incorrect import in Javascript unit test setup. This somehow flew under my radar last time.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Bugfix, no visual.
- [x] **DONE**

## Test coverage
- No tests: Fixes tests.

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
