### PR TITLE
Fix broken bubble message style in localfilelist.jsp

### DIFF
--- a/java/code/webapp/WEB-INF/pages/configuration/overview/localfilelist.jsp
+++ b/java/code/webapp/WEB-INF/pages/configuration/overview/localfilelist.jsp
@@ -16,10 +16,12 @@
 <form method="post" role="form" name="rhn_list" action="/rhn/configuration/file/LocalConfigFileList.do">
   <rhn:csrf />
   <rhn:submitted />
+
+  <div class="alert alert-info">
+    <bean:message key="localfilelist.jsp.summary"/>
+  </div>
+
   <div class="panel panel-default">
-    <div class="panel-heading">
-        <h4><bean:message key="localfilelist.jsp.summary"/></h4>
-    </div>
     <div class="panel-body">
       <rhn:list pageList="${requestScope.pageList}" noDataText="localfilelist.jsp.noFiles">
         <rhn:listdisplay filterBy="localfilelist.jsp.path">


### PR DESCRIPTION
## What does this PR change?

Fix broken bubble message style
The bubble message is now aligned with the other "sister" page the [`globalfilelist.jsp`](https://github.com/uyuni-project/uyuni/blob/master/java/code/webapp/WEB-INF/pages/configuration/overview/globalfilelist.jsp#L20)

## GUI diff

Before:
![Screenshot from 2020-12-16 10-48-39](https://user-images.githubusercontent.com/7080830/102332617-9dc77d00-3f8c-11eb-81e5-03004f219ea7.png)


After:
![Screenshot from 2020-12-16 10-48-59](https://user-images.githubusercontent.com/7080830/102332643-a5872180-3f8c-11eb-9abe-4da9478baa6e.png)


- [x] **DONE**

## Documentation
- No documentation needed: simple broken style fix

- [x] **DONE**

## Test coverage
- No tests:  simple broken style fix

- [x] **DONE**

## Links

Fixes #
Tracks # TODO for SUSE Manager 4.1

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
