### PR TITLE
Fixed RHEL setup routine.

### DIFF
--- a/projects/perl-Satcon/bin/satcon-deploy-tree.pl
+++ b/projects/perl-Satcon/bin/satcon-deploy-tree.pl
@@ -90,8 +90,8 @@ sub process_file {
     # save permissions also but clear access for other
     my $mode =  (stat("$sourcedir/$relative_path"))[2] & 07770;
     chmod $mode, "$destdir/$relative_path";
-    # chgrp apache
-    chown 0, scalar(getgrnam("www")), "$destdir/$relative_path";
+    # chgrp apache (Different OS uses different group name, so use both).
+    chown 0, (getgrnam("www") // "") . (getgrnam("apache") // ""), "$destdir/$relative_path";
 
     system '/sbin/restorecon', '-vv', "$destdir/$relative_path";
 

--- a/projects/perl-Satcon/perl-Satcon.changes
+++ b/projects/perl-Satcon/perl-Satcon.changes
@@ -1,3 +1,5 @@
+- Added RHEL Apache uid.
+
 -------------------------------------------------------------------
 Fri Sep 18 11:16:00 CEST 2020 - jgonzalez@suse.com
 

--- a/spacewalk/admin/rhn-config-satellite.pl
+++ b/spacewalk/admin/rhn-config-satellite.pl
@@ -56,7 +56,8 @@ unlink $tmpfile if -e $tmpfile;
 umask 0027;
 open(TMP, "> $tmpfile") or die "Could not open $tmpfile for writing: $OS_ERROR";
 if ($tmpfile =~ m!^/etc/rhn/!) {
-  chown 0, scalar(getgrnam("www")), $tmpfile;
+  # Chown for different potential apache group names (SUSE/RHEL)
+  chown 0, (getgrnam("www") // "") . (getgrnam("apache") // ""), $tmpfile;
 }
 
 while (my $line = <TARGET>) {

--- a/spacewalk/admin/spacewalk-admin.changes
+++ b/spacewalk/admin/spacewalk-admin.changes
@@ -1,3 +1,5 @@
+- Added RHEL Apache permissions.
+
 -------------------------------------------------------------------
 Wed Nov 25 12:18:40 CET 2020 - jgonzalez@suse.com
 

--- a/spacewalk/setup/bin/spacewalk-make-mount-points
+++ b/spacewalk/setup/bin/spacewalk-make-mount-points
@@ -13,8 +13,9 @@ use Spacewalk::Setup ();
 my %dirs;
 @dirs{@ARGV} = ();
 
-my $apache_uid = getpwnam('wwwrun');
-if (not defined $apache_uid) {
+# Add both potential Apache group IDs (SUSE/RHEL)
+my $apache_uid = (getpwnam('wwwrun') // "") . (getpwnam('apache') // "");
+if ($apache_uid eq "" ) {
         die "Failed to retrieve uid of user apache, the user does not seem to exist.\n";
 }
 my $seen_nfs = 0;

--- a/spacewalk/setup/bin/spacewalk-setup
+++ b/spacewalk/setup/bin/spacewalk-setup
@@ -144,7 +144,8 @@ mkdir_mount_points($config_opts->{'mount_point'},
         $config_opts->{'mount_point'} . '/systems',
         $config_opts->{'kickstart_mount_point'});
 chmod 0775, $config_opts->{'mount_point'} . '/systems';
-my $www_gid = getgrnam "www";
+# Check for both potential Apache groups (SUSE/RHEL)
+my $www_gid = (getgrnam("www") // "") . (getgrnam("apache") // "");
 chown -1, $www_gid, $config_opts->{'mount_point'} . '/systems';
 
 setup_sudoers();

--- a/spacewalk/setup/spacewalk-setup.changes
+++ b/spacewalk/setup/spacewalk-setup.changes
@@ -1,3 +1,4 @@
+- Added RHEL Apache gid handling.
 - Drop the ssl_available option (SSL is always present)
 - Added dynamic path for trust store and doc root.
 - Updated SPEC for RHEL and Fedora.

--- a/susemanager/bin/mgr-setup
+++ b/susemanager/bin/mgr-setup
@@ -667,7 +667,9 @@ do_migration() {
     mv /etc/rhn/rhn.conf /etc/rhn/rhn.conf.setup
     cp /etc/rhn/rhn.conf-$FROMVERSION /etc/rhn/rhn.conf
     chmod 640 /etc/rhn/rhn.conf
-    chown root:www /etc/rhn/rhn.conf
+    # Detect the Apache group name (SUSE/RHEL differences)
+    APACHE_GROUP=`cut -d: -f3 < <((getent group www);(getent group apache))`
+    chown root:${APACHE_GROUP} /etc/rhn/rhn.conf
 }
 
 do_setup() {

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- Updated file permissions in mgr-setup.
 - internal code cleanup (dropping unused table rhnErrataTmp)
 - Drop the ssl_available option (SSL is always present)
 - remove the virtpoller beacon

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,4 +1,5 @@
 - Updated file permissions in mgr-setup.
+- Variable folder installation location.
 - internal code cleanup (dropping unused table rhnErrataTmp)
 - Drop the ssl_available option (SSL is always present)
 - remove the virtpoller beacon

--- a/susemanager/susemanager.spec
+++ b/susemanager/susemanager.spec
@@ -28,7 +28,8 @@
 %global tftp_group root
 %global salt_user root
 %global salt_group root
-%global wwwdocroot %{_var}/www/html
+%global wwwroot %{_var}/www
+%global wwwdocroot %{wwwroot}/html
 %endif
 
 %if 0%{?suse_version}
@@ -37,7 +38,8 @@
 %global tftp_group tftp
 %global salt_user salt
 %global salt_group salt
-%global wwwdocroot /srv/www/htdocs
+%global wwwroot /srv/www
+%global wwwdocroot %{wwwroot}/htdocs
 %endif
 
 %global debug_package %{nil}
@@ -176,7 +178,7 @@ install -m 0644 etc/logrotate.d/susemanager-tools %{buildroot}/%{_sysconfdir}/lo
 install -m 0644 etc/slp.reg.d/susemanager.reg %{buildroot}/%{_sysconfdir}/slp.reg.d
 install -m 755 etc/init.d/susemanager %{buildroot}/%{_sysconfdir}/init.d
 make -C src install PREFIX=$RPM_BUILD_ROOT PYTHON_BIN=%{pythonX} MANDIR=%{_mandir}
-install -d -m 755 %{buildroot}/srv/www/os-images/
+install -d -m 755 %{buildroot}/%{wwwroot}/os-images/
 
 # empty repo for rhel base channels
 mkdir -p %{buildroot}%{wwwdocroot}/pub/repositories/
@@ -304,7 +306,7 @@ fi
 %else
 %{_datadir}/applications/YaST2/com.suse.yast2.SUSEManager.desktop
 %endif
-%attr(775,%{salt_user},susemanager) %dir /srv/www/os-images/
+%attr(775,%{salt_user},susemanager) %dir %{wwwroot}/os-images/
 %if 0%{?suse_version} > 1320
 %{_prefix}/lib/firewalld/services/suse-manager-server.xml
 %else

--- a/uyuni/base/uyuni-base.changes
+++ b/uyuni/base/uyuni-base.changes
@@ -1,3 +1,5 @@
+- Removed RHEL specific folder rights from SPEC file.
+
 -------------------------------------------------------------------
 Thu Dec 03 13:59:47 CET 2020 - jgonzalez@suse.com
 

--- a/uyuni/base/uyuni-base.spec
+++ b/uyuni/base/uyuni-base.spec
@@ -28,13 +28,8 @@
 %define apache_group www
 %else
 %define www_path %{_var}
-%if 0%{?rhel}
-%define apache_user root
-%define apache_group root
-%else
 %define apache_user apache
 %define apache_group apache
-%endif
 %endif
 
 Name:           uyuni-base

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Fixed variable installation location.
 - Drop the ssl_available option (SSL is always present)
 - Prevent deletion of CLM environments if they're used in an autoinstallation
   profile (bsc#1179552)

--- a/web/spacewalk-web.spec
+++ b/web/spacewalk-web.spec
@@ -18,11 +18,11 @@
 
 
 %if 0%{?suse_version}
-%define www_path /srv/
+%define www_path /srv/www/htdocs
 %define apache_user wwwrun
 %define apache_group www
 %else
-%define www_path %{_var}
+%define www_path %{_var}/www/html
 %if 0%{?rhel}
 %define apache_user root
 %define apache_group root
@@ -200,13 +200,13 @@ sed -i -r "s/^(web.buildtimestamp *= *)_OBS_BUILD_TIMESTAMP_$/\1$(date +'%%Y%%m%
 
 %install
 make -C modules install DESTDIR=$RPM_BUILD_ROOT PERLARGS="INSTALLDIRS=vendor" %{?_smp_mflags}
-make -C html install PREFIX=$RPM_BUILD_ROOT INSTALL_DEST=%{www_path}/www/htdocs
+make -C html install PREFIX=$RPM_BUILD_ROOT INSTALL_DEST=%{www_path}
 make -C po install PREFIX=$RPM_BUILD_ROOT
 
 find $RPM_BUILD_ROOT -type f -name perllocal.pod -exec rm -f {} \;
 find $RPM_BUILD_ROOT -type f -name .packlist -exec rm -f {} \;
 
-mkdir -p $RPM_BUILD_ROOT/%{www_path}/www/htdocs/pub
+mkdir -p $RPM_BUILD_ROOT/%{www_path}/pub
 mkdir -p $RPM_BUILD_ROOT/%{_prefix}/share/rhn/config-defaults
 mkdir -p $RPM_BUILD_ROOT/%{_sysconfdir}/init.d
 mkdir -p $RPM_BUILD_ROOT/%{_sysconfdir}/httpd/conf
@@ -216,26 +216,26 @@ install -m 644 conf/rhn_web.conf $RPM_BUILD_ROOT%{_prefix}/share/rhn/config-defa
 install -m 644 conf/rhn_dobby.conf $RPM_BUILD_ROOT%{_prefix}/share/rhn/config-defaults
 install -m 755 modules/dobby/scripts/check-database-space-usage.sh $RPM_BUILD_ROOT/%{_sysconfdir}/cron.daily/check-database-space-usage.sh
 
-%{__mkdir_p} %{buildroot}/%{www_path}/www/htdocs/javascript/manager
-cp -r html/src/dist/javascript/manager %{buildroot}/%{www_path}/www/htdocs/javascript
+%{__mkdir_p} %{buildroot}/%{www_path}/javascript/manager
+cp -r html/src/dist/javascript/manager %{buildroot}/%{www_path}/javascript
 
-%{__mkdir_p} %{buildroot}/%{www_path}/www/htdocs/vendors
-cp html/src/dist/vendors/vendors.bundle.js %{buildroot}/%{www_path}/www/htdocs/vendors/vendors.bundle.js
-cp html/src/dist/vendors/vendors.bundle.js.map %{buildroot}/%{www_path}/www/htdocs/vendors/vendors.bundle.js.map
-cp html/src/dist/vendors/vendors.bundle.js.LICENSE %{buildroot}/%{www_path}/www/htdocs/vendors/vendors.bundle.js.LICENSE
+%{__mkdir_p} %{buildroot}/%{www_path}/vendors
+cp html/src/dist/vendors/vendors.bundle.js %{buildroot}/%{www_path}/vendors/vendors.bundle.js
+cp html/src/dist/vendors/vendors.bundle.js.map %{buildroot}/%{www_path}/vendors/vendors.bundle.js.map
+cp html/src/dist/vendors/vendors.bundle.js.LICENSE %{buildroot}/%{www_path}/vendors/vendors.bundle.js.LICENSE
 
 %find_lang spacewalk-web
 
 %files -n susemanager-web-libs
 %defattr(644,root,root,755)
-%dir %{www_path}/www/htdocs/vendors
-%{www_path}/www/htdocs/vendors/*.js
-%{www_path}/www/htdocs/vendors/*.js.LICENSE
+%dir %{www_path}/vendors
+%{www_path}/vendors/*.js
+%{www_path}/vendors/*.js.LICENSE
 
 %files -n susemanager-web-libs-debug
 %defattr(644,root,root,755)
-%dir %{www_path}/www/htdocs/vendors
-%{www_path}/www/htdocs/vendors/*.map
+%dir %{www_path}/vendors
+%{www_path}/vendors/*.map
 
 %files -n spacewalk-base
 %defattr(644,root,root,755)
@@ -270,18 +270,18 @@ cp html/src/dist/vendors/vendors.bundle.js.LICENSE %{buildroot}/%{www_path}/www/
 
 %files -n spacewalk-html -f spacewalk-web.lang
 %defattr(644,root,root,755)
-%dir %{www_path}/www/htdocs/javascript
-%dir %{www_path}/www/htdocs/javascript/manager
-%{www_path}/www/htdocs/robots.txt
-%{www_path}/www/htdocs/pub
-%{www_path}/www/htdocs/javascript/manager/*.js
-%{www_path}/www/htdocs/javascript/*.js
+%dir %{www_path}/javascript
+%dir %{www_path}/javascript/manager
+%{www_path}/robots.txt
+%{www_path}/pub
+%{www_path}/javascript/manager/*.js
+%{www_path}/javascript/*.js
 %doc LICENSE
 
 %files -n spacewalk-html-debug
 %defattr(644,root,root,755)
-%dir %{www_path}/www/htdocs/javascript
-%dir %{www_path}/www/htdocs/javascript/manager
-%{www_path}/www/htdocs/javascript/manager/*.map
+%dir %{www_path}/javascript
+%dir %{www_path}/javascript/manager
+%{www_path}/javascript/manager/*.map
 
 %changelog


### PR DESCRIPTION
## What does this PR change?

uyuni-base: Removed RHEL specific folder rights from SPEC file.
Added RHEL Apache group to perl-Satcon.
Added RHEL Apache group to spacewalk-admin.
Added RHEL Apache group to spacewalk-setup scripts.
Added RHEL Apache group to mgr-setup.
Added variable folder location (javascript/vendors) to susemanager.
Fixed variable folder location in spacewalk-html.

## GUI diff

No difference.

- [X] **DONE**

## Documentation

No documentation needed: No functional change.

- [X] **DONE**

## Test coverage
- No tests: Not sure whether necessary. The code lines have been individually tested manually on CentOS 8 and LEAP15.2. Installation has been verified on CentOS 8 (not Leap though).

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
