### PR TITLE
Truncate author name in the changelog

### DIFF
--- a/backend/server/importlib/packageImport.py
+++ b/backend/server/importlib/packageImport.py
@@ -288,9 +288,10 @@ class PackageImport(ChannelPackageSubscription):
         unique_package_changelog_hash = {}
         unique_package_changelog = []
         for changelog in package['changelog']:
-            key = (self._fix_encoding(changelog['name']), self._fix_encoding(changelog['time']), self._fix_encoding(changelog['text'])[:3000])
+            key = (self._fix_encoding(changelog['name'][:128]), self._fix_encoding(changelog['time']), self._fix_encoding(changelog['text'])[:3000])
             if key not in unique_package_changelog_hash:
                 self.changelog_data[key] = None
+                changelog['name'] = changelog['name'][:128]
                 changelog['text'] = changelog['text'][:3000]
                 unique_package_changelog.append(changelog)
                 unique_package_changelog_hash[key] = 1

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,6 +1,7 @@
 - Drop Transfer-Encoding header from proxy respone to fix error response messages (bsc#1176906)
 - Prevent tracebacks on missing mail configuration (bsc#1179990)
 - Fix pycurl.error handling in suseLib.py (bsc#1179990)
+- Truncate author name in the changelog (bsc#1180285)
 - harden extratag key import by execute_values to ignore conflicts
 - internal code cleanup (dropping unused table rhnErrataTmp)
 - Fix Debian package version comparison


### PR DESCRIPTION
## What does this PR change?

The table in the database to store the changelog has a varchar column of
128 to store the author name. Thus, the sync fails if, for some reason,
the author name has more chars. This commits changes the code to truncate
the author name in 128 chars.

Before:

Changelog author was not truncate. Allowing name with more than 128 chars

After:

The changelog author is truncated in 128 chars

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/13541

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql" 
- [ ] Re-run test "java_pgsql_tests" (Test skipped, there are no changes to test)
- [x] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql" (Test skipped, there are no changes to test)
- [ ] Re-run test "susemanager_unittests" (Test skipped, there are no changes to test)
- [ ] Re-run test "javascript_lint" (Test skipped, there are no changes to test)
- [ ] Re-run test "spacecmd_unittests" (Test skipped, there are no changes to test)
