### PR TITLE
spacewalk-admin: Fixed salt certificate creation.

### DIFF
--- a/spacewalk/admin/salt-secrets-config.py
+++ b/spacewalk/admin/salt-secrets-config.py
@@ -69,5 +69,5 @@ if (not all([os.path.isfile(f) for f in ["/etc/salt/pki/api/salt-api.crt", "/etc
     # Detect CA management tool.
     if os.system("update-ca-certificates"):
         print('Using "update-ca-trust" instead of "update-ca-certificates".')
-        os.system("update-ca-trust")
+        os.system("update-ca-trust extract")
 

--- a/spacewalk/admin/salt-secrets-config.py
+++ b/spacewalk/admin/salt-secrets-config.py
@@ -14,6 +14,11 @@ initCFG('java')
 
 thread_pool_size = CFG.salt_event_thread_pool_size
 
+# To be moved into a config file in future
+cert_location = "/etc/pki/trust/anchors"
+if not os.path.isdir(cert_location):
+    cert_location = "/etc/pki/ca-trust/source/anchors"
+
 initCFG()
 
 mgr_events_config = {
@@ -60,5 +65,9 @@ if (not all([os.path.isfile(f) for f in ["/etc/salt/pki/api/salt-api.crt", "/etc
     os.chmod("/etc/salt/pki/api/salt-api.crt", 0o600)
     os.chown("/etc/salt/pki/api/salt-api.key", pwd.getpwnam("salt").pw_uid, grp.getgrnam("salt").gr_gid)
     os.chmod("/etc/salt/pki/api/salt-api.key", 0o600)
-    shutil.copyfile("/etc/salt/pki/api/salt-api.crt", "/etc/pki/trust/anchors/salt-api.crt")
-    os.system("update-ca-certificates")
+    shutil.copyfile("/etc/salt/pki/api/salt-api.crt", cert_location + "/salt-api.crt")
+    # Detect CA management tool.
+    if os.system("update-ca-certificates"):
+        print('Using "update-ca-trust" instead of "update-ca-certificates".')
+        os.system("update-ca-trust")
+

--- a/spacewalk/admin/spacewalk-admin.changes
+++ b/spacewalk/admin/spacewalk-admin.changes
@@ -1,3 +1,6 @@
+- Added salt-secrets-config to the default service list.
+- Updated salt certificate script to use variable certificate path and alternative certificate manager.
+- Updated source URL in spec file.
 - Added RHEL Apache permissions.
 
 -------------------------------------------------------------------

--- a/spacewalk/admin/spacewalk-admin.spec
+++ b/spacewalk/admin/spacewalk-admin.spec
@@ -30,7 +30,7 @@ Name:           spacewalk-admin
 Url:            https://github.com/uyuni-project/uyuni
 Version:        4.2.2
 Release:        1%{?dist}
-Source0:        https://github.com/spacewalkproject/spacewalk/archive/%{name}-%{version}.tar.gz
+Source0:        https://github.com/uyuni-project/uyuni/archive/%{name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 Requires:       lsof
 Requires:       spacewalk-base

--- a/spacewalk/admin/spacewalk.target
+++ b/spacewalk/admin/spacewalk.target
@@ -14,6 +14,7 @@ Requires=rhn-search.service
 Requires=cobblerd.service
 Requires=taskomatic.service
 Requires=spacewalk-wait-for-taskomatic.service
+Requires=salt-secrets-config.service
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## What does this PR change?

- Added salt-secrets-config to the default service list.
- Updated salt certificate script to variable certificate path and message on failing update-ca-certificates.
- Updated source URL in spec file.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: no functional changes

- [X] **DONE**

## Test coverage
- No tests: tested during automatic build.
Manual tests of code segments done on Leap 15.2 and CentOS 8.
Build tested successfully for CentOS 7/8 and Leap 15.2. Installation tested successfully on CentOS 8

- [X] **DONE**

## Links

Fixes #

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
