### PR TITLE
spacecmd: Fix package details duplicated results

### DIFF
--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,4 @@
+- Fixed advanced search on 'package_listinstalledsystems'
 - Fixed duplicate results when using multiple search criteria (bsc#1180585)
 
 -------------------------------------------------------------------

--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,5 @@
+- Fixed duplicate results when using multiple search criteria (bsc#1180585)
+
 -------------------------------------------------------------------
 Wed Jan 27 12:57:11 CET 2021 - jgonzalez@suse.com
 

--- a/spacecmd/src/spacecmd/package.py
+++ b/spacecmd/src/spacecmd/package.py
@@ -293,9 +293,7 @@ def do_package_listinstalledsystems(self, args):
         self.help_package_listinstalledsystems()
         return 1
 
-    packages = []
-    for package in args:
-        packages.extend(self.do_package_search(package, True))
+    packages = self.do_package_search(' '.join(args), True)
 
     if not packages:
         logging.warning(_N('No packages found'))

--- a/spacecmd/src/spacecmd/package.py
+++ b/spacecmd/src/spacecmd/package.py
@@ -61,9 +61,7 @@ def do_package_details(self, args):
         self.help_package_details()
         return
 
-    packages = []
-    for package in args:
-        packages.extend(self.do_package_search(' '.join(args), True))
+    packages = self.do_package_search(' '.join(args), True)
 
     if not packages:
         logging.warning(_N('No packages found'))
@@ -344,9 +342,7 @@ def do_package_listerrata(self, args):
         self.help_package_listerrata()
         return 1
 
-    packages = []
-    for package in args:
-        packages.extend(self.do_package_search(' '.join(args), True))
+    packages = self.do_package_search(' '.join(args), True)
 
     if not packages:
         logging.warning(_N('No packages found'))
@@ -388,9 +384,7 @@ def do_package_listdependencies(self, args):
         self.help_package_listdependencies()
         return 1
 
-    packages = []
-    for package in args:
-        packages.extend(self.do_package_search(' '.join(args), True))
+    packages = self.do_package_search(' '.join(args), True)
 
     if not packages:
         logging.warning(_N('No packages found'))

--- a/spacecmd/src/spacecmd/softwarechannel.py
+++ b/spacecmd/src/spacecmd/softwarechannel.py
@@ -1377,9 +1377,7 @@ def do_softwarechannel_addpackages(self, args):
         return 1
 
     # expand the arguments to search for packages
-    package_names = []
-    for item in args:
-        package_names.extend(self.do_package_search(item, True))
+    package_names = self.do_package_search(' '.join(args), True)
 
     # get the package IDs from the names
     package_ids = []


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue that is causing duplicated results when using multiple search criteria on `package_details`, `package_listdependencies`, and `package_listerrata` commands.

This PR also fixes the "advanced search" on the `package_listinstalledsystems` command.

### [package_details, package_listdependencies and package_listerrata]
#### Before
```
server:~ # spacecmd -- package_details name:zypper | grep 'Name:' | wc -l
INFO: Connected to https://server.tf.local/rpc/api as admin
8

server:~ # spacecmd -- package_details name:zypper name:an_invalid_package | grep 'Name:' | wc -l
INFO: Connected to https://server.tf.local/rpc/api as admin
16
```

#### After
```
server:~ # spacecmd -- package_details name:zypper | grep 'Name:' | wc -l
INFO: Connected to https://server.tf.local/rpc/api as admin
8

server:~ # spacecmd -- package_details name:zypper name:an_invalid_package | grep 'Name:' | wc -l
INFO: Connected to https://server.tf.local/rpc/api as admin
8
```

### [package_listinstalledsystems]
#### Before
```
server:~ # spacecmd -- package_listinstalledsystems name:zypper and name:invalid | grep 'perl-apparmor\|zypper'
INFO: Connected to https://server.tf.local/rpc/api as admin
zypper-1.13.40-21.16.1.x86_64
zypper-1.13.45-21.21.2.x86_64
zypper-1.13.45-21.23.4.x86_64
zypper-1.13.51-21.26.4.x86_64
zypper-1.13.54-18.40.2.x86_64
zypper-1.13.55-18.43.3.x86_64
zypper-migration-plugin-0.11.1520597355.bcf74ad-1.10.noarch
zypper-migration-plugin-0.11.1520597355.bcf74ad-3.3.2.noarch

server:~ # spacecmd -- package_listinstalledsystems name:zypper or name:invalid | grep 'perl-apparmor\|zypper'
INFO: Connected to https://server.tf.local/rpc/api as admin
zypper-1.13.40-21.16.1.x86_64
zypper-1.13.45-21.21.2.x86_64
zypper-1.13.45-21.23.4.x86_64
zypper-1.13.51-21.26.4.x86_64
zypper-1.13.54-18.40.2.x86_64
zypper-1.13.55-18.43.3.x86_64
zypper-migration-plugin-0.11.1520597355.bcf74ad-1.10.noarch
zypper-migration-plugin-0.11.1520597355.bcf74ad-3.3.2.noarch
perl-apparmor-2.8.2-49.21.x86_64
perl-apparmor-2.8.2-51.10.1.x86_64
perl-apparmor-2.8.2-51.15.1.x86_64
perl-apparmor-2.8.2-51.18.3.x86_64
perl-apparmor-2.8.2-51.21.5.x86_64
```

#### After
```
server:~ # spacecmd -- package_listinstalledsystems name:zypper and name:invalid | grep 'perl-apparmor\|zypper'
INFO: Connected to https://server.tf.local/rpc/api as admin
WARNING: No packages found

server:~ # spacecmd -- package_listinstalledsystems name:zypper or name:invalid | grep 'perl-apparmor\|zypper'
INFO: Connected to https://server.tf.local/rpc/api as admin
zypper-1.13.40-21.16.1.x86_64
zypper-1.13.45-21.21.2.x86_64
zypper-1.13.45-21.23.4.x86_64
zypper-1.13.51-21.26.4.x86_64
zypper-1.13.54-18.40.2.x86_64
zypper-1.13.55-18.43.3.x86_64
zypper-migration-plugin-0.11.1520597355.bcf74ad-1.10.noarch
zypper-migration-plugin-0.11.1520597355.bcf74ad-3.3.2.noarch
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: This PR only fixes the expected behavior

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/13575

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
