### PR TITLE
Add second arg head

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -667,7 +667,7 @@ When(/^I bootstrap (traditional|minion) client "([^"]*)" using bootstrap script 
   # Prepare bootstrap script for different types of clients
   client = client_type == 'traditional' ? '--traditional' : ''
   node = get_target(host)
-  gpg_keys = get_gpg_keys(node)
+  gpg_keys = get_gpg_keys(node, target)
   cmd = "mgr-bootstrap #{client} &&
   sed -i s\'/^exit 1//\' /srv/www/htdocs/pub/bootstrap/bootstrap.sh &&
   sed -i '/^ACTIVATION_KEYS=/c\\ACTIVATION_KEYS=#{key}' /srv/www/htdocs/pub/bootstrap/bootstrap.sh &&

--- a/testsuite/features/support/client_stack.rb
+++ b/testsuite/features/support/client_stack.rb
@@ -87,15 +87,15 @@ def get_os_version(node)
 end
 # rubocop:enable Metrics/AbcSize
 
-def get_gpg_keys(node)
+def get_gpg_keys(node, target = $server)
   host = get_target(node)
   os_version, os_family = get_os_version(host)
   if os_family =~ /^sles/
-    gpg_keys, _code = $server.run("cd /srv/www/htdocs/pub/ && ls -1 sle#{os_version}*", false)
+    gpg_keys, _code = target.run("cd /srv/www/htdocs/pub/ && ls -1 sle#{os_version}*", false)
   elsif os_family =~ /^centos/
-    gpg_keys, _code = $server.run("cd /srv/www/htdocs/pub/ && ls -1 #{os_family}#{os_version}* res*", false)
+    gpg_keys, _code = target.run("cd /srv/www/htdocs/pub/ && ls -1 #{os_family}#{os_version}* res*", false)
   else
-    gpg_keys, _code = $server.run("cd /srv/www/htdocs/pub/ && ls -1 #{os_family}*", false)
+    gpg_keys, _code = target.run("cd /srv/www/htdocs/pub/ && ls -1 #{os_family}*", false)
   end
   gpg_keys.lines.map(&:strip)
 end

--- a/testsuite/features/support/client_stack.rb
+++ b/testsuite/features/support/client_stack.rb
@@ -88,8 +88,7 @@ end
 # rubocop:enable Metrics/AbcSize
 
 def get_gpg_keys(node, target = $server)
-  host = get_target(node)
-  os_version, os_family = get_os_version(host)
+  os_version, os_family = get_os_version(node)
   if os_family =~ /^sles/
     gpg_keys, _code = target.run("cd /srv/www/htdocs/pub/ && ls -1 sle#{os_version}*", false)
   elsif os_family =~ /^centos/


### PR DESCRIPTION
## What does this PR change?

Pass the right type for the first argument
Add a 2nd optional arg with the target from where to obtain the GPG keys ($server, default).

## Links

Fixes https://github.com/uyuni-project/uyuni/pull/2986
### Ports
- Manager-4.0: https://github.com/SUSE/spacewalk/pull/13393
- Manager-4.1: https://github.com/SUSE/spacewalk/pull/13392

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)
