### PR TITLE
Fix storybook missing t() definition

### DIFF
--- a/web/html/src/.storybook/preview-head.html
+++ b/web/html/src/.storybook/preview-head.html
@@ -8,7 +8,7 @@
 <link rel="stylesheet" href="https://localhost:8080/css/bootstrap-datepicker.css?cb=${cb_version}" />
 <link rel="stylesheet" href="https://localhost:8080/javascript/select2/select2.css?cb=${cb_version}" />
 <link rel="stylesheet" href="https://localhost:8080/javascript/select2/select2-bootstrap.css?cb=${cb_version}" />
-<link rel="stylesheet" href="https://localhost:8080/css/spacewalk.css?cb=${cb_version}" />
+<link rel="stylesheet" href="https://localhost:8080/css/uyuni.css?cb=${cb_version}" />
 
 <script src="https://localhost:8080/javascript/loggerhead.js?cb=${cb_version}"></script>
 <script src="https://localhost:8080/javascript/frontend-log.js?cb=${cb_version}"></script>
@@ -16,7 +16,6 @@
 <script src="https://localhost:8080/javascript/bootstrap.js?cb=${cb_version}"></script>
 <script src="https://localhost:8080/javascript/select2/select2.js?cb=${cb_version}"></script>
 <script src="https://localhost:8080/javascript/spacewalk-essentials.js?cb=${cb_version}"></script>
-<script src="https://localhost:8080/javascript/susemanager-translate.js?cb=${cb_version}"></script>
 <script src="https://localhost:8080/javascript/spacewalk-checkall.js?cb=${cb_version}"></script>
 <script src="https://localhost:8080/rhn/dwr/engine.js?cb=${cb_version}"></script>
 <script src="https://localhost:8080/rhn/dwr/util.js?cb=${cb_version}"></script>
@@ -24,3 +23,9 @@
 <script src="https://localhost:8080/javascript/jquery.timepicker.js?cb=${cb_version}"></script>
 <script src="https://localhost:8080/javascript/bootstrap-datepicker.js?cb=${cb_version}"></script>
 <script src='https://localhost:8080/javascript/momentjs/moment-with-langs.min.js?cb=${cb_version}' type='text/javascript'></script>
+<script type='text/javascript'>
+  function translate(value) {
+    return value;
+  }
+  window.t = translate;
+</script>


### PR DESCRIPTION
## What does this PR change?

Fix storybook

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: fixing a sort of documentation is documentation after all

- [X] **DONE**

## Test coverage
- No tests: story book is not tested

- [X] **DONE**

## Links

Fixes # https://github.com/SUSE/spacewalk/issues/13491
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
