### PR TITLE
Faster and more robust checkbox test

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -511,8 +511,9 @@ end
 
 Then(/^I should see the "(.*?)" selected$/) do |product|
   xpath = "//span[contains(text(), '#{product}')]/ancestor::div[contains(@class, 'product-details-wrapper')]"
-  product_identifier = find(:xpath, xpath)['data-identifier']
-  raise "#{product_identifier} is not checked" unless has_checked_field?('checkbox-for-' + product_identifier)
+  within(:xpath, xpath) do
+    raise "#{find(:xpath, '.')['data-identifier']} is not checked" unless find(:xpath, "./div/input[@type='checkbox']").checked?
+  end
 end
 
 And(/^I wait until I see "(.*?)" product has been added$/) do |product|


### PR DESCRIPTION
## What does this PR change?

Test for a selected product can be made faster (do not search in the page twice) and more robuts (current test fails in certain conditions).


## Links

Ports:
* 4.1: SUSE/spacewalk#13381
* 4.0: SUSE/spacewalk#13383


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
