### PR TITLE
QAM: Implementing remote command for traditional client

### DIFF
--- a/testsuite/Rakefile
+++ b/testsuite/Rakefile
@@ -84,16 +84,8 @@ namespace :utils do
     end
   end
 
-  desc 'Generate all the features need for Build Validation from templates'
+  desc 'Generate all the features we need for a Build Validation from templates'
   task :generate_build_validation_features do
-    Rake::Task['utils:generate_smoke_tests'].invoke
-    Rake::Task['utils:generate_smoke_tests'].reenable
-    Rake::Task['utils:generate_add_activation_keys_features'].invoke
-    Rake::Task['utils:generate_add_activation_keys_features'].reenable
-  end
-
-  desc 'Generate all the features need for QAM from templates'
-  task :generate_qam_features do
     Rake::Task['utils:generate_smoke_tests'].invoke
     Rake::Task['utils:generate_smoke_tests'].reenable
     Rake::Task['utils:generate_add_maintenance_update_repository_features'].invoke

--- a/testsuite/features/build_validation/smoke_tests/smoke_tests.template
+++ b/testsuite/features/build_validation/smoke_tests/smoke_tests.template
@@ -29,7 +29,7 @@ Feature: Smoke tests for <client>
     And I click on "Confirm"
     Then I should see a "1 patch update has been scheduled for" text
     When I force picking pending events on "<client>" if necessary
-    Then I wait until event "Patch Update:" is completed
+    And I wait until event "Patch Update:" is completed
 
   Scenario: Install a package on the <client>
     Given I am on the Systems overview page of this "<client>"
@@ -40,7 +40,7 @@ Feature: Smoke tests for <client>
     And I click on "Confirm"
     Then I should see a "1 package install has been scheduled for" text
     When I force picking pending events on "<client>" if necessary
-    Then I wait until event "Package Install/Upgrade scheduled by admin" is completed
+    And I wait until event "Package Install/Upgrade scheduled by admin" is completed
 
   Scenario: Remove package from <client>
     Given I am on the Systems overview page of this "<client>"
@@ -51,7 +51,7 @@ Feature: Smoke tests for <client>
     And I click on "Confirm"
     Then I should see a "1 package removal has been scheduled" text
     When I force picking pending events on "<client>" if necessary
-    Then I wait until event "Package Removal scheduled by admin" is completed
+    And I wait until event "Package Removal scheduled by admin" is completed
 
 @skip_for_traditional
   Scenario: Run a remote command on <client> minion
@@ -68,14 +68,26 @@ Feature: Smoke tests for <client>
     And I expand the results for "<client>"
     Then I should see "My remote command output" in the command output for "<client>"
 
-  #TODO: Run a remote command on traditional clients
+@skip_for_minion
+  Scenario: Run a remote command on <client> traditional client
+    Given I am on the Systems overview page of this "<client>"
+    When I follow "Remote Command" in the content area
+    And I enter as remote command this script in
+      """
+      #!/bin/bash
+      touch /tmp/remote-command-on-<client>
+      """
+    And I click on "Schedule"
+    Then I should see a "Remote Command has been scheduled successfully" text
+    When I force picking pending events on "<client>" if necessary
+    And I wait until file "/tmp/remote-command-on-<client>" exists on "<client>"
 
   Scenario: Check that Software package refresh works on a <client>
     When I am on the Systems overview page of this "<client>"
     And I follow "Software" in the content area
     And I click on "Update Package List"
     And I force picking pending events on "<client>" if necessary
-    Then I wait until event "Package List Refresh scheduled by admin" is completed
+    And I wait until event "Package List Refresh scheduled by admin" is completed
 
   Scenario: Check that Hardware Refresh button works on a <client>
     Given I am on the Systems overview page of this "<client>"
@@ -83,7 +95,7 @@ Feature: Smoke tests for <client>
     And I click on "Schedule Hardware Refresh"
     Then I should see a "You have successfully scheduled a hardware profile refresh" text
     When I force picking pending events on "<client>" if necessary
-    Then I wait until event "Hardware List Refresh scheduled by admin" is completed
+    And I wait until event "Hardware List Refresh scheduled by admin" is completed
 
   Scenario: Subscribe a <client> to the configuration channel
     When I am on the Systems overview page of this "<client>"


### PR DESCRIPTION
## What does this PR change?

This PR adds a remote command scenario for the traditional clients of a Build Validation test suite.
Also, it removes a deprecated rake task, as we renamed everything from qam to build_validation, as it's a more generic name that involves Maintenance Updates testing and new major/minor versions testing (which also use Maintenance Incidence mechanism in order to provide the un-released packages)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.0: https://github.com/SUSE/spacewalk/pull/13778
- Manager-4.1: https://github.com/SUSE/spacewalk/pull/13777

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
