### PR TITLE
reposync: Add yum_dnf_src plugin.

### DIFF
--- a/backend/satellite_tools/repo_plugins/Makefile
+++ b/backend/satellite_tools/repo_plugins/Makefile
@@ -20,7 +20,7 @@ TOP	= ../..
 
 # Specific stuff
 SUBDIR	= satellite_tools/repo_plugins
-SPACEWALK_FILES	= __init__ yum_src uln_src deb_src
+SPACEWALK_FILES	= __init__ yum_src uln_src deb_src yum_dnf_src
 
 include $(TOP)/Makefile.defs
 

--- a/backend/satellite_tools/repo_plugins/yum_src.py
+++ b/backend/satellite_tools/repo_plugins/yum_src.py
@@ -72,6 +72,8 @@ REPOSYNC_EXTRA_HTTP_HEADERS_CONF = '/etc/rhn/spacewalk-repo-sync/extra_headers.c
 
 RPM_PUBKEY_VERSION_RELEASE_RE = re.compile(r'^gpg-pubkey-([0-9a-fA-F]+)-([0-9a-fA-F]+)')
 
+APACHE_USER = 'wwwrun'
+APACHE_GROUP = 'www'
 
 class ZyppoSync:
     """
@@ -157,9 +159,9 @@ class ZypperRepo:
            self.urls[0] += '/'
        # Make sure root paths are created
        if not os.path.isdir(self.root):
-           fileutils.makedirs(self.root, user='wwwrun', group='www')
+           fileutils.makedirs(self.root, user=APACHE_USER, group=APACHE_GROUP)
        if not os.path.isdir(self.pkgdir):
-           fileutils.makedirs(self.pkgdir, user='wwwrun', group='www')
+           fileutils.makedirs(self.pkgdir, user=APACHE_USER, group=APACHE_GROUP)
        self.is_configured = False
        self.includepkgs = []
        self.exclude = []
@@ -1142,7 +1144,6 @@ type=rpm-md
         if not os.path.exists(target_dir):
             os.makedirs(target_dir, int('0755', 8))
 
-        params['authtoken'] = self.authtoken
         params['urls'] = self.repo.urls
         params['relative_path'] = relative_path
         params['authtoken'] = self.authtoken

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Added dnf plugin to reposync.
 - Drop Transfer-Encoding header from proxy respone to fix error response messages (bsc#1176906)
 - Prevent tracebacks on missing mail configuration (bsc#1179990)
 - Fix pycurl.error handling in suseLib.py (bsc#1179990)

--- a/backend/spacewalk-backend.spec
+++ b/backend/spacewalk-backend.spec
@@ -234,7 +234,7 @@ BuildRequires:	systemd-rpm-macros
 Requires:       (python3-dateutil or python3-python-dateutil)
 Requires:       python3-rhn-client-tools
 Requires:       python3-solv
-Requires:       python3-urlgrabber
+Requires:       python3-urlgrabber < 4
 Requires:       spacewalk-admin >= 0.1.1-0
 Requires:       spacewalk-certs-tools
 Requires:       susemanager-tools
@@ -704,6 +704,7 @@ fi
 %attr(755,root,%{apache_group}) %dir %{_var}/log/rhn/reposync
 %{python3rhnroot}/satellite_tools/repo_plugins/__init__.py*
 %{python3rhnroot}/satellite_tools/repo_plugins/yum_src.py*
+%{python3rhnroot}/satellite_tools/repo_plugins/yum_dnf_src.py*
 %{python3rhnroot}/satellite_tools/repo_plugins/uln_src.py*
 %{python3rhnroot}/satellite_tools/repo_plugins/deb_src.py*
 %dir %{python3rhnroot}/satellite_tools/__pycache__/


### PR DESCRIPTION
## What does this PR change?

- Parameterised apache owners in `backend/satellite_tools/reposync.py` and `backend/satellite_tools/repo_plugins/yum_src.py`
- Forcing URLGrabber version < 4 (see #3113).
- Added yum_dnf_src plugin.

Working features:
- Basic reposync (i.e. CentOS8 and SUSE Leap repositories)

Not implemented features:
- `ContentSource` Options: `insecure` and `interactive` are ignored.
- Creating kickstartable tree fails (see #3134).
- Test cases (see section test cases below).

Unverified features:
- Proxy
- HTTP Headers
- Not all expected features have been tested.
- Some of the functionality might still need alignment (additional logic, correct folder locations,...)

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: No functional change.

- [X] **DONE**

## Test coverage
- No tests: As the dnf module requires an actual repository to load, this makes the test more complicated. The test case is still WIP.

Tested successful package build for CentOS 8 and Leap 15.2.

- [X] **DONE**

## Links

Fixes #3074 
Relates #3113 

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
