### PR TITLE
Checked server-app-module in uyuni head testsuite

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -548,7 +548,7 @@ Then(/^the SLE15 SP2 products should be added$/) do
   output = sshcmd('echo -e "admin\nadmin\n" | mgr-sync list channels', ignore_err: true)
   raise unless output[:stdout].include? '[I] SLE-Product-SLES15-SP2-Pool for x86_64 SUSE Linux Enterprise Server 15 SP2 x86_64 [sle-product-sles15-sp2-pool-x86_64]'
   raise unless output[:stdout].include? '[I] SLE-Module-Basesystem15-SP2-Updates for x86_64 Basesystem Module 15 SP2 x86_64 [sle-module-basesystem15-sp2-updates-x86_64]'
-  raise unless output[:stdout].include? '[ ] SLE-Module-Server-Applications15-SP2-Pool for x86_64 Server Applications Module 15 SP2 x86_64 [sle-module-server-applications15-sp2-pool-x86_64]'
+  raise unless output[:stdout].include? '[I] SLE-Module-Server-Applications15-SP2-Pool for x86_64 Server Applications Module 15 SP2 x86_64 [sle-module-server-applications15-sp2-pool-x86_64]'
 end
 
 When(/^I click the channel list of product "(.*?)"$/) do |product|


### PR DESCRIPTION
## What does this PR change?
without this commit, the uyuni head testuite is
failing, because it expects to have all recommended channels.

Testsuite should not stumble into the `./features/step_definitions/common_steps.rb:551:in` error anymore, since all recommended channels are checked accordingly.

## Links

uyuni branch only

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
