### PR TITLE
Take the later package on resolving duplicate NEVRAs in package profile update

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
@@ -341,6 +341,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 assertEquals("13.2+git20140911.61c1681", pkg.getEvr().getVersion());
                 assertEquals("12.1", pkg.getEvr().getRelease());
                 assertEquals("x86_64", pkg.getArch().getName());
+                assertEquals(1459866434000L, pkg.getInstallTime().toInstant().toEpochMilli());
             }
             else if (pkg.getName().getName().equals("bash")) {
                 if (pkg.getArch().getName().equals("x86_64")) {

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -1482,7 +1482,7 @@ public class SaltUtils {
                 .collect(Collectors.toMap(
                         SaltUtils::packageToKey,
                         Function.identity(),
-                        (first, duplicate) -> first // Deal with duplicates: ignore additional entries
+                        (first, second) -> resolveDuplicatePackage(first, second)
                 ));
 
         Collection<InstalledPackage> unchanged = oldPackageMap.entrySet().stream().filter(
@@ -1495,6 +1495,26 @@ public class SaltUtils {
         ).collect(Collectors.toMap(Map.Entry::getKey, e -> new Tuple2(e.getValue().getKey(), e.getValue().getValue())));
 
         packages.addAll(createPackagesFromSalt(packagesToAdd, server));
+    }
+
+    private static Map.Entry<String, Info> resolveDuplicatePackage(Map.Entry<String, Info> firstEntry,
+            Map.Entry<String, Info> secondEntry) {
+        Info first = firstEntry.getValue();
+        Info second = secondEntry.getValue();
+
+        if (first.getInstallDateUnixTime().isEmpty() && second.getInstallDateUnixTime().isEmpty()) {
+            LOG.warn(String.format("Got duplicate packages NEVRA and the install timestamp is missing." +
+                    " Taking the first one. First:  %s, second: %s", first, second));
+            return firstEntry;
+        }
+
+        // the later one wins
+        if (first.getInstallDateUnixTime().get() > second.getInstallDateUnixTime().get()) {
+            return firstEntry;
+        }
+        else {
+            return secondEntry;
+        }
     }
 
     /**


### PR DESCRIPTION
## What does this PR change?

Follow-up of https://github.com/uyuni-project/uyuni/pull/3039

This PR makes the algorithm more deterministic.


## Documentation
- No documentation needed:fix
- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"