### PR TITLE
Add Typescript compilation & type checking to Github Actions

### DIFF
--- a/.github/workflows/javascript-unit-tests.yml
+++ b/.github/workflows/javascript-unit-tests.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/typescript-compilation.yml
+++ b/.github/workflows/typescript-compilation.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/typescript-compilation.yml
+++ b/.github/workflows/typescript-compilation.yml
@@ -1,0 +1,44 @@
+name: Typescript compilation
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'web/html/src/**'
+  pull_request:
+    paths:
+      - 'web/html/src/**'
+
+jobs:
+  javascript_unit_tests:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Get Yarn cache directory
+      id: yarn-cache-dir-path
+      run: echo "::set-output name=dir::$(yarn cache dir)"
+
+    - name: Use Yarn cache
+      uses: actions/cache@v2
+      id: yarn-cache
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}
+
+    - name: Install dependencies
+      run: yarn --cwd susemanager-frontend install --frozen-lockfile --prefer-offline
+
+    - name: Run tests
+      run: yarn --cwd web/html/src tsc

--- a/.github/workflows/typescript-compilation.yml
+++ b/.github/workflows/typescript-compilation.yml
@@ -11,7 +11,7 @@ on:
       - 'web/html/src/**'
 
 jobs:
-  javascript_unit_tests:
+  typescript_compilation:
     runs-on: ubuntu-latest
 
     strategy:
@@ -40,5 +40,5 @@ jobs:
     - name: Install dependencies
       run: yarn --cwd susemanager-frontend install --frozen-lockfile --prefer-offline
 
-    - name: Run tests
+    - name: Compile Typescript
       run: yarn --cwd web/html/src tsc


### PR DESCRIPTION
## What does this PR change?

Adds Typescript type checking and compilation to Github Actions so we have better confidence in the type safety of every PR.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Github Action was added

- [x] **DONE**

## Links

Fixes: https://github.com/SUSE/spacewalk/issues/13502

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
