### PR TITLE
Add definition of 15sp2 and 15sp3 to twopence

### DIFF
--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -266,6 +266,30 @@ Before('@sle15sp1_client') do
   skip_this_scenario unless $sle15sp1_client
 end
 
+Before('@sle15sp2_ssh_minion') do
+  skip_this_scenario unless $sle15sp2_ssh_minion
+end
+
+Before('@sle15sp2_minion') do
+  skip_this_scenario unless $sle15sp2_minion
+end
+
+Before('@sle15sp2_client') do
+  skip_this_scenario unless $sle15sp2_client
+end
+
+Before('@sle15sp3_ssh_minion') do
+  skip_this_scenario unless $sle15sp3_ssh_minion
+end
+
+Before('@sle15sp3_minion') do
+  skip_this_scenario unless $sle15sp3_minion
+end
+
+Before('@sle15sp3_client') do
+  skip_this_scenario unless $sle15sp3_client
+end
+
 Before('@skip_for_ubuntu') do |scenario|
   skip_this_scenario if scenario.feature.location.file.include? 'ubuntu'
 end

--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -47,6 +47,12 @@ if $build_validation
   $sle15sp1_minion = twopence_init("ssh:#{ENV['SLE15SP1_MINION']}") if ENV['SLE15SP1_MINION']
   $sle15sp1_ssh_minion = twopence_init("ssh:#{ENV['SLE15SP1_SSHMINION']}") if ENV['SLE15SP1_SSHMINION']
   $sle15sp1_client = twopence_init("ssh:#{ENV['SLE15SP1_CLIENT']}") if ENV['SLE15SP1_CLIENT']
+  $sle15sp2_minion = twopence_init("ssh:#{ENV['SLE15SP2_MINION']}") if ENV['SLE15SP2_MINION']
+  $sle15sp2_ssh_minion = twopence_init("ssh:#{ENV['SLE15SP2_SSHMINION']}") if ENV['SLE15SP2_SSHMINION']
+  $sle15sp2_client = twopence_init("ssh:#{ENV['SLE15SP2_CLIENT']}") if ENV['SLE15SP2_CLIENT']
+  $sle15sp3_minion = twopence_init("ssh:#{ENV['SLE15SP3_MINION']}") if ENV['SLE15SP3_MINION']
+  $sle15sp3_ssh_minion = twopence_init("ssh:#{ENV['SLE15SP3_SSHMINION']}") if ENV['SLE15SP3_SSHMINION']
+  $sle15sp3_client = twopence_init("ssh:#{ENV['SLE15SP3_CLIENT']}") if ENV['SLE15SP3_CLIENT']
   $ceos6_minion = twopence_init("ssh:#{ENV['CENTOS6_MINION']}") if ENV['CENTOS6_MINION']
   $ceos6_ssh_minion = twopence_init("ssh:#{ENV['CENTOS6_SSHMINION']}") if ENV['CENTOS6_SSHMINION']
   $ceos6_client = twopence_init("ssh:#{ENV['CENTOS6_CLIENT']}") if ENV['CENTOS6_CLIENT']
@@ -71,6 +77,8 @@ if $build_validation
              $sle12sp4_minion, $sle12sp4_ssh_minion, $sle12sp4_client,
              $sle15_minion, $sle15_ssh_minion, $sle15_client,
              $sle15sp1_minion, $sle15sp1_ssh_minion, $sle15sp1_client,
+             $sle15sp2_minion, $sle15sp2_ssh_minion, $sle15sp2_client,
+             $sle15sp3_minion, $sle15sp3_ssh_minion, $sle15sp3_client,
              $ceos6_minion, $ceos6_ssh_minion, $ceos6_client,
              $ceos7_minion, $ceos7_ssh_minion, $ceos7_client,
              $ceos8_minion, $ceos8_ssh_minion,
@@ -253,4 +261,16 @@ $node_by_host = { 'localhost'                 => $localhost,
                   'sle15_client'              => $sle15_client,
                   'sle15sp1_ssh_minion'       => $sle15sp1_ssh_minion,
                   'sle15sp1_minion'           => $sle15sp1_minion,
-                  'sle15sp1_client'           => $sle15sp1_client }
+                  'sle15sp1_client'           => $sle15sp1_client,
+                  'sle15sp2_ssh_minion'       => $sle15sp2_ssh_minion,
+                  'sle15sp2_minion'           => $sle15sp2_minion,
+                  'sle15sp2_client'           => $sle15sp2_client,
+                  'sle15sp3_ssh_minion'       => $sle15sp3_ssh_minion,
+                  'sle15sp3_minion'           => $sle15sp3_minion,
+                  'sle15sp3_client'           => $sle15sp3_client,
+                  'sle15sp2_buildhost'        => $sle15sp2_buildhost,
+                  'sle15sp2_terminal'         => $sle15sp2_terminal,
+                  'sle12sp4_buildhost'        => $sle12sp4_buildhost,
+                  'sle12sp4_terminal'         => $sle12sp4_terminal,
+                  'sle11sp4_buildhost'        => $sle11sp4_buildhost,
+                  'sle11sp3_terminal'         => $sle11sp3_terminal }

--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -85,6 +85,9 @@ if $build_validation
              $ubuntu1604_ssh_minion, $ubuntu1604_minion,
              $ubuntu1804_ssh_minion, $ubuntu1804_minion,
              $ubuntu2004_ssh_minion, $ubuntu2004_minion,
+             $sle15sp2_buildhost,$sle15sp2_terminal,
+             $sle12sp4_buildhost,$sle12sp4_terminal,
+             $sle11sp4_buildhost,$sle11sp3_terminal,
              $client, $minion, $ceos_minion, $ubuntu_minion, $ssh_minion]
 else
   # Define twopence objects for QA environment

--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -85,9 +85,9 @@ if $build_validation
              $ubuntu1604_ssh_minion, $ubuntu1604_minion,
              $ubuntu1804_ssh_minion, $ubuntu1804_minion,
              $ubuntu2004_ssh_minion, $ubuntu2004_minion,
-             $sle15sp2_buildhost,$sle15sp2_terminal,
-             $sle12sp4_buildhost,$sle12sp4_terminal,
-             $sle11sp4_buildhost,$sle11sp3_terminal,
+             $sle15sp2_buildhost, $sle15sp2_terminal,
+             $sle12sp4_buildhost, $sle12sp4_terminal,
+             $sle11sp4_buildhost, $sle11sp3_terminal,
              $client, $minion, $ceos_minion, $ubuntu_minion, $ssh_minion]
 else
   # Define twopence objects for QA environment


### PR DESCRIPTION
## What does this PR change?

Port of https://github.com/SUSE/spacewalk/pull/13838
## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes


- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes #13581
Tracks #https://github.com/SUSE/spacewalk/pull/13838

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
