### PR TITLE
Update CentOS6 URLs to use vault.centos.org

### DIFF
--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- Update CentOS6 URLs to use vault.centos.org
 - Changed to versioned Python3 to SPEC file.
 - Python3 port for blend tool
 - add missing unique index on suse tables

--- a/schema/spacewalk/upgrade/susemanager-schema-4.2.4-to-susemanager-schema-4.2.5/900-centos6-vault.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.2.4-to-susemanager-schema-4.2.5/900-centos6-vault.sql
@@ -1,0 +1,4 @@
+--- After CentOS EoL, it got removed from the mirrorlist and moved to the vault
+UPDATE rhnContentSource
+SET source_url = concat('https://vault.centos.org/centos/6/', array_to_string(regexp_match(source_url, 'repo=(.+)'), ''), '/' ,array_to_string(regexp_match(source_url, 'arch=(.+)&'), ''), '/')
+WHERE source_url LIKE 'http://mirrorlist.centos.org/?release=6%' AND org_id IS NOT NULL;

--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -538,7 +538,7 @@ name     = CentOS 6 (%(arch)s)
 gpgkey_url = http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-6
 gpgkey_id = C105B9DE
 gpgkey_fingerprint = C1DA C52D 1664 E8A4 386D  BA43 0946 FCA2 C105 B9DE
-repo_url = http://mirrorlist.centos.org/?release=6&arch=%(arch)s&repo=os
+repo_url = https://vault.centos.org/centos/6/os/%(arch)/
 dist_map_release = 6
 
 [centos6-centosplus]
@@ -546,35 +546,35 @@ label    = %(base_channel)s-centosplus
 archs    = %(_x86_archs)s
 name     = CentOS 6 Plus (%(arch)s)
 base_channels = centos6-%(arch)s
-repo_url = http://mirrorlist.centos.org/?release=6&arch=%(arch)s&repo=centosplus
+repo_url = https://vault.centos.org/centos/6/centosplus/%(arch)/
 
 [centos6-contrib]
 label    = %(base_channel)s-contrib
 archs    = %(_x86_archs)s
 name     = CentOS 6 Contrib (%(arch)s)
 base_channels = centos6-%(arch)s
-repo_url = http://mirrorlist.centos.org/?release=6&arch=%(arch)s&repo=contrib
+repo_url = https://vault.centos.org/centos/6/contrib/%(arch)/
 
 [centos6-extras]
 label    = %(base_channel)s-extras
 archs    = %(_x86_archs)s
 name     = CentOS 6 Extras (%(arch)s)
 base_channels = centos6-%(arch)s
-repo_url = http://mirrorlist.centos.org/?release=6&arch=%(arch)s&repo=extras
+repo_url = https://vault.centos.org/centos/6/extras/%(arch)/
 
 [centos6-fasttrack]
 label    = %(base_channel)s-fasttrack
 archs    = %(_x86_archs)s
 name     = CentOS 6 FastTrack (%(arch)s)
 base_channels = centos6-%(arch)s
-repo_url = http://mirrorlist.centos.org/?release=6&arch=%(arch)s&repo=fasttrack
+repo_url = https://vault.centos.org/centos/6/fasttrack/%(arch)/
 
 [centos6-updates]
 label    = %(base_channel)s-updates
 archs    = %(_x86_archs)s
 name     = CentOS 6 Updates (%(arch)s)
 base_channels = centos6-%(arch)s
-repo_url = http://mirrorlist.centos.org/?release=6&arch=%(arch)s&repo=updates
+repo_url = https://vault.centos.org/centos/6/updates/%(arch)/
 
 [centos6-uyuni-client]
 name     = Uyuni Client Tools for %(base_channel_name)s

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,4 @@
+- spacewalk-common-channels: Update CentOS6 URLs to use vault.centos.org
 - spacewalk-common-channels: re-use repositories when different channels
   use the same one
 


### PR DESCRIPTION
## What does this PR change?

Update CentOS6 URLs to use vault.centos.org. Required after CentOS6 EoL, as it's not available anymore at mirrorlist.centos.org

After applying the SQL script:

```
                        | External - Uyuni Client Tools for CentOS 6 (i386)               | N               | 2021-01-18 13:13:57.288531+01 | 2021-01-18 13:13:57.288531+01
 537 |      1 |     500 | https://vault.centos.org/centos/6/os/i386/                                                                                                                                                                                                           
                        | External - CentOS 6 (i386)                                      | N               | 2021-01-18 13:13:56.899931+01 | 2021-01-18 13:13:56.899931+01
 538 |      1 |     500 | https://vault.centos.org/centos/6/centosplus/i386/                                                                                                                                                                                                   
                        | External - CentOS 6 Plus (i386)                                 | N               | 2021-01-18 13:13:56.965678+01 | 2021-01-18 13:13:56.965678+01
 539 |      1 |     500 | https://vault.centos.org/centos/6/contrib/i386/                                                                                                                                                                                                      
                        | External - CentOS 6 Contrib (i386)                              | N               | 2021-01-18 13:13:57.014543+01 | 2021-01-18 13:13:57.014543+01
 540 |      1 |     500 | https://vault.centos.org/centos/6/extras/i386/                                                                                                                                                                                                       
                        | External - CentOS 6 Extras (i386)                               | N               | 2021-01-18 13:13:57.076939+01 | 2021-01-18 13:13:57.076939+01
 541 |      1 |     500 | https://vault.centos.org/centos/6/fasttrack/i386/                                                                                                                                                                                                    
                        | External - CentOS 6 FastTrack (i386)                            | N               | 2021-01-18 13:13:57.135171+01 | 2021-01-18 13:13:57.135171+01
 542 |      1 |     500 | https://vault.centos.org/centos/6/updates/i386/                                                                                                                                                                                                      
                        | External - CentOS 6 Updates (i386)                              | N               | 2021-01-18 13:13:57.189569+01 | 2021-01-18 13:13:57.189569+01
 545 |      1 |     500 | https://vault.centos.org/centos/6/os/x86_64/                                                                                                                                                                                                         
                        | External - CentOS 6 (x86_64)                                    | N               | 2021-01-18 13:13:57.329493+01 | 2021-01-18 13:13:57.329493+01
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Change is transparent for the user. The channel names didn't change, and the SQL script will take care of changing the URLs for users that are already syncing CentOS6.

- [x] **DONE**

## Test coverage
- No tests: Covered already by SQL tests and cucumber

- [x] **DONE**

## Links

Fixes #https://github.com/SUSE/spacewalk/issues/13615

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
