### PR TITLE
Improve misleading UI message displayed on systems with modules activated

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -3097,7 +3097,7 @@ button below, and &lt;b&gt;will be unable to log back in&lt;/b&gt;.</source>
         </context-group>
       </trans-unit>
       <trans-unit id="packagelist.jsp.modulespresent" xml:space="preserve">
-        <source>At least one of the channels this system is subscribed to contains modules. If you have activated modules on this system, please refrain from using @@PRODUCT_NAME@@ for package operations. Instead, perform all package actions from the client using dnf.</source>
+        <source>At least one of the channels this system is subscribed to contains modules. If you have activated modules on this system, please refrain from using @@PRODUCT_NAME@@ for package operations. Instead, use &lt;a href="/rhn/manager/contentmanagement/projects"&gt;Content Lifecycle Management&lt;/a&gt; to &lt;strong&gt;create regular channels that include module packages&lt;/strong&gt;.</source>
       </trans-unit>
       <!-- upgradable.jsp -->
       <trans-unit id="upgradable.jsp.header" xml:space="preserve">

--- a/java/code/webapp/WEB-INF/decorators/layout_c.jsp
+++ b/java/code/webapp/WEB-INF/decorators/layout_c.jsp
@@ -37,7 +37,7 @@
             <div class="alert alert-warning">
               <ul>
               <html:messages id="message">
-                <li><c:out value="${message}"/></li>
+                <li><c:out escapeXml="false" value="${message}"/></li>
               </html:messages>
               </ul>
             </div>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Improves misleading UI message displayed on systems with modules activated (bsc#1179525)
 - Fix availability check for debian repositories (bsc#1180127)
 - Added 'contents' argument to the 'configchannel.create' XMLRPC API method (bsc#1179566)
 - Ignore duplicate NEVRAs in package profile update (bsc#1176018)


### PR DESCRIPTION
## What does this PR change?

This PR improves misleading UI message that is displayed on systems with modules activated.

Note that the original issue suggests including a link for the documentation, but since that requires access to **user docs locale**, which requires a refactor on multiple legacy `jsp` actions, I'm suggesting not including that in this PR.

## GUI diff

Before:

![Screenshot from 2020-12-16 13-56-24](https://user-images.githubusercontent.com/14297426/102359195-623aac00-3fa8-11eb-84ce-37c17d3df6fa.png)

After:

![Screenshot from 2020-12-16 13-51-54](https://user-images.githubusercontent.com/14297426/102359464-bb0a4480-3fa8-11eb-9291-c2be9958985a.png)


- [x] **DONE**

## Documentation
- No documentation needed: This PR only improves an existing UI message.

- [x] **DONE**

## Test coverage
- No tests: This PR only improves an existing UI message.

- [x] **DONE**

## Links

Fixes: https://github.com/SUSE/spacewalk/issues/13326

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
