### PR TITLE
Skip image store test if registry is not available

### DIFF
--- a/testsuite/features/core/srv_docker.feature
+++ b/testsuite/features/core/srv_docker.feature
@@ -35,6 +35,7 @@ Feature: Prepare server for using Docker
     And I click on "Update Activation Key"
     Then I should see a "Activation key Docker testing has been modified" text
 
+@no_auth_registry
   Scenario: Create an image store without credentials
     Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Images > Stores"


### PR DESCRIPTION
## What does this PR change?

This PR is related to https://github.com/uyuni-project/uyuni/pull/2224, and will skip the `Create an image store without credentials` test scenario if the registry is not available.

This will prevent the following error when the registry is not available:

![Screenshot from 2020-12-03 16-39-52](https://user-images.githubusercontent.com/14297426/101065056-99629380-358c-11eb-9b83-5b8308173278.png)


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: This is just a test fix

- [x] **DONE**

## Test coverage
- Cucumber test was fixed/improved

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/13358
Tracks https://github.com/SUSE/spacewalk/pull/13359

- [x] **DONE**

## Changelogs

- [x] No changelog needed

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
