### PR TITLE
Upgrade jQuery version - vul GHSA-gxr4-xjj5-5px2

### DIFF
--- a/susemanager-frontend/susemanager-nodejs-sdk-devel/package.json
+++ b/susemanager-frontend/susemanager-nodejs-sdk-devel/package.json
@@ -36,7 +36,7 @@
     "eslint-plugin-react-hooks": "^1.0.2",
     "flow-bin": "^0.107.0",
     "jest": "^26.6.3",
-    "jquery": "3.1.0",
+    "jquery": "3.5.1",
     "license-checker-webpack-plugin": "^0.0.9",
     "msw": "^0.22.0",
     "shelljs": "^0.8.3",

--- a/susemanager-frontend/susemanager-nodejs-sdk-devel/susemanager-nodejs-sdk-devel.changes
+++ b/susemanager-frontend/susemanager-nodejs-sdk-devel/susemanager-nodejs-sdk-devel.changes
@@ -1,3 +1,4 @@
+- Upgrade jQuery version - vul GHSA-gxr4-xjj5-5px2
 - Add @testing-library/react and msw, update relevant dependencies
 - Upgrade lodash to 4.17.19, this is already in the changelog, but
   the change was not added to package.json.

--- a/susemanager-frontend/yarn.lock
+++ b/susemanager-frontend/yarn.lock
@@ -7776,10 +7776,10 @@ joi@14.3.1:
     isemail "3.x.x"
     topo "3.x.x"
 
-jquery@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.1.0.tgz#129f6f1ae94b18f09010b008d0d6011e40613d7f"
-  integrity sha1-Ep9vGulLGPCQELAI0NYBHkBhPX8=
+jquery@3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.5.1.tgz#d7b4d08e1bfdb86ad2f1a3d039ea17304717abb5"
+  integrity sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg==
 
 js-levenshtein@^1.1.3:
   version "1.1.6"


### PR DESCRIPTION
## What does this PR change?

Fix vul GHSA-gxr4-xjj5-5px2

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed:

- [x] **DONE**

## Test coverage
- No tests: 

- [x] **DONE**

## Links

Fixes # https://github.com/SUSE/spacewalk/issues/13309
Tracks #

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
