### PR TITLE
improved actionchain error handling

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/action/ActionChain.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/ActionChain.hbm.xml
@@ -10,6 +10,7 @@
         </id>
 
         <property name="label" column="label" type="string"/>
+        <property name="dispatched" column="dispatched" type="yes_no"/>
         <property name="created" column="created" type="timestamp" insert="false" update="false"/>
         <property name="modified" column="modified" type="timestamp" insert="false"/>
 

--- a/java/code/src/com/redhat/rhn/domain/action/ActionChain.java
+++ b/java/code/src/com/redhat/rhn/domain/action/ActionChain.java
@@ -45,6 +45,8 @@ public class ActionChain extends BaseDomainHelper {
     /** The entries. */
     private Set<ActionChainEntry> entries;
 
+    private boolean dispatched;
+
     /**
      * Default constructor.
      */
@@ -98,6 +100,31 @@ public class ActionChain extends BaseDomainHelper {
      */
     public void setUser(User userIn) {
         user = userIn;
+    }
+
+    /**
+     * @return true if the actionchain was already dispatched.
+     */
+    public boolean isDispatched() {
+        return dispatched;
+    }
+
+    /**
+     * @return if all actions associated with this action chain are done
+     * (either completed or failed)
+     */
+    public boolean isDone() {
+        return getEntries().stream()
+                .flatMap(ace -> ace.getAction().getServerActions().stream())
+                .allMatch(sa -> sa.getStatus().isDone());
+    }
+
+    /**
+     * Sets if the actionchain was already dispatched.
+     * @param dispatchedIn
+     */
+    public void setDispatched(boolean dispatchedIn) {
+        this.dispatched = dispatchedIn;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
@@ -989,12 +989,6 @@ public class ActionFactory extends HibernateFactory {
             lookupActionStatusByName("Failed");
 
     /**
-     * The constant representing the Action Status PICKEDUP
-     */
-    public static final ActionStatus STATUS_PICKEDUP =
-            lookupActionStatusByName("Picked Up");
-
-    /**
      * The constant representing Package Refresh List action.  [ID:1]
      */
     public static final ActionType TYPE_PACKAGES_REFRESH_LIST =

--- a/java/code/src/com/redhat/rhn/domain/action/ActionStatus.java
+++ b/java/code/src/com/redhat/rhn/domain/action/ActionStatus.java
@@ -54,6 +54,15 @@ public class ActionStatus {
         this.name = n;
     }
 
+
+    /**
+     * @return if the status represents an action that is in its final state and considered done.
+     * (either completed or failed)
+     */
+    public boolean isDone() {
+        return this.equals(ActionFactory.STATUS_COMPLETED) || this.equals(ActionFactory.STATUS_FAILED);
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemHistoryEventAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemHistoryEventAction.java
@@ -93,7 +93,7 @@ public class SystemHistoryEventAction extends RhnAction {
         request.setAttribute("failed",
                 serverAction.getStatus().equals(ActionFactory.STATUS_FAILED));
         request.setAttribute("pickedup",
-                serverAction.getStatus().equals(ActionFactory.STATUS_PICKEDUP));
+                serverAction.getStatus().equals(ActionFactory.STATUS_PICKED_UP));
         request.setAttribute("completed",
                 serverAction.getStatus().equals(ActionFactory.STATUS_COMPLETED));
         boolean typeDistUpgradeDryRun = action.getActionType().equals(ActionFactory.TYPE_DIST_UPGRADE) &&

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/schedule/ScheduleHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/schedule/ScheduleHandler.java
@@ -60,7 +60,7 @@ public class ScheduleHandler extends BaseHandler {
         for (Integer actionId : actionIds) {
             Action action = ActionManager.lookupAction(loggedInUser, Long.valueOf(actionId));
             for (ServerAction sa : action.getServerActions()) {
-                if (ActionFactory.STATUS_PICKEDUP.equals(sa.getStatus())) {
+                if (ActionFactory.STATUS_PICKED_UP.equals(sa.getStatus())) {
                     throw new ActionIsPickedUpException("Cannot cancel actions in " +
                             "PICKED UP state, aborting...");
                 }

--- a/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
+++ b/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
@@ -188,7 +188,7 @@ public class ActionManager extends BaseManager {
         }
         Date now = Calendar.getInstance().getTime();
         if (serverAction.getStatus().equals(ActionFactory.STATUS_QUEUED) ||
-                serverAction.getStatus().equals((ActionFactory.STATUS_PICKEDUP))) {
+                serverAction.getStatus().equals((ActionFactory.STATUS_PICKED_UP))) {
             serverAction.setStatus(ActionFactory.STATUS_FAILED);
             serverAction.setResultMsg(message);
             serverAction.setCompletionTime(now);
@@ -360,7 +360,7 @@ public class ActionManager extends BaseManager {
         Set<ServerAction> serverActions = actionsToDelete.stream()
                 .flatMap(a -> a.getServerActions().stream())
                 .filter(sa -> ActionFactory.STATUS_QUEUED.equals(sa.getStatus()) ||
-                        ActionFactory.STATUS_PICKEDUP.equals(sa.getStatus()))
+                        ActionFactory.STATUS_PICKED_UP.equals(sa.getStatus()))
                 .filter(Opt.fold(serverIds,
                         // if serverIds is not specified, do not filter at all
                         () -> (a -> true),
@@ -405,7 +405,7 @@ public class ActionManager extends BaseManager {
                         ActionFactory.delete(sa);
                     }
                     // Set to FAILED if the state is PICKED_UP
-                    else if (ActionFactory.STATUS_PICKEDUP.equals(sa.getStatus())) {
+                    else if (ActionFactory.STATUS_PICKED_UP.equals(sa.getStatus())) {
                         failSystemAction(user, sa.getServerId(), sa.getParentAction().getId(),
                                 "Canceled by " + user.getLogin());
                     }

--- a/java/code/src/com/redhat/rhn/manager/action/test/ActionManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/action/test/ActionManagerTest.java
@@ -422,7 +422,7 @@ public class ActionManagerTest extends JMockBaseTestCaseWithUser {
      * not be affected of a cancellation (bsc#1098993).
      */
     public void testCancelMinionActionsMixedStatus() throws Exception {
-        Action action = createActionWithMinionServerActions(user, ActionFactory.STATUS_PICKEDUP, 3);
+        Action action = createActionWithMinionServerActions(user, ActionFactory.STATUS_PICKED_UP, 3);
 
         // Set first server action to COMPLETED
         Iterator<ServerAction> iterator = action.getServerActions().iterator();

--- a/java/code/src/com/suse/manager/reactor/messaging/JobReturnEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/JobReturnEventMessageAction.java
@@ -150,8 +150,6 @@ public class JobReturnEventMessageAction implements MessageAction {
 
             saltServerActionService.handleActionChainResult(jobReturnEvent.getMinionId(),
                     jobReturnEvent.getJobId(),
-                    jobReturnEvent.getData().getRetcode(),
-                    jobReturnEvent.getData().isSuccess(),
                     actionChainResult,
                     stateResult -> false);
 

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -716,7 +716,7 @@ public class SaltServerActionService {
                     failActionChain(minionId, firstChunkActionId, Optional.of("Unexpected response: " + msg));
                     return false;
                 }
-                handleActionChainResult(minionId, "", 0, true,
+                handleActionChainResult(minionId, "",
                         actionChainResult,
                         // skip reboot, needs special handling
                         stateResult -> SYSTEM_REBOOT.equals(stateResult.getName()));
@@ -2451,13 +2451,11 @@ public class SaltServerActionService {
      *
      * @param minionId the minion id
      * @param jobId the job id
-     * @param retCode the ret code
-     * @param success whether result is successful or not
      * @param actionChainResult job result
      * @param skipFunction function to check if a result should be skipped from handling
      */
     public void handleActionChainResult(
-            String minionId, String jobId, int retCode, boolean success,
+            String minionId, String jobId,
             Map<String, StateApplyResult<Ret<JsonElement>>> actionChainResult,
             Function<StateApplyResult<Ret<JsonElement>>, Boolean> skipFunction) {
         int chunk = 1;

--- a/java/code/src/com/suse/manager/webui/utils/salt/custom/ScheduleMetadata.java
+++ b/java/code/src/com/suse/manager/webui/utils/salt/custom/ScheduleMetadata.java
@@ -26,6 +26,7 @@ public class ScheduleMetadata {
     public static final String SUMA_ACTION_CHAIN = "suma-action-chain";
     public static final String SUMA_MINION_STARTUP = "suma-minion-startup";
     public static final String BATCH_MODE = "batch-mode";
+    public static final String SUMA_ACTION_CHAIN_ID = "suma-action-chain-id";
 
     @SerializedName(SUMA_ACTION_ID)
     private Long sumaActionId = 0L;
@@ -42,6 +43,9 @@ public class ScheduleMetadata {
     @SerializedName(SUMA_MINION_STARTUP)
     private boolean minionStartup;
 
+    @SerializedName(SUMA_ACTION_CHAIN_ID)
+    private Long actionChainId;
+
     /**
      * Constructor for ScheduleMetadata
      * @param sumaActionIdIn the Id of the action
@@ -49,15 +53,17 @@ public class ScheduleMetadata {
      * @param actionChainIn whether the schedule action is corresponds to an action chain
      * @param batchModeIn whether the schedule action is executed in batch mode
      * @param minionStartupIn whether the schedule action corresponds to a minion start up
+     * @param actionChainIdIn action chain id
      */
     public ScheduleMetadata(Long sumaActionIdIn, boolean forcePackageListRefreshIn, boolean actionChainIn,
-            boolean batchModeIn, boolean minionStartupIn) {
+            boolean batchModeIn, boolean minionStartupIn, Long actionChainIdIn) {
         super();
         this.sumaActionId = sumaActionIdIn;
         this.forcePackageListRefresh = forcePackageListRefreshIn;
         this.actionChain = actionChainIn;
         this.batchMode = batchModeIn;
         this.minionStartup = minionStartupIn;
+        this.actionChainId = actionChainIdIn;
     }
 
     /**
@@ -66,14 +72,16 @@ public class ScheduleMetadata {
      * @param actionChainIn whether the schedule action is corresponds to an action chain
      * @param batchModeIn whether the schedule action is executed in batch mode
      * @param minionStartupIn whether the schedule action corresponds to a minion start up
+     * @param actionChainIdIn action chain id
      */
     public ScheduleMetadata(boolean forcePackageListRefreshIn, boolean actionChainIn,
-            boolean batchModeIn, boolean minionStartupIn) {
+            boolean batchModeIn, boolean minionStartupIn, Long actionChainIdIn) {
         super();
         this.forcePackageListRefresh = forcePackageListRefreshIn;
         this.actionChain = actionChainIn;
         this.batchMode = batchModeIn;
         this.minionStartup = minionStartupIn;
+        this.actionChainId = actionChainIdIn;
     }
 
     /**
@@ -81,7 +89,7 @@ public class ScheduleMetadata {
      * @return the new instance of ScheduleMetadata
      */
     public static ScheduleMetadata getDefaultMetadata() {
-        return new ScheduleMetadata(false, false, false, false);
+        return new ScheduleMetadata(false, false, false, false, null);
     }
 
     /**
@@ -94,9 +102,9 @@ public class ScheduleMetadata {
     public static ScheduleMetadata getMetadataForRegularMinionActions(boolean isStagingJob,
             boolean forcePackageListRefresh, long actionId) {
         if (!isStagingJob) {
-            return new ScheduleMetadata(actionId, forcePackageListRefresh, false, false, false);
+            return new ScheduleMetadata(actionId, forcePackageListRefresh, false, false, false, null);
         }
-        return new ScheduleMetadata(forcePackageListRefresh, false, false, false);
+        return new ScheduleMetadata(forcePackageListRefresh, false, false, false, null);
     }
 
     /**
@@ -104,15 +112,18 @@ public class ScheduleMetadata {
      * @return an instance of ScheduleMetadata with batchMode flag set in true
      */
     public ScheduleMetadata withBatchMode() {
-        return new ScheduleMetadata(sumaActionId, forcePackageListRefresh, actionChain, true, minionStartup);
+        return new ScheduleMetadata(sumaActionId, forcePackageListRefresh, actionChain, true, minionStartup,
+                actionChainId);
     }
 
     /**
-     * Sets the actionChain flag in true
+     * Sets the actionChain flag in true and adds action chain id
+     * @param actionChainIdIn action chain id
      * @return an instance of ScheduleMetadata with the actionChain flag set in true
      */
-    public ScheduleMetadata withActionChain() {
-        return new ScheduleMetadata(sumaActionId, forcePackageListRefresh, true, batchMode, minionStartup);
+    public ScheduleMetadata withActionChain(long actionChainIdIn) {
+        return new ScheduleMetadata(sumaActionId, forcePackageListRefresh, true, batchMode, minionStartup,
+                actionChainIdIn);
     }
 
     /**
@@ -120,7 +131,11 @@ public class ScheduleMetadata {
      * @return an instance of ScheduleMetadata with the minionStartup flag set in true
      */
     public ScheduleMetadata withMinionStartup() {
-        return new ScheduleMetadata(sumaActionId, forcePackageListRefresh, actionChain, batchMode, true);
+        return new ScheduleMetadata(sumaActionId, forcePackageListRefresh, actionChain, batchMode, true, actionChainId);
+    }
+
+    public Long getActionChainId() {
+        return actionChainId;
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/websocket/VirtNotifications.java
+++ b/java/code/src/com/suse/manager/webui/websocket/VirtNotifications.java
@@ -139,9 +139,7 @@ public class VirtNotifications {
                     // Send out a list of the latest pending actions to display
                     Server server = SystemManager.lookupByIdAndUser(newId, userOpt.get());
                     List<ServerAction> serverActions = ActionFactory.listServerActionsForServer(server,
-                            Arrays.asList(ActionFactory.STATUS_QUEUED,
-                                          ActionFactory.STATUS_PICKEDUP,
-                                          ActionFactory.STATUS_PICKED_UP));
+                            Arrays.asList(ActionFactory.STATUS_QUEUED, ActionFactory.STATUS_PICKED_UP));
 
                     Map<String, List<ServerAction>> groupedActions = serverActions.stream()
                             .filter(sa -> ActionFactory.isVirtualizationActionType(

--- a/schema/spacewalk/common/tables/rhnActionChain.sql
+++ b/schema/spacewalk/common/tables/rhnActionChain.sql
@@ -15,6 +15,10 @@ CREATE TABLE rhnActionChain
     id          NUMERIC        NOT NULL
                     CONSTRAINT rhn_action_chain_id_pk PRIMARY KEY,
     label       VARCHAR(256) NOT NULL,
+    dispatched  CHAR(1)
+                   DEFAULT ('N') NOT NULL
+                   CONSTRAINT rhn_actionchain_dispatched_ck
+                       CHECK (dispatched in ('Y','N')),
     user_id     NUMERIC        NOT NULL
                     CONSTRAINT rhn_actionchain_uid_fk
                         REFERENCES web_contact (id)

--- a/schema/spacewalk/upgrade/susemanager-schema-4.2.6-to-susemanager-schema-4.2.7/900-actionchaindispatch.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.2.6-to-susemanager-schema-4.2.7/900-actionchaindispatch.sql
@@ -1,0 +1,2 @@
+ALTER TABLE rhnActionChain DROP CONSTRAINT IF EXISTS rhn_actionchain_dispatched_ck;
+ALTER TABLE rhnActionChain ADD COLUMN IF NOT EXISTS dispatched CHAR(1) DEFAULT ('N') NOT NULL CONSTRAINT rhn_actionchain_dispatched_ck CHECK (dispatched in ('Y', 'N'));


### PR DESCRIPTION
## What does this PR change?

This PR adds error handling when the actionchain module `mgractionchains` is not present on a minion. Before this would not complete the actions and only a later cleanup task would set them to failed. Now those actions will be set to failed directly with the proper error message.

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests: already covered


- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/12826


- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql" 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
