### PR TITLE
spacewalk-abrt: Added versioned Python2 for RHEL8 build.

### DIFF
--- a/client/tools/spacewalk-abrt/spacewalk-abrt.changes
+++ b/client/tools/spacewalk-abrt/spacewalk-abrt.changes
@@ -1,3 +1,5 @@
+- Added versioned Python2 for RHEL8 build.
+
 -------------------------------------------------------------------
 Fri Sep 18 12:12:48 CEST 2020 - jgonzalez@suse.com
 

--- a/client/tools/spacewalk-abrt/spacewalk-abrt.spec
+++ b/client/tools/spacewalk-abrt/spacewalk-abrt.spec
@@ -36,12 +36,16 @@ License:        GPL-2.0-only
 Group:          Applications/System
 
 Url:            https://github.com/uyuni-project/uyuni
-Source0:        https://github.com/spacewalkproject/spacewalk/archive/%{name}-%{version}.tar.gz
+Source0:        https://github.com/uyuni-project/uyuni/archive/%{name}-%{version}-1.tar.gz
 Source1:        %{name}-rpmlintrc
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
 BuildRequires:  gettext
+%if 0%{?rhel} >= 8
+BuildRequires:  python2-devel
+%else
 BuildRequires:  python-devel
+%endif
 Requires:       %{pythonX}-%{name} = %{version}-%{release}
 Requires:       abrt
 Requires:       abrt-cli
@@ -53,7 +57,11 @@ spacewalk-abrt - rhn-check plug-in for collecting information about crashes hand
 %package -n python2-%{name}
 Summary:        ABRT plug-in for rhn-check
 Group:          Applications/System
-BuildRequires:  python
+%if 0%{?rhel} >= 8
+BuildRequires:       python2
+%else
+BuildRequires:       python
+%endif
 Requires:       python2-rhn-check
 Requires:       python2-rhn-client-tools
 


### PR DESCRIPTION
## What does this PR change?

Added versioned Python2 for RHEL8 build.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: No functional change.

- [X] **DONE**

## Test coverage
- No tests: Tested during package build.
Manually tested build successfully on CentOS6+, LEAP15.2, Fedora32+

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
