### PR TITLE
Moved salt minion restarting to another scenario

### DIFF
--- a/testsuite/features/secondary/min_salt_software_states.feature
+++ b/testsuite/features/secondary/min_salt_software_states.feature
@@ -123,7 +123,9 @@ Feature: Salt package states
     And I run "pkill salt-minion" on "sle_minion"
     And I follow "Highstate" in the content area
     And I wait until I see "No reply from minion" text
-    And I run "rcsalt-minion restart" on "sle_minion"
+
+  Scenario: Cleanup: restart the salt service on SLES minion
+    When I run "rcsalt-minion restart" on "sle_minion"
 
   Scenario: Cleanup: remove old packages from SLES minion
     When I disable repository "test_repo_rpm_pool" on this "sle_minion"


### PR DESCRIPTION
 Co-author Eric Bischoff <ebischoff@suse.com>

 Without this patch, the sle_minion with killed
 salt-minion will not have it restarted if some
 steps fail prior to that step.

## What does this PR change?

**add description**

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
