### PR TITLE
Improve extra key handling

### DIFF
--- a/backend/server/importlib/backend.py
+++ b/backend/server/importlib/backend.py
@@ -307,12 +307,12 @@ class Backend:
             missing AS (
               SELECT nextval('rhn_package_extra_tags_keys_id_seq') AS id, wanted.name
                 FROM wanted
-           LEFT JOIN rhnPackageExtraTagKey ON rhnPackageExtraTagKey.name = wanted.name
+                    LEFT JOIN rhnPackageExtraTagKey ON rhnPackageExtraTagKey.name = wanted.name
                WHERE rhnPackageExtraTagKey.id IS NULL
             )
             INSERT INTO rhnPackageExtraTagKey (id, name)
-            SELECT * from missing
-            ON CONFLICT DO NOTHING
+                SELECT * from missing
+                ON CONFLICT DO NOTHING
         """
         values = [key for key in extraTags.keys() if key != '']
         if not values:

--- a/backend/server/importlib/backend.py
+++ b/backend/server/importlib/backend.py
@@ -60,8 +60,7 @@ sequences = {
     'suseEula': 'suse_eula_id_seq',
     'suseProducts': 'suse_products_id_seq',
     'suseSCCRepository': 'suse_sccrepository_id_seq',
-    'suseProductSCCRepository': 'suse_prdrepo_id_seq',
-    'rhnPackageExtraTagKey': 'rhn_package_extra_tags_keys_id_seq'
+    'suseProductSCCRepository': 'suse_prdrepo_id_seq'
 }
 
 
@@ -299,40 +298,40 @@ class Backend:
         h.executemany(id=toinsert[0], name=toinsert[1])
 
     def processExtraTags(self, extraTags):
-        query_lookup = """
-            SELECT id
-              FROM rhnPackageExtraTagKey
-             WHERE name = :name
-        """
-        h_lookup = self.dbmodule.prepare(query_lookup)
-        toinsert = [[], []]
-
-        for name in list(extraTags.keys()):
-            val = {}
-            _buildExternalValue(val, { 'name'     : name},
-                                self.tables['rhnPackageExtraTagKey'])
-            h_lookup.execute(name=name)
-            row = h_lookup.fetchone_dict()
-            if row:
-                extraTags[name] = row['id']
-                continue
-
-            # Generate an id
-            id = self.sequences['rhnPackageExtraTagKey'].next()
-            extraTags[name] = id
-
-            toinsert[0].append(id)
-            toinsert[1].append(val['name'])
-
-        if not toinsert[0]:
-            # Nothing to do
+        if not extraTags:
             return
-
-        query_insert = """
+        sql = """
+            WITH wanted (name) AS (
+              VALUES %s
+            )
+            missing AS (
+              SELECT nextval('rhn_package_extra_tags_keys_id_seq') AS id, wanted.name
+                FROM wanted
+           LEFT JOIN rhnPackageExtraTagKey ON rhnPackageExtraTagKey.name = wanted.name
+               WHERE rhnPackageExtraTagKey.id IS NULL
+            )
             INSERT INTO rhnPackageExtraTagKey (id, name)
-            VALUES (:id, :name)"""
-        h_insert = self.dbmodule.prepare(query_insert)
-        h_insert.executemany(id=toinsert[0], name=toinsert[1])
+            SELECT * from missing
+            ON CONFLICT DO NOTHING
+        """
+        values = [key for key in extraTags.keys() if key != '']
+        if not values:
+            return
+        h = self.dbmodule.prepare(sql)
+        r = h.execute_values(sql, values, fetch=False)
+
+        sql = """
+            WITH wanted (name) AS (
+              VALUES %s
+            )
+            SELECT wanted.id, wanted.name
+              FROM wanted
+              JOIN rhnPackageExtraTagKey ON rhnPackageExtraTagKey.name = wanted.name
+        """
+        h = self.dbmodule.prepare(sql)
+        tags = h.execute_values(sql, values)
+        for tag in tags:
+            extraTags[tag[1]] = tag[0]
 
     def lookupErrataFileTypes(self, hash):
         hash.clear()

--- a/backend/server/importlib/backendOracle.py
+++ b/backend/server/importlib/backendOracle.py
@@ -632,14 +632,6 @@ class OracleBackend(Backend):
             pk          = ['package_id', 'eula_id'],
             attribute   = 'eulas',
         ),
-        Table('rhnPackageExtraTagKey',
-              fields={
-                  'id'      : DBint(),
-                  'name'    : DBstring(256),
-              },
-              pk=['id'],
-              attribute='extra_tags',
-              ),
         Table('rhnPackageExtraTag',
             fields={
               'package_id'  : DBint(),

--- a/backend/server/rhnServer/server_packages.py
+++ b/backend/server/rhnServer/server_packages.py
@@ -450,6 +450,7 @@ def processPackageKeyAssociations(header, checksum_type, checksum):
         insert into rhnPackagekey
             (id, key_id, key_type_id) values
             (sequence_nextval('rhn_pkey_id_seq'), :key_id, :key_type_id)
+            on conflict do nothing
     """)
 
     lookup_keyid_sql = rhnSQL.prepare("""

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- harden extratag key import by execute_values to ignore conflicts
 - internal code cleanup (dropping unused table rhnErrataTmp)
 - Fix Debian package version comparison
 - Removal of python-gzipstream since it's no longer used


### PR DESCRIPTION
## What does this PR change?

Adding new extratag keys during reposync can fail with 

```
duplicate key value violates unique constraint "rhn_pkg_extra_tag_key_idx"
DETAIL:  Key (name)=(Cnf-Extra-Commands) already exists.
```
This result in failed imports of a bunch of packages. To improve the creation of new keys, this PR declare lookup and insert functions and make use of it in the import code.

Second case found while inserting into rhnPackageKey.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **manual**

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/3040
Tracks https://github.com/SUSE/spacewalk/pull/13545

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"