### PR TITLE
yum-rhn-plugin: Added RHEL8 build.

### DIFF
--- a/client/rhel/yum-rhn-plugin/yum-rhn-plugin.changes
+++ b/client/rhel/yum-rhn-plugin/yum-rhn-plugin.changes
@@ -1,3 +1,6 @@
+- Added RHEL8 build.
+- Updated Source url.
+
 -------------------------------------------------------------------
 Thu Dec 03 14:00:54 CET 2020 - jgonzalez@suse.com
 

--- a/client/rhel/yum-rhn-plugin/yum-rhn-plugin.spec
+++ b/client/rhel/yum-rhn-plugin/yum-rhn-plugin.spec
@@ -16,6 +16,7 @@
 # Please submit bugfixes or comments via https://bugs.opensuse.org/
 #
 
+%define __python /usr/bin/python2
 
 # package renaming fun :(
 %define rhn_client_tools spacewalk-client-tools
@@ -29,13 +30,13 @@ Group:          System Environment/Base
 Name:           yum-rhn-plugin
 Version:        4.2.3
 Release:        1%{?dist}
-Source0:        https://github.com/spacewalkproject/spacewalk/archive/%{name}-%{version}.tar.gz
+Source0:        https://github.com/uyuni-project/uyuni/archive/%{name}-%{version}.tar.gz
 Url:            https://github.com/uyuni-project/uyuni
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 %if %{?suse_version: %{?suse_version} > 1110} %{!?suse_version:1}
 BuildArch:      noarch
 %endif
-%if 0%{?fedora} >= 28
+%if 0%{?fedora} >= 28 || 0%{?rhel} >= 8
 BuildRequires:  python2
 %else
 BuildRequires:  python
@@ -50,7 +51,7 @@ Requires:       python-m2crypto >= 0.16-6
 %else
 Requires:       m2crypto >= 0.16-6
 %endif
-%if 0%{?fedora} >= 28
+%if 0%{?fedora} >= 28 || 0%{?rhel} >= 8
 Requires:       python2-iniparse
 %else
 Requires:       python-iniparse


### PR DESCRIPTION
## What does this PR change?

Updates SPEC file to build on RHEL8.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: No functional changes.

- [X] **DONE**

## Test coverage
- No tests: tested during autobuild.
- Build tested successfully for CentOS6+, Fedora 32+, Leap15.2.

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
