### PR TITLE
spacewalk-backend-tools: Limit required python3-urlgrabber version to < 4.

### DIFF
--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Limit required python3-urlgrabber version to < 4.
 - Drop Transfer-Encoding header from proxy respone to fix error response messages (bsc#1176906)
 - Prevent tracebacks on missing mail configuration (bsc#1179990)
 - Fix pycurl.error handling in suseLib.py (bsc#1179990)

--- a/backend/spacewalk-backend.spec
+++ b/backend/spacewalk-backend.spec
@@ -234,7 +234,7 @@ BuildRequires:	systemd-rpm-macros
 Requires:       (python3-dateutil or python3-python-dateutil)
 Requires:       python3-rhn-client-tools
 Requires:       python3-solv
-Requires:       python3-urlgrabber
+Requires:       python3-urlgrabber < 4
 Requires:       spacewalk-admin >= 0.1.1-0
 Requires:       spacewalk-certs-tools
 Requires:       susemanager-tools


### PR DESCRIPTION
## What does this PR change?

Limit required python3-urlgrabber version to < 4. reposync fails with urlgrabber = 4

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: No functional change

- [X] **DONE**

## Test coverage
- No tests: Tested during automatic build.
spacewalk-backend build tested successfully on CentOS8, Leap15.2

- [X] **DONE**

## Links

Requested Enhancement #3113 

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
