### PR TITLE
Leave more time for Hardware List Refresh on all platforms

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -875,11 +875,10 @@ When(/^I wait until onboarding is completed for "([^"]*)"$/) do |host|
     # Ubuntu minion clients need more time to finish all onboarding events
     node = get_target(host)
     _os_version, os_family = get_os_version(node)
-    onboarding_timeout = os_family.include?('ubuntu') ? DEFAULT_TIMEOUT * 2 : DEFAULT_TIMEOUT
     steps %(
-      And I wait at most #{onboarding_timeout} seconds until event "Hardware List Refresh" is completed
-      And I wait at most #{onboarding_timeout} seconds until event "Apply states" is completed
-      And I wait at most #{onboarding_timeout} seconds until event "Package List Refresh" is completed
+      And I wait at most 500 seconds until event "Hardware List Refresh" is completed
+      And I wait at most 250 seconds until event "Apply states" is completed
+      And I wait at most 250 seconds until event "Package List Refresh" is completed
     )
   end
 end


### PR DESCRIPTION
## What does this PR change?

Addresses this (seen on 4.1 with SLES minion):
```
 And I wait until onboarding is completed for "sle_minion" 4m 44s 624msShow Error -
                                            
 Timeout after 250 seconds (Timeout.timeout): Text 'Hardware List Refresh' is still visible (RuntimeError)
```

Let a long, fixed, timeout for the `Hardware List Refresh`, no matter which operating system runs on the minion.


## Links

Ports:
* 4.0: SUSE/spacewalk#13578
* 4.1: SUSE/spacewalk#13577


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
