### PR TITLE
Reuse repos for common channels

### DIFF
--- a/utils/spacewalk-common-channels
+++ b/utils/spacewalk-common-channels
@@ -164,6 +164,16 @@ def channel_get_details(client, channel_label):
     except xmlrpclib.Fault as e:
         return None
 
+def get_existing_repos(client):
+    result = {}
+    try:
+        user_repos = client.channel.software.listUserRepos(key)
+        for repo in user_repos:
+            result[repo['sourceUrl']] = repo['label']
+    except xmlrpclib.Fault as e:
+        return None
+    return result
+
 
 if __name__ == "__main__":
     # options parsing
@@ -282,7 +292,12 @@ Create everything as well as unlimited activation key for every channel:
     if not matching_channels:
         sys.stderr.write("No channels matching your selection.\n")
         sys.exit(2)
-                    
+
+    existing_repo_urls = get_existing_repos(client)
+    if existing_repo_urls is None:
+        sys.stderr.write("Unable to get exsiting repositories from server.\n")
+        sys.exit(2)
+
     for (base_channel_label, create_channel) in sorted(base_channels.items()):
 
         if create_channel:
@@ -308,11 +323,17 @@ Create everything as well as unlimited activation key for every channel:
                                                    {'url': base_info['gpgkey_url'],
                                                     'id': base_info['gpgkey_id'],
                                                     'fingerprint': base_info['gpgkey_fingerprint']})
-                    client.channel.software.createRepo(key,
-                                                       base_info['yum_repo_label'], repo_type,
-                                                       base_info['repo_url'])
-                    client.channel.software.associateRepo(key,
-                                                          base_info['label'], base_info['yum_repo_label'])
+                    if base_info['repo_url'] in existing_repo_urls:
+                        # use existing repo
+                        client.channel.software.associateRepo(key,
+                                                              base_info['label'],
+                                                              existing_repo_urls[base_info['repo_url']])
+                    else:
+                        client.channel.software.createRepo(key,
+                                                           base_info['yum_repo_label'], repo_type,
+                                                           base_info['repo_url'])
+                        client.channel.software.associateRepo(key,
+                                                              base_info['label'], base_info['yum_repo_label'])
                 except xmlrpclib.Fault as e:
                     if e.faultCode == 1200:  # ignore if channel exists
                         sys.stdout.write("INFO: %s exists\n" % base_info['label'])
@@ -383,11 +404,17 @@ Create everything as well as unlimited activation key for every channel:
                                                    {'url': child_info['gpgkey_url'],
                                                        'id': child_info['gpgkey_id'],
                                                        'fingerprint': child_info['gpgkey_fingerprint']})
-                    client.channel.software.createRepo(key,
-                                                       child_info['yum_repo_label'], repo_type,
-                                                       child_info['repo_url'])
-                    client.channel.software.associateRepo(key,
-                                                          child_info['label'], child_info['yum_repo_label'])
+                    if child_info['repo_url'] in existing_repo_urls:
+                        # use existing repo
+                        client.channel.software.associateRepo(key,
+                                                              child_info['label'],
+                                                              existing_repo_urls[child_info['repo_url']])
+                    else:
+                        client.channel.software.createRepo(key,
+                                                           child_info['yum_repo_label'], repo_type,
+                                                           child_info['repo_url'])
+                        client.channel.software.associateRepo(key,
+                                                              child_info['label'], child_info['yum_repo_label'])
                 except xmlrpclib.Fault as e:
                     if e.faultCode == 1200:  # ignore if channel exists
                         sys.stderr.write("WARNING: %s: %s\n" % (

--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -107,7 +107,7 @@ name     = Fedora 30 (%(arch)s)
 gpgkey_url = https://getfedora.org/static/fedora.gpg
 gpgkey_id = CFC659B9
 gpgkey_fingerprint = F1D8 EC98 F241 AAF2 0DF6  9420 EF3C 111F CFC6 59B9
-yumrepo_url = https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=%(arch)s
+repo_url = https://mirrors.fedoraproject.org/metalink?repo=fedora-30&arch=%(arch)s
 dist_map_release = 30
 
 [fedora30-modular]
@@ -116,7 +116,7 @@ name     = Fedora 30 Modular (%(arch)s)
 archs    = %(_x86_archs)s
 checksum = sha256
 base_channels = fedora30-%(arch)s
-yumrepo_url = https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-30&arch=%(arch)s
+repo_url = https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-30&arch=%(arch)s
 
 [fedora30-updates]
 label    = %(base_channel)s-updates
@@ -124,7 +124,7 @@ name     = Fedora 30 Updates (%(arch)s)
 archs    = %(_x86_archs)s
 checksum = sha256
 base_channels = fedora30-%(arch)s
-yumrepo_url = https://mirrors.fedoraproject.org/metalink?repo=updates-released-f30&arch=%(arch)s
+repo_url = https://mirrors.fedoraproject.org/metalink?repo=updates-released-f30&arch=%(arch)s
 
 [fedora30-updates-modular]
 label    = %(base_channel)s-updates-modular
@@ -132,7 +132,7 @@ name     = Fedora 30 Updates Modular (%(arch)s)
 archs    = %(_x86_archs)s
 checksum = sha256
 base_channels = fedora30-%(arch)s
-yumrepo_url = https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-f30&arch=%(arch)s
+repo_url = https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-f30&arch=%(arch)s
 
 [fedora30-debug]
 label    = %(base_channel)s-debug
@@ -140,7 +140,7 @@ name    = Fedora 30 Debug (%(arch)s)
 archs    = %(_x86_archs)s
 checksum = sha256
 base_channels = fedora30-%(arch)s
-yumrepo_url = https://mirrors.fedoraproject.org/metalink?repo=fedora-debug-30&arch=%(arch)s
+repo_url = https://mirrors.fedoraproject.org/metalink?repo=fedora-debug-30&arch=%(arch)s
 
 [fedora30-updates-debug]
 label    = %(base_channel)s-updates-debug
@@ -148,7 +148,7 @@ name    = Fedora 30 Updates Debug (%(arch)s)
 archs    = %(_x86_archs)s
 checksum = sha256
 base_channels = fedora30-%(arch)s
-yumrepo_url = https://mirrors.fedoraproject.org/metalink?repo=updates-released-debug-f30&arch=%(arch)s
+repo_url = https://mirrors.fedoraproject.org/metalink?repo=updates-released-debug-f30&arch=%(arch)s
 
 [centos8]
 archs    = x86_64, ppc64le
@@ -749,7 +749,7 @@ base_channels = fedora30-%(arch)s
 gpgkey_url = %(_spacewalk_nightly_gpgkey_url)s
 gpgkey_id = %(_spacewalk_nightly_gpgkey_id)s
 gpgkey_fingerprint = %(_spacewalk_nightly_gpgkey_fingerprint)s
-yumrepo_url = https://copr-be.cloud.fedoraproject.org/results/@spacewalkproject/nightly/fedora-30-%(arch)s/
+repo_url = https://copr-be.cloud.fedoraproject.org/results/@spacewalkproject/nightly/fedora-30-%(arch)s/
 
 
 [spacewalk-nightly-client-fedora30]
@@ -759,7 +759,7 @@ base_channels = fedora30-%(arch)s
 gpgkey_url = %(_spacewalk_nightlyclient_gpgkey_url)s
 gpgkey_id = %(_spacewalk_nightlyclient_gpgkey_id)s
 gpgkey_fingerprint = %(_spacewalk_nightlyclient_gpgkey_fingerprint)s
-yumrepo_url = https://copr-be.cloud.fedoraproject.org/results/@spacewalkproject/nightly-client/fedora-30-%(arch)s/
+repo_url = https://copr-be.cloud.fedoraproject.org/results/@spacewalkproject/nightly-client/fedora-30-%(arch)s/
 
 
 [spacewalk-nightly-client-scientific6]

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,6 @@
+- spacewalk-common-channels: re-use repositories when different channels
+  use the same one
+
 -------------------------------------------------------------------
 Thu Dec 03 13:54:48 CET 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Repository URLs must be unique inside of an org. When different channels use the same repository url this lead into
an error in spacewalk-common-channels.
This PR query existing repository URLs and re-use repositories if they already exists.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **manual tested**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/12008
Tracks

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
