### PR TITLE
Allow to specify file contents when creating state channel via API

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/configchannel/ConfigChannelHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/configchannel/ConfigChannelHandler.java
@@ -54,6 +54,7 @@ import com.redhat.rhn.manager.system.SystemManager;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -113,9 +114,40 @@ public class ConfigChannelHandler extends BaseHandler {
      * $ConfigChannelSerializer
      */
     public ConfigChannel create(User user, String label, String name, String description, String channelType) {
+        return create(user, label, name, description, channelType, new HashMap<>());
+    }
+
+    /**
+     * Creates a new global config channel based on the values provided..
+     * @param user The current user
+     * @param label label of the config channel
+     * @param name name of the config channel
+     * @param description description of the config channel
+     * @param channelType type of config channel(possible values are 'state', 'normal')
+     * @param data a map containing 'content' and 'contents_enc64' (only applicable for channelType 'state')
+     * @return the newly created config channel
+     *
+     * @xmlrpc.doc Create a new global config channel. Caller must be at least a
+     * config admin or an organization admin.
+     * @xmlrpc.param #session_key()
+     * @xmlrpc.param #param("string", "channelLabel")
+     * @xmlrpc.param #param("string", "channelName")
+     * @xmlrpc.param #param("string", "channelDescription")
+     * @xmlrpc.param #param_desc("string", "channelType", "The channel type either 'normal' or 'state'.")
+     * @xmlrpc.param
+     *  #struct_begin("path info")
+     *      #prop_desc("string", "contents", "Contents of the init.sls file")
+     *      #prop_desc("boolean", "contents_enc64", "Identifies base64 encoded content(default: disabled)")
+     *  #struct_end()
+     * @xmlrpc.returntype
+     * $ConfigChannelSerializer
+     */
+    public ConfigChannel create(User user, String label, String name, String description, String channelType,
+                                Map<String, Object> data) {
         ensureConfigAdmin(user);
 
         ConfigChannelCreationHelper helper = new ConfigChannelCreationHelper();
+        XmlRpcConfigChannelHelper ccHelper = XmlRpcConfigChannelHelper.getInstance();
         try {
             helper.validate(label, name, description);
             ConfigChannelType ct = helper.getGlobalChannelType(channelType);
@@ -123,7 +155,16 @@ public class ConfigChannelHandler extends BaseHandler {
             helper.update(cc, name, label, description);
             ConfigurationManager.getInstance().save(cc, empty());
             cc  = (ConfigChannel) HibernateFactory.reload(cc);
-            helper.createInitSlsFile(user, cc, "");
+            String contents = "";
+            if (data.containsKey(ConfigRevisionSerializer.CONTENTS)) {
+                try {
+                    contents = ccHelper.getContents(data);
+                }
+                catch (UnsupportedEncodingException e) {
+                    throw new ConfigFileErrorException(e.getMessage());
+                }
+            }
+            helper.createInitSlsFile(user, cc, contents);
             return cc;
         }
         catch (ValidatorException ve) {

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Added 'contents' argument to the 'configchannel.create' XMLRPC API method (bsc#1179566)
 - Ignore duplicate NEVRAs in package profile update (bsc#1176018)
 - Prevent deletion of CLM environments if they're used in an autoinstallation
   profile (bsc#1179552)

--- a/testsuite/features/secondary/min_config_state_channel_xmlrpc.feature
+++ b/testsuite/features/secondary/min_config_state_channel_xmlrpc.feature
@@ -1,0 +1,22 @@
+# Copyright (c) 2020 SUSE LLC.
+# Licensed under the terms of the MIT license.
+
+Feature: Configuration state channels via XML-RPC API
+
+  Scenario: Create a state channel via XML-RPC
+    Given I am logged in via XML-RPC configchannel as user "admin" and password "admin"
+    When I create state channel "statechannel1" via XML-RPC
+    And I call configchannel.get_file_revision with file "/init.sls", revision "1" and channel "statechannel1" via XML-RPC
+    Then I should get file contents ""
+
+  Scenario: Create a state channel with contents via XML-RPC
+    Given I am logged in via XML-RPC configchannel as user "admin" and password "admin"
+    When I create state channel "statechannel2" containing "touch /root/foobar:\n  cmd.run:\n    - creates: /root/foobar" via XML-RPC
+    And I call configchannel.get_file_revision with file "/init.sls", revision "1" and channel "statechannel2" via XML-RPC
+    Then I should get file contents "touch /root/foobar:\n  cmd.run:\n    - creates: /root/foobar"
+
+  Scenario: Cleanup: remove state channels via XML-RPC
+    Given I am logged in via XML-RPC configchannel as user "admin" and password "admin"
+    Then I delete channel "statechannel1" via XML-RPC without error control
+    And I delete channel "statechannel2" via XML-RPC without error control
+    And I logout from XML-RPC configchannel namespace

--- a/testsuite/features/step_definitions/xmlrpc_common.rb
+++ b/testsuite/features/step_definitions/xmlrpc_common.rb
@@ -653,12 +653,36 @@ Then(/^"([^"]*)" should not be subscribed to channel "([^"]*)"$/) do |host, chan
   assert_equal(0, result.count { |item| item['name'] == system_name })
 end
 
+When(/^I create state channel "([^"]*)" via XML\-RPC$/) do |channel|
+  @configuration_channel_api.create_channel(channel, channel, channel, 'state')
+end
+
+When(/^I create state channel "([^"]*)" containing "([^"]*)" via XML\-RPC$/) do |channel, contents|
+  @configuration_channel_api.create_channel_with_data(channel, channel, channel, 'state', { 'contents' => contents })
+end
+
+When(/^I call configchannel.get_file_revision with file "([^"]*)", revision "([^"]*)" and channel "([^"]*)" via XML\-RPC$/) do |file_path, revision, channel|
+  @get_file_revision_result = @configuration_channel_api.get_file_revision(channel, file_path, revision.to_i)
+end
+
+Then(/^I should get file contents "([^\"]*)"$/) do |contents|
+  assert_equal(contents, @get_file_revision_result['contents'])
+end
+
 When(/^I add file "([^"]*)" containing "([^"]*)" to channel "([^"]*)"$/) do |file, contents, channel|
   @configuration_channel_api.create_or_update_path(channel, file, contents)
 end
 
 When(/^I deploy all systems registered to channel "([^"]*)"$/) do |channel|
   @configuration_channel_api.deploy_all_systems(channel)
+end
+
+When(/^I delete channel "([^"]*)" via XML\-RPC((?: without error control)?)$/) do |channel, error_control|
+  begin
+    @configuration_channel_api.delete_channels([channel])
+  rescue XMLRPC::FaultException => e
+    raise format('Error delete_channels: XML-RPC failure, code %s: %s', e.faultCode, e.faultString) if error_control.empty?
+  end
 end
 
 When(/^I logout from XML\-RPC configchannel namespace$/) do

--- a/testsuite/features/support/xmlrpc_configchannel.rb
+++ b/testsuite/features/support/xmlrpc_configchannel.rb
@@ -17,6 +17,18 @@ class XMLRPCConfigChannelTest < XMLRPCBaseTest
     @connection.call('configchannel.list_subscribed_systems', @sid, channel)
   end
 
+  def get_file_revision(channel, file_path, revision)
+    @connection.call('configchannel.get_file_revision', @sid, channel, file_path, revision)
+  end
+
+  def create_channel(label, name, description, type)
+    @connection.call('configchannel.create', @sid, label, name, description, type)
+  end
+
+  def create_channel_with_data(label, name, description, type, data)
+    @connection.call('configchannel.create', @sid, label, name, description, type, data)
+  end
+
   def create_or_update_path(channel, file, contents)
     @connection.call('configchannel.create_or_update_path',
                      @sid,
@@ -32,5 +44,9 @@ class XMLRPCConfigChannelTest < XMLRPCBaseTest
 
   def deploy_all_systems(channel)
     @connection.call('configchannel.deploy_all_systems', @sid, channel)
+  end
+
+  def delete_channels(channels)
+    @connection.call('configchannel.delete_channels', @sid, channels)
   end
 end


### PR DESCRIPTION
## What does this PR change?

With this PR, users will be able to provide "init.sls file contents" when creating a new state config channel via XML-RPC.

**Motivation:** Allow "inter server sync" to create an `init.sls` with contents and "revision 1".

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: The API documentation, which is acessible via "Help > API" on the left menu, is automatically generated.

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes: https://github.com/SUSE/spacewalk/issues/13345

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
