### PR TITLE
Make HMR and key usage consistent

### DIFF
--- a/web/html/src/manager/clusters/add-cluster/add-cluster.js
+++ b/web/html/src/manager/clusters/add-cluster/add-cluster.js
@@ -1,5 +1,5 @@
 // @flow
-import {hot} from 'react-hot-loader';
+import { hot } from 'react-hot-loader/root';
 import * as React from 'react';
 import {useState} from 'react';
 import withPageWrapper from 'components/general/with-page-wrapper';

--- a/web/html/src/manager/clusters/cluster/cluster.js
+++ b/web/html/src/manager/clusters/cluster/cluster.js
@@ -1,5 +1,5 @@
 // @flow
-import {hot} from 'react-hot-loader';
+import { hot } from 'react-hot-loader/root';
 import withPageWrapper from 'components/general/with-page-wrapper';
 import * as React from 'react';
 import {useEffect, useState} from 'react';

--- a/web/html/src/manager/clusters/join-cluster/join-cluster.js
+++ b/web/html/src/manager/clusters/join-cluster/join-cluster.js
@@ -1,5 +1,5 @@
 // @flow
-import {hot} from 'react-hot-loader';
+import { hot } from 'react-hot-loader/root';
 import * as React from 'react';
 import {useState} from 'react';
 import {TopPanel} from "components/panels/TopPanel";

--- a/web/html/src/manager/clusters/remove-node/remove-node.js
+++ b/web/html/src/manager/clusters/remove-node/remove-node.js
@@ -1,5 +1,5 @@
 // @flow
-import {hot} from 'react-hot-loader';
+import { hot } from 'react-hot-loader/root';
 import * as React from 'react';
 import {useState}  from 'react';
 import {TopPanel} from "components/panels/TopPanel";

--- a/web/html/src/manager/content-management/create-project/create-project.js
+++ b/web/html/src/manager/content-management/create-project/create-project.js
@@ -6,7 +6,7 @@ import TopPanelButtons from "./top-panel-buttons";
 import PropertiesCreate from "../shared/components/panels/properties/properties-create";
 import {showErrorToastr} from "components/toastr/toastr";
 import withPageWrapper from 'components/general/with-page-wrapper';
-import {hot} from 'react-hot-loader';
+import { hot } from 'react-hot-loader/root';
 import useRoles from "core/auth/use-roles";
 import {isOrgAdmin} from "core/auth/auth.utils";
 import useLifecycleActionsApi from "../shared/api/use-lifecycle-actions-api";

--- a/web/html/src/manager/content-management/list-filters/list-filters.js
+++ b/web/html/src/manager/content-management/list-filters/list-filters.js
@@ -8,7 +8,7 @@ import {Table} from 'components/table/Table';
 import {Utils} from 'utils/functions';
 import {showSuccessToastr} from 'components/toastr/toastr';
 import withPageWrapper from 'components/general/with-page-wrapper';
-import {hot} from 'react-hot-loader';
+import { hot } from 'react-hot-loader/root';
 import FilterEdit from "./filter-edit";
 import {mapResponseToFilterForm} from "./filter.utils";
 import type {FilterFormType, FilterServerType} from "../shared/type/filter.type";

--- a/web/html/src/manager/content-management/list-projects/list-projects.js
+++ b/web/html/src/manager/content-management/list-projects/list-projects.js
@@ -9,7 +9,7 @@ import {Utils} from 'utils/functions';
 import {LinkButton} from 'components/buttons';
 import {showSuccessToastr} from 'components/toastr/toastr';
 import withPageWrapper from 'components/general/with-page-wrapper';
-import {hot} from 'react-hot-loader';
+import { hot } from 'react-hot-loader/root';
 import useRoles from "core/auth/use-roles";
 import {isOrgAdmin} from "core/auth/auth.utils";
 import _truncate from "lodash/truncate";

--- a/web/html/src/manager/content-management/project/project.js
+++ b/web/html/src/manager/content-management/project/project.js
@@ -15,7 +15,7 @@ import {ModalButton} from "components/dialog/ModalButton";
 import withPageWrapper from 'components/general/with-page-wrapper';
 
 import type {ProjectType} from '../shared/type/project.type';
-import {hot} from 'react-hot-loader';
+import { hot } from 'react-hot-loader/root';
 import _last from "lodash/last";
 import _groupBy from "lodash/groupBy";
 import useRoles from "core/auth/use-roles";

--- a/web/html/src/manager/minion/packages/package-states.js
+++ b/web/html/src/manager/minion/packages/package-states.js
@@ -7,7 +7,7 @@ import {InnerPanel} from 'components/panels/InnerPanel';
 import {TextField} from "components/fields";
 import {Messages} from "components/messages";
 import withPageWrapper from "components/general/with-page-wrapper";
-import {hot} from 'react-hot-loader';
+import { hot } from 'react-hot-loader/root';
 import {showErrorToastr} from "components/toastr/toastr";
 import usePackageStatesApi from "./use-package-states.api";
 import type {
@@ -198,10 +198,8 @@ const PackageStates = ({serverId}: PropsType) => {
   const buttons = [
     <AsyncButton id="save" action={save} text={t("Save")} disabled={!isApplyButtonDisabled}
                  key={"save"}/>,
-    <span {...(isApplyButtonDisabled) ? {title: t("Please save all your changes before applying!")} : {}}>
-      <AsyncButton id="apply" action={applyPackageState} text={t("Apply changes")}
-                   disabled={isApplyButtonDisabled} key={"apply"}
-      />
+    <span {...(isApplyButtonDisabled) ? {title: t("Please save all your changes before applying!")} : {}} key="apply">
+      <AsyncButton id="apply" action={applyPackageState} text={t("Apply changes")} disabled={isApplyButtonDisabled} />
     </span>
   ];
 

--- a/web/html/src/manager/salt/formula-catalog/org-formula-catalog.js
+++ b/web/html/src/manager/salt/formula-catalog/org-formula-catalog.js
@@ -8,7 +8,7 @@ import { TopPanel } from "components/panels/TopPanel";
 import { Messages } from "components/messages";
 import Network from 'utils/network';
 import withPageWrapper from "../../../components/general/with-page-wrapper";
-import {hot} from 'react-hot-loader';
+import { hot } from 'react-hot-loader/root';
 
 class FormulaCatalog extends React.Component {
     constructor(props) {

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Fix inconsistent HMR and key usage bug (bsc#1180580)
 - Fixed variable installation location.
 - Drop the ssl_available option (SSL is always present)
 - Prevent deletion of CLM environments if they're used in an autoinstallation


### PR DESCRIPTION
## What does this PR change?

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1180580. The problem was a mix of old and new HMR use, but it was triggered by the key issue in the related page.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: No gui diff, fixes existing page.

- [x] **DONE**

## Test coverage
- No tests: Needs to pass existing tests.

- [x] **DONE**

## Links

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1180580

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
