### PR TITLE
QA: Chromedriver should ignore certificate errors

### DIFF
--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -57,7 +57,7 @@ Capybara.register_driver(:headless_chrome) do |app|
   # WORKAROUND failure at Scenario: Test IPMI functions: increase from 60 s to 180 s
   client.read_timeout = 180
   # Chrome driver options
-  chrome_options = %w[no-sandbox disable-dev-shm-usage disable-gpu window-size=2048,2048, js-flags=--max_old_space_size=2048]
+  chrome_options = %w[no-sandbox disable-dev-shm-usage ignore-certificate-errors disable-gpu window-size=2048,2048, js-flags=--max_old_space_size=2048]
   chrome_options << 'headless' unless $debug_mode
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
     chromeOptions: {


### PR DESCRIPTION
## What does this PR change?

When we run our tests not using the headless option, the browser opened expects that we click on a button to ignore certificate errors. To avoid it, we will pass an extra parameter in the options of chrome driver.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
 - Manager-4.0 https://github.com/SUSE/spacewalk/pull/13527
 - Manager-4.1 https://github.com/SUSE/spacewalk/pull/13526

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
