### PR TITLE
replace custom vercmp function with PackageEvr.compareTo

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageEvr.java
+++ b/java/code/src/com/redhat/rhn/domain/rhnpackage/PackageEvr.java
@@ -29,7 +29,6 @@ public class PackageEvr implements Comparable<PackageEvr> {
 
     private static final RpmVersionComparator RPMVERCMP = new RpmVersionComparator();
     private static final DebVersionComparator DEBVERCMP = new DebVersionComparator();
-    private static final Integer ZERO = 0;
 
     private Long id;
     private String epoch;
@@ -191,7 +190,7 @@ public class PackageEvr implements Comparable<PackageEvr> {
         // does almost the same, but has a subtle difference when it comes
         // to null epochs (the RHN::DB::Package version does not treat null
         // epochs the same as epoch == 0, but sorts them as Integer.MIN_VALUE)
-        int result = epochAsInteger().compareTo(other.epochAsInteger());
+        int result = Integer.compare(epochAsInteger(), other.epochAsInteger());
         if (result != 0) {
             return result;
         }
@@ -209,7 +208,7 @@ public class PackageEvr implements Comparable<PackageEvr> {
     }
 
     private int debCompareTo(PackageEvr other) {
-        int result = epochAsInteger().compareTo(other.epochAsInteger());
+        int result = Integer.compare(epochAsInteger(), other.epochAsInteger());
         if (result != 0) {
             return result;
         }
@@ -248,12 +247,13 @@ public class PackageEvr implements Comparable<PackageEvr> {
         }
     }
 
-    private Integer epochAsInteger() {
-        Integer result = ZERO;
-        if (getEpoch() != null) {
-            result = Integer.valueOf(getEpoch());
+    private int epochAsInteger() {
+        if (getEpoch() == null) {
+            return 0;
         }
-        return result;
+        else {
+            return Integer.parseInt(getEpoch());
+        }
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -56,6 +56,7 @@ import com.redhat.rhn.domain.org.OrgFactory;
 import com.redhat.rhn.domain.product.SUSEProductSet;
 import com.redhat.rhn.domain.rhnpackage.Package;
 import com.redhat.rhn.domain.rhnpackage.PackageArch;
+import com.redhat.rhn.domain.rhnpackage.PackageEvr;
 import com.redhat.rhn.domain.rhnpackage.PackageEvrFactory;
 import com.redhat.rhn.domain.rhnpackage.PackageFactory;
 import com.redhat.rhn.domain.rhnpackage.PackageName;
@@ -1045,6 +1046,13 @@ public class SystemHandler extends BaseHandler {
         // Get the logged in user and server
         Server server = lookupServer(loggedInUser, sid);
 
+        PackageEvr inputEvr = new PackageEvr(
+                epoch == null ? "0" : epoch,
+                version == null ? "" : version,
+                release == null ? "" : release,
+                server.getPackageType()
+        );
+
         List toCheck = packagesToCheck(server, name);
 
         List returnList = new ArrayList();
@@ -1060,9 +1068,14 @@ public class SystemHandler extends BaseHandler {
             String pkgRelease = (String) pkg.get("release");
             String pkgEpoch   = (String) pkg.get("epoch");
 
-            int c = PackageManager.verCmp(pkgEpoch, pkgVersion, pkgRelease,
-                    epoch, version, release);
-            if (0 > c) {
+            PackageEvr pkgEvr = new PackageEvr(
+                    pkgEpoch == null ? "0" : pkgEpoch,
+                    pkgVersion == null ? "" : pkgVersion,
+                    pkgRelease == null ? "" : pkgRelease,
+                    server.getPackageType()
+            );
+
+            if (0 > pkgEvr.compareTo(inputEvr)) {
                 returnList.add(fillOutPackage(pkgName, pkgVersion, pkgRelease, pkgEpoch));
             }
         }
@@ -1108,6 +1121,14 @@ public class SystemHandler extends BaseHandler {
                     throws FaultException {
         // Get the logged in user and server
         Server server = lookupServer(loggedInUser, sid);
+
+        PackageEvr inputEvr = new PackageEvr(
+                epoch == null ? "0" : epoch,
+                version == null ? "" : version,
+                release == null ? "" : release,
+                server.getPackageType()
+        );
+
         List toCheck = packagesToCheck(server, name);
         List returnList = new ArrayList();
         /*
@@ -1121,9 +1142,14 @@ public class SystemHandler extends BaseHandler {
             String pkgRelease = (String) pkg.get("release");
             String pkgEpoch   = (String) pkg.get("epoch");
 
-            int c = PackageManager.verCmp(pkgEpoch, pkgVersion, pkgRelease,
-                    epoch, version, release);
-            if (0 < c) {
+            PackageEvr pkgEvr = new PackageEvr(
+                    pkgEpoch == null ? "0" : pkgEpoch,
+                    pkgVersion == null ? "" : pkgVersion,
+                    pkgRelease == null ? "" : pkgRelease,
+                    server.getPackageType()
+            );
+
+            if (0 < pkgEvr.compareTo(inputEvr)) {
                 returnList.add(fillOutPackage(pkgName, pkgVersion, pkgRelease, pkgEpoch));
             }
         }

--- a/java/code/src/com/redhat/rhn/manager/kickstart/KickstartScheduleCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/KickstartScheduleCommand.java
@@ -1210,12 +1210,10 @@ public class KickstartScheduleCommand extends BaseSystemOperation {
         up2dateversion = up2dateversion == null ? "0" : up2dateversion;
         up2daterelease = up2daterelease == null ? "0" : up2daterelease;
 
-        int comp = PackageManager.verCmp(up2dateepoch,
-                up2dateversion,
-                up2daterelease,
-                "0",
-                UP2DATE_VERSION,
-                "0");
+        PackageEvr v1 = new PackageEvr(up2dateepoch, up2dateversion, up2daterelease, hostServer.getPackageType());
+        PackageEvr v2 = new PackageEvr("0", UP2DATE_VERSION, "0", hostServer.getPackageType());
+        int comp = v1.compareTo(v2);
+
         log.debug("    Got back comp from verCmp: " + comp);
         if (comp < 0) {
             Long packageId = PackageManager.

--- a/java/code/src/com/redhat/rhn/manager/rhnpackage/PackageManager.java
+++ b/java/code/src/com/redhat/rhn/manager/rhnpackage/PackageManager.java
@@ -24,7 +24,6 @@ import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.common.security.PermissionException;
 import com.redhat.rhn.common.util.CompressionUtil;
-import com.redhat.rhn.common.util.RpmVersionComparator;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.channel.ChannelFactory;
 import com.redhat.rhn.domain.channel.DistChannelMap;
@@ -732,40 +731,6 @@ public class PackageManager extends BaseManager {
         }
     }
 
-
-    /**
-     * Compares an evr to another evr.
-     * @param epoch1 Epoch 1
-     * @param version1 Version 1
-     * @param release1 Release 1
-     * @param epoch2 Epoch 2
-     * @param version2 Version 2
-     * @param release2 Release 2
-     * @return {@literal Returns 1 if EVR1 > EVR2, -1 if EVR1 < EVR2,
-     *  and 0 if EVR1 == EVR2.}
-     */
-    public static int verCmp(String epoch1, String version1, String release1,
-                             String epoch2, String version2, String release2) {
-
-        // Compare the Epochs
-        int c = compareEpochs(epoch1, epoch2);
-        if (c != 0) {
-            return c;
-        }
-
-        // Compare the Versions
-        RpmVersionComparator cmp = new RpmVersionComparator();
-        c = cmp.compare(StringUtils.defaultString(version1),
-                        StringUtils.defaultString(version2));
-        if (c != 0) {
-            return c;
-        }
-
-        // Compare the Releases
-        return cmp.compare(StringUtils.defaultString(release1),
-                           StringUtils.defaultString(release2));
-    }
-
     /**
      * Deletes a package from the system
      * @param user calling user
@@ -841,43 +806,6 @@ public class PackageManager extends BaseManager {
                     "cleanup_package_" + CLEANUP_QUERIES[x]);
             writeMode.executeUpdate(params);
         }
-    }
-
-    /**
-     * Helper method to compare two epoch strings according to the algorithm contained
-     * in: modules/rhn/RHN/DB/Package.pm --> sub vercmp
-     * @param epoch1 Epoch 1
-     * @param epoch2 Epoch 2
-     * @return Returns 1 if epoch1 > epoch2, -1 if epoch1 < epoch2,
-     * and 0 if epoch1 == epoch2
-     */
-    private static int compareEpochs(String epoch1, String epoch2) {
-        //Trim the epoch strings to null
-        epoch1 = StringUtils.trimToNull(epoch1);
-        epoch2 = StringUtils.trimToNull(epoch2);
-
-        //Check the epochs
-        Integer e1 = null;
-        Integer e2 = null;
-        if (epoch1 != null && StringUtils.isNumeric(epoch1)) {
-            e1 = Integer.valueOf(epoch1);
-        }
-        if (epoch2 != null && StringUtils.isNumeric(epoch2)) {
-            e2 = Integer.valueOf(epoch2);
-        }
-        //handle null cases
-        if (e1 != null && e2 == null) {
-            return 1;
-        }
-        if (e1 == null && e2 != null) {
-            return -1;
-        }
-        if (e1 == null && e2 == null) {
-            return 0;
-        }
-
-        // If we made it here, it is safe to do an Integer comparison between the two
-        return e1.compareTo(e2);
     }
 
     private static void schedulePackageFileForDeletion(String fileName) {

--- a/java/code/src/com/redhat/rhn/manager/rhnpackage/test/PackageManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/rhnpackage/test/PackageManagerTest.java
@@ -326,64 +326,6 @@ public class PackageManagerTest extends BaseTestCaseWithUser {
         assertNotNull(dr);
     }
 
-    public void testVerCmp() {
-
-        //epoch
-        int result = testEpoch("1", "2");
-        assertEquals(-1, result);
-
-        result = testEpoch("2", "1");
-        assertEquals(1, result);
-
-        result = testEpoch(null, "1");
-        assertEquals(-1, result);
-
-        result = testEpoch("2", null);
-        assertEquals(1, result);
-
-        //version
-        result = testVersion("1", "2");
-        assertEquals(-1, result);
-
-        result = testVersion("2", "1");
-        assertEquals(1, result);
-
-        result = testVersion(null, "1");
-        assertEquals(-1, result);
-
-        result = testVersion("1", null);
-        assertEquals(1, result);
-
-        //release
-        result = testRelease("1", "2");
-        assertEquals(-1, result);
-
-        result = testRelease("2", "1");
-        assertEquals(1, result);
-
-        result = testRelease(null, "1");
-        assertEquals(-1, result);
-
-        result = testRelease("1", null);
-        assertEquals(1, result);
-
-        //make sure we test alpha-numerics through rpmVersionComparator
-        result = testRelease("1.2b", "1.2c");
-        assertEquals(-1, result);
-
-        result = testRelease("1.2b3a", "1.2b2");
-        assertEquals(1, result);
-
-        //test all nulls
-        result = testEpoch(null, null);
-        assertEquals(0, result);
-
-        //test equals
-        result = PackageManager.verCmp("4", "2.1", "b3",
-                                       "4", "2.1", "b3");
-        assertEquals(0, result);
-    }
-
     /**
      * Add the up2date package to a system and a channel.  Version
      * should be specified such as "2.9.0"
@@ -426,18 +368,6 @@ public class PackageManagerTest extends BaseTestCaseWithUser {
 
 
         return p;
-    }
-
-    private int testEpoch(String e1, String e2) {
-        return PackageManager.verCmp(e1, null, null, e2, null, null);
-    }
-
-    private int testVersion(String v1, String v2) {
-        return PackageManager.verCmp("1", v1, null, "1", v2, null);
-    }
-
-    private int testRelease(String r1, String r2) {
-        return PackageManager.verCmp("1", "2", r1, "1", "2", r2);
     }
 
     /**


### PR DESCRIPTION
## What does this PR change?

This PR has some missed additions to the recent version compare refactoring using the PackageEvr.compareTo instead of some custom vercmp while its special null handling has been moved to the call sites.

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests: The existing tests for the custom vercmp was temporarily adjusted to run against the PackageEvr.compareTo while doing the same special null handling the call sites do now. All the test still passed but since it really does not test any non test code anymore they were removed as version compare already has its own tests.

- [x] **DONE**

## Links


- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
