### PR TITLE
fix arch macro and missing arch definition in channel names

### DIFF
--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -538,7 +538,7 @@ name     = CentOS 6 (%(arch)s)
 gpgkey_url = http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-6
 gpgkey_id = C105B9DE
 gpgkey_fingerprint = C1DA C52D 1664 E8A4 386D  BA43 0946 FCA2 C105 B9DE
-repo_url = https://vault.centos.org/centos/6/os/%(arch)/
+repo_url = https://vault.centos.org/centos/6/os/%(arch)s/
 dist_map_release = 6
 
 [centos6-centosplus]
@@ -546,35 +546,35 @@ label    = %(base_channel)s-centosplus
 archs    = %(_x86_archs)s
 name     = CentOS 6 Plus (%(arch)s)
 base_channels = centos6-%(arch)s
-repo_url = https://vault.centos.org/centos/6/centosplus/%(arch)/
+repo_url = https://vault.centos.org/centos/6/centosplus/%(arch)s/
 
 [centos6-contrib]
 label    = %(base_channel)s-contrib
 archs    = %(_x86_archs)s
 name     = CentOS 6 Contrib (%(arch)s)
 base_channels = centos6-%(arch)s
-repo_url = https://vault.centos.org/centos/6/contrib/%(arch)/
+repo_url = https://vault.centos.org/centos/6/contrib/%(arch)s/
 
 [centos6-extras]
 label    = %(base_channel)s-extras
 archs    = %(_x86_archs)s
 name     = CentOS 6 Extras (%(arch)s)
 base_channels = centos6-%(arch)s
-repo_url = https://vault.centos.org/centos/6/extras/%(arch)/
+repo_url = https://vault.centos.org/centos/6/extras/%(arch)s/
 
 [centos6-fasttrack]
 label    = %(base_channel)s-fasttrack
 archs    = %(_x86_archs)s
 name     = CentOS 6 FastTrack (%(arch)s)
 base_channels = centos6-%(arch)s
-repo_url = https://vault.centos.org/centos/6/fasttrack/%(arch)/
+repo_url = https://vault.centos.org/centos/6/fasttrack/%(arch)s/
 
 [centos6-updates]
 label    = %(base_channel)s-updates
 archs    = %(_x86_archs)s
 name     = CentOS 6 Updates (%(arch)s)
 base_channels = centos6-%(arch)s
-repo_url = https://vault.centos.org/centos/6/updates/%(arch)/
+repo_url = https://vault.centos.org/centos/6/updates/%(arch)s/
 
 [centos6-uyuni-client]
 name     = Uyuni Client Tools for %(base_channel_name)s
@@ -1038,7 +1038,7 @@ gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
 
 [sles12-sp3-uyuni-client]
-name     = Uyuni Client Tools for SLES12 SP3
+name     = Uyuni Client Tools for SLES12 SP3 %(arch)s
 archs    =  x86_64, s390x, aarch64, ppc64le
 base_channels = sles12-sp3-pool-%(arch)s
 checksum = sha256
@@ -1048,7 +1048,7 @@ gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/SLE12-Uyuni-Client-Tools/SLE_12/
 
 [sles12-sp3-uyuni-client-devel]
-name     = Uyuni Client Tools for SLES12 SP3 (Development)
+name     = Uyuni Client Tools for SLES12 SP3 %(arch)s (Development)
 archs    =  x86_64, s390x, aarch64, ppc64le
 base_channels = sles12-sp3-pool-%(arch)s
 checksum = sha256
@@ -1058,7 +1058,7 @@ gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/SLE12-Uyuni-Client-Tools/SLE_12/
 
 [sles12-sp4-uyuni-client]
-name     = Uyuni Client Tools for SLES12 SP4
+name     = Uyuni Client Tools for SLES12 SP4 %(arch)s
 archs    =  x86_64, s390x, aarch64, ppc64le
 base_channels = sles12-sp4-pool-%(arch)s
 checksum = sha256
@@ -1068,7 +1068,7 @@ gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/SLE12-Uyuni-Client-Tools/SLE_12/
 
 [sles12-sp4-uyuni-client-devel]
-name     = Uyuni Client Tools for SLES12 SP4 (Development)
+name     = Uyuni Client Tools for SLES12 SP4 %(arch)s (Development)
 archs    =  x86_64, s390x, aarch64, ppc64le
 base_channels = sles12-sp4-pool-%(arch)s
 checksum = sha256
@@ -1078,7 +1078,7 @@ gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/SLE12-Uyuni-Client-Tools/SLE_12/
 
 [sles15-uyuni-client]
-name     = Uyuni Client Tools for SLES15
+name     = Uyuni Client Tools for SLES15 %(arch)s
 archs    =  x86_64, s390x, aarch64, ppc64le
 base_channels = sle-product-sles15-pool-%(arch)s
 checksum = sha256
@@ -1088,7 +1088,7 @@ gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/SLE15-Uyuni-Client-Tools/SLE_15/
 
 [sles15-uyuni-client-devel]
-name     = Uyuni Client Tools for SLES15 (Development)
+name     = Uyuni Client Tools for SLES15 %(arch)s (Development)
 archs    =  x86_64, s390x, aarch64, ppc64le
 base_channels = sle-product-sles15-pool-%(arch)s
 checksum = sha256
@@ -1098,7 +1098,7 @@ gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/SLE15-Uyuni-Client-Tools/SLE_15/
 
 [sles15-sp1-uyuni-client]
-name     = Uyuni Client Tools for SLES15 SP1
+name     = Uyuni Client Tools for SLES15 SP1 %(arch)s
 archs    =  x86_64, s390x, aarch64, ppc64le
 base_channels = sle-product-sles15-sp1-pool-%(arch)s
 checksum = sha256
@@ -1108,7 +1108,7 @@ gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/SLE15-Uyuni-Client-Tools/SLE_15/
 
 [sles15-sp1-devel-uyuni-client]
-name     = Uyuni Client Tools for SLES15 SP1 (Development)
+name     = Uyuni Client Tools for SLES15 SP1 %(arch)s (Development)
 archs    =  x86_64, s390x, aarch64, ppc64le
 base_channels = sle-product-sles15-sp1-pool-%(arch)s
 checksum = sha256
@@ -1118,7 +1118,7 @@ gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/SLE15-Uyuni-Client-Tools/SLE_15/
 
 [sles15-sp2-uyuni-client]
-name     = Uyuni Client Tools for SLES15 SP2
+name     = Uyuni Client Tools for SLES15 SP2 %(arch)s
 archs    =  x86_64, s390x, aarch64, ppc64le
 base_channels = sle-product-sles15-sp2-pool-%(arch)s
 checksum = sha256
@@ -1128,7 +1128,7 @@ gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/SLE15-Uyuni-Client-Tools/SLE_15/
 
 [sles15-sp2-devel-uyuni-client]
-name     = Uyuni Client Tools for SLES15 SP2 (Development)
+name     = Uyuni Client Tools for SLES15 SP2 %(arch)s (Development)
 archs    =  x86_64, s390x, aarch64, ppc64le
 base_channels = sle-product-sles15-sp2-pool-%(arch)s
 checksum = sha256


### PR DESCRIPTION
## What does this PR change?

Fixes:
- wrong use of %(arch) macro
- missing arch in channel names for multi arch channel definitions 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **manual**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
