### PR TITLE
use sub selects for EVR cleanup to speedup the query (bsc#1181116)

### DIFF
--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -2,6 +2,7 @@
 Wed Jan 27 13:10:03 CET 2021 - jgonzalez@suse.com
 
 - version 4.2.5-1
+- Improve cleanup time after fixing Debian package version comparison (bsc#1181116)
 - Update to postgresql13 (jsc#SLE-17030)
 - Update CentOS6 URLs to use vault.centos.org
 - Changed to versioned Python3 to SPEC file.

--- a/schema/spacewalk/upgrade/susemanager-schema-4.2.4-to-susemanager-schema-4.2.5/702-debvercmp.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.2.4-to-susemanager-schema-4.2.5/702-debvercmp.sql
@@ -464,43 +464,26 @@ where rhntransactionpackage.id = sub.id;
 -- delete all rhnpackageevr entries that are not referenced anymore
 delete from rhnpackageevr p
  using (
-    select p.id, p.evr from rhnpackageevr p left join
-        rhnactionpackage f1 on f1.evr_id = p.id left join
-        rhnactionpackageremovalfailure f2 on f2.evr_id = p.id left join
-        rhnchannelnewestpackage f3 on f3.evr_id = p.id left join
-        rhnpackage f4 on f4.evr_id = p.id left join
-        rhnpackagenevra f5 on f5.evr_id = p.id left join
-        rhnproxyinfo f6 on f6.proxy_evr_id = p.id left join
-        rhnserveractionverifymissing f7 on f7.package_evr_id = p.id left join
-        rhnserveractionverifyresult f8 on f8.package_evr_id = p.id left join
-        rhnsatelliteinfo f9 on f9.evr_id = p.id left join
-        rhnservercrash f10 on f10.package_evr_id = p.id left join
-        rhnserverprofilepackage f11 on f11.evr_id = p.id left join
-        rhntransactionpackage f12 on f12.evr_id = p.id left join
-        rhnversioninfo f13 on f13.evr_id = p.id left join
-        rhnlockedpackages f14 on f14.evr_id = p.id left join
-        rhnserverpackage f15 on f15.evr_id = p.id left join
-        susepackagestate f16 on f16.evr_id = p.id left join
-        suseproductfile f17 on f17.evr_id = p.id left join
-        suseimageinfopackage f18 on f18.evr_id = p.id
-    where f1.evr_id is null and
-          f2.evr_id is null and
-          f3.evr_id is null and
-          f4.evr_id is null and
-          f5.evr_id is null and
-          f6.proxy_evr_id is null and
-          f7.package_evr_id is null and
-          f8.package_evr_id is null and
-          f9.evr_id is null and
-          f10.package_evr_id is null and
-          f11.evr_id is null and
-          f12.evr_id is null and
-          f13.evr_id is null and
-          f14.evr_id is null and
-          f15.evr_id is null and
-          f16.evr_id is null and
-          f17.evr_id is null and
-          f18.evr_id is null
+select pe.id
+  from rhnpackageevr pe
+ where not exists (select 1 from rhnactionpackage f1 where f1.evr_id = pe.id)
+   and not exists (select 1 from rhnactionpackageremovalfailure f2 where f2.evr_id = pe.id)
+   and not exists (select 1 from rhnchannelnewestpackage f3 where f3.evr_id = pe.id)
+   and not exists (select 1 from rhnpackage f4 where f4.evr_id = pe.id)
+   and not exists (select 1 from rhnpackagenevra f5 where f5.evr_id = pe.id)
+   and not exists (select 1 from rhnproxyinfo f6 where f6.proxy_evr_id = pe.id)
+   and not exists (select 1 from rhnserveractionverifymissing f7 where f7.package_evr_id = pe.id)
+   and not exists (select 1 from rhnserveractionverifyresult f8 where f8.package_evr_id = pe.id)
+   and not exists (select 1 from rhnsatelliteinfo f9 where f9.evr_id = pe.id)
+   and not exists (select 1 from rhnservercrash f10 where f10.package_evr_id = pe.id)
+   and not exists (select 1 from rhnserverprofilepackage f11 where f11.evr_id = pe.id)
+   and not exists (select 1 from rhntransactionpackage f12 where f12.evr_id = pe.id)
+   and not exists (select 1 from rhnversioninfo f13 where f13.evr_id = pe.id)
+   and not exists (select 1 from rhnlockedpackages f14 where f14.evr_id = pe.id)
+   and not exists (select 1 from rhnserverpackage f15 where f15.evr_id = pe.id)
+   and not exists (select 1 from susepackagestate f16 where f16.evr_id = pe.id)
+   and not exists (select 1 from suseproductfile f17 where f17.evr_id = pe.id)
+   and not exists (select 1 from suseimageinfopackage f18 where f18.evr_id = pe.id)
  ) as sub
 where p.id = sub.id;
 


### PR DESCRIPTION
## What does this PR change?

Speedup the schema migration by using sub-selects in the cleanup query

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/13810

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
