### PR TITLE
Update the jade4j library (1.0.7 -> 1.2.5)

### DIFF
--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -39,7 +39,7 @@
         <dependency org="suse" name="httpcore" rev="4.4.10" />
         <dependency org="suse" name="httpcore-nio" rev="4.4.10" />
         <dependency org="suse" name="ical4j" rev="3.0.18" />
-        <dependency org="suse" name="jade4j" rev="1.0.7" />
+        <dependency org="suse" name="jade4j" rev="1.2.5" />
         <dependency org="suse" name="jaf" rev="1.1.1" />
         <dependency org="suse" name="jakarta-persistence-api" rev="2.2.2" />
         <dependency org="suse" name="java-saml" rev="2.4.0" />


### PR DESCRIPTION
## What does this PR change?

This patch updates the jade4j library and initially pulls it from [my OBS home repository](https://build.opensuse.org/project/show/home:j_renner:branches:systemsmanagement:Uyuni:Master:Other) for CI testing. When the updated library has been submitted to [the official Uyuni OBS project](https://build.opensuse.org/project/show/systemsmanagement:Uyuni:Master:Other) it will be resolved from there.

Version 1.2.5 is the jade4j version that is used for [the latest release of spark-template-jade](https://github.com/perwendel/spark-template-engines/blob/master/spark-template-jade/pom.xml#L36).

## GUI diff

No difference.

- [X] **DONE**

## Documentation

- No documentation needed, everything should behave exactly as before.

- [X] **DONE**

## Test coverage

- No tests needed, everything should behave exactly as before.

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/13283 (downstream issue).

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below).

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"   
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
