### PR TITLE
added zypper refresh before zypper in

### DIFF
--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -202,6 +202,7 @@ end
 
 # Salt formulas
 When(/^I manually install the "([^"]*)" formula on the server$/) do |package|
+  $server.run("zypper --non-interactive refresh")
   $server.run("zypper --non-interactive install --force #{package}-formula")
 end
 


### PR DESCRIPTION
This is a port of https://github.com/SUSE/spacewalk/pull/13714


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)



