### PR TITLE
QA: Fix XML-RPC common step

### DIFF
--- a/testsuite/features/step_definitions/xmlrpc_common.rb
+++ b/testsuite/features/step_definitions/xmlrpc_common.rb
@@ -544,7 +544,6 @@ end
 Given(/^I am logged in via XML\-RPC powermgmt as user "([^"]*)" and password "([^"]*)"$/) do |luser, password|
   @powermanagenent_api = XMLRPCPowermanagementTest.new($server.ip)
   @powermanagenent_api.login(luser, password)
-  @system_api.login(luser, password)
 end
 
 When(/^I fetch power management values$/) do


### PR DESCRIPTION
## What does this PR change?

Fixing a mistake in the step
```
 Given(/^I am logged in via XML\-RPC powermgmt as user "([^"]*)" and password "([^"]*)"$/) do |luser, password|
  @powermanagenent_api = XMLRPCPowermanagementTest.new($server.ip)
  @powermanagenent_api.login(luser, password)
  @system_api.login(luser, password)  # <------ THIS SHOULDN'T BE HERE
end
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Tracks # https://github.com/SUSE/spacewalk/pull/13443

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
