### PR TITLE
Testsuite: Restore idempotency

### DIFF
--- a/testsuite/features/secondary/minssh_salt_install_package.feature
+++ b/testsuite/features/secondary/minssh_salt_install_package.feature
@@ -27,3 +27,9 @@ Feature: Install a package on the SSH minion via Salt through the UI
     When I wait until event "Package Install/Upgrade scheduled by admin" is completed
     Then "hoag-dummy-1.1-1.1" should be installed on "ssh_minion"
 
+@ssh_minion
+  Scenario: Cleanup: remove the package from the SSH minion
+   When I remove package "hoag-dummy-1.1-1.1" from this "ssh_minion"
+   And "hoag-dummy-1.1-1.1" should not be installed on "ssh_minion"
+   And I refresh packages list via spacecmd on "ssh_minion"
+   And I wait until refresh package list on "ssh_minion" is finished


### PR DESCRIPTION
## What does this PR change?
Restore idempotency in one test.

Bring back the system to the initial state.
- testsuite/features/secondary/minssh_salt_install_package.feature:
Remove the installed package and refresh the package list.

## Links
### Ports
- Manager-4.1: https://github.com/SUSE/spacewalk/pull/13505
- Manager-4.0: https://github.com/SUSE/spacewalk/pull/13506


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)
