### PR TITLE
Use sanitized repo label to build reposync repo cache path (bsc#1179410)

### DIFF
--- a/backend/satellite_tools/repo_plugins/deb_src.py
+++ b/backend/satellite_tools/repo_plugins/deb_src.py
@@ -264,15 +264,13 @@ class ContentSource:
         self.proxy_addr, self.proxy_user, self.proxy_pass = get_proxy(self.url)
         self.authtoken = None
 
-        # Exclude non-valid characters from reponame
-        self.reponame = self.name
-        for chr in ["$", " ", ".", ";", "/"]:
-            self.reponame = self.reponame.replace(chr, "_")
+        # Replace non-valid characters from reponame (only alphanumeric chars allowed)
+        self.reponame = "".join([x if x.isalnum() else "_" for x in self.name])
         self.channel_label = channel_label
 
-        # The repository cache root will be "/var/cache/rhn/reposync/CHANNEL_LABEL/"
-        # and failback to reponame with excluded non-valid characters if channel label is empty
-        root = os.path.join(CACHE_DIR, str(org or "NULL"), self.channel_label or self.reponame)
+        # SUSE vendor repositories belongs to org = NULL
+        # The repository cache root will be "/var/cache/rhn/reposync/REPOSITORY_LABEL/"
+        root = os.path.join(CACHE_DIR, str(org or "NULL"), self.reponame)
         self.repo = DebRepo(url, root,
                             os.path.join(CFG.MOUNT_POINT, CFG.PREPENDED_DIR, self.org, 'stage'),
                             self.proxy_addr, self.proxy_user, self.proxy_pass, gpg_verify=not(insecure))
@@ -398,7 +396,7 @@ class ContentSource:
 
     def clear_cache(self, directory=None):
         if directory is None:
-            directory = os.path.join(CACHE_DIR, self.org, self.name)
+            directory = self.repo.basecachedir
         # remove content in directory
         for item in os.listdir(directory):
             path = os.path.join(directory, item)

--- a/backend/satellite_tools/repo_plugins/deb_src.py
+++ b/backend/satellite_tools/repo_plugins/deb_src.py
@@ -264,7 +264,16 @@ class ContentSource:
         self.proxy_addr, self.proxy_user, self.proxy_pass = get_proxy(self.url)
         self.authtoken = None
 
-        self.repo = DebRepo(url, os.path.join(CACHE_DIR, self.org, name),
+        # Exclude non-valid characters from reponame
+        self.reponame = self.name
+        for chr in ["$", " ", ".", ";", "/"]:
+            self.reponame = self.reponame.replace(chr, "_")
+        self.channel_label = channel_label
+
+        # The repository cache root will be "/var/cache/rhn/reposync/CHANNEL_LABEL/"
+        # and failback to reponame with excluded non-valid characters if channel label is empty
+        root = os.path.join(CACHE_DIR, str(org or "NULL"), self.channel_label or self.reponame)
+        self.repo = DebRepo(url, root,
                             os.path.join(CFG.MOUNT_POINT, CFG.PREPENDED_DIR, self.org, 'stage'),
                             self.proxy_addr, self.proxy_user, self.proxy_pass, gpg_verify=not(insecure))
         self.repo.verify()

--- a/backend/satellite_tools/repo_plugins/yum_src.py
+++ b/backend/satellite_tools/repo_plugins/yum_src.py
@@ -453,10 +453,13 @@ class ContentSource:
 
         # Exclude non-valid characters from reponame
         self.reponame = self.name
-        for chr in ["$", " ", ".", ";"]:
+        for chr in ["$", " ", ".", ";", "/"]:
             self.reponame = self.reponame.replace(chr, "_")
         self.channel_label = channel_label
+
         # SUSE vendor repositories belongs to org = NULL
+        # The repository cache root will be "/var/cache/rhn/reposync/CHANNEL_LABEL/"
+        # and failback to reponame with excluded non-valid characters if channel label is empty
         root = os.path.join(CACHE_DIR, str(org or "NULL"), self.channel_label or self.reponame)
 
         self.repo = ZypperRepo(root=root, url=self.url, org=self.org)

--- a/backend/satellite_tools/repo_plugins/yum_src.py
+++ b/backend/satellite_tools/repo_plugins/yum_src.py
@@ -451,16 +451,13 @@ class ContentSource:
         if self.urls[0][-1] != '/':
             self.urls[0] += '/'
 
-        # Exclude non-valid characters from reponame
-        self.reponame = self.name
-        for chr in ["$", " ", ".", ";", "/"]:
-            self.reponame = self.reponame.replace(chr, "_")
+        # Replace non-valid characters from reponame (only alphanumeric chars allowed)
+        self.reponame = "".join([x if x.isalnum() else "_" for x in self.name])
         self.channel_label = channel_label
 
         # SUSE vendor repositories belongs to org = NULL
-        # The repository cache root will be "/var/cache/rhn/reposync/CHANNEL_LABEL/"
-        # and failback to reponame with excluded non-valid characters if channel label is empty
-        root = os.path.join(CACHE_DIR, str(org or "NULL"), self.channel_label or self.reponame)
+        # The repository cache root will be "/var/cache/rhn/reposync/REPOSITORY_LABEL/"
+        root = os.path.join(CACHE_DIR, str(org or "NULL"), self.reponame)
 
         self.repo = ZypperRepo(root=root, url=self.url, org=self.org)
         self.num_packages = 0

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,4 +1,4 @@
-- Use channel label to calculate DEB repo cache path (bsc#1179410)
+- Use sanitized repo label to build reposync repo cache path (bsc#1179410)
 - SPEC file update: Source0 URL, Python3 build requirements.
 - Added logging for dpkg repository detection
 - Added RHEL8 build.

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Use channel label to calculate DEB repo cache path (bsc#1179410)
 - SPEC file update: Source0 URL, Python3 build requirements.
 - Added logging for dpkg repository detection
 - Added RHEL8 build.

--- a/java/code/src/com/redhat/rhn/frontend/action/channel/manage/repo/RepoDetailsAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/channel/manage/repo/RepoDetailsAction.java
@@ -365,8 +365,14 @@ public class RepoDetailsAction extends RhnAction {
                     "edit.channel.repo.repourlinvalid"));
         }
         catch (InvalidRepoLabelException e) {
-            errors.add(ActionMessages.GLOBAL_MESSAGE, new ActionMessage(
-                    "edit.channel.repo.repolabelinuse", repoCmd.getLabel()));
+            if (e.getReason() == InvalidRepoLabelException.Reason.REGEX_FAILS) {
+                errors.add(ActionMessages.GLOBAL_MESSAGE, new ActionMessage(
+                        "edit.channel.repo.invalidrepolabel", repoCmd.getLabel()));
+	    }
+            else {
+                errors.add(ActionMessages.GLOBAL_MESSAGE, new ActionMessage(
+                        "edit.channel.repo.repolabelinuse", repoCmd.getLabel()));
+            }
         }
         catch (InvalidCertificateException e) {
             errors.add(ActionMessages.GLOBAL_MESSAGE, new ActionMessage(

--- a/java/code/src/com/redhat/rhn/frontend/action/channel/manage/repo/RepoDetailsAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/channel/manage/repo/RepoDetailsAction.java
@@ -368,7 +368,7 @@ public class RepoDetailsAction extends RhnAction {
             if (e.getReason() == InvalidRepoLabelException.Reason.REGEX_FAILS) {
                 errors.add(ActionMessages.GLOBAL_MESSAGE, new ActionMessage(
                         "edit.channel.repo.invalidrepolabel", repoCmd.getLabel()));
-	    }
+            }
             else {
                 errors.add(ActionMessages.GLOBAL_MESSAGE, new ActionMessage(
                         "edit.channel.repo.repolabelinuse", repoCmd.getLabel()));

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -8445,6 +8445,9 @@ Follow this url to see the full list of inactive systems:
       <trans-unit id="edit.channel.repo.repolabelinuse" xml:space="preserve">
         <source>The repository label '{0}' is already in use, please choose a different label</source>
       </trans-unit>
+      <trans-unit id="edit.channel.repo.invalidrepolabel" xml:space="preserve">
+        <source>The repository label '{0}' is invalid. Repository label must begin with a letter and may contain only lowercase letters, hyphens ('-'), periods ('.'), underscores ('_'), numerals, spaces, parentheses and forward slashes ('/').</source>
+      </trans-unit>
       <trans-unit id="edit.channel.repo.invalidrepotype" xml:space="preserve">
         <source>The repository type '{0}' is invalid or already in use with given url, please choose a different type</source>
       </trans-unit>

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/repo/InvalidRepoLabelException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/repo/InvalidRepoLabelException.java
@@ -24,6 +24,11 @@ import com.redhat.rhn.FaultException;
 public class InvalidRepoLabelException extends FaultException {
 
     /**
+     * Indicates why the repository label is invalid.
+     */
+    private Reason reason;
+
+    /**
      * Comment for <code>serialVersionUID</code>
      */
     private static final long serialVersionUID = -8506595413724954752L;
@@ -35,6 +40,50 @@ public class InvalidRepoLabelException extends FaultException {
     public InvalidRepoLabelException(String repoLabel) {
         super(2, "Repo label already in use", "edit.channel.repo.repolabelinuse",
                 new Object[] {repoLabel});
+        this.label = repoLabel;
+        this.reason = Reason.LABEL_IN_USE;
+    }
+
+    /**
+     * Creates a new indication that a given repository label is invalid
+     *
+     * @param labelIn  label the user attempted to give the repository
+     * @param reasonIn flag indicating why the repository name is invalid; cannot be
+     *                 <code>null</code>
+     * @param messageIdIn the string resource message ID
+     * @param argIn an optional argument that is associated with messageId.  If there
+     * is no argument, pass in an empty string.
+     */
+    public InvalidRepoLabelException(String repoLabel, Reason reasonIn,
+            String messageIdIn, String argIn) {
+        super(2, "invalidRepositoryLabel", messageIdIn, new Object[] {argIn});
+
+        this.label = repoLabel;
+        this.reason = reasonIn;
+    }
+
+    /**
+     * @return invalid label that caused this exception; may be <code>null</code>
+     */
+    public String getLabel() {
+        return label;
+    }
+
+    /**
+     * @return flag indicating what made the label returned from {@link #getLabel()}
+     *         invalid; may be <code>null</code>
+     */
+    public Reason getReason() {
+        return reason;
+    }
+
+    /**
+     * Flags indicating the different reasons that may have caused a repository label
+     * to be invalid.
+     */
+    public enum Reason {
+        REGEX_FAILS,
+        LABEL_IN_USE
     }
 
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/repo/InvalidRepoLabelException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/channel/repo/InvalidRepoLabelException.java
@@ -47,7 +47,7 @@ public class InvalidRepoLabelException extends FaultException {
     /**
      * Creates a new indication that a given repository label is invalid
      *
-     * @param labelIn  label the user attempted to give the repository
+     * @param repoLabel label the user attempted to give the repository
      * @param reasonIn flag indicating why the repository name is invalid; cannot be
      *                 <code>null</code>
      * @param messageIdIn the string resource message ID

--- a/java/code/src/com/redhat/rhn/manager/channel/repo/BaseRepoCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/repo/BaseRepoCommand.java
@@ -223,8 +223,8 @@ public abstract class BaseRepoCommand {
             }
             if (!Pattern.compile(REPOSITORY_LABEL_REGEX).matcher(this.label).find()) {
                 throw new InvalidRepoLabelException(label,
-		InvalidRepoLabelException.Reason.REGEX_FAILS,
-                "edit.channel.repo.invalidrepolabel", "");
+                    InvalidRepoLabelException.Reason.REGEX_FAILS,
+                    "edit.channel.repo.invalidrepolabel", "");
             }
             repo.setLabel(this.label);
         }

--- a/java/code/src/com/redhat/rhn/manager/channel/repo/BaseRepoCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/repo/BaseRepoCommand.java
@@ -35,6 +35,7 @@ import java.net.URI;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.regex.Pattern;
 
 
 /**
@@ -42,6 +43,10 @@ import java.util.Set;
  * @version $Rev: 119601 $
  */
 public abstract class BaseRepoCommand {
+
+    public static final String REPOSITORY_LABEL_REGEX =
+        "^[a-zA-Z\\d][\\w\\d\\s\\-\\.\\'\\(\\)\\/\\_]*$";
+
 
     protected ContentSource repo;
 
@@ -215,6 +220,11 @@ public abstract class BaseRepoCommand {
         if (this.label != null && !this.label.equals(repo.getLabel())) {
             if (ChannelFactory.lookupContentSourceByOrgAndLabel(org, label) != null) {
                 throw new InvalidRepoLabelException(label);
+            }
+            if (!Pattern.compile(REPOSITORY_LABEL_REGEX).matcher(this.label).find()) {
+                throw new InvalidRepoLabelException(label,
+		InvalidRepoLabelException.Reason.REGEX_FAILS,
+                "edit.channel.repo.invalidrepolabel", "");
             }
             repo.setLabel(this.label);
         }

--- a/java/code/src/com/redhat/rhn/manager/channel/test/BaseRepoCommandTest.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/test/BaseRepoCommandTest.java
@@ -194,6 +194,7 @@ public class BaseRepoCommandTest extends RhnBaseTestCase {
 
         try {
             ccc.store();
+            fail("invalid repository label should have thrown error: " + label);
         }
         catch (InvalidRepoUrlException e) {
             fail("non duplicate url caused error");

--- a/java/code/src/com/redhat/rhn/manager/channel/test/BaseRepoCommandTest.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/test/BaseRepoCommandTest.java
@@ -130,4 +130,82 @@ public class BaseRepoCommandTest extends RhnBaseTestCase {
             fail("valid repo type caused error: " + url);
         }
     }
+
+    public void testRepoLabelInput() {
+
+        // Repository label must contain only letters, hyphens, periods, underscores and numeral
+
+        // I N V A L I D
+        invalidRepoLabelInput("");
+        invalidRepoLabelInput("example/repo");
+        invalidRepoLabelInput("example;repo");
+        invalidRepoLabelInput("example_repo$");
+        invalidRepoLabelInput("my*examplerepo");
+        invalidRepoLabelInput("example^repo");
+
+        // V A L I D
+        validRepoLabelInput("my example repo");
+        validRepoLabelInput("my-example-repo");
+        validRepoLabelInput("my-example_repo");
+        validRepoLabelInput("my_repo_22");
+        validRepoLabelInput("My-Example-Repo");
+        validRepoLabelInput("My/Example/Repo/15");
+        validRepoLabelInput("My_Example_Repo_15.5");
+        validRepoLabelInput("My_Example_Repo_(15.5)");
+        validRepoLabelInput("My_Example_Repo_'15.5'");
+    }
+
+    private void validRepoLabelInput(String label) {
+        // give it a valid url
+        ccc.setUrl("http://localhost/" + label_count++);
+        // need to create unique label names.
+        ccc.setLabel(label);
+        // need to specify a type
+        ccc.setType("yum");
+        // need to specify MetadataSigned
+        ccc.setMetadataSigned(Boolean.FALSE);
+
+        try {
+            ccc.store();
+        }
+        catch (InvalidRepoUrlException e) {
+            fail("non duplicate url caused error");
+        }
+        catch (InvalidRepoUrlInputException e) {
+            fail("valid repo url input caused error");
+        }
+        catch (InvalidRepoLabelException e) {
+            fail("valid repo label caused error");
+        }
+        catch (InvalidRepoTypeException e) {
+            fail("valid repo type caused error");
+        }
+    }
+
+    private void invalidRepoLabelInput(String label) {
+        // give it a valid url
+        ccc.setUrl("http://localhost/");
+        // need to create unique label names.
+        ccc.setLabel(label);
+        // need to specify a type
+        ccc.setType("yum");
+        // need to specify MetadataSigned
+        ccc.setMetadataSigned(Boolean.FALSE);
+
+        try {
+            ccc.store();
+        }
+        catch (InvalidRepoUrlException e) {
+            fail("non duplicate url caused error");
+        }
+        catch (InvalidRepoUrlInputException e) {
+            fail("valid repo url input caused error");
+        }
+        catch (InvalidRepoLabelException e) {
+            // expected
+        }
+        catch (InvalidRepoTypeException e) {
+            fail("valid repo type caused error");
+        }
+    }
 }

--- a/java/code/src/com/redhat/rhn/manager/channel/test/BaseRepoCommandTest.java
+++ b/java/code/src/com/redhat/rhn/manager/channel/test/BaseRepoCommandTest.java
@@ -137,7 +137,6 @@ public class BaseRepoCommandTest extends RhnBaseTestCase {
 
         // I N V A L I D
         invalidRepoLabelInput("");
-        invalidRepoLabelInput("example/repo");
         invalidRepoLabelInput("example;repo");
         invalidRepoLabelInput("example_repo$");
         invalidRepoLabelInput("my*examplerepo");

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add validation for custom repository labels
 - Fix configuration file download links to actually download files instead of redirecting to the home page (bsc#1179324)
 - Add lang attribute to html tags
 - SPEC file libxml2-devel addition, Source0 update.


### PR DESCRIPTION
## What does this PR change?

This PR makes fixes some issues we have in `spacewalk-repo-sync` when dealing with custom DEB repositories that contains non-valid characters on its label (like `/`).

The summary of changes is:
- Add validation to custom repository label (same as channel name): allow uppercase, spaces, slashes, etc.
- Fix `deb_src` reposync plugin to use a sanitized "repository label" when building the repository cache root path.
- Fix `yum_src` reposync plugin to use a sanitized "repository label" (instead of channel label) when building the repository cache root path.

These are the current regex we use for validation:
```java
CHANNEL_NAME_REGEX = "^[a-zA-Z\\d][\\w\\d\\s\\-\\.\\'\\(\\)\\/\\_]*$"
CHANNEL_LABEL_REGEX = "^[a-z\\d][a-z\\d\\-\\.\\_]*"
REPO_LABEL_REGEX = "^[a-zA-Z\\d][\\w\\d\\s\\-\\.\\'\\(\\)\\/\\_]*$"
```

So, with this PR, reposync will use a sanitized "repository label" (which only allows alphanumerical characters) to build the reposync repo cache path for both RPM and DEB reposync plugins.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/13294

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
