### PR TITLE
Testsuite: Use the right client for this feature

### DIFF
--- a/testsuite/features/secondary/min_centos_openscap_audit.feature
+++ b/testsuite/features/secondary/min_centos_openscap_audit.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 SUSE LLC
+# Copyright (c) 2017-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @scope_openscap
@@ -10,7 +10,7 @@ Feature: OpenSCAP audit of CentOS Salt minion
 
 @centos_minion
   Scenario: Install the OpenSCAP packages on the CentOS minion
-    Given I am on the Systems overview page of this "sle_minion"
+    Given I am on the Systems overview page of this "ceos_minion"
     When I enable repository "CentOS-Base" on this "ceos_minion"
     And I install OpenSCAP dependencies on "ceos_minion"
     And I fix CentOS 7 OpenSCAP files on "ceos_minion"


### PR DESCRIPTION
## What does this PR change?
Use the right client for this feature.

- testsuite/features/secondary/min_centos_openscap_audit.feature:
Replace "sle_minion" with "ceos_minion" in the first scenario.

## Links
It fixes https://github.com/uyuni-project/uyuni/pull/2894

### Ports
- Manager-4.0: https://github.com/SUSE/spacewalk/pull/13728
- Manager-4.1: https://github.com/SUSE/spacewalk/pull/13729


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)
