### PR TITLE
Server side field-level validations infrastructure (and usage on CLM)

### DIFF
--- a/java/code/src/com/redhat/rhn/common/validator/ValidatorResult.java
+++ b/java/code/src/com/redhat/rhn/common/validator/ValidatorResult.java
@@ -14,8 +14,10 @@
  */
 package com.redhat.rhn.common.validator;
 
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * <p>
@@ -25,10 +27,9 @@ import java.util.List;
  * @version $Rev$
  */
 public class ValidatorResult {
-    private List<ValidatorError> validationErrors =
-                                new LinkedList<ValidatorError>();
-    private List<ValidatorWarning> validationWarnings =
-                                    new LinkedList<ValidatorWarning>();
+    private List<ValidatorError> validationErrors = new LinkedList<>();
+    private List<ValidatorWarning> validationWarnings = new LinkedList<>();
+    private Map<String, List<ValidatorError>> fieldValidationErrors = new HashMap<>();
 
     /**
      * Add a ValidatorError to the list of errors.
@@ -48,6 +49,29 @@ public class ValidatorResult {
      */
     public void addError(String key, Object... args) {
         addError(new ValidatorError(key, args));
+    }
+
+    /**
+     * Add a ValidatorError to the list of field errors.
+     *
+     * @param field Field where the ValidatorError should be added.
+     * @param error ValidatorError to be added.
+     */
+    public void addFieldError(String field, ValidatorError error) {
+        fieldValidationErrors.putIfAbsent(field, new LinkedList());
+        fieldValidationErrors.get(field).add(error);
+    }
+
+    /**
+     * Add a ValidatorError to the list of field errors.
+     *
+     * @param field Field associated with the ValidatorError.
+     * @param key the message key of the error
+     * @param args the args that go with the error message.
+     *
+     */
+    public void addFieldError(String field, String key, Object... args) {
+        addFieldError(field, new ValidatorError(key, args));
     }
 
     /**
@@ -79,6 +103,15 @@ public class ValidatorResult {
     }
 
     /**
+     * Retrieve the list of ValidatorErrors.
+     *
+     * @return List of ValidatorError objects.
+     */
+    public Map<String, List<ValidatorError>> getFieldErrors() {
+        return fieldValidationErrors;
+    }
+
+    /**
      * Retrieve the list of ValidatorWarnings.
      *
      * @return List of ValidatorWarning objects.
@@ -95,6 +128,10 @@ public class ValidatorResult {
     public void append(ValidatorResult result) {
         getErrors().addAll(result.getErrors());
         getWarnings().addAll(result.getWarnings());
+        result.getFieldErrors().forEach((field, fieldErrors) -> {
+            fieldValidationErrors.putIfAbsent(field, new LinkedList<>());
+            fieldValidationErrors.get(field).addAll(fieldErrors);
+        });
     }
 
     /**
@@ -110,6 +147,14 @@ public class ValidatorResult {
             }
 
         }
+        if (!fieldValidationErrors.isEmpty()) {
+            str.append("FIELD_ERRORS:\n");
+            fieldValidationErrors.forEach((field, fieldErrors) -> {
+                fieldErrors.forEach((fieldError) ->
+                        str.append(field).append(" - ").append(fieldError.getMessage()).append("\n")
+                );
+            });
+        }
         if (!validationWarnings.isEmpty()) {
             str.append("WARNINGS:\n");
             for (ValidatorWarning warning : validationWarnings) {
@@ -124,13 +169,13 @@ public class ValidatorResult {
      * @return true if there are no errors or warnings..
      */
     public boolean isEmpty() {
-        return getWarnings().isEmpty() && getErrors().isEmpty();
+        return getWarnings().isEmpty() && !hasErrors();
     }
 
     /**
      * @return true if errors exist in this result.
      */
     public boolean hasErrors() {
-        return getErrors().size() > 0;
+        return !getErrors().isEmpty() || !getFieldErrors().isEmpty();
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/validation/ContentPropertiesValidator.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/validation/ContentPropertiesValidator.java
@@ -122,11 +122,11 @@ public class ContentPropertiesValidator {
         ValidatorResult result = new ValidatorResult();
 
         if (StringUtils.isEmpty(name)) {
-            result.addError("contentmanagement.name_required");
+            result.addFieldError("filter_name", "contentmanagement.name_required");
         }
 
         if (name.length() > 128) {
-            result.addError("contentmanagement.filter_name_too_long");
+            result.addFieldError("filter_name", "contentmanagement.filter_name_too_long");
         }
 
         if (result.hasErrors()) {

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/validation/ContentPropertiesValidator.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/validation/ContentPropertiesValidator.java
@@ -88,23 +88,23 @@ public class ContentPropertiesValidator {
         ValidatorResult result = new ValidatorResult();
 
         if (StringUtils.isEmpty(label)) {
-            result.addError("contentmanagement.label_required");
+            result.addFieldError("label", "contentmanagement.label_required");
         }
 
         if (StringUtils.isEmpty(name)) {
-            result.addError("contentmanagement.name_required");
+            result.addFieldError("name", "contentmanagement.name_required");
         }
 
         if (!isLabelValid(label)) {
-            result.addError("contentmanagement.label_invalid");
+            result.addFieldError("label", "contentmanagement.label_invalid");
         }
 
         if (label.length() > 16) {
-            result.addError("contentmanagement.environment_lbl_too_long");
+            result.addFieldError("label", "contentmanagement.environment_lbl_too_long");
         }
 
         if (name.length() > 128) {
-            result.addError("contentmanagement.environment_name_too_long");
+            result.addFieldError("name", "contentmanagement.environment_name_too_long");
         }
 
         if (result.hasErrors()) {

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/validation/ContentPropertiesValidator.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/validation/ContentPropertiesValidator.java
@@ -47,28 +47,28 @@ public class ContentPropertiesValidator {
         ValidatorResult result = new ValidatorResult();
 
         if (StringUtils.isEmpty(label)) {
-            result.addError("contentmanagement.label_required");
+            result.addFieldError("label", "contentmanagement.label_required");
         }
 
         if (!isLabelValid(label)) {
-            result.addError("contentmanagement.label_invalid");
+            result.addFieldError("label", "contentmanagement.label_invalid");
         }
 
         if (label.length() > 24) {
-            result.addError("contentmanagement.project_label_too_long");
+            result.addFieldError("label", "contentmanagement.project_label_too_long");
         }
 
         if (StringUtils.isEmpty(name)) {
-            result.addError("contentmanagement.name_required");
+            result.addFieldError("name", "contentmanagement.name_required");
         }
 
         if (name.length() > 128) {
-            result.addError("contentmanagement.project_name_too_long");
+            result.addFieldError("name", "contentmanagement.project_name_too_long");
         }
 
         ContentManager.lookupProjectByNameAndOrg(name, user).ifPresent(cp -> {
             if (!cp.getLabel().equals(label)) {
-                result.addError("contentmanagement.name_already_exists");
+                result.addFieldError("name", "contentmanagement.name_already_exists");
             }
         });
 

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/EnvironmentApiController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/EnvironmentApiController.java
@@ -24,10 +24,9 @@ import com.redhat.rhn.common.validator.ValidatorException;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.contentmgmt.ContentManager;
 
+import com.google.gson.Gson;
 import com.suse.manager.webui.controllers.contentmanagement.request.EnvironmentRequest;
 import com.suse.manager.webui.utils.gson.ResultJson;
-
-import com.google.gson.Gson;
 
 import org.apache.http.HttpStatus;
 
@@ -82,7 +81,8 @@ public class EnvironmentApiController {
         }
         catch (ValidatorException e) {
             return json(GSON, res, HttpStatus.SC_BAD_REQUEST,
-                    ResultJson.error(ValidationUtils.convertValidationErrors(e)));
+                    ResultJson.error(ValidationUtils.convertValidationErrors(e),
+                            ValidationUtils.convertFieldValidationErrors(e)));
         }
 
         return ControllerApiUtils.fullProjectJsonResponse(res, createEnvironmentRequest.getProjectLabel(), user);
@@ -109,7 +109,8 @@ public class EnvironmentApiController {
         }
         catch (ValidatorException e) {
             return json(GSON, res, HttpStatus.SC_BAD_REQUEST,
-                    ResultJson.error(ValidationUtils.convertValidationErrors(e)));
+                    ResultJson.error(ValidationUtils.convertValidationErrors(e),
+                            ValidationUtils.convertFieldValidationErrors(e)));
         }
 
         return ControllerApiUtils.fullProjectJsonResponse(res, updateEnvironmentRequest.getProjectLabel(), user);

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/FilterApiController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/FilterApiController.java
@@ -31,16 +31,18 @@ import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.EntityExistsException;
 import com.redhat.rhn.manager.contentmgmt.ContentManager;
 
+import com.google.gson.Gson;
 import com.suse.manager.webui.controllers.contentmanagement.request.FilterRequest;
 import com.suse.manager.webui.controllers.contentmanagement.request.ProjectFiltersUpdateRequest;
 import com.suse.manager.webui.utils.FlashScopeHelper;
 import com.suse.manager.webui.utils.gson.ResultJson;
 
-import com.google.gson.Gson;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -166,11 +168,16 @@ public class FilterApiController {
             );
         }
         catch (EntityExistsException error) {
-            return json(GSON, res, HttpStatus.SC_BAD_REQUEST, ResultJson.error("contentmanagement.filter_exists"));
+            return json(GSON, res, HttpStatus.SC_BAD_REQUEST, ResultJson.error(
+                    new LinkedList<>(),
+                    Collections.singletonMap("filter_name",
+                            Arrays.asList(LOC.getMessage("contentmanagement.filter_exists")))
+            ));
         }
         catch (ValidatorException e) {
             return json(GSON, res, HttpStatus.SC_BAD_REQUEST,
-                    ResultJson.error(ValidationUtils.convertValidationErrors(e)));
+                    ResultJson.error(ValidationUtils.convertValidationErrors(e),
+                            ValidationUtils.convertFieldValidationErrors(e)));
         }
 
         if (!StringUtils.isEmpty(createFilterRequest.getProjectLabel())) {
@@ -210,7 +217,8 @@ public class FilterApiController {
         }
         catch (ValidatorException e) {
             return json(GSON, res, HttpStatus.SC_BAD_REQUEST,
-                    ResultJson.error(ValidationUtils.convertValidationErrors(e)));
+                    ResultJson.error(ValidationUtils.convertValidationErrors(e),
+                            ValidationUtils.convertFieldValidationErrors(e)));
         }
 
         if (!StringUtils.isEmpty(updateFilterRequest.getProjectLabel())) {

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/ProjectApiController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/ProjectApiController.java
@@ -29,12 +29,11 @@ import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.EntityExistsException;
 import com.redhat.rhn.manager.contentmgmt.ContentManager;
 
+import com.google.gson.Gson;
 import com.suse.manager.webui.controllers.contentmanagement.request.NewProjectRequest;
 import com.suse.manager.webui.controllers.contentmanagement.request.ProjectPropertiesRequest;
 import com.suse.manager.webui.utils.FlashScopeHelper;
 import com.suse.manager.webui.utils.gson.ResultJson;
-
-import com.google.gson.Gson;
 
 import org.apache.http.HttpStatus;
 
@@ -94,7 +93,8 @@ public class ProjectApiController {
         }
         catch (ValidatorException e) {
             return json(GSON, res, HttpStatus.SC_BAD_REQUEST,
-                    ResultJson.error(ValidationUtils.convertValidationErrors(e)));
+                    ResultJson.error(ValidationUtils.convertValidationErrors(e),
+                            ValidationUtils.convertFieldValidationErrors(e)));
         }
         catch (ContentManagementException error) {
             return json(GSON, res, HttpStatus.SC_BAD_REQUEST, ResultJson.error(error.getMessage()));
@@ -155,7 +155,8 @@ public class ProjectApiController {
         }
         catch (ValidatorException e) {
             return json(GSON, res, HttpStatus.SC_BAD_REQUEST,
-                    ResultJson.error(ValidationUtils.convertValidationErrors(e)));
+                    ResultJson.error(ValidationUtils.convertValidationErrors(e),
+                            ValidationUtils.convertFieldValidationErrors(e)));
         }
 
         return ControllerApiUtils.fullProjectJsonResponse(res, updatedProject.getLabel(), user);

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/ValidationUtils.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/ValidationUtils.java
@@ -17,6 +17,7 @@ package com.suse.manager.webui.controllers.contentmanagement.handlers;
 import com.redhat.rhn.common.validator.ValidatorException;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
@@ -35,5 +36,17 @@ public class ValidationUtils {
         return exc.getResult().getErrors().stream()
                 .map(e -> e.getLocalizedMessage())
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * Extract field validation errors from {@link ValidatorException} and convert them into localized messages.
+     * @param exc the {@link ValidatorException}
+     * @return the map with the list of localized messages for each field
+     */
+    public static Map<String, List<String>> convertFieldValidationErrors(ValidatorException exc) {
+        return exc.getResult().getFieldErrors().entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, m -> m.getValue().stream()
+                        .map(e -> e.getLocalizedMessage())
+                        .collect(Collectors.toList())));
     }
 }

--- a/java/code/src/com/suse/manager/webui/utils/gson/ResultJson.java
+++ b/java/code/src/com/suse/manager/webui/utils/gson/ResultJson.java
@@ -16,6 +16,7 @@ package com.suse.manager.webui.utils.gson;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Generic JSON response wrapper class
@@ -25,6 +26,7 @@ public class ResultJson<T> {
 
     private final boolean success;
     private final List<String> messages;
+    private final Map<String, List<String>> errors;
     private final T data;
 
     /**
@@ -51,12 +53,25 @@ public class ResultJson<T> {
      * Create an error result with the given messages.
      *
      * @param messagesIn a list of messages
-     * @param dataIn the data
+     * @param errorsIn a map of field level errors
      * @param <T> the type of data
      * @return a ResultJson
      */
-    public static <T> ResultJson<T> error(List<String> messagesIn, T dataIn) {
-        return new ResultJson<>(false, messagesIn, dataIn);
+    public static <T> ResultJson<T> error(List<String> messagesIn, Map<String, List<String>> errorsIn) {
+        return new ResultJson<>(false, messagesIn, errorsIn, null);
+    }
+
+    /**
+     * Create an error result with the given messages.
+     *
+     * @param messagesIn a list of messages
+     * @param dataIn the data
+     * @param errorsIn a map of field level errors
+     * @param <T> the type of data
+     * @return a ResultJson
+     */
+    public static <T> ResultJson<T> error(List<String> messagesIn, Map<String, List<String>> errorsIn, T dataIn) {
+        return new ResultJson<>(false, messagesIn, errorsIn, dataIn);
     }
 
     /**
@@ -76,7 +91,7 @@ public class ResultJson<T> {
      * @return a ResultJson
      */
     public static <T> ResultJson<T> success(T dataIn) {
-        return new ResultJson<>(true, null, dataIn);
+        return new ResultJson<>(true, null, null, dataIn);
     }
 
     /**
@@ -87,7 +102,7 @@ public class ResultJson<T> {
      * @return a ResultJson
      */
     public static <T> ResultJson<T> successMessage(String... messagesIn) {
-        return new ResultJson<>(true, Arrays.asList(messagesIn), null);
+        return new ResultJson<>(true, Arrays.asList(messagesIn), null, null);
     }
 
     /**
@@ -95,11 +110,13 @@ public class ResultJson<T> {
      *
      * @param successIn  the success
      * @param messagesIn the messages
+     * @param errorsIn   the field level errors
      * @param dataIn     the data
      */
-    public ResultJson(boolean successIn, List<String> messagesIn, T dataIn) {
+    public ResultJson(boolean successIn, List<String> messagesIn, Map<String, List<String>> errorsIn, T dataIn) {
         this.success = successIn;
         this.messages = messagesIn;
+        this.errors = errorsIn;
         this.data = dataIn;
     }
 
@@ -110,6 +127,15 @@ public class ResultJson<T> {
      */
     public List<String> getMessages() {
         return messages;
+    }
+
+    /**
+     * Gets field level errors.
+     *
+     * @return the field level errors
+     */
+    public Map<String, List<String>> getErrors() {
+        return errors;
     }
 
     /**

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Content Lifecycle Management input validation errors are now displayed at the field-level instead of a popup
 - Add an API endpoint to allow/disallow scheduling irrelevant patches (bsc#1180757)
 - Fix CVE audit results for affected and patched entries (bsc#1180893)
 - Replace custom version comparison method with the standard one which also takes debian packages into account

--- a/web/html/src/components/input/Form.js
+++ b/web/html/src/components/input/Form.js
@@ -7,6 +7,8 @@ type Props = {
    *  Each field name in the form needs to map to a property of this
    *  object. The value is the one displayed in the form */
   model: Object,
+  /** Object storing form field errors */
+  errors: Object,
   /** Function to trigger when the Submit button is clicked */
   onSubmit?: Function,
   /** Function to trigger when the Submit button is clicked while the model is invalid */
@@ -33,6 +35,7 @@ type Props = {
 
 type FormContextType = {
   model: Object,
+  errors: Object,
   setModelValue: Function,
   registerInput: Function,
   unregisterInput: Function,
@@ -54,13 +57,16 @@ export class Form extends React.Component<Props> {
   inputs = {};
 
   setModelValue(name: string, value: any) {
-    const { model } = this.props;
+    const { model, errors } = this.props;
     if (value == null && model[name] != null) {
       delete model[name];
       this.props.onChange(model);
     } else if (value != null) {
       model[name] = value;
       this.props.onChange(model);
+    }
+    if (errors) {
+      delete errors[name];
     }
   }
 
@@ -99,8 +105,9 @@ export class Form extends React.Component<Props> {
   }
 
   componentDidUpdate(prevProps: Object) {
-    if (prevProps.model !== this.props.model) {
-      Object.keys(this.inputs).forEach(name => this.inputs[name].validate(this.props.model[name]));
+    if (prevProps.model !== this.props.model ||
+        prevProps.errors !== this.props.errors) {
+      Object.keys(this.inputs).forEach(name => this.inputs[name].validate(this.props.model[name], this.props.errors && this.props.errors[name]));
     }
   }
 
@@ -109,6 +116,7 @@ export class Form extends React.Component<Props> {
       <FormContext.Provider value={
         {
           model: this.props.model,
+          errors: this.props.errors,
           setModelValue: this.setModelValue.bind(this),
           registerInput: this.registerInput.bind(this),
           unregisterInput: this.unregisterInput.bind(this),

--- a/web/html/src/components/input/InputBase.js
+++ b/web/html/src/components/input/InputBase.js
@@ -43,10 +43,10 @@ export type Props = {
 type State = {
   isValid: boolean,
   showErrors: boolean,
-  /** Error message received from FormContext
-   *  (typically an error message received from server response)
+  /** Error messages received from FormContext
+   *  (typically errors messages received from server response)
    */
-  error: string
+  errors: Array<string>
 };
 
 export class InputBase extends React.Component<Props, State> {
@@ -67,7 +67,7 @@ export class InputBase extends React.Component<Props, State> {
     this.state = {
       isValid: true,
       showErrors: false,
-      error: null
+      errors: null
     };
   }
 
@@ -119,8 +119,7 @@ export class InputBase extends React.Component<Props, State> {
     const results = [];
     let isValid = true;
 
-    const error = errors && errors.length > 0 ? errors[0] : null;
-    if (error != null) {
+    if (errors && errors.length > 0) {
       isValid = false;
     }
 
@@ -141,8 +140,8 @@ export class InputBase extends React.Component<Props, State> {
       });
       this.setState((state) => ({
           isValid: isValid,
-          error: error,
-          showErrors: state.showErrors || error != null
+          errors: errors,
+          showErrors: state.showErrors || errors && errors.length > 0
         }), () => {
         if (this.context.validateForm != null) {
           this.context.validateForm();
@@ -160,12 +159,27 @@ export class InputBase extends React.Component<Props, State> {
     if (this.props.onChange) this.props.onChange(name, value);
   }
 
+  pushHint(hints, hint) {
+    if (hint) {
+      if (hints.length > 0) {
+        hints.push(<br />)
+      }
+      hints.push(hint);
+    }
+  }
+
   render() {
     const isError = this.state.showErrors && !this.state.isValid;
     const invalidHint = isError && (
-      this.state.error || this.props.invalidHint || (this.props.required && (`${this.props.label} is required.`))
+      this.props.invalidHint || (this.props.required && (`${this.props.label} is required.`))
     );
-    const hint = [this.props.hint, (invalidHint && this.props.hint && <br />), invalidHint];
+    const hints = [];
+    this.pushHint(hints, this.props.hint);
+    if (this.state.errors) {
+      this.state.errors.forEach((error) => this.pushHint(hints, error));
+    } else {
+      this.pushHint(hints, invalidHint);
+    }
     return (
       <FormGroup isError={isError}>
         {
@@ -185,10 +199,10 @@ export class InputBase extends React.Component<Props, State> {
               onBlur: this.onBlur.bind(this),
             })
           }
-          { hint
+          { hints
             && (
               <div className="help-block">
-                {hint}
+                {hints}
               </div>
             )
           }

--- a/web/html/src/components/panels/CreatorPanel.js
+++ b/web/html/src/components/panels/CreatorPanel.js
@@ -36,8 +36,10 @@ const CreatorPanel = (props: Props) => {
 
   const [open, setOpen] = useState(false);
   const [item, setItem] = useState({});
+  const [errors, setErrors] = useState(null);
 
   const setStateItem = (item: Object) => setItem(item);
+  const setStateErrors = (errors: Object) => setErrors(errors);
   const modalNameId = `${props.id}-modal`;
   const panelCollapseId = props.collapsible ? `${props.id}-panel` : null;
 
@@ -59,7 +61,10 @@ const CreatorPanel = (props: Props) => {
             target={modalNameId}
             onClick={() => {
               setOpen(true)
-              props.onOpen && props.onOpen({setItem: setStateItem})
+              props.onOpen && props.onOpen({
+                setItem: setStateItem,
+                setErrors: setStateErrors
+              })
             }}
           />
         }>
@@ -79,7 +84,8 @@ const CreatorPanel = (props: Props) => {
                   props.renderCreationContent({
                     open,
                     item,
-                    setItem: setStateItem
+                    setItem: setStateItem,
+                    errors
                   })
                 }
                 onClosePopUp={() => setOpen(false)}
@@ -119,7 +125,8 @@ const CreatorPanel = (props: Props) => {
                           disabled={props.disableOperations}
                           handler={() => props.onSave({
                             item,
-                            closeDialog: () => closeDialog(modalNameId)
+                            closeDialog: () => closeDialog(modalNameId),
+                            setErrors: setStateErrors
                           })}
                         />
                       </div>

--- a/web/html/src/manager/content-management/create-project/create-project.js
+++ b/web/html/src/manager/content-management/create-project/create-project.js
@@ -19,7 +19,8 @@ const CreateProject = () => {
         name: "",
         description: "",
         historyEntries: [],
-      }
+      },
+      errors:{}
   });
   const { onAction } = useLifecycleActionsApi({resource: 'projects'});
   const roles = useRoles();
@@ -43,7 +44,8 @@ const CreateProject = () => {
                       }
                     )
                     .catch((error) => {
-                      showErrorToastr(error, {autoHide: false});
+                      setProject({...project, errors: error.errors});
+                      showErrorToastr(error.messages, {autoHide: false});
                     })
                 }
               />
@@ -51,6 +53,7 @@ const CreateProject = () => {
           >
             <PropertiesCreate
               properties={project.properties}
+              errors={project.errors}
               onChange={(newProperties) => setProject({...project, properties: newProperties})}
             />
           </TopPanel>

--- a/web/html/src/manager/content-management/list-filters/appstreams/select-input.js
+++ b/web/html/src/manager/content-management/list-filters/appstreams/select-input.js
@@ -21,7 +21,7 @@ export default function SelectInput(props: SelectInputProps) {
       setShowInputs(true);
       onAction(null, "get", value)
         .then(setModules)
-        .catch(showErrorToastr);
+        .catch((error) => showErrorToastr(error.messages));
     } else {
       setModules({});
     }

--- a/web/html/src/manager/content-management/list-filters/filter-edit.js
+++ b/web/html/src/manager/content-management/list-filters/filter-edit.js
@@ -13,7 +13,7 @@ import {mapFilterFormToRequest} from "./filter.utils";
 import _isEmpty from "lodash/isEmpty";
 import useUserLocalization from "core/user-localization/use-user-localization";
 
-const FilterEditModalContent = ({open, isLoading, filter, onChange, onClientValidate, editing}) => {
+const FilterEditModalContent = ({open, isLoading, filter, errors, onChange, onClientValidate, editing}) => {
   if (!open) {
     return null;
   }
@@ -27,6 +27,7 @@ const FilterEditModalContent = ({open, isLoading, filter, onChange, onClientVali
   return (
     <FilterForm
       filter={filter}
+      errors={errors}
       editing={editing}
       onChange={(updatedFilter) => onChange(updatedFilter)}
       onClientValidate={onClientValidate}
@@ -53,6 +54,7 @@ const FilterEdit = (props: FilterEditProps) => {
 
   const [open, setOpen] = useState(false);
   const [item, setFormData] = useState(props.initialFilterForm);
+  const [errors, setErrors] = useState({});
   const [formValidInClient, setFormValidInClient] = useState(true);
   const {localTime} = useUserLocalization();
 
@@ -93,6 +95,7 @@ const FilterEdit = (props: FilterEditProps) => {
               content={
                 <FilterEditModalContent
                   filter={item}
+                  errors={errors}
                   open={open}
                   onChange={setFormData}
                   onClientValidate={setFormValidInClient}
@@ -159,6 +162,7 @@ const FilterEdit = (props: FilterEditProps) => {
                                   }
                                 })
                                 .catch((error) => {
+                                  setErrors(error.errors);
                                   showErrorToastr(error.messages, {autoHide: false});
                                 })
                             } else {
@@ -173,6 +177,7 @@ const FilterEdit = (props: FilterEditProps) => {
                                   }
                                 })
                                 .catch((error) => {
+                                  setErrors(error.errors);
                                   showErrorToastr(error.messages, {autoHide: false});
                                 })
                             }

--- a/web/html/src/manager/content-management/list-filters/filter-edit.js
+++ b/web/html/src/manager/content-management/list-filters/filter-edit.js
@@ -117,7 +117,7 @@ const FilterEdit = (props: FilterEditProps) => {
                               props.onChange(updatedListOfFilters);
                             })
                             .catch((error) => {
-                              showErrorToastr(error, {autoHide: false});
+                              showErrorToastr(error.messages, {autoHide: false});
                             })
                         }}
                       />
@@ -159,7 +159,7 @@ const FilterEdit = (props: FilterEditProps) => {
                                   }
                                 })
                                 .catch((error) => {
-                                  showErrorToastr(error, {autoHide: false});
+                                  showErrorToastr(error.messages, {autoHide: false});
                                 })
                             } else {
                               onAction(mapFilterFormToRequest(item, props.projectLabel, localTime), "create")
@@ -173,7 +173,7 @@ const FilterEdit = (props: FilterEditProps) => {
                                   }
                                 })
                                 .catch((error) => {
-                                  showErrorToastr(error, {autoHide: false});
+                                  showErrorToastr(error.messages, {autoHide: false});
                                 })
                             }
                           }

--- a/web/html/src/manager/content-management/list-filters/filter-form.js
+++ b/web/html/src/manager/content-management/list-filters/filter-form.js
@@ -15,6 +15,7 @@ import produce from "immer";
 
 type Props = {
   filter: FilterFormType,
+  errors: Object,
   onChange: Function,
   onClientValidate: Function,
   editing?: boolean
@@ -51,6 +52,7 @@ const FilterForm = (props: Props) => {
   return (
     <Form
       model={{...props.filter}}
+      errors={props.errors}
       onValidate={props.onClientValidate}
       onChange={model => {
         props.onChange(model);

--- a/web/html/src/manager/content-management/project/project.js
+++ b/web/html/src/manager/content-management/project/project.js
@@ -110,7 +110,7 @@ const Project = (props: Props) => {
                           window.pageRenderers.spaengine.navigate(`/rhn/manager/contentmanagement/projects`);
                         })
                         .catch((error) => {
-                          showErrorToastr(error, {autoHide: false});
+                          showErrorToastr(error.messages, {autoHide: false});
                         })
                     }
       />

--- a/web/html/src/manager/content-management/shared/api/use-lifecycle-actions-api.js
+++ b/web/html/src/manager/content-management/shared/api/use-lifecycle-actions-api.js
@@ -34,7 +34,10 @@ const getApiUrl = (resource, nestedResource, id) => {
   }
 }
 
-const getErrorMessage = ({messages = [], errors}) => messages.filter(Boolean);
+const getErrorMessage = ({messages = [], errors = {}}) => ({
+    messages: messages.filter(Boolean),
+    errors: errors
+});
 
 
 const useLifecycleActionsApi = (props:Props): returnUseProjectActionsApi => {

--- a/web/html/src/manager/content-management/shared/components/panels/build/build.js
+++ b/web/html/src/manager/content-management/shared/components/panels/build/build.js
@@ -133,7 +133,7 @@ const Build = ({projectId, onBuild, currentHistoryEntry = {}, changesToBuild, di
                               onBuild(projectWithUpdatedSources)
                             })
                             .catch((error) => {
-                              showErrorToastr(error, {autoHide: false});
+                              showErrorToastr(error.messages, {autoHide: false});
                               closeDialog();
                             });
                         }}

--- a/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment-form.js
+++ b/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment-form.js
@@ -8,6 +8,7 @@ import type {ProjectEnvironmentType} from '../../../type/project.type.js';
 
 type Props = {
   environment: ProjectEnvironmentType,
+  errors: Object,
   environments: Array<ProjectEnvironmentType>,
   onChange: Function,
   editing?: boolean
@@ -16,6 +17,7 @@ type Props = {
 const EnvironmentForm = (props: Props) =>
   <Form
     model={props.environment}
+    errors={props.errors}
     onChange={model => {
       props.onChange(model);
     }}

--- a/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment-lifecycle.js
+++ b/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment-lifecycle.js
@@ -55,7 +55,7 @@ const EnvironmentLifecycle = (props: Props) => {
             props.onChange(projectWithCreatedEnvironment)
           })
           .catch((error) => {
-            showErrorToastr(error, {autoHide: false});
+            showErrorToastr(error.messages, {autoHide: false});
           })}
       onOpen={({ setItem }) => setItem({})}
       onCancel={() => cancelAction()}
@@ -105,7 +105,7 @@ const EnvironmentLifecycle = (props: Props) => {
                             showSuccessToastr(t("Environment updated successfully"));
                           })
                           .catch((error) => {
-                            showErrorToastr(error, {autoHide: false});
+                            showErrorToastr(error.messages, {autoHide: false});
                           })}
                       onOpen={({ setItem }) => setItem(environment)}
                       onCancel={() => cancelAction()}
@@ -120,7 +120,7 @@ const EnvironmentLifecycle = (props: Props) => {
                             showSuccessToastr(t("Environment {0} deleted successfully", environment.label));
                           })
                           .catch((error) => {
-                            showErrorToastr(error, {autoHide: false});
+                            showErrorToastr(error.messages, {autoHide: false});
                           })
                       }}
                       renderCreationContent={({ open, item, setItem }) => {

--- a/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment-lifecycle.js
+++ b/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment-lifecycle.js
@@ -47,7 +47,7 @@ const EnvironmentLifecycle = (props: Props) => {
       collapsible
       customIconClass="fa-small"
       disableOperations={isLoading}
-      onSave={({ item, closeDialog }) =>
+      onSave={({ item, closeDialog, setErrors }) =>
         onAction(mapAddEnvironmentRequest(item, props.environments, props.projectId), "create", props.projectId)
           .then((projectWithCreatedEnvironment) => {
             closeDialog();
@@ -55,11 +55,12 @@ const EnvironmentLifecycle = (props: Props) => {
             props.onChange(projectWithCreatedEnvironment)
           })
           .catch((error) => {
+            setErrors(error.errors);
             showErrorToastr(error.messages, {autoHide: false});
           })}
       onOpen={({ setItem }) => setItem({})}
       onCancel={() => cancelAction()}
-      renderCreationContent={({ open, item, setItem }) => {
+      renderCreationContent={({ open, item, setItem, errors }) => {
 
         if (!open) {
           return null;
@@ -74,6 +75,7 @@ const EnvironmentLifecycle = (props: Props) => {
         return (
           <EnvironmentForm
             environment={{...item}}
+            errors={errors}
             environments={props.environments}
             onChange={(item) => setItem(item)}/>
         )
@@ -97,7 +99,7 @@ const EnvironmentLifecycle = (props: Props) => {
                       panelLevel="3"
                       disableEditing={!hasEditingPermissions}
                       disableOperations={isLoading}
-                      onSave={({ item, closeDialog }) =>
+                      onSave={({ item, closeDialog, setErrors }) =>
                         onAction(mapUpdateEnvironmentRequest(item, props.projectId), "update", props.projectId)
                           .then((projectWithUpdatedEnvironment) => {
                             props.onChange(projectWithUpdatedEnvironment)
@@ -105,6 +107,7 @@ const EnvironmentLifecycle = (props: Props) => {
                             showSuccessToastr(t("Environment updated successfully"));
                           })
                           .catch((error) => {
+                            setErrors(error.errors);
                             showErrorToastr(error.messages, {autoHide: false});
                           })}
                       onOpen={({ setItem }) => setItem(environment)}
@@ -123,7 +126,7 @@ const EnvironmentLifecycle = (props: Props) => {
                             showErrorToastr(error.messages, {autoHide: false});
                           })
                       }}
-                      renderCreationContent={({ open, item, setItem }) => {
+                      renderCreationContent={({ open, item, setItem, errors }) => {
                         if (!open) {
                           return null;
                         }
@@ -144,6 +147,7 @@ const EnvironmentLifecycle = (props: Props) => {
                             }
                             <EnvironmentForm
                               environment={{...item}}
+                              errors={errors}
                               environments={props.environments}
                               onChange={(item) => setItem(item)}
                               editing

--- a/web/html/src/manager/content-management/shared/components/panels/filters-project/filters-project.js
+++ b/web/html/src/manager/content-management/shared/components/panels/filters-project/filters-project.js
@@ -110,7 +110,7 @@ const FiltersProject = (props:  FiltersProps) => {
             props.onChange(projectWithUpdatedSources)
           })
           .catch((error) => {
-            showErrorToastr(error, {autoHide: false});
+            showErrorToastr(error.messages, {autoHide: false});
           });
       }}
       renderCreationContent={({setItem}) => {

--- a/web/html/src/manager/content-management/shared/components/panels/filters-project/filters-project.js
+++ b/web/html/src/manager/content-management/shared/components/panels/filters-project/filters-project.js
@@ -97,7 +97,7 @@ const FiltersProject = (props:  FiltersProps) => {
       disableEditing={!hasEditingPermissions}
       onCancel={() => cancelAction()}
       onOpen={({setItem}) => setItem(props.selectedFilters.map(filter => filter.id))}
-      onSave={({closeDialog, item}) => {
+      onSave={({closeDialog, item, setErrors}) => {
         const requestParam = {
           projectLabel: props.projectId,
           filtersIds: item,
@@ -110,6 +110,7 @@ const FiltersProject = (props:  FiltersProps) => {
             props.onChange(projectWithUpdatedSources)
           })
           .catch((error) => {
+            setErrors(error.errors);
             showErrorToastr(error.messages, {autoHide: false});
           });
       }}

--- a/web/html/src/manager/content-management/shared/components/panels/promote/promote.js
+++ b/web/html/src/manager/content-management/shared/components/panels/promote/promote.js
@@ -120,7 +120,7 @@ const Promote = (props: Props) => {
                       props.onChange(projectWithUpdatedSources)
                     })
                     .catch((error) => {
-                      showErrorToastr(error, {autoHide: false});
+                      showErrorToastr(error.messages, {autoHide: false});
                       closeDialog();
                     });
                 }}

--- a/web/html/src/manager/content-management/shared/components/panels/properties/properties-create.js
+++ b/web/html/src/manager/content-management/shared/components/panels/properties/properties-create.js
@@ -7,6 +7,7 @@ import type {ProjectPropertiesType} from '../../../type/project.type.js';
 
 type Props = {
   properties: ProjectPropertiesType,
+  errors: Object,
   onChange: Function,
 };
 
@@ -18,6 +19,7 @@ const Properties = (props: Props) => {
       <div className="col-md-8">
         <PropertiesForm
           properties={props.properties}
+          errors={props.errors}
           onChange={props.onChange}
         />
       </div>

--- a/web/html/src/manager/content-management/shared/components/panels/properties/properties-edit.js
+++ b/web/html/src/manager/content-management/shared/components/panels/properties/properties-edit.js
@@ -54,9 +54,13 @@ const PropertiesEdit = (props: Props) => {
         title={t('Project Properties')}
         collapsible
         customIconClass="fa-small"
-        onOpen={({ setItem }) => setItem(props.properties)}
+        onOpen={({ setItem, setErrors }) => {
+            setItem(props.properties);
+            setErrors(null);
+          }
+        }
         disableOperations={isLoading}
-        onSave={({ item, closeDialog }) => {
+        onSave={({ item, closeDialog, setErrors}) => {
           return onAction(item, "update", props.projectId)
             .then((editedProject) => {
               closeDialog();
@@ -64,7 +68,8 @@ const PropertiesEdit = (props: Props) => {
               props.onChange(editedProject)
             })
             .catch((error) => {
-              showErrorToastr(error, {autoHide: false});
+              setErrors(error.errors);
+              showErrorToastr(error.messages, {autoHide: false});
             })
         }}
         onCancel={() => cancelAction()}
@@ -74,7 +79,7 @@ const PropertiesEdit = (props: Props) => {
             <PropertiesView properties={propertiesToShow}/>
           </React.Fragment>
         }
-        renderCreationContent={({ open, item, setItem }) => {
+        renderCreationContent={({ open, item, setItem, errors }) => {
 
           if (isLoading) {
             return (
@@ -85,6 +90,7 @@ const PropertiesEdit = (props: Props) => {
           return (
             <PropertiesForm
               properties={{...item}}
+              errors={errors}
               onChange={(editedProperties) => setItem(editedProperties)}
               editing
             />

--- a/web/html/src/manager/content-management/shared/components/panels/properties/properties-form.js
+++ b/web/html/src/manager/content-management/shared/components/panels/properties/properties-form.js
@@ -7,6 +7,7 @@ import type {ProjectPropertiesType} from '../../../type/project.type.js';
 
 type Props = {
   properties: ProjectPropertiesType,
+  errors: Object,
   onChange: Function,
   editing?: boolean
 };
@@ -14,6 +15,7 @@ type Props = {
 const PropertiesForm = (props: Props) => (
   <Form
     model={props.properties}
+    errors={props.errors}
     onChange={model => {
       props.onChange(model);
     }}

--- a/web/html/src/manager/content-management/shared/components/panels/sources/sources.js
+++ b/web/html/src/manager/content-management/shared/components/panels/sources/sources.js
@@ -110,7 +110,7 @@ const Sources = (props: SourcesProps) => {
             props.onChange(projectWithUpdatedSources)
           })
           .catch((error) => {
-            showErrorToastr(error, {autoHide: false});
+            showErrorToastr(error.messages, {autoHide: false});
           });
       }}
       renderCreationContent={({setItem}) => {


### PR DESCRIPTION
## What does this PR change?

This PR introduces the infrastructure to implement and display server-side validation errors at the field-level.

This PR also makes usage of that infrastructure on `Content LifeCycle Management` forms, which can be used as an example (separate commits for easier review).

### Infrastructure

A new `errors` field was added to the response format, to represent **field-level input errors**, see the following example:
```
{
   "success":false,
   "messages":[
      "Global message will be shown in a popup"
   ],
   "errors":{
      "filter_name":[
         "Field-level error message that will be displayed next to the 'filter_name' input"
      ]
   },
   "data":null
}
```

#### Backend

Those new "field errors" can be added via `addFieldError`:
```
ValidatorResult result = new ValidatorResult();
result.addFieldError(<field_name>, <message_key>);
```

Note that the way we add "global errors" has not changed:
```
ValidatorResult result = new ValidatorResult();
result.addError(<message_key>);
```

#### Frontend

To display server-side "field errors", just provide them to the `Form` component via `errors` property the same way we provide `model`:
```
 <Form
    model={model}
    errors={errors}
    ...
```
Errors will then be automatically displayed next to the corresponding input, just like we are now displaying the "frontend-only" validation errors. Note that ATM the frontend will not display more than one error per field.

### Content LifeCycle Management

Content LifeCycle Management input validation errors will now be displayed at field-level, including the "filter name already exists" mentioned on issue https://github.com/SUSE/spacewalk/issues/7639.

## GUI diff

Before:

![Screenshot from 2020-12-18 12-17-06](https://user-images.githubusercontent.com/14297426/102613981-54616400-412b-11eb-96a0-c0edd94b7bd5.png)

After:

![Screenshot from 2020-12-18 12-14-46](https://user-images.githubusercontent.com/14297426/102614055-72c75f80-412b-11eb-9dff-88b4ba892ebd.png)


- [x] **DONE**

## Documentation
- No documentation needed: No documentation required for users. Developers can look into PR description and "Content LifeCycle Management" example in the code.

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/7639
Fixes https://github.com/SUSE/spacewalk/issues/13510

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

