### PR TITLE
Testsuite - remove duplicity scenario and use tag for suma specific one

### DIFF
--- a/testsuite/features/reposync/srv_sync_channels.feature
+++ b/testsuite/features/reposync/srv_sync_channels.feature
@@ -23,6 +23,7 @@ Feature: Be able to list available channels and enable them
     And I shouldn't get "sles11-extras"
 
 @scc_credentials
+@susemanager
   Scenario: List products
     When I execute mgr-sync "list products"
     Then I should get "[ ] SUSE Linux Enterprise Server 12 SP4 x86_64"
@@ -36,13 +37,6 @@ Feature: Be able to list available channels and enable them
     And I should get "[ ] SUSE Manager Proxy 4.0 x86_64"
     And I should get "  [ ] (R) SUSE Linux Enterprise Client Tools RES 7 x86_64"
     And I should get "  [ ] (R) SUSE Manager Tools 15 x86_64"
-
-@scc_credentials
-@uyuni
-  Scenario: List all products for Uyuni
-    When I execute mgr-sync "list products --expand"
-    Then I should get "[ ] SUSE Linux Enterprise Server 12 SP4 x86_64"
-    And I should get "[ ] SUSE Manager Proxy 4.0 x86_64"
 
 @scc_credentials
   Scenario: List products with filter


### PR DESCRIPTION
## What does this PR change?

This PR adds tag for SUSE Manager specific scenario and removes `List all products for Uyuni` scenario as this is fully covered by the steps from previous one (`List all products for SUSE Manager`) and also is specific for SUSE Manager again.

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
