### PR TITLE
Fallback to sysfs when reading info from python-dmidecode fails (bsc#1182603, bsc#1173893)

### DIFF
--- a/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes
+++ b/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes
@@ -1,3 +1,4 @@
+- Fallback to sysfs when reading info from python-dmidecode fails (bsc#1182603)
 - log an error when product detection failed (bsc#1182339)
 
 -------------------------------------------------------------------

--- a/client/rhel/spacewalk-client-tools/src/up2date_client/hardware.py
+++ b/client/rhel/spacewalk-client-tools/src/up2date_client/hardware.py
@@ -900,9 +900,6 @@ def get_hal_system_and_smbios():
 def get_smbios():
     """ Returns dictionary with values we are interested for.
         For historical reason it is in format, which use HAL.
-        Currently in dictionary are keys:
-        smbios.system.uuid, smbios.bios.vendor, smbios.system.serial,
-        smbios.system.manufacturer.
     """
     _initialize_dmi_data()
     if _dmi_not_available:

--- a/client/rhel/spacewalk-client-tools/src/up2date_client/hardware.py
+++ b/client/rhel/spacewalk-client-tools/src/up2date_client/hardware.py
@@ -59,9 +59,9 @@ import platform
 
 if platform.processor() not in ['s390', 's390x', 'aarch64']:
     import dmidecode
-    _dmi_not_available = 0
+    _dmi_available = 1
 else:
-    _dmi_not_available = 1
+    _dmi_available = 0
 
 from up2date_client import up2dateLog
 
@@ -93,7 +93,7 @@ except ImportError:
 _dmi_data           = None
 
 def dmi_warnings():
-    if _dmi_not_available:
+    if not _dmi_available:
         return None
 
     if not hasattr(dmidecode, 'get_warnings'):
@@ -102,16 +102,16 @@ def dmi_warnings():
     return dmidecode.get_warnings()
 
 dmi_warn = dmi_warnings()
-if dmi_warn and not _dmi_not_available:
+if dmi_warn and _dmi_available:
     dmidecode.clear_warnings()
     log = up2dateLog.initLog()
     log.log_debug("Warnings collected during dmidecode import: %s" % dmi_warn)
 
 def _initialize_dmi_data():
     """ Initialize _dmi_data unless it already exist and returns it """
-    global _dmi_data, _dmi_not_available
+    global _dmi_data, _dmi_available
     if _dmi_data is None:
-        if _dmi_not_available:
+        if not _dmi_available:
             # do not try to initialize it again and again if not available
             return None
         else :
@@ -127,7 +127,7 @@ def _initialize_dmi_data():
                     log.log_debug("dmidecode warnings: %s" % dmi_warn)
             except:
                 # DMI decode FAIL, this can happend e.g in PV guest
-                _dmi_not_available = 1
+                _dmi_available = 0
                 dmi_warn = dmi_warnings()
                 if dmi_warn:
                     dmidecode.clear_warnings()
@@ -902,7 +902,7 @@ def get_smbios():
         For historical reason it is in format, which use HAL.
     """
     _initialize_dmi_data()
-    if _dmi_not_available:
+    if not _dmi_available:
         return {}
     else:
         return {

--- a/client/rhel/spacewalk-client-tools/src/up2date_client/hardware.py
+++ b/client/rhel/spacewalk-client-tools/src/up2date_client/hardware.py
@@ -59,9 +59,9 @@ import platform
 
 if platform.processor() not in ['s390', 's390x', 'aarch64']:
     import dmidecode
-    _dmi_available = 1
+    _dmi_available = True
 else:
-    _dmi_available = 0
+    _dmi_available = False
 
 from up2date_client import up2dateLog
 
@@ -127,7 +127,7 @@ def _initialize_dmi_data():
                     log.log_debug("dmidecode warnings: %s" % dmi_warn)
             except:
                 # DMI decode FAIL, this can happend e.g in PV guest
-                _dmi_available = 0
+                _dmi_available = False
                 dmi_warn = dmi_warnings()
                 if dmi_warn:
                     dmidecode.clear_warnings()

--- a/client/rhel/spacewalk-client-tools/src/up2date_client/hardware.py
+++ b/client/rhel/spacewalk-client-tools/src/up2date_client/hardware.py
@@ -940,20 +940,16 @@ def get_smbios():
     """ Returns dictionary with values we are interested for.
         For historical reason it is in format, which use HAL.
     """
-    _initialize_dmi_data()
-    if not _dmi_available:
-        return {}
-    else:
-        return {
-            'smbios.system.uuid': dmi_system_uuid(),
-            'smbios.bios.vendor': dmi_vendor(),
-            'smbios.system.serial': get_dmi_data('/dmidecode/SystemInfo/SerialNumber'),
-            'smbios.system.manufacturer': get_dmi_data('/dmidecode/SystemInfo/Manufacturer'),
-            'smbios.system.product': get_dmi_data('/dmidecode/SystemInfo/ProductName'),
-            'smbios.system.skunumber': get_dmi_data('/dmidecode/SystemInfo/SKUnumber'),
-            'smbios.system.family': get_dmi_data('/dmidecode/SystemInfo/Family'),
-            'smbios.system.version': get_dmi_data('/dmidecode/SystemInfo/Version'),
-        }
+    return {
+        'smbios.system.uuid': dmi_system_uuid(),
+        'smbios.bios.vendor': dmi_vendor(),
+        'smbios.system.serial': get_dmi_data('/dmidecode/SystemInfo/SerialNumber'),
+        'smbios.system.manufacturer': get_dmi_data('/dmidecode/SystemInfo/Manufacturer'),
+        'smbios.system.product': get_dmi_data('/dmidecode/SystemInfo/ProductName'),
+        'smbios.system.skunumber': get_dmi_data('/dmidecode/SystemInfo/SKUnumber'),
+        'smbios.system.family': get_dmi_data('/dmidecode/SystemInfo/Family'),
+        'smbios.system.version': get_dmi_data('/dmidecode/SystemInfo/Version'),
+    }
 
 def get_sysinfo():
     s = rhnserver.RhnServer()


### PR DESCRIPTION
(review commit-by-commit - there is some small refactoring as well)

We use `python-dmidecode` to get various hardware info on traditional clients. The problem is, that it doesn't behave well on systems that have kernel lockdown feature enabled (i.e. when `Secure boot enabled and kernel locked down` appears in the `dmesg` output).

Whereas current (plain) `dmidecode` works on such systems, `python-dmidecode` does not as it relies on reading `/dev/mem`, which seems to be restricted.

The best solution would be to align `python-dmidecode` to the latest `dmidecode` codebase, but `python-dmidecode` seems to be a inactive project since some years and aligning wourd require too much effort.
Likewise, backporting just the `/dev/mem` from `dmidecode` to `python-dmidecode` doesn't seem to be an option either, since the codebases diverged massively in the latest years.

This PR solves the problem in our `up2date_client`. The code reads the needed data directly from sysfs (`/sys/devices/virtual/dmi/id`), see `dmidecode.8`:
```
Note: on Linux, most of these strings can alternatively be read  directly
from sysfs, typically from files under /sys/devices/virtual/dmi/id.  Most
of these files are even readable by regular users.
```

The code reading info from sysfs kick in only in cases when reading via `python-dmidecode` fails (so on systems without kernel lockdown, nothing should change).

## GUI diff

- [x] **DONE**

## Documentation
bugfix

## Test coverage
- No tests in the legacy client code AFAIK

- [x] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/13654

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"