### PR TITLE
Add origin server hostname to Salt pillar data (bsc#1180439)

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/utils/AbstractMinionBootstrapper.java
+++ b/java/code/src/com/suse/manager/webui/controllers/utils/AbstractMinionBootstrapper.java
@@ -220,6 +220,7 @@ public abstract class AbstractMinionBootstrapper {
                 .orElse(ConfigDefaults.get().getCobblerHost());
 
         pillarData.put("mgr_server", mgrServer);
+        pillarData.put("mgr_origin_server", ConfigDefaults.get().getCobblerHost());
         pillarData.put("minion_id", input.getHost());
         pillarData.put("contact_method", contactMethod);
         pillarData.put("mgr_sudo_user", SaltSSHService.getSSHUser());

--- a/java/code/src/com/suse/manager/webui/controllers/utils/test/RegularMinionBootstrapperTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/utils/test/RegularMinionBootstrapperTest.java
@@ -121,6 +121,7 @@ public class RegularMinionBootstrapperTest extends AbstractMinionBootstrapperTes
     protected Map<String, Object> createPillarData(Optional<ActivationKey> key) {
         Map<String, Object> pillarData = new HashMap<>();
         pillarData.put("mgr_server", ConfigDefaults.get().getCobblerHost());
+        pillarData.put("mgr_origin_server", ConfigDefaults.get().getCobblerHost());
         pillarData.put("contact_method", key
                 .map(k -> k.getContactMethod().getLabel())
                 .orElse(getDefaultContactMethod()));

--- a/java/code/src/com/suse/manager/webui/controllers/utils/test/SSHMinionBootstrapperTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/utils/test/SSHMinionBootstrapperTest.java
@@ -82,6 +82,7 @@ public class SSHMinionBootstrapperTest extends AbstractMinionBootstrapperTestBas
     protected Map<String, Object> createPillarData(Optional<ActivationKey> key) {
         Map<String, Object> pillarData = new HashMap<>();
         pillarData.put("mgr_server", ConfigDefaults.get().getCobblerHost());
+        pillarData.put("mgr_origin_server", ConfigDefaults.get().getCobblerHost());
         pillarData.put("minion_id", "myhost");
         pillarData.put("contact_method", key
                 .map(k -> k.getContactMethod().getLabel())

--- a/java/code/src/com/suse/manager/webui/services/pillar/MinionGeneralPillarGenerator.java
+++ b/java/code/src/com/suse/manager/webui/services/pillar/MinionGeneralPillarGenerator.java
@@ -63,6 +63,7 @@ public class MinionGeneralPillarGenerator implements MinionPillarGenerator {
 
         pillar.add("contact_method", minion.getContactMethod().getLabel());
         pillar.add("mgr_server", minion.getChannelHost());
+        pillar.add("mgr_origin_server", ConfigDefaults.get().getCobblerHost());
         pillar.add("machine_password", MachinePasswordUtils.machinePassword(minion));
 
         Map<String, Object> chanPillar = new HashMap<>();

--- a/java/code/src/com/suse/manager/webui/services/pillar/test/MinionPillarManagerTest.java
+++ b/java/code/src/com/suse/manager/webui/services/pillar/test/MinionPillarManagerTest.java
@@ -91,6 +91,10 @@ public class MinionPillarManagerTest extends BaseTestCaseWithUser {
 
         assertTrue(map.containsKey("org_id"));
         assertEquals(minion.getOrg().getId(), Long.valueOf((int) map.get("org_id")));
+        assertTrue(map.containsKey("mgr_server"));
+        assertEquals(ConfigDefaults.get().getCobblerHost(), map.get("mgr_server"));
+        assertTrue(map.containsKey("mgr_origin_server"));
+        assertEquals(ConfigDefaults.get().getCobblerHost(), map.get("mgr_origin_server"));
 
         assertTrue(map.containsKey("channels"));
         Map<String, Object> channels = (Map<String, Object>) map.get("channels");
@@ -235,6 +239,11 @@ public class MinionPillarManagerTest extends BaseTestCaseWithUser {
         try (FileInputStream fi = new FileInputStream(filePath.toFile())) {
             map = new Yaml().loadAs(fi, Map.class);
         }
+
+        assertTrue(map.containsKey("mgr_server"));
+        assertEquals(proxyHostname, map.get("mgr_server"));
+        assertTrue(map.containsKey("mgr_origin_server"));
+        assertEquals(ConfigDefaults.get().getCobblerHost(), map.get("mgr_origin_server"));
 
         Map<String, Object> channels = (Map<String, Object>) map.get("channels");
         assertEquals(1, channels.size());

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add 'mgr_origin_server' to Salt pillar data (bsc#1180439)
 - enable openscap auditing for salt systems in SSM (bsc#1157711)
 - Removed "Software Crashes" feature
 - detect debian products (bsc#1181416)


### PR DESCRIPTION
## What does this PR change?

Origin server hostname is useful e.g. for setting up monitoring in environments
where Prometheus server is installed on the minion registered on the
proxy. The name _origin server_ always refers to the server where Uyuni server is installed.

Partially fixes https://bugzilla.suse.com/1180439

## GUI diff

No difference.

## Documentation
- [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pull/772)
- [Follow-up Documentation PR](https://github.com/uyuni-project/uyuni-docs/pull/797)

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Fixes # SUSE/spacewalk#13543

- [x] **DONE**

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
