### PR TITLE
Section is optional and fix for re-raise

### DIFF
--- a/uyuni/common-libs/common/rhn_deb.py
+++ b/uyuni/common-libs/common/rhn_deb.py
@@ -56,7 +56,6 @@ class deb_Header:
                 'arch': debcontrol.get_as_string('Architecture') + '-deb',
                 'summary': debcontrol.get_as_string('Description').splitlines()[0],
                 'vendor': debcontrol.get_as_string('Maintainer'),
-                'package_group': debcontrol.get_as_string('Section'),
                 'epoch':   '',
                 'version': 0,
                 'release': 0,
@@ -130,7 +129,8 @@ class DEB_Package(A_Package):
             self.header_data.seek(0, 0)
             self.header = deb_Header(self.header_data)
         except:
-            raise_with_tb(InvalidPackageError, sys.exc_info()[2])
+            e = sys.exc_info()[1]
+            raise_with_tb(InvalidPackageError(e), sys.exc_info()[2])
 
     def save_payload(self, output_stream):
         c_hash = checksum.getHashlibInstance(self.checksum_type, False)

--- a/uyuni/common-libs/uyuni-common-libs.changes
+++ b/uyuni/common-libs/uyuni-common-libs.changes
@@ -1,3 +1,5 @@
+- Section in Debian packages in now treated as optional (bsc#1179555)
+
 -------------------------------------------------------------------
 Wed Nov 25 12:37:09 CET 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

* Section seems to optional for Debian packages (Recommended) so not every Debian package has that. Later on all missing keys get added anyway. So it's added if it is there.

* Re-raising without the actual error is not working. Error information are now being passed.


## GUI diff

No difference.

## Documentation
- No documentation needed: Just a fix.

## Test coverage
- No tests: …

- [ ] **DONE**

## Links

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1179555


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
