### PR TITLE
Change centos6 urls

### DIFF
--- a/susemanager-sync-data/additional_products.json
+++ b/susemanager-sync-data/additional_products.json
@@ -878,8 +878,8 @@
         ],
         "repositories" : [
             {
-                "id" : -123,
-                "url" : "http://mirrorlist.centos.org/?release=6&arch=x86_64&repo=os",
+                "id" : -230,
+                "url" : "https://vault.centos.org/centos/6/os/x86_64/",
                 "name" : "centos6",
                 "distro_target" : "x86_64",
                 "description" : "CentOS 6",
@@ -888,8 +888,8 @@
                 "installer_updates" : false
             },
             {
-                "id" : -124,
-                "url" : "http://mirrorlist.centos.org/?release=6&arch=x86_64&repo=centosplus",
+                "id" : -231,
+                "url" : "https://vault.centos.org/centos/6/centosplus/x86_64/",
                 "name" : "centos6-centosplus",
                 "distro_target" : "x86_64",
                 "description" : "CentOS 6 Plus",
@@ -898,8 +898,8 @@
                 "installer_updates" : false
             },
             {
-                "id" : -125,
-                "url" : "http://mirrorlist.centos.org/?release=6&arch=x86_64&repo=contrib",
+                "id" : -232,
+                "url" : "https://vault.centos.org/centos/6/contrib/x86_64/",
                 "name" : "centos6-contrib",
                 "distro_target" : "x86_64",
                 "description" : "CentOS 6 Contrib",
@@ -908,8 +908,8 @@
                 "installer_updates" : false
             },
             {
-                "id" : -126,
-                "url" : "http://mirrorlist.centos.org/?release=6&arch=x86_64&repo=extras",
+                "id" : -233,
+                "url" : "https://vault.centos.org/centos/6/extras/x86_64/",
                 "name" : "centos6-extras",
                 "distro_target" : "x86_64",
                 "description" : "CentOS 6 Extras",
@@ -918,8 +918,8 @@
                 "installer_updates" : false
             },
             {
-                "id" : -127,
-                "url" : "http://mirrorlist.centos.org/?release=6&arch=x86_64&repo=fasttrack",
+                "id" : -234,
+                "url" : "https://vault.centos.org/centos/6/fasttrack/x86_64/",
                 "name" : "centos6-fasttrack",
                 "distro_target" : "x86_64",
                 "description" : "CentOS 6 FastTrack",
@@ -928,8 +928,8 @@
                 "installer_updates" : false
             },
             {
-                "id" : -128,
-                "url" : "http://mirrorlist.centos.org/?release=6&arch=x86_64&repo=updates",
+                "id" : -235,
+                "url" : "https://vault.centos.org/centos/6/updates/x86_64/",
                 "name" : "centos6-updates",
                 "distro_target" : "x86_64",
                 "description" : "CentOS 6 Updates",
@@ -975,8 +975,8 @@
         ],
         "repositories" : [
             {
-                "id" : -114,
-                "url" : "http://mirrorlist.centos.org/?release=6&arch=i386&repo=os",
+                "id" : -220,
+                "url" : "https://vault.centos.org/centos/6/os/i386/",
                 "name" : "centos6",
                 "distro_target" : "i386",
                 "description" : "CentOS 6",
@@ -985,8 +985,8 @@
                 "installer_updates" : false
             },
             {
-                "id" : -115,
-                "url" : "http://mirrorlist.centos.org/?release=6&arch=i386&repo=centosplus",
+                "id" : -221,
+                "url" : "https://vault.centos.org/centos/6/centosplus/i386/",
                 "name" : "centos6-centosplus",
                 "distro_target" : "i386",
                 "description" : "CentOS 6 Plus",
@@ -995,8 +995,8 @@
                 "installer_updates" : false
             },
             {
-                "id" : -116,
-                "url" : "http://mirrorlist.centos.org/?release=6&arch=i386&repo=contrib",
+                "id" : -222,
+                "url" : "https://vault.centos.org/centos/6/contrib/i386/",
                 "name" : "centos6-contrib",
                 "distro_target" : "i386",
                 "description" : "CentOS 6 Contrib",
@@ -1005,8 +1005,8 @@
                 "installer_updates" : false
             },
             {
-                "id" : -118,
-                "url" : "http://mirrorlist.centos.org/?release=6&arch=i386&repo=extras",
+                "id" : -223,
+                "url" : "https://vault.centos.org/centos/6/extras/i386/",
                 "name" : "centos6-extras",
                 "distro_target" : "i386",
                 "description" : "CentOS 6 Extras",
@@ -1015,8 +1015,8 @@
                 "installer_updates" : false
             },
             {
-                "id" : -119,
-                "url" : "http://mirrorlist.centos.org/?release=6&arch=i386&repo=fasttrack",
+                "id" : -224,
+                "url" : "https://vault.centos.org/centos/6/fasttrack/i386/",
                 "name" : "centos6-fasttrack",
                 "distro_target" : "i386",
                 "description" : "CentOS 6 FastTrack",
@@ -1025,8 +1025,8 @@
                 "installer_updates" : false
             },
             {
-                "id" : -120,
-                "url" : "http://mirrorlist.centos.org/?release=6&arch=i386&repo=updates",
+                "id" : -225,
+                "url" : "https://vault.centos.org/centos/6/updates/i386/",
                 "name" : "centos6-updates",
                 "distro_target" : "i386",
                 "description" : "CentOS 6 Updates",

--- a/susemanager-sync-data/susemanager-sync-data.changes
+++ b/susemanager-sync-data/susemanager-sync-data.changes
@@ -1,3 +1,4 @@
+- change centos 6 URLs to vault.centos.org
 - add SLE15 SP1 LTSS
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

CentOS 6 is EOL and the mirror list was removed. Change the URLs to vault.centos.org

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/13615
Tracks https://github.com/SUSE/spacewalk/pull/13671 https://github.com/SUSE/spacewalk/pull/13672

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
