### PR TITLE
Fix: login gets an ISE when SSO is enabled (bsc#1181048)

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/SSOController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/SSOController.java
@@ -121,7 +121,7 @@ public final class SSOController {
                         }
                     }
                     else {
-                        LOG.error("SAML attribute named 'uid' not found in SAML attributes. Cannot log the user in." +
+                        LOG.error("SAML attribute named 'uid' not found in SAML attributes. Cannot log the user in. " +
                                 "Please check with your Identity Provider (IdP) the presence of this attribute.");
                     }
                 }
@@ -137,8 +137,8 @@ public final class SSOController {
             }
             catch (LookupException e) {
                 LOG.error("Unable to find user: " + e.getMessage());
-                return "Internal error during SSO authentication phase." +
-                        "Have you created the corresponding user in SUSE Manager? See product documentation";
+                return "Internal error during SSO authentication phase. Have you created the corresponding user in " +
+                        "SUSE Manager? See product documentation";
             }
             catch (SettingsException e) {
                 LOG.error("Unable to parse settings for SSO: " + e.getMessage());

--- a/java/code/src/com/suse/manager/webui/controllers/test/LoginControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/test/LoginControllerTest.java
@@ -57,7 +57,6 @@ public class LoginControllerTest extends BaseControllerTestCase {
 
     public void testLoginWithSSO() throws UnsupportedEncodingException {
         Config.get().setBoolean(ConfigDefaults.SINGLE_SIGN_ON_ENABLED, "true");
-
         final String requestUrl = "http://localhost:8080/rhn/manager/login";
         final RouteMatch match = new RouteMatch(new Object(), requestUrl, requestUrl, "");
         final RhnMockHttpServletRequest mockRequest = new RhnMockHttpServletRequest();
@@ -72,6 +71,8 @@ public class LoginControllerTest extends BaseControllerTestCase {
         response = RequestResponseFactory.create(new RhnMockHttpServletResponse());
         ModelAndView result = LoginController.loginView(RequestResponseFactory.create(match, mockRequest), response);
         assertNotNull(result); // redirect to the SSO login page
+        // we still need to check that the model has been correctly populated
+        assertNotNull(((Map<String, Object>) result.getModel()).get("webTheme"));
     }
 
     public void testUrlBounceNotAuthenticated() throws UnsupportedEncodingException {

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix: login gets an ISE when SSO is enabled (bsc#1181048)
 - Content Lifecycle Management input validation errors are now displayed at the field-level instead of a popup
 - Add an API endpoint to allow/disallow scheduling irrelevant patches (bsc#1180757)
 - Fix CVE audit results for affected and patched entries (bsc#1180893)


### PR DESCRIPTION
## What does this PR change?

Some variables needed for rendering the Jade login template were added after the introduction of SSO (e.g. `webTheme`).
Back in the day, the needed variables for SSO were only in `SparkApplicationHelper`. Now, login with SSO gets an ISE because the
Jade compiler cannot find model variables that were added.

This PR unifies the code path for non-SSO and SSO fixes the problem above while also unifies the code paths for non-SSO and SSO to
avoid the problem in the future.

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1181048

## GUI diff

No difference.

- [X] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- Unit tests were added

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/13680
Tracks https://github.com/SUSE/spacewalk/pull/13688

- [X] **DONE**

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
