### PR TITLE
QAM: Add Ubuntu 20.04 product sync

### DIFF
--- a/testsuite/features/qam/reposync/srv_sync_qam_products.feature
+++ b/testsuite/features/qam/reposync/srv_sync_qam_products.feature
@@ -22,6 +22,14 @@ Feature: Synchronize products in the products page of the Setup Wizard
     When I click the Add Product button
     And I wait until I see "Ubuntu 18.04" product has been added
 
+  Scenario: Add Ubuntu 20.04
+    Given I am on the Products page
+    When I enter "Ubuntu 20.04" as the filtered product description
+    And I select "Ubuntu 20.04" as a product
+    Then I should see the "Ubuntu 20.04" selected
+    When I click the Add Product button
+    And I wait until I see "Ubuntu 20.04" product has been added
+
   Scenario: SUSE Linux Enterprise Server 12 SP4
     Given I am on the Products page
     When I enter "SUSE Linux Enterprise Server 12 SP4" as the filtered product description


### PR DESCRIPTION
## What does this PR change?

Related card https://github.com/SUSE/spacewalk/issues/13372

Synchronize Ubuntu 20.04 at QAM environment

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.0
- Manager-4.1

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
