### PR TITLE
Fix: Truncate the repository label to 64 chars

### DIFF
--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -227,6 +227,7 @@ def generate_repository_name(repo_url)
   repo_name.delete_prefix! 'http://download.suse.de/ibs/SUSE:/Maintenance:/'
   repo_name.delete_prefix! 'http://minima-mirror-qam.mgr.prv.suse.net/ibs/SUSE:/Maintenance:/'
   repo_name.sub!('/', '_')
+  repo_name[0...64] # HACK: Due to the 64 characters size limit of a repository label
 end
 
 def extract_logs_from_node(node)


### PR DESCRIPTION
## What does this PR change?

Due to a limitation in the size of a repository label, we are forced to truncate the autogenerated label name in our QAM test suite step.

Example:
![Clipboard - 28 de enero de 2021 12_36](https://user-images.githubusercontent.com/2827771/106135612-76a5c300-6168-11eb-8fe6-a3b3e03c3869.png)


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.0 https://github.com/SUSE/spacewalk/pull/13806
- Manager-4.1 https://github.com/SUSE/spacewalk/pull/13805

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
