### PR TITLE
Fallback to centos when redhat release is empty

### DIFF
--- a/java/code/src/com/suse/manager/reactor/utils/RhelUtils.java
+++ b/java/code/src/com/suse/manager/reactor/utils/RhelUtils.java
@@ -207,7 +207,7 @@ public class RhelUtils {
                 .filter(pkg -> StringUtils.startsWith(pkg, "sles_es-release")).isPresent();
         if (hasRESChannels || hasRESReleasePackage) {
             // we got a RES. find the corresponding SUSE product
-            Optional<ReleaseFile> releaseFile = rhelReleaseFile
+            Optional<ReleaseFile> releaseFile = rhelReleaseFile.or(() -> centosReleaseFile)
                     .flatMap(RhelUtils::parseReleaseFile);
             // Find the corresponding SUSEProduct in the database
             String name = releaseFile.map(ReleaseFile::getName).orElse("RES");
@@ -273,7 +273,7 @@ public class RhelUtils {
                 .filter(pkg -> StringUtils.startsWith(pkg, "sles_es-release")).isPresent();
         if (hasRESChannels || hasRESReleasePackage) {
             // we got a RES. find the corresponding SUSE product
-            Optional<ReleaseFile> releaseFile = rhelReleaseFile
+            Optional<ReleaseFile> releaseFile = rhelReleaseFile.or(() -> centosReleaseFile)
                     .flatMap(RhelUtils::parseReleaseFile);
             // Find the corresponding SUSEProduct in the database
             String name = releaseFile.map(ReleaseFile::getName).orElse("RES");

--- a/java/code/src/com/suse/manager/reactor/utils/test/RhelUtilsTest.java
+++ b/java/code/src/com/suse/manager/reactor/utils/test/RhelUtilsTest.java
@@ -160,6 +160,22 @@ public class RhelUtilsTest extends JMockBaseTestCaseWithUser {
         });
     }
 
+    public void testDetectCentOSProductRES() throws Exception {
+        doTestDetectRhelProduct("dummy_packages_redhatprodinfo_centos2.json",
+                minionServer -> {
+                    Channel resChannel = createResChannel(user, "6");
+                    minionServer.addChannel(resChannel);
+                    minionServer.setServerArch(ServerFactory.lookupServerArchByLabel("x86_64-redhat-linux"));
+                },
+                prod -> {
+                    assertTrue("SUSE Product not found", prod.get().getSuseProduct().isPresent());
+                    assertEquals("res", prod.get().getSuseProduct().get().getName());
+                    assertEquals("CentOS", prod.get().getName());
+                    assertEquals("Final", prod.get().getRelease());
+                    assertEquals("6", prod.get().getVersion());
+        });
+    }
+
     public void testDetectRhelProductRHEL() throws Exception {
         doTestDetectRhelProduct("dummy_packages_redhatprodinfo_rhel.json",
                 null,

--- a/java/code/src/com/suse/manager/reactor/utils/test/dummy_packages_redhatprodinfo_centos2.json
+++ b/java/code/src/com/suse/manager/reactor/utils/test/dummy_packages_redhatprodinfo_centos2.json
@@ -1,0 +1,50 @@
+{
+  "cmd_|-respkgquery_|-rpm -q --whatprovides 'sles_es-release-server'_|-run": {
+    "comment": "onlyif execution failed",
+    "__id__": "respkgquery",
+    "name": "rpm -q --whatprovides 'sles_es-release-server'",
+    "duration": 86.271,
+    "__run_num__": 3,
+    "start_time": "10:30:07.714911",
+    "skip_watch": true,
+    "changes": {},
+    "result": true
+  },
+  "cmd_|-centosrelease_|-cat /etc/centos-release_|-run": {
+    "comment": "Command \"cat /etc/centos-release\" run",
+    "name": "cat /etc/centos-release",
+    "start_time": "10:30:07.679765",
+    "result": true,
+    "duration": 22.903,
+    "__run_num__": 1,
+    "changes": {
+      "pid": 15301,
+      "retcode": 0,
+      "stderr": "",
+      "stdout": "CentOS release 6.10 (Final)"
+    },
+    "__id__": "centosrelease"
+  },
+  "cmd_|-rhelrelease_|-cat /etc/redhat-release_|-run": {
+    "comment": "onlyif execution failed",
+    "__id__": "rhelrelease",
+    "name": "cat /etc/redhat-release",
+    "duration": 20.257,
+    "__run_num__": 0,
+    "start_time": "10:30:07.658925",
+    "skip_watch": true,
+    "changes": {},
+    "result": true
+  },
+  "cmd_|-oraclerelease_|-cat /etc/oracle-release_|-run": {
+    "comment": "onlyif execution failed",
+    "__id__": "oraclerelease",
+    "name": "cat /etc/oracle-release",
+    "duration": 11.193,
+    "__run_num__": 2,
+    "start_time": "10:30:07.703200",
+    "skip_watch": true,
+    "changes": {},
+    "result": true
+  }
+}

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- fix expanded support detection based on CentOS installations (bsc#1179589)
 - Generalize the reactivation key message (bsc#1178483)
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

When detecting Expanded Support, we parse redhat-release to get the version number.
But in case of CentOS image was used to install the server, we do not read redhat-release but centos-release file.

This PR implement a fallback when redhat-release value does not exist and parse centos-release value as second try.
(Oracle Linux is not a valid base for Expanded Support. So it can be ignored)

Port of https://github.com/SUSE/spacewalk/pull/13354

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
