### PR TITLE
Updated 'node' requirements.

### DIFF
--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,5 @@
+- Improved node requirements in spec file.
+- Updated Source to Uyuni repo.
 - Fix source selection form in CLM project page
 - Default to preferred items per page in content lifecycle lists (bsc#1180558)
 - Fix sorting in content lifecycle projects and cluster tables (bsc#1180558)

--- a/web/spacewalk-web.spec
+++ b/web/spacewalk-web.spec
@@ -40,18 +40,20 @@ Group:          Applications/Internet
 Version:        4.2.4
 Release:        1%{?dist}
 Url:            https://github.com/uyuni-project/uyuni
-Source0:        https://github.com/spacewalkproject/spacewalk/archive/%{name}-%{version}.tar.gz
+Source0:        https://github.com/uyuni-project/uyuni/archive/%{name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
 Requires(pre):  uyuni-base-common
 BuildRequires:  uyuni-base-common
 BuildRequires:  perl(ExtUtils::MakeMaker)
 BuildRequires:  susemanager-nodejs-sdk-devel
+BuildRequires:  nodejs-packaging
 
 %if 0%{?suse_version}
 BuildRequires:  apache2
-BuildRequires:  nodejs-packaging
-
+BuildRequires:  nodejs10
+%else
+BuildRequires:  nodejs
 %endif
 
 %description


### PR DESCRIPTION
## What does this PR change?

Added build requirements for node.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: No changes

- [X] **DONE**

## Test coverage
- No tests: Tested during package build process.
Build of CentOS 8 verified. Leap 15.2 not due to test system issues.

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
