### PR TITLE
[Port] QAM: Add proxy to our Ubuntu SSH Minions (#13356)

### DIFF
--- a/testsuite/features/qam/init_clients/ubuntu1604_minion.feature
+++ b/testsuite/features/qam/init_clients/ubuntu1604_minion.feature
@@ -14,8 +14,10 @@ Feature: Bootstrap a Ubuntu 16.04 minion and do some basic operations on it
     Given I am authorized
     When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
-    And I enter the hostname of "ubuntu1604_minion" as "hostname"
+    When I enter the hostname of "ubuntu1604_minion" as "hostname"
+    And I enter "root" as "user"
     And I enter "linux" as "password"
+    And I enter "22" as "port"
     And I select "1-ubuntu1604_minion_key" from "activationKeys"
     And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"

--- a/testsuite/features/qam/init_clients/ubuntu1604_ssh_minion.feature
+++ b/testsuite/features/qam/init_clients/ubuntu1604_ssh_minion.feature
@@ -14,10 +14,13 @@ Feature: Bootstrap a SSH-managed Ubuntu 16.04 minion and do some basic operation
     Given I am authorized
     When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
-    When I check "manageWithSSH"
-    And I select "1-ubuntu1604_ssh_minion_key" from "activationKeys"
-    And I enter the hostname of "ubuntu1604_ssh_minion" as "hostname"
+    When I enter the hostname of "ubuntu1604_ssh_minion" as "hostname"
+    And I enter "root" as "user"
     And I enter "linux" as "password"
+    And I enter "22" as "port"
+    And I select "1-ubuntu1604_ssh_minion_key" from "activationKeys"
+    And I select the hostname of "proxy" from "proxies"
+    And I check "manageWithSSH"
     And I click on "Bootstrap"
     Then I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "ubuntu1604_ssh_minion"

--- a/testsuite/features/qam/init_clients/ubuntu1804_minion.feature
+++ b/testsuite/features/qam/init_clients/ubuntu1804_minion.feature
@@ -14,8 +14,10 @@ Feature: Bootstrap a Ubuntu 18.04 minion and do some basic operations on it
     Given I am authorized
     When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
-    And I enter the hostname of "ubuntu1804_minion" as "hostname"
+    When I enter the hostname of "ubuntu1804_minion" as "hostname"
+    And I enter "root" as "user"
     And I enter "linux" as "password"
+    And I enter "22" as "port"
     And I select "1-ubuntu1804_minion_key" from "activationKeys"
     And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"

--- a/testsuite/features/qam/init_clients/ubuntu1804_ssh_minion.feature
+++ b/testsuite/features/qam/init_clients/ubuntu1804_ssh_minion.feature
@@ -14,10 +14,13 @@ Feature: Bootstrap a SSH-managed Ubuntu 18.04 minion and do some basic operation
     Given I am authorized
     When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
-    When I check "manageWithSSH"
-    And I select "1-ubuntu1804_ssh_minion_key" from "activationKeys"
-    And I enter the hostname of "ubuntu1804_ssh_minion" as "hostname"
+    When I enter the hostname of "ubuntu1804_ssh_minion" as "hostname"
+    And I enter "root" as "user"
     And I enter "linux" as "password"
+    And I enter "22" as "port"
+    And I select "1-ubuntu1804_ssh_minion_key" from "activationKeys"
+    And I select the hostname of "proxy" from "proxies"
+    And I check "manageWithSSH"
     And I click on "Bootstrap"
     Then I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "ubuntu1804_ssh_minion"

--- a/testsuite/features/qam/init_clients/ubuntu2004_minion.feature
+++ b/testsuite/features/qam/init_clients/ubuntu2004_minion.feature
@@ -14,7 +14,10 @@ Feature: Bootstrap a Ubuntu 20.04 Salt minion
     Given I am authorized
     When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
-    And I enter the hostname of "ubuntu2004_minion" as "hostname"
+    When I enter the hostname of "ubuntu2004_minion" as "hostname"
+    And I enter "root" as "user"
+    And I enter "linux" as "password"
+    And I enter "22" as "port"
     And I enter "linux" as "password"
     And I select "1-ubuntu2004_minion_key" from "activationKeys"
     And I select the hostname of "proxy" from "proxies"

--- a/testsuite/features/qam/init_clients/ubuntu2004_ssh_minion.feature
+++ b/testsuite/features/qam/init_clients/ubuntu2004_ssh_minion.feature
@@ -14,10 +14,13 @@ Feature: Bootstrap a Ubuntu 20.04 Salt SSH Minion
     Given I am authorized
     When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
-    When I check "manageWithSSH"
-    And I select "1-ubuntu2004_ssh_minion_key" from "activationKeys"
-    And I enter the hostname of "ubuntu2004_ssh_minion" as "hostname"
+    When I enter the hostname of "ubuntu2004_ssh_minion" as "hostname"
+    And I enter "root" as "user"
     And I enter "linux" as "password"
+    And I enter "22" as "port"
+    And I select "1-ubuntu2004_ssh_minion_key" from "activationKeys"
+    And I select the hostname of "proxy" from "proxies"
+    And I check "manageWithSSH"
     And I click on "Bootstrap"
     Then I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "ubuntu2004_ssh_minion"


### PR DESCRIPTION
## What does this PR change?

Port of https://github.com/SUSE/spacewalk/pull/13356

Related Card: #13346

Select the proxy to bootstrap our Ubuntu SSH Minions

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
 - Manager-4.1 https://github.com/SUSE/spacewalk/pull/13356

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

