### PR TITLE
Fix arch in spacewalk common channels

### DIFF
--- a/utils/spacewalk-common-channels
+++ b/utils/spacewalk-common-channels
@@ -61,6 +61,32 @@ CHANNEL_ARCH = {
     'mips-deb':     'channel-mips-deb'
 
 }
+CHANNEL_NAME_TO_ARCH = {
+    'AArch64': 'aarch64',
+    'Alpha': 'alpha',
+    'Alpha Debian': 'alpha-deb',
+    'AMD64 Debian': 'amd64-deb',
+    'ARM64 Debian': 'arm64-deb',
+    'arm Debian': 'arm-deb',
+    'ARM hard. FP':  'armhfp',
+    'ARM soft. FP': 'arm',
+    'IA-32':  'i386',
+    'IA-32 Debian': 'ia32-deb',
+    'IA-64': 'ia64',
+    'IA-64 Debian': 'ia64-deb',
+    'iSeries': 'iSeries',
+    'mips Debian': 'mips-deb',
+    'PowerPC Debian': 'powerpc-deb',
+    'PPC': 'ppc',
+    'PPC64LE': 'ppc64le',
+    'pSeries': 'pSeries',
+    's390': 's390',
+    's390 Debian': 's390-deb',
+    's390x': 's390x',
+    'Sparc': 'sparc',
+    'Sparc Debian': 'sparc-deb',
+    'x86_64': 'x86_64'
+}
 
 SPLIT_PATTERN = '[ ,]+'
 
@@ -120,7 +146,7 @@ def add_channels(channels, section, arch, client):
                 channels[channel['base_channel']] = {'label': channel_base_server['label'],
                                                      'name' : channel_base_server['name'],
                                                      'summary': channel_base_server['summary'],
-                                                     'arch': channel_base_server['arch_name'],
+                                                     'arch': CHANNEL_NAME_TO_ARCH[channel_base_server['arch_name']],
                                                      'checksum': channel_base_server['checksum_label'],
                                                      'gpgkey_url': channel_base_server['gpg_key_url'],
                                                      'gpgkey_id': channel_base_server['gpg_key_id'],

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,4 @@
+- Fix arch handling in spacewalk-common-channels
 - Fix modular data handling for cloned channels (bsc#1177508)
 - spacewalk-common-channels: Update CentOS6 URLs to use vault.centos.org
 - spacewalk-common-channels: re-use repositories when different channels


### PR DESCRIPTION
## What does this PR change?

spacewalk-common-channels:
The arch name is sometimes written a bit exotic. Translate it to a more normal string compartible with the values used in the config file

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **manual**

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/2838

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
