### PR TITLE
CLM: Mark required inputs in the 'Environment Lifecycle' form

### DIFF
--- a/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment-form.js
+++ b/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment-form.js
@@ -23,6 +23,7 @@ const EnvironmentForm = (props: Props) =>
     <React.Fragment>
       <div className="row">
         <Text
+          required
           name="name"
           // ref={nameInputRef}
           label={t("Name")}
@@ -33,6 +34,7 @@ const EnvironmentForm = (props: Props) =>
       </div>
       <div className="row">
         <Text
+          required
           name="label"
           label={t("Label")}
           labelClass="col-md-3"

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Mark required inputs in the 'Environment Lifecycle' form
 - Replace Select component implementation to use react-select
 - Fix Package States page display error (bsc#1180580)
 - Fixed variable installation location.


### PR DESCRIPTION
## What does this PR change?

`Name` and `Label` inputs are required on the `Environment Lifecycle` form, so we should display the corresponding `*` sign.

## GUI diff

Before:

![Screenshot from 2021-01-08 10-17-54](https://user-images.githubusercontent.com/14297426/104005691-6ddf5400-519d-11eb-97c0-e35eaa311a87.png)

After:

![Screenshot from 2021-01-08 10-20-08](https://user-images.githubusercontent.com/14297426/104005731-7a63ac80-519d-11eb-93b8-5e9a4c5cde1b.png)

- [x] **DONE**

## Documentation
- No documentation needed: This is only a visualization improvement.

- [x] **DONE**

## Test coverage
- No tests: This is only a visualization improvement.

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/13514

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
