### PR TITLE
Provide Custom Info as Pillar data

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
@@ -117,7 +117,8 @@ public class ServerFactory extends HibernateFactory {
         }
         server.getCustomDataValues().clear();
         server.asMinionServer().ifPresent(minion -> {
-           MinionPillarManager.INSTANCE.generatePillar(minion);
+           MinionPillarManager.INSTANCE.generatePillar(minion, false,
+               MinionPillarManager.PillarSubset.CUSTOM_INFO);
         });
     }
 
@@ -134,7 +135,8 @@ public class ServerFactory extends HibernateFactory {
             SINGLETON.removeObject(value);
         }
         server.asMinionServer().ifPresent(minion -> {
-           MinionPillarManager.INSTANCE.generatePillar(minion);
+           MinionPillarManager.INSTANCE.generatePillar(minion, false,
+               MinionPillarManager.PillarSubset.CUSTOM_INFO);
         });
     }
 
@@ -693,7 +695,8 @@ public class ServerFactory extends HibernateFactory {
             server.getCustomDataValues().remove(value);
             SINGLETON.removeObject(value);
             server.asMinionServer().ifPresent(minion -> {
-                MinionPillarManager.INSTANCE.generatePillar(minion);
+                MinionPillarManager.INSTANCE.generatePillar(minion, false,
+                    MinionPillarManager.PillarSubset.CUSTOM_INFO);
             });
         }
 

--- a/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
@@ -40,6 +40,7 @@ import com.redhat.rhn.manager.rhnset.RhnSetDecl;
 import com.redhat.rhn.manager.system.UpdateBaseChannelCommand;
 
 import com.suse.manager.model.maintenance.MaintenanceSchedule;
+import com.suse.manager.webui.services.pillar.MinionPillarManager;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
@@ -115,6 +116,9 @@ public class ServerFactory extends HibernateFactory {
             SINGLETON.removeObject(value);
         }
         server.getCustomDataValues().clear();
+        server.asMinionServer().ifPresent(minion -> {
+           MinionPillarManager.INSTANCE.generatePillar(minion);
+        });
     }
 
     /**
@@ -129,6 +133,9 @@ public class ServerFactory extends HibernateFactory {
         if (value != null) {
             SINGLETON.removeObject(value);
         }
+        server.asMinionServer().ifPresent(minion -> {
+           MinionPillarManager.INSTANCE.generatePillar(minion);
+        });
     }
 
     /**
@@ -682,7 +689,12 @@ public class ServerFactory extends HibernateFactory {
         List<CustomDataValue> values = lookupCustomDataValues(keyIn);
         for (Iterator itr = values.iterator(); itr.hasNext();) {
             CustomDataValue value = (CustomDataValue) itr.next();
+            Server server = value.getServer();
+            server.getCustomDataValues().remove(value);
             SINGLETON.removeObject(value);
+            server.asMinionServer().ifPresent(minion -> {
+                MinionPillarManager.INSTANCE.generatePillar(minion);
+            });
         }
 
         SINGLETON.removeObject(keyIn);

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/UpdateCustomDataAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/UpdateCustomDataAction.java
@@ -134,6 +134,11 @@ public class UpdateCustomDataAction extends RhnAction {
             cdv.setModified(new Date());
             cdv.setLastModifier(user);
             server.addCustomDataValue(cdv);
+            server.asMinionServer().ifPresent(minion -> {
+                MinionPillarManager.INSTANCE.generatePillar(minion, false,
+                    MinionPillarManager.PillarSubset.CUSTOM_INFO);
+            });
+
             request.setAttribute(VAL_PARAM, form.get(VAL_PARAM));
             return getStrutsDelegate().forwardParams(mapping.findForward("updated"),
                     params);

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/UpdateCustomDataAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/UpdateCustomDataAction.java
@@ -27,6 +27,7 @@ import com.redhat.rhn.frontend.struts.RhnHelper;
 import com.redhat.rhn.frontend.struts.RhnValidationHelper;
 import com.redhat.rhn.frontend.struts.StrutsDelegate;
 import com.redhat.rhn.manager.system.SystemManager;
+import com.suse.manager.webui.services.pillar.MinionPillarManager;
 
 import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionForward;
@@ -134,6 +135,9 @@ public class UpdateCustomDataAction extends RhnAction {
             cdv.setCreator(user);
             cdv.setLastModifier(user);
             request.setAttribute(VAL_PARAM, form.get(VAL_PARAM));
+            server.asMinionServer().ifPresent(minion -> {
+                MinionPillarManager.INSTANCE.generatePillar(minion);
+            });
             return getStrutsDelegate().forwardParams(mapping.findForward("updated"),
                     params);
         }

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/UpdateCustomDataAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/UpdateCustomDataAction.java
@@ -124,20 +124,17 @@ public class UpdateCustomDataAction extends RhnAction {
                 return getStrutsDelegate().forwardParams(
                         mapping.findForward(RhnHelper.DEFAULT_FORWARD), params);
             }
-            server.addCustomDataValue(key.getLabel(), (String)form.get(VAL_PARAM), user);
             if (cdv == null) {
                 cdv = new CustomDataValue();
                 cdv.setKey(key);
-                cdv.setValue((String)form.get(VAL_PARAM));
+                cdv.setCreated(new Date());
+                cdv.setCreator(user);
             }
+            cdv.setValue((String)form.get(VAL_PARAM));
             cdv.setModified(new Date());
-            cdv.setCreated(new Date());
-            cdv.setCreator(user);
             cdv.setLastModifier(user);
+            server.addCustomDataValue(cdv);
             request.setAttribute(VAL_PARAM, form.get(VAL_PARAM));
-            server.asMinionServer().ifPresent(minion -> {
-                MinionPillarManager.INSTANCE.generatePillar(minion);
-            });
             return getStrutsDelegate().forwardParams(mapping.findForward("updated"),
                     params);
         }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -2015,7 +2015,8 @@ public class SystemHandler extends BaseHandler {
         }
 
         server.asMinionServer().ifPresent(minion -> {
-            MinionPillarManager.INSTANCE.generatePillar(minion);
+            MinionPillarManager.INSTANCE.generatePillar(minion, false,
+                MinionPillarManager.PillarSubset.CUSTOM_INFO);
         });
 
         // If we skipped any keys, we need to throw an exception and let the user know.

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -170,6 +170,7 @@ import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 import com.redhat.rhn.manager.token.ActivationKeyManager;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 
+import com.suse.manager.webui.services.pillar.MinionPillarManager;
 import com.suse.manager.webui.utils.gson.BootstrapParameters;
 
 import org.apache.commons.lang3.StringUtils;
@@ -2012,6 +2013,10 @@ public class SystemHandler extends BaseHandler {
                 skippedKeys.add(label);
             }
         }
+
+        server.asMinionServer().ifPresent(minion -> {
+            MinionPillarManager.INSTANCE.generatePillar(minion);
+        });
 
         // If we skipped any keys, we need to throw an exception and let the user know.
         if (skippedKeys.size() > 0) {

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
@@ -1083,7 +1083,7 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
     private Map<String, Object> readCustomInfoPillar(MinionServer minion) throws Exception {
         Path filePath = tmpPillarRoot.resolve(
                 PILLAR_DATA_FILE_PREFIX + "_" +
-                minion.getMinionId() + "." +
+                minion.getMinionId() + "_custom_info." +
                 PILLAR_DATA_FILE_EXT);
 
         assertTrue(Files.exists(filePath));
@@ -1187,8 +1187,12 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
         val = server.getCustomDataValue(testKey);
         assertNull(val);
 
-        pillar = readCustomInfoPillar(server);
-        assertFalse(pillar.containsKey(keyLabel));
+        Path filePath = tmpPillarRoot.resolve(
+                PILLAR_DATA_FILE_PREFIX + "_" +
+                server.getMinionId() + "_custom_info." +
+                PILLAR_DATA_FILE_EXT);
+
+        assertFalse(Files.exists(filePath));
     }
 
     public void testListUserSystems() throws Exception {

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
@@ -151,7 +151,11 @@ import org.jmock.Mockery;
 import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.jmock.integration.junit3.JUnit3Mockery;
 import org.jmock.lib.concurrent.Synchroniser;
+import org.yaml.snakeyaml.Yaml;
 
+import java.io.FileInputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
@@ -169,6 +173,9 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+
+import static com.suse.manager.webui.services.SaltConstants.PILLAR_DATA_FILE_PREFIX;
+import static com.suse.manager.webui.services.SaltConstants.PILLAR_DATA_FILE_EXT;
 
 public class SystemHandlerTest extends BaseHandlerTestCase {
 
@@ -1073,8 +1080,27 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
         return longString.toString();
     }
 
+    private Map<String, Object> readCustomInfoPillar(MinionServer minion) throws Exception {
+        Path filePath = tmpPillarRoot.resolve(
+                PILLAR_DATA_FILE_PREFIX + "_" +
+                minion.getMinionId() + "." +
+                PILLAR_DATA_FILE_EXT);
+
+        assertTrue(Files.exists(filePath));
+
+        Map<String, Object> map;
+        try (FileInputStream fi = new FileInputStream(filePath.toFile())) {
+            map = new Yaml().loadAs(fi, Map.class);
+        }
+
+        assertTrue(map.containsKey("custom_info"));
+        map = (Map<String, Object>)map.get("custom_info");
+
+        return map;
+    }
+
     public void testCustomDataValues() throws Exception {
-        Server server = ServerFactoryTest.createTestServer(admin);
+        MinionServer server = MinionServerFactoryTest.createTestMinionServer(admin);
         CustomDataKey testKey = CustomDataKeyTest.createTestCustomDataKey(admin);
 
         // setCustomValues
@@ -1104,6 +1130,11 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
         val = server.getCustomDataValue(testKey);
         assertEquals(val2, val.getValue());
         assertEquals(1, setResult);
+
+        Map<String, Object> pillar = readCustomInfoPillar(server);
+
+        assertTrue(pillar.containsKey(keyLabel));
+        assertEquals(val2, pillar.get(keyLabel));
 
         // try to set custom values with some undefined keys
         valuesToSet.put(fooKey, val1);
@@ -1138,6 +1169,10 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
         val = server.getCustomDataValue(testKey);
         assertNotNull(val);
 
+        pillar = readCustomInfoPillar(server);
+        assertTrue(pillar.containsKey(keyLabel));
+        assertEquals(val2, pillar.get(keyLabel));
+
         result = handler.getCustomValues(admin, server.getId().intValue());
         assertEquals(1, result.size());
 
@@ -1151,6 +1186,9 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
         assertEquals(1, setResult);
         val = server.getCustomDataValue(testKey);
         assertNull(val);
+
+        pillar = readCustomInfoPillar(server);
+        assertFalse(pillar.containsKey(keyLabel));
     }
 
     public void testListUserSystems() throws Exception {

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/test/BaseHandlerTestCase.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/test/BaseHandlerTestCase.java
@@ -26,6 +26,7 @@ import com.redhat.rhn.testing.UserTestUtils;
 import com.suse.manager.webui.services.pillar.MinionGeneralPillarGenerator;
 import com.suse.manager.webui.services.pillar.MinionGroupMembershipPillarGenerator;
 import com.suse.manager.webui.services.pillar.MinionPillarFileManager;
+import com.suse.manager.webui.services.pillar.MinionPillarManager;
 import com.suse.manager.webui.services.SaltStateGeneratorService;
 
 import java.nio.file.Files;
@@ -88,6 +89,7 @@ public class BaseHandlerTestCase extends RhnBaseTestCase {
         minionGeneralPillarFileManager.setPillarDataPath(tmpPillarRoot.toAbsolutePath());
         SaltStateGeneratorService.INSTANCE.setSuseManagerStatesFilesRoot(tmpSaltRoot
                 .toAbsolutePath());
+        MinionPillarManager.INSTANCE.setPillarDataPath(tmpPillarRoot.toAbsolutePath());
         Files.createDirectory(tmpSaltRoot.resolve(SALT_CONFIG_STATES_DIR));
     }
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/test/BaseHandlerTestCase.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/test/BaseHandlerTestCase.java
@@ -23,9 +23,6 @@ import com.redhat.rhn.testing.RhnBaseTestCase;
 import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
 
-import com.suse.manager.webui.services.pillar.MinionGeneralPillarGenerator;
-import com.suse.manager.webui.services.pillar.MinionGroupMembershipPillarGenerator;
-import com.suse.manager.webui.services.pillar.MinionPillarFileManager;
 import com.suse.manager.webui.services.pillar.MinionPillarManager;
 import com.suse.manager.webui.services.SaltStateGeneratorService;
 
@@ -49,10 +46,6 @@ public class BaseHandlerTestCase extends RhnBaseTestCase {
     protected String satAdminKey;
     protected Path tmpPillarRoot;
     protected Path tmpSaltRoot;
-    protected MinionPillarFileManager minionGroupMembershipPillarFileManager =
-            new MinionPillarFileManager(new MinionGroupMembershipPillarGenerator());
-    protected MinionPillarFileManager minionGeneralPillarFileManager =
-            new MinionPillarFileManager(new MinionGeneralPillarGenerator());
 
     @Override
     public void setUp() throws Exception {
@@ -85,11 +78,9 @@ public class BaseHandlerTestCase extends RhnBaseTestCase {
 
         tmpPillarRoot = Files.createTempDirectory("pillar");
         tmpSaltRoot = Files.createTempDirectory("salt");
-        minionGroupMembershipPillarFileManager.setPillarDataPath(tmpPillarRoot.toAbsolutePath());
-        minionGeneralPillarFileManager.setPillarDataPath(tmpPillarRoot.toAbsolutePath());
+        MinionPillarManager.INSTANCE.setPillarDataPath(tmpPillarRoot.toAbsolutePath());
         SaltStateGeneratorService.INSTANCE.setSuseManagerStatesFilesRoot(tmpSaltRoot
                 .toAbsolutePath());
-        MinionPillarManager.INSTANCE.setPillarDataPath(tmpPillarRoot.toAbsolutePath());
         Files.createDirectory(tmpSaltRoot.resolve(SALT_CONFIG_STATES_DIR));
     }
 

--- a/java/code/src/com/redhat/rhn/manager/system/ServerGroupManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/ServerGroupManager.java
@@ -31,8 +31,7 @@ import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.domain.user.UserFactory;
 
 import com.suse.manager.webui.services.SaltStateGeneratorService;
-import com.suse.manager.webui.services.pillar.MinionGroupMembershipPillarGenerator;
-import com.suse.manager.webui.services.pillar.MinionPillarFileManager;
+import com.suse.manager.webui.services.pillar.MinionPillarManager;
 import com.suse.utils.Opt;
 
 import org.apache.log4j.Logger;
@@ -53,17 +52,6 @@ public class ServerGroupManager {
 
     /** Logger */
     private static final Logger LOG = Logger.getLogger(ServerGroupManager.class);
-
-    private MinionPillarFileManager minionGroupMembershipPillarFileManager =
-            new MinionPillarFileManager(new MinionGroupMembershipPillarGenerator());
-
-    /**
-     * Only used for unit tests.
-     * @param pillarFileManagerIn to set
-     */
-    public void setMinionGroupMembershipPillarFileManager(MinionPillarFileManager pillarFileManagerIn) {
-        this.minionGroupMembershipPillarFileManager = pillarFileManagerIn;
-    }
 
     /**
      * Lookup a ServerGroup by ID and organization.
@@ -350,7 +338,8 @@ public class ServerGroupManager {
      */
     public void updatePillarAfterGroupUpdateForServers(Collection<Server> servers) {
         servers.stream().map(server -> server.asMinionServer()).flatMap(Opt::stream)
-                .forEach(this.minionGroupMembershipPillarFileManager::updatePillarFile);
+                .forEach(s -> MinionPillarManager.INSTANCE.generatePillar(s, false,
+                         MinionPillarManager.PillarSubset.GROUP_MEMBERSHIP));
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/system/entitling/SystemEntitler.java
+++ b/java/code/src/com/redhat/rhn/manager/system/entitling/SystemEntitler.java
@@ -45,8 +45,7 @@ import com.suse.manager.webui.services.iface.MonitoringManager;
 import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.VirtManager;
 import com.suse.manager.webui.services.impl.SaltSSHService;
-import com.suse.manager.webui.services.pillar.MinionPillarFileManager;
-import com.suse.manager.webui.services.pillar.MinionVirtualizationPillarGenerator;
+import com.suse.manager.webui.services.pillar.MinionPillarManager;
 
 import org.apache.log4j.Logger;
 
@@ -138,7 +137,8 @@ public class SystemEntitler {
             if (wasVirtEntitled && !EntitlementManager.VIRTUALIZATION.equals(ent) ||
                     !wasVirtEntitled && EntitlementManager.VIRTUALIZATION.equals(ent)) {
                 this.updateLibvirtEngine(minion);
-                new MinionPillarFileManager(new MinionVirtualizationPillarGenerator()).updatePillarFile(minion);
+                MinionPillarManager.INSTANCE.generatePillar(minion, false,
+                    MinionPillarManager.PillarSubset.VIRTUALIZATION);
             }
 
             if (EntitlementManager.MONITORING.equals(ent)) {

--- a/java/code/src/com/redhat/rhn/manager/system/entitling/SystemUnentitler.java
+++ b/java/code/src/com/redhat/rhn/manager/system/entitling/SystemUnentitler.java
@@ -25,8 +25,7 @@ import com.redhat.rhn.manager.system.ServerGroupManager;
 
 import com.suse.manager.webui.services.iface.MonitoringManager;
 import com.suse.manager.webui.services.iface.VirtManager;
-import com.suse.manager.webui.services.pillar.MinionPillarFileManager;
-import com.suse.manager.webui.services.pillar.MinionVirtualizationPillarGenerator;
+import com.suse.manager.webui.services.pillar.MinionPillarManager;
 
 import org.apache.log4j.Logger;
 
@@ -101,7 +100,8 @@ public class SystemUnentitler {
 
             if (EntitlementManager.VIRTUALIZATION.equals(ent)) {
                 virtManager.updateLibvirtEngine(s);
-                new MinionPillarFileManager(new MinionVirtualizationPillarGenerator()).updatePillarFile(s);
+                MinionPillarManager.INSTANCE.generatePillar(s, false,
+                    MinionPillarManager.PillarSubset.VIRTUALIZATION);
             }
         });
     }

--- a/java/code/src/com/redhat/rhn/testing/BaseTestCaseWithUser.java
+++ b/java/code/src/com/redhat/rhn/testing/BaseTestCaseWithUser.java
@@ -19,9 +19,7 @@ import com.redhat.rhn.domain.org.OrgFactory;
 import com.redhat.rhn.domain.user.User;
 
 import com.suse.manager.webui.services.SaltStateGeneratorService;
-import com.suse.manager.webui.services.pillar.MinionGeneralPillarGenerator;
-import com.suse.manager.webui.services.pillar.MinionGroupMembershipPillarGenerator;
-import com.suse.manager.webui.services.pillar.MinionPillarFileManager;
+import com.suse.manager.webui.services.pillar.MinionPillarManager;
 
 import org.apache.commons.io.FileUtils;
 
@@ -39,10 +37,6 @@ public abstract class BaseTestCaseWithUser extends RhnBaseTestCase {
     private boolean committed = false;
     protected Path tmpPillarRoot;
     protected Path tmpSaltRoot;
-    protected MinionPillarFileManager minionGroupMembershipPillarFileManager =
-            new MinionPillarFileManager(new MinionGroupMembershipPillarGenerator());
-    protected MinionPillarFileManager minionGeneralPillarFileManager =
-            new MinionPillarFileManager(new MinionGeneralPillarGenerator());
 
     /**
      * {@inheritDoc}
@@ -55,8 +49,7 @@ public abstract class BaseTestCaseWithUser extends RhnBaseTestCase {
         KickstartDataTest.setupTestConfiguration(user);
         tmpPillarRoot = Files.createTempDirectory("pillar");
         tmpSaltRoot = Files.createTempDirectory("salt");
-        minionGroupMembershipPillarFileManager.setPillarDataPath(tmpPillarRoot.toAbsolutePath());
-        minionGeneralPillarFileManager.setPillarDataPath(tmpPillarRoot.toAbsolutePath());
+        MinionPillarManager.INSTANCE.setPillarDataPath(tmpPillarRoot.toAbsolutePath());
         SaltStateGeneratorService.INSTANCE.setSuseManagerStatesFilesRoot(tmpSaltRoot
                 .toAbsolutePath());
         Files.createDirectory(tmpSaltRoot.resolve(SALT_CONFIG_STATES_DIR));

--- a/java/code/src/com/redhat/rhn/testing/JMockBaseTestCaseWithUser.java
+++ b/java/code/src/com/redhat/rhn/testing/JMockBaseTestCaseWithUser.java
@@ -14,14 +14,11 @@
  */
 package com.redhat.rhn.testing;
 
-import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.kickstart.test.KickstartDataTest;
 import com.redhat.rhn.domain.user.User;
 
 import com.suse.manager.webui.services.SaltStateGeneratorService;
-import com.suse.manager.webui.services.pillar.MinionGeneralPillarGenerator;
-import com.suse.manager.webui.services.pillar.MinionGroupMembershipPillarGenerator;
-import com.suse.manager.webui.services.pillar.MinionPillarFileManager;
+import com.suse.manager.webui.services.pillar.MinionPillarManager;
 
 import org.apache.commons.io.FileUtils;
 
@@ -38,10 +35,6 @@ public abstract class JMockBaseTestCaseWithUser extends RhnJmockBaseTestCase {
     protected User user;
     protected Path tmpPillarRoot;
     protected Path tmpSaltRoot;
-    protected MinionPillarFileManager minionGroupMembershipPillarFileManager =
-            new MinionPillarFileManager(new MinionGroupMembershipPillarGenerator());
-    protected MinionPillarFileManager minionGeneralPillarFileManager =
-            new MinionPillarFileManager(new MinionGeneralPillarGenerator());
 
     /**
      * {@inheritDoc}
@@ -54,13 +47,10 @@ public abstract class JMockBaseTestCaseWithUser extends RhnJmockBaseTestCase {
         KickstartDataTest.setupTestConfiguration(user);
         tmpPillarRoot = Files.createTempDirectory("pillar");
         tmpSaltRoot = Files.createTempDirectory("salt");
-        minionGroupMembershipPillarFileManager.setPillarDataPath(tmpPillarRoot.toAbsolutePath());
-        minionGeneralPillarFileManager.setPillarDataPath(tmpPillarRoot.toAbsolutePath());
+        MinionPillarManager.INSTANCE.setPillarDataPath(tmpPillarRoot.toAbsolutePath());
         SaltStateGeneratorService.INSTANCE.setSuseManagerStatesFilesRoot(tmpSaltRoot
                 .toAbsolutePath());
         Files.createDirectory(tmpSaltRoot.resolve(SALT_CONFIG_STATES_DIR));
-        GlobalInstanceHolder.SERVER_GROUP_MANAGER
-                .setMinionGroupMembershipPillarFileManager(minionGroupMembershipPillarFileManager);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/testing/RhnMockStrutsTestCase.java
+++ b/java/code/src/com/redhat/rhn/testing/RhnMockStrutsTestCase.java
@@ -23,9 +23,7 @@ import java.util.TimeZone;
 import javax.servlet.http.Cookie;
 
 import com.suse.manager.webui.services.SaltStateGeneratorService;
-import com.suse.manager.webui.services.pillar.MinionGeneralPillarGenerator;
-import com.suse.manager.webui.services.pillar.MinionGroupMembershipPillarGenerator;
-import com.suse.manager.webui.services.pillar.MinionPillarFileManager;
+import com.suse.manager.webui.services.pillar.MinionPillarManager;
 
 import org.apache.struts.action.DynaActionForm;
 import org.hibernate.HibernateException;
@@ -54,10 +52,6 @@ import com.redhat.rhn.frontend.struts.RhnAction;
 public class RhnMockStrutsTestCase extends MockStrutsTestCase {
 
     protected User user;
-    protected MinionPillarFileManager minionGroupMembershipPillarFileManager =
-            new MinionPillarFileManager(new MinionGroupMembershipPillarGenerator());
-    protected MinionPillarFileManager minionGeneralPillarFileManager =
-            new MinionPillarFileManager(new MinionGeneralPillarGenerator());
 
     /**
      * {@inheritDoc}
@@ -96,8 +90,7 @@ public class RhnMockStrutsTestCase extends MockStrutsTestCase {
         //Set temporary Salt directories for local runs
         Path tmpPillarRoot = Files.createTempDirectory("pillar");
         Path tmpSaltRoot = Files.createTempDirectory("salt");
-        minionGroupMembershipPillarFileManager.setPillarDataPath(tmpPillarRoot.toAbsolutePath());
-        minionGeneralPillarFileManager.setPillarDataPath(tmpPillarRoot.toAbsolutePath());
+        MinionPillarManager.INSTANCE.setPillarDataPath(tmpPillarRoot.toAbsolutePath());
         SaltStateGeneratorService.INSTANCE.setSuseManagerStatesFilesRoot(tmpSaltRoot
                 .toAbsolutePath());
     }

--- a/java/code/src/com/suse/manager/webui/services/pillar/MinionCustomInfoPillarGenerator.java
+++ b/java/code/src/com/suse/manager/webui/services/pillar/MinionCustomInfoPillarGenerator.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.suse.manager.webui.services.pillar;
+
+import static com.suse.manager.webui.services.SaltConstants.PILLAR_DATA_FILE_EXT;
+import static com.suse.manager.webui.services.SaltConstants.PILLAR_DATA_FILE_PREFIX;
+
+import com.redhat.rhn.domain.server.MinionServer;
+
+import com.suse.manager.webui.utils.SaltPillar;
+
+import org.apache.log4j.Logger;
+
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Class for generating minion pillar data containing CustomInfo information of minions
+ */
+public class MinionCustomInfoPillarGenerator implements MinionPillarGenerator {
+
+    /** Logger */
+    private static final Logger LOG = Logger.getLogger(MinionCustomInfoPillarGenerator.class);
+
+    public static final MinionCustomInfoPillarGenerator INSTANCE = new MinionCustomInfoPillarGenerator();
+
+    /**
+     * Generates pillar data containing CustomInfo information of the passed minion
+     * @param minion the minion server
+     * @return the SaltPillar containing the pillar data
+     */
+    @Override
+    public Optional<SaltPillar> generatePillarData(MinionServer minion) {
+        if (minion.getCustomDataValues().isEmpty()) {
+            return Optional.empty();
+        }
+        SaltPillar pillar = new SaltPillar();
+        pillar.add("custom_info", minion.getCustomDataValues().stream()
+                .collect(Collectors.toMap(a -> a.getKey().getLabel(), a -> a.getValue())));
+        return Optional.of(pillar);
+    }
+
+    @Override
+    public String getFilename(String minionId) {
+        return PILLAR_DATA_FILE_PREFIX + "_" + minionId + "_custom_info." + PILLAR_DATA_FILE_EXT;
+    }
+
+}

--- a/java/code/src/com/suse/manager/webui/services/pillar/MinionGeneralPillarGenerator.java
+++ b/java/code/src/com/suse/manager/webui/services/pillar/MinionGeneralPillarGenerator.java
@@ -32,7 +32,6 @@ import org.apache.log4j.Logger;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Class for generating minion pillar data containing general information of minions
@@ -88,8 +87,6 @@ public class MinionGeneralPillarGenerator implements MinionPillarGenerator {
             pillar.add("beacons", beaconConfig);
         }
 
-        pillar.add("custom_info", minion.getCustomDataValues().stream()
-                .collect(Collectors.toMap(a -> a.getKey().getLabel(), a -> a.getValue())));
         return Optional.of(pillar);
     }
 

--- a/java/code/src/com/suse/manager/webui/services/pillar/MinionGeneralPillarGenerator.java
+++ b/java/code/src/com/suse/manager/webui/services/pillar/MinionGeneralPillarGenerator.java
@@ -32,6 +32,7 @@ import org.apache.log4j.Logger;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * Class for generating minion pillar data containing general information of minions
@@ -86,6 +87,9 @@ public class MinionGeneralPillarGenerator implements MinionPillarGenerator {
         if (!beaconConfig.isEmpty()) {
             pillar.add("beacons", beaconConfig);
         }
+
+        pillar.add("custom_info", minion.getCustomDataValues().stream()
+                .collect(Collectors.toMap(a -> a.getKey().getLabel(), a -> a.getValue())));
         return Optional.of(pillar);
     }
 

--- a/java/code/src/com/suse/manager/webui/services/pillar/MinionPillarManager.java
+++ b/java/code/src/com/suse/manager/webui/services/pillar/MinionPillarManager.java
@@ -21,6 +21,7 @@ import com.redhat.rhn.domain.server.MinionServer;
 
 import org.apache.log4j.Logger;
 
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -79,6 +80,13 @@ public class MinionPillarManager {
      */
     public void removePillar(String minionId) {
         this.pillarFileManagers.stream().forEach(m -> m.removePillarFile(minionId));
+    }
+
+    /**
+     * @param pillarDataPathIn the root path where pillar files are generated
+     */
+    public void setPillarDataPath(Path pillarDataPathIn) {
+        this.pillarFileManagers.stream().forEach(m -> m.setPillarDataPath(pillarDataPathIn));
     }
 
 }

--- a/java/code/src/com/suse/manager/webui/services/pillar/MinionPillarManager.java
+++ b/java/code/src/com/suse/manager/webui/services/pillar/MinionPillarManager.java
@@ -22,10 +22,8 @@ import com.redhat.rhn.domain.server.MinionServer;
 import org.apache.log4j.Logger;
 
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 
 /**
  * Manager class for generating or removing minion pillar files.
@@ -36,6 +34,7 @@ public class MinionPillarManager {
         GENERAL,
         GROUP_MEMBERSHIP,
         VIRTUALIZATION,
+        CUSTOM_INFO
     };
 
     /** Logger */
@@ -44,24 +43,29 @@ public class MinionPillarManager {
     public static final MinionPillarManager INSTANCE = new MinionPillarManager(
                     new MinionPillarFileManager(MinionGeneralPillarGenerator.INSTANCE),
                     new MinionPillarFileManager(MinionGroupMembershipPillarGenerator.INSTANCE),
-                    new MinionPillarFileManager(MinionVirtualizationPillarGenerator.INSTANCE));
+                    new MinionPillarFileManager(MinionVirtualizationPillarGenerator.INSTANCE),
+                    new MinionPillarFileManager(MinionCustomInfoPillarGenerator.INSTANCE));
 
     private MinionPillarFileManager generalPillarFileManager;
     private MinionPillarFileManager groupMembershipPillarFileManager;
     private MinionPillarFileManager virtualizationPillarFileManager;
+    private MinionPillarFileManager customInfoPillarFileManager;
 
     /**
      * Constructor for MinionPillarManager
      * @param generalPillarFileManagerIn general pillar file manager
      * @param groupMembershipPillarFileManagerIn group membership pillar file manager
      * @param virtualizationPillarFileManagerIn virtualization pillar file manager
+     * @param customInfoPillarFileManagerIn custom info pillar file manager
      */
     public MinionPillarManager(MinionPillarFileManager generalPillarFileManagerIn,
                                MinionPillarFileManager groupMembershipPillarFileManagerIn,
-                               MinionPillarFileManager virtualizationPillarFileManagerIn) {
+                               MinionPillarFileManager virtualizationPillarFileManagerIn,
+                               MinionPillarFileManager customInfoPillarFileManagerIn) {
         this.generalPillarFileManager = generalPillarFileManagerIn;
         this.groupMembershipPillarFileManager = groupMembershipPillarFileManagerIn;
         this.virtualizationPillarFileManager = virtualizationPillarFileManagerIn;
+        this.customInfoPillarFileManager = customInfoPillarFileManagerIn;
     }
 
     /**
@@ -94,6 +98,9 @@ public class MinionPillarManager {
                 case VIRTUALIZATION:
                     virtualizationPillarFileManager.updatePillarFile(minion);
                     break;
+                case CUSTOM_INFO:
+                    customInfoPillarFileManager.updatePillarFile(minion);
+                    break;
                 default:
                     throw new RuntimeException("unreachable");
             }
@@ -116,6 +123,7 @@ public class MinionPillarManager {
         generalPillarFileManager.updatePillarFile(minion);
         groupMembershipPillarFileManager.updatePillarFile(minion);
         virtualizationPillarFileManager.updatePillarFile(minion);
+        customInfoPillarFileManager.updatePillarFile(minion);
     }
 
     /**
@@ -126,6 +134,7 @@ public class MinionPillarManager {
         generalPillarFileManager.removePillarFile(minionId);
         groupMembershipPillarFileManager.removePillarFile(minionId);
         virtualizationPillarFileManager.removePillarFile(minionId);
+        customInfoPillarFileManager.removePillarFile(minionId);
     }
 
     /**
@@ -135,6 +144,7 @@ public class MinionPillarManager {
         generalPillarFileManager.setPillarDataPath(pillarDataPathIn);
         groupMembershipPillarFileManager.setPillarDataPath(pillarDataPathIn);
         virtualizationPillarFileManager.setPillarDataPath(pillarDataPathIn);
+        customInfoPillarFileManager.setPillarDataPath(pillarDataPathIn);
     }
 
 }

--- a/java/code/src/com/suse/manager/webui/services/pillar/test/MinionGroupMembershipPillarGeneratorTest.java
+++ b/java/code/src/com/suse/manager/webui/services/pillar/test/MinionGroupMembershipPillarGeneratorTest.java
@@ -23,6 +23,9 @@ import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
 import com.redhat.rhn.domain.server.test.ServerGroupTest;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
 import com.redhat.rhn.testing.TestUtils;
+import com.suse.manager.webui.services.pillar.MinionGroupMembershipPillarGenerator;
+import com.suse.manager.webui.services.pillar.MinionPillarFileManager;
+
 import org.apache.commons.codec.digest.DigestUtils;
 import org.yaml.snakeyaml.Yaml;
 
@@ -41,9 +44,13 @@ import static com.suse.manager.webui.services.SaltConstants.PILLAR_DATA_FILE_EXT
  */
 public class MinionGroupMembershipPillarGeneratorTest extends BaseTestCaseWithUser {
 
+    protected MinionPillarFileManager minionGroupMembershipPillarFileManager =
+            new MinionPillarFileManager(new MinionGroupMembershipPillarGenerator());
+
     @Override
     public void setUp() throws Exception {
         super.setUp();
+        minionGroupMembershipPillarFileManager.setPillarDataPath(tmpPillarRoot.toAbsolutePath());
         Config.get().setString("server.secret_key",
                 DigestUtils.sha256Hex(TestUtils.randomString()));
     }

--- a/java/code/src/com/suse/manager/webui/services/pillar/test/MinionPillarManagerTest.java
+++ b/java/code/src/com/suse/manager/webui/services/pillar/test/MinionPillarManagerTest.java
@@ -49,15 +49,11 @@ import static com.suse.manager.webui.services.SaltConstants.PILLAR_DATA_FILE_EXT
  */
 public class MinionPillarManagerTest extends BaseTestCaseWithUser {
 
-    protected MinionPillarManager minionPillarManager;
-
     @Override
     public void setUp() throws Exception {
         super.setUp();
         Config.get().setString("server.secret_key",
                 DigestUtils.sha256Hex(TestUtils.randomString()));
-        minionPillarManager = new MinionPillarManager(
-                Arrays.asList(this.minionGeneralPillarFileManager, this.minionGroupMembershipPillarFileManager));
     }
 
     public void testGeneratePillarForServer() throws Exception {
@@ -75,7 +71,7 @@ public class MinionPillarManagerTest extends BaseTestCaseWithUser {
         minion.addChannel(channel2);
 
         ServerFactory.save(minion);
-        minionPillarManager.generatePillar(minion);
+        MinionPillarManager.INSTANCE.generatePillar(minion);
 
         Path filePath = tmpPillarRoot.resolve(
                 PILLAR_DATA_FILE_PREFIX + "_" +
@@ -143,7 +139,7 @@ public class MinionPillarManagerTest extends BaseTestCaseWithUser {
         minion.addChannel(channel1);
         ServerFactory.save(minion);
 
-        minionPillarManager.generatePillar(minion);
+        MinionPillarManager.INSTANCE.generatePillar(minion);
 
         Path filePath = tmpPillarRoot
                 .resolve(PILLAR_DATA_FILE_PREFIX + "_" + minion.getMinionId() + "." + PILLAR_DATA_FILE_EXT);
@@ -172,7 +168,7 @@ public class MinionPillarManagerTest extends BaseTestCaseWithUser {
         minion.addChannel(channel1);
         ServerFactory.save(minion);
 
-        minionPillarManager.generatePillar(minion);
+        MinionPillarManager.INSTANCE.generatePillar(minion);
 
         Path filePath = tmpPillarRoot.resolve(
             PILLAR_DATA_FILE_PREFIX + "_" +
@@ -228,7 +224,7 @@ public class MinionPillarManagerTest extends BaseTestCaseWithUser {
         HibernateFactory.getSession().flush();
         HibernateFactory.getSession().refresh(minion);
 
-        minionPillarManager.generatePillar(minion);
+        MinionPillarManager.INSTANCE.generatePillar(minion);
 
         Path filePath = tmpPillarRoot.resolve(
                 PILLAR_DATA_FILE_PREFIX + "_" +

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Provide Custom Info as Pillar data
 - remove deprecated xmlrpc functions
 - Only update the kickstart path in cobbler if necessary (bsc#1175216)
 - enhance config channel API with list assigned groups

--- a/susemanager-utils/susemanager-sls/modules/pillar/suma_minion.py
+++ b/susemanager-utils/susemanager-sls/modules/pillar/suma_minion.py
@@ -47,7 +47,7 @@ MANAGER_GLOBAL_PILLAR = [
 ]
 
 MINION_PILLAR_FILES_PREFIX = "pillar_{minion_id}"
-MINION_PILLAR_FILES_SUFFIXES = [".yml", "_group_memberships.yml", "_virtualization.yml"]
+MINION_PILLAR_FILES_SUFFIXES = [".yml", "_group_memberships.yml", "_virtualization.yml", "_custom_info.yml"]
 
 CONFIG_FILE = '/etc/rhn/rhn.conf'
 

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Provide Custom Info as Pillar data
 - Add support for Amazon Linux 2
 - add allow vendor change option to pathing via salt 
 - Prevent useless package list refresh actions on zypper minions (bsc#1183661)


### PR DESCRIPTION
## What does this PR change?

Provide Custom Info as Pillar data

## GUI diff

No difference.

## Documentation

- TBD
- [ ] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/12016

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
