### PR TITLE
Fix system pkg listing

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Package_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Package_queries.xml
@@ -515,10 +515,13 @@ ORDER BY UPPER(X.nvre)
 <mode name="system_package_list" class="com.redhat.rhn.frontend.dto.PackageListItem">
   <query params="sid">
   SELECT (SELECT max(p.id) FROM rhnPackage p
+                           JOIN rhnChannelPackage cp on p.id = cp.package_id
+                           JOIN rhnServerChannel sc on cp.channel_id = sc.channel_id
                           WHERE p.name_id = pn.id
                             AND p.evr_id = pe.id
                             AND p.package_arch_id = pa.id
                             AND (p.org_id = s.org_id or p.org_id is null)
+                            AND sc.server_id = :sid
           ) as package_id,
          pn.id || '|' || pe.id || '|' || pa.id as id_combo,
          pn.name || '-' || evr_t_as_vre_simple(pe.evr) as nvre,

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- show packages from channels assigned to the targeted system (bsc#1181423)
+
 -------------------------------------------------------------------
 Thu Jan 28 11:42:47 CET 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

When creating the package list for a system we should only return package ids of packages from channels which are assigned to the system. Otherwise we might show debian 9 package for debian 10 systems.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/13772
Tracks https://github.com/SUSE/spacewalk/pull/13866 https://github.com/SUSE/spacewalk/pull/13867

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
