### PR TITLE
Changing xpath for "promote" button in common_steps

### DIFF
--- a/testsuite/features/secondary/srv_content_lifecycle.feature
+++ b/testsuite/features/secondary/srv_content_lifecycle.feature
@@ -113,7 +113,7 @@ Feature: Content lifecycle
     And I wait until I see "Version 1: test version message 1" text in the environment "dev_name"
     And I wait at most 600 seconds until I see "Built" text in the environment "dev_name"
 
-  Scenario: Promote promote the sources in the project
+  Scenario: Promote the sources in the project
     Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Content Lifecycle > Projects"
     Then I should see a "clp_name" text

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2020 SUSE LLC.
+# Copyright (c) 2010-2021 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 require 'jwt'
@@ -1204,11 +1204,11 @@ When(/^I click the environment build button$/) do
 end
 
 When(/^I click promote from Development to QA$/) do
-  raise 'Click on promote from Development failed' unless find_button('dev_name-promote-modal-link', disabled: false, wait: DEFAULT_TIMEOUT).click
+  raise 'Click on promote from Development failed' unless find_button('dev_label-promote-modal-link', disabled: false, wait: DEFAULT_TIMEOUT).click
 end
 
 When(/^I click promote from QA to Production$/) do
-  raise 'Click on promote from QA failed' unless find_button('qa_name-promote-modal-link', disabled: false, wait: DEFAULT_TIMEOUT).click
+  raise 'Click on promote from QA failed' unless find_button('qa_label-promote-modal-link', disabled: false, wait: DEFAULT_TIMEOUT).click
 end
 
 Then(/^I should see a "([^"]*)" text in the environment "([^"]*)"$/) do |text, env|


### PR DESCRIPTION
## What does this PR change?

Without this patch, the testsuite is going to always fail because there was the field label added. Accordingly, <promote> buttons aren't dev_name-* or qa_name-* anymore, but dev_label-* and qa_label-*.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.0 https://github.com/SUSE/spacewalk/pull/13647 
- Manager-4.1 https://github.com/SUSE/spacewalk/pull/13642 

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
