### PR TITLE
Testsuite - add beta tools to do not kill list

### DIFF
--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -112,9 +112,13 @@ def compute_list_to_leave_running
         %w[sle-product-sles15-sp2-pool-x86_64
            sle-manager-tools15-pool-x86_64-sp2
            sle-module-containers15-sp2-pool-x86_64
+           sle-module-server-applications15-sp2-pool-x86_64
+           sle-manager-tools15-beta-updates-x86_64-sp2
            sle-product-sles15-sp2-updates-x86_64
            sle-manager-tools15-updates-x86_64-sp2
-           sle-module-containers15-sp2-updates-x86_64]
+           sle-module-containers15-sp2-updates-x86_64
+           sle-module-server-applications15-sp2-updates-x86_64
+           sle-manager-tools15-beta-updates-x86_64-sp2]
       else
         []
       end


### PR DESCRIPTION
## What does this PR change?

This PR adds beta tools and server apps repos to do not kill list for repo synchronization.

## Links

https://github.com/SUSE/spacewalk/issues/13284

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
