### PR TITLE
QAM: Fix selection of RES8 product in Product Wizard

### DIFF
--- a/testsuite/features/qam/reposync/srv_sync_qam_products.feature
+++ b/testsuite/features/qam/reposync/srv_sync_qam_products.feature
@@ -97,32 +97,32 @@ Feature: Synchronize products in the products page of the Setup Wizard
     When I click the Add Product button
     And I wait until I see "SUSE Linux Enterprise Server 15 SP2 x86_64" product has been added
 
-  Scenario: SUSE Linux Enterprise Server with Expanded Support 6 x86_64
+  Scenario: SUSE Linux Enterprise Server with Expanded Support 6
     Given I am on the Products page
-    When I enter "SUSE Linux Enterprise Server with Expanded Support 6 x86_64" as the filtered product description
-    And I select "SUSE Linux Enterprise Server with Expanded Support 6 x86_64" as a product
-    Then I should see the "SUSE Linux Enterprise Server with Expanded Support 6 x86_64" selected
+    When I enter "SUSE Linux Enterprise Server with Expanded Support 6" as the filtered product description
+    And I select "SUSE Linux Enterprise Server with Expanded Support 6" as a product
+    Then I should see the "SUSE Linux Enterprise Server with Expanded Support 6" selected
     When I click the Add Product button
-    And I wait until I see "SUSE Linux Enterprise Server with Expanded Support 6 x86_64" product has been added
+    And I wait until I see "SUSE Linux Enterprise Server with Expanded Support 6" product has been added
 
-  Scenario: SUSE Linux Enterprise Server with Expanded Support 7 x86_64
+  Scenario: SUSE Linux Enterprise Server with Expanded Support 7
     Given I am on the Products page
-    When I enter "SUSE Linux Enterprise Server with Expanded Support 7 x86_64" as the filtered product description
-    And I select "SUSE Linux Enterprise Server with Expanded Support 7 x86_64" as a product
-    Then I should see the "SUSE Linux Enterprise Server with Expanded Support 7 x86_64" selected
+    When I enter "SUSE Linux Enterprise Server with Expanded Support 7" as the filtered product description
+    And I select "SUSE Linux Enterprise Server with Expanded Support 7" as a product
+    Then I should see the "SUSE Linux Enterprise Server with Expanded Support 7" selected
     When I click the Add Product button
-    And I wait until I see "SUSE Linux Enterprise Server with Expanded Support 7 x86_64" product has been added
+    And I wait until I see "SUSE Linux Enterprise Server with Expanded Support 7" product has been added
 
-  Scenario: SUSE Linux Enterprise Server with Expanded Support 8 x86_64
+  Scenario: SUSE Linux Enterprise Server with Expanded Support 8
     Given I am on the Products page
-    When I enter "RHEL or SLES ES or CentOS 8 Base x86_64" as the filtered product description
-    And I select "RHEL or SLES ES or CentOS 8 Base x86_64" as a product
-    Then I should see the "RHEL or SLES ES or CentOS 8 Base x86_64" selected
-    When I open the sub-list of the product "RHEL or SLES ES or CentOS 8 Base x86_64"
-    And I select "SUSE Linux Enterprise Server with Expanded Support 8 x86_64" as a product
-    Then I should see the "SUSE Linux Enterprise Server with Expanded Support 8 x86_64" selected
+    When I enter "RHEL or SLES ES or CentOS 8 Base" as the filtered product description
+    And I select "RHEL or SLES ES or CentOS 8 Base" as a product
+    Then I should see the "RHEL or SLES ES or CentOS 8 Base" selected
+    When I open the sub-list of the product "RHEL or SLES ES or CentOS 8 Base"
+    And I select "SUSE Linux Enterprise Server with Expanded Support 8" as a product
+    Then I should see the "SUSE Linux Enterprise Server with Expanded Support 8" selected
     When I click the Add Product button
-    And I wait until I see "RHEL or SLES ES or CentOS 8 Base x86_64" product has been added
+    And I wait until I see "RHEL or SLES ES or CentOS 8 Base" product has been added
 
   Scenario: SUSE Manager Proxy 4.2 x86_64
     Given I am on the Products page


### PR DESCRIPTION
## What does this PR change?

On RES8 product, SCC removed the architecture from the description text.
This caused a problem matching with the step written for that purpose in our test suite.
This PR get rid of the architecture text from the description text.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.1 https://github.com/SUSE/spacewalk/pull/13695
- Manager-4.0 https://github.com/SUSE/spacewalk/pull/13696

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
