### PR TITLE
spacecmd: support multiple package names on "package_details" command

### DIFF
--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,4 @@
+- Fixed "non-advanced" package search when using multiple package names (bsc#1180584)
 - Added '-r REVISION' option to the 'configchannel_updateinitsls' command (bsc#1179566)
 - Fix: internal: workaround for future tee of logs translation
 

--- a/spacecmd/src/spacecmd/package.py
+++ b/spacecmd/src/spacecmd/package.py
@@ -164,7 +164,7 @@ def do_package_search(self, args, doreturn=False):
         # the APIs for searching; this is done because the fuzzy
         # search on the server gives a lot of garbage back
         packages = filter_results(self.get_package_names(True),
-                                  [args], search=True)
+                                  _args, search=True)
 
     if doreturn:
         return packages

--- a/spacecmd/tests/test_package.py
+++ b/spacecmd/tests/test_package.py
@@ -257,6 +257,30 @@ class TestSCPackage:
         assert mprint.called
         assert_expect(mprint.call_args_list, 'emacs-melpa\nemacs-nox\nemacs-x11')
 
+    def test_package_search_multiple_packages(self, shell):
+        """
+        Test do_package_search with multiple arguments of standard fields
+        """
+        shell.help_package_search = MagicMock()
+        shell.get_package_names = MagicMock(return_value=[
+            "emacs-x11", "emacs-melpa", "emacs-nox", "vim", "pico", "gedit", "sed"
+        ])
+        shell.client.packages.search.advanced = MagicMock()
+
+        logger = MagicMock()
+        mprint = MagicMock()
+
+        with patch("spacecmd.package.print", mprint) as prn, \
+                patch("spacecmd.package.logging", logger) as lgr:
+            out = spacecmd.package.do_package_search(shell, "emacs-melpa emacs-x11", doreturn=False)
+
+        assert not shell.help_package_search.called
+        assert not logger.debug.called
+        assert not shell.client.packages.search.advanced.called
+        assert out is None
+        assert mprint.called
+        assert_expect(mprint.call_args_list, 'emacs-melpa\nemacs-x11')
+
     def test_package_search_advanced(self, shell):
         """
         Test do_package_search with arguments of advanced fields.


### PR DESCRIPTION
## What does this PR change?

With this PR, the spacecmd package_details and package_search commands will now allow to specify multiple package names on "non-advanced" search, e.g.: `spacecmd -- package_details zypper apparmor`.

### Before
```
server:~ # spacecmd -- package_details zypper | grep 'Name:' | sort | uniq | wc -l
INFO: Connected to https://server.tf.local/rpc/api as admin
2

server:~ # spacecmd -- package_details apparmor | grep 'Name:' | sort | uniq | wc -l
INFO: Connected to https://server.tf.local/rpc/api as admin
5

server:~ # spacecmd -- package_details name:zypper name:apparmor | grep 'Name:' | sort | uniq | wc -l
INFO: Connected to https://server.tf.local/rpc/api as admin
7

server:~ # spacecmd -- package_details zypper apparmor | grep 'Name:' | sort | uniq | wc -l
INFO: Connected to https://server.tf.local/rpc/api as admin
WARNING: No packages found
0
```
### After

```
server:~ # spacecmd -- package_details zypper | grep 'Name:' | sort | uniq | wc -l
INFO: Connected to https://server.tf.local/rpc/api as admin
2

server:~ # spacecmd -- package_details apparmor | grep 'Name:' | sort | uniq | wc -l
INFO: Connected to https://server.tf.local/rpc/api as admin
5

server:~ # spacecmd -- package_details name:zypper name:apparmor | grep 'Name:' | sort | uniq | wc -l
INFO: Connected to https://server.tf.local/rpc/api as admin
7

server:~ # spacecmd -- package_details zypper apparmor | grep 'Name:' | sort | uniq | wc -l
INFO: Connected to https://server.tf.local/rpc/api as admin
WARNING: No packages found
7
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Feature is already documented on command `--help`

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/13574

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
