### PR TITLE
Make the core features lighter - activation keys

### DIFF
--- a/testsuite/features/core/srv_create_activationkey.feature
+++ b/testsuite/features/core/srv_create_activationkey.feature
@@ -1,49 +1,17 @@
-# Copyright (c) 2010-2019 SUSE LLC
+# Copyright (c) 2010-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-Feature: Be able to create and manipulate activation keys
+Feature: Create activation keys
   In order to register systems to the spacewalk server
   As the testing user
   I want to use activation keys
-
-  Scenario: Create an activation key
-    Given I am on the Systems page
-    When I follow the left menu "Systems > Activation Keys"
-    And I follow "Create Key"
-    And I enter "SUSE Test Key i586" as "description"
-    And I enter "SUSE-DEV-i586" as "key"
-    And I check "virtualization_host"
-    And I click on "Create Activation Key"
-    Then I should see a "Activation key SUSE Test Key i586 has been created." text
-    And I should see a "Details" link
-    And I should see a "Packages" link
-    And I should see a "Configuration" link in the content area
-    And I should see a "Groups" link
-    And I should see a "Activated Systems" link
-
-  Scenario: Change limit of the activation key
-    Given I am on the Systems page
-    When I follow the left menu "Systems > Activation Keys"
-    And I follow "SUSE Test Key i586"
-    And I enter "20" as "usageLimit"
-    And I click on "Update Activation Key"
-    Then I should see a "Activation key SUSE Test Key i586 has been modified." text
-    And I should see "20" in field "usageLimit"
-
-  Scenario: Change the base channel of the activation key
-    Given I am on the Systems page
-    When I follow the left menu "Systems > Activation Keys"
-    And I follow "SUSE Test Key i586"
-    And I select "Test-Channel-i586" from "selectedBaseChannel"
-    And I click on "Update Activation Key"
-    Then I should see a "Activation key SUSE Test Key i586 has been modified." text
 
   Scenario: Create an activation key with a channel
     Given I am on the Systems page
     When I follow the left menu "Systems > Activation Keys"
     And I follow "Create Key"
     And I enter "SUSE Test Key x86_64" as "description"
-    And I enter "SUSE-DEV-x86_64" as "key"
+    And I enter "SUSE-KEY-x86_64" as "key"
     And I check "virtualization_host"
     And I enter "20" as "usageLimit"
     And I select "Test-Channel-x86_64" from "selectedBaseChannel"
@@ -55,50 +23,13 @@ Feature: Be able to create and manipulate activation keys
     And I should see a "Groups" link
     And I should see a "Activated Systems" link
 
-  Scenario: Create an activation key with a channel and a package list for x86_64
-    Given I am on the Systems page
-    When I follow the left menu "Systems > Activation Keys"
-    And I follow "Create Key"
-    And I enter "SUSE Test PKG Key x86_64" as "description"
-    And I enter "SUSE-PKG-x86_64" as "key"
-    And I enter "20" as "usageLimit"
-    And I select "Test-Channel-x86_64" from "selectedBaseChannel"
-    And I click on "Create Activation Key"
-    And I follow "Packages"
-    And I enter "sed" as "packages"
-    And I click on "Update Activation Key"
-    Then I should see a "Activation key SUSE Test PKG Key x86_64 has been modified." text
-    And I should see a "Details" link
-    And I should see a "Packages" link
-    And I should see a "Configuration" link in the content area
-    And I should see a "Groups" link
-    And I should see a "Activated Systems" link
-
-  Scenario: Create an activation key with a channel and a package list for i586
-    Given I am on the Systems page
-    When I follow the left menu "Systems > Activation Keys"
-    And I follow "Create Key"
-    And I enter "SUSE Test PKG Key i586" as "description"
-    And I enter "SUSE-PKG-i586" as "key"
-    And I enter "20" as "usageLimit"
-    And I select "Test-Channel-i586" from "selectedBaseChannel"
-    And I click on "Create Activation Key"
-    And I follow "Packages"
-    And I enter "sed" as "packages"
-    And I click on "Update Activation Key"
-    Then I should see a "Activation key SUSE Test PKG Key i586 has been modified." text
-    And I should see a "Details" link
-    And I should see a "Packages" link
-    And I should see a "Configuration" link in the content area
-    And I should see a "Groups" link
-    And I should see a "Activated Systems" link
-
+@ubuntu_minion
   Scenario: Create an activation key for Ubuntu
     Given I am on the Systems page
     When I follow the left menu "Systems > Activation Keys"
     And I follow "Create Key"
     And I enter "Ubuntu Test Key" as "description"
-    And I enter "UBUNTU-TEST" as "key"
+    And I enter "UBUNTU-KEY" as "key"
     And I select "Test-Channel-Deb-AMD64" from "selectedBaseChannel"
     And I click on "Create Activation Key"
     Then I should see a "Activation key Ubuntu Test Key has been created" text
@@ -113,7 +44,7 @@ Feature: Be able to create and manipulate activation keys
     When I follow the left menu "Systems > Activation Keys"
     And I follow "Create Key"
     And I enter "SUSE SSH Test Key x86_64" as "description"
-    And I enter "SUSE-SSH-DEV-x86_64" as "key"
+    And I enter "SUSE-SSH-KEY-x86_64" as "key"
     And I enter "20" as "usageLimit"
     And I select "Test-Channel-x86_64" from "selectedBaseChannel"
     And I select "Push via SSH" from "contact-method"
@@ -125,9 +56,8 @@ Feature: Be able to create and manipulate activation keys
     When I follow the left menu "Systems > Activation Keys"
     And I follow "Create Key"
     And I enter "SUSE SSH Tunnel Test Key x86_64" as "description"
-    And I enter "SUSE-SSH-TUNNEL-DEV-x86_64" as "key"
+    And I enter "SUSE-SSH-TUNNEL-KEY-x86_64" as "key"
     And I enter "20" as "usageLimit"
     And I select "Test-Channel-x86_64" from "selectedBaseChannel"
     And I select "Push via SSH tunnel" from "contact-method"
     And I click on "Create Activation Key"
-    Then I should see a "Activation key SUSE SSH Tunnel Test Key x86_64 has been created" text

--- a/testsuite/features/init_clients/min_centos_salt.feature
+++ b/testsuite/features/init_clients/min_centos_salt.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2020 SUSE LLC
+# Copyright (c) 2016-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 #  1) bootstrap a new CentOS minion via salt
@@ -15,7 +15,7 @@ Feature: Bootstrap a CentOS minion and do some basic operations on it
     And I enter "22" as "port"
     And I enter "root" as "user"
     And I enter "linux" as "password"
-    And I select "1-SUSE-PKG-x86_64" from "activationKeys"
+    And I select "1-SUSE-KEY-x86_64" from "activationKeys"
     And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text

--- a/testsuite/features/init_clients/min_ubuntu_salt.feature
+++ b/testsuite/features/init_clients/min_ubuntu_salt.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2020 SUSE LLC
+# Copyright (c) 2016-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 #  1) bootstrap a new Ubuntu minion
@@ -15,7 +15,7 @@ Feature: Bootstrap an Ubuntu minion and do some basic operations on it
     And I enter "22" as "port"
     And I enter "root" as "user"
     And I enter "linux" as "password"
-    And I select "1-UBUNTU-TEST" from "activationKeys"
+    And I select "1-UBUNTU-KEY" from "activationKeys"
     And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text

--- a/testsuite/features/init_clients/sle_client.feature
+++ b/testsuite/features/init_clients/sle_client.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2020 SUSE LLC
+# Copyright (c) 2015-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Register a traditional client
@@ -7,7 +7,7 @@ Feature: Register a traditional client
 
   Scenario: Register a traditional client
     Given I am authorized
-    When I bootstrap traditional client "sle_client" using bootstrap script with activation key "1-SUSE-DEV-x86_64" from the proxy
+    When I bootstrap traditional client "sle_client" using bootstrap script with activation key "1-SUSE-KEY-x86_64" from the proxy
     And I wait until onboarding is completed for "sle_client"
     Then I should see "sle_client" via spacecmd
 

--- a/testsuite/features/secondary/min_activationkey.feature
+++ b/testsuite/features/secondary/min_activationkey.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 SUSE LLC
+# Copyright (c) 2018-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @scope_onboarding
@@ -122,7 +122,7 @@ Feature: Bootstrap a Salt minion via the GUI with an activation key
     And I follow "Minion testing" in the content area
     And I follow "Delete Key"
     And I click on "Delete Activation Key"
-    And I should see a "Activation key Minion testing has been deleted." text
+    Then I should see a "Activation key Minion testing has been deleted." text
 
   Scenario: Check events history for failures on SLES minion with activation key
     Given I am on the Systems overview page of this "sle_minion"

--- a/testsuite/features/secondary/min_bootstrap_script.feature
+++ b/testsuite/features/secondary/min_bootstrap_script.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2020 SUSE LLC
+# Copyright (c) 2019-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 #
@@ -19,7 +19,7 @@ Feature: Register a Salt minion via Bootstrap-script
     Then "sle_minion" should not be registered
 
   Scenario: Bootstrap the minion using the script
-    When I bootstrap minion client "sle_minion" using bootstrap script with activation key "1-SUSE-PKG-x86_64" from the proxy
+    When I bootstrap minion client "sle_minion" using bootstrap script with activation key "1-SUSE-KEY-x86_64" from the proxy
     And I wait at most 10 seconds until Salt master sees "sle_minion" as "unaccepted"
     And I accept "sle_minion" key in the Salt master
     Then I should see "sle_minion" via spacecmd
@@ -35,7 +35,7 @@ Feature: Register a Salt minion via Bootstrap-script
 
   Scenario: Check the activation key
     Given I am on the Systems overview page of this "sle_minion"
-    Then I should see a "1-SUSE-PKG-x86_64" text
+    Then I should see a "1-SUSE-KEY-x86_64" text
 
   Scenario: Subscribe the script-bootstrapped SLES minion to a base channel
     Given I am on the Systems overview page of this "sle_minion"

--- a/testsuite/features/secondary/min_ssh_tunnel.feature
+++ b/testsuite/features/secondary/min_ssh_tunnel.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 SUSE LLC
+# Copyright (c) 2020-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @scope_salt_ssh
@@ -20,7 +20,7 @@ Feature: Register a salt system to be managed via SSH tunnel
     And I enter "22" as "port"
     And I enter "root" as "user"
     And I enter "linux" as "password"
-    And I select "1-SUSE-SSH-TUNNEL-DEV-x86_64" from "activationKeys"
+    And I select "1-SUSE-SSH-TUNNEL-KEY-x86_64" from "activationKeys"
     And I select the hostname of "proxy" from "proxies"
     And I check "manageWithSSH"
     And I click on "Bootstrap"
@@ -80,7 +80,7 @@ Feature: Register a salt system to be managed via SSH tunnel
     Then "sle_ssh_tunnel_minion" should not be registered
 
   Scenario: Cleanup: register a salt minion after SSH tunnel tests
-    When I bootstrap minion client "sle_minion" using bootstrap script with activation key "1-SUSE-PKG-x86_64" from the proxy
+    When I bootstrap minion client "sle_minion" using bootstrap script with activation key "1-SUSE-KEY-x86_64" from the proxy
     And I wait at most 10 seconds until Salt master sees "sle_minion" as "unaccepted"
     And I accept "sle_minion" key in the Salt master
     Then I should see "sle_minion" via spacecmd

--- a/testsuite/features/secondary/minkvm_guests.feature
+++ b/testsuite/features/secondary/minkvm_guests.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 SUSE LLC
+# Copyright (c) 2018-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @scope_virtualization
@@ -13,7 +13,7 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I enter "22" as "port"
     And I enter "root" as "user"
     And I enter "kvm_server" password
-    And I select "1-SUSE-PKG-x86_64" from "activationKeys"
+    And I select "1-SUSE-KEY-x86_64" from "activationKeys"
     And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text
@@ -379,7 +379,7 @@ Feature: Be able to manage KVM virtual machines via the GUI
     When I enter "self_update=0" as "kernel_options"
     And I click on "Update"
     And I follow "Variables"
-    And I enter "distrotree=SLE-15-SP2-TFTP\nregistration_key=1-SUSE-PKG-x86_64" as "variables" text area
+    And I enter "distrotree=SLE-15-SP2-TFTP\nregistration_key=1-SUSE-KEY-x86_64" as "variables" text area
     And I click on "Update Variables"
     And I follow "Autoinstallation File"
     Then I should see a "SLE-15-SP2-TFTP" text

--- a/testsuite/features/secondary/minxen_guests.feature
+++ b/testsuite/features/secondary/minxen_guests.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 SUSE LLC
+# Copyright (c) 2018-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @scope_virtualization
@@ -13,7 +13,7 @@ Feature: Be able to manage XEN virtual machines via the GUI
     And I enter "22" as "port"
     And I enter "root" as "user"
     And I enter "xen_server" password
-    And I select "1-SUSE-PKG-x86_64" from "activationKeys"
+    And I select "1-SUSE-KEY-x86_64" from "activationKeys"
     And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
     And I wait at most 300 seconds until I see "Successfully bootstrapped host!" text

--- a/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
+++ b/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 SUSE LLC
+# Copyright (c) 2018-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # This feature depends on a JeOS image present on the proxy
@@ -338,7 +338,7 @@ Feature: PXE boot a Retail terminal
   Scenario: Bootstrap the PXE boot minion
     Given I am authorized
     When I stop and disable avahi on the PXE boot minion
-    And I create bootstrap script and set the activation key "1-SUSE-DEV-x86_64" in the bootstrap script on the proxy
+    And I create bootstrap script and set the activation key "1-SUSE-KEY-x86_64" in the bootstrap script on the proxy
     And I bootstrap pxeboot minion via bootstrap script on the proxy
     And I wait at most 180 seconds until Salt master sees "pxeboot_minion" as "unaccepted"
     And I accept key of pxeboot minion in the Salt master

--- a/testsuite/features/secondary/srv_manage_activationkey.feature
+++ b/testsuite/features/secondary/srv_manage_activationkey.feature
@@ -1,0 +1,86 @@
+# Copyright (c) 2010-2021 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+Feature: Manipulate activation keys
+  In order to register systems to the spacewalk server
+  As the testing user
+  I want to create and edit activation keys
+
+  Scenario: Create an activation key for i586
+    Given I am on the Systems page
+    When I follow the left menu "Systems > Activation Keys"
+    And I follow "Create Key"
+    And I enter "SUSE Test Key i586" as "description"
+    And I enter "SUSE-TEST-i586" as "key"
+    And I check "virtualization_host"
+    And I click on "Create Activation Key"
+    Then I should see a "Activation key SUSE Test Key i586 has been created." text
+
+  Scenario: Change limit of the i586 activation key
+    Given I am on the Systems page
+    When I follow the left menu "Systems > Activation Keys"
+    And I follow "SUSE Test Key i586"
+    And I enter "20" as "usageLimit"
+    And I click on "Update Activation Key"
+    Then I should see a "Activation key SUSE Test Key i586 has been modified." text
+    And I should see "20" in field "usageLimit"
+
+  Scenario: Change the base channel of the i586 activation key
+    Given I am on the Systems page
+    When I follow the left menu "Systems > Activation Keys"
+    And I follow "SUSE Test Key i586"
+    And I select "Test-Channel-i586" from "selectedBaseChannel"
+    And I click on "Update Activation Key"
+    Then I should see a "Activation key SUSE Test Key i586 has been modified." text
+
+  Scenario: Delete the i586 activation key
+    Given I am on the Systems page
+    When I follow the left menu "Systems > Activation Keys"
+    And I follow "SUSE Test Key i586" in the content area
+    And I follow "Delete Key"
+    And I click on "Delete Activation Key"
+    Then I should see a "Activation key SUSE Test Key i586 has been deleted." text
+
+  Scenario: Create an activation key with a channel and a package list for i586
+    Given I am on the Systems page
+    When I follow the left menu "Systems > Activation Keys"
+    And I follow "Create Key"
+    And I enter "SUSE Test PKG Key i586" as "description"
+    And I enter "SUSE-TEST-2-i586" as "key"
+    And I enter "20" as "usageLimit"
+    And I select "Test-Channel-i586" from "selectedBaseChannel"
+    And I click on "Create Activation Key"
+    And I follow "Packages"
+    And I enter "sed" as "packages"
+    And I click on "Update Activation Key"
+    Then I should see a "Activation key SUSE Test PKG Key i586 has been modified." text
+
+  Scenario: Delete the i586 activation key with packages
+    Given I am on the Systems page
+    When I follow the left menu "Systems > Activation Keys"
+    And I follow "SUSE Test PKG Key i586" in the content area
+    And I follow "Delete Key"
+    And I click on "Delete Activation Key"
+    Then I should see a "Activation key SUSE Test PKG Key i586 has been deleted." text
+
+  Scenario: Create an activation key with a channel and a package list for x86_64
+    Given I am on the Systems page
+    When I follow the left menu "Systems > Activation Keys"
+    And I follow "Create Key"
+    And I enter "SUSE Test PKG Key x86_64" as "description"
+    And I enter "SUSE-TEST-x86_64" as "key"
+    And I enter "20" as "usageLimit"
+    And I select "Test-Channel-x86_64" from "selectedBaseChannel"
+    And I click on "Create Activation Key"
+    And I follow "Packages"
+    And I enter "sed" as "packages"
+    And I click on "Update Activation Key"
+    Then I should see a "Activation key SUSE Test PKG Key x86_64 has been modified." text
+
+  Scenario: Delete the x86_64 activation key with packages
+    Given I am on the Systems page
+    When I follow the left menu "Systems > Activation Keys"
+    And I follow "SUSE Test PKG Key x86_64" in the content area
+    And I follow "Delete Key"
+    And I click on "Delete Activation Key"
+    Then I should see a "Activation key SUSE Test PKG Key x86_64 has been deleted." text

--- a/testsuite/features/secondary/trad_baremetal_discovery.feature
+++ b/testsuite/features/secondary/trad_baremetal_discovery.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2020 SUSE LLC
+# Copyright (c) 2015-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @scope_traditional_client
@@ -118,7 +118,7 @@ Feature: Bare metal discovery
     And the PXE default profile should be disabled
 
   Scenario: Cleanup: register a traditional client after bare metal tests
-    When I bootstrap traditional client "sle_client" using bootstrap script with activation key "1-SUSE-DEV-x86_64" from the proxy
+    When I bootstrap traditional client "sle_client" using bootstrap script with activation key "1-SUSE-KEY-x86_64" from the proxy
     Then I should see "sle_client" via spacecmd
 
   Scenario: Cleanup: remove remaining systems from SSM after bare metal tests

--- a/testsuite/features/secondary/trad_migrate_to_minion.feature
+++ b/testsuite/features/secondary/trad_migrate_to_minion.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 SUSE LLC
+# Copyright (c) 2017-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @scope_traditional_client
@@ -14,7 +14,7 @@ Feature: Migrate a traditional client into a Salt minion
     And I enter "22" as "port"
     And I enter "root" as "user"
     And I enter "linux" as "password"
-    And I select "1-SUSE-PKG-x86_64" from "activationKeys"
+    And I select "1-SUSE-KEY-x86_64" from "activationKeys"
     And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text
@@ -43,11 +43,9 @@ Feature: Migrate a traditional client into a Salt minion
     When I run "systemctl status nhsd" on "sle_migrated_minion" without error control
     Then the command should fail
 
-  # bsc#1031081 - old and new activation keys shown for the migrated client
-  Scenario: Check that minion only has the new activation key
+  Scenario: Check that minion has the new activation key
     Given I am on the Systems overview page of this "sle_migrated_minion"
-    Then I should see a "Activation Key:	1-SUSE-PKG-x86_64" text
-    And I should not see a "1-SUSE-DEV-x86_64" text
+    Then I should see a "Activation Key:	1-SUSE-KEY-x86_64" text
 
   Scenario: Check that channels are still the same after migration
     Given I am on the Systems overview page of this "sle_migrated_minion"
@@ -100,15 +98,14 @@ Feature: Migrate a traditional client into a Salt minion
     When I enable SUSE Manager tools repositories on "sle_client"
     And I install the traditional stack utils on "sle_client"
     And I remove package "salt-minion" from this "sle_client"
-    And I bootstrap traditional client "sle_client" using bootstrap script with activation key "1-SUSE-DEV-x86_64" from the proxy
+    And I bootstrap traditional client "sle_client" using bootstrap script with activation key "1-SUSE-KEY-x86_64" from the proxy
     Then I should see "sle_client" via spacecmd
 
-  Scenario: Cleanup: check that this is again a traditional client
+  Scenario: Cleanup: check that the migrated minion is again a traditional client
     Given I am on the Systems overview page of this "sle_client"
     When I follow "Properties" in the content area
     Then I wait until I see "Base System Type:     Management" text, refreshing the page
 
-  Scenario: Cleanup: check that we have again the old activation key
+  Scenario: Cleanup: check that we still have the activation key
     Given I am on the Systems overview page of this "sle_client"
-    Then I should see a "Activation Key:	1-SUSE-DEV-x86_64" text
-    And I should not see a "1-SUSE-PKG-x86_64" text
+    Then I should see a "Activation Key:	1-SUSE-KEY-x86_64" text

--- a/testsuite/features/secondary/trad_migrate_to_sshminion.feature
+++ b/testsuite/features/secondary/trad_migrate_to_sshminion.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2020 SUSE LLC
+# Copyright (c) 2019-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @scope_traditional_client
@@ -22,10 +22,10 @@ Feature: Migrate a traditional client into a Salt SSH minion
   Scenario: Change contact method of activation key to ssh-push
     Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Systems > Activation Keys"
-    And I follow "SUSE Test PKG Key x86_64" in the content area
+    And I follow "SUSE Test Key x86_64" in the content area
     And I select "Push via SSH" from "contactMethodId"
     And I click on "Update Activation Key"
-    Then I should see a "Activation key SUSE Test PKG Key x86_64 has been modified" text
+    Then I should see a "Activation key SUSE Test Key x86_64 has been modified" text
 
   Scenario: Migrate a SLES client into a Salt SSH minion
     Given I am authorized
@@ -34,7 +34,7 @@ Feature: Migrate a traditional client into a Salt SSH minion
     And I enter "22" as "port"
     And I enter "root" as "user"
     And I enter "linux" as "password"
-    And I select "1-SUSE-PKG-x86_64" from "activationKeys"
+    And I select "1-SUSE-KEY-x86_64" from "activationKeys"
     And I select the hostname of "proxy" from "proxies"
     And I check "manageWithSSH"
     And I click on "Bootstrap"
@@ -65,11 +65,9 @@ Feature: Migrate a traditional client into a Salt SSH minion
     When I run "systemctl status nhsd" on "sle_migrated_minion" without error control
     Then the command should fail
 
-  # bsc#1031081 - old and new activation keys shown for the migrated client
-  Scenario: Check that SSH minion only has the new activation key
+  Scenario: Check that SSH minion has the new activation key
     Given I am on the Systems overview page of this "sle_migrated_minion"
-    Then I should see a "Activation Key:	1-SUSE-PKG-x86_64" text
-    And I should not see a "1-SUSE-DEV-x86_64" text
+    Then I should see a "Activation Key:       1-SUSE-KEY-x86_64" text
 
   Scenario: Check that channels are still the same after migration to Salt SSH
     Given I am on the Systems overview page of this "sle_migrated_minion"
@@ -122,23 +120,22 @@ Feature: Migrate a traditional client into a Salt SSH minion
   Scenario: Cleanup: register SSH minion again as traditional client
     When I enable SUSE Manager tools repositories on "sle_client"
     And I install the traditional stack utils on "sle_client"
-    And I bootstrap traditional client "sle_client" using bootstrap script with activation key "1-SUSE-DEV-x86_64" from the proxy
+    And I bootstrap traditional client "sle_client" using bootstrap script with activation key "1-SUSE-KEY-x86_64" from the proxy
     Then I should see "sle_client" via spacecmd
 
   Scenario: Cleanup: change contact method of activation key back to default
     Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Systems > Activation Keys"
-    And I follow "SUSE Test PKG Key x86_64" in the content area
+    And I follow "SUSE Test Key x86_64" in the content area
     And I select "Default" from "contactMethodId"
     And I click on "Update Activation Key"
-    Then I should see a "Activation key SUSE Test PKG Key x86_64 has been modified" text
+    Then I should see a "Activation key SUSE Test Key x86_64 has been modified" text
 
-  Scenario: Cleanup: check that this minion is a traditional client again
+  Scenario: Cleanup: check that the migrated SSH minion is a traditional client again
     Given I am on the Systems overview page of this "sle_client"
     When I follow "Properties" in the content area
     Then I wait until I see "Base System Type:     Management" text, refreshing the page
 
-  Scenario: Cleanup: check that we have again the old activation key after migration
+  Scenario: Cleanup: check that we still have the activation key after migration
     Given I am on the Systems overview page of this "sle_client"
-    Then I should see a "Activation Key:	1-SUSE-DEV-x86_64" text
-    And I should not see a "1-SUSE-PKG-x86_64" text
+    Then I should see a "Activation Key:	1-SUSE-KEY-x86_64" text

--- a/testsuite/features/secondary/trad_ssh_tunnel.feature
+++ b/testsuite/features/secondary/trad_ssh_tunnel.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2020 SUSE LLC
+# Copyright (c) 2016-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @scope_traditional_client
@@ -13,7 +13,7 @@ Feature: Register a traditional system to be managed via SSH push
     Then "sle_client" should not be registered
 
   Scenario: Create bootstrap script for traditional SSH push via tunnel
-    When I execute mgr-bootstrap "--activation-keys=1-SUSE-SSH-TUNNEL-DEV-x86_64 --script=bootstrap-ssh-push-tunnel.sh --no-up2date --traditional"
+    When I execute mgr-bootstrap "--activation-keys=1-SUSE-SSH-TUNNEL-KEY-x86_64 --script=bootstrap-ssh-push-tunnel.sh --no-up2date --traditional"
     Then I should get "* bootstrap script (written):"
     And I should get "    '/srv/www/htdocs/pub/bootstrap/bootstrap-ssh-push-tunnel.sh'"
 
@@ -40,5 +40,5 @@ Feature: Register a traditional system to be managed via SSH push
     And I remove server hostname from hosts file on "sle_ssh_tunnel_client"
 
   Scenario: Cleanup: register a traditional client after SSH tunnel tests
-    When I bootstrap traditional client "sle_client" using bootstrap script with activation key "1-SUSE-DEV-x86_64" from the proxy
+    When I bootstrap traditional client "sle_client" using bootstrap script with activation key "1-SUSE-KEY-x86_64" from the proxy
     Then I should see "sle_client" via spacecmd

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -314,7 +314,7 @@ end
 
 When(/^I execute mgr\-bootstrap "([^"]*)"$/) do |arg1|
   arch = 'x86_64'
-  $command_output = sshcmd("mgr-bootstrap --activation-keys=1-SUSE-PKG-#{arch} #{arg1}")[:stdout]
+  $command_output = sshcmd("mgr-bootstrap --activation-keys=1-SUSE-KEY-#{arch} #{arg1}")[:stdout]
 end
 
 When(/^I fetch "([^"]*)" to "([^"]*)"$/) do |file, host|

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -837,7 +837,7 @@ When(/^I register using "([^"]*)" key$/) do |key|
 end
 
 When(/^I register "([^"]*)" as traditional client$/) do |client|
-  step %(I register "#{client}" as traditional client with activation key "1-SUSE-DEV-x86_64")
+  step %(I register "#{client}" as traditional client with activation key "1-SUSE-KEY-x86_64")
 end
 
 And(/^I register "([^*]*)" as traditional client with activation key "([^*]*)"$/) do |client, key|

--- a/testsuite/features/step_definitions/xmlrpc_common.rb
+++ b/testsuite/features/step_definitions/xmlrpc_common.rb
@@ -1,4 +1,4 @@
-# Copyright 2015-2020 SUSE LLC
+# Copyright 2015-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 require 'json'
@@ -21,7 +21,7 @@ end
 When(/^I call system\.bootstrap\(\) on host "([^"]*)" and salt\-ssh "([^"]*)"$/) do |host, salt_ssh_enabled|
   system_name = get_system_name(host)
   salt_ssh = (salt_ssh_enabled == 'enabled')
-  akey = salt_ssh ? '1-SUSE-SSH-DEV-x86_64' : '1-SUSE-DEV-x86_64'
+  akey = salt_ssh ? '1-SUSE-SSH-KEY-x86_64' : '1-SUSE-KEY-x86_64'
   result = @system_api.bootstrap_system(system_name, akey, salt_ssh)
   assert(result == 1, 'Bootstrap return code not equal to 1.')
 end
@@ -41,7 +41,7 @@ When(/^I call system\.bootstrap\(\) on a salt minion with saltSSH = true, \
 but with activation key with Default contact method, I should get an XML-RPC fault with code -1$/) do
   exception_thrown = false
   begin
-    @system_api.bootstrap_system($minion.full_hostname, '1-SUSE-DEV-x86_64', true)
+    @system_api.bootstrap_system($minion.full_hostname, '1-SUSE-KEY-x86_64', true)
   rescue XMLRPC::FaultException => fault
     exception_thrown = true
     assert(fault.faultCode == -1, 'Fault code must be == -1.')

--- a/testsuite/run_sets/secondary_parallelizable.yml
+++ b/testsuite/run_sets/secondary_parallelizable.yml
@@ -12,6 +12,7 @@
 - features/secondary/srv_check_sync_source_packages.feature
 - features/secondary/srv_change_password.feature
 - features/secondary/srv_clone_channel_npn.feature
+- features/secondary/srv_manage_activationkey.feature
 - features/secondary/srv_xmlrpc_activationkey.feature
 - features/secondary/srv_distro_cobbler.feature
 - features/secondary/srv_mainpage.feature


### PR DESCRIPTION
## What does this PR change?

Move all scenarios related to activation keys that are not used to set up a client to secondary features.

I took the occasion to rename all testsuite-wide activation keys to `KEY`, and the ones from secondary feature to `TEST`.

I had to remove one scenario from migration features because it was using two keys to check for an old bug.


## Links

Ports:
* 4.0: SUSE/spacewalk#13820
* 4.1: SUSE/spacewalk#13818

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
