### PR TITLE
replace custom vercmp function with PackageEvr.compareTo

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Package_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Package_queries.xml
@@ -424,6 +424,7 @@ SELECT PN.id || '|' || PE.id || '|' || PA.id AS ID_COMBO,
        PN.name || '-' || evr_t_as_vre_simple(PE.evr) AS NVRE,
        P.summary,
        PA.id AS arch_id,
+       AT.label AS PACKAGE_TYPE,
        PE.epoch,
        PE.version,
        PE.release,
@@ -431,12 +432,13 @@ SELECT PN.id || '|' || PE.id || '|' || PA.id AS ID_COMBO,
        PN.id as name_id,
        PE.id as evr_id
   FROM rhnPackageArch PA, rhnPackageName PN, rhnPackageEVR PE, rhnPackage P,
-       rhnChannelPackage CP
+       rhnChannelPackage CP, rhnArchType AT
  WHERE CP.channel_id = :cid
    AND CP.package_id = P.id
    AND P.name_id = PN.id
    AND P.evr_id = PE.id
    AND PA.id = P.package_arch_id
+   AND AT.id = PA.arch_type_id
 ORDER BY UPPER(PN.name), UPPER(evr_t_as_vre_simple(PE.evr))
   </query>
 </mode>
@@ -551,13 +553,15 @@ SELECT PN.id || '|' || SPE.id AS ID_COMBO,
        SP.evr_id,
        SP.package_arch_id AS ARCH_ID,
        PA.label AS ARCH,
+       AT.label AS PACKAGE_TYPE,
        evr_t_as_vre_simple(SPE.evr) AS EVR,
        evr_t_as_vre_simple(SPE.evr) || (CASE WHEN SP.package_arch_id IS NULL THEN '' ELSE '.' || PA.label END) AS EVRA,
        SPE.epoch,
        SPE.version,
        SPE.release
   FROM rhnServerPackage SP LEFT OUTER JOIN
-       rhnPackageArch PA ON SP.package_arch_id = PA.id INNER JOIN
+       rhnPackageArch PA ON SP.package_arch_id = PA.id LEFT OUTER JOIN
+       rhnArchType AT ON AT.id = PA.arch_type_id INNER JOIN
        rhnPackageName PN ON SP.name_id = PN.id INNER JOIN
        rhnPackageEVR SPE ON SP.evr_id = SPE.id
  WHERE SP.server_id = :sid
@@ -574,6 +578,7 @@ SELECT PN.id || '|' || SPE.id AS ID_COMBO,
        SP.evr_id,
        SP.package_arch_id AS ARCH_ID,
        PA.label AS ARCH,
+       AT.label AS PACKAGE_TYPE,
        evr_t_as_vre_simple(SPE.evr) AS EVR,
        evr_t_as_vre_simple(SPE.evr) || '.' || PA.label AS NVREA,
        evr_t_as_vre_simple(SPE.evr) || (CASE WHEN SP.package_arch_id IS NULL THEN '' ELSE '.' || PA.label END) AS EVRA,
@@ -581,7 +586,8 @@ SELECT PN.id || '|' || SPE.id AS ID_COMBO,
        SPE.version,
        SPE.release
   FROM rhnServerProfilePackage SP LEFT OUTER JOIN
-       rhnPackageArch PA ON SP.package_arch_id = PA.id INNER JOIN
+       rhnPackageArch PA ON SP.package_arch_id = PA.id LEFT OUTER JOIN
+       rhnArchType AT ON AT.id = PA.arch_type_id INNER JOIN
        rhnPackageName PN ON SP.name_id = PN.id INNER JOIN
        rhnPackageEVR SPE ON SP.evr_id = SPE.id
  WHERE SP.server_profile_id = :prid

--- a/java/code/src/com/redhat/rhn/frontend/dto/PackageListItem.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/PackageListItem.java
@@ -46,6 +46,7 @@ public class PackageListItem extends IdComboDto {
     private Long nameId;
     private Long evrId;
     private Long archId;
+    private String packageType;
     private String path;
     private String arch;
     private List channelName;
@@ -413,6 +414,20 @@ public class PackageListItem extends IdComboDto {
      */
     public void setNvrea(String aNvrea) {
         this.nvrea = aNvrea;
+    }
+
+    /**
+     * @return Returns The package type.
+     */
+    public String getPackageType() {
+        return packageType;
+    }
+
+    /**
+     * @param packageTypeIn The package type to set.
+     */
+    public void setPackageType(String packageTypeIn) {
+        this.packageType = packageTypeIn;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/dto/PackageMetadata.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/PackageMetadata.java
@@ -261,6 +261,16 @@ public class PackageMetadata extends BaseDto implements Comparable<PackageMetada
     }
 
     /**
+     * @return The package type.
+     */
+    public String getPackageType() {
+        if (comparison == KEY_THIS_ONLY) {
+            return system.getPackageType();
+        }
+        return other.getPackageType();
+    }
+
+    /**
      * Returns the epoch of the Package, if both the system and
      * other PackageListItem are null, returns null.
      * @return the epoch of the Package, if both the system and

--- a/java/code/src/com/redhat/rhn/manager/profile/test/ProfileManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/profile/test/ProfileManagerTest.java
@@ -219,6 +219,7 @@ public class ProfileManagerTest extends BaseTestCaseWithUser {
         pli.setEvr("kernel-2.4.21-27.EL");
         pli.setVersion("2.4.21");
         pli.setEpoch(null);
+        pli.setPackageType("rpm");
         a.add(pli);
 
         pli = new PackageListItem();
@@ -230,6 +231,7 @@ public class ProfileManagerTest extends BaseTestCaseWithUser {
         pli.setEvr("kernel-2.4.22-27.EL-bretm");
         pli.setVersion("2.4.22");
         pli.setEpoch(null);
+        pli.setPackageType("rpm");
         a.add(pli);
 
         List<PackageListItem> b = new ArrayList<>();
@@ -242,6 +244,7 @@ public class ProfileManagerTest extends BaseTestCaseWithUser {
         pli.setEvr("kernel-2.4.21-27.EL");
         pli.setVersion("2.4.21");
         pli.setEpoch(null);
+        pli.setPackageType("rpm");
         b.add(pli);
 
         List<PackageMetadata> diff = ProfileManager.comparePackageLists(new DataResult<PackageListItem>(a),
@@ -268,6 +271,7 @@ public class ProfileManagerTest extends BaseTestCaseWithUser {
         pli.setEvr("kernel-2.4.22-27.EL-bretm");
         pli.setVersion("2.4.22");
         pli.setEpoch(null);
+        pli.setPackageType("rpm");
         a.add(pli);
 
         List<PackageListItem> b = new ArrayList<>();
@@ -280,6 +284,7 @@ public class ProfileManagerTest extends BaseTestCaseWithUser {
         pli.setEvr("kernel-2.4.21-27.EL");
         pli.setVersion("2.4.21");
         pli.setEpoch(null);
+        pli.setPackageType("rpm");
         b.add(pli);
 
         List<PackageMetadata> diff = ProfileManager.comparePackageLists(new DataResult<PackageListItem>(a),
@@ -303,6 +308,7 @@ public class ProfileManagerTest extends BaseTestCaseWithUser {
         pli.setEvr("kernel-2.4.22-27.EL-bretm");
         pli.setVersion("2.4.22");
         pli.setEpoch(null);
+        pli.setPackageType("rpm");
         b.add(pli);
 
         List<PackageListItem> a = new ArrayList<>();
@@ -315,6 +321,7 @@ public class ProfileManagerTest extends BaseTestCaseWithUser {
         pli.setEvr("kernel-2.4.21-27.EL");
         pli.setVersion("2.4.21");
         pli.setEpoch(null);
+        pli.setPackageType("rpm");
         a.add(pli);
 
         List<PackageMetadata> diff = ProfileManager.comparePackageLists(new DataResult<PackageListItem>(a),
@@ -343,6 +350,7 @@ public class ProfileManagerTest extends BaseTestCaseWithUser {
         pli1.setNameId(500000341L);
         pli1.setEvr("kernel-2.4.22-27.EL-bretm");
         pli1.setVersion("2.4.22");
+        pli1.setPackageType("rpm");
 
         List<PackageListItem> b = new ArrayList<PackageListItem>();
         PackageListItem pli2 = new PackageListItem();
@@ -353,6 +361,7 @@ public class ProfileManagerTest extends BaseTestCaseWithUser {
         pli2.setNameId(500000341L);
         pli2.setEvr("kernel-2.4.21-27.EL");
         pli2.setVersion("2.4.21");
+        pli2.setPackageType("rpm");
 
         for (int i = 0; i < pkg1Epochs.length; i++) {
             pli1.setEpoch(pkg1Epochs[i]);
@@ -386,6 +395,7 @@ public class ProfileManagerTest extends BaseTestCaseWithUser {
         pli.setIdCombo(nameId + "|" + evrString.hashCode());
         pli.setEvr(evrString);
         pli.setNameId((long) nameId);
+        pli.setPackageType("rpm");
         return pli;
     }
 
@@ -432,6 +442,7 @@ public class ProfileManagerTest extends BaseTestCaseWithUser {
         PackageArch pa = PackageFactory.lookupPackageArchByLabel("x86_64");
         pli.setArch(pa.getLabel());
         pli.setArchId(pa.getId());
+        pli.setPackageType("rpm");
         return pli;
     }
 
@@ -446,6 +457,7 @@ public class ProfileManagerTest extends BaseTestCaseWithUser {
         pli.setEvr("kernel-2.4.22-27.EL-bretm");
         pli.setVersion("2.4.22");
         pli.setEpoch(null);
+        pli.setPackageType("rpm");
         a.add(pli);
 
 
@@ -459,6 +471,7 @@ public class ProfileManagerTest extends BaseTestCaseWithUser {
         pli.setEvr("kernel-2.4.22-27.EL-bretm");
         pli.setVersion("2.4.22");
         pli.setEpoch(null);
+        pli.setPackageType("rpm");
         b.add(pli);
 
         List<PackageMetadata> diff = ProfileManager.comparePackageLists(new DataResult<PackageListItem>(a),
@@ -478,6 +491,7 @@ public class ProfileManagerTest extends BaseTestCaseWithUser {
         pli.setVersion("2.6.9");
         pli.setEpoch(null);
         pli.setArch(null);
+        pli.setPackageType("rpm");
         a.add(pli);
 
         pli = new PackageListItem();
@@ -490,6 +504,7 @@ public class ProfileManagerTest extends BaseTestCaseWithUser {
         pli.setVersion("2.6.9");
         pli.setEpoch(null);
         pli.setArch(null);
+        pli.setPackageType("rpm");
         a.add(pli);
 
         pli = new PackageListItem();
@@ -502,6 +517,7 @@ public class ProfileManagerTest extends BaseTestCaseWithUser {
         pli.setVersion("2.6.9");
         pli.setEpoch(null);
         pli.setArch(null);
+        pli.setPackageType("rpm");
         a.add(pli);
 
         pli = new PackageListItem();
@@ -514,6 +530,7 @@ public class ProfileManagerTest extends BaseTestCaseWithUser {
         pli.setVersion("2.6.9");
         pli.setEpoch(null);
         pli.setArch(null);
+        pli.setPackageType("rpm");
         a.add(pli);
 
         pli = new PackageListItem();
@@ -526,6 +543,7 @@ public class ProfileManagerTest extends BaseTestCaseWithUser {
         pli.setVersion("2.4");
         pli.setEpoch("1");
         pli.setArch(null);
+        pli.setPackageType("rpm");
         a.add(pli);
 
         // SETUP B
@@ -540,6 +558,7 @@ public class ProfileManagerTest extends BaseTestCaseWithUser {
         pli.setVersion("2.6.9");
         pli.setEpoch(null);
         pli.setArch(null);
+        pli.setPackageType("rpm");
         b.add(pli);
 
         pli = new PackageListItem();
@@ -552,6 +571,7 @@ public class ProfileManagerTest extends BaseTestCaseWithUser {
         pli.setVersion("2.6.9");
         pli.setEpoch(null);
         pli.setArch(null);
+        pli.setPackageType("rpm");
         b.add(pli);
 
         pli = new PackageListItem();
@@ -564,6 +584,7 @@ public class ProfileManagerTest extends BaseTestCaseWithUser {
         pli.setVersion("2.4");
         pli.setEpoch("1");
         pli.setArch(null);
+        pli.setPackageType("rpm");
         b.add(pli);
 
         List<PackageMetadata> diff = ProfileManager.comparePackageLists(new DataResult<PackageListItem>(a),
@@ -588,6 +609,7 @@ public class ProfileManagerTest extends BaseTestCaseWithUser {
         pli3.setEvr("kernel-2.6.9-42.0.2.EL");
         pli3.setVersion("2.6.9");
         pli3.setEpoch(null);
+        pli3.setPackageType("rpm");
         serverList.add(pli3);
 
         List<PackageListItem> otherServerList = new ArrayList<>();
@@ -600,6 +622,7 @@ public class ProfileManagerTest extends BaseTestCaseWithUser {
         pli.setEvr("kernel-2.6.9-22.EL");
         pli.setVersion("2.6.9");
         pli.setEpoch(null);
+        pli3.setPackageType("rpm");
         otherServerList.add(pli);
 
         PackageListItem pli2 = new PackageListItem();
@@ -611,6 +634,7 @@ public class ProfileManagerTest extends BaseTestCaseWithUser {
         pli2.setEvr("kernel-2.6.9-42.0.2.EL");
         pli2.setVersion("2.6.9");
         pli2.setEpoch(null);
+        pli3.setPackageType("rpm");
         otherServerList.add(pli2);
 
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Replace custom version comparison method with the standard one which also takes debian packages into account
 - Default to preferred items per page in content lifecycle lists (bsc#1180558)
 - Removed Java module com.sun.bind if it is not available; Load jaxb bundles if available.
 - internal code cleanup (dropping unused table rhnErrataTmp)


### PR DESCRIPTION
## What does this PR change?

Removing another custom version comparison method with the standard one which also takes debian packages into account. 

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests: already covered


- [x] **DONE**

## Links


- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
