### PR TITLE
Tftpsync fix option parsing

### DIFF
--- a/tftpsync/susemanager-tftpsync-recv/configure-tftpsync.sh
+++ b/tftpsync/susemanager-tftpsync-recv/configure-tftpsync.sh
@@ -60,11 +60,11 @@ while [ $# -ge 1 ]; do
         --help | -h)  print_help;;
         --answer-file=*) parse_answer_file $1;;
         --non-interactive) INTERACTIVE=0;;
-        --tftpbootdir) TFTPBOOT=$(echo $1 | cut -d= -f2-);;
-        --server-fqdn) SUMA_FQDN=$(echo $1 | cut -d= -f2-);;
-        --server-ip) SUMA_IP=$(echo $1 | cut -d= -f2-);;
-        --proxy-fqdn) SUMA_PROXY_FQDN=$(echo $1 | cut -d= -f2-);;
-        --proxy-ip) SUMA_PROXY_IP=$(echo $1 | cut -d= -f2-);;
+        --tftpbootdir=*) TFTPBOOT=$(echo $1 | cut -d= -f2-);;
+        --server-fqdn=*) SUMA_FQDN=$(echo $1 | cut -d= -f2-);;
+        --server-ip=*) SUMA_IP=$(echo $1 | cut -d= -f2-);;
+        --proxy-fqdn=*) SUMA_PROXY_FQDN=$(echo $1 | cut -d= -f2-);;
+        --proxy-ip=*) SUMA_PROXY_IP=$(echo $1 | cut -d= -f2-);;
         *) echo Error: Invalid option $1
     esac
     shift

--- a/tftpsync/susemanager-tftpsync-recv/susemanager-tftpsync-recv.changes
+++ b/tftpsync/susemanager-tftpsync-recv/susemanager-tftpsync-recv.changes
@@ -1,3 +1,4 @@
+- fix option parsing in configure-tftpsync (bsc#1180017)
 - Added RHEL8 compatibility.
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Parsing commandline options in configure-tftpsync.sh was broken

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **internal**

- [x] **DONE**

## Test coverage
- No tests: **manual**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/13465
Tracks https://github.com/SUSE/spacewalk/pull/13474 https://github.com/SUSE/spacewalk/pull/13475

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
