### PR TITLE
zypper ref before reinstalling traditional stack packages

### DIFF
--- a/testsuite/features/secondary/trad_migrate_to_minion.feature
+++ b/testsuite/features/secondary/trad_migrate_to_minion.feature
@@ -85,6 +85,9 @@ Feature: Migrate a traditional client into a Salt minion
   Scenario: Cleanup: remove package from the migrated minion
     When I remove package "perseus-dummy-1.1-1.1" from this "sle_migrated_minion"
 
+  Scenario: Cleanup: ensure the package information is up to date before migrating back
+    When I refresh the metadata for "sle_migrated_minion"
+
   Scenario: Cleanup: unregister migrated minion
     Given I am on the Systems overview page of this "sle_migrated_minion"
     When I follow "Delete System"

--- a/testsuite/features/secondary/trad_migrate_to_sshminion.feature
+++ b/testsuite/features/secondary/trad_migrate_to_sshminion.feature
@@ -108,6 +108,9 @@ Feature: Migrate a traditional client into a Salt SSH minion
     When I remove package "perseus-dummy-1.1-1.1" from this "sle_migrated_minion"
     And I remove package "orion-dummy-1.1-1.1" from this "sle_migrated_minion"
 
+  Scenario: Cleanup: ensure the package information is up to date before migrating back
+    When I refresh the metadata for "sle_migrated_minion"
+
   Scenario: Cleanup: unregister migrated SSH minion
     Given I am on the Systems overview page of this "sle_migrated_minion"
     When I follow "Delete System"


### PR DESCRIPTION
## What does this PR change?

We have such errors
```
Feature:Migrate a traditional client into a Salt minion
Scenario:Cleanup: register minion again as traditional client
And I install the traditional stack utils on "sle_client"

FAIL: zypper --non-interactive install -y spacewalk-client-tools spacewalk-check spacewalk-client-setup 
  mgr-daemon mgr-osad mgr-cfg-actions returned 8. output : Loading repository data...
(...)
File './noarch/python3-spacewalk-client-tools-4.1.8-411.2.13.devel41.noarch.rpm' not found on medium
```
that can happen when the tools are rebuilt while we test.

This PR does a `zypper refresh` (or equivalent) just before reinstalling traditional stack packages.


## Links

Ports:
* 4.0: SUSE/spacewalk#13791 SUSE/spacewalk#13803
* 4.1: SUSE/spacewalk#13790 SUSE/spacewalk#13802


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
