### PR TITLE
Fix deb repo detection

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -748,7 +748,7 @@ public class ContentSyncManager {
             }
             else {
                 try {
-                    String fullUrl = buildRepoFileUrl(url, repo);
+                    List<String> fullUrl = buildRepoFileUrl(url, repo);
                     if (accessibleUrl(fullUrl)) {
                         URI uri = new URI(url);
                         if (uri.getUserInfo() == null) {
@@ -994,28 +994,42 @@ public class ContentSyncManager {
     }
 
     /**
-     * Build URL pointing to a file to test availablity of a repository.
+     * Build a list of URLs pointing to a file to test availablity of a repository.
      * Support either repomd or Debian style repos.
+     * The first accessible defines that the repo exists and is valid
      *
      * @param url the repo url
      * @param repo the repo object
-     * @return full URL pointing to a file which should be available depending on the repo type
+     * @return List of full URLs pointing to a file which should be available depending on the repo type
      * @throws URISyntaxException in case of an error
      */
-    public String buildRepoFileUrl(String url, SCCRepository repo) throws URISyntaxException {
+    public List<String> buildRepoFileUrl(String url, SCCRepository repo) throws URISyntaxException {
         if (url.contains("mirrorlist")) {
-            return url;
+            return Arrays.asList(url);
         }
         URI uri = new URI(url);
-        String relFile = "/repodata/repomd.xml";
+        List<String> relFiles = new LinkedList<>();
+        List<String> urls = new LinkedList<>();
 
         // Debian repo
         if (repo.getDistroTarget() != null && repo.getDistroTarget().equals("amd64")) {
-            relFile = "Release";
+            // There is not only 1 file we can test.
+            // https://wiki.debian.org/DebianRepository/Format
+            relFiles.add("Packages.xz");
+            relFiles.add("Release");
+            relFiles.add("Packages.gz");
+            relFiles.add("Packages");
+            relFiles.add("InRelease");
         }
-        Path urlPath = new File(StringUtils.defaultString(uri.getRawPath(), "/"), relFile).toPath();
-        return new URI(uri.getScheme(), null, uri.getHost(), uri.getPort(), urlPath.toString(),
-                uri.getQuery(), null).toString();
+        else {
+            relFiles.add("/repodata/repomd.xml");
+        }
+        for (String relFile : relFiles) {
+            Path urlPath = new File(StringUtils.defaultString(uri.getRawPath(), "/"), relFile).toPath();
+            urls.add(new URI(uri.getScheme(), null, uri.getHost(), uri.getPort(), urlPath.toString(),
+                    uri.getQuery(), null).toString());
+        }
+        return urls;
     }
 
     /**
@@ -2149,6 +2163,26 @@ public class ContentSyncManager {
     }
 
     /**
+     * Check if one of the given URLs can be reached.
+     * @param urls the urls
+     * @return Returns true in case we can access at least one of this URLs, otherwise false
+     */
+    protected boolean accessibleUrl(List<String> urls) {
+        return urls.stream().anyMatch(u -> accessibleUrl(u));
+    }
+
+    /**
+     * Check if one of the given URLs can be reached.
+     * @param urls the urls
+     * @param user the username
+     * @param password the password
+     * @return Returns true in case we can access at least one of this URLs, otherwise false
+     */
+    protected boolean accessibleUrl(List<String> urls, String user, String password) {
+        return urls.stream().anyMatch(u -> accessibleUrl(u, user, password));
+    }
+
+    /**
      * Check if the given URL can be reached.
      * @param url the url
      * @return Returns true in case we can access this URL, otherwise false
@@ -2170,6 +2204,7 @@ public class ContentSyncManager {
         }
         return false;
     }
+
     /**
      * Check if the given URL can be reached using provided username and password
      * @param url the url

--- a/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -706,7 +706,12 @@ public class ContentSyncManager {
                 .forEach(a -> SCCCachingFactory.deleteRepositoryAuth(a));
         }
         allRepoAuths = null;
+        List<SCCRepository> oesRepos = SCCCachingFactory.lookupRepositoriesByChannelFamily(OES_CHANNEL_FAMILY);
         for (SCCRepositoryJson jrepo : repositories) {
+            if (oesRepos.stream().anyMatch(oes -> oes.getSccId().equals(jrepo.getSCCId()))) {
+                // OES repos are handled later
+                continue;
+            }
             SCCRepository repo = availableRepos.get(jrepo.getSCCId());
             if (repo == null) {
                 log.error("No repository with ID '" + jrepo.getSCCId() + "' found");
@@ -814,7 +819,7 @@ public class ContentSyncManager {
         }
 
         // OES
-        repoIdsFromCredential.addAll(refreshOESRepositoryAuth(c, mirrorUrl));
+        repoIdsFromCredential.addAll(refreshOESRepositoryAuth(c, mirrorUrl, oesRepos));
 
         // check if we have to remove auths which exists before
         List<SCCRepositoryAuth> authList = SCCCachingFactory.lookupRepositoryAuthByCredential(c);
@@ -867,14 +872,17 @@ public class ContentSyncManager {
      *
      * @param c credential to use for the check
      * @param mirrorUrl optional mirror url
+     * @param oesRepos cached list of OES Repositories or NULL
      * @return list of available repository ids
      */
-    public List<Long> refreshOESRepositoryAuth(Credentials c, String mirrorUrl) {
+    public List<Long> refreshOESRepositoryAuth(Credentials c, String mirrorUrl, List<SCCRepository> oesRepos) {
         List<Long> oesRepoIds = new LinkedList<>();
         if (!(c == null || accessibleUrl(OES_URL, c.getUsername(), c.getPassword()))) {
             return oesRepoIds;
         }
-        List<SCCRepository> oesRepos = SCCCachingFactory.lookupRepositoriesByChannelFamily(OES_CHANNEL_FAMILY);
+        if (oesRepos == null) {
+            oesRepos = SCCCachingFactory.lookupRepositoriesByChannelFamily(OES_CHANNEL_FAMILY);
+        }
         for (SCCRepository repo : oesRepos) {
             Set<SCCRepositoryAuth> allAuths = repo.getRepositoryAuth();
             Set<SCCRepositoryAuth> authsThisCred = allAuths.stream()

--- a/java/code/src/com/redhat/rhn/manager/content/test/ContentSyncManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/content/test/ContentSyncManagerTest.java
@@ -1739,8 +1739,15 @@ public class ContentSyncManagerTest extends BaseTestCaseWithUser {
         String repourl = "http://localhost/pub/myrepo/";
         ContentSyncManager csm = new ContentSyncManager();
 
-        assertEquals(repourl + "Release", csm.buildRepoFileUrl(repourl, debrepo));
-        assertEquals(repourl + "repodata/repomd.xml", csm.buildRepoFileUrl(repourl, rpmrepo));
+        assertContains(csm.buildRepoFileUrl(repourl, rpmrepo), repourl + "repodata/repomd.xml");
+        assertEquals(1, csm.buildRepoFileUrl(repourl, rpmrepo).size());
+
+        assertContains(csm.buildRepoFileUrl(repourl, debrepo), repourl + "Packages.xz");
+        assertContains(csm.buildRepoFileUrl(repourl, debrepo), repourl + "Packages.gz");
+        assertContains(csm.buildRepoFileUrl(repourl, debrepo), repourl + "Packages");
+        assertContains(csm.buildRepoFileUrl(repourl, debrepo), repourl + "Release");
+        assertContains(csm.buildRepoFileUrl(repourl, debrepo), repourl + "InRelease");
+        assertEquals(5, csm.buildRepoFileUrl(repourl, debrepo).size());
     }
 
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix availability check for debian repositories (bsc#1180127)
 - Added 'contents' argument to the 'configchannel.create' XMLRPC API method (bsc#1179566)
 - Ignore duplicate NEVRAs in package profile update (bsc#1176018)
 - Prevent deletion of CLM environments if they're used in an autoinstallation


### PR DESCRIPTION
## What does this PR change?

The debian repo format has not one single file which must be available and can be used to test if a repo is available.
To fix the detection multiple files are now tested. Only one must be available.

Added a patch to speedup repository syncing while skipping OES checks in the main loop.
This cause HEAD requests for every OES repo which take a long time.
But OES is tested in an extra function by just testing one credential.
This speedup repository syncing from ~3 Minutes to ~30 Seconds

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **fix a bug**

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/13374
Fixes https://github.com/SUSE/spacewalk/issues/13488

Tracks https://github.com/SUSE/spacewalk/pull/13503 https://github.com/SUSE/spacewalk/pull/13504

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
