### PR TITLE
disable password validation on user creation with empty password and pam enabled. (bsc#1179579)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/user/CreateUserAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/user/CreateUserAction.java
@@ -47,7 +47,7 @@ public class CreateUserAction extends RhnAction {
     public static final String FAILURE = "failure";
     public static final String SUCCESS_INTO_ORG = "existorgsuccess";
 
-    private ActionErrors populateCommand(DynaActionForm form, CreateUserCommand command) {
+    private ActionErrors populateCommand(DynaActionForm form, CreateUserCommand command, boolean validatePassword) {
         ActionErrors errors = new ActionErrors();
 
         command.setEmail(form.getString("email"));
@@ -68,7 +68,7 @@ public class CreateUserAction extends RhnAction {
         String passwd = (String)form.get(UserActionHelper.DESIRED_PASS);
         String passwdConfirm = (String)form.get(UserActionHelper.DESIRED_PASS_CONFIRM);
         if (passwd.equals(passwdConfirm)) {
-            command.setPassword(passwd);
+            command.setPassword(passwd, validatePassword);
         }
         else {
             errors.add(ActionMessages.GLOBAL_MESSAGE,
@@ -124,14 +124,17 @@ public class CreateUserAction extends RhnAction {
          * in the db (even though it won't be used), we'll just validate it like a regular
          * password and allow it.
          */
+        boolean validatePassword = true;
         if (form.get("usepam") != null && ((Boolean) form.get("usepam")).booleanValue()) {
             String hash = MD5Crypt.crypt("" + System.currentTimeMillis());
             if (form.get(UserActionHelper.DESIRED_PASS) == null ||
                     form.get(UserActionHelper.DESIRED_PASS).equals("")) {
+                validatePassword = false;
                 form.set(UserActionHelper.DESIRED_PASS, hash);
             }
             if (form.get(UserActionHelper.DESIRED_PASS_CONFIRM) == null ||
                     form.get(UserActionHelper.DESIRED_PASS_CONFIRM).equals("")) {
+                validatePassword = false;
                 form.set(UserActionHelper.DESIRED_PASS_CONFIRM, hash);
             }
         }
@@ -145,7 +148,7 @@ public class CreateUserAction extends RhnAction {
 
         // Create the user and do some more validation
         CreateUserCommand command = getCommand();
-        ActionErrors errors = populateCommand(form, command);
+        ActionErrors errors = populateCommand(form, command, validatePassword);
         if (!errors.isEmpty()) {
             return returnError(mapping, request, errors);
         }

--- a/java/code/src/com/redhat/rhn/manager/user/CreateUserCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/user/CreateUserCommand.java
@@ -323,11 +323,21 @@ public class CreateUserCommand {
 
     /**
      * @param passwordIn The password to set
+     * @param validate if password requirements should be validated
+     */
+    public void setPassword(String passwordIn, boolean validate) {
+        passwordErrors = new ArrayList(); //init password errors list
+        if (validate) {
+            validatePassword(passwordIn);
+        }
+        user.setPassword(passwordIn);
+    }
+
+    /**
+     * @param passwordIn The password to set
      */
     public void setPassword(String passwordIn) {
-        passwordErrors = new ArrayList(); //init password errors list
-        validatePassword(passwordIn);
-        user.setPassword(passwordIn);
+        setPassword(passwordIn, true);
     }
 
     /**

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix user creation with pam auth and no password (bsc#1179579)
 - Cleanup sessions via SQL query instead of SQL function (bsc#1180224)
 - Do not call page decorator in HEAD requests (bsc#1181228)
 - Allow to configure request timeout (bsc#1178767)


### PR DESCRIPTION
## What does this PR change?

This fixes an issue when creating a user with pam authentication where no password is provided. In this case there will be a dummy password generated to get though struts from validation. Later There is again validation checking the password against the configured requirements. This validation can fail since the dummy password is a constant length hash that won't always fit the configured requirements. This fix disabled the seconds password requirements validation for said dummy password but keeps it in place for all other cases.

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

Fixes #https://github.com/SUSE/spacewalk/issues/13355

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
