### PR TITLE
Add saltkey to api

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/saltkey/SaltKeyHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/saltkey/SaltKeyHandler.java
@@ -14,8 +14,10 @@
  */
 package com.redhat.rhn.frontend.xmlrpc.saltkey;
 
+import com.redhat.rhn.common.security.PermissionException;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.xmlrpc.BaseHandler;
+import com.redhat.rhn.frontend.xmlrpc.PermissionCheckFailureException;
 
 import com.suse.manager.utils.SaltKeyUtils;
 
@@ -39,7 +41,7 @@ public class SaltKeyHandler extends BaseHandler {
      * API endpoint to delete minion keys
      * @param loggedInUser the user
      * @param minionId the key identifier (minionId)
-     * @return 1 on success otherwise 0
+     * @return 1 on success
      *
      * @xmlrpc.doc Delete a minion key
      * @xmlrpc.param #param("string", "sessionKey")
@@ -48,9 +50,12 @@ public class SaltKeyHandler extends BaseHandler {
      */
     public int delete(User loggedInUser, String minionId) {
         ensureOrgAdmin(loggedInUser);
-        if (saltKeyUtils.deleteSaltKey(loggedInUser, minionId)) {
-            return 1;
+        try {
+            saltKeyUtils.deleteSaltKey(loggedInUser, minionId);
         }
-        return 0;
+        catch (PermissionException e) {
+            throw new PermissionCheckFailureException(e);
+        }
+        return 1;
     }
 }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- register saltkey XMLRPC handler and fix behavior of delete salt key (bsc#1179872)
 - Added 'revision' argument to the 'configchannel.updateInitSls' XMLRPC API method (bsc#1179566)
 - Add validation for custom repository labels
 - Fix configuration file download links to actually download files instead of redirecting to the home page (bsc#1179324)


### PR DESCRIPTION
## What does this PR change?

The bahavior of the saltKey API was not behaving like described.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **already covered**

- [x] **DONE**

## Test coverage
- No tests: **already covered**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/13418

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
