### PR TITLE
Add support to debug using a browser (skip headless mode)

### DIFF
--- a/testsuite/Gemfile
+++ b/testsuite/Gemfile
@@ -11,6 +11,9 @@ gem 'nokogiri', '1.10.8'
 gem 'rake', '12.3.3'
 gem 'selenium-webdriver', '3.141.0'
 #gem 'simplecov', '0.17.0'
+# Pre-requisite:
+# Add repository https://download.opensuse.org/repositories/systemsmanagement:/sumaform:/tools/<your_distro> and install twopence RPMs
+# or build & install from https://github.com/openSUSE/twopence
 gem 'twopence'
 gem 'xmlrpc', '0.3.0'
 gem 'minitest', ' 5.11.3'

--- a/testsuite/documentation/static-run.md
+++ b/testsuite/documentation/static-run.md
@@ -23,7 +23,8 @@ Set up the following environment variables:
 * `UBUNTUMINION` the Ubuntu Salt minion
 
 Once you have the machines configured, you can run the testsuite.
-To run all standard tests, from the controller:
+
+- To run all standard tests, from the controller:
 
 ```console
 export SERVER="${PREFIX}suma3pg.tf.local"
@@ -34,4 +35,39 @@ export SSHMINION="${PREFIX}minssh-sles15.tf.local"
 export CENTOSMINION="${PREFIX}mincentos7.tf.local"
 export UBUNTUMINION="${PREFIX}min-ubuntu.tf.local"
 run-testsuite
+```
+
+- To run the tests from your local machine you must do some extra steps:
+```console
+zypper addrepo https://download.opensuse.org/repositories/systemsmanagement:/sumaform:/tools/openSUSE_Leap_15.2/
+zypper install *twopence*
+```
+```console
+cd <your_repo>/testsuite
+bundle install
+```
+```console
+export SERVER="${PREFIX}srv.tf.local"
+export CLIENT="${PREFIX}cli-sles15.tf.local"
+export MINION="${PREFIX}min-sles15.tf.local"
+...
+```
+Before you are able to run your tests in local, you must assure that your ssh connection to any of the nodes can be done without adding user/pass.
+I recommend you to configure your `.ssh/config` to use a ssh private key. 
+In case you deployed the environment with sumaform, just use the ssh key `.ssh/id_rsa` stored in the controller.
+Example:
+```console
+# cat .ssh/config 
+Host *.tf.local
+    User root
+    IdentityFile ~/.ssh/id_rsa_test_env
+```
+```console
+rake -T # List all different possibilities i.e. rake cucumber:sanity_check 
+```
+
+- To debug your tests, you might want to see the browser in your Desktop from where the Cucumber actions will happen. 
+  To enable it:
+```console
+export DEBUG=1
 ```

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -22,7 +22,8 @@ require 'pp'
 # SimpleCov.start
 
 server = ENV['SERVER']
-$long_tests_enabled = !ENV['LONG_TESTS'].nil?
+$debug_mode = true if ENV['DEBUG']
+$long_tests_enabled = true if ENV['LONG_TESTS']
 puts "Executing long running tests" if $long_tests_enabled
 
 # maximal wait before giving up
@@ -56,9 +57,12 @@ Capybara.register_driver(:headless_chrome) do |app|
   client = Selenium::WebDriver::Remote::Http::Default.new
   # WORKAROUND failure at Scenario: Test IPMI functions: increase from 60 s to 180 s
   client.read_timeout = 180
+  # Chrome driver options
+  chrome_options = %w[no-sandbox disable-dev-shm-usage disable-gpu window-size=2048,2048, js-flags=--max_old_space_size=2048]
+  chrome_options << 'headless' unless $debug_mode
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
     chromeOptions: {
-      args: %w[headless no-sandbox disable-dev-shm-usage disable-gpu window-size=2048,2048, js-flags=--max_old_space_size=2048],
+      args: chrome_options,
       w3c: false,
       prefs: {
         'download.default_directory': '/tmp/downloads'

--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -25,7 +25,7 @@ def twopence_init(target)
 end
 
 # Define common twopence objects
-$localhost = twopence_init("ssh:#{ENV['HOSTNAME']}")
+$localhost = twopence_init("ssh:#{ENV['HOSTNAME']}") unless $debug_mode
 $proxy = twopence_init("ssh:#{ENV['PROXY']}") if ENV['PROXY']
 $server = twopence_init("ssh:#{ENV['SERVER']}")
 $kvm_server = twopence_init("ssh:#{ENV['VIRTHOST_KVM_URL']}") if ENV['VIRTHOST_KVM_URL'] && ENV['VIRTHOST_KVM_PASSWORD']


### PR DESCRIPTION
## What does this PR change?

Add support to debug using a browser (skip headless mode)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.0
- Manager-4.1

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
