### PR TITLE
Fix XML-RPC powermgmt login of system api (#13444)

### DIFF
--- a/testsuite/features/secondary/srv_xmlrpc_activationkey.feature
+++ b/testsuite/features/secondary/srv_xmlrpc_activationkey.feature
@@ -1,19 +1,19 @@
-# Copyright (c) 2015 SUSE LLC
+# Copyright (c) 2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: XML-RPC "activationkey" namespace
 
-  Scenario: List all activation keys
+  Background:
     Given I am logged in via XML-RPC activationkey as user "admin" and password "admin"
+
+  Scenario: List all activation keys
     When I call listActivationKeys I should get some
 
   Scenario: Create activation key
-    Given I am logged in via XML-RPC activationkey as user "admin" and password "admin"
     When I create an AK with id "testkey", description "Key for testing" and limit of 10
     Then I should get it listed with a call of listActivationKeys
 
   Scenario: Activation key details
-    Given I am logged in via XML-RPC activationkey as user "admin" and password "admin"
     When I call activationkey.set_details() to the key setting as description "Key description"
     Then I have to see them by calling activationkey.get_details() having as description "Key description"
 

--- a/testsuite/features/secondary/srv_xmlrpc_channel.feature
+++ b/testsuite/features/secondary/srv_xmlrpc_channel.feature
@@ -3,22 +3,22 @@
 
 Feature: XML-RPC "channel" namespace and sub-namespaces
 
-  Scenario: Create a custom software channel
+  Background:
     Given I am logged in via XML-RPC channel as user "admin" and password "admin"
+
+  Scenario: Create a custom software channel
     When I create the following channels:
       | LABEL  | NAME   | SUMMARY | ARCH           | PARENT |
       | foobar | foobar | foobar  | channel-x86_64 |        |
     Then "foobar" should get listed with a call of listSoftwareChannels
 
   Scenario: Create a repository
-    Given I am logged in via XML-RPC channel as user "admin" and password "admin"
     When I create a repo with label "foobar" and url
     And I associate repo "foobar" with channel "foobar"
     Then channel "foobar" should have attribute "last_modified" from type "XMLRPC::DateTime"
     And channel "foobar" should not have attribute "yumrepo_last_sync"
 
   Scenario: Create a custom software channel as the child of another one
-    Given I am logged in via XML-RPC channel as user "admin" and password "admin"
     When I create the following channels:
       | LABEL        | NAME         | SUMMARY         | ARCH           | PARENT |
       | foobar-child | foobar-child | child of foobar | channel-x86_64 | foobar |
@@ -26,20 +26,16 @@ Feature: XML-RPC "channel" namespace and sub-namespaces
     And "foobar" should be the parent channel of "foobar-child"
 
   Scenario: List software channels
-    Given I am logged in via XML-RPC channel as user "admin" and password "admin"
     Then something should get listed with a call of listSoftwareChannels
 
   Scenario: Delete a child software channel
-    Given I am logged in via XML-RPC channel as user "admin" and password "admin"
     When I delete the software channel with label "foobar-child"
     Then "foobar-child" should not get listed with a call of listSoftwareChannels
 
   Scenario: Delete a software channel
-    Given I am logged in via XML-RPC channel as user "admin" and password "admin"
     When I delete the repo with label "foobar"
     And I delete the software channel with label "foobar"
     Then "foobar" should not get listed with a call of listSoftwareChannels
 
   Scenario: Check last synchronization of a synced channel
-    Given I am logged in via XML-RPC channel as user "admin" and password "admin"
     Then channel "test-channel-i586" should have attribute "yumrepo_last_sync" from type "XMLRPC::DateTime"

--- a/testsuite/features/secondary/srv_xmlrpc_user.feature
+++ b/testsuite/features/secondary/srv_xmlrpc_user.feature
@@ -1,22 +1,24 @@
-# Copyright (c) 2015 SUSE LLC
+# Copyright (c) 2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: XML-RPC "user" namespace
 
-  Scenario: Basic user operations
+  Background:
     Given I am logged in via XML-RPC user as user "admin" and password "admin"
+
+  Scenario: Basic user operations
     When I call user.list_users()
     Then I should get at least user "admin"
     When I call user.get_details() on user "admin"
     Then I should see at least one role that matches "_admin" suffix
 
+  Scenario: Create user
     Given I make sure "testluser" is not present
     When I call user.create(sid, login, pwd, name, lastname, email) with login "testluser"
     Then when I call user.list_users(), I should see a user "testluser"
     And I logout from XML-RPC user namespace
 
   Scenario: Role operations
-    Given I am logged in via XML-RPC user as user "admin" and password "admin"
     When I call user.add_role() on "testluser" with the role "org_admin"
     Then I should see "org_admin" when I call user.list_roles() with "testluser"
     When I call user.remove_role() against uid "testluser" with the role "org_admin"
@@ -24,6 +26,5 @@ Feature: XML-RPC "user" namespace
     And I logout from XML-RPC user namespace
 
   Scenario: Cleanup: user tests
-    Given I am logged in via XML-RPC user as user "admin" and password "admin"
     When I delete user "testluser"
     Then I logout from XML-RPC user namespace

--- a/testsuite/features/step_definitions/xmlrpc_common.rb
+++ b/testsuite/features/step_definitions/xmlrpc_common.rb
@@ -544,6 +544,8 @@ end
 Given(/^I am logged in via XML\-RPC powermgmt as user "([^"]*)" and password "([^"]*)"$/) do |luser, password|
   @powermanagenent_api = XMLRPCPowermanagementTest.new($server.ip)
   @powermanagenent_api.login(luser, password)
+  @system_api = XMLRPCSystemTest.new($server.ip)
+  @system_api.login(luser, password)
 end
 
 When(/^I fetch power management values$/) do


### PR DESCRIPTION
## What does this PR change?

Fixing a mistake in the step, as a further step of the scenarios of powermgmt depends on system api
```
 Given(/^I am logged in via XML\-RPC powermgmt as user "([^"]*)" and password "([^"]*)"$/) do |luser, password|
  @powermanagenent_api = XMLRPCPowermanagementTest.new($server.ip)
  @powermanagenent_api.login(luser, password)
end
```
Also adding a small refactor to fix another dependency of step issue.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Tracks # https://github.com/SUSE/spacewalk/pull/13444

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
