### PR TITLE
Drop Transfer-Encoding header from proxy respone (bsc#1176906)Master wsgi drop chuncked transfer encoding

### DIFF
--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Drop Transfer-Encoding header from proxy respone to fix error response messages (bsc#1176906)
 - Prevent tracebacks on missing mail configuration (bsc#1179990)
 - Fix pycurl.error handling in suseLib.py (bsc#1179990)
 - harden extratag key import by execute_values to ignore conflicts

--- a/backend/wsgi/wsgiRequest.py
+++ b/backend/wsgi/wsgiRequest.py
@@ -86,6 +86,10 @@ class WsgiRequest:
         if not self.headers_out.has_key('Content-Type'):
             self.headers_out['Content-Type'] = 'text/xml'
 
+        # leave transfer encoding settings to wsgi as at least 'chunked'
+        # create problems
+        self.headers_out.remove_key('Transfer-Encoding')
+
         self.start_response(self.status, list(self.headers_out.items()))
         return
 
@@ -168,6 +172,9 @@ class WsgiMPtable:
 
     def keys(self):
         return list(self.dict.keys())
+
+    def remove_key(self, key):
+        self.dict.pop(key, None)
 
     def __str__(self):
         return str(self.items())


### PR DESCRIPTION
## What does this PR change?

When copying headers from parent requests in the proxy we can get also the `Transfer-Encoding` header field which may be set to `chunked`. Using this as input for WSGI to return a result to the client cause timeout issues as it does not handle correctly (at least not when setting it from external).
The proxy code remove this header already for successful responses, but in case of an error (404 Not Found) that header was still present.

This PR remove the Transfer Encoding header just before sending it back to the client.

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Fixes #2241
Tracks SUSE/spacewalk#13618

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
