### PR TITLE
Allow to specify 'Revision' when updating 'init.sls' via CLI or API

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/configchannel/ConfigChannelHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/configchannel/ConfigChannelHandler.java
@@ -379,7 +379,7 @@ public class ConfigChannelHandler extends BaseHandler {
      * Update the init.sls file for the given state channel with the given contents.
      * @param user The current user
      * @param channelLabel the label of the config channel.
-     * @param data a map containing 'content' and 'contents_enc64'
+     * @param data a map containing 'content', 'contents_enc64' and 'revision'
      * @return returns the updated config revision..
      *
      * @xmlrpc.doc Update the init.sls file for the given state channel. User can only update contents, nothing else.
@@ -389,6 +389,7 @@ public class ConfigChannelHandler extends BaseHandler {
      *  #struct_begin("path info")
      *      #prop_desc("string","contents", "Contents of the init.sls file")
      *      #prop_desc("boolean","contents_enc64", "Identifies base64 encoded content(default: disabled)")
+     *      #prop_desc("int", "revision", "next revision number, auto increment for null")
      *  #struct_end()
      * @xmlrpc.returntype
      * $ConfigRevisionSerializer
@@ -399,6 +400,7 @@ public class ConfigChannelHandler extends BaseHandler {
         Set<String> validKeys = new HashSet<String>();
         validKeys.add(ConfigRevisionSerializer.CONTENTS);
         validKeys.add(ConfigRevisionSerializer.CONTENTS_ENC64);
+        validKeys.add(ConfigRevisionSerializer.REVISION);
         validateMap(validKeys, data);
         XmlRpcConfigChannelHelper helper = XmlRpcConfigChannelHelper.getInstance();
         ConfigChannel channel = helper.lookupGlobal(user, channelLabel);
@@ -415,6 +417,9 @@ public class ConfigChannelHandler extends BaseHandler {
             form.setGroup(configInfo.getGroupname());
             form.setOwner(configInfo.getUsername());
             form.setPermissions(configInfo.getFilemode().toString());
+            if (data.containsKey(ConfigRevisionSerializer.REVISION)) {
+                form.setRevNumber(String.valueOf(data.get(ConfigRevisionSerializer.REVISION)));
+            }
             result = ConfigFileBuilder.getInstance().update(form, user, configFile);
 
          }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Added 'revision' argument to the 'configchannel.updateInitSls' XMLRPC API method (bsc#1179566)
 - Add validation for custom repository labels
 - Fix configuration file download links to actually download files instead of redirecting to the home page (bsc#1179324)
 - Add lang attribute to html tags

--- a/spacecmd/po/de.po
+++ b/spacecmd/po/de.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-20 12:55+0100\n"
+"POT-Creation-Date: 2020-12-11 09:25+0000\n"
 "PO-Revision-Date: 2020-10-16 10:51+0200\n"
 "Last-Translator: Pascal Arlt <parlt@suse.com>\n"
 "Language-Team: German <https://l10n.opensuse.org/projects/uyuni/spacecmd/de/"
@@ -308,7 +308,7 @@ msgid "Software Channels"
 msgstr ""
 
 #: ../src/spacecmd/activationkey.py:960 ../src/spacecmd/configchannel.py:765
-#: ../src/spacecmd/configchannel.py:870 ../src/spacecmd/system.py:3057
+#: ../src/spacecmd/configchannel.py:872 ../src/spacecmd/system.py:3057
 msgid "Configuration Channels"
 msgstr ""
 
@@ -499,7 +499,7 @@ msgstr ""
 msgid "Cloned Key:"
 msgstr ""
 
-#: ../src/spacecmd/activationkey.py:1472 ../src/spacecmd/configchannel.py:1376
+#: ../src/spacecmd/activationkey.py:1472 ../src/spacecmd/configchannel.py:1389
 msgid "Error - must specify either -c or -x options!"
 msgstr ""
 
@@ -535,7 +535,7 @@ msgstr ""
 msgid "does not exist, skipping!"
 msgstr ""
 
-#: ../src/spacecmd/activationkey.py:1584 ../src/spacecmd/configchannel.py:1428
+#: ../src/spacecmd/activationkey.py:1584 ../src/spacecmd/configchannel.py:1441
 #, python-format
 msgid "Failed to clone %s to %s"
 msgstr ""
@@ -783,7 +783,7 @@ msgid "Binary:          %s"
 msgstr ""
 
 #: ../src/spacecmd/configchannel.py:263 ../src/spacecmd/configchannel.py:696
-#: ../src/spacecmd/configchannel.py:933 ../src/spacecmd/kickstart.py:1903
+#: ../src/spacecmd/configchannel.py:946 ../src/spacecmd/kickstart.py:1903
 #: ../src/spacecmd/snippet.py:161
 msgid "Contents"
 msgstr ""
@@ -952,16 +952,16 @@ msgstr ""
 msgid "SELinux Context [%s]:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:575
+#: ../src/spacecmd/configchannel.py:575 ../src/spacecmd/configchannel.py:911
 msgid "Revision [next]:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:593
+#: ../src/spacecmd/configchannel.py:593 ../src/spacecmd/configchannel.py:916
 msgid "The revision must be an integer"
 msgstr ""
 
 #. get the contents of the script
-#: ../src/spacecmd/configchannel.py:596 ../src/spacecmd/configchannel.py:896
+#: ../src/spacecmd/configchannel.py:596 ../src/spacecmd/configchannel.py:898
 #: ../src/spacecmd/cryptokey.py:68 ../src/spacecmd/kickstart.py:1954
 #: ../src/spacecmd/snippet.py:141
 msgid "Read an existing file [y/N]:"
@@ -975,7 +975,7 @@ msgstr ""
 msgid "The path is required"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:630 ../src/spacecmd/configchannel.py:913
+#: ../src/spacecmd/configchannel.py:630 ../src/spacecmd/configchannel.py:922
 msgid "You must provide the file contents"
 msgstr ""
 
@@ -1054,11 +1054,11 @@ msgstr ""
 msgid "Path:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:805 ../src/spacecmd/configchannel.py:924
+#: ../src/spacecmd/configchannel.py:805 ../src/spacecmd/configchannel.py:935
 msgid "No config channel specified!"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:810 ../src/spacecmd/configchannel.py:929
+#: ../src/spacecmd/configchannel.py:810 ../src/spacecmd/configchannel.py:940
 msgid "Error obtaining file info"
 msgstr ""
 
@@ -1072,51 +1072,57 @@ msgid ""
 "\n"
 "options:\n"
 "  -c CHANNEL\n"
+"  -r REVISION\n"
 "  -f local path to file contents\n"
 "  -y automatically proceed with file contents\n"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:892
+#: ../src/spacecmd/configchannel.py:894
 #, python-format
 msgid "No existing file information found for %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:932
+#: ../src/spacecmd/configchannel.py:944
+#, python-format
+msgid "revision:                 %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:945
 #, python-format
 msgid "contents_enc64:           %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:959
+#: ../src/spacecmd/configchannel.py:972
 msgid "configchannel_removefiles: Remove configuration files"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:960
+#: ../src/spacecmd/configchannel.py:973
 msgid "usage: configchannel_removefiles CHANNEL <FILE ...>"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:997
+#: ../src/spacecmd/configchannel.py:1010
 msgid "configchannel_verifyfile: Verify a configuration file"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:998
+#: ../src/spacecmd/configchannel.py:1011
 msgid "usage: configchannel_verifyfile CHANNEL FILE <SYSTEMS>"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1037
+#: ../src/spacecmd/configchannel.py:1050
 msgid "No valid system selected"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1045 ../src/spacecmd/system.py:509
+#: ../src/spacecmd/configchannel.py:1058 ../src/spacecmd/system.py:509
 #: ../src/spacecmd/system.py:529 ../src/spacecmd/system.py:959
 #, python-format
 msgid "Action ID: %i"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1053
+#: ../src/spacecmd/configchannel.py:1066
 msgid "configchannel_export: export config channel(s) to json format file"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1054
+#: ../src/spacecmd/configchannel.py:1067
 msgid ""
 "usage: configchannel_export <CHANNEL>... [options])\n"
 "options:\n"
@@ -1130,116 +1136,116 @@ msgid ""
 msgstr ""
 
 #. Get the cc details
-#: ../src/spacecmd/configchannel.py:1070
+#: ../src/spacecmd/configchannel.py:1083
 #, python-format
 msgid "Getting config channel details for %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1090
+#: ../src/spacecmd/configchannel.py:1103
 #, python-format
 msgid "Failed to get details for file %s from %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1136
+#: ../src/spacecmd/configchannel.py:1149
 #, python-format
 msgid "File %s could not be exported "
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1137
+#: ../src/spacecmd/configchannel.py:1150
 msgid "with this API version(needs base64 encoding)"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1139
+#: ../src/spacecmd/configchannel.py:1152
 #, python-format
 msgid "File %s could not be exported as"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1140
+#: ../src/spacecmd/configchannel.py:1153
 msgid " text...getting base64 encoded version"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1163
+#: ../src/spacecmd/configchannel.py:1176
 #, python-format
 msgid "Passed filename '%s' to do_configchannel_export command."
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1171
+#: ../src/spacecmd/configchannel.py:1184
 #, python-format
 msgid "Exporting ALL config channels to %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1178
+#: ../src/spacecmd/configchannel.py:1191
 msgid ""
 "Error, no valid config channel passed, check name is  correct with spacecmd "
 "configchannel_list"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1193
+#: ../src/spacecmd/configchannel.py:1206
 #, python-format
 msgid "Exporting cc %s to %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1200
+#: ../src/spacecmd/configchannel.py:1213
 msgid "File '{}' exists, confirm overwrite file? (y/n)"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1203
+#: ../src/spacecmd/configchannel.py:1216
 #, python-format
 msgid "Error saving exported config channels to file: %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1212
+#: ../src/spacecmd/configchannel.py:1225
 msgid "configchannel_import: import config channel(s) from json file"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1213
+#: ../src/spacecmd/configchannel.py:1226
 msgid "usage: configchannel_import <JSONFILES...>"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1222 ../src/spacecmd/kickstart.py:2330
+#: ../src/spacecmd/configchannel.py:1235 ../src/spacecmd/kickstart.py:2330
 msgid "Error, no filename passed"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1230 ../src/spacecmd/kickstart.py:2338
+#: ../src/spacecmd/configchannel.py:1243 ../src/spacecmd/kickstart.py:2338
 #, python-format
 msgid "Error, could not read json data from %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1234
+#: ../src/spacecmd/configchannel.py:1247
 #, python-format
 msgid "Error importing configchannel %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1246
+#: ../src/spacecmd/configchannel.py:1259
 #, python-format
 msgid "Config channel %s already exists! Skipping!"
 msgstr ""
 
 #. create the cc, we need to drop the org prefix from the cc name
-#: ../src/spacecmd/configchannel.py:1251
+#: ../src/spacecmd/configchannel.py:1264
 #, python-format
 msgid "Importing config channel  %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1294
+#: ../src/spacecmd/configchannel.py:1307
 #, python-format
 msgid "Failed trying to import file %s (empty content)"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1296
+#: ../src/spacecmd/configchannel.py:1309
 msgid "Older APIs can't export encoded files"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1319
+#: ../src/spacecmd/configchannel.py:1332
 #, python-format
 msgid "Error adding file %s to %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1329
+#: ../src/spacecmd/configchannel.py:1342
 msgid "configchannel_clone: Clone config channel(s)"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1330
+#: ../src/spacecmd/configchannel.py:1343
 msgid ""
 "usage examples:\n"
 "                 configchannel_clone foo_label -c bar_label\n"
@@ -1257,101 +1263,101 @@ msgid ""
 "  Note : If no -c or -x option is specified, interactive is assumed"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1359
+#: ../src/spacecmd/configchannel.py:1372
 msgid "No config channels found"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1362
+#: ../src/spacecmd/configchannel.py:1375
 msgid "Config Channels"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1368
+#: ../src/spacecmd/configchannel.py:1381
 #, python-format
 msgid "Channel to clone: %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1372
+#: ../src/spacecmd/configchannel.py:1385
 msgid "Channel to clone:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1373
+#: ../src/spacecmd/configchannel.py:1386
 msgid "Clone label:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1382
+#: ../src/spacecmd/configchannel.py:1395
 msgid "Error no channel label passed!"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1391
+#: ../src/spacecmd/configchannel.py:1404
 msgid "No suitable channels to clone has been found."
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1444
+#: ../src/spacecmd/configchannel.py:1457
 msgid "no configchannel given"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1447
+#: ../src/spacecmd/configchannel.py:1460
 msgid "invalid configchannel label "
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1473
+#: ../src/spacecmd/configchannel.py:1486
 msgid "configchannel_diff: diff between config channels"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1475
+#: ../src/spacecmd/configchannel.py:1488
 msgid "usage: configchannel_diff SOURCE_CHANNEL TARGET_CHANNEL"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1524
+#: ../src/spacecmd/configchannel.py:1537
 msgid "configchannel_sync:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1525
+#: ../src/spacecmd/configchannel.py:1538
 msgid "sync config files between two config channels"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1527
+#: ../src/spacecmd/configchannel.py:1540
 msgid "usage: configchannel_sync SOURCE_CHANNEL TARGET_CHANNEL"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1565
+#: ../src/spacecmd/configchannel.py:1578
 msgid "syncing files from configchannel "
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1572
+#: ../src/spacecmd/configchannel.py:1585
 msgid "files common in both channels:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1578
+#: ../src/spacecmd/configchannel.py:1591
 msgid "files only in source "
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1584
+#: ../src/spacecmd/configchannel.py:1597
 msgid "files only in target "
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1589
+#: ../src/spacecmd/configchannel.py:1602
 msgid ""
 "files that are in both channels will be overwritten in the target channel"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1591
+#: ../src/spacecmd/configchannel.py:1604
 msgid "files only in the source channel will be added to the target channel"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1593
+#: ../src/spacecmd/configchannel.py:1606
 msgid "files only in the target channel will be deleted"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1596
+#: ../src/spacecmd/configchannel.py:1609
 msgid "nothing to do"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1600
+#: ../src/spacecmd/configchannel.py:1613
 msgid "perform synchronisation [y/N]:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1652
+#: ../src/spacecmd/configchannel.py:1665
 msgid "unknown file type "
 msgstr ""
 

--- a/spacecmd/po/es.po
+++ b/spacecmd/po/es.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-20 12:55+0100\n"
+"POT-Creation-Date: 2020-12-11 09:25+0000\n"
 "PO-Revision-Date: 2020-10-16 10:51+0200\n"
 "Last-Translator: Pascal Arlt <parlt@suse.com>\n"
 "Language-Team: Spanish <https://l10n.opensuse.org/projects/uyuni/spacecmd/es/"
@@ -308,7 +308,7 @@ msgid "Software Channels"
 msgstr ""
 
 #: ../src/spacecmd/activationkey.py:960 ../src/spacecmd/configchannel.py:765
-#: ../src/spacecmd/configchannel.py:870 ../src/spacecmd/system.py:3057
+#: ../src/spacecmd/configchannel.py:872 ../src/spacecmd/system.py:3057
 msgid "Configuration Channels"
 msgstr ""
 
@@ -499,7 +499,7 @@ msgstr ""
 msgid "Cloned Key:"
 msgstr ""
 
-#: ../src/spacecmd/activationkey.py:1472 ../src/spacecmd/configchannel.py:1376
+#: ../src/spacecmd/activationkey.py:1472 ../src/spacecmd/configchannel.py:1389
 msgid "Error - must specify either -c or -x options!"
 msgstr ""
 
@@ -535,7 +535,7 @@ msgstr ""
 msgid "does not exist, skipping!"
 msgstr ""
 
-#: ../src/spacecmd/activationkey.py:1584 ../src/spacecmd/configchannel.py:1428
+#: ../src/spacecmd/activationkey.py:1584 ../src/spacecmd/configchannel.py:1441
 #, python-format
 msgid "Failed to clone %s to %s"
 msgstr ""
@@ -783,7 +783,7 @@ msgid "Binary:          %s"
 msgstr ""
 
 #: ../src/spacecmd/configchannel.py:263 ../src/spacecmd/configchannel.py:696
-#: ../src/spacecmd/configchannel.py:933 ../src/spacecmd/kickstart.py:1903
+#: ../src/spacecmd/configchannel.py:946 ../src/spacecmd/kickstart.py:1903
 #: ../src/spacecmd/snippet.py:161
 msgid "Contents"
 msgstr ""
@@ -952,16 +952,16 @@ msgstr ""
 msgid "SELinux Context [%s]:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:575
+#: ../src/spacecmd/configchannel.py:575 ../src/spacecmd/configchannel.py:911
 msgid "Revision [next]:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:593
+#: ../src/spacecmd/configchannel.py:593 ../src/spacecmd/configchannel.py:916
 msgid "The revision must be an integer"
 msgstr ""
 
 #. get the contents of the script
-#: ../src/spacecmd/configchannel.py:596 ../src/spacecmd/configchannel.py:896
+#: ../src/spacecmd/configchannel.py:596 ../src/spacecmd/configchannel.py:898
 #: ../src/spacecmd/cryptokey.py:68 ../src/spacecmd/kickstart.py:1954
 #: ../src/spacecmd/snippet.py:141
 msgid "Read an existing file [y/N]:"
@@ -975,7 +975,7 @@ msgstr ""
 msgid "The path is required"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:630 ../src/spacecmd/configchannel.py:913
+#: ../src/spacecmd/configchannel.py:630 ../src/spacecmd/configchannel.py:922
 msgid "You must provide the file contents"
 msgstr ""
 
@@ -1054,11 +1054,11 @@ msgstr ""
 msgid "Path:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:805 ../src/spacecmd/configchannel.py:924
+#: ../src/spacecmd/configchannel.py:805 ../src/spacecmd/configchannel.py:935
 msgid "No config channel specified!"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:810 ../src/spacecmd/configchannel.py:929
+#: ../src/spacecmd/configchannel.py:810 ../src/spacecmd/configchannel.py:940
 msgid "Error obtaining file info"
 msgstr ""
 
@@ -1072,51 +1072,57 @@ msgid ""
 "\n"
 "options:\n"
 "  -c CHANNEL\n"
+"  -r REVISION\n"
 "  -f local path to file contents\n"
 "  -y automatically proceed with file contents\n"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:892
+#: ../src/spacecmd/configchannel.py:894
 #, python-format
 msgid "No existing file information found for %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:932
+#: ../src/spacecmd/configchannel.py:944
+#, python-format
+msgid "revision:                 %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:945
 #, python-format
 msgid "contents_enc64:           %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:959
+#: ../src/spacecmd/configchannel.py:972
 msgid "configchannel_removefiles: Remove configuration files"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:960
+#: ../src/spacecmd/configchannel.py:973
 msgid "usage: configchannel_removefiles CHANNEL <FILE ...>"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:997
+#: ../src/spacecmd/configchannel.py:1010
 msgid "configchannel_verifyfile: Verify a configuration file"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:998
+#: ../src/spacecmd/configchannel.py:1011
 msgid "usage: configchannel_verifyfile CHANNEL FILE <SYSTEMS>"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1037
+#: ../src/spacecmd/configchannel.py:1050
 msgid "No valid system selected"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1045 ../src/spacecmd/system.py:509
+#: ../src/spacecmd/configchannel.py:1058 ../src/spacecmd/system.py:509
 #: ../src/spacecmd/system.py:529 ../src/spacecmd/system.py:959
 #, python-format
 msgid "Action ID: %i"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1053
+#: ../src/spacecmd/configchannel.py:1066
 msgid "configchannel_export: export config channel(s) to json format file"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1054
+#: ../src/spacecmd/configchannel.py:1067
 msgid ""
 "usage: configchannel_export <CHANNEL>... [options])\n"
 "options:\n"
@@ -1130,116 +1136,116 @@ msgid ""
 msgstr ""
 
 #. Get the cc details
-#: ../src/spacecmd/configchannel.py:1070
+#: ../src/spacecmd/configchannel.py:1083
 #, python-format
 msgid "Getting config channel details for %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1090
+#: ../src/spacecmd/configchannel.py:1103
 #, python-format
 msgid "Failed to get details for file %s from %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1136
+#: ../src/spacecmd/configchannel.py:1149
 #, python-format
 msgid "File %s could not be exported "
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1137
+#: ../src/spacecmd/configchannel.py:1150
 msgid "with this API version(needs base64 encoding)"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1139
+#: ../src/spacecmd/configchannel.py:1152
 #, python-format
 msgid "File %s could not be exported as"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1140
+#: ../src/spacecmd/configchannel.py:1153
 msgid " text...getting base64 encoded version"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1163
+#: ../src/spacecmd/configchannel.py:1176
 #, python-format
 msgid "Passed filename '%s' to do_configchannel_export command."
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1171
+#: ../src/spacecmd/configchannel.py:1184
 #, python-format
 msgid "Exporting ALL config channels to %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1178
+#: ../src/spacecmd/configchannel.py:1191
 msgid ""
 "Error, no valid config channel passed, check name is  correct with spacecmd "
 "configchannel_list"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1193
+#: ../src/spacecmd/configchannel.py:1206
 #, python-format
 msgid "Exporting cc %s to %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1200
+#: ../src/spacecmd/configchannel.py:1213
 msgid "File '{}' exists, confirm overwrite file? (y/n)"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1203
+#: ../src/spacecmd/configchannel.py:1216
 #, python-format
 msgid "Error saving exported config channels to file: %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1212
+#: ../src/spacecmd/configchannel.py:1225
 msgid "configchannel_import: import config channel(s) from json file"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1213
+#: ../src/spacecmd/configchannel.py:1226
 msgid "usage: configchannel_import <JSONFILES...>"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1222 ../src/spacecmd/kickstart.py:2330
+#: ../src/spacecmd/configchannel.py:1235 ../src/spacecmd/kickstart.py:2330
 msgid "Error, no filename passed"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1230 ../src/spacecmd/kickstart.py:2338
+#: ../src/spacecmd/configchannel.py:1243 ../src/spacecmd/kickstart.py:2338
 #, python-format
 msgid "Error, could not read json data from %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1234
+#: ../src/spacecmd/configchannel.py:1247
 #, python-format
 msgid "Error importing configchannel %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1246
+#: ../src/spacecmd/configchannel.py:1259
 #, python-format
 msgid "Config channel %s already exists! Skipping!"
 msgstr ""
 
 #. create the cc, we need to drop the org prefix from the cc name
-#: ../src/spacecmd/configchannel.py:1251
+#: ../src/spacecmd/configchannel.py:1264
 #, python-format
 msgid "Importing config channel  %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1294
+#: ../src/spacecmd/configchannel.py:1307
 #, python-format
 msgid "Failed trying to import file %s (empty content)"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1296
+#: ../src/spacecmd/configchannel.py:1309
 msgid "Older APIs can't export encoded files"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1319
+#: ../src/spacecmd/configchannel.py:1332
 #, python-format
 msgid "Error adding file %s to %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1329
+#: ../src/spacecmd/configchannel.py:1342
 msgid "configchannel_clone: Clone config channel(s)"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1330
+#: ../src/spacecmd/configchannel.py:1343
 msgid ""
 "usage examples:\n"
 "                 configchannel_clone foo_label -c bar_label\n"
@@ -1257,101 +1263,101 @@ msgid ""
 "  Note : If no -c or -x option is specified, interactive is assumed"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1359
+#: ../src/spacecmd/configchannel.py:1372
 msgid "No config channels found"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1362
+#: ../src/spacecmd/configchannel.py:1375
 msgid "Config Channels"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1368
+#: ../src/spacecmd/configchannel.py:1381
 #, python-format
 msgid "Channel to clone: %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1372
+#: ../src/spacecmd/configchannel.py:1385
 msgid "Channel to clone:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1373
+#: ../src/spacecmd/configchannel.py:1386
 msgid "Clone label:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1382
+#: ../src/spacecmd/configchannel.py:1395
 msgid "Error no channel label passed!"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1391
+#: ../src/spacecmd/configchannel.py:1404
 msgid "No suitable channels to clone has been found."
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1444
+#: ../src/spacecmd/configchannel.py:1457
 msgid "no configchannel given"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1447
+#: ../src/spacecmd/configchannel.py:1460
 msgid "invalid configchannel label "
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1473
+#: ../src/spacecmd/configchannel.py:1486
 msgid "configchannel_diff: diff between config channels"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1475
+#: ../src/spacecmd/configchannel.py:1488
 msgid "usage: configchannel_diff SOURCE_CHANNEL TARGET_CHANNEL"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1524
+#: ../src/spacecmd/configchannel.py:1537
 msgid "configchannel_sync:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1525
+#: ../src/spacecmd/configchannel.py:1538
 msgid "sync config files between two config channels"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1527
+#: ../src/spacecmd/configchannel.py:1540
 msgid "usage: configchannel_sync SOURCE_CHANNEL TARGET_CHANNEL"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1565
+#: ../src/spacecmd/configchannel.py:1578
 msgid "syncing files from configchannel "
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1572
+#: ../src/spacecmd/configchannel.py:1585
 msgid "files common in both channels:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1578
+#: ../src/spacecmd/configchannel.py:1591
 msgid "files only in source "
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1584
+#: ../src/spacecmd/configchannel.py:1597
 msgid "files only in target "
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1589
+#: ../src/spacecmd/configchannel.py:1602
 msgid ""
 "files that are in both channels will be overwritten in the target channel"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1591
+#: ../src/spacecmd/configchannel.py:1604
 msgid "files only in the source channel will be added to the target channel"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1593
+#: ../src/spacecmd/configchannel.py:1606
 msgid "files only in the target channel will be deleted"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1596
+#: ../src/spacecmd/configchannel.py:1609
 msgid "nothing to do"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1600
+#: ../src/spacecmd/configchannel.py:1613
 msgid "perform synchronisation [y/N]:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1652
+#: ../src/spacecmd/configchannel.py:1665
 msgid "unknown file type "
 msgstr ""
 

--- a/spacecmd/po/it.po
+++ b/spacecmd/po/it.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-20 12:55+0100\n"
+"POT-Creation-Date: 2020-12-11 09:25+0000\n"
 "PO-Revision-Date: 2020-10-16 10:51+0200\n"
 "Last-Translator: Pascal Arlt <parlt@suse.com>\n"
 "Language-Team: Italian <https://l10n.opensuse.org/projects/uyuni/spacecmd/it/"
@@ -308,7 +308,7 @@ msgid "Software Channels"
 msgstr ""
 
 #: ../src/spacecmd/activationkey.py:960 ../src/spacecmd/configchannel.py:765
-#: ../src/spacecmd/configchannel.py:870 ../src/spacecmd/system.py:3057
+#: ../src/spacecmd/configchannel.py:872 ../src/spacecmd/system.py:3057
 msgid "Configuration Channels"
 msgstr ""
 
@@ -499,7 +499,7 @@ msgstr ""
 msgid "Cloned Key:"
 msgstr ""
 
-#: ../src/spacecmd/activationkey.py:1472 ../src/spacecmd/configchannel.py:1376
+#: ../src/spacecmd/activationkey.py:1472 ../src/spacecmd/configchannel.py:1389
 msgid "Error - must specify either -c or -x options!"
 msgstr ""
 
@@ -535,7 +535,7 @@ msgstr ""
 msgid "does not exist, skipping!"
 msgstr ""
 
-#: ../src/spacecmd/activationkey.py:1584 ../src/spacecmd/configchannel.py:1428
+#: ../src/spacecmd/activationkey.py:1584 ../src/spacecmd/configchannel.py:1441
 #, python-format
 msgid "Failed to clone %s to %s"
 msgstr ""
@@ -783,7 +783,7 @@ msgid "Binary:          %s"
 msgstr ""
 
 #: ../src/spacecmd/configchannel.py:263 ../src/spacecmd/configchannel.py:696
-#: ../src/spacecmd/configchannel.py:933 ../src/spacecmd/kickstart.py:1903
+#: ../src/spacecmd/configchannel.py:946 ../src/spacecmd/kickstart.py:1903
 #: ../src/spacecmd/snippet.py:161
 msgid "Contents"
 msgstr ""
@@ -952,16 +952,16 @@ msgstr ""
 msgid "SELinux Context [%s]:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:575
+#: ../src/spacecmd/configchannel.py:575 ../src/spacecmd/configchannel.py:911
 msgid "Revision [next]:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:593
+#: ../src/spacecmd/configchannel.py:593 ../src/spacecmd/configchannel.py:916
 msgid "The revision must be an integer"
 msgstr ""
 
 #. get the contents of the script
-#: ../src/spacecmd/configchannel.py:596 ../src/spacecmd/configchannel.py:896
+#: ../src/spacecmd/configchannel.py:596 ../src/spacecmd/configchannel.py:898
 #: ../src/spacecmd/cryptokey.py:68 ../src/spacecmd/kickstart.py:1954
 #: ../src/spacecmd/snippet.py:141
 msgid "Read an existing file [y/N]:"
@@ -975,7 +975,7 @@ msgstr ""
 msgid "The path is required"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:630 ../src/spacecmd/configchannel.py:913
+#: ../src/spacecmd/configchannel.py:630 ../src/spacecmd/configchannel.py:922
 msgid "You must provide the file contents"
 msgstr ""
 
@@ -1054,11 +1054,11 @@ msgstr ""
 msgid "Path:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:805 ../src/spacecmd/configchannel.py:924
+#: ../src/spacecmd/configchannel.py:805 ../src/spacecmd/configchannel.py:935
 msgid "No config channel specified!"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:810 ../src/spacecmd/configchannel.py:929
+#: ../src/spacecmd/configchannel.py:810 ../src/spacecmd/configchannel.py:940
 msgid "Error obtaining file info"
 msgstr ""
 
@@ -1072,51 +1072,57 @@ msgid ""
 "\n"
 "options:\n"
 "  -c CHANNEL\n"
+"  -r REVISION\n"
 "  -f local path to file contents\n"
 "  -y automatically proceed with file contents\n"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:892
+#: ../src/spacecmd/configchannel.py:894
 #, python-format
 msgid "No existing file information found for %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:932
+#: ../src/spacecmd/configchannel.py:944
+#, python-format
+msgid "revision:                 %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:945
 #, python-format
 msgid "contents_enc64:           %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:959
+#: ../src/spacecmd/configchannel.py:972
 msgid "configchannel_removefiles: Remove configuration files"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:960
+#: ../src/spacecmd/configchannel.py:973
 msgid "usage: configchannel_removefiles CHANNEL <FILE ...>"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:997
+#: ../src/spacecmd/configchannel.py:1010
 msgid "configchannel_verifyfile: Verify a configuration file"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:998
+#: ../src/spacecmd/configchannel.py:1011
 msgid "usage: configchannel_verifyfile CHANNEL FILE <SYSTEMS>"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1037
+#: ../src/spacecmd/configchannel.py:1050
 msgid "No valid system selected"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1045 ../src/spacecmd/system.py:509
+#: ../src/spacecmd/configchannel.py:1058 ../src/spacecmd/system.py:509
 #: ../src/spacecmd/system.py:529 ../src/spacecmd/system.py:959
 #, python-format
 msgid "Action ID: %i"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1053
+#: ../src/spacecmd/configchannel.py:1066
 msgid "configchannel_export: export config channel(s) to json format file"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1054
+#: ../src/spacecmd/configchannel.py:1067
 msgid ""
 "usage: configchannel_export <CHANNEL>... [options])\n"
 "options:\n"
@@ -1130,116 +1136,116 @@ msgid ""
 msgstr ""
 
 #. Get the cc details
-#: ../src/spacecmd/configchannel.py:1070
+#: ../src/spacecmd/configchannel.py:1083
 #, python-format
 msgid "Getting config channel details for %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1090
+#: ../src/spacecmd/configchannel.py:1103
 #, python-format
 msgid "Failed to get details for file %s from %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1136
+#: ../src/spacecmd/configchannel.py:1149
 #, python-format
 msgid "File %s could not be exported "
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1137
+#: ../src/spacecmd/configchannel.py:1150
 msgid "with this API version(needs base64 encoding)"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1139
+#: ../src/spacecmd/configchannel.py:1152
 #, python-format
 msgid "File %s could not be exported as"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1140
+#: ../src/spacecmd/configchannel.py:1153
 msgid " text...getting base64 encoded version"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1163
+#: ../src/spacecmd/configchannel.py:1176
 #, python-format
 msgid "Passed filename '%s' to do_configchannel_export command."
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1171
+#: ../src/spacecmd/configchannel.py:1184
 #, python-format
 msgid "Exporting ALL config channels to %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1178
+#: ../src/spacecmd/configchannel.py:1191
 msgid ""
 "Error, no valid config channel passed, check name is  correct with spacecmd "
 "configchannel_list"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1193
+#: ../src/spacecmd/configchannel.py:1206
 #, python-format
 msgid "Exporting cc %s to %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1200
+#: ../src/spacecmd/configchannel.py:1213
 msgid "File '{}' exists, confirm overwrite file? (y/n)"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1203
+#: ../src/spacecmd/configchannel.py:1216
 #, python-format
 msgid "Error saving exported config channels to file: %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1212
+#: ../src/spacecmd/configchannel.py:1225
 msgid "configchannel_import: import config channel(s) from json file"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1213
+#: ../src/spacecmd/configchannel.py:1226
 msgid "usage: configchannel_import <JSONFILES...>"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1222 ../src/spacecmd/kickstart.py:2330
+#: ../src/spacecmd/configchannel.py:1235 ../src/spacecmd/kickstart.py:2330
 msgid "Error, no filename passed"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1230 ../src/spacecmd/kickstart.py:2338
+#: ../src/spacecmd/configchannel.py:1243 ../src/spacecmd/kickstart.py:2338
 #, python-format
 msgid "Error, could not read json data from %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1234
+#: ../src/spacecmd/configchannel.py:1247
 #, python-format
 msgid "Error importing configchannel %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1246
+#: ../src/spacecmd/configchannel.py:1259
 #, python-format
 msgid "Config channel %s already exists! Skipping!"
 msgstr ""
 
 #. create the cc, we need to drop the org prefix from the cc name
-#: ../src/spacecmd/configchannel.py:1251
+#: ../src/spacecmd/configchannel.py:1264
 #, python-format
 msgid "Importing config channel  %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1294
+#: ../src/spacecmd/configchannel.py:1307
 #, python-format
 msgid "Failed trying to import file %s (empty content)"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1296
+#: ../src/spacecmd/configchannel.py:1309
 msgid "Older APIs can't export encoded files"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1319
+#: ../src/spacecmd/configchannel.py:1332
 #, python-format
 msgid "Error adding file %s to %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1329
+#: ../src/spacecmd/configchannel.py:1342
 msgid "configchannel_clone: Clone config channel(s)"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1330
+#: ../src/spacecmd/configchannel.py:1343
 msgid ""
 "usage examples:\n"
 "                 configchannel_clone foo_label -c bar_label\n"
@@ -1257,101 +1263,101 @@ msgid ""
 "  Note : If no -c or -x option is specified, interactive is assumed"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1359
+#: ../src/spacecmd/configchannel.py:1372
 msgid "No config channels found"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1362
+#: ../src/spacecmd/configchannel.py:1375
 msgid "Config Channels"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1368
+#: ../src/spacecmd/configchannel.py:1381
 #, python-format
 msgid "Channel to clone: %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1372
+#: ../src/spacecmd/configchannel.py:1385
 msgid "Channel to clone:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1373
+#: ../src/spacecmd/configchannel.py:1386
 msgid "Clone label:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1382
+#: ../src/spacecmd/configchannel.py:1395
 msgid "Error no channel label passed!"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1391
+#: ../src/spacecmd/configchannel.py:1404
 msgid "No suitable channels to clone has been found."
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1444
+#: ../src/spacecmd/configchannel.py:1457
 msgid "no configchannel given"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1447
+#: ../src/spacecmd/configchannel.py:1460
 msgid "invalid configchannel label "
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1473
+#: ../src/spacecmd/configchannel.py:1486
 msgid "configchannel_diff: diff between config channels"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1475
+#: ../src/spacecmd/configchannel.py:1488
 msgid "usage: configchannel_diff SOURCE_CHANNEL TARGET_CHANNEL"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1524
+#: ../src/spacecmd/configchannel.py:1537
 msgid "configchannel_sync:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1525
+#: ../src/spacecmd/configchannel.py:1538
 msgid "sync config files between two config channels"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1527
+#: ../src/spacecmd/configchannel.py:1540
 msgid "usage: configchannel_sync SOURCE_CHANNEL TARGET_CHANNEL"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1565
+#: ../src/spacecmd/configchannel.py:1578
 msgid "syncing files from configchannel "
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1572
+#: ../src/spacecmd/configchannel.py:1585
 msgid "files common in both channels:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1578
+#: ../src/spacecmd/configchannel.py:1591
 msgid "files only in source "
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1584
+#: ../src/spacecmd/configchannel.py:1597
 msgid "files only in target "
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1589
+#: ../src/spacecmd/configchannel.py:1602
 msgid ""
 "files that are in both channels will be overwritten in the target channel"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1591
+#: ../src/spacecmd/configchannel.py:1604
 msgid "files only in the source channel will be added to the target channel"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1593
+#: ../src/spacecmd/configchannel.py:1606
 msgid "files only in the target channel will be deleted"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1596
+#: ../src/spacecmd/configchannel.py:1609
 msgid "nothing to do"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1600
+#: ../src/spacecmd/configchannel.py:1613
 msgid "perform synchronisation [y/N]:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1652
+#: ../src/spacecmd/configchannel.py:1665
 msgid "unknown file type "
 msgstr ""
 

--- a/spacecmd/po/ja.po
+++ b/spacecmd/po/ja.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-20 12:55+0100\n"
+"POT-Creation-Date: 2020-12-11 09:25+0000\n"
 "PO-Revision-Date: 2020-11-21 02:26+0000\n"
 "Last-Translator: Yasuhiko Kamata <belphegor@belbel.or.jp>\n"
 "Language-Team: Japanese <https://l10n.opensuse.org/projects/uyuni/spacecmd/"
@@ -344,7 +344,7 @@ msgid "Software Channels"
 msgstr "ソフトウェアチャンネル"
 
 #: ../src/spacecmd/activationkey.py:960 ../src/spacecmd/configchannel.py:765
-#: ../src/spacecmd/configchannel.py:870 ../src/spacecmd/system.py:3057
+#: ../src/spacecmd/configchannel.py:872 ../src/spacecmd/system.py:3057
 msgid "Configuration Channels"
 msgstr "設定チャンネル"
 
@@ -564,7 +564,7 @@ msgstr "元のキー:"
 msgid "Cloned Key:"
 msgstr "複製されたキー:"
 
-#: ../src/spacecmd/activationkey.py:1472 ../src/spacecmd/configchannel.py:1376
+#: ../src/spacecmd/activationkey.py:1472 ../src/spacecmd/configchannel.py:1389
 msgid "Error - must specify either -c or -x options!"
 msgstr "エラー - オプション -c と -x は同時に指定できません！"
 
@@ -600,7 +600,7 @@ msgstr "設定チャンネル %s (キー %s) %s "
 msgid "does not exist, skipping!"
 msgstr "が存在しません。読み飛ばしています！"
 
-#: ../src/spacecmd/activationkey.py:1584 ../src/spacecmd/configchannel.py:1428
+#: ../src/spacecmd/activationkey.py:1584 ../src/spacecmd/configchannel.py:1441
 #, python-format
 msgid "Failed to clone %s to %s"
 msgstr "%s を %s に複製する処理が失敗しました"
@@ -865,7 +865,7 @@ msgid "Binary:          %s"
 msgstr "バイナリ:          %s"
 
 #: ../src/spacecmd/configchannel.py:263 ../src/spacecmd/configchannel.py:696
-#: ../src/spacecmd/configchannel.py:933 ../src/spacecmd/kickstart.py:1903
+#: ../src/spacecmd/configchannel.py:946 ../src/spacecmd/kickstart.py:1903
 #: ../src/spacecmd/snippet.py:161
 msgid "Contents"
 msgstr "内容"
@@ -1046,16 +1046,16 @@ msgstr "モード [%s]:"
 msgid "SELinux Context [%s]:"
 msgstr "SELinux コンテキスト [%s]:"
 
-#: ../src/spacecmd/configchannel.py:575
+#: ../src/spacecmd/configchannel.py:575 ../src/spacecmd/configchannel.py:911
 msgid "Revision [next]:"
 msgstr "リビジョン [次の値]:"
 
-#: ../src/spacecmd/configchannel.py:593
+#: ../src/spacecmd/configchannel.py:593 ../src/spacecmd/configchannel.py:916
 msgid "The revision must be an integer"
 msgstr "リビジョンは整数でなければなりません"
 
 #. get the contents of the script
-#: ../src/spacecmd/configchannel.py:596 ../src/spacecmd/configchannel.py:896
+#: ../src/spacecmd/configchannel.py:596 ../src/spacecmd/configchannel.py:898
 #: ../src/spacecmd/cryptokey.py:68 ../src/spacecmd/kickstart.py:1954
 #: ../src/spacecmd/snippet.py:141
 msgid "Read an existing file [y/N]:"
@@ -1069,7 +1069,7 @@ msgstr "ファイル:"
 msgid "The path is required"
 msgstr "パスを指定する必要があります"
 
-#: ../src/spacecmd/configchannel.py:630 ../src/spacecmd/configchannel.py:913
+#: ../src/spacecmd/configchannel.py:630 ../src/spacecmd/configchannel.py:922
 msgid "You must provide the file contents"
 msgstr "ファイルの内容を指定しなければなりません"
 
@@ -1174,11 +1174,11 @@ msgstr "正しいチャンネルを取得できませんでした。中止して
 msgid "Path:"
 msgstr "パス:"
 
-#: ../src/spacecmd/configchannel.py:805 ../src/spacecmd/configchannel.py:924
+#: ../src/spacecmd/configchannel.py:805 ../src/spacecmd/configchannel.py:935
 msgid "No config channel specified!"
 msgstr "設定チャンネルを指定していません！"
 
-#: ../src/spacecmd/configchannel.py:810 ../src/spacecmd/configchannel.py:929
+#: ../src/spacecmd/configchannel.py:810 ../src/spacecmd/configchannel.py:940
 msgid "Error obtaining file info"
 msgstr "ファイル情報の取得時にエラー"
 
@@ -1187,11 +1187,13 @@ msgid "configchannel_updateinitsls: Update init.sls file"
 msgstr "configchannel_updateinitsls: init.sls ファイルを更新"
 
 #: ../src/spacecmd/configchannel.py:846
+#, fuzzy
 msgid ""
 "usage: configchannel_updateinitsls -c CHANNEL -f LOCAL_FILE_PATH [OPTIONS])\n"
 "\n"
 "options:\n"
 "  -c CHANNEL\n"
+"  -r REVISION\n"
 "  -f local path to file contents\n"
 "  -y automatically proceed with file contents\n"
 msgstr ""
@@ -1203,48 +1205,53 @@ msgstr ""
 "  -f (ファイルの内容を含むローカルパス)\n"
 "  -y ファイルの内容を自動処理する\n"
 
-#: ../src/spacecmd/configchannel.py:892
+#: ../src/spacecmd/configchannel.py:894
 #, python-format
 msgid "No existing file information found for %s"
 msgstr "%s に対する既存のファイル情報がありません"
 
-#: ../src/spacecmd/configchannel.py:932
+#: ../src/spacecmd/configchannel.py:944
+#, fuzzy, python-format
+msgid "revision:                 %s"
+msgstr "キー:                    %s"
+
+#: ../src/spacecmd/configchannel.py:945
 #, python-format
 msgid "contents_enc64:           %s"
 msgstr "contents_enc64:           %s"
 
-#: ../src/spacecmd/configchannel.py:959
+#: ../src/spacecmd/configchannel.py:972
 msgid "configchannel_removefiles: Remove configuration files"
 msgstr "configchannel_removefiles: 設定ファイルを削除"
 
-#: ../src/spacecmd/configchannel.py:960
+#: ../src/spacecmd/configchannel.py:973
 msgid "usage: configchannel_removefiles CHANNEL <FILE ...>"
 msgstr "使用方法: configchannel_removefiles チャンネル <ファイル ...>"
 
-#: ../src/spacecmd/configchannel.py:997
+#: ../src/spacecmd/configchannel.py:1010
 msgid "configchannel_verifyfile: Verify a configuration file"
 msgstr "configchannel_verifyfile: 設定ファイルを検証"
 
-#: ../src/spacecmd/configchannel.py:998
+#: ../src/spacecmd/configchannel.py:1011
 msgid "usage: configchannel_verifyfile CHANNEL FILE <SYSTEMS>"
 msgstr "使用方法: configchannel_verifyfile チャンネル ファイル <システム>"
 
-#: ../src/spacecmd/configchannel.py:1037
+#: ../src/spacecmd/configchannel.py:1050
 msgid "No valid system selected"
 msgstr "正しいシステムを選択していません"
 
-#: ../src/spacecmd/configchannel.py:1045 ../src/spacecmd/system.py:509
+#: ../src/spacecmd/configchannel.py:1058 ../src/spacecmd/system.py:509
 #: ../src/spacecmd/system.py:529 ../src/spacecmd/system.py:959
 #, python-format
 msgid "Action ID: %i"
 msgstr "アクション ID: %i"
 
-#: ../src/spacecmd/configchannel.py:1053
+#: ../src/spacecmd/configchannel.py:1066
 msgid "configchannel_export: export config channel(s) to json format file"
 msgstr ""
 "configchannel_export: 設定チャンネルを JSON 形式のファイルにエクスポートする"
 
-#: ../src/spacecmd/configchannel.py:1054
+#: ../src/spacecmd/configchannel.py:1067
 msgid ""
 "usage: configchannel_export <CHANNEL>... [options])\n"
 "options:\n"
@@ -1268,45 +1275,45 @@ msgstr ""
 "注意 : <チャンネル> を指定しない場合、全てのチャンネルをエクスポートします"
 
 #. Get the cc details
-#: ../src/spacecmd/configchannel.py:1070
+#: ../src/spacecmd/configchannel.py:1083
 #, python-format
 msgid "Getting config channel details for %s"
 msgstr "%s に対する設定チャンネルの詳細を取得しています"
 
-#: ../src/spacecmd/configchannel.py:1090
+#: ../src/spacecmd/configchannel.py:1103
 #, python-format
 msgid "Failed to get details for file %s from %s"
 msgstr "ファイル %s に対する詳細情報を %s から取得する処理に失敗しました"
 
-#: ../src/spacecmd/configchannel.py:1136
+#: ../src/spacecmd/configchannel.py:1149
 #, python-format
 msgid "File %s could not be exported "
 msgstr "ファイル %s をエクスポートできませんでした "
 
-#: ../src/spacecmd/configchannel.py:1137
+#: ../src/spacecmd/configchannel.py:1150
 msgid "with this API version(needs base64 encoding)"
 msgstr "(この API バージョンを利用した場合、 base64 エンコーディングが必要)"
 
-#: ../src/spacecmd/configchannel.py:1139
+#: ../src/spacecmd/configchannel.py:1152
 #, python-format
 msgid "File %s could not be exported as"
 msgstr "ファイル %s をエクスポートできませんでした"
 
-#: ../src/spacecmd/configchannel.py:1140
+#: ../src/spacecmd/configchannel.py:1153
 msgid " text...getting base64 encoded version"
 msgstr " (テキスト形式で取得できませんでした。 base64 で取得し直しています)"
 
-#: ../src/spacecmd/configchannel.py:1163
+#: ../src/spacecmd/configchannel.py:1176
 #, python-format
 msgid "Passed filename '%s' to do_configchannel_export command."
 msgstr "do_configchannel_export コマンドにファイル名 '%s' を指定しています。"
 
-#: ../src/spacecmd/configchannel.py:1171
+#: ../src/spacecmd/configchannel.py:1184
 #, python-format
 msgid "Exporting ALL config channels to %s"
 msgstr "全ての設定チャンネルを %s にエクスポートしています"
 
-#: ../src/spacecmd/configchannel.py:1178
+#: ../src/spacecmd/configchannel.py:1191
 msgid ""
 "Error, no valid config channel passed, check name is  correct with spacecmd "
 "configchannel_list"
@@ -1314,72 +1321,72 @@ msgstr ""
 "エラーです。正しい設定チャンネルを指定していないものと思われます。 spacecmd "
 "configchannel_list で名前の一覧をご確認ください"
 
-#: ../src/spacecmd/configchannel.py:1193
+#: ../src/spacecmd/configchannel.py:1206
 #, python-format
 msgid "Exporting cc %s to %s"
 msgstr "cc %s を %s にエクスポートしています"
 
-#: ../src/spacecmd/configchannel.py:1200
+#: ../src/spacecmd/configchannel.py:1213
 msgid "File '{}' exists, confirm overwrite file? (y/n)"
 msgstr "ファイル '{}' は既に存在しています。ファイルを上書きしますか？ (y/n)"
 
-#: ../src/spacecmd/configchannel.py:1203
+#: ../src/spacecmd/configchannel.py:1216
 #, python-format
 msgid "Error saving exported config channels to file: %s"
 msgstr "設定チャンネルをファイルに保存する際にエラーが発生しました: %s"
 
-#: ../src/spacecmd/configchannel.py:1212
+#: ../src/spacecmd/configchannel.py:1225
 msgid "configchannel_import: import config channel(s) from json file"
 msgstr "configchannel_import: JSON ファイルから設定チャンネルをインポートする"
 
-#: ../src/spacecmd/configchannel.py:1213
+#: ../src/spacecmd/configchannel.py:1226
 msgid "usage: configchannel_import <JSONFILES...>"
 msgstr "使用方法: configchannel_import <JSONファイル...>"
 
-#: ../src/spacecmd/configchannel.py:1222 ../src/spacecmd/kickstart.py:2330
+#: ../src/spacecmd/configchannel.py:1235 ../src/spacecmd/kickstart.py:2330
 msgid "Error, no filename passed"
 msgstr "エラーです、ファイル名を指定していません"
 
-#: ../src/spacecmd/configchannel.py:1230 ../src/spacecmd/kickstart.py:2338
+#: ../src/spacecmd/configchannel.py:1243 ../src/spacecmd/kickstart.py:2338
 #, python-format
 msgid "Error, could not read json data from %s"
 msgstr "エラーです、 JSON データを %s から読み込めませんでした"
 
-#: ../src/spacecmd/configchannel.py:1234
+#: ../src/spacecmd/configchannel.py:1247
 #, python-format
 msgid "Error importing configchannel %s"
 msgstr "設定チャンネル %s をインポートする際にエラーが発生しました"
 
-#: ../src/spacecmd/configchannel.py:1246
+#: ../src/spacecmd/configchannel.py:1259
 #, python-format
 msgid "Config channel %s already exists! Skipping!"
 msgstr "設定チャンネル %s は既に存在しています。読み飛ばします！"
 
 #. create the cc, we need to drop the org prefix from the cc name
-#: ../src/spacecmd/configchannel.py:1251
+#: ../src/spacecmd/configchannel.py:1264
 #, python-format
 msgid "Importing config channel  %s"
 msgstr "設定チャンネル %s をインポートしています"
 
-#: ../src/spacecmd/configchannel.py:1294
+#: ../src/spacecmd/configchannel.py:1307
 #, python-format
 msgid "Failed trying to import file %s (empty content)"
 msgstr "ファイル %s をインポートする処理に失敗しました (内容がありません)"
 
-#: ../src/spacecmd/configchannel.py:1296
+#: ../src/spacecmd/configchannel.py:1309
 msgid "Older APIs can't export encoded files"
 msgstr "古い API ではエンコードされたファイルをエクスポートできません"
 
-#: ../src/spacecmd/configchannel.py:1319
+#: ../src/spacecmd/configchannel.py:1332
 #, python-format
 msgid "Error adding file %s to %s"
 msgstr "ファイル %s を %s に追加する際にエラー"
 
-#: ../src/spacecmd/configchannel.py:1329
+#: ../src/spacecmd/configchannel.py:1342
 msgid "configchannel_clone: Clone config channel(s)"
 msgstr "configchannel_clone: 設定チャンネルを複製"
 
-#: ../src/spacecmd/configchannel.py:1330
+#: ../src/spacecmd/configchannel.py:1343
 msgid ""
 "usage examples:\n"
 "                 configchannel_clone foo_label -c bar_label\n"
@@ -1410,105 +1417,105 @@ msgstr ""
 "                   (\"foo\" を \"bar\" に置き換える)\n"
 "  注意 : -c や -x オプションを指定しない場合、対話的に操作を行ないます"
 
-#: ../src/spacecmd/configchannel.py:1359
+#: ../src/spacecmd/configchannel.py:1372
 msgid "No config channels found"
 msgstr "設定チャンネルが見つかりませんでした"
 
-#: ../src/spacecmd/configchannel.py:1362
+#: ../src/spacecmd/configchannel.py:1375
 msgid "Config Channels"
 msgstr "設定チャンネル"
 
-#: ../src/spacecmd/configchannel.py:1368
+#: ../src/spacecmd/configchannel.py:1381
 #, python-format
 msgid "Channel to clone: %s"
 msgstr "複製するチャンネル: %s"
 
-#: ../src/spacecmd/configchannel.py:1372
+#: ../src/spacecmd/configchannel.py:1385
 msgid "Channel to clone:"
 msgstr "複製するチャンネル:"
 
-#: ../src/spacecmd/configchannel.py:1373
+#: ../src/spacecmd/configchannel.py:1386
 msgid "Clone label:"
 msgstr "複製するラベル:"
 
-#: ../src/spacecmd/configchannel.py:1382
+#: ../src/spacecmd/configchannel.py:1395
 msgid "Error no channel label passed!"
 msgstr "チャンネルラベルを指定していません！"
 
-#: ../src/spacecmd/configchannel.py:1391
+#: ../src/spacecmd/configchannel.py:1404
 msgid "No suitable channels to clone has been found."
 msgstr "複製すべきチャンネルが見つかりませんでした。"
 
-#: ../src/spacecmd/configchannel.py:1444
+#: ../src/spacecmd/configchannel.py:1457
 msgid "no configchannel given"
 msgstr "設定チャンネルを指定していません"
 
-#: ../src/spacecmd/configchannel.py:1447
+#: ../src/spacecmd/configchannel.py:1460
 msgid "invalid configchannel label "
 msgstr "設定チャンネルのラベルが正しくありません "
 
-#: ../src/spacecmd/configchannel.py:1473
+#: ../src/spacecmd/configchannel.py:1486
 msgid "configchannel_diff: diff between config channels"
 msgstr "configchannel_diff: 設定チャンネル間の差分表示"
 
-#: ../src/spacecmd/configchannel.py:1475
+#: ../src/spacecmd/configchannel.py:1488
 msgid "usage: configchannel_diff SOURCE_CHANNEL TARGET_CHANNEL"
 msgstr "使用方法: configchannel_diff チャンネル_1 チャンネル_2"
 
-#: ../src/spacecmd/configchannel.py:1524
+#: ../src/spacecmd/configchannel.py:1537
 msgid "configchannel_sync:"
 msgstr "configchannel_sync:"
 
-#: ../src/spacecmd/configchannel.py:1525
+#: ../src/spacecmd/configchannel.py:1538
 msgid "sync config files between two config channels"
 msgstr "2 つの設定チャンネル間で設定ファイルを同期"
 
-#: ../src/spacecmd/configchannel.py:1527
+#: ../src/spacecmd/configchannel.py:1540
 msgid "usage: configchannel_sync SOURCE_CHANNEL TARGET_CHANNEL"
 msgstr "使用方法: configchannel_sync 同期元チャンネル 同期先チャンネル"
 
-#: ../src/spacecmd/configchannel.py:1565
+#: ../src/spacecmd/configchannel.py:1578
 msgid "syncing files from configchannel "
 msgstr "設定チャンネルからファイルを同期しています "
 
-#: ../src/spacecmd/configchannel.py:1572
+#: ../src/spacecmd/configchannel.py:1585
 msgid "files common in both channels:"
 msgstr "両方のチャンネルでの共通ファイル:"
 
-#: ../src/spacecmd/configchannel.py:1578
+#: ../src/spacecmd/configchannel.py:1591
 msgid "files only in source "
 msgstr "同期元にしかないファイル "
 
-#: ../src/spacecmd/configchannel.py:1584
+#: ../src/spacecmd/configchannel.py:1597
 msgid "files only in target "
 msgstr "同期先にしかないファイル "
 
-#: ../src/spacecmd/configchannel.py:1589
+#: ../src/spacecmd/configchannel.py:1602
 msgid ""
 "files that are in both channels will be overwritten in the target channel"
 msgstr ""
 "両方のチャンネルに存在するファイルについては、同期先のファイルが上書きされま"
 "す"
 
-#: ../src/spacecmd/configchannel.py:1591
+#: ../src/spacecmd/configchannel.py:1604
 msgid "files only in the source channel will be added to the target channel"
 msgstr ""
 "同期元のチャンネルにしかないファイルについては、同期先のチャンネルに追加され"
 "ます"
 
-#: ../src/spacecmd/configchannel.py:1593
+#: ../src/spacecmd/configchannel.py:1606
 msgid "files only in the target channel will be deleted"
 msgstr "同期先のチャンネルにしかないファイルは削除されます"
 
-#: ../src/spacecmd/configchannel.py:1596
+#: ../src/spacecmd/configchannel.py:1609
 msgid "nothing to do"
 msgstr "何も行なう必要がありません"
 
-#: ../src/spacecmd/configchannel.py:1600
+#: ../src/spacecmd/configchannel.py:1613
 msgid "perform synchronisation [y/N]:"
 msgstr "同期を実行しますか [y/N]:"
 
-#: ../src/spacecmd/configchannel.py:1652
+#: ../src/spacecmd/configchannel.py:1665
 msgid "unknown file type "
 msgstr "不明なファイルタイプです "
 

--- a/spacecmd/po/pt.po
+++ b/spacecmd/po/pt.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-20 12:55+0100\n"
+"POT-Creation-Date: 2020-12-11 09:25+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -306,7 +306,7 @@ msgid "Software Channels"
 msgstr ""
 
 #: ../src/spacecmd/activationkey.py:960 ../src/spacecmd/configchannel.py:765
-#: ../src/spacecmd/configchannel.py:870 ../src/spacecmd/system.py:3057
+#: ../src/spacecmd/configchannel.py:872 ../src/spacecmd/system.py:3057
 msgid "Configuration Channels"
 msgstr ""
 
@@ -497,7 +497,7 @@ msgstr ""
 msgid "Cloned Key:"
 msgstr ""
 
-#: ../src/spacecmd/activationkey.py:1472 ../src/spacecmd/configchannel.py:1376
+#: ../src/spacecmd/activationkey.py:1472 ../src/spacecmd/configchannel.py:1389
 msgid "Error - must specify either -c or -x options!"
 msgstr ""
 
@@ -533,7 +533,7 @@ msgstr ""
 msgid "does not exist, skipping!"
 msgstr ""
 
-#: ../src/spacecmd/activationkey.py:1584 ../src/spacecmd/configchannel.py:1428
+#: ../src/spacecmd/activationkey.py:1584 ../src/spacecmd/configchannel.py:1441
 #, python-format
 msgid "Failed to clone %s to %s"
 msgstr ""
@@ -781,7 +781,7 @@ msgid "Binary:          %s"
 msgstr ""
 
 #: ../src/spacecmd/configchannel.py:263 ../src/spacecmd/configchannel.py:696
-#: ../src/spacecmd/configchannel.py:933 ../src/spacecmd/kickstart.py:1903
+#: ../src/spacecmd/configchannel.py:946 ../src/spacecmd/kickstart.py:1903
 #: ../src/spacecmd/snippet.py:161
 msgid "Contents"
 msgstr ""
@@ -950,16 +950,16 @@ msgstr ""
 msgid "SELinux Context [%s]:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:575
+#: ../src/spacecmd/configchannel.py:575 ../src/spacecmd/configchannel.py:911
 msgid "Revision [next]:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:593
+#: ../src/spacecmd/configchannel.py:593 ../src/spacecmd/configchannel.py:916
 msgid "The revision must be an integer"
 msgstr ""
 
 #. get the contents of the script
-#: ../src/spacecmd/configchannel.py:596 ../src/spacecmd/configchannel.py:896
+#: ../src/spacecmd/configchannel.py:596 ../src/spacecmd/configchannel.py:898
 #: ../src/spacecmd/cryptokey.py:68 ../src/spacecmd/kickstart.py:1954
 #: ../src/spacecmd/snippet.py:141
 msgid "Read an existing file [y/N]:"
@@ -973,7 +973,7 @@ msgstr ""
 msgid "The path is required"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:630 ../src/spacecmd/configchannel.py:913
+#: ../src/spacecmd/configchannel.py:630 ../src/spacecmd/configchannel.py:922
 msgid "You must provide the file contents"
 msgstr ""
 
@@ -1052,11 +1052,11 @@ msgstr ""
 msgid "Path:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:805 ../src/spacecmd/configchannel.py:924
+#: ../src/spacecmd/configchannel.py:805 ../src/spacecmd/configchannel.py:935
 msgid "No config channel specified!"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:810 ../src/spacecmd/configchannel.py:929
+#: ../src/spacecmd/configchannel.py:810 ../src/spacecmd/configchannel.py:940
 msgid "Error obtaining file info"
 msgstr ""
 
@@ -1070,51 +1070,57 @@ msgid ""
 "\n"
 "options:\n"
 "  -c CHANNEL\n"
+"  -r REVISION\n"
 "  -f local path to file contents\n"
 "  -y automatically proceed with file contents\n"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:892
+#: ../src/spacecmd/configchannel.py:894
 #, python-format
 msgid "No existing file information found for %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:932
+#: ../src/spacecmd/configchannel.py:944
+#, python-format
+msgid "revision:                 %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:945
 #, python-format
 msgid "contents_enc64:           %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:959
+#: ../src/spacecmd/configchannel.py:972
 msgid "configchannel_removefiles: Remove configuration files"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:960
+#: ../src/spacecmd/configchannel.py:973
 msgid "usage: configchannel_removefiles CHANNEL <FILE ...>"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:997
+#: ../src/spacecmd/configchannel.py:1010
 msgid "configchannel_verifyfile: Verify a configuration file"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:998
+#: ../src/spacecmd/configchannel.py:1011
 msgid "usage: configchannel_verifyfile CHANNEL FILE <SYSTEMS>"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1037
+#: ../src/spacecmd/configchannel.py:1050
 msgid "No valid system selected"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1045 ../src/spacecmd/system.py:509
+#: ../src/spacecmd/configchannel.py:1058 ../src/spacecmd/system.py:509
 #: ../src/spacecmd/system.py:529 ../src/spacecmd/system.py:959
 #, python-format
 msgid "Action ID: %i"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1053
+#: ../src/spacecmd/configchannel.py:1066
 msgid "configchannel_export: export config channel(s) to json format file"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1054
+#: ../src/spacecmd/configchannel.py:1067
 msgid ""
 "usage: configchannel_export <CHANNEL>... [options])\n"
 "options:\n"
@@ -1128,116 +1134,116 @@ msgid ""
 msgstr ""
 
 #. Get the cc details
-#: ../src/spacecmd/configchannel.py:1070
+#: ../src/spacecmd/configchannel.py:1083
 #, python-format
 msgid "Getting config channel details for %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1090
+#: ../src/spacecmd/configchannel.py:1103
 #, python-format
 msgid "Failed to get details for file %s from %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1136
+#: ../src/spacecmd/configchannel.py:1149
 #, python-format
 msgid "File %s could not be exported "
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1137
+#: ../src/spacecmd/configchannel.py:1150
 msgid "with this API version(needs base64 encoding)"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1139
+#: ../src/spacecmd/configchannel.py:1152
 #, python-format
 msgid "File %s could not be exported as"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1140
+#: ../src/spacecmd/configchannel.py:1153
 msgid " text...getting base64 encoded version"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1163
+#: ../src/spacecmd/configchannel.py:1176
 #, python-format
 msgid "Passed filename '%s' to do_configchannel_export command."
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1171
+#: ../src/spacecmd/configchannel.py:1184
 #, python-format
 msgid "Exporting ALL config channels to %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1178
+#: ../src/spacecmd/configchannel.py:1191
 msgid ""
 "Error, no valid config channel passed, check name is  correct with spacecmd "
 "configchannel_list"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1193
+#: ../src/spacecmd/configchannel.py:1206
 #, python-format
 msgid "Exporting cc %s to %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1200
+#: ../src/spacecmd/configchannel.py:1213
 msgid "File '{}' exists, confirm overwrite file? (y/n)"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1203
+#: ../src/spacecmd/configchannel.py:1216
 #, python-format
 msgid "Error saving exported config channels to file: %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1212
+#: ../src/spacecmd/configchannel.py:1225
 msgid "configchannel_import: import config channel(s) from json file"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1213
+#: ../src/spacecmd/configchannel.py:1226
 msgid "usage: configchannel_import <JSONFILES...>"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1222 ../src/spacecmd/kickstart.py:2330
+#: ../src/spacecmd/configchannel.py:1235 ../src/spacecmd/kickstart.py:2330
 msgid "Error, no filename passed"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1230 ../src/spacecmd/kickstart.py:2338
+#: ../src/spacecmd/configchannel.py:1243 ../src/spacecmd/kickstart.py:2338
 #, python-format
 msgid "Error, could not read json data from %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1234
+#: ../src/spacecmd/configchannel.py:1247
 #, python-format
 msgid "Error importing configchannel %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1246
+#: ../src/spacecmd/configchannel.py:1259
 #, python-format
 msgid "Config channel %s already exists! Skipping!"
 msgstr ""
 
 #. create the cc, we need to drop the org prefix from the cc name
-#: ../src/spacecmd/configchannel.py:1251
+#: ../src/spacecmd/configchannel.py:1264
 #, python-format
 msgid "Importing config channel  %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1294
+#: ../src/spacecmd/configchannel.py:1307
 #, python-format
 msgid "Failed trying to import file %s (empty content)"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1296
+#: ../src/spacecmd/configchannel.py:1309
 msgid "Older APIs can't export encoded files"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1319
+#: ../src/spacecmd/configchannel.py:1332
 #, python-format
 msgid "Error adding file %s to %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1329
+#: ../src/spacecmd/configchannel.py:1342
 msgid "configchannel_clone: Clone config channel(s)"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1330
+#: ../src/spacecmd/configchannel.py:1343
 msgid ""
 "usage examples:\n"
 "                 configchannel_clone foo_label -c bar_label\n"
@@ -1255,101 +1261,101 @@ msgid ""
 "  Note : If no -c or -x option is specified, interactive is assumed"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1359
+#: ../src/spacecmd/configchannel.py:1372
 msgid "No config channels found"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1362
+#: ../src/spacecmd/configchannel.py:1375
 msgid "Config Channels"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1368
+#: ../src/spacecmd/configchannel.py:1381
 #, python-format
 msgid "Channel to clone: %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1372
+#: ../src/spacecmd/configchannel.py:1385
 msgid "Channel to clone:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1373
+#: ../src/spacecmd/configchannel.py:1386
 msgid "Clone label:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1382
+#: ../src/spacecmd/configchannel.py:1395
 msgid "Error no channel label passed!"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1391
+#: ../src/spacecmd/configchannel.py:1404
 msgid "No suitable channels to clone has been found."
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1444
+#: ../src/spacecmd/configchannel.py:1457
 msgid "no configchannel given"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1447
+#: ../src/spacecmd/configchannel.py:1460
 msgid "invalid configchannel label "
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1473
+#: ../src/spacecmd/configchannel.py:1486
 msgid "configchannel_diff: diff between config channels"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1475
+#: ../src/spacecmd/configchannel.py:1488
 msgid "usage: configchannel_diff SOURCE_CHANNEL TARGET_CHANNEL"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1524
+#: ../src/spacecmd/configchannel.py:1537
 msgid "configchannel_sync:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1525
+#: ../src/spacecmd/configchannel.py:1538
 msgid "sync config files between two config channels"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1527
+#: ../src/spacecmd/configchannel.py:1540
 msgid "usage: configchannel_sync SOURCE_CHANNEL TARGET_CHANNEL"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1565
+#: ../src/spacecmd/configchannel.py:1578
 msgid "syncing files from configchannel "
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1572
+#: ../src/spacecmd/configchannel.py:1585
 msgid "files common in both channels:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1578
+#: ../src/spacecmd/configchannel.py:1591
 msgid "files only in source "
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1584
+#: ../src/spacecmd/configchannel.py:1597
 msgid "files only in target "
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1589
+#: ../src/spacecmd/configchannel.py:1602
 msgid ""
 "files that are in both channels will be overwritten in the target channel"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1591
+#: ../src/spacecmd/configchannel.py:1604
 msgid "files only in the source channel will be added to the target channel"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1593
+#: ../src/spacecmd/configchannel.py:1606
 msgid "files only in the target channel will be deleted"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1596
+#: ../src/spacecmd/configchannel.py:1609
 msgid "nothing to do"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1600
+#: ../src/spacecmd/configchannel.py:1613
 msgid "perform synchronisation [y/N]:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1652
+#: ../src/spacecmd/configchannel.py:1665
 msgid "unknown file type "
 msgstr ""
 

--- a/spacecmd/po/pt_BR.po
+++ b/spacecmd/po/pt_BR.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-20 12:55+0100\n"
+"POT-Creation-Date: 2020-12-11 09:25+0000\n"
 "PO-Revision-Date: 2020-11-22 17:26+0000\n"
 "Last-Translator: Rodrigo Macedo <rmsolucoeseminformatic4@gmail.com>\n"
 "Language-Team: Portuguese (Brazil) <https://l10n.opensuse.org/projects/uyuni/"
@@ -309,7 +309,7 @@ msgid "Software Channels"
 msgstr ""
 
 #: ../src/spacecmd/activationkey.py:960 ../src/spacecmd/configchannel.py:765
-#: ../src/spacecmd/configchannel.py:870 ../src/spacecmd/system.py:3057
+#: ../src/spacecmd/configchannel.py:872 ../src/spacecmd/system.py:3057
 msgid "Configuration Channels"
 msgstr "Canais de Configuração"
 
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Cloned Key:"
 msgstr ""
 
-#: ../src/spacecmd/activationkey.py:1472 ../src/spacecmd/configchannel.py:1376
+#: ../src/spacecmd/activationkey.py:1472 ../src/spacecmd/configchannel.py:1389
 msgid "Error - must specify either -c or -x options!"
 msgstr ""
 
@@ -536,7 +536,7 @@ msgstr ""
 msgid "does not exist, skipping!"
 msgstr ""
 
-#: ../src/spacecmd/activationkey.py:1584 ../src/spacecmd/configchannel.py:1428
+#: ../src/spacecmd/activationkey.py:1584 ../src/spacecmd/configchannel.py:1441
 #, python-format
 msgid "Failed to clone %s to %s"
 msgstr ""
@@ -784,7 +784,7 @@ msgid "Binary:          %s"
 msgstr ""
 
 #: ../src/spacecmd/configchannel.py:263 ../src/spacecmd/configchannel.py:696
-#: ../src/spacecmd/configchannel.py:933 ../src/spacecmd/kickstart.py:1903
+#: ../src/spacecmd/configchannel.py:946 ../src/spacecmd/kickstart.py:1903
 #: ../src/spacecmd/snippet.py:161
 msgid "Contents"
 msgstr ""
@@ -953,16 +953,16 @@ msgstr ""
 msgid "SELinux Context [%s]:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:575
+#: ../src/spacecmd/configchannel.py:575 ../src/spacecmd/configchannel.py:911
 msgid "Revision [next]:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:593
+#: ../src/spacecmd/configchannel.py:593 ../src/spacecmd/configchannel.py:916
 msgid "The revision must be an integer"
 msgstr ""
 
 #. get the contents of the script
-#: ../src/spacecmd/configchannel.py:596 ../src/spacecmd/configchannel.py:896
+#: ../src/spacecmd/configchannel.py:596 ../src/spacecmd/configchannel.py:898
 #: ../src/spacecmd/cryptokey.py:68 ../src/spacecmd/kickstart.py:1954
 #: ../src/spacecmd/snippet.py:141
 msgid "Read an existing file [y/N]:"
@@ -976,7 +976,7 @@ msgstr ""
 msgid "The path is required"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:630 ../src/spacecmd/configchannel.py:913
+#: ../src/spacecmd/configchannel.py:630 ../src/spacecmd/configchannel.py:922
 msgid "You must provide the file contents"
 msgstr ""
 
@@ -1055,11 +1055,11 @@ msgstr ""
 msgid "Path:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:805 ../src/spacecmd/configchannel.py:924
+#: ../src/spacecmd/configchannel.py:805 ../src/spacecmd/configchannel.py:935
 msgid "No config channel specified!"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:810 ../src/spacecmd/configchannel.py:929
+#: ../src/spacecmd/configchannel.py:810 ../src/spacecmd/configchannel.py:940
 msgid "Error obtaining file info"
 msgstr ""
 
@@ -1073,51 +1073,57 @@ msgid ""
 "\n"
 "options:\n"
 "  -c CHANNEL\n"
+"  -r REVISION\n"
 "  -f local path to file contents\n"
 "  -y automatically proceed with file contents\n"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:892
+#: ../src/spacecmd/configchannel.py:894
 #, python-format
 msgid "No existing file information found for %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:932
+#: ../src/spacecmd/configchannel.py:944
+#, python-format
+msgid "revision:                 %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:945
 #, python-format
 msgid "contents_enc64:           %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:959
+#: ../src/spacecmd/configchannel.py:972
 msgid "configchannel_removefiles: Remove configuration files"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:960
+#: ../src/spacecmd/configchannel.py:973
 msgid "usage: configchannel_removefiles CHANNEL <FILE ...>"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:997
+#: ../src/spacecmd/configchannel.py:1010
 msgid "configchannel_verifyfile: Verify a configuration file"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:998
+#: ../src/spacecmd/configchannel.py:1011
 msgid "usage: configchannel_verifyfile CHANNEL FILE <SYSTEMS>"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1037
+#: ../src/spacecmd/configchannel.py:1050
 msgid "No valid system selected"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1045 ../src/spacecmd/system.py:509
+#: ../src/spacecmd/configchannel.py:1058 ../src/spacecmd/system.py:509
 #: ../src/spacecmd/system.py:529 ../src/spacecmd/system.py:959
 #, python-format
 msgid "Action ID: %i"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1053
+#: ../src/spacecmd/configchannel.py:1066
 msgid "configchannel_export: export config channel(s) to json format file"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1054
+#: ../src/spacecmd/configchannel.py:1067
 msgid ""
 "usage: configchannel_export <CHANNEL>... [options])\n"
 "options:\n"
@@ -1131,116 +1137,116 @@ msgid ""
 msgstr ""
 
 #. Get the cc details
-#: ../src/spacecmd/configchannel.py:1070
+#: ../src/spacecmd/configchannel.py:1083
 #, python-format
 msgid "Getting config channel details for %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1090
+#: ../src/spacecmd/configchannel.py:1103
 #, python-format
 msgid "Failed to get details for file %s from %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1136
+#: ../src/spacecmd/configchannel.py:1149
 #, python-format
 msgid "File %s could not be exported "
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1137
+#: ../src/spacecmd/configchannel.py:1150
 msgid "with this API version(needs base64 encoding)"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1139
+#: ../src/spacecmd/configchannel.py:1152
 #, python-format
 msgid "File %s could not be exported as"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1140
+#: ../src/spacecmd/configchannel.py:1153
 msgid " text...getting base64 encoded version"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1163
+#: ../src/spacecmd/configchannel.py:1176
 #, python-format
 msgid "Passed filename '%s' to do_configchannel_export command."
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1171
+#: ../src/spacecmd/configchannel.py:1184
 #, python-format
 msgid "Exporting ALL config channels to %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1178
+#: ../src/spacecmd/configchannel.py:1191
 msgid ""
 "Error, no valid config channel passed, check name is  correct with spacecmd "
 "configchannel_list"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1193
+#: ../src/spacecmd/configchannel.py:1206
 #, python-format
 msgid "Exporting cc %s to %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1200
+#: ../src/spacecmd/configchannel.py:1213
 msgid "File '{}' exists, confirm overwrite file? (y/n)"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1203
+#: ../src/spacecmd/configchannel.py:1216
 #, python-format
 msgid "Error saving exported config channels to file: %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1212
+#: ../src/spacecmd/configchannel.py:1225
 msgid "configchannel_import: import config channel(s) from json file"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1213
+#: ../src/spacecmd/configchannel.py:1226
 msgid "usage: configchannel_import <JSONFILES...>"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1222 ../src/spacecmd/kickstart.py:2330
+#: ../src/spacecmd/configchannel.py:1235 ../src/spacecmd/kickstart.py:2330
 msgid "Error, no filename passed"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1230 ../src/spacecmd/kickstart.py:2338
+#: ../src/spacecmd/configchannel.py:1243 ../src/spacecmd/kickstart.py:2338
 #, python-format
 msgid "Error, could not read json data from %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1234
+#: ../src/spacecmd/configchannel.py:1247
 #, python-format
 msgid "Error importing configchannel %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1246
+#: ../src/spacecmd/configchannel.py:1259
 #, python-format
 msgid "Config channel %s already exists! Skipping!"
 msgstr ""
 
 #. create the cc, we need to drop the org prefix from the cc name
-#: ../src/spacecmd/configchannel.py:1251
+#: ../src/spacecmd/configchannel.py:1264
 #, python-format
 msgid "Importing config channel  %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1294
+#: ../src/spacecmd/configchannel.py:1307
 #, python-format
 msgid "Failed trying to import file %s (empty content)"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1296
+#: ../src/spacecmd/configchannel.py:1309
 msgid "Older APIs can't export encoded files"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1319
+#: ../src/spacecmd/configchannel.py:1332
 #, python-format
 msgid "Error adding file %s to %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1329
+#: ../src/spacecmd/configchannel.py:1342
 msgid "configchannel_clone: Clone config channel(s)"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1330
+#: ../src/spacecmd/configchannel.py:1343
 msgid ""
 "usage examples:\n"
 "                 configchannel_clone foo_label -c bar_label\n"
@@ -1258,101 +1264,101 @@ msgid ""
 "  Note : If no -c or -x option is specified, interactive is assumed"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1359
+#: ../src/spacecmd/configchannel.py:1372
 msgid "No config channels found"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1362
+#: ../src/spacecmd/configchannel.py:1375
 msgid "Config Channels"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1368
+#: ../src/spacecmd/configchannel.py:1381
 #, python-format
 msgid "Channel to clone: %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1372
+#: ../src/spacecmd/configchannel.py:1385
 msgid "Channel to clone:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1373
+#: ../src/spacecmd/configchannel.py:1386
 msgid "Clone label:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1382
+#: ../src/spacecmd/configchannel.py:1395
 msgid "Error no channel label passed!"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1391
+#: ../src/spacecmd/configchannel.py:1404
 msgid "No suitable channels to clone has been found."
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1444
+#: ../src/spacecmd/configchannel.py:1457
 msgid "no configchannel given"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1447
+#: ../src/spacecmd/configchannel.py:1460
 msgid "invalid configchannel label "
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1473
+#: ../src/spacecmd/configchannel.py:1486
 msgid "configchannel_diff: diff between config channels"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1475
+#: ../src/spacecmd/configchannel.py:1488
 msgid "usage: configchannel_diff SOURCE_CHANNEL TARGET_CHANNEL"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1524
+#: ../src/spacecmd/configchannel.py:1537
 msgid "configchannel_sync:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1525
+#: ../src/spacecmd/configchannel.py:1538
 msgid "sync config files between two config channels"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1527
+#: ../src/spacecmd/configchannel.py:1540
 msgid "usage: configchannel_sync SOURCE_CHANNEL TARGET_CHANNEL"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1565
+#: ../src/spacecmd/configchannel.py:1578
 msgid "syncing files from configchannel "
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1572
+#: ../src/spacecmd/configchannel.py:1585
 msgid "files common in both channels:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1578
+#: ../src/spacecmd/configchannel.py:1591
 msgid "files only in source "
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1584
+#: ../src/spacecmd/configchannel.py:1597
 msgid "files only in target "
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1589
+#: ../src/spacecmd/configchannel.py:1602
 msgid ""
 "files that are in both channels will be overwritten in the target channel"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1591
+#: ../src/spacecmd/configchannel.py:1604
 msgid "files only in the source channel will be added to the target channel"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1593
+#: ../src/spacecmd/configchannel.py:1606
 msgid "files only in the target channel will be deleted"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1596
+#: ../src/spacecmd/configchannel.py:1609
 msgid "nothing to do"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1600
+#: ../src/spacecmd/configchannel.py:1613
 msgid "perform synchronisation [y/N]:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1652
+#: ../src/spacecmd/configchannel.py:1665
 msgid "unknown file type "
 msgstr ""
 

--- a/spacecmd/po/sk.po
+++ b/spacecmd/po/sk.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-20 12:55+0100\n"
+"POT-Creation-Date: 2020-12-11 09:25+0000\n"
 "PO-Revision-Date: 2020-10-16 10:51+0200\n"
 "Last-Translator: Pascal Arlt <parlt@suse.com>\n"
 "Language-Team: Slovak <https://l10n.opensuse.org/projects/uyuni/spacecmd/sk/"
@@ -308,7 +308,7 @@ msgid "Software Channels"
 msgstr ""
 
 #: ../src/spacecmd/activationkey.py:960 ../src/spacecmd/configchannel.py:765
-#: ../src/spacecmd/configchannel.py:870 ../src/spacecmd/system.py:3057
+#: ../src/spacecmd/configchannel.py:872 ../src/spacecmd/system.py:3057
 msgid "Configuration Channels"
 msgstr ""
 
@@ -499,7 +499,7 @@ msgstr ""
 msgid "Cloned Key:"
 msgstr ""
 
-#: ../src/spacecmd/activationkey.py:1472 ../src/spacecmd/configchannel.py:1376
+#: ../src/spacecmd/activationkey.py:1472 ../src/spacecmd/configchannel.py:1389
 msgid "Error - must specify either -c or -x options!"
 msgstr ""
 
@@ -535,7 +535,7 @@ msgstr ""
 msgid "does not exist, skipping!"
 msgstr ""
 
-#: ../src/spacecmd/activationkey.py:1584 ../src/spacecmd/configchannel.py:1428
+#: ../src/spacecmd/activationkey.py:1584 ../src/spacecmd/configchannel.py:1441
 #, python-format
 msgid "Failed to clone %s to %s"
 msgstr ""
@@ -783,7 +783,7 @@ msgid "Binary:          %s"
 msgstr ""
 
 #: ../src/spacecmd/configchannel.py:263 ../src/spacecmd/configchannel.py:696
-#: ../src/spacecmd/configchannel.py:933 ../src/spacecmd/kickstart.py:1903
+#: ../src/spacecmd/configchannel.py:946 ../src/spacecmd/kickstart.py:1903
 #: ../src/spacecmd/snippet.py:161
 msgid "Contents"
 msgstr ""
@@ -952,16 +952,16 @@ msgstr ""
 msgid "SELinux Context [%s]:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:575
+#: ../src/spacecmd/configchannel.py:575 ../src/spacecmd/configchannel.py:911
 msgid "Revision [next]:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:593
+#: ../src/spacecmd/configchannel.py:593 ../src/spacecmd/configchannel.py:916
 msgid "The revision must be an integer"
 msgstr ""
 
 #. get the contents of the script
-#: ../src/spacecmd/configchannel.py:596 ../src/spacecmd/configchannel.py:896
+#: ../src/spacecmd/configchannel.py:596 ../src/spacecmd/configchannel.py:898
 #: ../src/spacecmd/cryptokey.py:68 ../src/spacecmd/kickstart.py:1954
 #: ../src/spacecmd/snippet.py:141
 msgid "Read an existing file [y/N]:"
@@ -975,7 +975,7 @@ msgstr ""
 msgid "The path is required"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:630 ../src/spacecmd/configchannel.py:913
+#: ../src/spacecmd/configchannel.py:630 ../src/spacecmd/configchannel.py:922
 msgid "You must provide the file contents"
 msgstr ""
 
@@ -1054,11 +1054,11 @@ msgstr ""
 msgid "Path:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:805 ../src/spacecmd/configchannel.py:924
+#: ../src/spacecmd/configchannel.py:805 ../src/spacecmd/configchannel.py:935
 msgid "No config channel specified!"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:810 ../src/spacecmd/configchannel.py:929
+#: ../src/spacecmd/configchannel.py:810 ../src/spacecmd/configchannel.py:940
 msgid "Error obtaining file info"
 msgstr ""
 
@@ -1072,51 +1072,57 @@ msgid ""
 "\n"
 "options:\n"
 "  -c CHANNEL\n"
+"  -r REVISION\n"
 "  -f local path to file contents\n"
 "  -y automatically proceed with file contents\n"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:892
+#: ../src/spacecmd/configchannel.py:894
 #, python-format
 msgid "No existing file information found for %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:932
+#: ../src/spacecmd/configchannel.py:944
+#, python-format
+msgid "revision:                 %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:945
 #, python-format
 msgid "contents_enc64:           %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:959
+#: ../src/spacecmd/configchannel.py:972
 msgid "configchannel_removefiles: Remove configuration files"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:960
+#: ../src/spacecmd/configchannel.py:973
 msgid "usage: configchannel_removefiles CHANNEL <FILE ...>"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:997
+#: ../src/spacecmd/configchannel.py:1010
 msgid "configchannel_verifyfile: Verify a configuration file"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:998
+#: ../src/spacecmd/configchannel.py:1011
 msgid "usage: configchannel_verifyfile CHANNEL FILE <SYSTEMS>"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1037
+#: ../src/spacecmd/configchannel.py:1050
 msgid "No valid system selected"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1045 ../src/spacecmd/system.py:509
+#: ../src/spacecmd/configchannel.py:1058 ../src/spacecmd/system.py:509
 #: ../src/spacecmd/system.py:529 ../src/spacecmd/system.py:959
 #, python-format
 msgid "Action ID: %i"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1053
+#: ../src/spacecmd/configchannel.py:1066
 msgid "configchannel_export: export config channel(s) to json format file"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1054
+#: ../src/spacecmd/configchannel.py:1067
 msgid ""
 "usage: configchannel_export <CHANNEL>... [options])\n"
 "options:\n"
@@ -1130,116 +1136,116 @@ msgid ""
 msgstr ""
 
 #. Get the cc details
-#: ../src/spacecmd/configchannel.py:1070
+#: ../src/spacecmd/configchannel.py:1083
 #, python-format
 msgid "Getting config channel details for %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1090
+#: ../src/spacecmd/configchannel.py:1103
 #, python-format
 msgid "Failed to get details for file %s from %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1136
+#: ../src/spacecmd/configchannel.py:1149
 #, python-format
 msgid "File %s could not be exported "
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1137
+#: ../src/spacecmd/configchannel.py:1150
 msgid "with this API version(needs base64 encoding)"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1139
+#: ../src/spacecmd/configchannel.py:1152
 #, python-format
 msgid "File %s could not be exported as"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1140
+#: ../src/spacecmd/configchannel.py:1153
 msgid " text...getting base64 encoded version"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1163
+#: ../src/spacecmd/configchannel.py:1176
 #, python-format
 msgid "Passed filename '%s' to do_configchannel_export command."
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1171
+#: ../src/spacecmd/configchannel.py:1184
 #, python-format
 msgid "Exporting ALL config channels to %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1178
+#: ../src/spacecmd/configchannel.py:1191
 msgid ""
 "Error, no valid config channel passed, check name is  correct with spacecmd "
 "configchannel_list"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1193
+#: ../src/spacecmd/configchannel.py:1206
 #, python-format
 msgid "Exporting cc %s to %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1200
+#: ../src/spacecmd/configchannel.py:1213
 msgid "File '{}' exists, confirm overwrite file? (y/n)"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1203
+#: ../src/spacecmd/configchannel.py:1216
 #, python-format
 msgid "Error saving exported config channels to file: %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1212
+#: ../src/spacecmd/configchannel.py:1225
 msgid "configchannel_import: import config channel(s) from json file"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1213
+#: ../src/spacecmd/configchannel.py:1226
 msgid "usage: configchannel_import <JSONFILES...>"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1222 ../src/spacecmd/kickstart.py:2330
+#: ../src/spacecmd/configchannel.py:1235 ../src/spacecmd/kickstart.py:2330
 msgid "Error, no filename passed"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1230 ../src/spacecmd/kickstart.py:2338
+#: ../src/spacecmd/configchannel.py:1243 ../src/spacecmd/kickstart.py:2338
 #, python-format
 msgid "Error, could not read json data from %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1234
+#: ../src/spacecmd/configchannel.py:1247
 #, python-format
 msgid "Error importing configchannel %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1246
+#: ../src/spacecmd/configchannel.py:1259
 #, python-format
 msgid "Config channel %s already exists! Skipping!"
 msgstr ""
 
 #. create the cc, we need to drop the org prefix from the cc name
-#: ../src/spacecmd/configchannel.py:1251
+#: ../src/spacecmd/configchannel.py:1264
 #, python-format
 msgid "Importing config channel  %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1294
+#: ../src/spacecmd/configchannel.py:1307
 #, python-format
 msgid "Failed trying to import file %s (empty content)"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1296
+#: ../src/spacecmd/configchannel.py:1309
 msgid "Older APIs can't export encoded files"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1319
+#: ../src/spacecmd/configchannel.py:1332
 #, python-format
 msgid "Error adding file %s to %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1329
+#: ../src/spacecmd/configchannel.py:1342
 msgid "configchannel_clone: Clone config channel(s)"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1330
+#: ../src/spacecmd/configchannel.py:1343
 msgid ""
 "usage examples:\n"
 "                 configchannel_clone foo_label -c bar_label\n"
@@ -1257,101 +1263,101 @@ msgid ""
 "  Note : If no -c or -x option is specified, interactive is assumed"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1359
+#: ../src/spacecmd/configchannel.py:1372
 msgid "No config channels found"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1362
+#: ../src/spacecmd/configchannel.py:1375
 msgid "Config Channels"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1368
+#: ../src/spacecmd/configchannel.py:1381
 #, python-format
 msgid "Channel to clone: %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1372
+#: ../src/spacecmd/configchannel.py:1385
 msgid "Channel to clone:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1373
+#: ../src/spacecmd/configchannel.py:1386
 msgid "Clone label:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1382
+#: ../src/spacecmd/configchannel.py:1395
 msgid "Error no channel label passed!"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1391
+#: ../src/spacecmd/configchannel.py:1404
 msgid "No suitable channels to clone has been found."
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1444
+#: ../src/spacecmd/configchannel.py:1457
 msgid "no configchannel given"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1447
+#: ../src/spacecmd/configchannel.py:1460
 msgid "invalid configchannel label "
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1473
+#: ../src/spacecmd/configchannel.py:1486
 msgid "configchannel_diff: diff between config channels"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1475
+#: ../src/spacecmd/configchannel.py:1488
 msgid "usage: configchannel_diff SOURCE_CHANNEL TARGET_CHANNEL"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1524
+#: ../src/spacecmd/configchannel.py:1537
 msgid "configchannel_sync:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1525
+#: ../src/spacecmd/configchannel.py:1538
 msgid "sync config files between two config channels"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1527
+#: ../src/spacecmd/configchannel.py:1540
 msgid "usage: configchannel_sync SOURCE_CHANNEL TARGET_CHANNEL"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1565
+#: ../src/spacecmd/configchannel.py:1578
 msgid "syncing files from configchannel "
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1572
+#: ../src/spacecmd/configchannel.py:1585
 msgid "files common in both channels:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1578
+#: ../src/spacecmd/configchannel.py:1591
 msgid "files only in source "
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1584
+#: ../src/spacecmd/configchannel.py:1597
 msgid "files only in target "
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1589
+#: ../src/spacecmd/configchannel.py:1602
 msgid ""
 "files that are in both channels will be overwritten in the target channel"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1591
+#: ../src/spacecmd/configchannel.py:1604
 msgid "files only in the source channel will be added to the target channel"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1593
+#: ../src/spacecmd/configchannel.py:1606
 msgid "files only in the target channel will be deleted"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1596
+#: ../src/spacecmd/configchannel.py:1609
 msgid "nothing to do"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1600
+#: ../src/spacecmd/configchannel.py:1613
 msgid "perform synchronisation [y/N]:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1652
+#: ../src/spacecmd/configchannel.py:1665
 msgid "unknown file type "
 msgstr ""
 

--- a/spacecmd/po/spacecmd.pot
+++ b/spacecmd/po/spacecmd.pot
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-20 12:55+0100\n"
+"POT-Creation-Date: 2020-12-11 09:25+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -307,7 +307,7 @@ msgid "Software Channels"
 msgstr ""
 
 #: ../src/spacecmd/activationkey.py:960 ../src/spacecmd/configchannel.py:765
-#: ../src/spacecmd/configchannel.py:870 ../src/spacecmd/system.py:3057
+#: ../src/spacecmd/configchannel.py:872 ../src/spacecmd/system.py:3057
 msgid "Configuration Channels"
 msgstr ""
 
@@ -498,7 +498,7 @@ msgstr ""
 msgid "Cloned Key:"
 msgstr ""
 
-#: ../src/spacecmd/activationkey.py:1472 ../src/spacecmd/configchannel.py:1376
+#: ../src/spacecmd/activationkey.py:1472 ../src/spacecmd/configchannel.py:1389
 msgid "Error - must specify either -c or -x options!"
 msgstr ""
 
@@ -534,7 +534,7 @@ msgstr ""
 msgid "does not exist, skipping!"
 msgstr ""
 
-#: ../src/spacecmd/activationkey.py:1584 ../src/spacecmd/configchannel.py:1428
+#: ../src/spacecmd/activationkey.py:1584 ../src/spacecmd/configchannel.py:1441
 #, python-format
 msgid "Failed to clone %s to %s"
 msgstr ""
@@ -782,7 +782,7 @@ msgid "Binary:          %s"
 msgstr ""
 
 #: ../src/spacecmd/configchannel.py:263 ../src/spacecmd/configchannel.py:696
-#: ../src/spacecmd/configchannel.py:933 ../src/spacecmd/kickstart.py:1903
+#: ../src/spacecmd/configchannel.py:946 ../src/spacecmd/kickstart.py:1903
 #: ../src/spacecmd/snippet.py:161
 msgid "Contents"
 msgstr ""
@@ -951,16 +951,16 @@ msgstr ""
 msgid "SELinux Context [%s]:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:575
+#: ../src/spacecmd/configchannel.py:575 ../src/spacecmd/configchannel.py:911
 msgid "Revision [next]:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:593
+#: ../src/spacecmd/configchannel.py:593 ../src/spacecmd/configchannel.py:916
 msgid "The revision must be an integer"
 msgstr ""
 
 #. get the contents of the script
-#: ../src/spacecmd/configchannel.py:596 ../src/spacecmd/configchannel.py:896
+#: ../src/spacecmd/configchannel.py:596 ../src/spacecmd/configchannel.py:898
 #: ../src/spacecmd/cryptokey.py:68 ../src/spacecmd/kickstart.py:1954
 #: ../src/spacecmd/snippet.py:141
 msgid "Read an existing file [y/N]:"
@@ -974,7 +974,7 @@ msgstr ""
 msgid "The path is required"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:630 ../src/spacecmd/configchannel.py:913
+#: ../src/spacecmd/configchannel.py:630 ../src/spacecmd/configchannel.py:922
 msgid "You must provide the file contents"
 msgstr ""
 
@@ -1053,11 +1053,11 @@ msgstr ""
 msgid "Path:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:805 ../src/spacecmd/configchannel.py:924
+#: ../src/spacecmd/configchannel.py:805 ../src/spacecmd/configchannel.py:935
 msgid "No config channel specified!"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:810 ../src/spacecmd/configchannel.py:929
+#: ../src/spacecmd/configchannel.py:810 ../src/spacecmd/configchannel.py:940
 msgid "Error obtaining file info"
 msgstr ""
 
@@ -1071,51 +1071,57 @@ msgid ""
 "\n"
 "options:\n"
 "  -c CHANNEL\n"
+"  -r REVISION\n"
 "  -f local path to file contents\n"
 "  -y automatically proceed with file contents\n"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:892
+#: ../src/spacecmd/configchannel.py:894
 #, python-format
 msgid "No existing file information found for %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:932
+#: ../src/spacecmd/configchannel.py:944
+#, python-format
+msgid "revision:                 %s"
+msgstr ""
+
+#: ../src/spacecmd/configchannel.py:945
 #, python-format
 msgid "contents_enc64:           %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:959
+#: ../src/spacecmd/configchannel.py:972
 msgid "configchannel_removefiles: Remove configuration files"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:960
+#: ../src/spacecmd/configchannel.py:973
 msgid "usage: configchannel_removefiles CHANNEL <FILE ...>"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:997
+#: ../src/spacecmd/configchannel.py:1010
 msgid "configchannel_verifyfile: Verify a configuration file"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:998
+#: ../src/spacecmd/configchannel.py:1011
 msgid "usage: configchannel_verifyfile CHANNEL FILE <SYSTEMS>"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1037
+#: ../src/spacecmd/configchannel.py:1050
 msgid "No valid system selected"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1045 ../src/spacecmd/system.py:509
+#: ../src/spacecmd/configchannel.py:1058 ../src/spacecmd/system.py:509
 #: ../src/spacecmd/system.py:529 ../src/spacecmd/system.py:959
 #, python-format
 msgid "Action ID: %i"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1053
+#: ../src/spacecmd/configchannel.py:1066
 msgid "configchannel_export: export config channel(s) to json format file"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1054
+#: ../src/spacecmd/configchannel.py:1067
 msgid ""
 "usage: configchannel_export <CHANNEL>... [options])\n"
 "options:\n"
@@ -1129,116 +1135,116 @@ msgid ""
 msgstr ""
 
 #. Get the cc details
-#: ../src/spacecmd/configchannel.py:1070
+#: ../src/spacecmd/configchannel.py:1083
 #, python-format
 msgid "Getting config channel details for %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1090
+#: ../src/spacecmd/configchannel.py:1103
 #, python-format
 msgid "Failed to get details for file %s from %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1136
+#: ../src/spacecmd/configchannel.py:1149
 #, python-format
 msgid "File %s could not be exported "
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1137
+#: ../src/spacecmd/configchannel.py:1150
 msgid "with this API version(needs base64 encoding)"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1139
+#: ../src/spacecmd/configchannel.py:1152
 #, python-format
 msgid "File %s could not be exported as"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1140
+#: ../src/spacecmd/configchannel.py:1153
 msgid " text...getting base64 encoded version"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1163
+#: ../src/spacecmd/configchannel.py:1176
 #, python-format
 msgid "Passed filename '%s' to do_configchannel_export command."
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1171
+#: ../src/spacecmd/configchannel.py:1184
 #, python-format
 msgid "Exporting ALL config channels to %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1178
+#: ../src/spacecmd/configchannel.py:1191
 msgid ""
 "Error, no valid config channel passed, check name is  correct with spacecmd "
 "configchannel_list"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1193
+#: ../src/spacecmd/configchannel.py:1206
 #, python-format
 msgid "Exporting cc %s to %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1200
+#: ../src/spacecmd/configchannel.py:1213
 msgid "File '{}' exists, confirm overwrite file? (y/n)"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1203
+#: ../src/spacecmd/configchannel.py:1216
 #, python-format
 msgid "Error saving exported config channels to file: %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1212
+#: ../src/spacecmd/configchannel.py:1225
 msgid "configchannel_import: import config channel(s) from json file"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1213
+#: ../src/spacecmd/configchannel.py:1226
 msgid "usage: configchannel_import <JSONFILES...>"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1222 ../src/spacecmd/kickstart.py:2330
+#: ../src/spacecmd/configchannel.py:1235 ../src/spacecmd/kickstart.py:2330
 msgid "Error, no filename passed"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1230 ../src/spacecmd/kickstart.py:2338
+#: ../src/spacecmd/configchannel.py:1243 ../src/spacecmd/kickstart.py:2338
 #, python-format
 msgid "Error, could not read json data from %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1234
+#: ../src/spacecmd/configchannel.py:1247
 #, python-format
 msgid "Error importing configchannel %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1246
+#: ../src/spacecmd/configchannel.py:1259
 #, python-format
 msgid "Config channel %s already exists! Skipping!"
 msgstr ""
 
 #. create the cc, we need to drop the org prefix from the cc name
-#: ../src/spacecmd/configchannel.py:1251
+#: ../src/spacecmd/configchannel.py:1264
 #, python-format
 msgid "Importing config channel  %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1294
+#: ../src/spacecmd/configchannel.py:1307
 #, python-format
 msgid "Failed trying to import file %s (empty content)"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1296
+#: ../src/spacecmd/configchannel.py:1309
 msgid "Older APIs can't export encoded files"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1319
+#: ../src/spacecmd/configchannel.py:1332
 #, python-format
 msgid "Error adding file %s to %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1329
+#: ../src/spacecmd/configchannel.py:1342
 msgid "configchannel_clone: Clone config channel(s)"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1330
+#: ../src/spacecmd/configchannel.py:1343
 msgid ""
 "usage examples:\n"
 "                 configchannel_clone foo_label -c bar_label\n"
@@ -1256,101 +1262,101 @@ msgid ""
 "  Note : If no -c or -x option is specified, interactive is assumed"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1359
+#: ../src/spacecmd/configchannel.py:1372
 msgid "No config channels found"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1362
+#: ../src/spacecmd/configchannel.py:1375
 msgid "Config Channels"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1368
+#: ../src/spacecmd/configchannel.py:1381
 #, python-format
 msgid "Channel to clone: %s"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1372
+#: ../src/spacecmd/configchannel.py:1385
 msgid "Channel to clone:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1373
+#: ../src/spacecmd/configchannel.py:1386
 msgid "Clone label:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1382
+#: ../src/spacecmd/configchannel.py:1395
 msgid "Error no channel label passed!"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1391
+#: ../src/spacecmd/configchannel.py:1404
 msgid "No suitable channels to clone has been found."
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1444
+#: ../src/spacecmd/configchannel.py:1457
 msgid "no configchannel given"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1447
+#: ../src/spacecmd/configchannel.py:1460
 msgid "invalid configchannel label "
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1473
+#: ../src/spacecmd/configchannel.py:1486
 msgid "configchannel_diff: diff between config channels"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1475
+#: ../src/spacecmd/configchannel.py:1488
 msgid "usage: configchannel_diff SOURCE_CHANNEL TARGET_CHANNEL"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1524
+#: ../src/spacecmd/configchannel.py:1537
 msgid "configchannel_sync:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1525
+#: ../src/spacecmd/configchannel.py:1538
 msgid "sync config files between two config channels"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1527
+#: ../src/spacecmd/configchannel.py:1540
 msgid "usage: configchannel_sync SOURCE_CHANNEL TARGET_CHANNEL"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1565
+#: ../src/spacecmd/configchannel.py:1578
 msgid "syncing files from configchannel "
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1572
+#: ../src/spacecmd/configchannel.py:1585
 msgid "files common in both channels:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1578
+#: ../src/spacecmd/configchannel.py:1591
 msgid "files only in source "
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1584
+#: ../src/spacecmd/configchannel.py:1597
 msgid "files only in target "
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1589
+#: ../src/spacecmd/configchannel.py:1602
 msgid ""
 "files that are in both channels will be overwritten in the target channel"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1591
+#: ../src/spacecmd/configchannel.py:1604
 msgid "files only in the source channel will be added to the target channel"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1593
+#: ../src/spacecmd/configchannel.py:1606
 msgid "files only in the target channel will be deleted"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1596
+#: ../src/spacecmd/configchannel.py:1609
 msgid "nothing to do"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1600
+#: ../src/spacecmd/configchannel.py:1613
 msgid "perform synchronisation [y/N]:"
 msgstr ""
 
-#: ../src/spacecmd/configchannel.py:1652
+#: ../src/spacecmd/configchannel.py:1665
 msgid "unknown file type "
 msgstr ""
 

--- a/spacecmd/po/zh_CN.po
+++ b/spacecmd/po/zh_CN.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-20 12:55+0100\n"
+"POT-Creation-Date: 2020-12-11 09:25+0000\n"
 "PO-Revision-Date: 2020-11-19 02:25+0000\n"
 "Last-Translator: Grace Yu <grace.yu@excel-gits.com>\n"
 "Language-Team: Chinese (China) <https://l10n.opensuse.org/projects/uyuni/"
@@ -322,7 +322,7 @@ msgid "Software Channels"
 msgstr "软件频道"
 
 #: ../src/spacecmd/activationkey.py:960 ../src/spacecmd/configchannel.py:765
-#: ../src/spacecmd/configchannel.py:870 ../src/spacecmd/system.py:3057
+#: ../src/spacecmd/configchannel.py:872 ../src/spacecmd/system.py:3057
 msgid "Configuration Channels"
 msgstr "配置频道"
 
@@ -537,7 +537,7 @@ msgstr "原始密钥："
 msgid "Cloned Key:"
 msgstr "克隆的密钥："
 
-#: ../src/spacecmd/activationkey.py:1472 ../src/spacecmd/configchannel.py:1376
+#: ../src/spacecmd/activationkey.py:1472 ../src/spacecmd/configchannel.py:1389
 msgid "Error - must specify either -c or -x options!"
 msgstr "错误 - 必须指定 -c 或 -x 选项！"
 
@@ -573,7 +573,7 @@ msgstr "已找到配置频道 %s - 密钥为 %s，%s "
 msgid "does not exist, skipping!"
 msgstr "不存在，正在跳过！"
 
-#: ../src/spacecmd/activationkey.py:1584 ../src/spacecmd/configchannel.py:1428
+#: ../src/spacecmd/activationkey.py:1584 ../src/spacecmd/configchannel.py:1441
 #, python-format
 msgid "Failed to clone %s to %s"
 msgstr "无法将 %s 克隆到 %s"
@@ -838,7 +838,7 @@ msgid "Binary:          %s"
 msgstr "二进制文件：%s"
 
 #: ../src/spacecmd/configchannel.py:263 ../src/spacecmd/configchannel.py:696
-#: ../src/spacecmd/configchannel.py:933 ../src/spacecmd/kickstart.py:1903
+#: ../src/spacecmd/configchannel.py:946 ../src/spacecmd/kickstart.py:1903
 #: ../src/spacecmd/snippet.py:161
 msgid "Contents"
 msgstr "内容"
@@ -1017,16 +1017,16 @@ msgstr "模式 [%s]："
 msgid "SELinux Context [%s]:"
 msgstr "SELinux 上下文 [%s]："
 
-#: ../src/spacecmd/configchannel.py:575
+#: ../src/spacecmd/configchannel.py:575 ../src/spacecmd/configchannel.py:911
 msgid "Revision [next]:"
 msgstr "修订版 [next]："
 
-#: ../src/spacecmd/configchannel.py:593
+#: ../src/spacecmd/configchannel.py:593 ../src/spacecmd/configchannel.py:916
 msgid "The revision must be an integer"
 msgstr "修订版必须是整数"
 
 #. get the contents of the script
-#: ../src/spacecmd/configchannel.py:596 ../src/spacecmd/configchannel.py:896
+#: ../src/spacecmd/configchannel.py:596 ../src/spacecmd/configchannel.py:898
 #: ../src/spacecmd/cryptokey.py:68 ../src/spacecmd/kickstart.py:1954
 #: ../src/spacecmd/snippet.py:141
 msgid "Read an existing file [y/N]:"
@@ -1040,7 +1040,7 @@ msgstr "文件："
 msgid "The path is required"
 msgstr "必须指定路径"
 
-#: ../src/spacecmd/configchannel.py:630 ../src/spacecmd/configchannel.py:913
+#: ../src/spacecmd/configchannel.py:630 ../src/spacecmd/configchannel.py:922
 msgid "You must provide the file contents"
 msgstr "必须提供文件内容"
 
@@ -1141,11 +1141,11 @@ msgstr "无法获取有效频道。正在中止。"
 msgid "Path:"
 msgstr "路径："
 
-#: ../src/spacecmd/configchannel.py:805 ../src/spacecmd/configchannel.py:924
+#: ../src/spacecmd/configchannel.py:805 ../src/spacecmd/configchannel.py:935
 msgid "No config channel specified!"
 msgstr "未指定配置频道！"
 
-#: ../src/spacecmd/configchannel.py:810 ../src/spacecmd/configchannel.py:929
+#: ../src/spacecmd/configchannel.py:810 ../src/spacecmd/configchannel.py:940
 msgid "Error obtaining file info"
 msgstr "获取文件信息时出错"
 
@@ -1154,11 +1154,13 @@ msgid "configchannel_updateinitsls: Update init.sls file"
 msgstr "configchannel_updateinitsls：更新 init.sls 文件"
 
 #: ../src/spacecmd/configchannel.py:846
+#, fuzzy
 msgid ""
 "usage: configchannel_updateinitsls -c CHANNEL -f LOCAL_FILE_PATH [OPTIONS])\n"
 "\n"
 "options:\n"
 "  -c CHANNEL\n"
+"  -r REVISION\n"
 "  -f local path to file contents\n"
 "  -y automatically proceed with file contents\n"
 msgstr ""
@@ -1169,47 +1171,52 @@ msgstr ""
 "  -f 文件内容的本地路径\n"
 "  -y 自动继续处理文件内容\n"
 
-#: ../src/spacecmd/configchannel.py:892
+#: ../src/spacecmd/configchannel.py:894
 #, python-format
 msgid "No existing file information found for %s"
 msgstr "未找到 %s 的现有文件信息"
 
-#: ../src/spacecmd/configchannel.py:932
+#: ../src/spacecmd/configchannel.py:944
+#, fuzzy, python-format
+msgid "revision:                 %s"
+msgstr "密钥：%s"
+
+#: ../src/spacecmd/configchannel.py:945
 #, python-format
 msgid "contents_enc64:           %s"
 msgstr "contents_enc64：%s"
 
-#: ../src/spacecmd/configchannel.py:959
+#: ../src/spacecmd/configchannel.py:972
 msgid "configchannel_removefiles: Remove configuration files"
 msgstr "configchannel_removefiles：去除配置文件"
 
-#: ../src/spacecmd/configchannel.py:960
+#: ../src/spacecmd/configchannel.py:973
 msgid "usage: configchannel_removefiles CHANNEL <FILE ...>"
 msgstr "用法：configchannel_removefiles CHANNEL <文件 ...>"
 
-#: ../src/spacecmd/configchannel.py:997
+#: ../src/spacecmd/configchannel.py:1010
 msgid "configchannel_verifyfile: Verify a configuration file"
 msgstr "configchannel_verifyfile：校验配置文件"
 
-#: ../src/spacecmd/configchannel.py:998
+#: ../src/spacecmd/configchannel.py:1011
 msgid "usage: configchannel_verifyfile CHANNEL FILE <SYSTEMS>"
 msgstr "用法：configchannel_verifyfile CHANNEL FILE <系统>"
 
-#: ../src/spacecmd/configchannel.py:1037
+#: ../src/spacecmd/configchannel.py:1050
 msgid "No valid system selected"
 msgstr "未选择有效系统"
 
-#: ../src/spacecmd/configchannel.py:1045 ../src/spacecmd/system.py:509
+#: ../src/spacecmd/configchannel.py:1058 ../src/spacecmd/system.py:509
 #: ../src/spacecmd/system.py:529 ../src/spacecmd/system.py:959
 #, python-format
 msgid "Action ID: %i"
 msgstr "操作 ID：%i"
 
-#: ../src/spacecmd/configchannel.py:1053
+#: ../src/spacecmd/configchannel.py:1066
 msgid "configchannel_export: export config channel(s) to json format file"
 msgstr "configchannel_export：将配置频道导出到 json 格式的文件"
 
-#: ../src/spacecmd/configchannel.py:1054
+#: ../src/spacecmd/configchannel.py:1067
 msgid ""
 "usage: configchannel_export <CHANNEL>... [options])\n"
 "options:\n"
@@ -1232,117 +1239,117 @@ msgstr ""
 "注意：频道列表是可选的，默认为全部导出"
 
 #. Get the cc details
-#: ../src/spacecmd/configchannel.py:1070
+#: ../src/spacecmd/configchannel.py:1083
 #, python-format
 msgid "Getting config channel details for %s"
 msgstr "正在获取 %s 的配置频道细节"
 
-#: ../src/spacecmd/configchannel.py:1090
+#: ../src/spacecmd/configchannel.py:1103
 #, python-format
 msgid "Failed to get details for file %s from %s"
 msgstr "无法获取文件 %s 的细节（从 %s）"
 
-#: ../src/spacecmd/configchannel.py:1136
+#: ../src/spacecmd/configchannel.py:1149
 #, python-format
 msgid "File %s could not be exported "
 msgstr "无法使用此 API 版本导出文件 %s "
 
-#: ../src/spacecmd/configchannel.py:1137
+#: ../src/spacecmd/configchannel.py:1150
 msgid "with this API version(needs base64 encoding)"
 msgstr "（需要 base64 编码）"
 
-#: ../src/spacecmd/configchannel.py:1139
+#: ../src/spacecmd/configchannel.py:1152
 #, python-format
 msgid "File %s could not be exported as"
 msgstr "无法将文件 %s 导出为"
 
-#: ../src/spacecmd/configchannel.py:1140
+#: ../src/spacecmd/configchannel.py:1153
 msgid " text...getting base64 encoded version"
 msgstr " 文本...正在获取 base64 编码的版本"
 
-#: ../src/spacecmd/configchannel.py:1163
+#: ../src/spacecmd/configchannel.py:1176
 #, python-format
 msgid "Passed filename '%s' to do_configchannel_export command."
 msgstr "已将文件名 '%s' 传递给 do_configchannel_export 命令。"
 
-#: ../src/spacecmd/configchannel.py:1171
+#: ../src/spacecmd/configchannel.py:1184
 #, python-format
 msgid "Exporting ALL config channels to %s"
 msgstr "正在将所有配置频道导出到 %s"
 
-#: ../src/spacecmd/configchannel.py:1178
+#: ../src/spacecmd/configchannel.py:1191
 msgid ""
 "Error, no valid config channel passed, check name is  correct with spacecmd "
 "configchannel_list"
 msgstr ""
 "错误：未传递有效配置频道，请使用 spacecmd configchannel_list 检查名称是否正确"
 
-#: ../src/spacecmd/configchannel.py:1193
+#: ../src/spacecmd/configchannel.py:1206
 #, python-format
 msgid "Exporting cc %s to %s"
 msgstr "正在将 cc %s 导出到 %s"
 
-#: ../src/spacecmd/configchannel.py:1200
+#: ../src/spacecmd/configchannel.py:1213
 msgid "File '{}' exists, confirm overwrite file? (y/n)"
 msgstr "文件 '{}' 已存在，请确认是否重写文件？(y/n)"
 
-#: ../src/spacecmd/configchannel.py:1203
+#: ../src/spacecmd/configchannel.py:1216
 #, python-format
 msgid "Error saving exported config channels to file: %s"
 msgstr "将导出的配置频道保存到文件时出错：%s"
 
-#: ../src/spacecmd/configchannel.py:1212
+#: ../src/spacecmd/configchannel.py:1225
 msgid "configchannel_import: import config channel(s) from json file"
 msgstr "configchannel_import：从 json 文件导入配置频道"
 
-#: ../src/spacecmd/configchannel.py:1213
+#: ../src/spacecmd/configchannel.py:1226
 msgid "usage: configchannel_import <JSONFILES...>"
 msgstr "用法：configchannel_import <JSON 文件...>"
 
-#: ../src/spacecmd/configchannel.py:1222 ../src/spacecmd/kickstart.py:2330
+#: ../src/spacecmd/configchannel.py:1235 ../src/spacecmd/kickstart.py:2330
 msgid "Error, no filename passed"
 msgstr "错误：未传递文件名"
 
-#: ../src/spacecmd/configchannel.py:1230 ../src/spacecmd/kickstart.py:2338
+#: ../src/spacecmd/configchannel.py:1243 ../src/spacecmd/kickstart.py:2338
 #, python-format
 msgid "Error, could not read json data from %s"
 msgstr "错误：无法读取 %s 中的 json 数据"
 
-#: ../src/spacecmd/configchannel.py:1234
+#: ../src/spacecmd/configchannel.py:1247
 #, python-format
 msgid "Error importing configchannel %s"
 msgstr "导入配置频道 %s 时出错"
 
-#: ../src/spacecmd/configchannel.py:1246
+#: ../src/spacecmd/configchannel.py:1259
 #, python-format
 msgid "Config channel %s already exists! Skipping!"
 msgstr "配置频道 %s 已存在！正在跳过！"
 
 #. create the cc, we need to drop the org prefix from the cc name
-#: ../src/spacecmd/configchannel.py:1251
+#: ../src/spacecmd/configchannel.py:1264
 #, python-format
 msgid "Importing config channel  %s"
 msgstr "正在导入配置频道 %s"
 
-#: ../src/spacecmd/configchannel.py:1294
+#: ../src/spacecmd/configchannel.py:1307
 #, python-format
 msgid "Failed trying to import file %s (empty content)"
 msgstr "尝试导入文件 %s 失败（空内容）"
 
-#: ../src/spacecmd/configchannel.py:1296
+#: ../src/spacecmd/configchannel.py:1309
 msgid "Older APIs can't export encoded files"
 msgstr "旧版 API 无法导出编码的文件"
 
-#: ../src/spacecmd/configchannel.py:1319
+#: ../src/spacecmd/configchannel.py:1332
 #, python-format
 msgid "Error adding file %s to %s"
 msgstr "将文件 %s 添加到 %s 时出错"
 
-#: ../src/spacecmd/configchannel.py:1329
+#: ../src/spacecmd/configchannel.py:1342
 msgid "configchannel_clone: Clone config channel(s)"
 msgstr "configchannel_clone：克隆配置频道"
 
-#: ../src/spacecmd/configchannel.py:1330
+#: ../src/spacecmd/configchannel.py:1343
 msgid ""
 "usage examples:\n"
 "                 configchannel_clone foo_label -c bar_label\n"
@@ -1373,101 +1380,101 @@ msgstr ""
 "                   标签和说明中的 foo 替换为 bar\n"
 "  注意：如果未指定 -c 或 -x 选项，则假定采用交互模式"
 
-#: ../src/spacecmd/configchannel.py:1359
+#: ../src/spacecmd/configchannel.py:1372
 msgid "No config channels found"
 msgstr "未找到配置频道"
 
-#: ../src/spacecmd/configchannel.py:1362
+#: ../src/spacecmd/configchannel.py:1375
 msgid "Config Channels"
 msgstr "配置频道"
 
-#: ../src/spacecmd/configchannel.py:1368
+#: ../src/spacecmd/configchannel.py:1381
 #, python-format
 msgid "Channel to clone: %s"
 msgstr "要克隆的频道：%s"
 
-#: ../src/spacecmd/configchannel.py:1372
+#: ../src/spacecmd/configchannel.py:1385
 msgid "Channel to clone:"
 msgstr "要克隆的频道："
 
-#: ../src/spacecmd/configchannel.py:1373
+#: ../src/spacecmd/configchannel.py:1386
 msgid "Clone label:"
 msgstr "克隆版本标签："
 
-#: ../src/spacecmd/configchannel.py:1382
+#: ../src/spacecmd/configchannel.py:1395
 msgid "Error no channel label passed!"
 msgstr "错误：未传递频道标签！"
 
-#: ../src/spacecmd/configchannel.py:1391
+#: ../src/spacecmd/configchannel.py:1404
 msgid "No suitable channels to clone has been found."
 msgstr "未找到适合克隆的频道。"
 
-#: ../src/spacecmd/configchannel.py:1444
+#: ../src/spacecmd/configchannel.py:1457
 msgid "no configchannel given"
 msgstr "未指定配置频道"
 
-#: ../src/spacecmd/configchannel.py:1447
+#: ../src/spacecmd/configchannel.py:1460
 msgid "invalid configchannel label "
 msgstr "无效的配置频道标签 "
 
-#: ../src/spacecmd/configchannel.py:1473
+#: ../src/spacecmd/configchannel.py:1486
 msgid "configchannel_diff: diff between config channels"
 msgstr "configchannel_diff：比较配置频道的差异"
 
-#: ../src/spacecmd/configchannel.py:1475
+#: ../src/spacecmd/configchannel.py:1488
 msgid "usage: configchannel_diff SOURCE_CHANNEL TARGET_CHANNEL"
 msgstr "用法：configchannel_diff SOURCE_CHANNEL TARGET_CHANNEL"
 
-#: ../src/spacecmd/configchannel.py:1524
+#: ../src/spacecmd/configchannel.py:1537
 msgid "configchannel_sync:"
 msgstr "configchannel_sync："
 
-#: ../src/spacecmd/configchannel.py:1525
+#: ../src/spacecmd/configchannel.py:1538
 msgid "sync config files between two config channels"
 msgstr "同步两个配置频道之间的配置文件"
 
-#: ../src/spacecmd/configchannel.py:1527
+#: ../src/spacecmd/configchannel.py:1540
 msgid "usage: configchannel_sync SOURCE_CHANNEL TARGET_CHANNEL"
 msgstr "用法：configchannel_sync SOURCE_CHANNEL TARGET_CHANNEL"
 
-#: ../src/spacecmd/configchannel.py:1565
+#: ../src/spacecmd/configchannel.py:1578
 msgid "syncing files from configchannel "
 msgstr "正在同步配置频道中的文件 "
 
-#: ../src/spacecmd/configchannel.py:1572
+#: ../src/spacecmd/configchannel.py:1585
 msgid "files common in both channels:"
 msgstr "两个频道共有的文件："
 
-#: ../src/spacecmd/configchannel.py:1578
+#: ../src/spacecmd/configchannel.py:1591
 msgid "files only in source "
 msgstr "仅包含在源中的文件 "
 
-#: ../src/spacecmd/configchannel.py:1584
+#: ../src/spacecmd/configchannel.py:1597
 msgid "files only in target "
 msgstr "仅包含在目标中的文件 "
 
-#: ../src/spacecmd/configchannel.py:1589
+#: ../src/spacecmd/configchannel.py:1602
 msgid ""
 "files that are in both channels will be overwritten in the target channel"
 msgstr "将在目标频道中重写位于这两个频道中的文件"
 
-#: ../src/spacecmd/configchannel.py:1591
+#: ../src/spacecmd/configchannel.py:1604
 msgid "files only in the source channel will be added to the target channel"
 msgstr "只会将源频道中的文件添加到目标频道"
 
-#: ../src/spacecmd/configchannel.py:1593
+#: ../src/spacecmd/configchannel.py:1606
 msgid "files only in the target channel will be deleted"
 msgstr "只会删除目标频道中的文件"
 
-#: ../src/spacecmd/configchannel.py:1596
+#: ../src/spacecmd/configchannel.py:1609
 msgid "nothing to do"
 msgstr "不执行任何操作"
 
-#: ../src/spacecmd/configchannel.py:1600
+#: ../src/spacecmd/configchannel.py:1613
 msgid "perform synchronisation [y/N]:"
 msgstr "执行同步 [y/N]:"
 
-#: ../src/spacecmd/configchannel.py:1652
+#: ../src/spacecmd/configchannel.py:1665
 msgid "unknown file type "
 msgstr "未知文件类型 "
 

--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,4 @@
+- Added '-r REVISION' option to the 'configchannel_updateinitsls' command (bsc#1179566)
 - Fix: internal: workaround for future tee of logs translation
 
 -------------------------------------------------------------------

--- a/spacecmd/src/spacecmd/configchannel.py
+++ b/spacecmd/src/spacecmd/configchannel.py
@@ -848,6 +848,7 @@ def help_configchannel_updateinitsls(self):
 
 options:
   -c CHANNEL
+  -r REVISION
   -f local path to file contents
   -y automatically proceed with file contents
 '''))
@@ -856,6 +857,7 @@ def do_configchannel_updateinitsls(self, args, update_path=''):
     arg_parser = get_argument_parser()
     arg_parser.add_argument('-c', '--channel')
     arg_parser.add_argument('-f', '--file')
+    arg_parser.add_argument('-r', '--revision')
     arg_parser.add_argument('-y', '--yes', action='store_true')
     (args, options) = parse_command_arguments(args, arg_parser)
 
@@ -907,6 +909,13 @@ def do_configchannel_updateinitsls(self, args, update_path=''):
                 template = ''
             (contents, _ignore) = editor(template=template, delete=True)
 
+        revision_input = prompt_user(_('Revision [next]:'))
+        if revision_input:
+            try:
+                options.revision = int(revision_input)
+            except ValueError:
+                logging.warning(_('The revision must be an integer'))
+
     else:
         if options.file:
             contents = read_file(options.file)
@@ -919,6 +928,8 @@ def do_configchannel_updateinitsls(self, args, update_path=''):
     file_info = {'contents': ''.join(contents),
                  'contents_enc64': True
                 }
+    if options.revision:
+        file_info['revision'] = options.revision
 
 
     if not options.channel:
@@ -930,6 +941,8 @@ def do_configchannel_updateinitsls(self, args, update_path=''):
         logging.error(_N("Error obtaining file info"))
         self.help_configchannel_updateinitsls()
         return 1
+    if 'revision' in file_info:
+        print(_('revision:                 %s') % file_info['revision'])
     print(_('contents_enc64:           %s') % file_info['contents_enc64'])
     print(_('Contents'))
     print('--------')

--- a/testsuite/features/secondary/min_state_config_channel.feature
+++ b/testsuite/features/secondary/min_state_config_channel.feature
@@ -40,9 +40,14 @@ Feature: State Configuration channels
   Scenario: Create the 3rd state channel with spacecmd
     Given I am authorized as "admin" with password "admin"
     When I create channel "statechannel3" from spacecmd of type "state"
-    When I follow the left menu "Configuration > Channels"
+    And I follow the left menu "Configuration > Channels"
     Then I should see a "statechannel3" text
-    And  I update init.sls from spacecmd with content "touch /root/statechannel3:\n  cmd.run:\n    - creates: /root/statechannel3" for channel "statechannel3"
+    When I update init.sls from spacecmd with content "touch /tmp/statechannel3:\n  cmd.run:\n    - creates: /tmp/statechannel3" for channel "statechannel3"
+    And I get "/init.sls" file details for channel "statechannel3" via spacecmd
+    Then I should see "Revision: 2" in the output
+    When  I update init.sls from spacecmd with content "touch /root/statechannel3:\n  cmd.run:\n    - creates: /root/statechannel3" for channel "statechannel3" and revision "100"
+    And I get "/init.sls" file details for channel "statechannel3" via spacecmd
+    Then I should see "Revision: 100" in the output
 
   Scenario: Subscribe a minion to 1st and 2nd state channels
     When I am on the Systems overview page of this "sle_minion"

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -658,6 +658,10 @@ When(/^I call spacewalk\-repo\-sync for channel "(.*?)" with a custom url "(.*?)
   @command_output = sshcmd("spacewalk-repo-sync -c #{arg1} -u #{arg2}")[:stdout]
 end
 
+When(/^I get "(.*?)" file details for channel "(.*?)" via spacecmd$/) do |arg1, arg2|
+  @command_output = sshcmd("spacecmd -u admin -p admin -q -- configchannel_filedetails #{arg2} '#{arg1}'")[:stdout]
+end
+
 When(/^I disable IPv6 forwarding on all interfaces of the SLE minion$/) do
   $minion.run('sysctl net.ipv6.conf.all.forwarding=0')
 end
@@ -1017,6 +1021,14 @@ When(/^I update init.sls from spacecmd with content "([^"]*)" for channel "([^"]
   filepath = "/tmp/#{label}"
   $server.run("echo -e \"#{content}\" > #{filepath}", true, 600, 'root')
   command = "spacecmd -u admin -p admin -- configchannel_updateinitsls -c #{label} -f  #{filepath} -y"
+  $server.run(command)
+  file_delete($server, filepath)
+end
+
+When(/^I update init.sls from spacecmd with content "([^"]*)" for channel "([^"]*)" and revision "([^"]*)"$/) do |content, label, revision|
+  filepath = "/tmp/#{label}"
+  $server.run("echo -e \"#{content}\" > #{filepath}", true, 600, 'root')
+  command = "spacecmd -u admin -p admin -- configchannel_updateinitsls -c #{label} -f #{filepath} -r #{revision} -y"
   $server.run(command)
   file_delete($server, filepath)
 end


### PR DESCRIPTION
## What does this PR change?

With this PR, users will be able to set the "Revision Number" when updating `init.sls` via CLI:

```
spacecmd> configchannel_updateinitsls ... -r <revision>
```
Or via API:

```
configchannel.updateInitSls(..., <revision>)
```

Note that this is already supported by the WebUI, so we are only adapting the CLI and API accordingly.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: The API documentation, which is acessible via "Help > API" on the left menu, is automatically generated.

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1179566 (Partially)
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
