### PR TITLE
QA: Fixing UI checks expecting old SLE15 channels

### DIFF
--- a/testsuite/features/reposync/srv_sync_products.feature
+++ b/testsuite/features/reposync/srv_sync_products.feature
@@ -59,4 +59,4 @@ Feature: Synchronize products in the products page of the Setup Wizard
     Then I should see the "Basesystem Module 15 SP2 x86_64" selected
     And I click the Add Product button
     And I wait until I see "SUSE Linux Enterprise Server 15 SP2 x86_64" product has been added
-    Then the SLE15 products should be added
+    Then the SLE15 SP2 products should be added

--- a/testsuite/features/secondary/allcli_software_channels_dependencies.feature
+++ b/testsuite/features/secondary/allcli_software_channels_dependencies.feature
@@ -14,18 +14,18 @@ Feature: Chanel subscription with recommended/required dependencies
     And I follow "Software Channels" in the content area
     # check that the required channel by the base one is selected and disabled
     And I wait until I do not see "Loading..." text
-    And I check radio button "SLE-Product-SLES15-Pool for x86_64"
+    And I check radio button "SLE-Product-SLES15-SP2-Pool for x86_64"
     And I wait until I do not see "Loading..." text
-    Then I should see the child channel "SLE-Product-SLES15-Updates for x86_64" "selected" and "disabled"
+    Then I should see the child channel "SLE-Product-SLES15-SP2-Updates for x86_64" "selected" and "disabled"
     And I should see the toggler "disabled"
-    And I should see a "SLE-Module-Basesystem15-Pool for x86_64" text
-    And I should see the child channel "SLE-Module-Basesystem15-Pool for x86_64" "unselected"
+    And I should see a "SLE-Module-Basesystem15-SP2-Pool for x86_64" text
+    And I should see the child channel "SLE-Module-Basesystem15-SP2-Pool for x86_64" "unselected"
     # check the a child channel selection that requires some channel trigger the selection of it
-    When I select the child channel "SLE-Module-Basesystem15-Updates for x86_64"
-    Then I should see the child channel "SLE-Module-Basesystem15-Pool for x86_64" "selected"
+    When I select the child channel "SLE-Module-Basesystem15-SP2-Updates for x86_64"
+    Then I should see the child channel "SLE-Module-Basesystem15-SP2-Pool for x86_64" "selected"
     # check a recommended channel not yet selected is checked  by the recommended toggler
     When I click on the "disabled" toggler
-    Then I should see the child channel "SLE-Module-Server-Applications15-Pool for x86_64" "selected"
+    Then I should see the child channel "SLE-Module-Server-Applications15-SP2-Pool for x86_64" "selected"
 
   Scenario: Play with recommended and required child channels selection in SSM
     Given I am authorized as "admin" with password "admin"
@@ -41,11 +41,11 @@ Feature: Chanel subscription with recommended/required dependencies
     When I select "System Default Base Channel" from drop-down in table line with "Test-Channel-x86_64"
     And I click on "Next"
     Then I should see the toggler "disabled"
-    And I should see a "SLE-Module-Basesystem15-Pool for x86_64" text
-    And I should see "No change" "selected" for the "SLE-Module-Basesystem15-Pool for x86_64" channel
+    And I should see a "SLE-Module-Basesystem15-SP2-Pool for x86_64" text
+    And I should see "No change" "selected" for the "SLE-Module-Basesystem15-SP2-Pool for x86_64" channel
     When I click on the "disabled" toggler
-    Then I should see "Subscribe" "selected" for the "SLE-Module-Basesystem15-Pool for x86_64" channel
-    And I should see "No change" "unselected" for the "SLE-Module-Basesystem15-Pool for x86_64" channel
+    Then I should see "Subscribe" "selected" for the "SLE-Module-Basesystem15-SP2-Pool for x86_64" channel
+    And I should see "No change" "unselected" for the "SLE-Module-Basesystem15-SP2-Pool for x86_64" channel
 
   Scenario: Cleanup: remove remaining systems from SSM after software channel tests
     When I am authorized as "admin" with password "admin"

--- a/testsuite/features/secondary/srv_distro_cobbler.feature
+++ b/testsuite/features/secondary/srv_distro_cobbler.feature
@@ -26,7 +26,7 @@ Feature: Cobbler and distribution autoinstallation
     And I follow "Create Distribution"
     And I enter "SLE-15-FAKE" as "label"
     And I enter "/install/SLES11-SP1-x86_64/DVD1/" as "basepath"
-    And I select "SLE-Product-SLES15-Pool for x86_64" from "channelid"
+    And I select "SLE-Product-SLES15-SP2-Pool for x86_64" from "channelid"
     And I select "SUSE Linux Enterprise 15" from "installtype"
     And I click on "Create Autoinstallable Distribution"
     Then I should see a "Autoinstallable Distributions" text

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -544,14 +544,7 @@ Then(/^the SLE12 products should be added$/) do
   raise unless output[:stdout].include? '[I] SLE-Module-Legacy12-Updates for x86_64 Legacy Module 12 x86_64 [sle-module-legacy12-updates-x86_64-sp5]'
 end
 
-Then(/^the SLE15 products should be added$/) do
-  output = sshcmd('echo -e "admin\nadmin\n" | mgr-sync list channels', ignore_err: true)
-  raise unless output[:stdout].include? '[I] SLE-Product-SLES15-SP2-Pool for x86_64 SUSE Linux Enterprise Server 15 SP2 x86_64 [sle-product-sles15-sp2-pool-x86_64]'
-  raise unless output[:stdout].include? '[I] SLE-Module-Basesystem15-SP2-Updates for x86_64 Basesystem Module 15 SP2 x86_64 [sle-module-basesystem15-sp2-updates-x86_64]'
-  raise unless output[:stdout].include? '[I] SLE-Module-Server-Applications15-SP2-Pool for x86_64 Server Applications Module 15 SP2 x86_64 [sle-module-server-applications15-sp2-pool-x86_64]'
-end
-
-Then(/^the SLE15SP2 base products should be added$/) do
+Then(/^the SLE15 SP2 products should be added$/) do
   output = sshcmd('echo -e "admin\nadmin\n" | mgr-sync list channels', ignore_err: true)
   raise unless output[:stdout].include? '[I] SLE-Product-SLES15-SP2-Pool for x86_64 SUSE Linux Enterprise Server 15 SP2 x86_64 [sle-product-sles15-sp2-pool-x86_64]'
   raise unless output[:stdout].include? '[I] SLE-Module-Basesystem15-SP2-Updates for x86_64 Basesystem Module 15 SP2 x86_64 [sle-module-basesystem15-sp2-updates-x86_64]'


### PR DESCRIPTION
## What does this PR change?

We recently upgraded the product SLES15 to SLES15 SP2, in our repo sync stage.
Some of our scenarios were expecting for SLES15 channel names, so this PR fix is replacing these names with the new names.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
