### PR TITLE
Let time in "Pending" tab be configurable

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -70,16 +70,23 @@ When(/^I wait until event "([^"]*)" is completed$/) do |event|
   step %(I wait at most #{DEFAULT_TIMEOUT} seconds until event "#{event}" is completed)
 end
 
-When(/^I wait at most (\d+) seconds until event "([^"]*)" is completed$/) do |final_timeout, event|
+When(/^I wait at most (\d+) seconds until event "([^"]*)" is completed$/) do |timeout, event|
+  starting = Time.now
+  initial_timeout = timeout.to_i
   # The code below is not perfect because there might be other events with the
   # same name in the events history - however, that's the best we have so far.
   steps %(
     When I follow "Events"
     And I follow "Pending"
-    And I wait until I do not see "#{event}" text, refreshing the page
+    And I wait at most #{initial_timeout} seconds until I do not see "#{event}" text, refreshing the page
     And I follow "History"
     And I wait until I see "System History" text
     And I wait until I see "#{event}" text, refreshing the page
+  )
+  ending = Time.now
+  final_timeout = timeout.to_i - (ending - starting).to_i
+  final_timeout = 3 if final_timeout < 3
+  steps %(
     And I follow first "#{event}"
     And I wait at most #{final_timeout} seconds until the event is completed, refreshing the page
   )

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2020 SUSE LLC.
+# Copyright (c) 2010-2021 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 #
@@ -91,9 +91,9 @@ When(/^I wait until I see the name of "([^"]*)", refreshing the page$/) do |host
   step %(I wait until I see "#{system_name}" text, refreshing the page)
 end
 
-When(/^I wait until I do not see "([^"]*)" text, refreshing the page$/) do |text|
+When(/^I wait at most (\d+) seconds until I do not see "([^"]*)" text, refreshing the page$/) do |timeout, text|
   next unless has_content?(text)
-  repeat_until_timeout(message: "Text '#{text}' is still visible") do
+  repeat_until_timeout(timeout: timeout.to_i, message: "Text '#{text}' is still visible") do
     break unless has_content?(text)
     begin
       accept_prompt do
@@ -103,6 +103,10 @@ When(/^I wait until I do not see "([^"]*)" text, refreshing the page$/) do |text
       # ignored
     end
   end
+end
+
+When(/^I wait until I do not see "([^"]*)" text, refreshing the page$/) do |text|
+  step %(I wait at most #{DEFAULT_TIMEOUT} seconds until I do not see "#{text}" text, refreshing the page)
 end
 
 When(/^I wait until I do not see the name of "([^"]*)", refreshing the page$/) do |host|


### PR DESCRIPTION
## What does this PR change?

When we bootstrap a minion, the time spent in "Pending" tab can be long for the first events.

This PR makes this time configurable.


## Links

Ports:
* 4.0: SUSE/spacewalk#13590
* 4.1: SUSE/spacewalk#13589


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
