### PR TITLE
QAM: Remove GPG import scenario and fix function for sle15 os_family

### DIFF
--- a/testsuite/features/build_validation/init_clients/ceos6_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ceos6_ssh_minion.feature
@@ -23,9 +23,6 @@ Feature: Bootstrap a CentOS 6 Salt SSH minion
     Then I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "ceos6_ssh_minion"
 
-  Scenario: Import the GPG keys for CentOS 6 Salt SSH minion
-    When I import the GPG keys for "ceos6_ssh_minion"
-
 @proxy
   Scenario: Check connection from CentOS 6 Salt SSH minion to proxy
     Given I am on the Systems overview page of this "ceos6_ssh_minion"

--- a/testsuite/features/build_validation/init_clients/ceos7_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ceos7_ssh_minion.feature
@@ -23,9 +23,6 @@ Feature: Bootstrap a CentOS 7 Salt SSH minion
     Then I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "ceos7_ssh_minion"
 
-  Scenario: Import the GPG keys for CentOS 7 Salt SSH minion
-    When I import the GPG keys for "ceos7_ssh_minion"
-
 @proxy
   Scenario: Check connection from CentOS 7 Salt SSH minion to proxy
     Given I am on the Systems overview page of this "ceos7_ssh_minion"

--- a/testsuite/features/build_validation/init_clients/ceos8_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ceos8_ssh_minion.feature
@@ -23,9 +23,6 @@ Feature: Bootstrap a CentOS 8 Salt SSH minion
     Then I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "ceos8_ssh_minion"
 
-  Scenario: Import the GPG keys for CentOS 8 Salt SSH minion
-    When I import the GPG keys for "ceos8_ssh_minion"
-
 @proxy
   Scenario: Check connection from CentOS 8 Salt SSH minion to proxy
     Given I am on the Systems overview page of this "ceos8_ssh_minion"

--- a/testsuite/features/build_validation/init_clients/disabled/ubuntu2004_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/disabled/ubuntu2004_ssh_minion.feature
@@ -25,9 +25,6 @@ Feature: Bootstrap a Ubuntu 20.04 Salt SSH Minion
     Then I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "ubuntu2004_ssh_minion"
 
-  Scenario: Import the GPG keys for Ubuntu 20.04 Salt SSH Minion
-    When I import the GPG keys for "ubuntu2004_ssh_minion"
-
   Scenario: Check events history for failures on SSH-managed Ubuntu 20.04 minion
     Given I am on the Systems overview page of this "ubuntu2004_ssh_minion"
     Then I check for failed events on history event page

--- a/testsuite/features/build_validation/init_clients/sle11sp4_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle11sp4_ssh_minion.feature
@@ -28,9 +28,6 @@ Feature: Bootstrap a SLES 11 SP4 Salt SSH Minion
     Given I am on the Systems overview page of this "sle11sp4_ssh_minion"
     When I remove package "sle-manager-tools-release" from highstate
 
-  Scenario: Import the GPG keys for SLES 11 SP4 Salt SSH Minion
-    When I import the GPG keys for "sle11sp4_ssh_minion"
-
 @proxy
   Scenario: Check connection from SLES 11 SP4 SSH minion to proxy
     Given I am on the Systems overview page of this "sle11sp4_ssh_minion"

--- a/testsuite/features/build_validation/init_clients/sle12sp4_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle12sp4_ssh_minion.feature
@@ -28,9 +28,6 @@ Feature: Bootstrap a SLES 12 SP4 Salt SSH Minion
     Given I am on the Systems overview page of this "sle12sp4_ssh_minion"
     When I remove package "sle-manager-tools-release" from highstate
 
-  Scenario: Import the GPG keys for SLES 12 SP4 SSH Minion
-    When I import the GPG keys for "sle12sp4_ssh_minion"
-
 @proxy
   Scenario: Check connection from SLES 12 SP4 SSH minion to proxy
     Given I am on the Systems overview page of this "sle12sp4_ssh_minion"

--- a/testsuite/features/build_validation/init_clients/sle15_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15_ssh_minion.feature
@@ -28,9 +28,6 @@ Feature: Bootstrap a SLES 15 Salt SSH Minion
     Given I am on the Systems overview page of this "sle15_ssh_minion"
     When I remove package "sle-manager-tools-release" from highstate
 
-  Scenario: Import the GPG keys for SLES 15 Salt SSH Minion
-    When I import the GPG keys for "sle15_ssh_minion"
-
 @proxy
   Scenario: Check connection from SLES 15 SSH minion to proxy
     Given I am on the Systems overview page of this "sle15_ssh_minion"

--- a/testsuite/features/build_validation/init_clients/sle15sp1_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp1_ssh_minion.feature
@@ -28,9 +28,6 @@ Feature: Bootstrap a SLES 15 SP1 Salt SSH Minion
     Given I am on the Systems overview page of this "sle15sp1_ssh_minion"
     When I remove package "sle-manager-tools-release" from highstate
 
-  Scenario: Import the GPG keys for SLES 15 SP1 Salt SSH Minion
-    When I import the GPG keys for "sle15sp1_ssh_minion"
-
 @proxy
   Scenario: Check connection from SLES 15 SP1 SSH minion to proxy
     Given I am on the Systems overview page of this "sle15sp1_ssh_minion"

--- a/testsuite/features/build_validation/init_clients/sle15sp2_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp2_ssh_minion.feature
@@ -28,9 +28,6 @@ Feature: Bootstrap a SLES 15 SP2 Salt SSH Minion
     Given I am on the Systems overview page of this "sle15sp2_ssh_minion"
     When I remove package "sle-manager-tools-release" from highstate
 
-  Scenario: Import the GPG keys for SLES 15 SP2 Salt SSH Minion
-    When I import the GPG keys for "sle15sp2_ssh_minion"
-
 @proxy
   Scenario: Check connection from SLES 15 SP2 SSH minion to proxy
     Given I am on the Systems overview page of this "sle15sp2_ssh_minion"

--- a/testsuite/features/build_validation/init_clients/sle15sp3_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp3_ssh_minion.feature
@@ -28,9 +28,6 @@ Feature: Bootstrap a SLES 15 SP3 Salt SSH Minion
     Given I am on the Systems overview page of this "sle15sp3_ssh_minion"
     When I remove package "sle-manager-tools-release" from highstate
 
-  Scenario: Import the GPG keys for SLES 15 SP3 Salt SSH Minion
-    When I import the GPG keys for "sle15sp3_ssh_minion"
-
 @proxy
   Scenario: Check connection from SLES 15 SP3 SSH minion to proxy
     Given I am on the Systems overview page of this "sle15sp3_ssh_minion"

--- a/testsuite/features/build_validation/init_clients/ubuntu1604_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ubuntu1604_ssh_minion.feature
@@ -25,9 +25,6 @@ Feature: Bootstrap a Ubuntu 16.04 Salt SSH minion
     Then I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "ubuntu1604_ssh_minion"
 
-  Scenario: Import the GPG keys for Ubuntu 16.04 Salt SSH minion
-    When I import the GPG keys for "ubuntu1604_ssh_minion"
-
   Scenario: Check events history for failures on SSH-managed Ubuntu 16.04 minion
     Given I am on the Systems overview page of this "ubuntu1604_ssh_minion"
     Then I check for failed events on history event page

--- a/testsuite/features/build_validation/init_clients/ubuntu1804_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ubuntu1804_ssh_minion.feature
@@ -25,9 +25,6 @@ Feature: Bootstrap a Ubuntu 18.04 Salt SSH Minion
     Then I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "ubuntu1804_ssh_minion"
 
-  Scenario: Import the GPG keys for 18.04 Salt SSH Minion
-    When I import the GPG keys for "ubuntu1804_ssh_minion"
-
   Scenario: Check events history for failures on SSH-managed Ubuntu 18.04 minion
     Given I am on the Systems overview page of this "ubuntu1804_ssh_minion"
     Then I check for failed events on history event page

--- a/testsuite/features/support/client_stack.rb
+++ b/testsuite/features/support/client_stack.rb
@@ -90,6 +90,8 @@ end
 def get_gpg_keys(node, target = $server)
   os_version, os_family = get_os_version(node)
   if os_family =~ /^sles/
+   # HACK: SLE 15 uses SLE 12 GPG key
+    os_version = 12 if os_version =~ /^15/
     gpg_keys, _code = target.run("cd /srv/www/htdocs/pub/ && ls -1 sle#{os_version}*", false)
   elsif os_family =~ /^centos/
     gpg_keys, _code = target.run("cd /srv/www/htdocs/pub/ && ls -1 #{os_family}#{os_version}* res*", false)

--- a/testsuite/features/support/client_stack.rb
+++ b/testsuite/features/support/client_stack.rb
@@ -90,7 +90,7 @@ end
 def get_gpg_keys(node, target = $server)
   os_version, os_family = get_os_version(node)
   if os_family =~ /^sles/
-   # HACK: SLE 15 uses SLE 12 GPG key
+    # HACK: SLE 15 uses SLE 12 GPG key
     os_version = 12 if os_version =~ /^15/
     gpg_keys, _code = target.run("cd /srv/www/htdocs/pub/ && ls -1 sle#{os_version}*", false)
   elsif os_family =~ /^centos/


### PR DESCRIPTION
## What does this PR change?

QAM: Remove GPG import scenario and fix function for sle15 os_family

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes #
Tracks https://github.com/SUSE/spacewalk/pull/13861

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
