### PR TITLE
Prevent deletion of CLM environments if they're attached to a kickstart profile (bsc#1179552)

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/ContentProjectFactory.java
@@ -292,6 +292,17 @@ public class ContentProjectFactory extends HibernateFactory {
      * @param target the Environment Target
      */
     public static void purgeTarget(EnvironmentTarget target) {
+        boolean hasDistributions = target
+                .asSoftwareTarget()
+                .map(SoftwareEnvironmentTarget::getChannel)
+                .map(Channel::containsDistributions)
+                .orElse(false);
+
+        if (hasDistributions) {
+            throw new ContentManagementException("The target " + target.toString() +
+                    " is being used in an autoinstallation profile. Cannot remove.");
+        }
+
         // firstly fix the original/clone relations of channels
         target.asSoftwareTarget().ifPresent(swTgt -> {
             Optional<Channel> prevChannel = swTgt.getChannel().asCloned().map(c -> c.getOriginal());

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentProjectFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentProjectFactoryTest.java
@@ -22,6 +22,7 @@ import com.redhat.rhn.domain.channel.ChannelFactory;
 import com.redhat.rhn.domain.channel.test.ChannelFactoryTest;
 import com.redhat.rhn.domain.contentmgmt.ContentEnvironment;
 import com.redhat.rhn.domain.contentmgmt.ContentFilter;
+import com.redhat.rhn.domain.contentmgmt.ContentManagementException;
 import com.redhat.rhn.domain.contentmgmt.ContentProject;
 import com.redhat.rhn.domain.contentmgmt.ContentProjectFactory;
 import com.redhat.rhn.domain.contentmgmt.ContentProjectHistoryEntry;
@@ -31,6 +32,7 @@ import com.redhat.rhn.domain.contentmgmt.ProjectSource;
 import com.redhat.rhn.domain.contentmgmt.ProjectSource.State;
 import com.redhat.rhn.domain.contentmgmt.SoftwareEnvironmentTarget;
 import com.redhat.rhn.domain.contentmgmt.SoftwareProjectSource;
+import com.redhat.rhn.domain.kickstart.test.KickstartableTreeTest;
 import com.redhat.rhn.domain.org.Org;
 import com.redhat.rhn.domain.org.OrgFactory;
 import com.redhat.rhn.domain.user.UserFactory;
@@ -560,6 +562,37 @@ public class ContentProjectFactoryTest extends BaseTestCaseWithUser {
         ContentProjectFactory.purgeTarget(target);
         assertEquals(0, envdev.getTargets().size());
         assertNull(ChannelFactory.lookupByLabel(channelLabel));
+    }
+
+    /**
+     * Test purging {@link SoftwareEnvironmentTarget} that is being used in a kickstart profile
+     *
+     * @throws Exception if anything goes wrong
+     */
+    public void testPurgeSwTargetWithKS() throws Exception {
+        ContentProject cp = new ContentProject("cplabel", "cpname", "cpdesc", user.getOrg());
+        ContentProjectFactory.save(cp);
+        ContentEnvironment envdev = new ContentEnvironment("dev", "Development", null, cp);
+        ContentProjectFactory.save(envdev);
+        cp.setFirstEnvironment(envdev);
+        Channel channel = ChannelTestUtils.createBaseChannel(user);
+        KickstartableTreeTest.createTestKickstartableTree(channel);
+        SoftwareEnvironmentTarget target = new SoftwareEnvironmentTarget(envdev, channel);
+        envdev.addTarget(target);
+        String channelLabel = channel.getLabel();
+
+        try {
+            ContentProjectFactory.purgeTarget(target);
+            fail("Must not purge.");
+        }
+        catch (ContentManagementException e) {
+            assertEquals("The target " + target.toString() +
+                    " is being used in an autoinstallation profile. Cannot remove.", e.getMessage());
+        }
+        finally {
+            assertEquals(1, envdev.getTargets().size());
+            assertNotNull(ChannelFactory.lookupByLabel(channelLabel));
+        }
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/mappers/ResponseMappers.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/mappers/ResponseMappers.java
@@ -17,13 +17,16 @@ package com.suse.manager.webui.controllers.contentmanagement.mappers;
 
 import static com.suse.utils.Opt.stream;
 
+import com.redhat.rhn.domain.channel.Channel;
+
 import com.redhat.rhn.domain.contentmgmt.ContentEnvironment;
 import com.redhat.rhn.domain.contentmgmt.ContentFilter;
 import com.redhat.rhn.domain.contentmgmt.ContentProject;
 import com.redhat.rhn.domain.contentmgmt.ContentProjectFilter;
+import com.redhat.rhn.domain.contentmgmt.EnvironmentTarget;
 import com.redhat.rhn.domain.contentmgmt.ProjectSource;
+import com.redhat.rhn.domain.contentmgmt.SoftwareEnvironmentTarget;
 import com.redhat.rhn.domain.contentmgmt.SoftwareProjectSource;
-
 import com.redhat.rhn.domain.contentmgmt.modulemd.ModulemdApi;
 import com.redhat.rhn.domain.contentmgmt.validation.ContentProjectValidator;
 import com.redhat.rhn.domain.contentmgmt.validation.ContentValidationMessage;
@@ -46,6 +49,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 
@@ -128,6 +132,12 @@ public class ResponseMappers {
                                     .orElse(null)
                     );
                     environmentResponse.setBuiltTime(envDB.computeBuiltTime().orElse(null));
+                    environmentResponse.setHasProfiles(envDB.getTargets().stream()
+                            .map(EnvironmentTarget::asSoftwareTarget)
+                            .flatMap(Optional::stream)
+                            .map(SoftwareEnvironmentTarget::getChannel)
+                            .anyMatch(Channel::containsDistributions)
+                    );
                     return environmentResponse;
                 })
                 .collect(Collectors.toList());

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/response/EnvironmentResponse.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/response/EnvironmentResponse.java
@@ -28,6 +28,7 @@ public class EnvironmentResponse {
     private Long version;
     private String status;
     private Date builtTime;
+    private boolean hasProfiles;
 
     public void setStatus(String statusIn) {
         this.status = statusIn;
@@ -55,5 +56,9 @@ public class EnvironmentResponse {
 
     public void setBuiltTime(Date builtTimeIn) {
         this.builtTime = builtTimeIn;
+    }
+
+    public void setHasProfiles(boolean hasProfilesIn) {
+        this.hasProfiles = hasProfilesIn;
     }
 }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Prevent deletion of CLM environments if they're used in an autoinstallation
+  profile (bsc#1179552)
 - Fix Debian package version comparison
 - register saltkey XMLRPC handler and fix behavior of delete salt key (bsc#1179872)
 - Added 'revision' argument to the 'configchannel.updateInitSls' XMLRPC API method (bsc#1179566)

--- a/web/html/src/components/panels/CreatorPanel.js
+++ b/web/html/src/components/panels/CreatorPanel.js
@@ -19,6 +19,7 @@ type Props = {
   onCancel?: Function,
   onOpen?: Function,
   onDelete?: Function,
+  disableDelete?: boolean,
   disableOperations?: boolean,
   collapsible?: boolean,
   customIconClass?: string,
@@ -90,7 +91,7 @@ const CreatorPanel = (props: Props) => {
                           id={`${props.id}-modal-delete-button`}
                           className="btn-danger"
                           text={t('Delete')}
-                          disabled={props.disableOperations}
+                          disabled={props.disableDelete || props.disableOperations}
                           handler={() => props.onDelete && props.onDelete({
                             item,
                             closeDialog: () => closeDialog(modalNameId)

--- a/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment-lifecycle.js
+++ b/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment-lifecycle.js
@@ -1,8 +1,10 @@
 // @flow
 import * as React from 'react';
-import CreatorPanel from "../../../../../../components/panels/CreatorPanel";
+import ReactHtmlParser from 'html-react-parser';
 import EnvironmentView from "./environment-view";
 import EnvironmentForm from "./environment-form";
+import {Messages, Utils as MsgUtils} from 'components/messages';
+import CreatorPanel from "components/panels/CreatorPanel";
 import {Loading} from "components/utils/Loading";
 import Promote from "../promote/promote";
 import {showErrorToastr, showSuccessToastr} from "components/toastr/toastr";
@@ -107,6 +109,7 @@ const EnvironmentLifecycle = (props: Props) => {
                           })}
                       onOpen={({ setItem }) => setItem(environment)}
                       onCancel={() => cancelAction()}
+                      disableDelete={environment.hasProfiles}
                       onDelete={({ item, closeDialog }) => {
                         return onAction(item, "delete", props.projectId)
                           .then((projectWithDeleteddEnvironment) => {
@@ -132,12 +135,20 @@ const EnvironmentLifecycle = (props: Props) => {
                         }
 
                         return (
-                          <EnvironmentForm
-                            environment={{...item}}
-                            environments={props.environments}
-                            onChange={(item) => setItem(item)}
-                            editing
-                          />
+                          <>
+                            {item.hasProfiles && <Messages items={MsgUtils.warning(
+                              <>
+                              {ReactHtmlParser(t("This environment cannot be deleted since it is being used in an {0}autoinstallation distribution{1}.", '<a target="_blank" href="/rhn/kickstart/ViewTrees.do">', '</a>'))}
+                              </>
+                            )}/>
+                            }
+                            <EnvironmentForm
+                              environment={{...item}}
+                              environments={props.environments}
+                              onChange={(item) => setItem(item)}
+                              editing
+                            />
+                          </>
                         )
                       }}
                       renderContent={() => <EnvironmentView

--- a/web/html/src/manager/content-management/shared/type/project.type.js
+++ b/web/html/src/manager/content-management/shared/type/project.type.js
@@ -27,6 +27,7 @@ export type ProjectEnvironmentType = {
   description: string,
   status: string,
   version: number,
+  hasProfiles: boolean,
   builtTime: ?string
 }
 

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,5 @@
+- Prevent deletion of CLM environments if they're used in an autoinstallation
+  profile (bsc#1179552)
 - Migrate CommonJS based React components to ES6
 - Add virtual guests refresh action to replace the virtpoller beacon
 - Fix question mark explanations for Recurring States (bsc#1179485)


### PR DESCRIPTION
Fix for https://bugzilla.suse.com/1179552

## GUI diff

Before:
![env-kickstart-before](https://user-images.githubusercontent.com/1103552/101523060-60f5f780-3988-11eb-979d-383f5dedfd6c.png)

After:
![env-kickstart-after](https://user-images.githubusercontent.com/1103552/101523057-605d6100-3988-11eb-9964-f7339cf63f74.png)

## Documentation
- No documentation needed: Bugfix

## Test coverage
- Unit tests were added

## Links

Fixes https://github.com/SUSE/spacewalk/issues/13337

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
