### PR TITLE
Fix CVE audit results for affected and patched entries (bsc#1180893)

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/audit/CVEAuditManager.java
+++ b/java/code/src/com/redhat/rhn/manager/audit/CVEAuditManager.java
@@ -775,13 +775,13 @@ public class CVEAuditManager {
 
         return results.stream()
                 .map(row -> {
-                    Optional<PackageEvr> packageEvr =
-                        Optional.ofNullable((String) row.get("package_epoch")).flatMap(pe ->
-                        Optional.ofNullable((String) row.get("package_version")).flatMap(pv ->
-                        Optional.ofNullable((String) row.get("package_release")).flatMap(pr ->
-                        Optional.ofNullable((String) row.get("package_type"))
-                                .map(pt -> new PackageEvr(pe, pv, pr, pt)))));
-
+                    // We check "package_version" to determine if we have an EVR
+                    // If the package is for an affected system, we should have at least the version and the release.
+                    // Otherwise, all values will be null (no EVR present)
+                    // (See: cve_audit_queries#list_systems_by_patch_status)
+                    Optional<PackageEvr> packageEvr = Optional.ofNullable((String) row.get("package_version"))
+                            .map(pv -> new PackageEvr((String) row.get("package_epoch"), pv,
+                                    (String) row.get("package_release"), (String) row.get("package_type")));
 
                     return new CVEPatchStatus(
                             (long) row.get("image_info_id"),
@@ -814,13 +814,13 @@ public class CVEAuditManager {
 
         return StreamSupport.stream(results.spliterator(), false)
                 .map(row -> {
-
-                    Optional<PackageEvr> packageEvr =
-                            Optional.ofNullable((String) row.get("package_epoch")).flatMap(pe ->
-                            Optional.ofNullable((String) row.get("package_version")).flatMap(pv ->
-                            Optional.ofNullable((String) row.get("package_release")).flatMap(pr ->
-                            Optional.ofNullable((String) row.get("package_type"))
-                                    .map(pt -> new PackageEvr(pe, pv, pr, pt)))));
+                    // We check "package_version" to determine if we have an EVR
+                    // If the package is for an affected system, we should have at least the version and the release.
+                    // Otherwise, all values will be null (no EVR present)
+                    // (See: cve_audit_queries#list_systems_by_patch_status)
+                    Optional<PackageEvr> packageEvr = Optional.ofNullable((String) row.get("package_version"))
+                            .map(pv -> new PackageEvr((String) row.get("package_epoch"), pv,
+                                    (String) row.get("package_release"), (String) row.get("package_type")));
 
                     return new CVEPatchStatus(
                             (long) row.get("system_id"),

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix CVE audit results for affected and patched entries (bsc#1180893)
 - Replace custom version comparison method with the standard one which also takes debian packages into account
 - Default to preferred items per page in content lifecycle lists (bsc#1180558)
 - Removed Java module com.sun.bind if it is not available; Load jaxb bundles if available.


### PR DESCRIPTION
The specific CVE audit query list_systems_by_patch_status merges server package data from both affected and non-affected systems. If the system is not affected, all the package related data (including EVR) is filled with nulls. But since epoch is a non-mandatory field, it can be null in both cases.

With the recent update to PackageEvr, the code assumes that an epoch is always present in an EVR, and ignores the rest of it if it is not. This causes an NPE down the line.

This fix checks the version to determine if we have an EVR instead.

Fixes: https://bugzilla.suse.com/1180893
Port of: https://github.com/SUSE/spacewalk/pull/13649

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [x] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
