### PR TITLE
use generated jar name

### DIFF
--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -615,7 +615,6 @@ rm -rf $RPM_BUILD_ROOT%{_datadir}/rhn/unittest.xml
 
 # Pretifying symlinks for RHEL
 %if 0%{?rhel}
-mv $RPM_BUILD_ROOT%{jardir}/apache-commons-jexl_commons-jexl.jar $RPM_BUILD_ROOT%{jardir}/commons-jexl.jar
 mv $RPM_BUILD_ROOT%{jardir}/jboss-loggingjboss-logging.jar $RPM_BUILD_ROOT%{jardir}/jboss-logging.jar
 mv $RPM_BUILD_ROOT%{jardir}/jafjakarta.activation.jar $RPM_BUILD_ROOT%{jardir}/jaf.jar
 mv $RPM_BUILD_ROOT%{jardir}/javamailjavax.mail.jar $RPM_BUILD_ROOT%{jardir}/javamail.jar
@@ -749,7 +748,7 @@ chown tomcat:%{apache_group} /var/log/rhn/gatherer.log
 
 %{jardir}/snakeyaml.jar
 # SUSE extra runtime dependencies: spark, jade4j, salt API client + dependencies
-%{jardir}/commons-jexl.jar
+%{jardir}/apache-commons-jexl_commons-jexl.jar
 %{jardir}/commons-lang3.jar
 %{jardir}/google-gson_google-gsongson.jar
 %{jardir}/httpcomponents_httpclient.jar


### PR DESCRIPTION
## What does this PR change?

Using maven generated package result in a different jar name.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **build details**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
