### PR TITLE
add missing unique index on suse tables

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/distupgrade/test/DistUpgradeManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/distupgrade/test/DistUpgradeManagerTest.java
@@ -232,21 +232,11 @@ public class DistUpgradeManagerTest extends BaseTestCaseWithUser {
         // Setup migration target product + upgrade path
         SUSEProduct targetBaseProduct = SUSEProductTestUtils.createTestSUSEProduct(family);
         Channel targetBaseChannel = SUSEProductTestUtils.createBaseChannelForBaseProduct(targetBaseProduct, user);
-        SUSEProductChannel pcbase = new SUSEProductChannel();
-        pcbase.setChannel(targetBaseChannel);
-        pcbase.setProduct(targetBaseProduct);
-        pcbase.setMandatory(true);
-        SUSEProductFactory.save(pcbase);
         sourceBaseProduct.setUpgrades(Collections.singleton(targetBaseProduct));
 
         // Setup target addon product + upgrade path
         SUSEProduct targetAddonProduct = SUSEProductTestUtils.createTestSUSEProduct(family);
         Channel targetAddonChannel = SUSEProductTestUtils.createChildChannelsForProduct(targetAddonProduct, targetBaseChannel, user);
-        SUSEProductChannel pcaddon = new SUSEProductChannel();
-        pcaddon.setChannel(targetAddonChannel);
-        pcaddon.setProduct(targetAddonProduct);
-        pcaddon.setMandatory(true);
-        SUSEProductFactory.save(pcaddon);
         sourceAddonProduct.setUpgrades(Collections.singleton(targetAddonProduct));
         SUSEProductExtension e2 = new SUSEProductExtension(sourceBaseProduct, targetAddonProduct, sourceBaseProduct, false);
         SUSEProductExtension e3 = new SUSEProductExtension(targetBaseProduct, targetAddonProduct, targetBaseProduct, false);
@@ -359,21 +349,11 @@ public class DistUpgradeManagerTest extends BaseTestCaseWithUser {
         // Setup migration target product + upgrade path
         SUSEProduct targetBaseProduct = SUSEProductTestUtils.createTestSUSEProduct(family);
         Channel targetBaseChannel = SUSEProductTestUtils.createBaseChannelForBaseProduct(targetBaseProduct, user);
-        SUSEProductChannel pcbase = new SUSEProductChannel();
-        pcbase.setChannel(targetBaseChannel);
-        pcbase.setProduct(targetBaseProduct);
-        pcbase.setMandatory(true);
-        SUSEProductFactory.save(pcbase);
         sourceBaseProduct.setUpgrades(Collections.singleton(targetBaseProduct));
 
         // Setup target addon product + upgrade path
         SUSEProduct targetAddonProduct = SUSEProductTestUtils.createTestSUSEProduct(family);
         Channel targetAddonChannel = SUSEProductTestUtils.createChildChannelsForProduct(targetAddonProduct, targetBaseChannel, user);
-        SUSEProductChannel pcaddon = new SUSEProductChannel();
-        pcaddon.setChannel(targetAddonChannel);
-        pcaddon.setProduct(targetAddonProduct);
-        pcaddon.setMandatory(true);
-        SUSEProductFactory.save(pcaddon);
         sourceAddonProduct.setUpgrades(Collections.singleton(targetAddonProduct));
         SUSEProductExtension e2 = new SUSEProductExtension(sourceBaseProduct, targetAddonProduct, sourceBaseProduct, false);
         SUSEProductExtension e3 = new SUSEProductExtension(targetBaseProduct, targetAddonProduct, targetBaseProduct, false);
@@ -479,11 +459,6 @@ public class DistUpgradeManagerTest extends BaseTestCaseWithUser {
         SUSEProduct targetBaseProduct = SUSEProductTestUtils.createTestSUSEProduct(family);
         Channel targetBaseChannel = SUSEProductTestUtils.createBaseChannelForBaseProduct(targetBaseProduct, user);
         targetBaseChannel.setLabel("targetBaseChannel");
-        SUSEProductChannel pcbase = new SUSEProductChannel();
-        pcbase.setChannel(targetBaseChannel);
-        pcbase.setProduct(targetBaseProduct);
-        pcbase.setMandatory(true);
-        SUSEProductFactory.save(pcbase);
         sourceBaseProduct.setUpgrades(Collections.singleton(targetBaseProduct));
 
         // Setup target addon product + upgrade path
@@ -783,23 +758,11 @@ public class DistUpgradeManagerTest extends BaseTestCaseWithUser {
         SUSEProduct slesSP1BaseProduct = SUSEProductTestUtils.createTestSUSEProduct(family);
         Channel slesSP1BaseChannel = SUSEProductTestUtils.createBaseChannelForBaseProduct(slesSP1BaseProduct, user);
 
-        SUSEProductChannel slesSP1Mirrored = new SUSEProductChannel();
-        slesSP1Mirrored.setChannel(slesSP1BaseChannel);
-        slesSP1Mirrored.setProduct(slesSP1BaseProduct);
-        slesSP1Mirrored.setMandatory(true);
-        SUSEProductFactory.save(slesSP1Mirrored);
-
         List<SUSEProduct> slesSP1Addons = new ArrayList<>();
         SUSEProduct ltssSP1AddonProduct = SUSEProductTestUtils.createTestSUSEProduct(family);
         Channel ltssSP1ChildChannel = SUSEProductTestUtils.createChildChannelsForProduct(ltssSP1AddonProduct, slesSP1BaseChannel, user);
         SUSEProductExtension e = new SUSEProductExtension(slesSP1BaseProduct, ltssSP1AddonProduct, slesSP1BaseProduct, false);
         TestUtils.saveAndReload(e);
-
-        SUSEProductChannel ltssSP1Mirrored = new SUSEProductChannel();
-        ltssSP1Mirrored.setChannel(ltssSP1ChildChannel);
-        ltssSP1Mirrored.setProduct(ltssSP1AddonProduct);
-        ltssSP1Mirrored.setMandatory(true);
-        SUSEProductFactory.save(ltssSP1Mirrored);
 
         slesSP1Addons.add(ltssSP1AddonProduct);
         SUSEProductSet sourceProducts = new SUSEProductSet(slesSP1BaseProduct, slesSP1Addons);
@@ -833,11 +796,6 @@ public class DistUpgradeManagerTest extends BaseTestCaseWithUser {
         // Setup migration target product + upgrade path
         SUSEProduct slesSP2BaseProduct = SUSEProductTestUtils.createTestSUSEProduct(family);
         Channel slesSP2BaseChannel = SUSEProductTestUtils.createBaseChannelForBaseProduct(slesSP2BaseProduct, user);
-        SUSEProductChannel slesSP2Mirrored = new SUSEProductChannel();
-        slesSP2Mirrored.setChannel(slesSP2BaseChannel);
-        slesSP2Mirrored.setProduct(slesSP2BaseProduct);
-        slesSP2Mirrored.setMandatory(true);
-        SUSEProductFactory.save(slesSP2Mirrored);
         slesSP1BaseProduct.setUpgrades(Collections.singleton(slesSP2BaseProduct));
 
         SCCRepository slesSP2SCCRepository = SUSEProductTestUtils.createSCCRepository();
@@ -869,11 +827,6 @@ public class DistUpgradeManagerTest extends BaseTestCaseWithUser {
         // Setup target ltss addon product + upgrade path
         SUSEProduct ltssSP2AddonProduct = SUSEProductTestUtils.createTestSUSEProduct(family);
         Channel ltssSP2AddonChannel = SUSEProductTestUtils.createChildChannelsForProduct(ltssSP2AddonProduct, slesSP2BaseChannel, user);
-        SUSEProductChannel ltssSP2Mirrored = new SUSEProductChannel();
-        ltssSP2Mirrored.setChannel(ltssSP2AddonChannel);
-        ltssSP2Mirrored.setProduct(ltssSP2AddonProduct);
-        ltssSP2Mirrored.setMandatory(true);
-        SUSEProductFactory.save(ltssSP2Mirrored);
 
         ltssSP1AddonProduct.setUpgrades(Collections.singleton(ltssSP2AddonProduct));
         SUSEProductExtension e3 = new SUSEProductExtension(slesSP2BaseProduct, ltssSP2AddonProduct, slesSP2BaseProduct, false);

--- a/schema/spacewalk/common/tables/suseMdKeyword.sql
+++ b/schema/spacewalk/common/tables/suseMdKeyword.sql
@@ -24,3 +24,6 @@ suseMdKeyword
 ;
 
 CREATE SEQUENCE suse_mdkeyword_id_seq;
+
+CREATE UNIQUE INDEX susemdkeyword_label_uq
+ON suseMdKeyword (label);

--- a/schema/spacewalk/common/tables/suseProductChannel.sql
+++ b/schema/spacewalk/common/tables/suseProductChannel.sql
@@ -34,3 +34,5 @@ suseProductChannel
 
 CREATE SEQUENCE suse_product_channel_id_seq;
 
+CREATE UNIQUE INDEX suseproductchannel_product_id_channel_id_uq
+ON suseProductChannel (product_id, channel_id);

--- a/schema/spacewalk/common/tables/suseUpgradePath.sql
+++ b/schema/spacewalk/common/tables/suseUpgradePath.sql
@@ -32,3 +32,5 @@ CREATE INDEX suseupgpath_fromid_idx
 ON suseUpgradePath (from_pdid)
 ;
 
+CREATE UNIQUE INDEX suseupgradepath_from_pdid_to_pdid_uq
+ON suseUpgradePath (from_pdid, to_pdid);

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- add missing unique index on suse tables
 - internal code cleanup (dropping unused table rhnErrataTmp)
 - Fix Debian package version comparison
 - Use versioned Python2 for RHEL8 and Fedora.

--- a/schema/spacewalk/upgrade/susemanager-schema-4.2.4-to-susemanager-schema-4.2.5/802-add-missing-uq-index.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.2.4-to-susemanager-schema-4.2.5/802-add-missing-uq-index.sql
@@ -1,0 +1,9 @@
+
+CREATE UNIQUE INDEX IF NOT EXISTS suseproductchannel_product_id_channel_id_uq
+ON suseProductChannel (product_id, channel_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS susemdkeyword_label_uq
+ON suseMdKeyword (label);
+
+CREATE UNIQUE INDEX IF NOT EXISTS suseupgradepath_from_pdid_to_pdid_uq
+ON suseUpgradePath (from_pdid, to_pdid);


### PR DESCRIPTION
Signed-off-by: Ricardo Mateus <rmateus@suse.com>

## What does this PR change?

During the development of "ISS Revamp: Data dumper implementation #12968" we found some tables with missing unique key constraints.
This PR will add a unique index to the following tables:
- suseproductchannel
- susemdkeyword
- suseupgradepath

## GUI diff

No difference.

## Documentation
- No documentation needed, schema changes.

## Test coverage
- No tests. Adding missing unique index.

## Links

Fixes https://github.com/SUSE/spacewalk/issues/13517
Tracks:
- Port to Manager 4.1 https://github.com/SUSE/spacewalk/pull/13591

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests" (Test skipped, there are no changes to test)
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
