### PR TITLE
Fixing the "label" error, typos, and removing unused code

### DIFF
--- a/testsuite/features/secondary/srv_content_lifecycle.feature
+++ b/testsuite/features/secondary/srv_content_lifecycle.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2020 SUSE LLC
+# Copyright (c) 2019-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @scc_credentials
@@ -66,18 +66,21 @@ Feature: Content lifecycle
     Then I should see a "No environments created" text
     When I follow "Add Environment"
     And I enter "dev_name" as "name"
+    And I enter "dev_label" as "label"
     And I enter "dev_desc" as "description"
     And I click on "Save"
     Then I wait until I see "dev_name" text
     And I should see a "dev_desc" text
     When I follow "Add Environment"
     And I enter "prod_name" as "name"
+    And I enter "prod_label" as "label"
     And I enter "prod_desc" as "description"
     And I click on "Save"
     Then I wait until I see "prod_name" text
     And I should see a "prod_desc" text
     When I follow "Add Environment"
     And I enter "qa_name" as "name"
+    And I enter "qa_label" as "label"
     And I enter "qa_desc" as "description"
     And I select "prod_name" from "predecessorLabel"
     And I click on "Save"

--- a/testsuite/features/secondary/srv_distro_cobbler.feature
+++ b/testsuite/features/secondary/srv_distro_cobbler.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2020 SUSE LLC.
+# Copyright (c) 2010-2021 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 @scope_cobbler
@@ -21,7 +21,7 @@ Feature: Cobbler and distribution autoinstallation
     Then I should see a "testprofile" text
     And I should see a "testdistro" text
 
-  Scenario: Create SUSE Distibution with installer updates
+  Scenario: Create SUSE distribution with installer updates
     When I follow the left menu "Systems > Autoinstallation > Distributions"
     And I follow "Create Distribution"
     And I enter "SLE-15-FAKE" as "label"

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2014-2020 SUSE LLC.
+# Copyright (c) 2014-2021 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 require 'xmlrpc/client'
@@ -684,14 +684,6 @@ When(/^I wait for the OpenSCAP audit to finish$/) do
   ensure
     @client_api.call('auth.logout', @sid)
   end
-end
-
-And(/I check status "([^"]*)" with spacecmd on "([^"]*)"$/) do |status, host|
-  system_name = get_system_name(host)
-  cmd = "spacecmd -u admin -p admin system_listevents #{system_name} | head -n5"
-  $server.run("spacecmd -u admin -p admin clear_caches")
-  out, _code = $server.run(cmd)
-  raise "#{out} should contain #{status}" unless out.include? status
 end
 
 When(/^I register this client for SSH push via tunnel$/) do


### PR DESCRIPTION
## What does this PR change?

**add description**

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
