### PR TITLE
spacewalk-setup-jabberd: Fix database setup query detection.

### DIFF
--- a/spacewalk/spacewalk-setup-jabberd/include/manage_database
+++ b/spacewalk/spacewalk-setup-jabberd/include/manage_database
@@ -3,7 +3,7 @@
 XSLPROC="xsltproc"
 SQLITE="sqlite3"
 STP_QUERY="/etc/jabberd/scripts/db-setup.sqlite"
-if [ -f "$STP_QUERY" ]; then
+if ! [ -f "$STP_QUERY" ]; then
     STP_QUERY="/usr/share/jabberd/db-setup.sqlite"
 fi
 

--- a/spacewalk/spacewalk-setup-jabberd/spacewalk-setup-jabberd.changes
+++ b/spacewalk/spacewalk-setup-jabberd/spacewalk-setup-jabberd.changes
@@ -1,3 +1,4 @@
+- Fixed database setup query detection.
 - Updated SPEC file for RHEL libxslt-devel requirement.
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Fixes database setup query detection.
Message during `zypper in spacealk-setup-jabberd`:
`Error: database setup query missing (/usr/share/jabberd/db-setup.sqlite)`



## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: No functional change.

- [X] **DONE**

## Test coverage
- No tests: unsure how to test.

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
