### PR TITLE
Revert node changelog entries

### DIFF
--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,5 +1,3 @@
-- Improved node requirements in spec file.
-- Updated Source to Uyuni repo.
 - Fix source selection form in CLM project page
 - Default to preferred items per page in content lifecycle lists (bsc#1180558)
 - Fix sorting in content lifecycle projects and cluster tables (bsc#1180558)


### PR DESCRIPTION
## What does this PR change?

Fixes the discussion here: https://github.com/uyuni-project/uyuni/pull/3143#discussion_r560040254

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes: https://github.com/uyuni-project/uyuni/pull/3143#discussion_r560040254

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
