### PR TITLE
Remove redundant nodejs requirement

### DIFF
--- a/web/spacewalk-web.spec
+++ b/web/spacewalk-web.spec
@@ -51,7 +51,6 @@ BuildRequires:  susemanager-nodejs-sdk-devel
 %if 0%{?suse_version}
 BuildRequires:  apache2
 BuildRequires:  nodejs-packaging
-BuildRequires:  nodejs
 
 %endif
 
@@ -69,7 +68,6 @@ BuildArch:      noarch
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildRequires:  nodejs-packaging
 BuildRequires:  susemanager-nodejs-sdk-devel
-BuildRequires:  nodejs
 
 %description -n susemanager-web-libs
 This package contains Vendor bundles needed for spacewalk-web


### PR DESCRIPTION
## What does this PR change?

Port of the fix uncovered in https://github.com/SUSE/spacewalk/pull/13412, namely https://github.com/SUSE/spacewalk/pull/13412/commits/c904c590dfc0e42f9594cc63889a2d629d1b5671
Requiring nodejs is redundant because nodejs-packaging [already requires it](https://build.opensuse.org/package/view_file/systemsmanagement:Uyuni:Master:Other/nodejs-packaging/nodejs-packaging.spec?expand=1).

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: No functional change.

- [x] **DONE**

## Test coverage
- No tests: Needs to pass existing tests.

- [x] **DONE**

## Links

Related: https://github.com/SUSE/spacewalk/pull/13412

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
