### PR TITLE
Channel subscription via SSM ignores the child channel

### DIFF
--- a/web/html/src/manager/systems/ssm/ssm-subscribe-channels.js
+++ b/web/html/src/manager/systems/ssm/ssm-subscribe-channels.js
@@ -7,6 +7,7 @@ import ReactDOM from 'react-dom';
 import { AsyncButton, Button } from 'components/buttons';
 import { ActionSchedule } from 'components/action-schedule';
 import Network from 'utils/network';
+import { replacer } from 'utils/json';
 import { Utils, Formats } from 'utils/functions';
 import { Messages } from 'components/messages';
 import { Table } from 'components/table/Table';
@@ -936,7 +937,7 @@ class SsmChannelPage extends React.Component<SsmChannelProps, SsmChannelState> {
       changes: this.state.finalChanges
     };
     return Network.post("/rhn/manager/systems/ssm/channels",
-        JSON.stringify(req), "application/json")
+        JSON.stringify(req, replacer), "application/json")
         .promise
         .then((data : JsonResult<SsmScheduleChannelChangesResultJson>) => {
           const msg = MessagesUtils.info(this.state.actionChain ?

--- a/web/html/src/tsconfig.json
+++ b/web/html/src/tsconfig.json
@@ -26,7 +26,8 @@
       "es5",
       "dom",
       "dom.iterable",
-      "es2019.array"
+      "es2019.array",
+      "es2019.object"
     ],
     "strict": true,
     // Should eventually be false

--- a/web/html/src/utils/json.test.js
+++ b/web/html/src/utils/json.test.js
@@ -1,0 +1,5 @@
+import { replacer } from './json';
+
+test("check Map stringify", () => {
+  expect(JSON.stringify(new Map([['a', 1]]), replacer)).toEqual('{"a":1}');
+})

--- a/web/html/src/utils/json.ts
+++ b/web/html/src/utils/json.ts
@@ -1,0 +1,17 @@
+/**
+ * This replacer is meant to be used on JSON.stringify in order to convert some ES6 types that are not
+ * converted out-of-the-box, for instance, the 'Map' type.
+ *
+ * Examples:
+ *  - JSON.stringify(new Map([['a', 1]])) will return '{}'
+ *  - JSON.stringify(new Map([['a', 1]]), replacer) will return '{"a":1}'
+ */
+function replacer(key, value) {
+    if(value instanceof Map) {
+        return Object.fromEntries(value);
+      } else {
+        return value;
+      }
+};
+
+export {replacer};

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,5 @@
+- Channel subscription via SSM should not ignore the child channel (bsc#1181520)
+
 -------------------------------------------------------------------
 Wed Jan 27 13:07:25 CET 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Channel subscription via SSM was not sending the `childChannelActions` field in the server request due to the fact that `JSON.stringify` does not convert `Map`fields.

With this PR, channel subscription via SSM will no longer ignore child channels:

A complete list of steps to reproduce the issue can be found in https://bugzilla.suse.com/show_bug.cgi?id=1181520

## GUI diff

Before:
![Screenshot from 2021-01-28 18-21-37](https://user-images.githubusercontent.com/14297426/106181604-b8992e00-6195-11eb-8ee0-8a9cad587b61.png)

After:
![Screenshot from 2021-01-28 18-21-27](https://user-images.githubusercontent.com/14297426/106181622-bcc54b80-6195-11eb-86e3-76d0728e766b.png)

- [x] **DONE**

## Documentation
- No documentation needed: This is just a bugfix, feature is already documented.

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/13809

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
