### PR TITLE
fix query using old EVR_T constructor (bsc#1181422)

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
@@ -400,9 +400,11 @@ ORDER BY  UPPER(COALESCE(S.NAME, '(none)')), S.ID
 <mode name="potential_systems_for_package" class="com.redhat.rhn.frontend.dto.SystemOverview">
   <query params="org_id, pid, user_id">
 SELECT  S.id, S.name, 1 as selectable
-  FROM  rhnPackage P, rhnChannelPackage CP, rhnServerChannel SC, rhnServer S
+  FROM  rhnPackage P, rhnChannelPackage CP, rhnServerChannel SC, rhnServer S, rhnServerArch SA, rhnArchType AT
  WHERE  S.org_id = :org_id
    AND  SC.server_id = S.id
+   AND  SA.id = S.server_arch_id
+   AND  AT.id = SA.arch_type_id
    AND  SC.channel_id = CP.channel_id
    AND  CP.package_id = :pid
    AND  CP.package_id = P.id
@@ -410,7 +412,7 @@ SELECT  S.id, S.name, 1 as selectable
            FROM rhnServerPackage SP, rhnPackageEvr PE
           WHERE SP.name_id = P.name_id
             AND SP.server_id = S.id
-            AND SP.evr_id = PE.id), (EVR_T(NULL, '0', '0'))
+            AND SP.evr_id = PE.id), (EVR_T(NULL, '0', '0', AT.label))
             )
         &lt;
         (SELECT EVR FROM rhnPackageEVR PE WHERE PE.id = P.evr_id)

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- fix query using old EVR_T constructor (bsc#1181422) 
 - Update to postgresql13 (jsc#SLE-17030)
 - Improve modular dependency resolution algorithm (bsc#1177267)
 - Display absolute timestamps for configuration files


### PR DESCRIPTION
## What does this PR change?

Fixes a query that still used the old EVR_T constructor syntax

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: 

- [x] **DONE**

## Test coverage
- No tests:

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/13770

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
