### PR TITLE
QAM: Renaming CentOS6-Base repositories to enable

### DIFF
--- a/testsuite/features/build_validation/init_clients/ceos6_client.feature
+++ b/testsuite/features/build_validation/init_clients/ceos6_client.feature
@@ -9,7 +9,7 @@ Feature: Bootstrap a CentOS 6 traditional client
 
   Scenario: Prepare a CentOS 6 traditional client
     When I enable SUSE Manager tools repositories on "ceos6_client"
-    And I enable repository "CentOS-Base" on this "ceos6_client"
+    And I enable the repositories "CentOS-Base_backup CentOS-Updates_backup" on this "ceos6_client"
     And I run "/usr/bin/update-ca-trust force-enable" on "ceos6_client"
     And I bootstrap traditional client "ceos6_client" using bootstrap script with activation key "1-ceos6_client_key" from the proxy
     And I install the traditional stack utils on "ceos6_client"


### PR DESCRIPTION
## What does this PR change?

As we use Sumaform to deploy our environment, and Sumaform change the default repository Centos-Base.repo from the CentOS6 system, as it was deprecated recently, we need to update our scenario to enable the new repositories created from cloud-init thanks to Sumaform.

Related to : https://github.com/SUSE/spacewalk/issues/13658

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.1
- Manager-4.0

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
