### PR TITLE
Add Javascript lint to Github Actions

### DIFF
--- a/.github/workflows/javascript-lint.yml
+++ b/.github/workflows/javascript-lint.yml
@@ -5,10 +5,12 @@ on:
     branches:
       - master
     paths:
-      - 'web/html/src/**'
+      - 'web/html/src/**/*jsx?'
+      - 'web/html/src/**/*tsx?'
   pull_request:
     paths:
-      - 'web/html/src/**'
+      - 'web/html/src/**/*jsx?'
+      - 'web/html/src/**/*tsx?'
 
 jobs:
   javascript_lint:

--- a/.github/workflows/javascript-lint.yml
+++ b/.github/workflows/javascript-lint.yml
@@ -1,0 +1,44 @@
+name: Javascript lint
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'web/html/src/**'
+  pull_request:
+    paths:
+      - 'web/html/src/**'
+
+jobs:
+  javascript_lint:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x]
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Get Yarn cache directory
+      id: yarn-cache-dir-path
+      run: echo "::set-output name=dir::$(yarn cache dir)"
+
+    - name: Use Yarn cache
+      uses: actions/cache@v2
+      id: yarn-cache
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}
+
+    - name: Install dependencies
+      run: yarn --cwd susemanager-frontend install --frozen-lockfile --prefer-offline
+
+    - name: Run lint
+      run: yarn --cwd web/html/src lint


### PR DESCRIPTION
## What does this PR change?

Add Javascript lint to Github Actions, tested on my own fork and works as expected.

Once this gets merged, it would make sense to remove the corresponding job from Jenkins for Uyuni, I'm not familiar with the process for that.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: linter integration.

- [x] **DONE**

## Links

Fixes: https://github.com/SUSE/spacewalk/issues/13403

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
