### PR TITLE
Testsuite: Give Ubuntu enough time to bootstrap

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -877,8 +877,8 @@ When(/^I wait until onboarding is completed for "([^"]*)"$/) do |host|
     _os_version, os_family = get_os_version(node)
     steps %(
       And I wait at most 500 seconds until event "Hardware List Refresh" is completed
-      And I wait at most 250 seconds until event "Apply states" is completed
-      And I wait at most 250 seconds until event "Package List Refresh" is completed
+      And I wait at most 500 seconds until event "Apply states" is completed
+      And I wait at most 500 seconds until event "Package List Refresh" is completed
     )
   end
 end


### PR DESCRIPTION
## What does this PR change?
Give Ubuntu enough time to bootstrap


## Links
Fixes https://github.com/uyuni-project/uyuni/pull/3077
### Ports
- Manager-4.1: https://github.com/SUSE/spacewalk/pull/13584
- Manager-4.0: https://github.com/SUSE/spacewalk/pull/13585

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
