### PR TITLE
Ignore duplicate NEVRAs in package profile update (bsc#1176018)

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
@@ -315,6 +315,9 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
      * minion which already has installed packages using the new return format which
      * includes all package versions installed on the minion.
      *
+     * Special case: Some packages are reported multiple times with the same NEVRA in the array output.
+     * The test runs against this case with the 'aaa_base' package in the test input (bsc#1176018).
+     *
      * @throws Exception in case of an error
      */
     public void testPackagesProfileUpdateAllVersions() throws Exception {

--- a/java/code/src/com/suse/manager/reactor/messaging/test/packages.profileupdate.allversions.json
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/packages.profileupdate.allversions.json
@@ -56,6 +56,18 @@
                 "arch": "x86_64",
                 "version": "13.2+git20140911.61c1681",
                 "install_date_time_t": "1459866432"
+              },
+              {
+                "release": "12.1",
+                "arch": "x86_64",
+                "version": "13.2+git20140911.61c1681",
+                "install_date_time_t": "1459866433"
+              },
+              {
+                "release": "12.1",
+                "arch": "x86_64",
+                "version": "13.2+git20140911.61c1681",
+                "install_date_time_t": "1459866434"
               }
             ],
             "bash": [

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -1481,7 +1481,8 @@ public class SaltUtils {
                 )
                 .collect(Collectors.toMap(
                         SaltUtils::packageToKey,
-                        Function.identity()
+                        Function.identity(),
+                        (first, duplicate) -> first // Deal with duplicates: ignore additional entries
                 ));
 
         Collection<InstalledPackage> unchanged = oldPackageMap.entrySet().stream().filter(

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Ignore duplicate NEVRAs in package profile update (bsc#1176018)
 - Prevent deletion of CLM environments if they're used in an autoinstallation
   profile (bsc#1179552)
 - Fix Debian package version comparison


### PR DESCRIPTION
With the newer output format, `pkg.info_installed` sometimes returns duplicate entries having the same NEVRA for a package. Since it's not an issue from SUMA's perspective, this update lets SUMA ignore the additional entries and continue the process.

## Documentation
- No documentation needed: Bugfix

## Test coverage
- Unit tests were adapted

Port of: https://github.com/SUSE/spacewalk/pull/13377

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
