### PR TITLE
Fix permission issue in Salt user group

### DIFF
--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -32,14 +32,13 @@
 %define appdir          /srv/tomcat/webapps
 %define jardir          /srv/tomcat/webapps/rhn/WEB-INF/lib
 %define apache_group    www
-%define salt_user-group    salt
+%define salt_user_group salt
 %define apache2         apache2
 %define java_version    11
 %else
 %define appdir          %{_localstatedir}/lib/tomcat/webapps
 %define jardir          %{_localstatedir}/lib/tomcat/webapps/rhn/WEB-INF/lib
 %define apache_group    apache
-%define salt_user_group root 
 %define apache2         httpd
 %define java_version    1:11
 %endif

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -39,6 +39,7 @@
 %define appdir          %{_localstatedir}/lib/tomcat/webapps
 %define jardir          %{_localstatedir}/lib/tomcat/webapps/rhn/WEB-INF/lib
 %define apache_group    apache
+%define salt_user_group salt
 %define apache2         httpd
 %define java_version    1:11
 %endif


### PR DESCRIPTION
## What does this PR change?

Fix `salt_user_group` being set to `root` which caused minion bootstrapping to fail due to permission issues.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Bugfix.

- [x] **DONE**

## Test coverage
- No tests: Needs to pass existing tests.

- [x] **DONE**

## Links

Related test runs: https://ci.suse.de/view/Manager/view/Manager-Head/job/manager-Head-cucumber-NUE/1046/testReport/

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
