### PR TITLE
Make the core features lighter - activation keys

### DIFF
--- a/testsuite/features/core/srv_create_activationkey.feature
+++ b/testsuite/features/core/srv_create_activationkey.feature
@@ -21,23 +21,6 @@ Feature: Be able to create and manipulate activation keys
     And I should see a "Groups" link
     And I should see a "Activated Systems" link
 
-  Scenario: Change limit of the activation key
-    Given I am on the Systems page
-    When I follow the left menu "Systems > Activation Keys"
-    And I follow "SUSE Test Key i586"
-    And I enter "20" as "usageLimit"
-    And I click on "Update Activation Key"
-    Then I should see a "Activation key SUSE Test Key i586 has been modified." text
-    And I should see "20" in field "usageLimit"
-
-  Scenario: Change the base channel of the activation key
-    Given I am on the Systems page
-    When I follow the left menu "Systems > Activation Keys"
-    And I follow "SUSE Test Key i586"
-    And I select "Test-Channel-i586" from "selectedBaseChannel"
-    And I click on "Update Activation Key"
-    Then I should see a "Activation key SUSE Test Key i586 has been modified." text
-
   Scenario: Create an activation key with a channel
     Given I am on the Systems page
     When I follow the left menu "Systems > Activation Keys"

--- a/testsuite/features/core/srv_create_activationkey.feature
+++ b/testsuite/features/core/srv_create_activationkey.feature
@@ -6,21 +6,6 @@ Feature: Be able to create and manipulate activation keys
   As the testing user
   I want to use activation keys
 
-  Scenario: Create an activation key
-    Given I am on the Systems page
-    When I follow the left menu "Systems > Activation Keys"
-    And I follow "Create Key"
-    And I enter "SUSE Test Key i586" as "description"
-    And I enter "SUSE-DEV-i586" as "key"
-    And I check "virtualization_host"
-    And I click on "Create Activation Key"
-    Then I should see a "Activation key SUSE Test Key i586 has been created." text
-    And I should see a "Details" link
-    And I should see a "Packages" link
-    And I should see a "Configuration" link in the content area
-    And I should see a "Groups" link
-    And I should see a "Activated Systems" link
-
   Scenario: Create an activation key with a channel
     Given I am on the Systems page
     When I follow the left menu "Systems > Activation Keys"
@@ -57,25 +42,7 @@ Feature: Be able to create and manipulate activation keys
     And I should see a "Groups" link
     And I should see a "Activated Systems" link
 
-  Scenario: Create an activation key with a channel and a package list for i586
-    Given I am on the Systems page
-    When I follow the left menu "Systems > Activation Keys"
-    And I follow "Create Key"
-    And I enter "SUSE Test PKG Key i586" as "description"
-    And I enter "SUSE-PKG-i586" as "key"
-    And I enter "20" as "usageLimit"
-    And I select "Test-Channel-i586" from "selectedBaseChannel"
-    And I click on "Create Activation Key"
-    And I follow "Packages"
-    And I enter "sed" as "packages"
-    And I click on "Update Activation Key"
-    Then I should see a "Activation key SUSE Test PKG Key i586 has been modified." text
-    And I should see a "Details" link
-    And I should see a "Packages" link
-    And I should see a "Configuration" link in the content area
-    And I should see a "Groups" link
-    And I should see a "Activated Systems" link
-
+@ubuntu_minion
   Scenario: Create an activation key for Ubuntu
     Given I am on the Systems page
     When I follow the left menu "Systems > Activation Keys"

--- a/testsuite/features/secondary/srv_manage_activation_keys.feature
+++ b/testsuite/features/secondary/srv_manage_activation_keys.feature
@@ -1,0 +1,24 @@
+# Copyright (c) 2010-2019 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+Feature: Be able to manipulate activation keys
+  In order to register systems to the spacewalk server
+  As the testing user
+  I want to use activation keys
+
+  Scenario: Change limit of the activation key
+    Given I am on the Systems page
+    When I follow the left menu "Systems > Activation Keys"
+    And I follow "SUSE Test Key i586"
+    And I enter "20" as "usageLimit"
+    And I click on "Update Activation Key"
+    Then I should see a "Activation key SUSE Test Key i586 has been modified." text
+    And I should see "20" in field "usageLimit"
+
+  Scenario: Change the base channel of the activation key
+    Given I am on the Systems page
+    When I follow the left menu "Systems > Activation Keys"
+    And I follow "SUSE Test Key i586"
+    And I select "Test-Channel-i586" from "selectedBaseChannel"
+    And I click on "Update Activation Key"
+    Then I should see a "Activation key SUSE Test Key i586 has been modified." text

--- a/testsuite/features/secondary/srv_manage_activation_keys.feature
+++ b/testsuite/features/secondary/srv_manage_activation_keys.feature
@@ -4,7 +4,41 @@
 Feature: Be able to manipulate activation keys
   In order to register systems to the spacewalk server
   As the testing user
-  I want to edit activation keys
+  I want to create and edit activation keys
+
+  Scenario: Create an activation key for i586
+    Given I am on the Systems page
+    When I follow the left menu "Systems > Activation Keys"
+    And I follow "Create Key"
+    And I enter "SUSE Test Key i586" as "description"
+    And I enter "SUSE-DEV-i586" as "key"
+    And I check "virtualization_host"
+    And I click on "Create Activation Key"
+    Then I should see a "Activation key SUSE Test Key i586 has been created." text
+    And I should see a "Details" link
+    And I should see a "Packages" link
+    And I should see a "Configuration" link in the content area
+    And I should see a "Groups" link
+    And I should see a "Activated Systems" link
+
+  Scenario: Create an activation key with a channel and a package list for i586
+    Given I am on the Systems page
+    When I follow the left menu "Systems > Activation Keys"
+    And I follow "Create Key"
+    And I enter "SUSE Test PKG Key i586" as "description"
+    And I enter "SUSE-PKG-i586" as "key"
+    And I enter "20" as "usageLimit"
+    And I select "Test-Channel-i586" from "selectedBaseChannel"
+    And I click on "Create Activation Key"
+    And I follow "Packages"
+    And I enter "sed" as "packages"
+    And I click on "Update Activation Key"
+    Then I should see a "Activation key SUSE Test PKG Key i586 has been modified." text
+    And I should see a "Details" link
+    And I should see a "Packages" link
+    And I should see a "Configuration" link in the content area
+    And I should see a "Groups" link
+    And I should see a "Activated Systems" link
 
   Scenario: Change limit of the activation key
     Given I am on the Systems page

--- a/testsuite/features/secondary/srv_manage_activation_keys.feature
+++ b/testsuite/features/secondary/srv_manage_activation_keys.feature
@@ -1,10 +1,10 @@
-# Copyright (c) 2010-2019 SUSE LLC
+# Copyright (c) 2010-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Be able to manipulate activation keys
   In order to register systems to the spacewalk server
   As the testing user
-  I want to use activation keys
+  I want to edit activation keys
 
   Scenario: Change limit of the activation key
     Given I am on the Systems page

--- a/testsuite/run_sets/secondary.yml
+++ b/testsuite/run_sets/secondary.yml
@@ -8,7 +8,6 @@
 
 # IDEMPOTENT
 
-- features/secondary/srv_manage_activation_keys.feature
 - features/secondary/srv_users.feature
 - features/secondary/buildhost_osimage_build_image.feature
 - features/secondary/allcli_reboot.feature

--- a/testsuite/run_sets/secondary.yml
+++ b/testsuite/run_sets/secondary.yml
@@ -8,6 +8,7 @@
 
 # IDEMPOTENT
 
+- features/secondary/srv_manage_activation_keys.feature
 - features/secondary/srv_users.feature
 - features/secondary/buildhost_osimage_build_image.feature
 - features/secondary/allcli_reboot.feature

--- a/testsuite/run_sets/secondary_parallelizable.yml
+++ b/testsuite/run_sets/secondary_parallelizable.yml
@@ -72,5 +72,6 @@
 - features/secondary/trad_check_patches_install.feature
 - features/secondary/trad_sp_migration.feature
 - features/secondary/trad_check_registration.feature
+- features/secondary/srv_manage_activation_keys.feature
 
 ## Parallelizable Secondary features END ##


### PR DESCRIPTION
## What does this PR change?

Move all features that are not link to setting up a client into secondary features for core/srv_create_activationkey.feature

## Documentation

- No documentation needed: only internal

## Links

https://github.com/SUSE/spacewalk/issues/13557


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Backports


https://github.com/SUSE/spacewalk/pull/13726

https://github.com/SUSE/spacewalk/pull/13727

