### PR TITLE
spacewalk-java: Updated RHEL8 jars

### DIFF
--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -617,22 +617,12 @@ rm -rf $RPM_BUILD_ROOT/classes/com/redhat/rhn/common/conf/test/conf
 rm -rf $RPM_BUILD_ROOT%{_datadir}/rhn/unittest.xml
 %endif
 
-# Pretifying symlinks for RHEL
+# Prettifying symlinks for RHEL
 %if 0%{?rhel}
 mv $RPM_BUILD_ROOT%{jardir}/jboss-loggingjboss-logging.jar $RPM_BUILD_ROOT%{jardir}/jboss-logging.jar
 mv $RPM_BUILD_ROOT%{jardir}/jafjakarta.activation.jar $RPM_BUILD_ROOT%{jardir}/jaf.jar
 mv $RPM_BUILD_ROOT%{jardir}/javamailjavax.mail.jar $RPM_BUILD_ROOT%{jardir}/javamail.jar
 mv $RPM_BUILD_ROOT%{jardir}/jta.jar $RPM_BUILD_ROOT%{jardir}/geronimo-jta-1.1-api.jar
-mv $RPM_BUILD_ROOT%{jardir}/struts_core.jar $RPM_BUILD_ROOT%{jardir}/struts.jar
-# Repointing some symlinks.
-ln -nsf /usr/share/java/c3p0/c3p0.jar $RPM_BUILD_ROOT%{jardir}/c3p0.jar
-ln -nsf /usr/share/java/concurrent/concurrent.jar $RPM_BUILD_ROOT%{jardir}/concurrent.jar
-ln -nsf /usr/share/java/hibernate-commons-annotations/hibernate-commons-annotations.jar $RPM_BUILD_ROOT%{jardir}/hibernate-commons-annotations.jar
-ln -nsf /usr/share/java/javamail/javax.mail.jar $RPM_BUILD_ROOT%{jardir}/javamail.jar
-ln -nsf /usr/share/java/c3p0/c3p0.jar $RPM_BUILD_ROOT$TASKOMATIC_BUILD_DIR/c3p0.jar
-ln -nsf /usr/share/java/concurrent/concurrent.jar $RPM_BUILD_ROOT$TASKOMATIC_BUILD_DIR/concurrent.jar
-ln -nsf /usr/share/java/hibernate-commons-annotations/hibernate-commons-annotations.jar $RPM_BUILD_ROOT$TASKOMATIC_BUILD_DIR/hibernate-commons-annotations.jar
-ln -nsf /usr/share/java/javamail/javax.mail.jar $RPM_BUILD_ROOT$TASKOMATIC_BUILD_DIR/javamail.jar
 # Removing unused symlinks.
 rm -rf $RPM_BUILD_ROOT%{jardir}/jafjakarta.activation-api.jar
 rm -rf $RPM_BUILD_ROOT%{jardir}/javamaildsn.jar
@@ -643,8 +633,6 @@ rm -rf $RPM_BUILD_ROOT%{jardir}/javamailmail.jar
 rm -rf $RPM_BUILD_ROOT%{jardir}/javamailmailapi.jar
 rm -rf $RPM_BUILD_ROOT%{jardir}/javamailpop3.jar
 rm -rf $RPM_BUILD_ROOT%{jardir}/javamailsmtp.jar
-rm -rf $RPM_BUILD_ROOT%{jardir}/struts_extras.jar
-rm -rf $RPM_BUILD_ROOT%{jardir}/struts_taglib.jar
 %endif
 
 # show all JAR symlinks


### PR DESCRIPTION
## What does this PR change?

Updated some jar names for HREL8 due to package rebuild on OBS.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: No functional changes.

- [X] **DONE**

## Test coverage
- No tests: Tested during auto-build.
Manually tested successfully on CentOS8 and LEAP15.2

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
