### PR TITLE
QAM: LTSS updates channel can't be synced from the WebUI

### DIFF
--- a/testsuite/features/qam/reposync/srv_sync_qam_products.feature
+++ b/testsuite/features/qam/reposync/srv_sync_qam_products.feature
@@ -38,11 +38,9 @@ Feature: Synchronize products in the products page of the Setup Wizard
     When I enter "SUSE Linux Enterprise Server 11 SP3 i586" as the filtered product description
     And I select "SUSE Linux Enterprise Server 11 SP3 i586" as a product
     Then I should see the "SUSE Linux Enterprise Server 11 SP3 i586" selected
-    When I open the sub-list of the product "SUSE Linux Enterprise Server 11 SP3 i586"
-    And I select "SUSE Linux Enterprise Server LTSS 11 SP3 i586" as a product
-    Then I should see the "SUSE Linux Enterprise Server LTSS 11 SP3 i586" selected
     When I click the Add Product button
     And I wait until I see "SUSE Linux Enterprise Server 11 SP3 i586" product has been added
+    And I add "sles11-sp3-ltss-updates-i586" channel
 
   Scenario: SUSE Linux Enterprise Server 11 SP4
     Given I am on the Products page
@@ -52,10 +50,9 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I open the sub-list of the product "SUSE Linux Enterprise Server 11 SP4 x86_64"
     And I select "SUSE Linux Enterprise Software Development Kit 11 SP4" as a product
     Then I should see the "SUSE Linux Enterprise Software Development Kit 11 SP4" selected
-    And I select "SUSE Linux Enterprise Server LTSS 11 SP4 x86_64" as a product
-    Then I should see the "SUSE Linux Enterprise Server LTSS 11 SP4 x86_64" selected
     When I click the Add Product button
     And I wait until I see "SUSE Linux Enterprise Server 11 SP4 x86_64" product has been added
+    And I add "sles11-sp4-ltss-updates-x86_64" channel
 
   Scenario: SUSE Linux Enterprise Server 15
     Given I am on the Products page


### PR DESCRIPTION
## What does this PR change?

Related card: https://github.com/SUSE/spacewalk/issues/11333

This PR fixes the issue of syncing LTSS channels, as they are not available as sub-products on the WebUI, but just as optional channels. So they must be synced from a console command.

@paususe @mcalmer should we consider this an enhancement in our WebUI?

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.0
- Manager-4.1

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
