### PR TITLE
Fix access to fault string attribute of XMLRPC::FaultException

### DIFF
--- a/testsuite/features/step_definitions/xmlrpc_common.rb
+++ b/testsuite/features/step_definitions/xmlrpc_common.rb
@@ -371,7 +371,7 @@ Then(/^I delete the action chain$/) do
   begin
     @action_chain_api.delete_chain($chain_label)
   rescue XMLRPC::FaultException => e
-    raise format('deleteChain: XML-RPC failure, code %s: %s', e.faultCode, e.fault_string)
+    raise format('deleteChain: XML-RPC failure, code %s: %s', e.faultCode, e.faultString)
   end
 end
 
@@ -379,7 +379,7 @@ Then(/^I delete an action chain, labeled "(.*?)"$/) do |label|
   begin
     @action_chain_api.delete_chain(label)
   rescue XMLRPC::FaultException => e
-    raise format('deleteChain: XML-RPC failure, code %s: %s', e.faultCode, e.fault_string)
+    raise format('deleteChain: XML-RPC failure, code %s: %s', e.faultCode, e.faultString)
   end
 end
 
@@ -390,7 +390,7 @@ Then(/^I delete all action chains$/) do
       @action_chain_api.delete_chain(label)
     end
   rescue XMLRPC::FaultException => e
-    raise format('deleteChain: XML-RPC failure, code %s: %s', e.faultCode, e.fault_string)
+    raise format('deleteChain: XML-RPC failure, code %s: %s', e.faultCode, e.faultString)
   end
 end
 
@@ -429,7 +429,7 @@ Then(/^I should be able to see all these actions in the action chain$/) do
       puts "\t- " + action['label']
     end
   rescue XMLRPC::FaultException => e
-    raise format('Error listChainActions: XML-RPC failure, code %s: %s', e.faultCode, e.fault_string)
+    raise format('Error listChainActions: XML-RPC failure, code %s: %s', e.faultCode, e.faultString)
   end
 end
 
@@ -475,7 +475,7 @@ When(/^I call actionchain\.remove_action on each action within the chain$/) do
       puts "\t- Removed \"" + action['label'] + '" action'
     end
   rescue XMLRPC::FaultException => e
-    raise format('Error remove_action: XML-RPC failure, code %s: %s', e.faultCode, e.fault_string)
+    raise format('Error remove_action: XML-RPC failure, code %s: %s', e.faultCode, e.faultString)
   end
 end
 


### PR DESCRIPTION
## What does this PR change?

According to documentation[1], attribute name is `faultString` instead of `fault_string`.

Failure example:

![Screenshot from 2020-12-15 15-04-07](https://user-images.githubusercontent.com/14297426/102233232-f5f87380-3ee7-11eb-97e0-56562919fc8d.png)

[1] https://ruby-doc.org/stdlib-2.2.10/libdoc/xmlrpc/rdoc/XMLRPC/FaultException.html

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Just fixing E2E tests code.

- [x] **DONE**

## Test coverage
- No tests: Just fixing E2E tests code.

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

