### PR TITLE
Adapt tests for "mgrcompat" module after deprecation changes

### DIFF
--- a/susemanager-utils/susemanager-sls/src/tests/test_state_mgrcompat.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_state_mgrcompat.py
@@ -20,12 +20,42 @@ mgrcompat.__opts__ = {}
 mgrcompat.__grains__ = {}
 
 
+def test_module_run_on_phosphorous():
+    mock = MagicMock(return_value={'changes': {'service.running': 'foobar'}})
+    mgrcompat.module.run = mock
+    with patch.dict(mgrcompat.__grains__, {'saltversioninfo': [3003, None, None, None]}):
+        mgrcompat.module_run(**MGRCOMPAT_MODULE_RUN_KWARGS)
+        mock.assert_called_once_with(**TAILORED_MODULE_RUN_KWARGS)
+
+def test_module_run_on_magnesium():
+    mock = MagicMock(return_value={'changes': {'service.running': 'foobar'}})
+    mgrcompat.module.run = mock
+    with patch.dict(mgrcompat.__grains__, {'saltversioninfo': [3002, None, None, None]}):
+        mgrcompat.module_run(**MGRCOMPAT_MODULE_RUN_KWARGS)
+        mock.assert_called_once_with(**MGRCOMPAT_MODULE_RUN_KWARGS)
+
+def test_module_run_on_magnesium_use_superseded():
+    mock = MagicMock(return_value={'changes': {'service.running': 'foobar'}})
+    mgrcompat.module.run = mock
+    with patch.dict(mgrcompat.__grains__, {'saltversioninfo': [3002, None, None, None]}):
+        with patch.dict(mgrcompat.__opts__, {'use_superseded': ['module.run']}):
+            mgrcompat.module_run(**MGRCOMPAT_MODULE_RUN_KWARGS)
+            mock.assert_called_once_with(**TAILORED_MODULE_RUN_KWARGS)
+
 def test_module_run_on_sodium():
     mock = MagicMock(return_value={'changes': {'service.running': 'foobar'}})
     mgrcompat.module.run = mock
     with patch.dict(mgrcompat.__grains__, {'saltversioninfo': [3001, None, None, None]}):
         mgrcompat.module_run(**MGRCOMPAT_MODULE_RUN_KWARGS)
-        mock.assert_called_once_with(**TAILORED_MODULE_RUN_KWARGS)
+        mock.assert_called_once_with(**MGRCOMPAT_MODULE_RUN_KWARGS)
+
+def test_module_run_on_sodium_use_superseded():
+    mock = MagicMock(return_value={'changes': {'service.running': 'foobar'}})
+    mgrcompat.module.run = mock
+    with patch.dict(mgrcompat.__grains__, {'saltversioninfo': [3001, None, None, None]}):
+        with patch.dict(mgrcompat.__opts__, {'use_superseded': ['module.run']}):
+            mgrcompat.module_run(**MGRCOMPAT_MODULE_RUN_KWARGS)
+            mock.assert_called_once_with(**TAILORED_MODULE_RUN_KWARGS)
 
 def test_module_run_on_neon():
     mock = MagicMock(return_value={'changes': {'service.running': 'foobar'}})


### PR DESCRIPTION
## What does this PR change?

This PR fixes the tests for `mgrcompat` module that are currently failing due a change on the expected deprecation behavior of Salt 3002. 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **tests changes**

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
