### PR TITLE
Testsuite - fix beta client tools deselection

### DIFF
--- a/testsuite/features/reposync/srv_sync_products.feature
+++ b/testsuite/features/reposync/srv_sync_products.feature
@@ -52,7 +52,8 @@ Feature: Synchronize products in the products page of the Setup Wizard
     Then I should see a "Basesystem Module 15 SP2 x86_64" text
     And I should see that the "Basesystem Module 15 SP2 x86_64" product is "recommended"
     When I select "SUSE Linux Enterprise Server 15 SP2 x86_64" as a product
-    # Drop following line if you wish to re-enable testing with beta client tools for SLE15
+    # Drop following 2 lines if you wish to re-enable testing with beta client tools for SLE15
+    And I open the sub-list of the product "Basesystem Module 15 SP2 x86_64"
     And I deselect "SUSE Manager Tools 15 x86_64 (BETA)" as a SUSE Manager product
     Then I should see the "SUSE Linux Enterprise Server 15 SP2 x86_64" selected
     Then I should see the "Basesystem Module 15 SP2 x86_64" selected


### PR DESCRIPTION
## What does this PR change?

Fix of https://github.com/uyuni-project/uyuni/pull/3017

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
