### PR TITLE
Open raw output in new tab for ScriptRunAction

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/action/script/ScriptRunAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/script/ScriptRunAction.java
@@ -64,7 +64,7 @@ public class ScriptRunAction extends ScriptAction {
                         .getReturnCode().toString()));
                 retval.append("</br>");
                 retval.append(ls.getMessage("system.event.scriptRawOutput"));
-                retval.append("<a href=\"" +
+                retval.append("<a data-senna-off=\"true\" target=\"_blank\" href=\"" +
                         DownloadManager.getScriptRawOutputDownloadPath(
                                 this.getId(), sr.getActionScriptId(), currentUser) +
                         "\">");

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Open raw output in new tab for ScriptRunAction (bsc#1180547)
+
 -------------------------------------------------------------------
 Wed Jan 27 13:04:11 CET 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

When clicking `view/download raw script output` in a remote command
execution event summary it links to the SSM Overview Remote command tab.
instead it should open a new tab with the raw output to view/download.

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- No tests: bugfix

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/13567

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
