### PR TITLE
get_gpg_keys expect a node

### DIFF
--- a/testsuite/features/reposync/srv_enable_sync_products.feature
+++ b/testsuite/features/reposync/srv_enable_sync_products.feature
@@ -9,25 +9,25 @@ Feature: Be able to list available products and enable them
   Scenario: List available products
     When I execute mgr-sync "list products" with user "admin" and password "admin"
     Then I should get "[I] SUSE Linux Enterprise Server 12 SP2 x86_64"
-    And I should get "[ ] SUSE Linux Enterprise Desktop 15 x86_64"
+    And I should get "[ ] SUSE Linux Enterprise Desktop 15 SP2 x86_64"
 
   Scenario: List all available products
     When I execute mgr-sync "list products -e"
-    Then I should get "[ ] SUSE Linux Enterprise Desktop 15 x86_64"
-    And I should get "  [ ] (R) Basesystem Module 15 x86_64"
-    And I should get "  [ ] Desktop Applications Module 15 x86_64"
+    Then I should get "[ ] SUSE Linux Enterprise Desktop 15 SP2 x86_64"
+    And I should get "  [ ] (R) Basesystem Module 15 SP2 x86_64"
+    And I should get "  [ ] Desktop Applications Module 15 SP2 x86_64"
 
-  Scenario: Enable "SUSE Linux Enterprise Desktop 15 x86_64" with recommended modules
-    When I enable product "SUSE Linux Enterprise Desktop 15 x86_64"
-    Then I should get "Adding channels required by 'SUSE Linux Enterprise Desktop 15 x86_64' product"
-    And I should get "- sle-product-sled15-updates-x86_64"
-    And I should get "- sle-product-sled15-pool-x86_64"
-    And I should get "- sle-module-basesystem15-updates-x86_64-sled"
-    And I should get "- sle-module-basesystem15-pool-x86_64-sled"
-    And I should get "- sle-module-desktop-applications15-updates-x86_64-sled"
-    And I should get "- sle-module-desktop-applications15-pool-x86_64-sled"
-    And I should get "- sle-product-we15-updates-x86_64-sled"
-    And I should get "- sle-product-we15-pool-x86_64-sled"
+  Scenario: Enable "SUSE Linux Enterprise Desktop 15 SP2 x86_64" with recommended modules
+    When I enable product "SUSE Linux Enterprise Desktop 15 SP2 x86_64"
+    Then I should get "Adding channels required by 'SUSE Linux Enterprise Desktop 15 SP2 x86_64' product"
+    And I should get "- sle-product-sled15-sp2-updates-x86_64"
+    And I should get "- sle-product-sled15-sp2-pool-x86_64"
+    And I should get "- sle-module-basesystem15-sp2-updates-x86_64-sled"
+    And I should get "- sle-module-basesystem15-sp2-pool-x86_64-sled"
+    And I should get "- sle-module-desktop-applications15-sp2-updates-x86_64-sled"
+    And I should get "- sle-module-desktop-applications15-sp2-pool-x86_64-sled"
+    And I should get "- sle-product-we15-sp2-updates-x86_64-sled"
+    And I should get "- sle-product-we15-sp2-pool-x86_64-sled"
     And I should get "Product successfully added"
 
   Scenario: Enable "SUSE Linux Enterprise Server for SAP Applications 15 x86_64" without recommended modules

--- a/testsuite/features/reposync/srv_enable_sync_products.feature
+++ b/testsuite/features/reposync/srv_enable_sync_products.feature
@@ -8,7 +8,7 @@ Feature: Be able to list available products and enable them
 
   Scenario: List available products
     When I execute mgr-sync "list products" with user "admin" and password "admin"
-    Then I should get "[I] SUSE Linux Enterprise Server 12 SP2 x86_64"
+    Then I should get "[I] SUSE Linux Enterprise Server 12 SP5 x86_64"
     And I should get "[ ] SUSE Linux Enterprise Desktop 15 SP2 x86_64"
 
   Scenario: List all available products

--- a/testsuite/features/reposync/srv_sync_channels.feature
+++ b/testsuite/features/reposync/srv_sync_channels.feature
@@ -11,29 +11,29 @@ Feature: Be able to list available channels and enable them
     # Order matters here, refresh first
     When I refresh SCC
     And I execute mgr-sync "list channels -e" with user "admin" and password "admin"
-    Then I should get "[ ] SLES11-SP1-Pool for x86_64 SUSE Linux Enterprise Server 11 SP1 x86_64 [sles11-sp1-pool-x86_64]"
-    And I should get "    [ ] SLE11-SDK-SP1-Updates for x86_64 SUSE Linux Enterprise Software Development Kit 11 SP1 [sle11-sdk-sp1-updates-x86_64]"
+    Then I should get "[ ] SLES11-SP4-Pool for x86_64 SUSE Linux Enterprise Server 11 SP4 x86_64 [sles11-sp4-pool-x86_64]"
+    And I should get "    [ ] SLE11-SDK-SP4-Updates for x86_64 SUSE Linux Enterprise Software Development Kit 11 SP4 [sle11-sdk-sp4-updates-x86_64]"
 
 @scc_credentials
   Scenario: List available mandatory channels
     When I execute mgr-sync "list channels -e --no-optional"
-    Then I should get "[ ] SLES11-SP1-Pool for x86_64 SUSE Linux Enterprise Server 11 SP1 x86_64 [sles11-sp1-pool-x86_64]"
-    And I should get "    [ ] SLE11-SDK-SP1-Updates for x86_64 SUSE Linux Enterprise Software Development Kit 11 SP1 [sle11-sdk-sp1-updates-x86_64]"
+    Then I should get "[ ] SLES11-SP4-Pool for x86_64 SUSE Linux Enterprise Server 11 SP4 x86_64 [sles11-sp4-pool-x86_64]"
+    And I should get "    [ ] SLE11-SDK-SP4-Updates for x86_64 SUSE Linux Enterprise Software Development Kit 11 SP4 [sle11-sdk-sp4-updates-x86_64]"
     And I shouldn't get "debuginfo"
     And I shouldn't get "sles11-extras"
 
 @scc_credentials
   Scenario: List products
     When I execute mgr-sync "list products"
-    Then I should get "[ ] SUSE Linux Enterprise Server 12 x86_64"
-    And I should get "[ ] SUSE Manager Proxy 2.1 x86_64"
+    Then I should get "[ ] SUSE Linux Enterprise Server 12 SP5 x86_64"
+    And I should get "[ ] SUSE Manager Proxy 4.0 x86_64"
 
 @scc_credentials
 @susemanager
   Scenario: List all products for SUSE Manager
     When I execute mgr-sync "list products --expand"
-    Then I should get "[ ] SUSE Linux Enterprise Server 12 x86_64"
-    And I should get "[ ] SUSE Manager Proxy 2.1 x86_64"
+    Then I should get "[ ] SUSE Linux Enterprise Server 12 SP5 x86_64"
+    And I should get "[ ] SUSE Manager Proxy 4.0 x86_64"
     And I should get "  [ ] (R) SUSE Linux Enterprise Client Tools RES 7 x86_64"
     And I should get "  [ ] (R) SUSE Manager Tools 15 x86_64"
 
@@ -41,13 +41,13 @@ Feature: Be able to list available channels and enable them
 @uyuni
   Scenario: List all products for Uyuni
     When I execute mgr-sync "list products --expand"
-    Then I should get "[ ] SUSE Linux Enterprise Server 12 x86_64"
-    And I should get "[ ] SUSE Manager Proxy 2.1 x86_64"
+    Then I should get "[ ] SUSE Linux Enterprise Server 12 SP5 x86_64"
+    And I should get "[ ] SUSE Manager Proxy 4.0 x86_64"
 
 @scc_credentials
   Scenario: List products with filter
     When I execute mgr-sync "list products --expand --filter x86_64"
-    Then I should get "[ ] SUSE Linux Enterprise Server 12 SP3 x86_64"
+    Then I should get "[ ] SUSE Linux Enterprise Server 12 SP5 x86_64"
     And I shouldn't get "ppc64"
     And I shouldn't get "s390x"
 

--- a/testsuite/features/reposync/srv_sync_products.feature
+++ b/testsuite/features/reposync/srv_sync_products.feature
@@ -30,32 +30,32 @@ Feature: Synchronize products in the products page of the Setup Wizard
 @scc_credentials
   Scenario: Add a product and one of its modules
     Given I am on the Products page
-    When I enter "SUSE Linux Enterprise Server 12 SP2" as the filtered product description
+    When I enter "SUSE Linux Enterprise Server 12 SP5" as the filtered product description
     And I select "x86_64" in the dropdown list of the architecture filter
-    And I select "SUSE Linux Enterprise Server 12 SP2 x86_64" as a product
-    Then I should see the "SUSE Linux Enterprise Server 12 SP2 x86_64" selected
-    When I open the sub-list of the product "SUSE Linux Enterprise Server 12 SP2 x86_64"
-    Then I should see the "SUSE Linux Enterprise Server 12 SP2 x86_64" selected
+    And I select "SUSE Linux Enterprise Server 12 SP5 x86_64" as a product
+    Then I should see the "SUSE Linux Enterprise Server 12 SP5 x86_64" selected
+    When I open the sub-list of the product "SUSE Linux Enterprise Server 12 SP5 x86_64"
+    Then I should see the "SUSE Linux Enterprise Server 12 SP5 x86_64" selected
     And I should see a "Legacy Module 12 x86_64" text
     When I select the addon "Legacy Module 12 x86_64"
     Then I should see the "Legacy Module 12 x86_64" selected
     When I click the Add Product button
-    And I wait until I see "SUSE Linux Enterprise Server 12 SP2 x86_64" product has been added
+    And I wait until I see "SUSE Linux Enterprise Server 12 SP5 x86_64" product has been added
     Then the SLE12 products should be added
 
 @scc_credentials
   Scenario: Add a product with recommended enabled
     Given I am on the Products page
-    When I enter "SUSE Linux Enterprise Server 15" as the filtered product description
+    When I enter "SUSE Linux Enterprise Server 15 SP2" as the filtered product description
     And I select "x86_64" in the dropdown list of the architecture filter
-    And I open the sub-list of the product "SUSE Linux Enterprise Server 15 x86_64"
-    Then I should see a "Basesystem Module 15 x86_64" text
-    And I should see that the "Basesystem Module 15 x86_64" product is "recommended"
-    When I select "SUSE Linux Enterprise Server 15 x86_64" as a product
-    Then I should see the "SUSE Linux Enterprise Server 15 x86_64" selected
-    Then I should see the "Basesystem Module 15 x86_64" selected
+    And I open the sub-list of the product "SUSE Linux Enterprise Server 15 SP2 x86_64"
+    Then I should see a "Basesystem Module 15 SP2 x86_64" text
+    And I should see that the "Basesystem Module 15 SP2 x86_64" product is "recommended"
+    When I select "SUSE Linux Enterprise Server 15 SP2 x86_64" as a product
+    Then I should see the "SUSE Linux Enterprise Server 15 SP2 x86_64" selected
+    Then I should see the "Basesystem Module 15 SP2 x86_64" selected
     And I click the Add Product button
-    And I wait until I see "SUSE Linux Enterprise Server 15 x86_64" product has been added
+    And I wait until I see "SUSE Linux Enterprise Server 15 SP2 x86_64" product has been added
     Then the SLE15 products should be added
 
 @long_test

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -431,7 +431,7 @@ end
 
 When(/^I import the GPG keys for "([^"]*)"$/) do |host|
   node = get_target(host)
-  gpg_keys = get_gpg_keys(host)
+  gpg_keys = get_gpg_keys(node)
   gpg_keys.each do |key|
     gpg_key_import_cmd = host.include?('ubuntu') ? 'apt-key add' : 'rpm --import'
     node.run("cd /tmp/ && curl --output #{key} #{$server.ip}/pub/#{key} && #{gpg_key_import_cmd} /tmp/#{key}")

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -536,18 +536,18 @@ end
 
 Then(/^the SLE12 products should be added$/) do
   output = sshcmd('echo -e "admin\nadmin\n" | mgr-sync list channels', ignore_err: true)
-  raise unless output[:stdout].include? '[I] SLES12-SP2-Pool for x86_64 SUSE Linux Enterprise Server 12 SP2 x86_64 [sles12-sp2-pool-x86_64]'
+  raise unless output[:stdout].include? '[I] SLES12-SP5-Pool for x86_64 SUSE Linux Enterprise Server 12 SP5 x86_64 [sles12-sp5-pool-x86_64]'
   if $product != 'Uyuni'
-    raise unless output[:stdout].include? '[I] SLE-Manager-Tools12-Pool for x86_64 SP2 SUSE Linux Enterprise Server 12 SP2 x86_64 [sle-manager-tools12-pool-x86_64-sp2]'
+    raise unless output[:stdout].include? '[I] SLE-Manager-Tools12-Pool for x86_64 SP5 SUSE Linux Enterprise Server 12 SP5 x86_64 [sle-manager-tools12-pool-x86_64-sp5]'
   end
-  raise unless output[:stdout].include? '[I] SLE-Module-Legacy12-Updates for x86_64 Legacy Module 12 x86_64 [sle-module-legacy12-updates-x86_64-sp2]'
+  raise unless output[:stdout].include? '[I] SLE-Module-Legacy12-Updates for x86_64 Legacy Module 12 x86_64 [sle-module-legacy12-updates-x86_64-sp5]'
 end
 
 Then(/^the SLE15 products should be added$/) do
   output = sshcmd('echo -e "admin\nadmin\n" | mgr-sync list channels', ignore_err: true)
-  raise unless output[:stdout].include? '[I] SLE-Product-SLES15-Pool for x86_64 SUSE Linux Enterprise Server 15 x86_64 [sle-product-sles15-pool-x86_64]'
-  raise unless output[:stdout].include? '[I] SLE-Module-Basesystem15-Updates for x86_64 Basesystem Module 15 x86_64 [sle-module-basesystem15-updates-x86_64]'
-  raise unless output[:stdout].include? '[I] SLE-Module-Server-Applications15-Pool for x86_64 Server Applications Module 15 x86_64 [sle-module-server-applications15-pool-x86_64]'
+  raise unless output[:stdout].include? '[I] SLE-Product-SLES15-SP2-Pool for x86_64 SUSE Linux Enterprise Server 15 SP2 x86_64 [sle-product-sles15-sp2-pool-x86_64]'
+  raise unless output[:stdout].include? '[I] SLE-Module-Basesystem15-SP2-Updates for x86_64 Basesystem Module 15 SP2 x86_64 [sle-module-basesystem15-sp2-updates-x86_64]'
+  raise unless output[:stdout].include? '[I] SLE-Module-Server-Applications15-SP2-Pool for x86_64 Server Applications Module 15 SP2 x86_64 [sle-module-server-applications15-sp2-pool-x86_64]'
 end
 
 Then(/^the SLE15SP2 base products should be added$/) do

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -666,7 +666,8 @@ When(/^I bootstrap (traditional|minion) client "([^"]*)" using bootstrap script 
 
   # Prepare bootstrap script for different types of clients
   client = client_type == 'traditional' ? '--traditional' : ''
-  gpg_keys = get_gpg_keys(host)
+  node = get_target(host)
+  gpg_keys = get_gpg_keys(node)
   cmd = "mgr-bootstrap #{client} &&
   sed -i s\'/^exit 1//\' /srv/www/htdocs/pub/bootstrap/bootstrap.sh &&
   sed -i '/^ACTIVATION_KEYS=/c\\ACTIVATION_KEYS=#{key}' /srv/www/htdocs/pub/bootstrap/bootstrap.sh &&

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -94,6 +94,8 @@ def compute_list_to_leave_running
       when '15-SP2'
         ['sle-product-sles15-sp2-pool-x86_64', 'sle-manager-tools15-pool-x86_64-sp2', 'sle-module-containers15-sp2-pool-x86_64',
          'sle-product-sles15-sp2-updates-x86_64', 'sle-manager-tools15-updates-x86_64-sp2', 'sle-module-containers15-sp2-updates-x86_64']
+      else
+        []
       end
   end
   do_not_kill.uniq


### PR DESCRIPTION
## What does this PR change?

get_gpg_key expect a node and not a host string

forward port changes from 4.1 branch to use newer products for synchronization

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **fix tests**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
