### PR TITLE
Testsuite: Fix install packages with staging

### DIFF
--- a/testsuite/features/step_definitions/datepicker_steps.rb
+++ b/testsuite/features/step_definitions/datepicker_steps.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 SUSE LLC.
+# Copyright (c) 2017-2021 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 require 'date'
@@ -96,6 +96,8 @@ end
 
 When(/^I pick (\d+) minutes from now as schedule time$/) do |arg1|
   action_time = get_future_time(arg1)
+  raise unless find(:xpath, "//*[@id='date_timepicker_widget_input']", wait: 2)
+
   execute_script("$('#date_timepicker_widget_input')
     .timepicker('setTime', '#{action_time}').trigger('changeTime');")
 end


### PR DESCRIPTION
## What does this PR change?
It fixes failures on install a package with staging, i.e., the features:
`Install a package on the Ubuntu minion with staging enabled`
`min_salt_install_with_staging.feature`

- testsuite/features/step_definitions/datepicker_steps.rb:
Ensure the timepicker is present before manipulate it.

## Links
### Ports
- Manager-3.2: https://github.com/SUSE/spacewalk/pull/13795
- Manager-4.0: https://github.com/SUSE/spacewalk/pull/13794
- Manager-4.1: https://github.com/SUSE/spacewalk/pull/13793

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)
