### PR TITLE
Precise apache dependency

### DIFF
--- a/tftpsync/susemanager-tftpsync-recv/susemanager-tftpsync-recv.changes
+++ b/tftpsync/susemanager-tftpsync-recv/susemanager-tftpsync-recv.changes
@@ -1,3 +1,5 @@
+- use macros to differ between SUSE and RedHat package names
+
 -------------------------------------------------------------------
 Wed Jan 27 13:16:25 CET 2021 - jgonzalez@suse.com
 

--- a/tftpsync/susemanager-tftpsync-recv/susemanager-tftpsync-recv.spec
+++ b/tftpsync/susemanager-tftpsync-recv/susemanager-tftpsync-recv.spec
@@ -30,8 +30,13 @@ Url:            https://github.com/uyuni-project/uyuni
 Source0:        %{name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
-Requires(pre):  (apache2 or httpd)
-Requires(pre):  (tftp(server) or tftp)
+%if 0%{?suse_version}
+Requires(pre):  apache2
+Requires(pre):  tftp(server)
+%else
+Requires(pre):  httpd
+Requires(pre):  tftp
+%endif
 %if 0%{?build_py3}
 Requires:       python3
 Requires:       (apache2-mod_wsgi-python3 or python3-mod_wsgi)


### PR DESCRIPTION
## What does this PR change?

Switch to use macros for differences between SUSE and RedHat package names.
As some other SUSE packages use `httpd` as provides we require buildservice tricks to get around this.
So let's be explicite in what we really require in this case.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
