### PR TITLE
Fix Salt package name on Ubuntu

### DIFF
--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -1,4 +1,4 @@
-# Copyright 2015-2020 SUSE LLC
+# Copyright 2015-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 require 'timeout'
@@ -677,7 +677,7 @@ When(/^I perform a full salt minion cleanup on "([^"]*)"$/) do |host|
   if host.include? 'ceos'
     node.run('yum -y remove salt salt-minion', false)
   elsif host.include? 'ubuntu'
-    node.run('apt-get --assume-yes remove salt salt-minion', false)
+    node.run('apt-get --assume-yes remove salt-common salt-minion', false)
   else
     node.run('zypper --non-interactive remove -y salt salt-minion', false)
   end


### PR DESCRIPTION
## What does this PR change?

Ubuntu (16.04, 18.04, and 20.04) uses `salt-common` instead of `salt`.


## Links

Ports:
* 4.0: SUSE/spacewalk#13855
* 4.1: SUSE/spacewalk#13854


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
