### PR TITLE
Display absolute timestamps for configuration files

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/configuration/files/FileDetailsAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/configuration/files/FileDetailsAction.java
@@ -30,6 +30,7 @@ import com.redhat.rhn.manager.configuration.ConfigFileBuilder;
 import com.redhat.rhn.manager.configuration.ConfigurationManager;
 
 import com.suse.manager.webui.services.ConfigChannelSaltManager;
+
 import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionForward;
 import org.apache.struts.action.ActionMapping;
@@ -137,19 +138,13 @@ public class FileDetailsAction extends RhnAction {
                     StringUtil.displayFileSize(
                             cr.getConfigContent().getFileSize().longValue()));
         }
-        request.setAttribute(REV_CREATED,
-                StringUtil.categorizeTime(cr.getConfigFile().getCreated().getTime(),
-                        StringUtil.WEEKS_UNITS));
+        request.setAttribute(REV_CREATED, cr.getConfigFile().getCreated());
 
         if (cr.getConfigContent() == null) {
-            request.setAttribute(REV_MODIFIED,
-                    StringUtil.categorizeTime(cr.getModified().getTime(),
-                                            StringUtil.WEEKS_UNITS));
+            request.setAttribute(REV_MODIFIED, cr.getModified());
         }
         else {
-            request.setAttribute(REV_MODIFIED,
-                    StringUtil.categorizeTime(cr.getConfigContent().getModified().getTime(),
-                                            StringUtil.WEEKS_UNITS));
+            request.setAttribute(REV_MODIFIED, cr.getConfigContent().getModified());
         }
 
 

--- a/java/code/src/com/redhat/rhn/frontend/dto/ConfigRevisionDto.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/ConfigRevisionDto.java
@@ -107,12 +107,4 @@ public class ConfigRevisionDto extends BaseDto {
         return StringUtil.displayFileSize(fileSize.longValue());
     }
 
-    /**
-     * @return A localized display of the time this revision was created relative
-     *         to now.  Using friendly time display.
-     */
-    public String getCreatedDisplay() {
-        return StringUtil.categorizeTime(created.getTime(), StringUtil.WEEKS_UNITS);
-    }
-
 }

--- a/java/code/webapp/WEB-INF/pages/common/fragments/configuration/files/details.jspf
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/configuration/files/details.jspf
@@ -52,7 +52,10 @@
                     <bean:message key="filedetails.details.jspf.creation-name" />
                 </label>
                 <div class="col-md-9">
-                    <p class="form-control-static">${created}</p>
+                    <p class="form-control-static">
+                        <rhn:formatDate humanStyle="from" value="${created}"
+                                        type="both" dateStyle="short" timeStyle="long"/>
+                    </p>
                 </div>
             </div>
             <div class="form-group">
@@ -61,6 +64,10 @@
                 </label>
                 <div class="col-md-9">
                     <p class="form-control-static">
+                        <c:set var="modifiedarg" scope="request">
+                            <rhn:formatDate humanStyle="from" value="${modified}"
+                                            type="both" dateStyle="short" timeStyle="long"/>
+                        </c:set>
                         <c:choose>
                             <c:when test="${lastUser != null}">
                                 <%--
@@ -81,11 +88,11 @@
                                     </rhn:require>
                                 </c:set>
                                 <bean:message key="filedetails.details.jspf.modifiedBy"
-                                              arg0="${modified}"
+                                              arg0="${modifiedarg}"
                                               arg1='${beanarg}' />
                             </c:when>
                             <c:otherwise>
-                                <bean:message key="filedetails.details.jspf.modifiedBy-unknown" arg0="${modified}"/>
+                                <bean:message key="filedetails.details.jspf.modifiedBy-unknown" arg0="${modifiedarg}"/>
                             </c:otherwise>
                         </c:choose>
                     </p>

--- a/java/code/webapp/WEB-INF/pages/configuration/files/comparerevision.jsp
+++ b/java/code/webapp/WEB-INF/pages/configuration/files/comparerevision.jsp
@@ -31,7 +31,8 @@
     </rhn:column>
 
     <rhn:column header="comparerevision.jsp.created">
-        ${current.createdDisplay}
+        <rhn:formatDate humanStyle="from" value="${current.created}"
+                        type="both" dateStyle="short" timeStyle="long"/>
     </rhn:column>
 
     <rhn:column header="comparerevision.jsp.comparison">

--- a/java/code/webapp/WEB-INF/pages/configuration/files/manage.jsp
+++ b/java/code/webapp/WEB-INF/pages/configuration/files/manage.jsp
@@ -40,7 +40,8 @@
         </rhn:require>
 
         <rhn:column header="manage.jsp.creation">
-            ${current.createdDisplay}
+            <rhn:formatDate humanStyle="from" value="${current.created}"
+                            type="both" dateStyle="short" timeStyle="long"/>
         </rhn:column>
       </rhn:listdisplay>
     </rhn:list>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Display absolute timestamps for configuration files
 - Fix modular data handling for cloned channels (bsc#1177508)
 - Fix: login gets an ISE when SSO is enabled (bsc#1181048)
 - Content Lifecycle Management input validation errors are now displayed at the field-level instead of a popup


### PR DESCRIPTION
## What does this PR change?

Relative times should have a tooltip with the absolute time value.

Those tooltips were missing on configuration files.

## GUI diff

Before:

![before1](https://user-images.githubusercontent.com/14297426/105200493-cd434980-5b37-11eb-84a3-8144445008b1.png)

---

![before2](https://user-images.githubusercontent.com/14297426/105200510-d0d6d080-5b37-11eb-9ad7-e073182e7149.png)

---

![before3](https://user-images.githubusercontent.com/14297426/105200518-d2a09400-5b37-11eb-99bc-50c739303115.png)

After:

![after1](https://user-images.githubusercontent.com/14297426/105200529-d6ccb180-5b37-11eb-9456-86a0238f4811.png)

---

![after2](https://user-images.githubusercontent.com/14297426/105200535-d92f0b80-5b37-11eb-8dfb-90ed96624fd0.png)

---

![after3](https://user-images.githubusercontent.com/14297426/105200542-daf8cf00-5b37-11eb-8655-7199864c4fec.png)


- [x] **DONE**

## Documentation
- No documentation needed: We are only adding a missing tooltip

- [x] **DONE**

## Test coverage
- No tests: we are not testing tooltips

- [x] **DONE**

## Links

Fixes: https://github.com/uyuni-project/uyuni/issues/2803
Fixes: https://github.com/SUSE/spacewalk/issues/13082

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
