### PR TITLE
Testsuite - do not use beta client tools for SLE15

### DIFF
--- a/testsuite/features/reposync/srv_sync_products.feature
+++ b/testsuite/features/reposync/srv_sync_products.feature
@@ -52,6 +52,8 @@ Feature: Synchronize products in the products page of the Setup Wizard
     Then I should see a "Basesystem Module 15 SP2 x86_64" text
     And I should see that the "Basesystem Module 15 SP2 x86_64" product is "recommended"
     When I select "SUSE Linux Enterprise Server 15 SP2 x86_64" as a product
+    # Drop following line if you wish to re-enable testing with beta client tools for SLE15
+    And I deselect "SUSE Manager Tools 15 x86_64 (BETA)" as a SUSE Manager product
     Then I should see the "SUSE Linux Enterprise Server 15 SP2 x86_64" selected
     Then I should see the "Basesystem Module 15 SP2 x86_64" selected
     And I click the Add Product button


### PR DESCRIPTION
## What does this PR change?

PR unselects `SUSE Manager Tools 15 x86_64 (BETA)` so only released client tools are used.

## Links

https://github.com/SUSE/spacewalk/issues/13284

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
