### PR TITLE
Fix question mark explanations for Recurring States

### DIFF
--- a/web/html/src/components/picker/recurring-event-picker.js
+++ b/web/html/src/components/picker/recurring-event-picker.js
@@ -8,7 +8,6 @@ const ReactDOM = require("react-dom");
 const {DateTimePicker} = require("../datetimepicker");
 const {Combobox} = require("../combobox");
 import type {ComboboxItem} from "../combobox";
-const { HelpLink } = require('components/utils/HelpLink');
 const { Form } = require('components/input/Form');
 const { Text } = require('components/input/Text');
 const Functions = require("utils/functions");
@@ -319,7 +318,7 @@ class RecurringEventPicker extends React.Component<RecurringEventPickerProps, Re
                                     <input className="form-control" name="minutes" type="number" value={this.state.minutes.id} min="0" max="59" onChange={this.onSelectMinutes} />
                                 </div>
                                 <div className={`col-sm-1 ${styles.helpIcon}`}>
-                                    <HelpLink text={t("The action will be executed every hour at the specified minute")}/>
+                                    <i className="fa fa-question-circle spacewalk-help-link" title={t("The action will be executed every hour at the specified minute")}/>
                                 </div>
                             </div>
                             <div className={`form-group ${styles.center}`}>
@@ -363,7 +362,7 @@ class RecurringEventPicker extends React.Component<RecurringEventPickerProps, Re
                                     <DateTimePicker onChange={this.onMonthlyTimeChanged} value={this.state.time} timezone={this.props.timezone} hideDatePicker={true} id="time-monthly"/>
                                 </div>
                                 <div className={`col-sm-1 ${styles.helpIcon}`}>
-                                    <HelpLink text={t("Days are limited to 28 to have a recurring schedule available for all the months")}/>
+                                    <i className="fa fa-question-circle spacewalk-help-link" title={t("Days are limited to 28 to have a recurring schedule available for all the months")}/>
                                 </div>
                             </div>
                             <div className={`form-group ${styles.center}`}>

--- a/web/html/src/manager/state/recurring-states-edit.js
+++ b/web/html/src/manager/state/recurring-states-edit.js
@@ -31,7 +31,6 @@ class RecurringStatesEdit extends React.Component {
     };
 
     getTargetType = () => {
-        console.log(window.entityType);
         if (window.entityType === "GROUP") {
             Object.assign(this.state, {
                 targetType: entityType,

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,5 @@
+- Fix question mark explanations for Recurring States (bsc#1179485)
+
 -------------------------------------------------------------------
 Thu Dec 03 13:55:25 CET 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Fix the help icons in the recurring states edit menu to link to an unavailable page.
In fact they should not lead to anything just provide some information displayed
through the icons title.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: 

- [x] **DONE**

## Test coverage

- No tests: 

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/13324

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
