### PR TITLE
Testsuite - sync product changes with 4.1 branch

### DIFF
--- a/testsuite/features/reposync/srv_check_installer_updates.feature
+++ b/testsuite/features/reposync/srv_check_installer_updates.feature
@@ -9,5 +9,5 @@ Feature: Installer update repositories
 @scc_credentials
   Scenario: Installer updates channels got enabled during add product
     When I execute mgr-sync "list channels" with user "admin" and password "admin"
-    Then I should get "    [I] SLES12-SP2-Installer-Updates for x86_64 SUSE Linux Enterprise Server 12 SP2 x86_64 [sles12-sp2-installer-updates-x86_64]"
-    And I should get "    [I] SLE15-Installer-Updates for x86_64 SUSE Linux Enterprise Server 15 x86_64 [sle15-installer-updates-x86_64]"
+    Then I should get "    [I] SLES12-SP5-Installer-Updates for x86_64 SUSE Linux Enterprise Server 12 SP5 x86_64 [sles12-sp5-installer-updates-x86_64]"
+    And I should get "    [I] SLE15-SP2-Installer-Updates for x86_64 SUSE Linux Enterprise Server 15 SP2 x86_64 [sle15-sp2-installer-updates-x86_64]"

--- a/testsuite/features/reposync/srv_sync_channels.feature
+++ b/testsuite/features/reposync/srv_sync_channels.feature
@@ -25,14 +25,14 @@ Feature: Be able to list available channels and enable them
 @scc_credentials
   Scenario: List products
     When I execute mgr-sync "list products"
-    Then I should get "[ ] SUSE Linux Enterprise Server 12 SP5 x86_64"
+    Then I should get "[ ] SUSE Linux Enterprise Server 12 SP4 x86_64"
     And I should get "[ ] SUSE Manager Proxy 4.0 x86_64"
 
 @scc_credentials
 @susemanager
   Scenario: List all products for SUSE Manager
     When I execute mgr-sync "list products --expand"
-    Then I should get "[ ] SUSE Linux Enterprise Server 12 SP5 x86_64"
+    Then I should get "[ ] SUSE Linux Enterprise Server 12 SP4 x86_64"
     And I should get "[ ] SUSE Manager Proxy 4.0 x86_64"
     And I should get "  [ ] (R) SUSE Linux Enterprise Client Tools RES 7 x86_64"
     And I should get "  [ ] (R) SUSE Manager Tools 15 x86_64"
@@ -41,13 +41,13 @@ Feature: Be able to list available channels and enable them
 @uyuni
   Scenario: List all products for Uyuni
     When I execute mgr-sync "list products --expand"
-    Then I should get "[ ] SUSE Linux Enterprise Server 12 SP5 x86_64"
+    Then I should get "[ ] SUSE Linux Enterprise Server 12 SP4 x86_64"
     And I should get "[ ] SUSE Manager Proxy 4.0 x86_64"
 
 @scc_credentials
   Scenario: List products with filter
     When I execute mgr-sync "list products --expand --filter x86_64"
-    Then I should get "[ ] SUSE Linux Enterprise Server 12 SP5 x86_64"
+    Then I should get "[ ] SUSE Linux Enterprise Server 12 SP4 x86_64"
     And I shouldn't get "ppc64"
     And I shouldn't get "s390x"
 
@@ -60,20 +60,20 @@ Feature: Be able to list available channels and enable them
     And I should see "Repo URL:" in the output
 
 @scc_credentials
-  Scenario: Enable sles12-sp5-pool-x86_64
-    When I execute mgr-sync "add channel sles12-sp5-pool-x86_64"
+  Scenario: Enable sles12-sp4-pool-x86_64
+    When I execute mgr-sync "add channel sles12-sp4-pool-x86_64"
     And I execute mgr-sync "list channels"
-    Then I should get "[I] SLES12-SP5-Pool for x86_64 SUSE Linux Enterprise Server 12 SP5 x86_64 [sles12-sp5-pool-x86_64]"
-    And I should get "    [I] SLES12-SP5-Updates for x86_64 SUSE Linux Enterprise Server 12 SP5 x86_64 [sles12-sp5-updates-x86_64]"
-    And I should get "    [ ] SLE-Module-Containers12-Pool for x86_64 Containers Module 12 x86_64 [sle-module-containers12-pool-x86_64-sp5]"
+    Then I should get "[I] SLES12-SP4-Pool for x86_64 SUSE Linux Enterprise Server 12 SP4 x86_64 [sles12-sp4-pool-x86_64]"
+    And I should get "    [I] SLES12-SP4-Updates for x86_64 SUSE Linux Enterprise Server 12 SP4 x86_64 [sles12-sp4-updates-x86_64]"
+    And I should get "    [ ] SLE-Module-Containers12-Pool for x86_64 Containers Module 12 x86_64 [sle-module-containers12-pool-x86_64-sp4]"
 
 @scc_credentials
-  Scenario: Enable sle-module-containers12-pool-x86_64-sp5
-    When I execute mgr-sync "add channel sle-module-containers12-pool-x86_64-sp5"
+  Scenario: Enable sle-module-containers12-pool-x86_64-sp4
+    When I execute mgr-sync "add channel sle-module-containers12-pool-x86_64-sp4"
     And I execute mgr-sync "list channels"
-    Then I should get "[I] SLES12-SP5-Pool for x86_64 SUSE Linux Enterprise Server 12 SP5 x86_64 [sles12-sp5-pool-x86_64]"
-    And I should get "    [I] SLE-Module-Containers12-Pool for x86_64 Containers Module 12 x86_64 [sle-module-containers12-pool-x86_64-sp5]"
-    And I should get "    [I] SLE-Module-Containers12-Updates for x86_64 Containers Module 12 x86_64 [sle-module-containers12-updates-x86_64-sp5]"
+    Then I should get "[I] SLES12-SP4-Pool for x86_64 SUSE Linux Enterprise Server 12 SP4 x86_64 [sles12-sp4-pool-x86_64]"
+    And I should get "    [I] SLE-Module-Containers12-Pool for x86_64 Containers Module 12 x86_64 [sle-module-containers12-pool-x86_64-sp4]"
+    And I should get "    [I] SLE-Module-Containers12-Updates for x86_64 Containers Module 12 x86_64 [sle-module-containers12-updates-x86_64-sp54"
 
 @scc_credentials
   Scenario: Let mgr-sync time out

--- a/testsuite/features/reposync/srv_sync_products.feature
+++ b/testsuite/features/reposync/srv_sync_products.feature
@@ -57,21 +57,3 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I click the Add Product button
     And I wait until I see "SUSE Linux Enterprise Server 15 SP2 x86_64" product has been added
     Then the SLE15 products should be added
-
-@long_test
-@scc_credentials
-  Scenario: Enable "SUSE Linux Enterprise Server 15 SP2 with Basesystem module for x86_64"
-    Given I am on the Products page
-    When I enter "SUSE Linux Enterprise Server 15 SP2" as the filtered product description
-    And I select "x86_64" in the dropdown list of the architecture filter
-    And I open the sub-list of the product "SUSE Linux Enterprise Server 15 SP2 x86_64"
-    Then I should see a "Basesystem Module 15 SP2 x86_64" text
-    And I should see that the "Basesystem Module 15 SP2 x86_64" product is "recommended"
-    When I open the sub-list of the product "Basesystem Module 15 SP2 x86_64"
-    Then I should see that the "Server Applications Module 15 SP2 x86_64" product is "recommended"
-    When I select "SUSE Linux Enterprise Server 15 SP2 x86_64" as a product
-    And I deselect "SUSE Manager Tools 15 x86_64 (BETA)" as a SUSE Manager product
-    And I deselect "Server Applications Module 15 SP2 x86_64" as a product
-    And I click the Add Product button
-    And I wait until I see "SUSE Linux Enterprise Server 15 SP2 x86_64" product has been added
-    Then the SLE15SP2 base products should be added


### PR DESCRIPTION
## What does this PR change?

Port of https://github.com/SUSE/spacewalk/pull/13376

This PR fixes multiple failures in testsuite core's setup and synchronizes products uses by testsuite.

## Links

Tracks https://github.com/SUSE/spacewalk/pull/13376

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
