### PR TITLE
Move services tests to sanity checks

### DIFF
--- a/testsuite/features/core/allcli_sanity.feature
+++ b/testsuite/features/core/allcli_sanity.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2020 SUSE LLC
+# Copyright (c) 2019-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Sanity checks
@@ -8,6 +8,26 @@ Feature: Sanity checks
   Scenario: The server is healthy
     Then "server" should have a FQDN
     And the clock from "server" should be exact
+    And service "apache2" is enabled on "server"
+    And service "apache2" is active on "server"
+    And service "cobblerd" is enabled on "server"
+    And service "cobblerd" is active on "server"
+    And service "jabberd" is enabled on "server"
+    And service "jabberd" is active on "server"
+    And service "osa-dispatcher" is enabled on "server"
+    And service "osa-dispatcher" is active on "server"
+    And service "rhn-search" is enabled on "server"
+    And service "rhn-search" is active on "server"
+    And service "salt-api" is enabled on "server"
+    And service "salt-api" is active on "server"
+    And service "salt-master" is enabled on "server"
+    And service "salt-master" is active on "server"
+    And service "taskomatic" is enabled on "server"
+    And service "taskomatic" is active on "server"
+    And socket "tftp" is enabled on "server"
+    And socket "tftp" is active on "server"
+    And service "tomcat" is enabled on "server"
+    And service "tomcat" is active on "server"
 
 @sle_client
   Scenario: The traditional client is healthy

--- a/testsuite/features/core/first_settings.feature
+++ b/testsuite/features/core/first_settings.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 SUSE LLC
+# Copyright (c) 2017-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Very first settings
@@ -51,28 +51,6 @@ Feature: Very first settings
 
   Scenario: Wait for refresh of list of products to finish
     When I wait until mgr-sync refresh is finished
-
-  Scenario: Check services which should run
-    Then service "apache2" is enabled on "server"
-    And service "apache2" is active on "server"
-    And service "cobblerd" is enabled on "server"
-    And service "cobblerd" is active on "server"
-    And service "jabberd" is enabled on "server"
-    And service "jabberd" is active on "server"
-    And service "osa-dispatcher" is enabled on "server"
-    And service "osa-dispatcher" is active on "server"
-    And service "rhn-search" is enabled on "server"
-    And service "rhn-search" is active on "server"
-    And service "salt-api" is enabled on "server"
-    And service "salt-api" is active on "server"
-    And service "salt-master" is enabled on "server"
-    And service "salt-master" is active on "server"
-    And service "taskomatic" is enabled on "server"
-    And service "taskomatic" is active on "server"
-    And socket "tftp" is enabled on "server"
-    And socket "tftp" is active on "server"
-    And service "tomcat" is enabled on "server"
-    And service "tomcat" is active on "server"
 
 @server_http_proxy
   Scenario: Setup HTTP proxy


### PR DESCRIPTION
## What does this PR change?

This PR moves the check for running services to sanity checks.

## Links

Spotted when trying to work on card SUSE/spacewalk#4965 (make core features lighter).

Ports:
* 4.0: SUSE/spacewalk#13553
* 4.1: SUSE/spacewalk#13552


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
