### PR TITLE
Increase apache ssl log information

### DIFF
--- a/spacewalk/config/etc/httpd/conf.d/zz-spacewalk-www.conf
+++ b/spacewalk/config/etc/httpd/conf.d/zz-spacewalk-www.conf
@@ -1,3 +1,6 @@
+Logformat "%t %h %{SSL_PROTOCOL}x %{SSL_CIPHER}x \
+\"%r\" %b \"%{Referer}i\" \"%{User-Agent}i\" %>s T%{ms}T"               ssl_combined
+
 <Directory "/srv/www/htdocs/*">
     Options Indexes FollowSymLinks
     AllowOverride All

--- a/spacewalk/config/spacewalk-config.changes
+++ b/spacewalk/config/spacewalk-config.changes
@@ -1,3 +1,5 @@
+- Increase apache ssl logs to include response code and process time
+
 -------------------------------------------------------------------
 Wed Jan 27 13:03:39 CET 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
Signed-off-by: Ricardo Mateus <rmateus@suse.com>

## What does this PR change?

Improve SSL log information by adding return code value and total time to process (in milis)

Before: 
[29/Jan/2021:22:02:28 +0000] 192.168.122.1 TLSv1.3 TLS_AES_256_GCM_SHA384 "POST /rhn/manager/frontend-log HTTP/1.1" 42 "https://hub-server.tf.local/" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36"

After:
[29/Jan/2021:22:02:28 +0000] 192.168.122.1 TLSv1.3 TLS_AES_256_GCM_SHA384 "POST /rhn/manager/frontend-log HTTP/1.1" 42 "https://hub-server.tf.local/" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36" 200 T43


## GUI diff

No difference.


- [X] **DONE**

## Documentation
- No documentation needed: changes in log information

- [X] **DONE**

## Test coverage
- No tests: changes in log information

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/13853
Tracks:
4.1: https://github.com/SUSE/spacewalk/pull/13851
4.0: https://github.com/SUSE/spacewalk/pull/13852

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
