### PR TITLE
uyuni-base: Added Apache as installation prerequisite

### DIFF
--- a/uyuni/base/uyuni-base.changes
+++ b/uyuni/base/uyuni-base.changes
@@ -1,3 +1,4 @@
+- Added Apache as prerequisite for RHEL and Fedora (due to required users).
 - Removed RHEL specific folder rights from SPEC file.
 
 -------------------------------------------------------------------

--- a/uyuni/base/uyuni-base.spec
+++ b/uyuni/base/uyuni-base.spec
@@ -52,6 +52,9 @@ Group:          System/Fhs
 %if 0%{?suse_version} >= 1500
 Requires(pre):  group(www)
 %endif
+%if 0%{?rhel} || 0%{?fedora}
+Requires(pre):  httpd
+%endif
 
 %description common
 Basic filesystem hierarchy for Uyuni server and proxy.
@@ -68,6 +71,9 @@ Requires(pre):  tomcat
 Requires(pre):  salt
 %if 0%{?suse_version} >= 1500
 Requires(pre):  user(wwwrun)
+%endif
+%if 0%{?rhel} || 0%{?fedora}
+Requires(pre):  httpd
 %endif
 
 %description server


### PR DESCRIPTION
## What does this PR change?

httpd as installation prerequisite for RHEL and Fedora to ensure that the apache user is available for permission setting inthe spec file.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: No functional change.

- [X] **DONE**

## Test coverage
- No tests: Tested during automatic build process.
Manually tested build successfully on CentOS6-8, Leap 15.2, Fedora 32-Rawhide.

- [X] **DONE**

## Links

Fixes #

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
