### PR TITLE
fix reboot action race condition (bsc#1177031)

### DIFF
--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -2396,8 +2396,6 @@ public class SaltServerActionService {
                         // Wait until next "minion/start/event" to set it to COMPLETED.
                         if (action.get().getActionType().equals(ActionFactory.TYPE_REBOOT) &&
                                 success && retcode == 0) {
-                            sa.setStatus(ActionFactory.STATUS_PICKED_UP);
-                            sa.setPickupTime(new Date());
                             return;
                         }
                         else if (action.get().getActionType().equals(ActionFactory.TYPE_KICKSTART_INITIATE) &&

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- fix reboot action race condition (bsc#1177031)
 - Improves misleading UI message displayed on systems with modules activated (bsc#1179525)
 - Fix availability check for debian repositories (bsc#1180127)
 - Added 'contents' argument to the 'configchannel.create' XMLRPC API method (bsc#1179566)


### PR DESCRIPTION
## What does this PR change?

This fixes a race condition where setting the picked up time again after the reboot has already been started could lead to the boot time being earlier then the pickup time of the action triggering the reboot.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests: manually tested

- [x] **DONE**

## Links

Fixes #https://github.com/SUSE/spacewalk/issues/12590


- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
