### PR TITLE
QAM: Fixing step def. typo on RES8 product sync

### DIFF
--- a/testsuite/features/qam/reposync/srv_sync_qam_products.feature
+++ b/testsuite/features/qam/reposync/srv_sync_qam_products.feature
@@ -114,8 +114,8 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I select "RHEL or SLES ES or CentOS 8 Base x86_64" as a product
     Then I should see the "RHEL or SLES ES or CentOS 8 Base x86_64" selected
     When I open the sub-list of the product "RHEL or SLES ES or CentOS 8 Base x86_64"
-    And I select "SUSE Linux Enterprise Server with Expanded Support 8 x86_64"
-    Then I should see "SUSE Linux Enterprise Server with Expanded Support 8 x86_64" selected
+    And I select "SUSE Linux Enterprise Server with Expanded Support 8 x86_64" as a product
+    Then I should see the "SUSE Linux Enterprise Server with Expanded Support 8 x86_64" selected
     When I click the Add Product button
     And I wait until I see "RHEL or SLES ES or CentOS 8 Base x86_64" product has been added
 


### PR DESCRIPTION
## What does this PR change?

Fixing a typo calling a step definition when syncing our QAM products

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.1 https://github.com/SUSE/spacewalk/pull/13662
- Manager-4.0 https://github.com/SUSE/spacewalk/pull/13661

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
