### PR TITLE
fix action chains reboot

### DIFF
--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -2396,6 +2396,13 @@ public class SaltServerActionService {
                         // Wait until next "minion/start/event" to set it to COMPLETED.
                         if (action.get().getActionType().equals(ActionFactory.TYPE_REBOOT) &&
                                 success && retcode == 0) {
+                            // In action chains at this point the action is still queued so we have
+                            // to set it to picked up.
+                            // This could still lead to the race condition on when event processing is slow.
+                            if (sa.getPickupTime() == null) {
+                                sa.setStatus(ActionFactory.STATUS_PICKED_UP);
+                                sa.setPickupTime(new Date());
+                            }
                             return;
                         }
                         else if (action.get().getActionType().equals(ActionFactory.TYPE_KICKSTART_INITIATE) &&


### PR DESCRIPTION
## What does this PR change?

https://github.com/uyuni-project/uyuni/pull/2998/ removed code that could lead to a race condition for reboot in case event processing is slow. This code was not needed in case of a single reboot action but it looks like reboot inside of action chains currently relies on picked up status being set at this point.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

Fixes SUSE/spacewalk#13535

Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
