### PR TITLE
Wsgi drop chuncked transfer encoding

### DIFF
--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- drop Transfer-Encoding header from proxy respone to fix error response messages (bsc#1176906)
 - harden extratag key import by execute_values to ignore conflicts
 - internal code cleanup (dropping unused table rhnErrataTmp)
 - Fix Debian package version comparison

--- a/backend/wsgi/wsgiRequest.py
+++ b/backend/wsgi/wsgiRequest.py
@@ -86,6 +86,15 @@ class WsgiRequest:
         if not self.headers_out.has_key('Content-Type'):
             self.headers_out['Content-Type'] = 'text/xml'
 
+        if self.headers_out.has_key('Transfer-Encoding'):
+            # leave transfer encoding settings to wsgi as at least 'chunked'
+            # create problems
+            hdr = WsgiMPtable()
+            for k,v in list(self.headers_out.items()):
+                if k == 'Transfer-Encoding':
+                    continue
+                hdr[k] = v
+            self.headers_out = hdr
         self.start_response(self.status, list(self.headers_out.items()))
         return
 


### PR DESCRIPTION
## What does this PR change?

When copying headers from parent requests in the proxy we can get also the `Transfer-Encoding` header field which may be set to `chunked`. Using this as input for WSGI to return a result to the client cause timeout issues as it does not handle correctly (at least not when setting it from external).
The proxy code remove this header already for successful responses, but in case of an error (404 Not Found) that header was still present.

This PR remove the Transfer Encoding header just before sending it back to the client.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/2241
Tracks https://github.com/SUSE/spacewalk/pull/13618

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
