### PR TITLE
Fix JS type check in CLM project form

### DIFF
--- a/web/html/src/manager/content-management/shared/components/panels/sources/channels/channels-selection.js
+++ b/web/html/src/manager/content-management/shared/components/panels/sources/channels/channels-selection.js
@@ -84,7 +84,7 @@ const ChannelsSelection = (props: PropsType) => {
             name='selectedBaseChannel'
             value={orderedBaseChannels.find(item => item.id === state.selectedBaseChannelId)}
             onChange={value => {
-                if (value instanceof "object" && !(value instanceof Array)) {
+                if (typeof value === "object" && !(Array.isArray(value))) {
                   dispatchChannelsSelection({
                   type: "lead_channel",
                   newBaseId: parseInt(value.id, 10)

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Fix source selection form in CLM project page
 - Default to preferred items per page in content lifecycle lists (bsc#1180558)
 - Fix sorting in content lifecycle projects and cluster tables (bsc#1180558)
 - Mark required inputs in the 'Environment Lifecycle' form


### PR DESCRIPTION
Fix JS type check in CLM project form

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
