### PR TITLE
uyunu-base: place the license below defattr

### DIFF
--- a/uyuni/base/uyuni-base.spec
+++ b/uyuni/base/uyuni-base.spec
@@ -110,9 +110,9 @@ getent passwd %{apache_user} >/dev/null && %{_sbindir}/usermod -a -G susemanager
 %endif
 
 %files common
+%defattr(-,root,root)
 %{!?_licensedir:%global license %doc}
 %license LICENSE
-%defattr(-,root,root)
 %dir %attr(750,root,%{apache_group}) /etc/rhn
 %dir %{_prefix}/share/rhn
 %dir %attr(755,root,%{apache_group}) %{_prefix}/share/rhn/config-defaults


### PR DESCRIPTION
## What does this PR change?

Otherwise SLE11 fails to build for SUSE Manager with:
```
[   78s] ... checking for files with abuild user/group
[   78s]   abuild abuild /usr/share/doc/packages/uyuni-base-common
[   78s]   abuild abuild /usr/share/doc/packages/uyuni-base-common/LICENSE
```
Tested at:
- https://build.suse.de/package/show/home:juliogonzalezgil:branches:Devel:Galaxy:Manager:Head:SLE11-SUSE-Manager-Tools/uyuni-base
- https://build.opensuse.org/package/show/home:juliogonzalezgil:branches:systemsmanagement:Uyuni:Master:CentOS6-Uyuni-Client-Tools/uyuni-base
## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bugfix

- [x] **DONE**

## Test coverage
- No tests: Tested by OBS

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
