### PR TITLE
spacewalk-config: Fixed Apache group for RHEL.

### DIFF
--- a/spacewalk/config/spacewalk-config.changes
+++ b/spacewalk/config/spacewalk-config.changes
@@ -1,3 +1,5 @@
+- Fixed apache group for RHEL.
+- Updated Source URL in SPEC.
 - Drop the ssl_available option (SSL is always present)
 
 -------------------------------------------------------------------

--- a/spacewalk/config/spacewalk-config.spec
+++ b/spacewalk/config/spacewalk-config.spec
@@ -24,11 +24,7 @@
 %else
 %define apacheconfdir %{_sysconfdir}/httpd
 %define apachepkg httpd
-%if 0%{?rhel}
-%define apache_group root
-%else
 %define apache_group apache
-%endif
 %endif
 
 Name:           spacewalk-config
@@ -38,7 +34,7 @@ Group:          Applications/System
 Version:        4.2.2
 Release:        1%{?dist}
 Url:            https://github.com/uyuni-project/uyuni
-Source0:        https://github.com/spacewalkproject/spacewalk/archive/%{name}-%{version}.tar.gz
+Source0:        https://github.com/uyuni-project/uyuni/archive/%{name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
 Requires:       perl(Satcon)


### PR DESCRIPTION
## What does this PR change?

- Fixed apache group for RHEL.
- Updated Source URL in SPEC.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: no functional changes

- [X] **DONE**

## Test coverage
- No tests: tested during automatic build.
Build tested successfully on CentOS8/Leap15.2

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
