### PR TITLE
Package locks for salt clients

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Package_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Package_queries.xml
@@ -833,7 +833,8 @@ SELECT P.id, P.summary, PP.name as provider
     pe.version AS version,
     pe.release AS release,
     pe.epoch AS epoch,
-    pa.label AS arch,
+    pe.type AS package_type,
+    pa.label AS arch
   FROM rhnActionPackage ap
     JOIN rhnLockedPackages lp
       ON ap.name_id = lp.name_id AND

--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Package_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Package_queries.xml
@@ -41,7 +41,7 @@ SELECT * FROM
                                       AND lck.evr_id = pkg.evr_id
                                       AND lck.arch_id = pkg.package_arch_id
                                       AND lck.server_id = :sid) pkgs
-order by name
+order by locked ASC NULLS LAST, name
   </query>
 </mode>
 
@@ -531,7 +531,7 @@ SELECT PN.name as NAME,
                                  AND lck.arch_id = SP.package_arch_id
                                  AND lck.server_id = SP.server_id
  WHERE SP.server_id = :sid
- ORDER BY NAME
+ ORDER BY locked ASC NULLS LAST, NAME
   </query>
 </mode>
 

--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Package_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Package_queries.xml
@@ -825,6 +825,32 @@ SELECT P.id, P.summary, PP.name as provider
   </query>
 </mode>
 
+<mode name="system_set_locked_packages"  class="com.redhat.rhn.frontend.dto.PackageListItem">
+  <query params="sid, aid">
+  SELECT DISTINCT
+    pn.id || '|' || pe.id || '|' || pa.id AS id_combo,
+    pn.name AS name,
+    pe.version AS version,
+    pe.release AS release,
+    pe.epoch AS epoch,
+    pa.label AS arch,
+  FROM rhnActionPackage ap
+    JOIN rhnLockedPackages lp
+      ON ap.name_id = lp.name_id AND
+         ap.evr_id  = lp.evr_id AND
+         ap.package_arch_id = lp.arch_id
+    LEFT JOIN rhnPackageArch pa
+      ON ap.package_arch_id = pa.id,
+         rhnPackageName pn,
+         rhnPackageEVR pe
+    WHERE ap.evr_id    = pe.id
+      AND ap.name_id   = pn.id
+      AND (lp.pending IS NULL OR lp.pending = 'L')
+      AND lp.server_id = :sid
+      AND ap.action_id = :aid
+      order by id_combo
+  </query>
+</mode>
 
 <mode name="system_locked_packages"  class="com.redhat.rhn.frontend.dto.PackageListItem">
   <query params="sid">
@@ -878,7 +904,8 @@ WHERE l.server_id = :sid
 <write-mode name="remove_orphan_lock_on_action_cancel">
   <query params="sid, action_id">
 DELETE FROM rhnlockedpackages l
-      WHERE l.pkg_id IN (SELECT lck.pkg_id
+      WHERE l.pending in ('L', 'U')
+      AND l.pkg_id IN (SELECT lck.pkg_id
                            FROM rhnaction act
                       LEFT JOIN rhnactionpackage ack ON ack.action_id = act.id
                       LEFT JOIN rhnlockedpackages lck ON lck.name_id = ack.name_id
@@ -886,6 +913,43 @@ DELETE FROM rhnlockedpackages l
                                                      AND lck.arch_id = ack.package_arch_id
                           WHERE lck.server_id = :sid AND act.id = :action_id)
   </query>
+</write-mode>
+
+<write-mode name="update_pkg_lock_on_action">
+  <query params="sid, action_id">
+    UPDATE rhnLockedPackages
+      SET pending = NULL
+      WHERE rhnLockedPackages.server_id = :sid AND
+        rhnLockedPackages.pkg_id IN (
+        SELECT pkg_id
+          FROM rhnLockedPackages JOIN rhnActionPackage
+            ON rhnLockedPackages.name_id = rhnActionPackage.name_id
+            AND rhnLockedPackages.evr_id = rhnActionPackage.evr_id
+            AND rhnLockedPackages.arch_id = rhnActionPackage.package_arch_id
+          WHERE rhnActionPackage.action_id = :action_id
+            AND rhnLockedPackages.server_id = :sid
+            AND rhnActionPackage.parameter = 'lock'
+            AND rhnLockedPackages.pending = 'L'
+        )
+  </query>
+</write-mode>
+
+<write-mode name="update_pkg_unlock_on_action">
+  <query params="sid, action_id">
+    DELETE FROM rhnLockedPackages
+      WHERE rhnLockedPackages.server_id = :sid
+        AND rhnLockedPackages.pkg_id IN (
+        SELECT pkg_id
+          FROM rhnLockedPackages
+          JOIN rhnActionPackage ON rhnLockedPackages.name_id = rhnActionPackage.name_id
+                               AND rhnLockedPackages.evr_id = rhnActionPackage.evr_id
+                               AND rhnLockedPackages.arch_id = rhnActionPackage.package_arch_id
+          WHERE rhnActionPackage.action_id = :action_id
+            AND rhnLockedPackages.server_id = :sid
+            AND rhnActionPackage.parameter = 'lock'
+            AND rhnLockedPackages.pending = 'U'
+        )
+ </query>
 </write-mode>
 
 <write-mode name="set_pending_lock_status">

--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Package_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Package_queries.xml
@@ -512,6 +512,28 @@ ORDER BY UPPER(X.nvre)
   </query>
 </mode>
 
+<mode name="system_installed_pkgs_non_suse_locking" class="com.redhat.rhn.frontend.dto.PackageListItem">
+  <query params="sid">
+SELECT PN.name as NAME,
+       PN.name || '-' || evr_t_as_vre_simple(SPE.evr) AS NVRE,
+       PN.name || '-' || evr_t_as_vre_simple(SPE.evr) || '.' || PA.label AS NVREA,
+       PN.id || '|' || lookup_evr((SPE.evr).epoch, (SPE.evr).version, (SPE.evr).release, (SPE.evr).type) || '|' || PA.id AS ID_COMBO,
+       PA.label AS ARCH,
+       lck.pending,
+       CASE WHEN lck.server_id IS NOT NULL THEN 'Y' ELSE NULL END AS locked
+  FROM rhnServerPackage SP
+  JOIN rhnPackageName PN ON SP.name_id = PN.id
+  JOIN rhnPackageEVR SPE ON SP.evr_id = SPE.id
+  LEFT JOIN rhnPackageArch PA ON SP.package_arch_id = PA.id
+  LEFT JOIN rhnArchType AT ON AT.id = PA.arch_type_id
+  LEFT JOIN rhnlockedpackages lck ON lck.name_id = SP.name_id
+                                 AND lck.evr_id = SP.evr_id
+                                 AND lck.arch_id = SP.package_arch_id
+                                 AND lck.server_id = SP.server_id
+ WHERE SP.server_id = :sid
+  </query>
+</mode>
+
 <mode name="system_package_list" class="com.redhat.rhn.frontend.dto.PackageListItem">
   <query params="sid">
   SELECT (SELECT max(p.id) FROM rhnPackage p

--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Package_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Package_queries.xml
@@ -531,6 +531,7 @@ SELECT PN.name as NAME,
                                  AND lck.arch_id = SP.package_arch_id
                                  AND lck.server_id = SP.server_id
  WHERE SP.server_id = :sid
+ ORDER BY NAME
   </query>
 </mode>
 

--- a/java/code/src/com/redhat/rhn/domain/action/rhnpackage/PackageAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/rhnpackage/PackageAction.java
@@ -75,6 +75,9 @@ public class PackageAction extends Action {
      */
     @Override
     public String getHistoryDetails(Server server, User currentUser) {
+        if (this.getClass().equals(PackageLockAction.class)) {
+            return "";
+        }
         LocalizationService ls = LocalizationService.getInstance();
         StringBuilder retval = new StringBuilder();
         retval.append("</br>");
@@ -84,7 +87,7 @@ public class PackageAction extends Action {
         else if (this.getClass().equals(PackageVerifyAction.class)) {
             retval.append(ls.getMessage("system.event.packagesVerify"));
         }
-        if (this.getClass().equals(PackageRemoveAction.class)) {
+        else if (this.getClass().equals(PackageRemoveAction.class)) {
             retval.append(ls.getMessage("system.event.packagesRemove"));
         }
         retval.append("</br><ul>");

--- a/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/LockPackageAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/LockPackageAction.java
@@ -18,6 +18,8 @@ package com.redhat.rhn.frontend.action.rhnpackage;
 import com.redhat.rhn.common.db.datasource.DataResult;
 import com.redhat.rhn.common.util.DatePicker;
 import com.redhat.rhn.domain.rhnpackage.Package;
+import com.redhat.rhn.domain.server.MinionServer;
+import com.redhat.rhn.domain.server.MinionServerFactory;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.action.systems.sdc.SdcHelper;
@@ -45,6 +47,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
@@ -61,8 +64,18 @@ public class LockPackageAction extends BaseSystemPackagesAction {
 
     @Override
     protected DataResult getDataResult(Server server) {
-        DataResult result = PackageManager.systemTotalPackages(server.getId(), null);
-        return result;
+        Optional<MinionServer> minion = MinionServerFactory.lookupById(server.getId());
+        // Check if this server is a minion
+        boolean isMinion = minion.isPresent();
+        LOG.debug(server.getId() + "is a minion system? " + isMinion);
+        // Check if this is a SUSE system (for minions only)
+        boolean isSUSEMinion = isMinion && minion.get().getOsFamily().equals("Suse");
+        LOG.debug(server.getId() + "is a SUSE system? " + isMinion);
+
+        if (isSUSEMinion || !isMinion) {
+            return PackageManager.systemTotalPackages(server.getId(), null);
+        }
+        return PackageManager.nonSUSEsystemLockingPackages(server.getId(), null);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/LockPackageAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/rhnpackage/LockPackageAction.java
@@ -70,7 +70,7 @@ public class LockPackageAction extends BaseSystemPackagesAction {
         LOG.debug(server.getId() + "is a minion system? " + isMinion);
         // Check if this is a SUSE system (for minions only)
         boolean isSUSEMinion = isMinion && minion.get().getOsFamily().equals("Suse");
-        LOG.debug(server.getId() + "is a SUSE system? " + isMinion);
+        LOG.debug(server.getId() + "is a SUSE system? " + isSUSEMinion);
 
         if (isSUSEMinion || !isMinion) {
             return PackageManager.systemTotalPackages(server.getId(), null);

--- a/java/code/src/com/redhat/rhn/manager/rhnpackage/PackageManager.java
+++ b/java/code/src/com/redhat/rhn/manager/rhnpackage/PackageManager.java
@@ -633,6 +633,24 @@ public class PackageManager extends BaseManager {
     }
 
     /**
+     * Get the list of packages which should be locked on a particular system.
+     *
+     * @param sid System ID.
+     * @param aid Action ID.
+     * @param pc Page control object.
+     * @return  DataResult containing locked packages data.
+     */
+    public static DataResult<PackageListItem> systemSetLockedPackages(
+            Long sid, Long aid, PageControl pc) {
+        SelectMode m = ModeFactory.getMode("Package_queries", "system_set_locked_packages");
+        Map params = new HashMap();
+        params.put("sid", sid);
+        params.put("aid", aid);
+        Map elabParams = new HashMap();
+        return makeDataResult(params, elabParams, pc, m);
+    }
+
+    /**
      * Lock packages.
      * If the package object has lock pending, then the package will be only half-locked.
      *
@@ -675,14 +693,38 @@ public class PackageManager extends BaseManager {
      *
      * @param sid System ID
      * @param actionId Action ID
-     * @throws java.lang.Exception in case of unknown pending status
      */
-    public static void syncLockedPackages(Long sid, Long actionId)
-            throws Exception {
+    public static void syncLockedPackages(Long sid, Long actionId) {
         Map params = new HashMap();
         params.put("sid", sid);
         params.put("action_id", actionId);
         ModeFactory.getWriteMode("Package_queries", "remove_orphan_lock_on_action_cancel").executeUpdate(params);
+    }
+
+    /**
+     * Update locked packages, when action succeeded.
+     *
+     * @param sid System ID
+     * @param actionId Action ID
+     */
+    public static void updateLockedPackages(Long sid, Long actionId) {
+        Map params = new HashMap();
+        params.put("sid", sid);
+        params.put("action_id", actionId);
+        ModeFactory.getWriteMode("Package_queries", "update_pkg_lock_on_action").executeUpdate(params);
+    }
+
+    /**
+     * Update unlocked packages, when action succeeded.
+     *
+     * @param sid System ID
+     * @param actionId Action ID
+     */
+    public static void updateUnlockedPackages(Long sid, Long actionId) {
+        Map params = new HashMap();
+        params.put("sid", sid);
+        params.put("action_id", actionId);
+        ModeFactory.getWriteMode("Package_queries", "update_pkg_unlock_on_action").executeUpdate(params);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/rhnpackage/PackageManager.java
+++ b/java/code/src/com/redhat/rhn/manager/rhnpackage/PackageManager.java
@@ -348,6 +348,16 @@ public class PackageManager extends BaseManager {
     }
 
     /**
+     * Returns the list of all installed packages available for locking on a none SUSE system
+     * @param sid Server Id
+     * @param pc PageControl can also be null.
+     * @return list of packages for given server
+     */
+    public static DataResult<PackageListItem> nonSUSEsystemLockingPackages(Long sid, PageControl pc) {
+        return PackageManager.getPackagesPerSystem(sid, "system_installed_pkgs_non_suse_locking", pc);
+    }
+
+    /**
      * Call any template from the Package_queries with the system ID.
      *
      * @param sid

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -31,6 +31,7 @@ import static java.util.stream.Collectors.toMap;
 import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
+import com.redhat.rhn.common.db.datasource.DataResult;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionChain;
@@ -54,6 +55,7 @@ import com.redhat.rhn.domain.action.errata.ErrataAction;
 import com.redhat.rhn.domain.action.kickstart.KickstartAction;
 import com.redhat.rhn.domain.action.kickstart.KickstartActionDetails;
 import com.redhat.rhn.domain.action.kickstart.KickstartInitiateAction;
+import com.redhat.rhn.domain.action.rhnpackage.PackageLockAction;
 import com.redhat.rhn.domain.action.rhnpackage.PackageRemoveAction;
 import com.redhat.rhn.domain.action.rhnpackage.PackageUpdateAction;
 import com.redhat.rhn.domain.action.salt.ApplyStatesAction;
@@ -118,9 +120,11 @@ import com.redhat.rhn.domain.server.VirtualInstanceFactory;
 import com.redhat.rhn.domain.token.ActivationKey;
 import com.redhat.rhn.domain.token.ActivationKeyFactory;
 import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.frontend.dto.PackageListItem;
 import com.redhat.rhn.manager.action.ActionManager;
 import com.redhat.rhn.manager.formula.FormulaManager;
 import com.redhat.rhn.manager.kickstart.cobbler.CobblerXMLRPCHelper;
+import com.redhat.rhn.manager.rhnpackage.PackageManager;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
 
@@ -224,6 +228,7 @@ public class SaltServerActionService {
     public static final String PACKAGES_PATCHINSTALL = "packages.patchinstall";
     private static final String PACKAGES_PATCHDOWNLOAD = "packages.patchdownload";
     private static final String PACKAGES_PKGREMOVE = "packages.pkgremove";
+    private static final String PACKAGES_PKGLOCK = "packages.pkglock";
     private static final String CONFIG_DEPLOY_FILES = "configuration.deploy_files";
     private static final String CONFIG_DIFF_FILES = "configuration.diff_files";
     private static final String PARAM_PKGS = "param_pkgs";
@@ -311,6 +316,9 @@ public class SaltServerActionService {
             Set<Long> errataIds = errataAction.getErrata().stream()
                     .map(Errata::getId).collect(Collectors.toSet());
             return errataAction(minions, errataIds, errataAction.getDetails().getAllowVendorChange());
+        }
+        else if (ActionFactory.TYPE_PACKAGES_LOCK.equals(actionType)) {
+            return packagesLockAction(minions, (PackageLockAction) actionIn);
         }
         else if (ActionFactory.TYPE_PACKAGES_UPDATE.equals(actionType)) {
             return packagesUpdateAction(minions, (PackageUpdateAction) actionIn);
@@ -1106,6 +1114,25 @@ public class SaltServerActionService {
                 );
             },
             Map.Entry::getValue));
+    }
+
+    private Map<LocalCall<?>, List<MinionSummary>> packagesLockAction(
+            List<MinionSummary> minionSummaries, PackageLockAction action) {
+        Map<LocalCall<?>, List<MinionSummary>> ret = new HashMap<>();
+
+        for (MinionSummary m : minionSummaries) {
+            DataResult<PackageListItem> setLockPkg = PackageManager.systemSetLockedPackages(
+                    m.getServerId(), action.getId(), null);
+            List<List<String>> pkgs = setLockPkg.stream().map(d -> Arrays.asList(d.getName(), d.getArch(),
+                    new PackageEvr(d.getEpoch(), d.getVersion(), d.getRelease(), "rpm").toUniversalEvrString()
+                    )).collect(Collectors.toList());
+            LocalCall<Map<String, ApplyResult>> localCall =
+                    State.apply(Arrays.asList(PACKAGES_PKGLOCK), Optional.of(singletonMap(PARAM_PKGS, pkgs)));
+            List<MinionSummary> mSums = ret.getOrDefault(localCall, new ArrayList<>());
+            mSums.add(m);
+            ret.put(localCall, mSums);
+        }
+        return ret;
     }
 
     private Map<LocalCall<?>, List<MinionSummary>> packagesUpdateAction(

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -1124,8 +1124,8 @@ public class SaltServerActionService {
             DataResult<PackageListItem> setLockPkg = PackageManager.systemSetLockedPackages(
                     m.getServerId(), action.getId(), null);
             List<List<String>> pkgs = setLockPkg.stream().map(d -> Arrays.asList(d.getName(), d.getArch(),
-                    new PackageEvr(d.getEpoch(), d.getVersion(), d.getRelease(), "rpm").toUniversalEvrString()
-                    )).collect(Collectors.toList());
+                    new PackageEvr(d.getEpoch(), d.getVersion(), d.getRelease(), d.getPackageType())
+                    .toUniversalEvrString())).collect(Collectors.toList());
             LocalCall<Map<String, ApplyResult>> localCall =
                     State.apply(Arrays.asList(PACKAGES_PKGLOCK), Optional.of(singletonMap(PARAM_PKGS, pkgs)));
             List<MinionSummary> mSums = ret.getOrDefault(localCall, new ArrayList<>());

--- a/java/code/webapp/WEB-INF/nav/system_detail.xml
+++ b/java/code/webapp/WEB-INF/nav/system_detail.xml
@@ -54,7 +54,7 @@
         <rhn-tab-url>/rhn/systems/details/packages/VerifyPackages.do</rhn-tab-url>
         <rhn-tab-url>/rhn/systems/details/packages/VerifyConfirm.do</rhn-tab-url>
       </rhn-tab>
-      <rhn-tab name="pkg.lock.menu" acl="system_feature(ftr_package_updates); not system_has_salt_entitlement()">
+      <rhn-tab name="pkg.lock.menu" acl="system_feature(ftr_package_lock)">
         <rhn-tab-url>/rhn/systems/details/packages/LockPackages.do</rhn-tab-url>
       </rhn-tab>
       <rhn-tab name="Profiles" acl="system_feature(ftr_profile_compare)">

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- implement package locking for salt minions
 - Show AppStreams tab just for modular channels
 - Fix Json null comparison in virtual network info parsing (bsc#1189167)
 - 'AppStreams with defaults' filter template in CLM

--- a/schema/spacewalk/common/data/rhnFeature.sql
+++ b/schema/spacewalk/common/data/rhnFeature.sql
@@ -115,3 +115,6 @@ values (sequence_nextval('rhn_feature_seq'), 'ftr_system_lock', 'Lock System',
 insert into rhnFeature (id, label, name, created, modified)
 values (sequence_nextval('rhn_feature_seq'), 'ftr_system_audit', 'Audit System',
         current_timestamp, current_timestamp);
+insert into rhnFeature (id, label, name, created, modified)
+values (sequence_nextval('rhn_feature_seq'), 'ftr_package_lock', 'Lock Packages',
+        current_timestamp, current_timestamp);

--- a/schema/spacewalk/common/data/rhnServerGroupTypeFeature.sql
+++ b/schema/spacewalk/common/data/rhnServerGroupTypeFeature.sql
@@ -22,6 +22,10 @@ values (lookup_sg_type('enterprise_entitled'), lookup_feature_type('ftr_package_
         current_timestamp,current_timestamp);
 insert into rhnServerGroupTypeFeature (server_group_type_id, feature_id,
                                        created, modified)
+values (lookup_sg_type('enterprise_entitled'), lookup_feature_type('ftr_package_lock'),
+        current_timestamp,current_timestamp);
+insert into rhnServerGroupTypeFeature (server_group_type_id, feature_id,
+                                       created, modified)
 values (lookup_sg_type('enterprise_entitled'), lookup_feature_type('ftr_errata_updates'),
         current_timestamp,current_timestamp);
 insert into rhnServerGroupTypeFeature (server_group_type_id, feature_id,
@@ -177,6 +181,11 @@ values (lookup_sg_type('bootstrap_entitled'), lookup_feature_type('ftr_system_gr
 insert into rhnServerGroupTypeFeature (server_group_type_id, feature_id,
                                        created, modified)
 values (lookup_sg_type('salt_entitled'), lookup_feature_type('ftr_package_updates'),
+        current_timestamp,current_timestamp);
+
+insert into rhnServerGroupTypeFeature (server_group_type_id, feature_id,
+                                       created, modified)
+values (lookup_sg_type('salt_entitled'), lookup_feature_type('ftr_package_lock'),
         current_timestamp,current_timestamp);
 
 insert into rhnServerGroupTypeFeature (server_group_type_id, feature_id,

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,5 @@
+- implement package locking for salt minions
+
 -------------------------------------------------------------------
 Mon Aug 09 11:10:15 CEST 2021 - jgonzalez@suse.com
 

--- a/schema/spacewalk/upgrade/susemanager-schema-4.3.1-to-susemanager-schema-4.3.2/001-package-lock-feature.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.3.1-to-susemanager-schema-4.3.2/001-package-lock-feature.sql
@@ -1,0 +1,18 @@
+insert into rhnFeature (id, label, name, created, modified)
+  select sequence_nextval('rhn_feature_seq'), 'ftr_package_lock', 'Lock Packages',
+         current_timestamp, current_timestamp from dual
+   where not exists (select 1 from rhnFeature where label = 'ftr_package_lock');
+
+insert into rhnServerGroupTypeFeature (server_group_type_id, feature_id, created, modified)
+  select lookup_sg_type('enterprise_entitled'), lookup_feature_type('ftr_package_lock'),
+         current_timestamp,current_timestamp from dual
+   where not exists ( select 1 from rhnServerGroupTypeFeature
+                              where server_group_type_id = lookup_sg_type('enterprise_entitled')
+                              and feature_id = lookup_feature_type('ftr_package_lock') );
+
+insert into rhnServerGroupTypeFeature (server_group_type_id, feature_id, created, modified)
+  select lookup_sg_type('salt_entitled'), lookup_feature_type('ftr_package_lock'),
+         current_timestamp,current_timestamp from dual
+   where not exists ( select 1 from rhnServerGroupTypeFeature
+                              where server_group_type_id = lookup_sg_type('salt_entitled')
+                              and feature_id = lookup_feature_type('ftr_package_lock') );

--- a/susemanager-utils/susemanager-sls/salt/packages/pkglock.sls
+++ b/susemanager-utils/susemanager-sls/salt/packages/pkglock.sls
@@ -1,0 +1,11 @@
+pkg_locked:
+  pkg.held:
+    - replace: True
+{% if pillar.get('param_pkgs') %}
+    - pkgs:
+{%- for pkg, arch, version in pillar.get('param_pkgs', []) %}
+        - {{ pkg }}
+{%- endfor %}
+{%- else %}
+    - pkgs: []
+{% endif %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,5 @@
+- implement package locking for salt minions
+
 -------------------------------------------------------------------
 Mon Aug 09 11:11:17 CEST 2021 - jgonzalez@suse.com
 

--- a/susemanager-utils/testing/automation/chown-objects.sh
+++ b/susemanager-utils/testing/automation/chown-objects.sh
@@ -11,7 +11,16 @@ if [ ! -f /tmp/objects-init.txt -o ! -s /tmp/objects-init.txt ]; then
   echo "No file with the initial list of objects"
   exit 0
 fi
+# remove known nodejs modules
+pushd /manager
+rm -rf ./web/html/src/node_modules
+rm -rf ./susemanager-frontend/susemanager-nodejs-sdk-devel/node_modules
+popd
 find /manager | sort > /tmp/objects-end.txt
 for LINE in $(diff /tmp/objects-init.txt /tmp/objects-end.txt|grep '^> .*$'|sed -e 's/^> //'); do
-  chown ${NEWUID}:${NEWGID} ${LINE}
+  case $LINE in
+    /manager/web/html/src/node_modules/*) ;;
+    /manager/susemanager-frontend/susemanager-nodejs-sdk-devel/node_modules/*) ;;
+    *) chown ${NEWUID}:${NEWGID} ${LINE};;
+  esac
 done

--- a/testsuite/features/secondary/min_salt_lock_packages.feature
+++ b/testsuite/features/secondary/min_salt_lock_packages.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2021 SUSE LLC
+# Copyright (c) 2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @sle_minion

--- a/testsuite/features/secondary/min_salt_lock_packages.feature
+++ b/testsuite/features/secondary/min_salt_lock_packages.feature
@@ -1,0 +1,126 @@
+# Copyright (c) 2015-2021 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+@sle_minion
+@scope_salt
+Feature: Lock packages on SLES salt minion
+
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
+  Scenario: Pre-requisite: install packages needed for locking test
+    When I install package "orion-dummy" on this "sle_minion"
+    And I install package "milkyway-dummy" on this "sle_minion"
+    And I remove package "hoag-dummy" from this "sle_minion" without error control
+
+  Scenario: Lock a package on the client
+    Given I am on the Systems overview page of this "sle_minion"
+    When I follow "Software" in the content area
+    And I follow "Lock"
+    And I check row with "hoag-dummy-1.1-1.1" and arch of "sle_minion"
+    And I click on "Lock"
+    Then I should see a "Packages has been requested for being locked." text
+    When I wait until event "Lock packages scheduled by admin" is completed
+    Then "hoag-dummy-1.1-1.1" is locked on "sle_minion"
+    When I follow "Software" in the content area
+    And I follow "Lock"
+    Then package "hoag-dummy-1.1-1.1" is reported as locked
+
+  Scenario: Attempt to install a locked package on the client
+    Given I am on the Systems overview page of this "sle_minion"
+    When I follow "Software" in the content area
+    And I follow "Lock"
+    And package "hoag-dummy-1.1-1.1" is reported as locked
+    And I follow "Install"
+    And I check row with "hoag-dummy-1.1-1.1" and arch of "sle_minion"
+    And I click on "Install Selected Packages"
+    And I click on "Confirm"
+    Then I should see a "1 package install has been scheduled for" text
+    When I follow "Events"
+    And I follow "History"
+    And I wait until I see the event "Package Install/Upgrade scheduled by admin" completed during last minute, refreshing the page
+    And I follow the event "Package Install/Upgrade scheduled by admin" completed during last minute
+    Then the package scheduled is "hoag-dummy-1.1-1.1"
+    And the action status is "Failed"
+
+  Scenario: Unlock a package on the client
+    Given I am on the Systems overview page of this "sle_minion"
+    When I follow "Software" in the content area
+    And I follow "Lock"
+    And package "hoag-dummy-1.1-1.1" is reported as locked
+    And I check row with "hoag-dummy-1.1-1.1" and arch of "sle_minion"
+    And I click on "Unlock"
+    Then I should see a "Packages has been requested for being unlocked." text
+    When I wait until event "Lock packages scheduled by admin" is completed
+    Then "hoag-dummy-1.1-1.1" is unlocked on "sle_minion"
+    When I follow "Software" in the content area
+    And I follow "Lock"
+    Then package "hoag-dummy-1.1-1.1" is reported as unlocked
+
+  Scenario: Schedule a package lock
+    Given I am on the Systems overview page of this "sle_minion"
+    When I follow "Software" in the content area
+    And I follow "Lock"
+    And I check row with "hoag-dummy-1.1-1.1" and arch of "sle_minion"
+    And I click on "Lock"
+    Then I should see a "Packages has been requested for being locked." text
+    And package "hoag-dummy-1.1-1.1" is reported as pending to be locked
+
+  Scenario: Schedule another package lock
+    Given I am on the Systems overview page of this "sle_minion"
+    When I follow "Software" in the content area
+    And I follow "Lock"
+    When I check row with "milkyway-dummy-2.0-1.1" and arch of "sle_minion"
+    And I click on "Lock"
+    Then I should see a "Packages has been requested for being locked." text
+    When I wait until event "Lock packages scheduled by admin" is completed
+    Then "hoag-dummy-1.1-1.1" is locked on "sle_minion"
+    And "milkyway-dummy-2.0-1.1" is locked on "sle_minion"
+    When I follow "Software" in the content area
+    And I follow "Lock"
+    Then package "hoag-dummy-1.1-1.1" is reported as locked
+    And package "milkyway-dummy-2.0-1.1" is reported as locked
+
+  Scenario: Mix package locks and unlock events
+    Given I am on the Systems overview page of this "sle_minion"
+    When I follow "Software" in the content area
+    And I follow "Lock"
+    And package "hoag-dummy-1.1-1.1" is reported as locked
+    And package "milkyway-dummy-2.0-1.1" is reported as locked
+    When I check row with "orion-dummy-1.1-1.1" and arch of "sle_minion"
+    And I click on "Lock"
+    Then I should see a "Packages has been requested for being locked." text
+    When I follow "Lock"
+    And I check row with "milkyway-dummy-2.0-1.1" and arch of "sle_minion"
+    And I uncheck row with "hoag-dummy-1.1-1.1" and arch of "sle_minion"
+    And I click on "Unlock"
+    Then I should see a "Packages has been requested for being unlocked." text
+    When I wait until event "Lock packages scheduled by admin" is completed
+    Then "hoag-dummy-1.1-1.1" is locked on "sle_minion"
+    And "milkyway-dummy-2.0-1.1" is unlocked on "sle_minion"
+    And "orion-dummy-1.1-1.1" is locked on "sle_minion"
+    When I follow "Software" in the content area
+    And I follow "Lock"
+    Then package "hoag-dummy-1.1-1.1" is reported as locked
+    And package "milkyway-dummy-2.0-1.1" is reported as unlocked
+    And package "orion-dummy-1.1-1.1" is reported as locked
+
+  Scenario: Mix package locks and unlock events part 2
+    Given I am on the Systems overview page of this "sle_minion"
+    And I follow "Software" in the content area
+    And I follow "Lock"
+    When I click on "Select All"
+    And I click on "Unlock"
+    Then I should see a "Packages has been requested for being unlocked." text
+    And only packages "hoag-dummy-1.1-1.1, orion-dummy-1.1-1.1" are reported as pending to be unlocked
+    When I wait until event "Lock packages scheduled by admin" is completed
+    Then "hoag-dummy-1.1-1.1" is unlocked on "sle_minion"
+    And "orion-dummy-1.1-1.1" is unlocked on "sle_minion"
+    When I follow "Software" in the content area
+    And I follow "Lock"
+    Then package "hoag-dummy-1.1-1.1" is reported as unlocked
+    And package "orion-dummy-1.1-1.1" is reported as unlocked
+
+  Scenario: Cleanup: remove packages after testing locks
+    Then I remove package "orion-dummy" from this "sle_minion"
+    And I remove package "milkyway-dummy" from this "sle_minion"

--- a/testsuite/features/secondary/trad_lock_packages.feature
+++ b/testsuite/features/secondary/trad_lock_packages.feature
@@ -22,7 +22,7 @@ Feature: Lock packages on traditional client
     And I click on "Lock"
     And I run "rhn_check -vvv" on "sle_client"
     Then I should see a "Packages has been requested for being locked." text
-    And "hoag-dummy-1.1-1.1" is locked on this client
+    And "hoag-dummy-1.1-1.1" is locked on "sle_client"
     When I follow "Lock"
     Then package "hoag-dummy-1.1-1.1" is reported as locked
 
@@ -51,7 +51,7 @@ Feature: Lock packages on traditional client
     And I click on "Unlock"
     And I run "rhn_check -vvv" on "sle_client"
     Then I should see a "Packages has been requested for being unlocked." text
-    And "hoag-dummy-1.1-1.1" is unlocked on this client
+    And "hoag-dummy-1.1-1.1" is unlocked on "sle_client"
     When I follow "Lock"
     Then package "hoag-dummy-1.1-1.1" is reported as unlocked
 
@@ -77,8 +77,8 @@ Feature: Lock packages on traditional client
     And package "milkyway-dummy-2.0-1.1" is reported as pending to be locked
     And package "milkyway-dummy-2.0-1.1" cannot be selected
     When I run "rhn_check -vvv" on "sle_client"
-    Then "hoag-dummy-1.1-1.1" is locked on this client
-    And "milkyway-dummy-2.0-1.1" is locked on this client
+    Then "hoag-dummy-1.1-1.1" is locked on "sle_client"
+    And "milkyway-dummy-2.0-1.1" is locked on "sle_client"
     When I follow "Lock"
     Then package "hoag-dummy-1.1-1.1" is reported as locked
     And package "milkyway-dummy-2.0-1.1" is reported as locked
@@ -104,9 +104,9 @@ Feature: Lock packages on traditional client
     And package "milkyway-dummy-2.0-1.1" is reported as pending to be unlocked
     And package "orion-dummy-1.1-1.1" is reported as pending to be locked
     When I run "rhn_check -vvv" on "sle_client"
-    Then "hoag-dummy-1.1-1.1" is locked on this client
-    And "milkyway-dummy-2.0-1.1" is unlocked on this client
-    And "orion-dummy-1.1-1.1" is locked on this client
+    Then "hoag-dummy-1.1-1.1" is locked on "sle_client"
+    And "milkyway-dummy-2.0-1.1" is unlocked on "sle_client"
+    And "orion-dummy-1.1-1.1" is locked on "sle_client"
     When I follow "Lock"
     Then package "hoag-dummy-1.1-1.1" is reported as locked
     And package "milkyway-dummy-2.0-1.1" is reported as unlocked

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -82,7 +82,6 @@ When(/^I wait until I see the event "([^"]*)" completed during last minute, refr
       break if find(:xpath, "//a[contains(text(),'#{event}')]/../..//td[4][contains(text(),'#{current_minute}') or contains(text(),'#{previous_minute}')]/../td[3]/a[1]", wait: 1)
     rescue Capybara::ElementNotFound
       # ignored - pending actions cannot be found
-      sleep 1
     end
     begin
       accept_prompt do

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -78,7 +78,12 @@ When(/^I wait until I see the event "([^"]*)" completed during last minute, refr
     now = Time.now
     current_minute = now.strftime('%H:%M')
     previous_minute = (now - 60).strftime('%H:%M')
-    break if find(:xpath, "//a[contains(text(),'#{event}')]/../..//td[4][contains(text(),'#{current_minute}') or contains(text(),'#{previous_minute}')]/../td[3]/a[1]", wait: 1)
+    begin
+      break if find(:xpath, "//a[contains(text(),'#{event}')]/../..//td[4][contains(text(),'#{current_minute}') or contains(text(),'#{previous_minute}')]/../td[3]/a[1]", wait: 1)
+    rescue Capybara::ElementNotFound
+      # ignored - pending actions cannot be found
+      sleep 1
+    end
     begin
       accept_prompt do
         execute_script 'window.location.reload()'

--- a/testsuite/features/step_definitions/lock_packages_on_client.rb
+++ b/testsuite/features/step_definitions/lock_packages_on_client.rb
@@ -1,12 +1,14 @@
 # Copyright (c) 2010-2019 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
-Then(/^"(.*?)" is locked on "(.*?)"$/) do |pkg, system|
+Then(/^"(.*?)" is (locked|unlocked) on "(.*?)"$/) do |pkg, action, system|
   node = get_target(system)
-  zypp_lock_file = '/etc/zypp/locks'
-  raise "File already exist: #{zypp_lock_file}" unless file_exists?($client, zypp_lock_file)
   command = "zypper locks  --solvables | grep #{pkg}"
-  node.run(command, timeout: 600)
+  if action == 'locked'
+    node.run(command, timeout: 600)
+  else
+    node.run(command, check_errors: false, timeout: 600)
+  end
 end
 
 Then(/^package "(.*?)" is reported as locked$/) do |pkg|
@@ -14,15 +16,6 @@ Then(/^package "(.*?)" is reported as locked$/) do |pkg|
   locked_pkgs = all(:xpath, "//i[@class='fa fa-lock']/../a")
   raise 'No packages locked' if locked_pkgs.empty?
   raise "Package #{pkg} not found as locked" unless locked_pkgs.find { |a| a.text =~ /^#{pkg}/ }
-end
-
-Then(/^"(.*?)" is unlocked on "(.*?)"$/) do |pkg, system|
-  node = get_target(system)
-  zypp_lock_file = '/etc/zypp/locks'
-  raise "File #{zypp_lock_file} not found" unless file_exists?($client, zypp_lock_file)
-
-  command = "zypper locks  --solvables | grep #{pkg}"
-  node.run(command, check_errors: false, timeout: 600)
 end
 
 Then(/^package "(.*?)" is reported as unlocked$/) do |pkg|

--- a/testsuite/features/step_definitions/lock_packages_on_client.rb
+++ b/testsuite/features/step_definitions/lock_packages_on_client.rb
@@ -1,11 +1,12 @@
 # Copyright (c) 2010-2019 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
-Then(/^"(.*?)" is locked on this client$/) do |pkg|
+Then(/^"(.*?)" is locked on "(.*?)"$/) do |pkg, system|
+  node = get_target(system)
   zypp_lock_file = '/etc/zypp/locks'
   raise "File already exist: #{zypp_lock_file}" unless file_exists?($client, zypp_lock_file)
   command = "zypper locks  --solvables | grep #{pkg}"
-  $client.run(command, timeout: 600)
+  node.run(command, timeout: 600)
 end
 
 Then(/^package "(.*?)" is reported as locked$/) do |pkg|
@@ -15,12 +16,13 @@ Then(/^package "(.*?)" is reported as locked$/) do |pkg|
   raise "Package #{pkg} not found as locked" unless locked_pkgs.find { |a| a.text =~ /^#{pkg}/ }
 end
 
-Then(/^"(.*?)" is unlocked on this client$/) do |pkg|
+Then(/^"(.*?)" is unlocked on "(.*?)"$/) do |pkg, system|
+  node = get_target(system)
   zypp_lock_file = '/etc/zypp/locks'
   raise "File #{zypp_lock_file} not found" unless file_exists?($client, zypp_lock_file)
 
   command = "zypper locks  --solvables | grep #{pkg}"
-  $client.run(command, check_errors: false, timeout: 600)
+  node.run(command, check_errors: false, timeout: 600)
 end
 
 Then(/^package "(.*?)" is reported as unlocked$/) do |pkg|

--- a/testsuite/run_sets/secondary.yml
+++ b/testsuite/run_sets/secondary.yml
@@ -42,6 +42,7 @@
 - features/secondary/trad_baremetal_discovery.feature
 - features/secondary/min_salt_minions_page.feature
 - features/secondary/min_salt_mgrcompat_state.feature
+- features/secondary/min_salt_lock_packages.feature
 - features/secondary/minkvm_guests.feature
 - features/secondary/minxen_guests.feature
 - features/secondary/min_empty_system_profiles.feature


### PR DESCRIPTION
## What does this PR change?

Package Locks are currently only available for traditionally managed systems.
This PR should bring this feature also for salt minions.

It requires some implementation in salt to support locking with zypp, yum, dnf and apt.

## GUI diff

![image](https://user-images.githubusercontent.com/1038917/126899528-0bba1c2c-93f4-4213-82d0-021abcb6a9c8.png)

![image](https://user-images.githubusercontent.com/1038917/126899541-1ed841c8-531a-4282-9e9f-3746073bcf64.png)

- [x] **DONE**

## Documentation
- Documentation issue was created: https://github.com/SUSE/spacewalk/issues/15572
  - Change Package Locking 
  - Change Feature checklist
  - Change UI description
 
- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/15305
Tracks https://github.com/SUSE/spacewalk/pull/15654

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"  
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
