### PR TITLE
Revert "Fix: slow refresh Ubuntu repos via SUMa proxy (bsc#1176906)"

### DIFF
--- a/proxy/proxy/httpd-conf/spacewalk-proxy.conf
+++ b/proxy/proxy/httpd-conf/spacewalk-proxy.conf
@@ -53,10 +53,6 @@
    # Redirect some http page to https for security reasons
    RewriteCond %{SERVER_PORT} 80
    RewriteRule ^/rhn/?$ https://%{SERVER_NAME}/rhn/manager/login  [R,L]
-
-   # Rewrite rules for APT repos metadata
-   RewriteRule ^/rhn/manager/download/dists/(.*)/main/(.*)/(Packages.*)$ /rhn/manager/download/$1/repodata/$3
-   RewriteRule ^/rhn/manager/download/dists/(.*)/(InRelease|Release.*)$ /rhn/manager/download/$1/repodata/$2
 </IfModule>
 
 

--- a/proxy/proxy/spacewalk-proxy.changes
+++ b/proxy/proxy/spacewalk-proxy.changes
@@ -1,4 +1,3 @@
-- Fix: slow refresh Ubuntu repos via SUMa proxy (bsc#1176906)
 - fix package manager string compare - python3 porting issue
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

This reverts https://github.com/uyuni-project/uyuni/pull/3076 as it generates this problem:

```
Exception: E: Failed to fetch https://suma-41-pxy.mgr.prv.suse.net:443/rhn/manager/download/dists/test-channel-deb-amd64/main/binary-amd64/Packages  404  Not Found [IP: 10.84.220.162 443
```

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
