### PR TITLE
Fix incorrect import paths, add missing Babel plugin

### DIFF
--- a/susemanager-frontend/susemanager-nodejs-sdk-devel/package.json
+++ b/susemanager-frontend/susemanager-nodejs-sdk-devel/package.json
@@ -7,6 +7,7 @@
     "@babel/core": "^7.3.3",
     "@babel/plugin-proposal-class-properties": "^7.3.3",
     "@babel/plugin-proposal-object-rest-spread": "^7.3.2",
+    "@babel/plugin-proposal-optional-chaining": "^7.12.7",
     "@babel/plugin-syntax-dynamic-import": "^7.2.0",
     "@babel/plugin-syntax-object-rest-spread": "^7.2.0",
     "@babel/plugin-transform-arrow-functions": "^7.2.0",

--- a/susemanager-frontend/yarn.lock
+++ b/susemanager-frontend/yarn.lock
@@ -370,6 +370,13 @@
     "@babel/template" "^7.7.4"
     "@babel/types" "^7.7.4"
 
+"@babel/helper-skip-transparent-expression-wrappers@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.12.1.tgz#462dc63a7e435ade8468385c63d2b84cce4b3cbf"
+  integrity sha512-Mf5AUuhG1/OCChOJ/HcADmvcHM42WJockombn8ATJG3OnyiSxBK/Mm5x78BQWvmtXZKHgbjdGL2kin/HOLlZGA==
+  dependencies:
+    "@babel/types" "^7.12.1"
+
 "@babel/helper-split-export-declaration@^7.10.4", "@babel/helper-split-export-declaration@^7.11.0":
   version "7.11.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.11.0.tgz#f8a491244acf6a676158ac42072911ba83ad099f"
@@ -553,6 +560,15 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-optional-chaining" "^7.7.4"
 
+"@babel/plugin-proposal-optional-chaining@^7.12.7":
+  version "7.12.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.12.7.tgz#e02f0ea1b5dc59d401ec16fb824679f683d3303c"
+  integrity sha512-4ovylXZ0PWmwoOvhU2vhnzVNnm88/Sm9nx7V8BPgMvAzn5zDou3/Awy0EjglyubVHasJj+XCEkr/r1X3P5elCA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.4"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.12.1"
+    "@babel/plugin-syntax-optional-chaining" "^7.8.0"
+
 "@babel/plugin-proposal-unicode-property-regex@^7.7.4", "@babel/plugin-proposal-unicode-property-regex@^7.7.7":
   version "7.7.7"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.7.7.tgz#433fa9dac64f953c12578b29633f456b68831c4e"
@@ -701,7 +717,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-optional-chaining@^7.2.0", "@babel/plugin-syntax-optional-chaining@^7.8.3":
+"@babel/plugin-syntax-optional-chaining@^7.2.0", "@babel/plugin-syntax-optional-chaining@^7.8.0", "@babel/plugin-syntax-optional-chaining@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz#4f69c2ab95167e0180cd5336613f8c5788f7d48a"
   integrity sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==
@@ -8659,7 +8675,7 @@ lodash.uniq@4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19:
+lodash@4.17.19, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==

--- a/web/html/src/.babelrc
+++ b/web/html/src/.babelrc
@@ -7,6 +7,7 @@
   ],
   "plugins": [
     "@babel/plugin-proposal-class-properties",
+    "@babel/plugin-proposal-optional-chaining",
     "@babel/plugin-transform-flow-strip-types",
     "@babel/plugin-syntax-object-rest-spread",
     "@babel/plugin-syntax-dynamic-import",

--- a/web/html/src/manager/admin/config/monitoring-admin.js
+++ b/web/html/src/manager/admin/config/monitoring-admin.js
@@ -10,7 +10,7 @@ import {Messages, Utils as MessagesUtils} from 'components/messages';
 import {Utils} from 'utils/functions';
 import {IconTag as Icon} from 'components/icontag';
 import withPageWrapper from 'components/general/with-page-wrapper';
-import useMonitoringApi from './use-monitoring-api.js';
+import useMonitoringApi from './use-monitoring-api';
 import './monitoring-admin.css';
 
 const {capitalize} = Utils;

--- a/web/html/src/manager/clusters/index.js
+++ b/web/html/src/manager/clusters/index.js
@@ -1,8 +1,8 @@
 export default {
-  'clusters/list': () => import('./list-clusters/list-clusters.renderer.js'),
-  'clusters/cluster': () => import('./cluster/cluster.renderer.js'),
-  'clusters/add': () => import('./add-cluster/add-cluster.renderer.js'),
-  'clusters/join-node': () => import('./join-cluster/join-cluster.renderer.js'),
-  'clusters/remove-node': () => import('./remove-node/remove-node.renderer.js'),
-  'clusters/upgrade-cluster': () => import('./upgrade-cluster/upgrade-cluster.renderer.js')
+  'clusters/list': () => import('./list-clusters/list-clusters.renderer'),
+  'clusters/cluster': () => import('./cluster/cluster.renderer'),
+  'clusters/add': () => import('./add-cluster/add-cluster.renderer'),
+  'clusters/join-node': () => import('./join-cluster/join-cluster.renderer'),
+  'clusters/remove-node': () => import('./remove-node/remove-node.renderer'),
+  'clusters/upgrade-cluster': () => import('./upgrade-cluster/upgrade-cluster.renderer')
 }

--- a/web/html/src/manager/content-management/index.js
+++ b/web/html/src/manager/content-management/index.js
@@ -1,6 +1,6 @@
 export default {
     'content-management/create-project': () => import('./create-project/create-project.renderer'),
     'content-management/list-filters': () => import('./list-filters/list-filters.renderer'),
-    'content-management/list-projects': () => import('./list-projects/list-projects.renderer.js'),
+    'content-management/list-projects': () => import('./list-projects/list-projects.renderer'),
     'content-management/project': () => import('./project/project.renderer')
 };

--- a/web/html/src/manager/content-management/shared/components/panels/sources/channels/channels-selection.js
+++ b/web/html/src/manager/content-management/shared/components/panels/sources/channels/channels-selection.js
@@ -15,7 +15,7 @@ import {
   initialStateChannelsSelection,
   reducerChannelsSelection
 } from "./channels-selection.state"
-import type {UseChannelsType} from "core/channels/api/use-channels-tree-api.js"
+import type {UseChannelsType} from "core/channels/api/use-channels-tree-api"
 import {getVisibleChannels, isGroupVisible, orderBaseChannels} from "./channels-selection.utils";
 import useMandatoryChannelsApi from "core/channels/api/use-mandatory-channels-api";
 import {getSelectedChannelsIdsInGroup} from "core/channels/utils/channels-state.utils";

--- a/web/html/src/manager/index.js
+++ b/web/html/src/manager/index.js
@@ -10,7 +10,7 @@ import './polyfills';
 import 'react-hot-loader';
 
 import SpaRenderer from "core/spa/spa-renderer";
-import 'core/spa/spa-engine.js';
+import 'core/spa/spa-engine';
 
 import Admin from "./admin";
 import Audit from "./audit";

--- a/web/html/src/manager/virtualization/ListTab.js
+++ b/web/html/src/manager/virtualization/ListTab.js
@@ -9,7 +9,7 @@ import { SearchField } from 'components/table/SearchField';
 import { ModalButton } from 'components/dialog/ModalButton';
 import { LinkButton } from 'components/buttons';
 import { VirtualizationListRefreshApi } from './virtualization-list-refresh-api';
-import { useVirtNotification } from './useVirtNotification.js';
+import { useVirtNotification } from './useVirtNotification';
 import { ActionConfirm } from 'components/dialog/ActionConfirm';
 import { ActionStatus } from 'components/action/ActionStatus';
 import { SimpleActionApi } from './SimpleActionApi';

--- a/web/html/src/manager/virtualization/pools/list/pools-list.js
+++ b/web/html/src/manager/virtualization/pools/list/pools-list.js
@@ -15,7 +15,7 @@ import { ModalButton } from 'components/dialog/ModalButton';
 import { ActionConfirm } from 'components/dialog/ActionConfirm';
 import { VirtualizationListRefreshApi } from '../../virtualization-list-refresh-api';
 import { VirtualizationPoolsActionApi } from '../virtualization-pools-action-api';
-import { useVirtNotification } from '../../useVirtNotification.js';
+import { useVirtNotification } from '../../useVirtNotification';
 import { HypervisorCheck } from '../../HypervisorCheck';
 
 import type {MessageType} from 'components/messages';

--- a/web/html/src/manager/visualization/data-tree.js
+++ b/web/html/src/manager/visualization/data-tree.js
@@ -1,11 +1,11 @@
 /* eslint-disable */
 'use strict';
 
-import * as HierarchyView from './ui/hierarchy-view.js';
-import * as Filters from './data-processing/filters.js';
-import * as Partitioning from './data-processing/partitioning.js';
-import * as Preprocessing from './data-processing/preprocessing.js';
-import * as Utils from './utils.js';
+import * as HierarchyView from './ui/hierarchy-view';
+import * as Filters from './data-processing/filters';
+import * as Partitioning from './data-processing/partitioning';
+import * as Preprocessing from './data-processing/preprocessing';
+import * as Utils from './utils';
 
 // Render hierarchy view - take data, transform with preprocessor, filters and
 // partitioning, render it in the container.

--- a/web/html/src/manager/visualization/hierarchy.js
+++ b/web/html/src/manager/visualization/hierarchy.js
@@ -6,10 +6,10 @@ import Network from '../../utils/network';
 import * as React from 'react';
 import ReactDOM from 'react-dom';
 import { TopPanel } from 'components/panels/TopPanel';
-import * as DataTree from './data-tree.js';
-import * as Preprocessing from './data-processing/preprocessing.js';
-import * as UI from './ui/components.js';
-import * as Utils from './utils.js';
+import * as DataTree from './data-tree';
+import * as Preprocessing from './data-processing/preprocessing';
+import * as UI from './ui/components';
+import * as Utils from './utils';
 
 function displayHierarchy(data) {
   // disable the #spacewalk-content observer:

--- a/web/html/src/manager/visualization/ui/hierarchy-view.js
+++ b/web/html/src/manager/visualization/ui/hierarchy-view.js
@@ -1,7 +1,7 @@
 /* eslint-disable */
 'use strict';
 
-import * as Utils from '../utils.js';
+import * as Utils from '../utils';
 
 // Display given hierarchy (given by it's root node) in given container using
 // force based layout.

--- a/web/html/src/manager/visualization/utils.js
+++ b/web/html/src/manager/visualization/utils.js
@@ -1,7 +1,7 @@
 /* eslint-disable */
 'use strict';
 
-import * as UI from './ui/components.js';
+import * as UI from './ui/components';
 
 function computeSvgDimensions() {
   const width = d3.select('#svg-wrapper').node().getBoundingClientRect().width - 2;

--- a/web/html/src/utils/test-utils/setup.js
+++ b/web/html/src/utils/test-utils/setup.js
@@ -1,4 +1,4 @@
-import "manager/polyfills.js";
+import "manager/polyfills";
 import jQuery from "jquery";
 
 // Allows us to mock and test the existing network layer easily


### PR DESCRIPTION
## What does this PR change?

Fix build issues as shown in https://ci.nue.suse.com/view/Manager/view/Manager-Head/job/manager-Head-2obs/23381/console

Hardcoding the `.js` extension is unnecessary and breaks when we have Typescript files as well. Also add optional chaining for production.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/13730

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
