### PR TITLE
Remove duplicate localization message key

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -4291,9 +4291,6 @@ organization. You may grant or remove the organization administrator role in the
       <trans-unit id="erratalist.jsp.erratamgmt" xml:space="preserve">
         <source>Patches Management</source>
       </trans-unit>
-      <trans-unit id="erratalist.jsp.noerrata" xml:space="preserve">
-        <source>No Patches</source>
-      </trans-unit>
       <trans-unit id="erratalist.jsp.errata" xml:space="preserve">
         <source>Patches</source>
       </trans-unit>


### PR DESCRIPTION
## What does this PR change?

Localization message `erratalist.jsp.noerrata` was duplicated, as reported in logs:

```
2021-01-20 15:32:14,855 [main] WARN  com.redhat.rhn.common.localization.XmlResourceBundleParser - Duplicate message key found in XML Resource file: erratalist.jsp.noerrata
```

This PR removes the duplicate message key.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: Not visible to the end-user

- [x] **DONE**

## Test coverage
- No tests: Just removing a duplicate message key

- [X] **DONE**

## Links

No open issue

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
