### PR TITLE
Fixed Kickstart and URLGrabber error handling.

### DIFF
--- a/backend/satellite_tools/repo_plugins/yum_src.py
+++ b/backend/satellite_tools/repo_plugins/yum_src.py
@@ -1165,6 +1165,15 @@ type=rpm-md
         try:
             try:
                 temp_file = ""
+                try:
+                    if not urlparse(path).scheme:
+                        (s,b,p,q,f,o) = urlparse(self.url)
+                        if p[-1] != '/':
+                            p = p + '/'
+                        p = p + path
+                        url = urlunparse((s,b,p,q,f,o))
+                except (ValueError, IndexError, KeyError) as e:
+                    return None
                 if local_base is not None:
                     target_file = os.path.join(local_base, path)
                     target_dir = os.path.dirname(target_file)
@@ -1178,7 +1187,7 @@ type=rpm-md
                     return target_file
                 else:
                     return urlgrabber.urlread(path)
-            except urlgrabber.URLGrabError:
+            except urlgrabber.grabber.URLGrabError:
                 return
         finally:
             if os.path.exists(temp_file):

--- a/backend/satellite_tools/repo_plugins/yum_src.py
+++ b/backend/satellite_tools/repo_plugins/yum_src.py
@@ -1137,12 +1137,13 @@ type=rpm-md
             return False
 
     # Get download parameters for threaded downloader
-    def set_download_parameters(self, params, relative_path, target_file, checksum_type=None,
+    def set_download_parameters(self, params, relative_path, target_file=None, checksum_type=None,
                                 checksum_value=None, bytes_range=None):
         # Create directories if needed
-        target_dir = os.path.dirname(target_file)
-        if not os.path.exists(target_dir):
-            os.makedirs(target_dir, int('0755', 8))
+        if target_file is not None:
+            target_dir = os.path.dirname(target_file)
+            if not os.path.exists(target_dir):
+                os.makedirs(target_dir, int('0755', 8))
 
         params['urls'] = self.repo.urls
         params['relative_path'] = relative_path
@@ -1171,9 +1172,10 @@ type=rpm-md
                         if p[-1] != '/':
                             p = p + '/'
                         p = p + path
-                        url = urlunparse((s,b,p,q,f,o))
+                        path = urlunparse((s,b,p,q,f,o))
                 except (ValueError, IndexError, KeyError) as e:
                     return None
+
                 if local_base is not None:
                     target_file = os.path.join(local_base, path)
                     target_dir = os.path.dirname(target_file)
@@ -1182,11 +1184,15 @@ type=rpm-md
                     temp_file = target_file + '..download'
                     if os.path.exists(temp_file):
                         os.unlink(temp_file)
-                    downloaded = urlgrabber.urlgrab(path, temp_file)
+                    urlgrabber_opts = {}
+                    self.set_download_parameters(urlgrabber_opts, path, temp_file)
+                    downloaded = urlgrabber.urlgrab(path, temp_file, **urlgrabber_opts)
                     os.rename(downloaded, target_file)
                     return target_file
                 else:
-                    return urlgrabber.urlread(path)
+                    urlgrabber_opts = {}
+                    self.set_download_parameters(urlgrabber_opts, path)
+                    return urlgrabber.urlread(path, **urlgrabber_opts)
             except urlgrabber.grabber.URLGrabError:
                 return
         finally:

--- a/backend/satellite_tools/reposync.py
+++ b/backend/satellite_tools/reposync.py
@@ -14,6 +14,8 @@
 # in this software or its documentation.
 #
 
+import base64
+import configparser
 import os
 import re
 import shutil
@@ -23,7 +25,6 @@ import sys
 import tempfile
 import time
 import traceback
-import base64
 from datetime import datetime
 try:
     from html.parser import HTMLParser
@@ -148,7 +149,7 @@ class KSDirHtmlParser(KSDirParser):
         if dir_html is None:
             return
 
-        for s in (m.group(1) for m in re.finditer(r'(?i)<a href="(.+?)"', dir_html)):
+        for s in (m.group(1) for m in re.finditer(r'(?i)<a href="(.+?)"', dir_html.decode())):
             if not (re.match(r'/', s) or re.search(r'\?', s) or re.search(r'\.\.', s) or re.match(r'[a-zA-Z]+:', s) or
                     re.search(r'\.rpm$', s)):
                 if re.search(r'/$', s):
@@ -182,14 +183,14 @@ class TreeInfoError(Exception):
 
 class TreeInfoParser(object):
     def __init__(self, filename):
-        self.parser = ConfigParser.RawConfigParser()
+        self.parser = configparser.RawConfigParser()
         # do not lowercase
         self.parser.optionxform = str
         fp = open(filename)
         try:
             try:
                 self.parser.readfp(fp)
-            except ConfigParser.ParsingError:
+            except configparser.ParsingError:
                 raise TreeInfoError("Could not parse treeinfo file!")
         finally:
             if fp is not None:

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,5 @@
+- Reposync: Fixed Kickstart functionality.
+- Reposync: Fixed URLGrabber error handling.
 - Reposync: Fix modular data handling for cloned channels (bsc#1177508)
 - Added dnf plugin to reposync.
 - Drop Transfer-Encoding header from proxy respone to fix error response messages (bsc#1176906)


### PR DESCRIPTION
## What does this PR change?

- Fixed kickstart download path (just.adding repo url if no protocol is included).
- Fixed an URLGrabber error handling class.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: No functional change.

- [X] **DONE**

## Test coverage
- No tests: 

- [X] **DONE**

## Links

Fixes #3134 #2583 

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
