### PR TITLE
susemanager-schema: Use versioned Python2 for RHEL8 and Fedora.

### DIFF
--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- Use versioned Python2 for RHEL8 and Fedora.
 - Move dist upgrade SQL file to the correct directory so it gets picked up in schema upgrades (bsc#1179759)
 - Changed to versioned Python2 to SPEC file.
 

--- a/schema/spacewalk/susemanager-schema.spec
+++ b/schema/spacewalk/susemanager-schema.spec
@@ -64,6 +64,9 @@ Provides schema-source-sanity-check.pl script for external usage.
 %prep
 
 %setup -q
+%if 0%{?rhel} || 0%{?fedora}
+sed -i '1s/python\b/python2/' blend
+%endif
 
 %build
 find . -name '*.91' | while read i ; do mv $i ${i%%.91} ; done


### PR DESCRIPTION
## What does this PR change?

Use versioned Python2 for RHEL8 and Fedora.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: No functional changes.

- [X] **DONE**

## Test coverage
- No tests: Tested during automatic build.
Built successfully on CentOS6-8, LEAP15.2 and Fedora32. Fails on Fedora33/Rawhide due to Perl.

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs
 
If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
