### PR TITLE
spacewalk-setup: Added dynamic path for trust store and doc root.

### DIFF
--- a/spacewalk/setup/bin/spacewalk-setup
+++ b/spacewalk/setup/bin/spacewalk-setup
@@ -747,9 +747,17 @@ sub setup_ssl_certs {
 
   print Spacewalk::Setup::loc("** SSL: Deploying CA certificate.\n");
 
+  # Set the document root depending on OS.
+  my $DOC_ROOT = $Spacewalk::Setup::DEFAULT_DOC_ROOT;
+  $DOC_ROOT = $Spacewalk::Setup::SUSE_DOC_ROOT if(is_suse_like());
+
+  # Set the trust store folder depending on OS.
+  my $CA_TRUST_DIR = $Spacewalk::Setup::CA_TRUST_DIR;
+  $CA_TRUST_DIR = $Spacewalk::Setup::SUSE_CA_TRUST_DIR if(is_suse_like());
+
   deploy_ca_cert("-source-dir" => $answers->{'ssl-dir'},
-                 "-target-dir" => $Spacewalk::Setup::DEFAULT_DOC_ROOT."/pub",
-                 "-trust-dir" => $Spacewalk::Setup::CA_TRUST_DIR);
+                 "-target-dir" => $DOC_ROOT."/pub",
+                 "-trust-dir" => $CA_TRUST_DIR);
 
   if (!$use_own_certs) {
       print Spacewalk::Setup::loc("** SSL: Generating server certificate.\n");
@@ -937,6 +945,10 @@ sub populate_initial_configs {
     # Define some db specific settings:
     Spacewalk::Setup::set_hibernate_conf($answers);
 
+    # Set the document root depending on OS.
+    my $DOC_ROOT = $Spacewalk::Setup::DEFAULT_DOC_ROOT;
+    $DOC_ROOT = $Spacewalk::Setup::SUSE_DOC_ROOT if(is_suse_like());
+
   my %config_opts =
     (
      mount_point => $answers->{'mount-point'} || '/var/spacewalk',
@@ -944,7 +956,7 @@ sub populate_initial_configs {
      serverDOTsatelliteDOThttp_proxy => ($opts->{'rhn-http-proxy'} ? $opts->{'rhn-http-proxy'} : $answers->{'rhn-http-proxy'}) || '',
      serverDOTsatelliteDOThttp_proxy_username => ($opts->{'rhn-http-proxy'} ? $opts->{'rhn-http-proxy-username'} : $answers->{'rhn-http-proxy-username'}) || '',
      serverDOTsatelliteDOThttp_proxy_password => ($opts->{'rhn-http-proxy'} ? $opts->{'rhn-http-proxy-password'} :$answers->{'rhn-http-proxy-password'}) || '',
-     osadispatcherDOTosa_ssl_cert => $Spacewalk::Setup::DEFAULT_DOC_ROOT."/pub/RHN-ORG-TRUSTED-SSL-CERT",
+     osadispatcherDOTosa_ssl_cert => $DOC_ROOT."/pub/RHN-ORG-TRUSTED-SSL-CERT",
      encrypted_passwords => 1,
      db_backend => $answers->{'db-backend'},
      db_user => $answers->{'db-user'},

--- a/spacewalk/setup/lib/Spacewalk/Setup.pm
+++ b/spacewalk/setup/lib/Spacewalk/Setup.pm
@@ -99,8 +99,11 @@ use constant ORACLE_RHNCONF_BACKUP =>
 
 use constant EMBEDDED_DB_ANSWERS =>
   '/usr/share/spacewalk/setup/defaults.d/embedded-postgresql.conf';
-our $DEFAULT_DOC_ROOT = "/srv/www/htdocs";
-our $CA_TRUST_DIR = '/etc/pki/trust/anchors';
+our $DEFAULT_DOC_ROOT = "/var/www/html";
+our $SUSE_DOC_ROOT = "/srv/www/htdocs";
+
+our $CA_TRUST_DIR = '/etc/pki/ca-trust/source/anchors';
+our $SUSE_CA_TRUST_DIR = '/etc/pki/trust/anchors';
 use constant DEFAULT_SUSEMANAGER_CONF =>
   '/usr/share/rhn/config-defaults/rhn_server_susemanager.conf';
 

--- a/spacewalk/setup/spacewalk-setup.changes
+++ b/spacewalk/setup/spacewalk-setup.changes
@@ -1,3 +1,4 @@
+- Added dynamic path for trust store and doc root.
 - Updated SPEC for RHEL and Fedora.
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

- Dynamic truststore location for SUSE and RHEL.
- Dynamic document root location for SUSE and RHEL.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: No functional change.

- [X] **DONE**

## Test coverage
- No tests: I don't know how to create tests for this.
Manually verified the installation still working on physical CentOS8 and LEAP15.2 system.

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
