### PR TITLE
Add id to selectedBaseChannel Select for testability

### DIFF
--- a/web/html/src/manager/content-management/shared/components/panels/sources/channels/channels-selection.js
+++ b/web/html/src/manager/content-management/shared/components/panels/sources/channels/channels-selection.js
@@ -82,6 +82,7 @@ const ChannelsSelection = (props: PropsType) => {
         <div className='col-lg-8'>
           <Select
             name='selectedBaseChannel'
+            id='selectedBaseChannel'
             value={orderedBaseChannels.find(item => item.id === state.selectedBaseChannelId)}
             onChange={value => {
                 if (typeof value === "object" && !(Array.isArray(value))) {


### PR DESCRIPTION
## What does this PR change?

The cucumber steps handling select fields need to have an id on the
`ReactSelect` component to tell those apart from regular select
components. Add it in the `selectedBaseChannel` since that one is not
using our `Select` wrapper component.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: no UI diff

- [X] **DONE**

## Test coverage
- No tests: fixes cucumber tests

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
