### PR TITLE
spacewalk-backend: SPEC file update Python3 build requirements/Source0

### DIFF
--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- SPEC file update: Source0 URL, Python3 build requirements.
 - Added logging for dpkg repository detection
 - Added RHEL8 build.
 

--- a/backend/spacewalk-backend.spec
+++ b/backend/spacewalk-backend.spec
@@ -50,7 +50,7 @@ Group:          System/Management
 Version:        4.2.4
 Release:        1%{?dist}
 Url:            https://github.com/uyuni-project/uyuni
-Source0:        https://github.com/spacewalkproject/spacewalk/archive/%{name}-%{version}.tar.gz
+Source0:        https://github.com/uyuni-project/uyuni/archive/%{name}-%{version}-1.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 %if !0%{?suse_version} || 0%{?suse_version} >= 1120
 BuildArch:      noarch
@@ -75,6 +75,7 @@ BuildRequires:  /usr/bin/docbook2man
 BuildRequires:  /usr/bin/msgfmt
 BuildRequires:  docbook-utils
 BuildRequires:  fdupes
+BuildRequires:  python3
 BuildRequires:  python3-gzipstream
 BuildRequires:  python3-rhn-client-tools
 BuildRequires:  python3-rhnlib >= 2.5.74


### PR DESCRIPTION
## What does this PR change?

SPEC file update:
- Source0 URL
- Python3 as build requirement.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: No functional change.

- [X] **DONE**

## Test coverage
- No tests: Tested during automatic package build.
Manually built successfully on LEAP15.2, CentOS8

- [X] **DONE**

## Links


- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
