### PR TITLE
Add API call to get all formula data

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/dto/EndpointInfo.java
+++ b/java/code/src/com/redhat/rhn/domain/dto/EndpointInfo.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.domain.dto;
+
+import java.util.Optional;
+
+/**
+ * Class for representing the endpoint information of applications or Prometheus exporters of a minion system
+ */
+public class EndpointInfo {
+
+    private final Long systemID;
+    private final String endpointName;
+    private final Integer port;
+    private final String path;
+    private final String module;
+    private final String exporterName;
+    private final Boolean tlsEnabled;
+
+    /**
+     * Instantiates a new endpoint information
+     * @param systemIDIn server ID
+     * @param endpointNameIn endpoint name
+     * @param exporterNameIn
+     * @param portIn
+     * @param moduleIn
+     * @param pathIn
+     * @param tlsEnabledIn
+     */
+    public EndpointInfo(Long systemIDIn,
+                        String endpointNameIn,
+                        String exporterNameIn,
+                        Integer portIn,
+                        String moduleIn,
+                        String pathIn,
+                        Boolean tlsEnabledIn) {
+        this.systemID = systemIDIn;
+        this.endpointName = endpointNameIn;
+        this.exporterName = exporterNameIn;
+        this.port = portIn;
+        this.module = moduleIn;
+        this.path = pathIn;
+        this.tlsEnabled = tlsEnabledIn;
+    }
+
+    public Long getSystemID() {
+        return systemID;
+    }
+
+    public String getEndpointName() {
+        return endpointName;
+    }
+
+    public Integer getPort() {
+        return port;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public String getModule() {
+        return module;
+    }
+
+    public Optional<String> getExporterName() {
+        return Optional.ofNullable(exporterName);
+    }
+
+    public Boolean isTlsEnabled() {
+        return tlsEnabled;
+    }
+
+    @Override
+    public String toString() {
+        return "EndpointInfo{" +
+                "systemID=" + systemID +
+                ", endpointName='" + endpointName + '\'' +
+                ", port=" + port +
+                ", path='" + path + '\'' +
+                ", module='" + module + '\'' +
+                ", exporterName='" + exporterName + '\'' +
+                ", tlsEnabled='" + tlsEnabled + '\'' +
+                '}';
+    }
+}

--- a/java/code/src/com/redhat/rhn/domain/formula/ExporterConfig.java
+++ b/java/code/src/com/redhat/rhn/domain/formula/ExporterConfig.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.domain.formula;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class ExporterConfig {
+
+    private static final String PORT_ARG_REGEX = "--(?:telemetry\\.address|web\\.listen-address)=[\"']?:([0-9]*)[\"']?";
+    private static final String PORT_ADDRESS_REGEX = ":([0-9]*)$";
+
+    private final Boolean enabled;
+    private final String name;
+    private final String endpointName;
+    private final String address;
+    private final String args;
+    private final String proxyModule;
+
+    /**
+     * Instantiates new exporter configuration object
+     * @param enabledIn flag enabling the exporter
+     * @param exporterNameIn exporter name
+     * @param endpointNameIn endpoint name
+     * @param addressIn the address of the endpoint where metrics are exposed
+     * @param argsIn the string with command line arguments
+     * @param proxyModuleIn module name for exporter exporter
+     */
+    public ExporterConfig(String exporterNameIn, Boolean enabledIn, String endpointNameIn,
+                          String addressIn, String argsIn, String proxyModuleIn) {
+        this.enabled = enabledIn;
+        this.name = exporterNameIn;
+        this.endpointName = endpointNameIn;
+        this.address = addressIn;
+        this.args = argsIn;
+        this.proxyModule = proxyModuleIn;
+    }
+
+    /**
+     * Instantiate new exporter using name and configuration map
+     * @param exporterName exporter name
+     * @param exporterConfigMap map with configuration values
+     */
+    public ExporterConfig(String exporterName, Map<String, Object> exporterConfigMap) {
+        this(
+                exporterName,
+                Optional.ofNullable(exporterConfigMap.getOrDefault("enabled", false))
+                        .filter(Boolean.class::isInstance).map(Boolean.class::cast).orElse(false),
+                Optional.ofNullable(exporterConfigMap.get("name"))
+                        .filter(String.class::isInstance).map(String.class::cast).orElse(null),
+                Optional.ofNullable(exporterConfigMap.get("address"))
+                        .filter(String.class::isInstance).map(String.class::cast).orElse(null),
+                Optional.ofNullable(exporterConfigMap.get("args"))
+                        .filter(String.class::isInstance).map(String.class::cast).orElse(null),
+                Optional.ofNullable(exporterConfigMap.get("proxy_module"))
+                        .filter(String.class::isInstance).map(String.class::cast).orElse(null)
+        );
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Optional<String> getEndpointName() {
+        return Optional.ofNullable(endpointName);
+    }
+
+    public Optional<String> getProxyModule() {
+        return Optional.ofNullable(proxyModule);
+    }
+
+    public String getEndpointNameOrFallback() {
+        return getEndpointName().orElseGet(this::getName);
+    }
+
+    public String getProxyModuleOrFallback() {
+        return getProxyModule().orElseGet(this::getEndpointNameOrFallback);
+    }
+
+    public Boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Get port number at which metrics are exposed
+     * @return port number
+     */
+    public Optional<Integer> getPort() {
+        Optional<Integer> port = getPatternMatchGroupAsInteger(PORT_ARG_REGEX, args);
+        if (port.isEmpty()) {
+            port = getPatternMatchGroupAsInteger(PORT_ADDRESS_REGEX, address);
+        }
+        return port;
+    }
+
+    private Optional<Integer> getPatternMatchGroupAsInteger(String regex, String input) {
+        Optional<Integer> intGroup = Optional.empty();
+        Optional<String> optInput = Optional.ofNullable(input);
+        if (optInput.isPresent()) {
+            Pattern intPattern = Pattern.compile(regex);
+            Matcher intMatcher = intPattern.matcher(optInput.get());
+            if (intMatcher.find()) {
+                intGroup = Optional.of(Integer.valueOf(intMatcher.group(1)));
+            }
+        }
+        return intGroup;
+    }
+}

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/HandlerFactory.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/HandlerFactory.java
@@ -65,6 +65,7 @@ import com.redhat.rhn.frontend.xmlrpc.system.SystemHandler;
 import com.redhat.rhn.frontend.xmlrpc.system.XmlRpcSystemHelper;
 import com.redhat.rhn.frontend.xmlrpc.system.config.ServerConfigHandler;
 import com.redhat.rhn.frontend.xmlrpc.system.custominfo.CustomInfoHandler;
+import com.redhat.rhn.frontend.xmlrpc.system.monitoring.SystemMonitoringHandler;
 import com.redhat.rhn.frontend.xmlrpc.system.provisioning.powermanagement.PowerManagementHandler;
 import com.redhat.rhn.frontend.xmlrpc.system.provisioning.snapshot.SnapshotHandler;
 import com.redhat.rhn.frontend.xmlrpc.system.scap.SystemScapHandler;
@@ -187,6 +188,7 @@ public class HandlerFactory {
         factory.addHandler("system", systemHandler);
         factory.addHandler("system.config", new ServerConfigHandler(taskomaticApi, xmlRpcSystemHelper));
         factory.addHandler("system.custominfo", new CustomInfoHandler());
+        factory.addHandler("system.monitoring", new SystemMonitoringHandler(formulaManager));
         factory.addHandler("system.provisioning.powermanagement", new PowerManagementHandler());
         factory.addHandler("system.provisioning.snapshot", new SnapshotHandler(xmlRpcSystemHelper));
         factory.addHandler("system.scap", new SystemScapHandler());

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/EndpointInfoSerializer.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/EndpointInfoSerializer.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.frontend.xmlrpc.serializer;
+
+
+import com.redhat.rhn.domain.dto.EndpointInfo;
+import com.redhat.rhn.frontend.xmlrpc.serializer.util.SerializerHelper;
+
+import java.io.IOException;
+import java.io.Writer;
+
+import redstone.xmlrpc.XmlRpcException;
+import redstone.xmlrpc.XmlRpcSerializer;
+
+/**
+ *
+ * EndpointInfoSerializer
+ *
+ * @xmlrpc.doc
+ *
+ * #struct_begin("endpoint_info")
+ *   #prop("int", "system_id")
+ *   #prop("string", "endpoint_name")
+ *   #prop("string", "exporter_name")
+ *   #prop("string", "module")
+ *   #prop("string", "path")
+ *   #prop("int", "port")
+ *   #prop("bool", "tls_enabled")
+ * #struct_end()
+ */
+public class EndpointInfoSerializer extends RhnXmlRpcCustomSerializer {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Class getSupportedClass() {
+        return EndpointInfo.class;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void doSerialize(Object obj, Writer writer, XmlRpcSerializer serializer)
+            throws XmlRpcException, IOException {
+        EndpointInfo endpointInfo = (EndpointInfo) obj;
+        SerializerHelper helper = new SerializerHelper(serializer);
+        helper.add("system_id", endpointInfo.getSystemID());
+        helper.add("endpoint_name", endpointInfo.getEndpointName());
+        helper.add("exporter_name", endpointInfo.getExporterName().orElse(null));
+        helper.add("module", endpointInfo.getModule());
+        helper.add("path", endpointInfo.getPath());
+        helper.add("port", endpointInfo.getPort());
+        helper.add("tls_enabled", endpointInfo.isTlsEnabled());
+
+        helper.writeTo(writer);
+    }
+}

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/SerializerRegistry.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/SerializerRegistry.java
@@ -50,6 +50,7 @@ public class SerializerRegistry {
         SERIALIZER_CLASSES.add(CpuSerializer.class);
         SERIALIZER_CLASSES.add(DeviceSerializer.class);
         SERIALIZER_CLASSES.add(DmiSerializer.class);
+        SERIALIZER_CLASSES.add(EndpointInfoSerializer.class);
         SERIALIZER_CLASSES.add(ErrataOverviewSerializer.class);
         SERIALIZER_CLASSES.add(ErrataSerializer.class);
         SERIALIZER_CLASSES.add(HistoryEventSerializer.class);

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/monitoring/SystemMonitoringHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/monitoring/SystemMonitoringHandler.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.frontend.xmlrpc.system.monitoring;
+
+import com.redhat.rhn.domain.dto.EndpointInfo;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.frontend.xmlrpc.BaseHandler;
+import com.redhat.rhn.manager.formula.FormulaManager;
+
+import java.util.List;
+
+/**
+ * SystemMonitoringHandler
+ * @xmlrpc.namespace system.monitoring
+ * @xmlrpc.doc Provides methods to access information about managed systems, applications and formulas which can be
+ * relevant for Prometheus monitoring
+ */
+public class SystemMonitoringHandler extends BaseHandler {
+
+    private final FormulaManager formulaManager;
+
+    /**
+     * Instantiates a new system handler for system.monitoring namespace
+     * @param formulaManagerIn instance of formula manager object
+     */
+    public SystemMonitoringHandler(FormulaManager formulaManagerIn) {
+        this.formulaManager = formulaManagerIn;
+    }
+
+    /**
+     * Get the endpoint details for all Prometheus exporters installed on the systems whose IDs match
+     * with the passed systems IDs and all of the groups those systems are member of.
+     *
+     * @param loggedInUser The current user
+     * @param systemIDs The system IDs
+     * @return a list containing endpoint details for all Prometheus exporters on the passed system IDs.
+     *
+     * @xmlrpc.param #session_key()
+     * @xmlrpc.param #array_single("int", "systemID")
+     * @xmlrpc.returntype
+     *   #array_begin()
+     *     $EndpointInfo
+     *   #array_end()
+     */
+    public List<EndpointInfo> listEndpoints(User loggedInUser, List<Long> systemIDs) {
+        return this.formulaManager.listEndpoints(systemIDs);
+    }
+}

--- a/java/code/src/com/redhat/rhn/manager/formula/test/prometheus-exporters-formula-data.json
+++ b/java/code/src/com/redhat/rhn/manager/formula/test/prometheus-exporters-formula-data.json
@@ -1,0 +1,28 @@
+{
+  "proxy_enabled": false,
+  "proxy_port": 9999,
+  "tls": {
+    "enabled": false,
+    "ca_certificate": "/etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT",
+    "server_certificate": "/etc/ssl/server.crt",
+    "server_key": "/etc/ssl/server.key"
+  },
+  "exporters": {
+    "node_exporter": {
+      "enabled": true,
+      "address": ":9100",
+      "args": "--collector.systemd"
+    },
+    "apache_exporter": {
+      "enabled": true,
+      "address": "",
+      "args": "--telemetry.address\u003d\":9117\""
+    },
+    "postgres_exporter": {
+      "enabled": false,
+      "address": ":9187",
+      "data_source_name": "postgresql://user:passwd@localhost:5432/database?sslmode\u003ddisable",
+      "args": ""
+    }
+  }
+}

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- XMLRPC: Add call for listing application monitoring endpoints
 - Bring back Beta product tag
 - fix NPE when no redhat info could be fetched
 


### PR DESCRIPTION
## What does this PR change?

Add API method

`listEndpoints(User, List<Long>)`

to list all available application and Prometheus exporters endpoints for the systems whose IDs
match with the passed systems IDs.

Requires SUSE/salt-formulas#102

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: change only to XMLRPC API with automatically generated reference documentation.

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Fixes #
Tracks https://github.com/SUSE/spacewalk/issues/12777

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"    
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests" (Test skipped, there are no changes to test)
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
