### PR TITLE
Make menu markup explicit

### DIFF
--- a/web/html/src/manager/shared/menu/menu.js
+++ b/web/html/src/manager/shared/menu/menu.js
@@ -218,7 +218,7 @@ class Breadcrumb extends React.Component {
     return (
       <div>
         {product_name_link}
-        <span>></span>
+        <span>&gt;</span>
         {
           breadcrumbArray.map((a, i) => {
             return (


### PR DESCRIPTION
## What does this PR change?

A very small change in preparation for https://github.com/SUSE/spacewalk/issues/13208.  
The Typescript parser is not happy about the `>>` in `<span>></span>` template, making the markup explicit with `&gt;` fixes the issue.  
This is the only instance of such an issue I could find.  

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: No functional change.

- [x] **DONE**

## Test coverage
- No tests: No functional change.

- [x] **DONE**

## Links

Related: https://github.com/SUSE/spacewalk/issues/13208

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
