### PR TITLE
WIP: Github action for Javascript unit tests

### DIFF
--- a/.github/workflows/javascript-unit-tests.yml
+++ b/.github/workflows/javascript-unit-tests.yml
@@ -14,16 +14,36 @@ jobs:
   javascript_unit_tests:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        node-version: [10.x]
+
     steps:
     - uses: actions/checkout@v2
 
-    - name: Use Node.js
+    - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@v1
       with:
-        node-version: '10.x'
+        node-version: ${{ matrix.node-version }}
 
+    # See: https://github.com/actions/cache/blob/main/examples.md#node---yarn
+    - name: Get Yarn cache directory
+      id: yarn-cache-dir-path
+      run: echo "::set-output name=dir::$(yarn cache dir)"
+
+    # FYI, caching node_modules directly instead of Yarn's cache offers no considerable speed benefit and increases the cache size
+    - name: Use Yarn cache
+      uses: actions/cache@v2
+      id: yarn-cache
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}
+
+    # This step is required even on a cache hit or the cache won't hydrate node_modules.
+    # `--prefer-offline` means we prefer the cache over fetching things from the network.
+    # See: https://stackoverflow.com/a/62244232/1470607
     - name: Install dependencies
-      run: yarn --cwd susemanager-frontend install --frozen-lockfile
+      run: yarn --cwd susemanager-frontend install --frozen-lockfile --prefer-offline
 
     - name: Run tests
       run: yarn --cwd web/html/src test --no-cache

--- a/.github/workflows/javascript-unit-tests.yml
+++ b/.github/workflows/javascript-unit-tests.yml
@@ -1,0 +1,31 @@
+name: Javascript unit tests
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'web/html/src/**'
+  pull_request:
+    paths:
+      - 'web/html/src/**'
+
+jobs:
+  javascript_unit_tests:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Use Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: '10.x'
+
+    - name: Install dependencies
+      run: yarn --cwd susemanager-frontend install --frozen-lockfile
+
+    - name: Run tests
+      run: yarn --cwd web/html/src test --no-cache
+      env:
+        BABEL_ENV: 'test'


### PR DESCRIPTION
## What does this PR change?

As I learned in the review meeting, frontend unit tests are currently not run against PRs.  
This is an initial implementation for the action.  

I could use some help with integrating `actions/cache@v2` for dependencies similar to `java-checkstyle`, I'm not that familiar with the tool.   
Perhaps @renner could give a helping hand?  

Also, I'm not sure how to correctly integrate with the test rerunner bot.

Other than that, I tested it on my own fork and it seems to work as intended.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Workflow setup, no user facing changes.

- [x] **DONE**

## Test coverage
- Unit tests were added to the pipeline.

- [x] **DONE**

## Links

Fixes: https://github.com/SUSE/spacewalk/issues/13382

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
