### PR TITLE
Better safety net mechanism

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -215,6 +215,11 @@ When(/^I execute mgr\-sync refresh$/) do
   $command_output = sshcmd('mgr-sync refresh', ignore_err: true)[:stderr]
 end
 
+# This function kills all spacewalk-repo-sync processes, excepted the ones in a whitelist.
+# It waits for all the reposyncs in the whitelist to complete, and kills all others.
+#
+# This function is written as a state machine. It bails out if no process is seen during
+# 30 seconds in a row, or if the whitelisted reposyncs last more than 7200 seconds in a row.
 When(/^I make sure no spacewalk\-repo\-sync is executing, excepted the ones needed to bootstrap$/) do
   do_not_kill = compute_list_to_leave_running
   reposync_not_running_streak = 0

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -59,26 +59,46 @@ def compute_image_name
   end
 end
 
-# compute list of reposyncs to avoid killing because they might be involved in bootstrapping
-# this is a safety net only, the best thing to do is to not start the reposync at all
+# If we for example
+#  - start a reposync in reposync/srv_sync_channels.feature.
+#  - then kill it in reposync/srv_abort_all_sync.feature
+#  - then restart it later on in init_clients/sle_minion.feature
+# then the channel will be in an inconsistent state.
+#
+# This function computes a list of reposyncs to avoid killing, because they might be involved in bootstrapping.
+#
+# This is a safety net only, the best thing to do is to not start the reposync at all.
+# rubocop:disable Metrics/MethodLength
 def compute_list_to_leave_running
-  # Keep the repos needed for the auto-installation tests.
-  do_not_kill = ['sle-product-sles15-sp2-pool-x86_64', 'sle-manager-tools15-pool-x86_64-sp2',
-                 'sle-product-sles15-sp2-updates-x86_64', 'sle-manager-tools15-updates-x86_64-sp2',
-                 'sle-module-basesystem15-sp2-pool-x86_64', 'sle-module-basesystem15-sp2-updates-x86_64']
+  do_not_kill = []
+  if $long_tests_enabled
+    # keep the repos needed for the auto-installation tests
+    do_not_kill += ['sle-product-sles15-sp2-pool-x86_64', 'sle-manager-tools15-pool-x86_64-sp2', 'sle-module-basesystem15-sp2-pool-x86_64',
+                    'sle-product-sles15-sp2-updates-x86_64', 'sle-manager-tools15-updates-x86_64-sp2', 'sle-module-basesystem15-sp2-updates-x86_64']
+  end
   [$minion, $build_host, $sshminion, $server].each do |node|
     next if node.nil?
     os_version, os_family = get_os_version(node)
-    if os_family == 'sles' && os_version == '12-SP4'
-      do_not_kill += ['sles12-sp4-pool-x86_64', 'sle-manager-tools12-pool-x86_64-sp4', 'sle-module-containers12-pool-x86_64-sp4',
-                      'sles12-sp4-updates-x86_64', 'sle-manager-tools12-updates-x86_64-sp4', 'sle-module-containers12-updates-x86_64-sp4']
-    elsif os_family == 'sles' && os_version == '15-SP1'
-      do_not_kill += ['sle-product-sles15-sp1-pool-x86_64', 'sle-manager-tools15-pool-x86_64-sp1', 'sle-module-containers15-sp1-pool-x86_64',
-                      'sle-product-sles15-sp1-updates-x86_64', 'sle-manager-tools15-updates-x86_64-sp1', 'sle-module-containers15-sp1-updates-x86_64']
-    end
+    next unless os_family == 'sles'
+    do_not_kill +=
+      case os_version
+      when '12-SP4'
+        ['sles12-sp4-pool-x86_64', 'sle-manager-tools12-pool-x86_64-sp4', 'sle-module-containers12-pool-x86_64-sp4',
+         'sles12-sp4-updates-x86_64', 'sle-manager-tools12-updates-x86_64-sp4', 'sle-module-containers12-updates-x86_64-sp4']
+      when '12-SP5'
+        ['sles12-sp5-pool-x86_64', 'sle-manager-tools12-pool-x86_64-sp5', 'sle-module-containers12-pool-x86_64-sp5',
+         'sles12-sp5-updates-x86_64', 'sle-manager-tools12-updates-x86_64-sp5', 'sle-module-containers12-updates-x86_64-sp5']
+      when '15-SP1'
+        ['sle-product-sles15-sp1-pool-x86_64', 'sle-manager-tools15-pool-x86_64-sp1', 'sle-module-containers15-sp1-pool-x86_64',
+         'sle-product-sles15-sp1-updates-x86_64', 'sle-manager-tools15-updates-x86_64-sp1', 'sle-module-containers15-sp1-updates-x86_64']
+      when '15-SP2'
+        ['sle-product-sles15-sp2-pool-x86_64', 'sle-manager-tools15-pool-x86_64-sp2', 'sle-module-containers15-sp2-pool-x86_64',
+         'sle-product-sles15-sp2-updates-x86_64', 'sle-manager-tools15-updates-x86_64-sp2', 'sle-module-containers15-sp2-updates-x86_64']
+      end
   end
-  do_not_kill
+  do_not_kill.uniq
 end
+# rubocop:enable Metrics/MethodLength
 
 # get registration URL
 # the URL depends on whether we use a proxy or not


### PR DESCRIPTION
## What does this PR change?

This PR:
 - explains better how "targetted assassinations" of reposyncs work,
    both in terms of workflow of the test suite and of implementation
 - adds safety net for SLES 15 SP2 and SLES 12 SP5 which we already use, or will use, in our test suite
 - does not add safety net for auto-installation if we don't perform it
 - removes possible duplicates from the list for faster execution

In 4.0 and 4.1 versions, it also adds a bugfix that was not backported (`15SP2` versus `15-SP2`).


## Links

Fixes SUSE/spacewalk#12895

Ports:
* 4.0: SUSE/spacewalk#13348
* 4.1: SUSE/spacewalk#13349

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
