### PR TITLE
Add lang attribute to html tags

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/login/templates/login.jade
+++ b/java/code/src/com/suse/manager/webui/controllers/login/templates/login.jade
@@ -1,5 +1,5 @@
 doctype html
-html
+html(lang=window.preferredLocale.replace("_", "-"))
     head
         // enclosing head tags in layout_c.jsp
         meta(http-equiv='X-UA-Compatible', content='IE=edge')

--- a/java/code/webapp/WEB-INF/decorators/layout_bare.jsp
+++ b/java/code/webapp/WEB-INF/decorators/layout_bare.jsp
@@ -8,7 +8,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 
 
-<html:html>
+<html:html lang="true">
   <head>
     <jsp:include page="layout_head.jsp" />
     <decorator:head />

--- a/java/code/webapp/WEB-INF/decorators/layout_c.jsp
+++ b/java/code/webapp/WEB-INF/decorators/layout_c.jsp
@@ -7,7 +7,7 @@
 %><%@ taglib uri="http://rhn.redhat.com/rhn" prefix="rhn"
 %><%@ page contentType="text/html; charset=UTF-8"
 %><!DOCTYPE HTML>
-<html:html>
+<html:html lang="true">
   <head>
     <jsp:include page="layout_head.jsp" />
     <decorator:head />

--- a/java/code/webapp/WEB-INF/decorators/layout_equals.jsp
+++ b/java/code/webapp/WEB-INF/decorators/layout_equals.jsp
@@ -8,7 +8,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 
 
-<html:html>
+<html:html lang="true">
   <head>
     <jsp:include page="layout_head.jsp" />
     <decorator:head />

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add lang attribute to html tags
 - SPEC file libxml2-devel addition, Source0 update.
 - Replace the virtpoller beacon by a guests refresh action
 - Added RHEL build support.


### PR DESCRIPTION
## What does this PR change?

Add the `lang` attribute to our `<html>` tags

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: 

- [x] **DONE**

## Test coverage

- No tests: 

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/13234

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
