### PR TITLE
Fix: CVE audit results for affected and patched entries (bsc#1180893)

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/audit/CVEAuditManager.java
+++ b/java/code/src/com/redhat/rhn/manager/audit/CVEAuditManager.java
@@ -775,13 +775,15 @@ public class CVEAuditManager {
 
         return results.stream()
                 .map(row -> {
-                    Optional<PackageEvr> packageEvr =
-                        Optional.ofNullable((String) row.get("package_epoch")).flatMap(pe ->
-                        Optional.ofNullable((String) row.get("package_version")).flatMap(pv ->
-                        Optional.ofNullable((String) row.get("package_release")).flatMap(pr ->
-                        Optional.ofNullable((String) row.get("package_type"))
-                                .map(pt -> new PackageEvr(pe, pv, pr, pt)))));
-
+                    /*
+                        We check "package_version" to determine if we have an EVR
+                        If the package is for an affected image, we should have at least the version and the release.
+                        Otherwise, all values will be null (no EVR present)
+                        (See: cve_audit_queries#list_images_by_patch_status)
+                    */
+                    Optional<PackageEvr> packageEvr = Optional.ofNullable((String) row.get("package_version"))
+                            .map(pv -> new PackageEvr((String) row.get("package_epoch"), pv,
+                                    (String) row.get("package_release"), (String) row.get("package_type")));
 
                     return new CVEPatchStatus(
                             (long) row.get("image_info_id"),
@@ -814,13 +816,15 @@ public class CVEAuditManager {
 
         return StreamSupport.stream(results.spliterator(), false)
                 .map(row -> {
-
-                    Optional<PackageEvr> packageEvr =
-                            Optional.ofNullable((String) row.get("package_epoch")).flatMap(pe ->
-                            Optional.ofNullable((String) row.get("package_version")).flatMap(pv ->
-                            Optional.ofNullable((String) row.get("package_release")).flatMap(pr ->
-                            Optional.ofNullable((String) row.get("package_type"))
-                                    .map(pt -> new PackageEvr(pe, pv, pr, pt)))));
+                    /*
+                        We check "package_version" to determine if we have an EVR
+                        If the package is for an affected system, we should have at least the version and the release.
+                        Otherwise, all values will be null (no EVR present)
+                        (See: cve_audit_queries#list_systems_by_patch_status)
+                    */
+                    Optional<PackageEvr> packageEvr = Optional.ofNullable((String) row.get("package_version"))
+                            .map(pv -> new PackageEvr((String) row.get("package_epoch"), pv,
+                                    (String) row.get("package_release"), (String) row.get("package_type")));
 
                     return new CVEPatchStatus(
                             (long) row.get("system_id"),

--- a/java/code/src/com/redhat/rhn/testing/ErrataTestUtils.java
+++ b/java/code/src/com/redhat/rhn/testing/ErrataTestUtils.java
@@ -368,15 +368,29 @@ public class ErrataTestUtils {
      * @throws Exception if anything goes wrong
      */
     public static Package createLaterTestPackage(User user, Errata errata, Channel channel,
-            Package previous) throws Exception {
+                                                 Package previous) throws Exception {
+        return createLaterTestPackage(user, errata, channel, previous, previous.getPackageEvr().getEpoch(),
+                previous.getPackageEvr().getVersion(),
+                (Integer.parseInt(previous.getPackageEvr().getRelease()) + 1) + "");
+    }
+
+    /**
+     * Create a {@link Package} which has a greater version number than another.
+     * @param user the package owner
+     * @param errata an errata that will contain the new package
+     * @param channel the channel in which the new package is to be published
+     * @param previous the previous channel
+     * @param epoch the package epoch
+     * @param version the package version
+     * @param release the package release
+     * @return the newly created patch
+     * @throws Exception if anything goes wrong
+     */
+    public static Package createLaterTestPackage(User user, Errata errata, Channel channel, Package previous,
+                                                 String epoch, String version, String release) throws Exception {
         Package result =
                 createTestPackage(user, errata, channel, previous.getPackageArch()
                         .getLabel());
-
-        PackageEvr previousEvr = previous.getPackageEvr();
-        String epoch = previousEvr.getEpoch();
-        String version = previousEvr.getVersion();
-        String release = (Integer.parseInt(previousEvr.getRelease()) + 1) + "";
         PackageEvr pevr =
                 PackageEvrFactory.lookupOrCreatePackageEvr(epoch, version, release,
                         previous.getPackageEvr().getPackageType());

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix CVE audit results for affected and patched entries (bsc#1180893)
 - Replace custom version comparison method with the standard one which also takes debian packages into account
 - Default to preferred items per page in content lifecycle lists (bsc#1180558)
 - Removed Java module com.sun.bind if it is not available; Load jaxb bundles if available.


### PR DESCRIPTION
## What does this PR change?

The specific CVE audit query `list_systems_by_patch_status` and `list_images_by_patch_status` merges server package data from both affected and non-affected systems. If the system is not affected, all the package related data (including EVR) is filled with nulls. But since epoch is a non-mandatory field, it can be null in both cases.

With the recent update to `PackageEvr`, the code assumes that an epoch is always present in an EVR, and ignores the rest of it if it is not. This causes an NPE down the line.

This fix checks the version to determine if we have an EVR instead.

Fixes: https://bugzilla.suse.com/1180893

## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
- Unit tests were added

- [X] **DONE**

## Links

Fixes: bugzilla.suse.com/1180893

To be ported to Manager-4.1, Manager-4.0

- [ ] **DONE**

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
