### PR TITLE
QA: Fix default Cucumber profile

### DIFF
--- a/testsuite/config/cucumber.yml
+++ b/testsuite/config/cucumber.yml
@@ -1,4 +1,4 @@
-default:
+default: -f pretty -r features
 smdba: --tags @scope_smdba
 spacecmd: --tags @scope_spacecmd
 spacewalk_utils: --tags @scope_spacewalk_utils


### PR DESCRIPTION
## What does this PR change?

The default Cucumber profile must have some content, otherwise it fails.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
