### PR TITLE
Fix XML-RPC tests

### DIFF
--- a/testsuite/features/secondary/srv_xmlrpc_activationkey.feature
+++ b/testsuite/features/secondary/srv_xmlrpc_activationkey.feature
@@ -14,8 +14,8 @@ Feature: XML-RPC "activationkey" namespace
 
   Scenario: Activation key details
     Given I am logged in via XML-RPC activationkey as user "admin" and password "admin"
-    When I call activationkey.set_details() to the key
-    Then I have to see them by calling activationkey.get_details()
+    When I call activationkey.set_details() to the key setting as description "Key description"
+    Then I have to see them by calling activationkey.get_details() having as description "Key description"
 
   Scenario: Cleanup: delete activation key
     Then I should get key deleted

--- a/testsuite/features/step_definitions/xmlrpc_common.rb
+++ b/testsuite/features/step_definitions/xmlrpc_common.rb
@@ -240,8 +240,17 @@ When(/^I add config channels "([^"]*)" to a newly created key$/) do |channel_nam
   raise if @activation_key_api.add_config_channels(key, [channel_name]) < 1
 end
 
-Then(/^I have to see them by calling activationkey\.get_details\(\)$/) do
-  raise unless @activation_key_api.get_details(key)
+When(/^I call activationkey\.set_details\(\) to the key setting as description "([^"]*)"$/) do |description|
+  raise unless @activation_key_api.set_details(key, description, '', 10, 'default')
+end
+
+Then(/^I have to see them by calling activationkey\.get_details\(\) having as description "([^"]*)"$/) do |description|
+  details = @activation_key_api.get_details(key)
+  puts "Key info for the key details['key']:"
+  details.each_pair do |k, v|
+    puts "  #{k}:#{v}"
+  end
+  raise unless details['description'] == description
 end
 
 When(/^I create an activation key including custom channels for "([^"]*)" via XML-RPC$/) do |client|
@@ -334,6 +343,7 @@ Given(/^I am logged in via XML\-RPC actionchain as user "(.*?)" and password "(.
   # Authenticate
   @action_chain_api = XMLRPCActionChain.new($server.ip)
   @schedule_api = XMLRPCScheduleTest.new($server.ip)
+  @system_api = XMLRPCSystemTest.new($server.ip)
   @action_chain_api.login(luser, password)
   @system_api.login(luser, password)
   @schedule_api.login(luser, password)

--- a/testsuite/features/support/xmlrpc_activationkey.rb
+++ b/testsuite/features/support/xmlrpc_activationkey.rb
@@ -55,14 +55,6 @@ class XMLRPCActivationKeyTest < XMLRPCBaseTest
   end
 
   def get_details(id)
-    keyinfo = @connection.call('activationkey.get_details', @sid, id)
-    puts '      Key info for the key ' + keyinfo['key']
-
-    keyinfo.each_pair do |k, v|
-      puts '        ' + k.to_s + ': ' + v.to_s
-    end
-
-    res = ('Test description of the key ' + id) == keyinfo['description']
-    res
+    @connection.call('activationkey.get_details', @sid, id)
   end
 end


### PR DESCRIPTION
## What does this PR change?

This PR fix two XML-RPC issues:
-  As we refactored the activation key API handler, we need to refactor the scenarios for get_details and set_details
- On the login method for the action chain API handler, we missed a instantiation

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
