### PR TITLE
spacecmd: Document "advanced search" on package commands that support it

### DIFF
--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,4 @@
+- Document advanced package search on '--help' (bsc#1180583)
 - Fixed advanced search on 'package_listinstalledsystems'
 - Fixed duplicate results when using multiple search criteria (bsc#1180585)
 

--- a/spacecmd/src/spacecmd/package.py
+++ b/spacecmd/src/spacecmd/package.py
@@ -44,8 +44,8 @@ except AttributeError:
     _ = translation.gettext
 
 def help_package_details(self):
-    print(('package_details: Show the details of a software package'))
-    print(('usage: package_details PACKAGE ...'))
+    self.help_package_search('package_details',
+                             _('Show the details of a software package'))
 
 
 def complete_package_details(self, text, line, beg, end):
@@ -117,11 +117,13 @@ def do_package_details(self, args):
 ####################
 
 
-def help_package_search(self):
-    print(_('package_search: Find packages that meet the given criteria'))
-    print(_('usage: package_search NAME|QUERY'))
+def help_package_search(self,
+                        command='package_search',
+                        description='Find packages that meet the given criteria'):
+    print('%s: %s' % (command, description))
+    print(_('usage: %s NAME|QUERY' % command))
     print('')
-    print(_('Example: package_search kernel'))
+    print(_('Example: %s kernel' % command))
     print('')
     print(_('Advanced Search:'))
     print(_('Available Fields: name, epoch, version, release, arch, description, summary'))
@@ -276,8 +278,8 @@ def do_package_removeorphans(self, args):
 
 
 def help_package_listinstalledsystems(self):
-    print(_('package_listinstalledsystems: List the systems with a package installed'))
-    print(_('usage: package_listinstalledsystems PACKAGE ...'))
+    self.help_package_search('package_listinstalledsystems',
+                             _('List the systems with a package installed'))
 
 
 def complete_package_listinstalledsystems(self, text, line, beg, end):
@@ -323,8 +325,8 @@ def do_package_listinstalledsystems(self, args):
 
 
 def help_package_listerrata(self):
-    print(_('package_listerrata: List the errata that provide this package'))
-    print(_('usage: package_listerrata PACKAGE ...'))
+    self.help_package_search('package_listerrata',
+                             _('List the errata that provide this package'))
 
 
 def complete_package_listerrata(self, text, line, beg, end):
@@ -369,8 +371,8 @@ def do_package_listerrata(self, args):
 
 
 def help_package_listdependencies(self):
-    print(_('package_listdependencies: List the dependencies for a package'))
-    print(_('usage: package_listdependencies PACKAGE'))
+    self.help_package_search('package_listdependencies',
+                             _('List the dependencies for a package'))
 
 
 def do_package_listdependencies(self, args):


### PR DESCRIPTION
## What does this PR change?

With this PR, all `spacecmd package_*` commands that support **"advanced package search"** will document it on `--help`:
- `package_search`
- `package_details`
- `package_listinstalledsystems`
- `package_listerrata`
- `package_listdependencies`

### Before
```
spacecmd {SSM:0}> package_search --help
package_search: Find packages that meet the given criteria
usage: package_search NAME|QUERY

Example: package_search kernel

Advanced Search:
Available Fields: name, epoch, version, release, arch, description, summary
Example: name:kernel AND version:2.6.18 AND -description:devel

-----------------------------------------------------------------------------------------------------------

spacecmd {SSM:0}> package_details --help
package_details: Show the details of a software package
usage: package_details PACKAGE ...

-----------------------------------------------------------------------------------------------------------

spacecmd {SSM:0}> package_listinstalledsystems --help
package_listinstalledsystems: List the systems with a package installed
usage: package_listinstalledsystems PACKAGE ...

-----------------------------------------------------------------------------------------------------------

spacecmd {SSM:0}> package_listerrata --help
package_listerrata: List the errata that provide this package
usage: package_listerrata PACKAGE ...

-----------------------------------------------------------------------------------------------------------

spacecmd {SSM:0}> package_listdependencies --help
package_listdependencies: List the dependencies for a package
usage: package_listdependencies PACKAGE
```

### After
```
spacecmd {SSM:0}> package_search --help
package_search: Find packages that meet the given criteria
usage: package_search NAME|QUERY

Example: package_search kernel

Advanced Search:
Available Fields: name, epoch, version, release, arch, description, summary
Example: name:kernel AND version:2.6.18 AND -description:devel

-----------------------------------------------------------------------------------------------------------

spacecmd {SSM:0}> package_details --help
package_details: Show the details of a software package
usage: package_details NAME|QUERY

Example: package_details kernel

Advanced Search:
Available Fields: name, epoch, version, release, arch, description, summary
Example: name:kernel AND version:2.6.18 AND description:devel

-----------------------------------------------------------------------------------------------------------

spacecmd {SSM:0}> package_listinstalledsystems --help
package_listinstalledsystems: List the systems with a package installed
usage: package_listinstalledsystems NAME|QUERY

Example: package_listinstalledsystems kernel

Advanced Search:
Available Fields: name, epoch, version, release, arch, description, summary
Example: name:kernel AND version:2.6.18 AND description:devel

-----------------------------------------------------------------------------------------------------------

spacecmd {SSM:0}> package_listerrata --help
package_listerrata: List the errata that provide this package
usage: package_listerrata NAME|QUERY

Example: package_listerrata kernel

Advanced Search:
Available Fields: name, epoch, version, release, arch, description, summary
Example: name:kernel AND version:2.6.18 AND description:devel

-----------------------------------------------------------------------------------------------------------

spacecmd {SSM:0}> package_listdependencies --help
package_listdependencies: List the dependencies for a package
usage: package_listdependencies NAME|QUERY

Example: package_listdependencies kernel

Advanced Search:
Available Fields: name, epoch, version, release, arch, description, summary
Example: name:kernel AND version:2.6.18 AND description:devel
```

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed: Only changes help texts

- [x] **DONE**

## Test coverage
- No tests: Only changes help texts

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/13573

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
