### PR TITLE
Fix "working directory" on cucumber tests that rely on downloaded files

### DIFF
--- a/testsuite/features/secondary/min_action_chain.feature
+++ b/testsuite/features/secondary/min_action_chain.feature
@@ -99,8 +99,8 @@ Feature: Action chains on Salt minions
     And I follow "List/Remove Files"
     And I follow "/etc/action-chain.cnf"
     And I follow "Download File"
-    And I wait until file "/root/action-chain.cnf" exists on "localhost"
-    Then file "/root/action-chain.cnf" should contain "Testchain=YES_PLEASE" on "localhost"
+    And I wait until file "/tmp/downloads/action-chain.cnf" exists on "localhost"
+    Then file "/tmp/downloads/action-chain.cnf" should contain "Testchain=YES_PLEASE" on "localhost"
 
   Scenario: Subscribe system to configuration channel for testing action chain on Salt minion
     Given I am on the Systems overview page of this "sle_minion"
@@ -276,4 +276,4 @@ Feature: Action chains on Salt minions
     And I run "rm -f /tmp/action_chain_one_system_done" on "sle_minion" without error control
 
   Scenario: Cleanup: remove downloaded files
-    When I run "rm -f /root/action-chain.cnf" on "localhost" without error control
+    When I run "rm -f /tmp/downloads/action-chain.cnf" on "localhost" without error control

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -57,7 +57,13 @@ Capybara.register_driver(:headless_chrome) do |app|
   # WORKAROUND failure at Scenario: Test IPMI functions: increase from 60 s to 180 s
   client.read_timeout = 180
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-    chromeOptions: { args: %w[headless no-sandbox disable-dev-shm-usage disable-gpu window-size=2048,2048, js-flags=--max_old_space_size=2048], w3c: false },
+    chromeOptions: {
+      args: %w[headless no-sandbox disable-dev-shm-usage disable-gpu window-size=2048,2048, js-flags=--max_old_space_size=2048],
+      w3c: false,
+      prefs: {
+        'download.default_directory': '/tmp/downloads'
+      }
+    },
     unexpectedAlertBehaviour: 'accept',
     unhandledPromptBehavior: 'accept'
   )


### PR DESCRIPTION
## What does this PR change?

PR https://github.com/uyuni-project/uyuni/pull/2921 assumed that E2E tests are executed from the `/root` location on the `controller` node.

If `CI` is running E2E tests from a different location, we will need to adapt accordingly.

This PR assumes that E2E tests are executed from `/root/spacewalk/testsuite/` location.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: just fixing tests

- [x] **DONE**

## Test coverage
- Cucumber tests were fixed

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
