### PR TITLE
Use generic code for the uyuni-base SPEC license file

### DIFF
--- a/uyuni/base/uyuni-base.spec
+++ b/uyuni/base/uyuni-base.spec
@@ -110,11 +110,8 @@ getent passwd %{apache_user} >/dev/null && %{_sbindir}/usermod -a -G susemanager
 %endif
 
 %files common
-%if 0%{?rhel} == 6
-%doc LICENSE
-%else
+%{!?_licensedir:%global license %doc}
 %license LICENSE
-%endif
 %defattr(-,root,root)
 %dir %attr(750,root,%{apache_group}) /etc/rhn
 %dir %{_prefix}/share/rhn


### PR DESCRIPTION
## What does this PR change?

Otherwise the current code doesn't build for SLE11 on SUSE manager.

Tested for CentOS6 at https://build.opensuse.org/package/rdiff/home:juliogonzalezgil:branches:systemsmanagement:Uyuni:Master:CentOS6-Uyuni-Client-Tools/uyuni-base?linkrev=base&rev=2 https://build.opensuse.org/package/show/home:juliogonzalezgil:branches:systemsmanagement:Uyuni:Master:CentOS6-Uyuni-Client-Tools/uyuni-base

Ping @sbluhm for awareness.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bugfix

- [x] **DONE**

## Test coverage
- No tests: covered already by OBS

- [x] **DONE**

## Links

None

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
