### PR TITLE
Testsuite: Fix get_gpg_keys function

### DIFF
--- a/testsuite/features/support/client_stack.rb
+++ b/testsuite/features/support/client_stack.rb
@@ -88,7 +88,8 @@ end
 # rubocop:enable Metrics/AbcSize
 
 def get_gpg_keys(node)
-  os_version, os_family = get_os_version(node)
+  host = get_target(node)
+  os_version, os_family = get_os_version(host)
   if os_family =~ /^sles/
     gpg_keys, _code = $server.run("cd /srv/www/htdocs/pub/ && ls -1 sle#{os_version}*", false)
   elsif os_family =~ /^centos/


### PR DESCRIPTION
## What does this PR change?
It fixes get_gpg_keys function

- testsuite/features/support/client_stack.rb:
Get the host and pass it as argument to get_os_version.


## Links
### Ports
- Manager-4.0: https://github.com/SUSE/spacewalk/pull/13385
- Manager-4.1: https://github.com/SUSE/spacewalk/pull/13386

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)
