### PR TITLE
Allow setting system primary FQDN via WebUI or XMLRPC-API

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/server/ServerFQDN.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerFQDN.hbm.xml
@@ -11,6 +11,7 @@
         <property name="name" column="name" type="string" length="253" />
         <property name="created" column="created" type="timestamp" insert="false" update="false" />
         <property name="modified" column="modified" type="timestamp" insert="false" update="false" />
+        <property name="primary" column="is_primary" type="yes_no" />
 
         <many-to-one name="server" class="com.redhat.rhn.domain.server.Server" not-null="true" column="server_id" />
     </class>

--- a/java/code/src/com/redhat/rhn/domain/server/ServerFQDN.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerFQDN.java
@@ -28,6 +28,7 @@ public class ServerFQDN extends BaseDomainHelper implements Identifiable {
     private Long id;
     private Server server;
     private String name;
+    private boolean primary;
 
     /**
      * Constructor for the class ServerFQDN
@@ -71,6 +72,20 @@ public class ServerFQDN extends BaseDomainHelper implements Identifiable {
      */
     public void setName(String nameIn) {
         this.name = nameIn;
+    }
+
+    /**
+     * @return Boolean which indicates primary FQDN
+     */
+    public boolean isPrimary() {
+        return primary;
+    }
+
+    /**
+     * @param primaryIn Boolean which sets primary FQDN
+     */
+    public void setPrimary(boolean primaryIn) {
+        primary = primaryIn;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemHardwareAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemHardwareAction.java
@@ -14,30 +14,13 @@
  */
 package com.redhat.rhn.frontend.action.systems.sdc;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.StringTokenizer;
-
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
-import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Logger;
-import org.apache.struts.action.ActionForm;
-import org.apache.struts.action.ActionForward;
-import org.apache.struts.action.ActionMapping;
-import org.apache.struts.action.DynaActionForm;
-
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionFactory;
 import com.redhat.rhn.domain.server.CPU;
 import com.redhat.rhn.domain.server.Device;
 import com.redhat.rhn.domain.server.NetworkInterface;
 import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerFQDN;
 import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.server.ServerNetAddress4;
 import com.redhat.rhn.domain.server.ServerNetAddress6;
@@ -50,6 +33,24 @@ import com.redhat.rhn.manager.action.ActionManager;
 import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.log4j.Logger;
+import org.apache.struts.action.ActionForm;
+import org.apache.struts.action.ActionForward;
+import org.apache.struts.action.ActionMapping;
+import org.apache.struts.action.DynaActionForm;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.StringTokenizer;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 /**
  * SystemHardwareAction handles the interaction of the ChannelDetails page.
@@ -83,10 +84,10 @@ public class SystemHardwareAction extends RhnAction {
         request.setAttribute(SID, sid);
 
         if (isSubmitted(form)) {
-            if (ctx.hasParam("update_interface")) {
+            if (ctx.hasParam("update_networking_properties")) {
                 server.setPrimaryInterfaceWithName(form.get("primaryInterface").toString());
-                createSuccessMessage(request, "message.interfaceSet",
-                        form.get("primaryInterface").toString());
+                server.setPrimaryFQDNWithName(form.get("primaryFQDN").toString());
+                createSuccessMessage(request, "message.interfaceSet", null);
             }
             else {
                 Action a = ActionManager.scheduleHardwareRefreshAction(user, server, now);
@@ -129,6 +130,11 @@ public class SystemHardwareAction extends RhnAction {
         }
         if (server.getActiveNetworkInterfaces() != null) {
             request.setAttribute("networkInterfaces", getNetworkInterfaces(server));
+        }
+        ServerFQDN fqdn = server.findPrimaryFqdn();
+        if (fqdn != null) {
+            daForm.set("primaryFQDN", fqdn.getName());
+            request.setAttribute("primaryFQDN", fqdn.getName());
         }
         request.setAttribute("system", server);
         if (cpu != null) {

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -1580,7 +1580,7 @@
         </context-group>
       </trans-unit>
       <trans-unit id="message.interfaceSet" xml:space="preserve">
-        <source>Primary network interface set to &lt;strong&gt;{0}&lt;/strong&gt;.</source>
+        <source>Networking properties updated.</source>
         <context-group name="ctx">
           <context context-type="sourcefile">NOT USED</context>
         </context-group>
@@ -7609,6 +7609,9 @@ Follow this url to see the full list of inactive systems:
       </trans-unit>
       <trans-unit id="api.system.nosuchnetiface" xml:space="preserve">
         <source>No such network interface: {0}.</source>
+      </trans-unit>
+      <trans-unit id="api.system.nosuchfqdn" xml:space="preserve">
+        <source>No such FQDN: {0}.</source>
       </trans-unit>
       <trans-unit id="api.errata.invalidadvisorytype" xml:space="preserve">
         <source>Invalid patch type, "{0}". Please use one of the following: "Security Advisory", "Product Enhancement Advisory", or "Bug Fix Advisory".</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -21407,7 +21407,7 @@ The Tree Path, Base Channel, and Installer Generation should always match. This 
         </context-group>
       </trans-unit>
       <trans-unit id="sdc.details.hardware.fqdns" xml:space="preserve">
-        <source>FQDNs:</source>
+        <source>Primary FQDN:</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/systems/details/SystemHardware.do</context>
         </context-group>

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/NoSuchFQDNException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/NoSuchFQDNException.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.frontend.xmlrpc;
+
+import com.redhat.rhn.FaultException;
+import com.redhat.rhn.common.localization.LocalizationService;
+
+/**
+ * No Such FQDN Interface Exception
+ */
+public class NoSuchFQDNException extends FaultException  {
+
+    /**
+     * NoSuchFQDNException
+     * @param fqdn FQDN which has not been found
+     */
+    public NoSuchFQDNException(String fqdn) {
+        super(1074, "No Such FQDN" , LocalizationService.getInstance().
+                getMessage("api.system.nosuchfqdn", fqdn));
+    }
+}

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
@@ -220,6 +220,19 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
         assertEquals(device.getIPv4Addresses(), dev.getIPv4Addresses());
     }
 
+    public void testGetNetworkForSystems() throws Exception {
+        Server server = ServerFactoryTest.createTestServer(admin, true);
+        server.addFqdn("domain1.test.local");
+        server.addFqdn("domain2.test.local");
+        ServerFactory.save(server);
+
+        List<Map<String, Object>> returned = handler.getNetworkForSystems(admin,
+                Collections.singletonList(server.getId().intValue()));
+
+        assertEquals(1, returned.size());
+        assertEquals("domain1.test.local", returned.get(0).get("primary_fqdn"));
+    }
+
     public void testObtainReactivationKey() throws Exception {
         Server server = ServerFactoryTest.createUnentitledTestServer(admin, true,
                 ServerFactoryTest.TYPE_SERVER_NORMAL, new Date());

--- a/java/code/webapp/WEB-INF/pages/systems/sdc/hardware.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/sdc/hardware.jsp
@@ -171,9 +171,11 @@
                           <tr>
                             <th><bean:message key="sdc.details.hardware.fqdns" /></th>
                             <td>
-                              <c:forEach items="${fqdns}" var="fqdn" varStatus="loop">
-                                  ${fqdn.name}<br />
-                              </c:forEach>
+                              <c:if test="${not empty fqdns}">
+                                <html:select property="primaryFQDN" styleId="primaryFQDN">
+                                  <html:options collection="fqdns" property="name" labelProperty="name" />
+                                </html:select>
+                              </c:if>
                             </td>
                           </tr>
                         </c:if>
@@ -186,8 +188,8 @@
 
         <rhn:require acl="system_has_management_entitlement() or system_has_salt_entitlement()">
             <div class="text-right margin-bottom-sm">
-              <c:if test="${not empty networkInterfaces}">
-                <html:submit property="update_interface" styleClass="btn btn-default">
+              <c:if test="${not empty networkInterfaces || not empty fqdns}">
+                <html:submit property="update_networking_properties" styleClass="btn btn-default">
                     <bean:message key="sdc.details.edit.update" />
                 </html:submit>
               </c:if>

--- a/java/code/webapp/WEB-INF/struts-config.xml
+++ b/java/code/webapp/WEB-INF/struts-config.xml
@@ -887,6 +887,7 @@
                <form-property name="sid" type="java.lang.Long"/>
                <form-property name="submitted" type="java.lang.Boolean"/>
                              <form-property name="primaryInterface" type="java.lang.String"/>
+                             <form-property name="primaryFQDN" type="java.lang.String"/>
     </form-bean>
 
     <form-bean name="systemDetailsForm"

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Allow setting a primary FQDN per system, either via WebUI or XMLRPC-API
 - Speed up pages to compare or add packages to channels (bsc#1178767)
 - Remove validator.js from jade templates
 - Homogenizes style in filter buttons, facilitating testability

--- a/schema/spacewalk/common/tables/rhnServerFQDN.sql
+++ b/schema/spacewalk/common/tables/rhnServerFQDN.sql
@@ -21,6 +21,7 @@ CREATE TABLE rhnServerFQDN
     server_id  NUMERIC NOT NULL
                    CONSTRAINT rhn_serverfqdn_sid_fk
                        REFERENCES rhnServer (id),
+    is_primary CHAR(1) DEFAULT ('N') NOT NULL,
     created    TIMESTAMPTZ
                    DEFAULT (current_timestamp) NOT NULL,
     modified   TIMESTAMPTZ

--- a/schema/spacewalk/postgres/tables/rhnServerFQDN_index.sql
+++ b/schema/spacewalk/postgres/tables/rhnServerFQDN_index.sql
@@ -1,0 +1,5 @@
+-- function index for rhnServerFQDN
+
+CREATE UNIQUE INDEX rhn_srv_fqdn_prim_fqdn
+  ON rhnServerFQDN
+  (server_id) where is_primary = 'Y';

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- Add 'is_primary' column to rhnServerFqdn table
 - Fix: increase password length in the database (bsc#1182687)
 
 -------------------------------------------------------------------

--- a/schema/spacewalk/upgrade/susemanager-schema-4.2.8-to-susemanager-schema-4.2.9/701-rhn_server_fqdn.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.2.8-to-susemanager-schema-4.2.9/701-rhn_server_fqdn.sql
@@ -1,0 +1,9 @@
+ALTER TABLE rhnServerFQDN ADD COLUMN IF NOT EXISTS is_primary CHAR(1) DEFAULT ('N') NOT NULL;
+
+UPDATE rhnServerFQDN f1 SET is_primary = 'Y'
+WHERE f1.name = (SELECT MIN(f2.name) FROM rhnServerFQDN f2 WHERE f2.server_id = f1.server_id)
+AND NOT EXISTS (SELECT 1 FROM rhnServerFQDN f3 WHERE f3.server_id = f1.server_id AND is_primary='Y');
+
+CREATE UNIQUE INDEX IF NOT EXISTS rhn_srv_fqdn_prim_fqdn
+  ON rhnServerFQDN
+  (server_id) where is_primary = 'Y';

--- a/testsuite/features/secondary/min_salt_minion_details.feature
+++ b/testsuite/features/secondary/min_salt_minion_details.feature
@@ -22,3 +22,9 @@ Feature: Verify the minion registration
     And I click on "Schedule Hardware Refresh"
     Then I should see a "You have successfully scheduled a hardware profile refresh" text
     And I wait until event "Hardware List Refresh scheduled by admin" is completed
+
+  Scenario: Check that Update Properties button works
+    Given I am on the Systems overview page of this "sle_minion"
+    And I follow "Hardware"
+    And I click on "Update Properties"
+    Then I should see a "Networking properties updated." text


### PR DESCRIPTION
## What does this PR change?

With this PR, it will now be possible to set/get the primary FQDN of a given system (via WebUI or XMLRPC-API).

**XMLRPC-API**
- The existing `system.getNetworkForSystems` method will now return a new `fqdn` field with the primary FQDN
- A new `system.setPrimaryFqdn` method has been added to set the primary FQDN of a given system

**WEBUI**
- The primary FQDN of a given systems can ve visualized/set via `System > Details > Hardware` page.

**Schema**
- The primary FQDN is stored in a new `is_primary` column on the `rhnServerFqdn` table

## GUI diff

Before:

![Screenshot from 2021-01-25 15-12-12](https://user-images.githubusercontent.com/14297426/105724547-e117f280-5f1f-11eb-97fa-9897e5bb28b4.png)

After:

![107793387-24f75e00-6d4e-11eb-9214-378c32f62231](https://user-images.githubusercontent.com/14297426/109627265-57200280-7b39-11eb-8b5b-4c41f276c698.png)

- [x] **DONE**

## Documentation
- Documentation issue was created: https://github.com/SUSE/spacewalk/issues/13759

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/13480

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql" (Test skipped, there are no changes to test)
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests" (Test skipped, there are no changes to test)
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
