### PR TITLE
Detect debian products

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
@@ -381,6 +381,13 @@ public class RegistrationUtils {
                 return Collections.singleton(product);
             }
         }
+        else if ("debian".equalsIgnoreCase(grains.getValueAsString(OS))) {
+           SUSEProduct product = SUSEProductFactory.findSUSEProduct("debian-client",
+                   grains.getValueAsString("osmajorrelease"), null, grains.getValueAsString(OS_ARCH) + "-deb", false);
+           if (product != null) {
+               return Collections.singleton(product);
+           }
+        }
         return emptySet();
     }
 

--- a/java/code/src/com/suse/manager/reactor/messaging/test/README.md
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/README.md
@@ -1,15 +1,15 @@
 # How to generate JSON dumps of Salt commands like the ones in this directory
 
-Run on the SUSE Manager server:
+Run on the SUSE Manager server (password is the `server.secret_key` from /etc/rhn/rhn.conf) :
 
 ```
-curl -si localhost:9080/login -d "username=admin" -d "password=admin" -d eauth=auto
+curl -si https://localhost:9080/login -d "username=admin" -d "password=<password>" -d eauth=file
 ```
 
 Take the resulting token and:
 
 ```
-curl -NsS localhost:9080/events?token=<your token>
+curl -NsS https://localhost:9080/events?token=<your token>
 ```
 
 Then run Salt command(s)

--- a/java/code/src/com/suse/manager/reactor/messaging/test/packages.profileupdate.debian.json
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/packages.profileupdate.debian.json
@@ -1,0 +1,383 @@
+{
+    "tag": "salt/job/20210202153417159021/ret/minion.debian.local",
+    "data": {
+        "cmd": "_return",
+        "id": "minion.debian.local",
+        "success": true,
+        "return": {
+            "saltutil_|-sync_grains_|-sync_grains_|-sync_grains": {
+                "name": "sync_grains",
+                "changes": {},
+                "result": true,
+                "comment": "No updates to sync",
+                "__sls__": "util.syncgrains",
+                "__run_num__": 0,
+                "start_time": "16:34:39.371452",
+                "duration": 385.498,
+                "__id__": "sync_grains"
+            },
+            "saltutil_|-sync_states_|-sync_states_|-sync_states": {
+                "name": "sync_states",
+                "changes": {},
+                "result": true,
+                "comment": "No updates to sync",
+                "__sls__": "util.syncstates",
+                "__run_num__": 1,
+                "start_time": "16:34:39.757433",
+                "duration": 266.829,
+                "__id__": "sync_states"
+            },
+            "saltutil_|-sync_modules_|-sync_modules_|-sync_modules": {
+                "name": "sync_modules",
+                "changes": {},
+                "result": true,
+                "comment": "No updates to sync",
+                "__sls__": "util.syncmodules",
+                "__run_num__": 2,
+                "start_time": "16:34:40.024374",
+                "duration": 130.836,
+                "__id__": "sync_modules"
+            },
+            "mgrcompat_|-packages_|-pkg.info_installed_|-module_run": {
+                "name": "pkg.info_installed",
+                "changes": {
+                    "ret": {
+                        "libgcc1": [
+                            {
+                                "arch": "amd64",
+                                "version": "1:8.3.0-6",
+                                "install_date_time_t": 1611053972
+                            }
+                        ],
+                        "systemd": [
+                            {
+                                "arch": "amd64",
+                                "version": "241-7~deb10u5",
+                                "install_date_time_t": 1611053979
+                            }
+                        ],
+                        "xserver-common": [
+                            {
+                                "arch": "all",
+                                "version": "2:1.20.4-1+deb10u2",
+                                "install_date_time_t": 1611054169
+                            }
+                        ]
+                    }
+                },
+                "comment": "Module function pkg.info_installed executed",
+                "result": true,
+                "__sls__": "packages.profileupdate",
+                "__run_num__": 3,
+                "start_time": "16:34:40.157951",
+                "duration": 524.332,
+                "__id__": "packages"
+            },
+            "cmd_|-debianrelease_|-cat /etc/os-release_|-run": {
+                "name": "cat /etc/os-release",
+                "changes": {
+                    "pid": 13835,
+                    "retcode": 0,
+                    "stdout": "PRETTY_NAME=\"Debian GNU/Linux 10 (buster)\"\nNAME=\"Debian GNU/Linux\"\nVERSION_ID=\"10\"\nVERSION=\"10 (buster)\"\nVERSION_CODENAME=buster\nID=debian\nHOME_URL=\"https://www.debian.org/\"\nSUPPORT_URL=\"https://www.debian.org/support\"\nBUG_REPORT_URL=\"https://bugs.debian.org/\"",
+                    "stderr": ""
+                },
+                "result": true,
+                "comment": "Command \"cat /etc/os-release\" run",
+                "__sls__": "packages.profileupdate",
+                "__run_num__": 4,
+                "start_time": "16:34:40.683970",
+                "duration": 10.782,
+                "__id__": "debianrelease"
+            },
+            "mgrcompat_|-grains_update_|-grains.items_|-module_run": {
+                "name": "grains.items",
+                "changes": {
+                    "ret": {
+                        "cwd": "/",
+                        "ip_gw": true,
+                        "ip4_gw": "10.161.255.254",
+                        "ip6_gw": false,
+                        "dns": {
+                            "nameservers": [
+                                "10.161.224.15"
+                            ],
+                            "ip4_nameservers": [
+                                "10.161.224.15"
+                            ],
+                            "ip6_nameservers": [],
+                            "sortlist": [],
+                            "domain": "",
+                            "search": [
+                                "qam.suse.de",
+                                "suse.de",
+                                "qam.suse.cz",
+                                "suse.cz",
+                                "arch.suse.cz"
+                            ],
+                            "options": []
+                        },
+                        "fqdns": [],
+                        "machine_id": "79c0efb70c2c4331a33267c814f84375",
+                        "master": "mgr-proxy-41.qam.suse.de",
+                        "server_id": 340132540,
+                        "localhost": "d421",
+                        "fqdn": "d421.qam.suse.de",
+                        "host": "d421",
+                        "domain": "qam.suse.de",
+                        "hwaddr_interfaces": {
+                            "lo": "00:00:00:00:00:00",
+                            "ens3": "52:54:00:d1:36:00"
+                        },
+                        "id": "minion.debian.local",
+                        "ip4_interfaces": {
+                            "lo": [
+                                "127.0.0.1"
+                            ],
+                            "ens3": [
+                                "10.161.229.135"
+                            ]
+                        },
+                        "ip6_interfaces": {
+                            "lo": [
+                                "::1"
+                            ],
+                            "ens3": [
+                                "fe80::5054:ff:fed1:3600"
+                            ]
+                        },
+                        "ipv4": [
+                            "10.161.229.135",
+                            "127.0.0.1"
+                        ],
+                        "ipv6": [
+                            "::1",
+                            "fe80::5054:ff:fed1:3600"
+                        ],
+                        "fqdn_ip4": [
+                            "127.0.1.1"
+                        ],
+                        "fqdn_ip6": [],
+                        "ip_interfaces": {
+                            "lo": [
+                                "127.0.0.1",
+                                "::1"
+                            ],
+                            "ens3": [
+                                "10.161.229.135",
+                                "fe80::5054:ff:fed1:3600"
+                            ]
+                        },
+                        "locale_info": {
+                            "defaultlanguage": "en_US",
+                            "defaultencoding": "UTF-8",
+                            "detectedencoding": "UTF-8",
+                            "timezone": "CET"
+                        },
+                        "num_gpus": 1,
+                        "gpus": [
+                            {
+                                "vendor": "unknown",
+                                "model": "QXL paravirtual graphic card"
+                            }
+                        ],
+                        "kernel": "Linux",
+                        "nodename": "d421",
+                        "kernelrelease": "4.19.0-13-amd64",
+                        "kernelversion": "#1 SMP Debian 4.19.160-2 (2020-11-28)",
+                        "cpuarch": "x86_64",
+                        "systemd": {
+                            "version": "241",
+                            "features": "+PAM +AUDIT +SELINUX +IMA +APPARMOR +SMACK +SYSVINIT +UTMP +LIBCRYPTSETUP +GCRYPT +GNUTLS +ACL +XZ +LZ4 +SECCOMP +BLKID +ELFUTILS +KMOD -IDN2 +IDN -PCRE2 default-hierarchy=hybrid"
+                        },
+                        "init": "systemd",
+                        "lsb_distrib_description": "Debian GNU/Linux 10 (buster)",
+                        "lsb_distrib_release": "10",
+                        "lsb_distrib_codename": "buster",
+                        "lsb_distrib_id": "Debian",
+                        "osfullname": "Debian",
+                        "osrelease": "10",
+                        "oscodename": "buster",
+                        "os": "Debian",
+                        "num_cpus": 2,
+                        "cpu_model": "Intel Core Processor (Broadwell, IBRS)",
+                        "cpu_flags": [
+                            "fpu",
+                            "vme",
+                            "de",
+                            "pse",
+                            "tsc",
+                            "msr",
+                            "pae",
+                            "mce",
+                            "cx8",
+                            "apic",
+                            "sep",
+                            "mtrr",
+                            "pge",
+                            "mca",
+                            "cmov",
+                            "pat",
+                            "pse36",
+                            "clflush",
+                            "mmx",
+                            "fxsr",
+                            "sse",
+                            "sse2",
+                            "syscall",
+                            "nx",
+                            "rdtscp",
+                            "lm",
+                            "constant_tsc",
+                            "rep_good",
+                            "nopl",
+                            "xtopology",
+                            "cpuid",
+                            "tsc_known_freq",
+                            "pni",
+                            "pclmulqdq",
+                            "ssse3",
+                            "fma",
+                            "cx16",
+                            "pcid",
+                            "sse4_1",
+                            "sse4_2",
+                            "x2apic",
+                            "movbe",
+                            "popcnt",
+                            "tsc_deadline_timer",
+                            "aes",
+                            "xsave",
+                            "avx",
+                            "f16c",
+                            "rdrand",
+                            "hypervisor",
+                            "lahf_lm",
+                            "abm",
+                            "3dnowprefetch",
+                            "cpuid_fault",
+                            "invpcid_single",
+                            "pti",
+                            "ibrs",
+                            "ibpb",
+                            "fsgsbase",
+                            "bmi1",
+                            "hle",
+                            "avx2",
+                            "smep",
+                            "bmi2",
+                            "erms",
+                            "invpcid",
+                            "rtm",
+                            "rdseed",
+                            "adx",
+                            "smap",
+                            "xsaveopt",
+                            "arat"
+                        ],
+                        "os_family": "Debian",
+                        "osarch": "amd64",
+                        "mem_total": 1995,
+                        "swap_total": 974,
+                        "biosversion": "rel-1.12.0-0-ga698c89-rebuilt.suse.com",
+                        "productname": "Standard PC (i440FX + PIIX, 1996)",
+                        "manufacturer": "QEMU",
+                        "biosreleasedate": "04/01/2014",
+                        "uuid": "79c0efb7-0c2c-4331-a332-67c814f84375",
+                        "serialnumber": "",
+                        "virtual": "kvm",
+                        "ps": "ps -efHww",
+                        "osrelease_info": [
+                            10
+                        ],
+                        "osmajorrelease": 10,
+                        "osfinger": "Debian-10",
+                        "path": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+                        "pythonexecutable": "/usr/bin/python3",
+                        "pythonpath": [
+                            "/usr/bin",
+                            "/usr/lib/python37.zip",
+                            "/usr/lib/python3.7",
+                            "/usr/lib/python3.7/lib-dynload",
+                            "/usr/local/lib/python3.7/dist-packages",
+                            "/usr/lib/python3/dist-packages"
+                        ],
+                        "pythonversion": [
+                            3,
+                            7,
+                            3,
+                            "final",
+                            0
+                        ],
+                        "saltpath": "/usr/lib/python3/dist-packages/salt",
+                        "saltversion": "3000",
+                        "saltversioninfo": [
+                            3000,
+                            null,
+                            null,
+                            0
+                        ],
+                        "zmqversion": "4.3.1",
+                        "cpusockets": 2,
+                        "total_num_cpus": 2,
+                        "disks": [
+                            "sr0",
+                            "vda"
+                        ],
+                        "SSDs": [],
+                        "shell": "/bin/sh",
+                        "__suse_reserved_pkg_all_versions_support": true,
+                        "__suse_reserved_pkg_patches_support": true,
+                        "__suse_reserved_saltutil_states_support": true,
+                        "transactional": false,
+                        "efi": false,
+                        "efi-secure-boot": false,
+                        "username": "root",
+                        "groupname": "root",
+                        "pid": 3436,
+                        "gid": 0,
+                        "uid": 0,
+                        "zfs_support": false,
+                        "zfs_feature_flags": false,
+                        "susemanager": null
+                    }
+                },
+                "comment": "Module function grains.items executed",
+                "result": true,
+                "__sls__": "packages.profileupdate",
+                "__run_num__": 5,
+                "start_time": "16:34:40.695323",
+                "duration": 2.428,
+                "__id__": "grains_update"
+            },
+            "mgrcompat_|-kernel_live_version_|-sumautil.get_kernel_live_version_|-module_run": {
+                "name": "sumautil.get_kernel_live_version",
+                "changes": {
+                    "ret": null
+                },
+                "comment": "Module function sumautil.get_kernel_live_version executed",
+                "result": true,
+                "__sls__": "packages.profileupdate",
+                "__run_num__": 6,
+                "start_time": "16:34:40.698003",
+                "duration": 2.722,
+                "__id__": "kernel_live_version"
+            }
+        },
+        "retcode": 0,
+        "jid": "20210202153417159021",
+        "fun": "state.apply",
+        "fun_args": [
+            {
+                "mods": [
+                    "packages.profileupdate"
+                ],
+                "queue": true
+            }
+        ],
+        "metadata": {
+            "suma-action-id": 59
+        },
+        "out": "highstate",
+        "_stamp": "2021-02-02T15:34:19.410525"
+    }
+}

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -1369,6 +1369,9 @@ public class SaltUtils {
                 .map(StateApplyResult::getChanges)
                 .filter(ret -> ret.getStdout() != null)
                 .map(CmdResult::getStdout);
+
+        ValueMap grains = new ValueMap(result.getGrains());
+
         if (rhelReleaseFile.isPresent() || centosReleaseFile.isPresent() ||
                 oracleReleaseFile.isPresent() || resReleasePkg.isPresent()) {
             Set<InstalledProduct> products = getInstalledProductsForRhel(
@@ -1376,15 +1379,27 @@ public class SaltUtils {
                     rhelReleaseFile, centosReleaseFile, oracleReleaseFile);
             server.setInstalledProducts(products);
         }
-        else if ("ubuntu".equalsIgnoreCase((String) result.getGrains().get("os"))) {
-            String osArch = result.getGrains().get("osarch") + "-deb";
-            String osVersion = (String) result.getGrains().get("osrelease");
+        else if ("ubuntu".equalsIgnoreCase(grains.getValueAsString("os"))) {
+            String osArch = grains.getValueAsString("osarch") + "-deb";
+            String osVersion = grains.getValueAsString("osrelease");
             // Check if we have a product for the specific arch and version
             SUSEProduct ubuntuProduct = SUSEProductFactory.findSUSEProduct("ubuntu-client", osVersion, null, osArch,
                     false);
             if (ubuntuProduct != null) {
                 InstalledProduct installedProduct = SUSEProductFactory.findInstalledProduct(ubuntuProduct)
                         .orElse(new InstalledProduct(ubuntuProduct));
+                server.setInstalledProducts(Collections.singleton(installedProduct));
+            }
+        }
+        else if ("debian".equalsIgnoreCase(grains.getValueAsString("os"))) {
+            String osArch = grains.getValueAsString("osarch") + "-deb";
+            String osVersion = grains.getValueAsString("osmajorrelease");
+            // Check if we have a product for the specific arch and version
+            SUSEProduct debianProduct = SUSEProductFactory.findSUSEProduct("debian-client", osVersion, null, osArch,
+                    false);
+            if (debianProduct != null) {
+                InstalledProduct installedProduct = SUSEProductFactory.findInstalledProduct(debianProduct)
+                        .orElse(new InstalledProduct(debianProduct));
                 server.setInstalledProducts(Collections.singleton(installedProduct));
             }
         }
@@ -1396,7 +1411,6 @@ public class SaltUtils {
 
         // Update grains
         if (!result.getGrains().isEmpty()) {
-            ValueMap grains = new ValueMap(result.getGrains());
             server.setOsFamily(grains.getValueAsString("os_family"));
             server.setRunningKernel(grains.getValueAsString("kernelrelease"));
             server.setOs(grains.getValueAsString("osfullname"));

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- detect debian products (bsc#1181416)
 - show packages from channels assigned to the targeted system (bsc#1181423)
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Debian 9/10 were not found as Installed Products. The detection of these products were missing.

## GUI diff

No difference.

Before:

![image](https://user-images.githubusercontent.com/1038917/106722226-fb2f9000-6605-11eb-9d26-4a25d0dfc604.png)

After:

![image](https://user-images.githubusercontent.com/1038917/106724220-40ed5800-6608-11eb-9144-b42454cad13c.png)


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/13875
Tracks https://github.com/SUSE/spacewalk/pull/13874

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
