### PR TITLE
spacewalk-reports: Added RHEL/Fedora to Python3 builds.

### DIFF
--- a/reporting/spacewalk-reports.changes
+++ b/reporting/spacewalk-reports.changes
@@ -1,3 +1,5 @@
+- Added RHEL and Fedora to the Python3 builds.
+
 -------------------------------------------------------------------
 Wed Nov 25 12:23:18 CET 2020 - jgonzalez@suse.com
 

--- a/reporting/spacewalk-reports.spec
+++ b/reporting/spacewalk-reports.spec
@@ -17,7 +17,7 @@
 #
 
 
-%if 0%{?suse_version} > 1320
+%if 0%{?suse_version} > 1320 || 0%{?rhel} || 0%{?fedora}
 # SLE15 builds on Python 3
 %global build_py3   1
 %endif


### PR DESCRIPTION
## What does this PR change?

- Added RHEL/Fedora to Python3 builds.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: No functional changes.

- [X] **DONE**

## Test coverage
- No tests: Tested during automatic build.
Tested successful builds on CentOS 6+, LEAP 15.2, Fedora 31+

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
