### PR TITLE
Fix maven to obs after pkg rename

### DIFF
--- a/java/buildconf/ivy/obs-maven-config.yaml
+++ b/java/buildconf/ivy/obs-maven-config.yaml
@@ -50,8 +50,8 @@ artifacts:
     package: jakarta-commons-discovery
     repository: Leap
   - artifact: commons-el
-    package: jakarta-commons-el
-    repository: Uyuni_Other
+    package: apache-commons-el
+    repository: Leap
   - artifact: commons-fileupload
     package: jakarta-commons-fileupload
     repository: Leap

--- a/java/buildconf/ivy/obs-maven-config.yaml
+++ b/java/buildconf/ivy/obs-maven-config.yaml
@@ -60,7 +60,8 @@ artifacts:
     repository: Leap
   - artifact: commons-jexl
     package: apache-commons-jexl
-    repository: Uyuni_Other
+    jar: commons-jexl\.jar
+    repository: Leap
   - artifact: commons-lang3
     package: apache-commons-lang3
     repository: Leap


### PR DESCRIPTION
## What does this PR change?

jakarta-commons-el => apache-commons-el from Leap
apache-commons-jexl use package from Leap instead of own build one.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **internal**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
