### PR TITLE
Move dist upgrade allow vendor change sql to newer directory

### DIFF
--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- Move dist upgrade SQL file to the correct directory so it gets picked up in schema upgrades (bsc#1179759)
 - Changed to versioned Python2 to SPEC file.
 
 -------------------------------------------------------------------


### PR DESCRIPTION
Fixes issue when allow vendor change column sql file is in the an older schema directory. 
https://bugzilla.suse.com/show_bug.cgi?id=1179759
#13388 
port of https://github.com/SUSE/spacewalk/pull/13416

## What does this PR change?

Port of # **remove rest of file if this is a port**
## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed

- [ ] **DONE**

## Test coverage
- No tests: 

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
