### PR TITLE
Fix: slow refresh Ubuntu repos via SUMa proxy (bsc#1176906)

### DIFF
--- a/proxy/proxy/httpd-conf/spacewalk-proxy.conf
+++ b/proxy/proxy/httpd-conf/spacewalk-proxy.conf
@@ -53,6 +53,10 @@
    # Redirect some http page to https for security reasons
    RewriteCond %{SERVER_PORT} 80
    RewriteRule ^/rhn/?$ https://%{SERVER_NAME}/rhn/manager/login  [R,L]
+
+   # Rewrite rules for APT repos metadata
+   RewriteRule ^/rhn/manager/download/dists/(.*)/main/(.*)/(Packages.*)$ /rhn/manager/download/$1/repodata/$3
+   RewriteRule ^/rhn/manager/download/dists/(.*)/(InRelease|Release.*)$ /rhn/manager/download/$1/repodata/$2
 </IfModule>
 
 

--- a/proxy/proxy/spacewalk-proxy.changes
+++ b/proxy/proxy/spacewalk-proxy.changes
@@ -1,3 +1,4 @@
+- Fix: slow refresh Ubuntu repos via SUMa proxy (bsc#1176906)
 - fix package manager string compare - python3 porting issue
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

When an Ubuntu client is connected through a SUMa proxy, `apt update` is slow.
By comparing the requests issued on the server-side between an Ubuntu client connected to a proxy and one directly connected to SUMa server:

Via proxy:

```
10.84.220.172 - - [05/Jan/2021:16:25:51 +0100] "GET /rhn/manager/download/dists/test-channel-deb-amd64/InRelease HTTP/1.1" 404 -
10.84.220.162 - - [05/Jan/2021:16:25:51 +0100] "GET /rhn/manager/download/dists/test-channel-deb-amd64/InRelease HTTP/1.1" 404 - "-" "Debian APT-HTTP/1.3 (2.0.2ubuntu0.1) non-interactive"
10.84.220.162 - - [05/Jan/2021:16:26:07 +0100] "GET /rhn/manager/download/dists/test-channel-deb-amd64/Release HTTP/1.1" 304 - "-" "Debian APT-HTTP/1.3 (2.0.2ubuntu0.1) non-interactive"
10.84.220.172 - - [05/Jan/2021:16:26:07 +0100] "GET /rhn/manager/download/dists/test-channel-deb-amd64/Release HTTP/1.1" 304 -
10.84.220.162 - - [05/Jan/2021:16:26:07 +0100] "GET /rhn/manager/download/dists/test-channel-deb-amd64/Release.gpg HTTP/1.1" 404 - "-" "Debian APT-HTTP/1.3 (2.0.2ubuntu0.1) non-interactive"
10.84.220.172 - - [05/Jan/2021:16:26:07 +0100] "GET /rhn/manager/download/dists/test-channel-deb-amd64/Release.gpg HTTP/1.1" 404 -
```

Without proxy:

```
10.84.220.172 - - [05/Jan/2021:16:28:45 +0100] "GET /rhn/manager/download/dists/test-channel-deb-amd64/InRelease HTTP/1.1" 302 - "-" "Debian APT-HTTP/1.3 (2.0.2ubuntu0.1) non-interactive"
10.84.220.172 - - [05/Jan/2021:16:28:45 +0100] "GET /rhn/manager/download/test-channel-deb-amd64/repodata/InRelease HTTP/1.1" 403 7415
10.84.220.172 - - [05/Jan/2021:16:28:45 +0100] "GET /rhn/manager/download/dists/test-channel-deb-amd64/Release HTTP/1.1" 302 - "-" "Debian APT-HTTP/1.3 (2.0.2ubuntu0.1) non-interactive"
10.84.220.172 - - [05/Jan/2021:16:28:45 +0100] "GET /rhn/manager/download/test-channel-deb-amd64/repodata/Release HTTP/1.1" 403 7413
10.84.220.172 - - [05/Jan/2021:16:28:45 +0100] "GET /rhn/manager/download/dists/test-channel-deb-amd64/main/binary-amd64/Packages.xz HTTP/1.1" 302 - "-" "Debian APT-HTTP/1.3 (2.0.2ubuntu0.1) non-interactive"
[...]
10.84.220.172 - - [05/Jan/2021:16:28:45 +0100] "GET /rhn/manager/download/test-channel-deb-amd64/repodata/Packages HTTP/1.1" 403 7414
10.84.220.172 - - [05/Jan/2021:16:28:45 +0100] "GET /rhn/manager/download/dists/test-channel-deb-amd64/main/i18n/Translation-en HTTP/1.1" 404 7749
10.84.220.172 - - [05/Jan/2021:16:28:45 +0100] "GET /rhn/manager/download/dists/test-channel-deb-amd64/main/cnf/Commands-amd64 HTTP/1.1" 404 7748
10.84.220.172 - - [05/Jan/2021:16:28:45 +0100] "GET /rhn/manager/download/dists/test-channel-deb-amd64/main/cnf/Commands-all HTTP/1.1" 404 7746
```

The different behavior generates a huge delay when issuing an `apt update` command:

With proxy:

```
# time apt update
Ign:1 https://suma-41-pxy.mgr.prv.suse.net:443/rhn/manager/download test-channel-deb-amd64 InRelease
Hit:2 https://suma-41-pxy.mgr.prv.suse.net:443/rhn/manager/download test-channel-deb-amd64 Release
Ign:3 https://suma-41-pxy.mgr.prv.suse.net:443/rhn/manager/download test-channel-deb-amd64 Release.gpg
Reading package lists... Done
Building dependency tree       
Reading state information... Done
All packages are up to date.

real	0m31.082s
user	0m0.193s
sys	0m0.070s
```

Without proxy:

```
# time apt update
Ign:1 http://suma-41-srv.mgr.prv.suse.net/rhn/manager/download test-channel-deb-amd64 InRelease
Ign:2 http://suma-41-srv.mgr.prv.suse.net/rhn/manager/download test-channel-deb-amd64 Release
Ign:3 http://suma-41-srv.mgr.prv.suse.net/rhn/manager/download test-channel-deb-amd64/main all Packages
[...]

real	0m0.832s
user	0m0.211s
sys	0m0.136s
```

This PR makes the proxy use the same rewrite rules used on the server. The result is that an Ubuntu client connected via proxy no longer experiences a huge delay when issuing an `apt update`.

## GUI diff

No difference.

- [X] **DONE**

## Documentation

- No documentation needed: internal

- [X] **DONE**

## Test coverage
- No tests: internal

- [X] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/2241 
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
