### PR TITLE
Scap for minions in ssm

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -390,7 +390,7 @@ public class RegisterMinionEventMessageAction implements MessageAction {
             setServerPaths(minion, master, isSaltSSH, saltSSHProxyId);
 
             ServerFactory.save(minion);
-            giveCapabilities(minion);
+            giveCapabilities(minion, isSaltSSH);
 
             // Assign the Salt base entitlement by default
             GlobalInstanceHolder.SYSTEM_ENTITLEMENT_MANAGER.setBaseEntitlement(minion, EntitlementManager.SALT);
@@ -681,12 +681,14 @@ public class RegisterMinionEventMessageAction implements MessageAction {
         server.getServerPaths().addAll(proxyPaths.orElse(Collections.emptySet()));
     }
 
-    private void giveCapabilities(MinionServer server) {
+    private void giveCapabilities(MinionServer server, boolean isSaltSSH) {
         // Salt systems always have the script.run capability
         SystemManager.giveCapability(server.getId(), SystemManager.CAP_SCRIPT_RUN, 1L);
 
-        // Salt systems can be audited
-        SystemManager.giveCapability(server.getId(), SystemManager.CAP_SCAP, 1L);
+        if (!isSaltSSH) {
+            // Not Salt ssh systems can be audited
+            SystemManager.giveCapability(server.getId(), SystemManager.CAP_SCAP, 1L);
+        }
 
         //Capabilities to enable configuration management for minions
         SystemManager.giveCapability(server.getId(),

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- enable openscap auditing for salt systems in SSM (bsc#1157711)
 - Removed "Software Crashes" feature
 - detect debian products (bsc#1181416)
 - show packages from channels assigned to the targeted system (bsc#1181423)

--- a/schema/spacewalk/common/data/rhnServerGroupTypeFeature.sql
+++ b/schema/spacewalk/common/data/rhnServerGroupTypeFeature.sql
@@ -264,6 +264,11 @@ values (lookup_sg_type('salt_entitled'), lookup_feature_type('ftr_system_custom_
 
 insert into rhnServerGroupTypeFeature (server_group_type_id, feature_id,
                                        created, modified)
+values (lookup_sg_type('salt_entitled'), lookup_feature_type('ftr_system_audit'),
+        current_timestamp,current_timestamp);
+
+insert into rhnServerGroupTypeFeature (server_group_type_id, feature_id,
+                                       created, modified)
 values (lookup_sg_type('salt_entitled'), lookup_feature_type('ftr_kickstart'),
         current_timestamp,current_timestamp);
 

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- enable openscap auditing for salt systems in SSM (bsc#1157711)
 - Removed "Software Crashes" feature
 
 -------------------------------------------------------------------

--- a/schema/spacewalk/upgrade/susemanager-schema-4.2.6-to-susemanager-schema-4.2.7/100-enable-audit-for-salt.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.2.6-to-susemanager-schema-4.2.7/100-enable-audit-for-salt.sql
@@ -1,0 +1,7 @@
+insert into rhnServerGroupTypeFeature (server_group_type_id, feature_id,
+                                       created, modified)
+select lookup_sg_type('salt_entitled'), lookup_feature_type('ftr_system_audit'),
+        current_timestamp,current_timestamp from dual
+where not exists ( select 1 from rhnServerGroupTypeFeature
+    where server_group_type_id = lookup_sg_type('salt_entitled')
+      and feature_id = lookup_feature_type('ftr_system_audit') );


### PR DESCRIPTION
## What does this PR change?

Openscap auditing was already working for salt systems in the single system details view.
But it was missing in SSM.
The reason was, that we use different ACLs for testing the capability. We have now added the `ftr_system_audit`
capability to salt entitled systems.

This PR also restrict the audit capability to default salt minions. Salt SSH minions do not get it as openscap auditing will not
work.

## GUI diff

No difference.

After:

![image](https://user-images.githubusercontent.com/1038917/106898207-2ee8e380-66f4-11eb-9ca5-cfbc72345f22.png)


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/10253
Tracks https://github.com/SUSE/spacewalk/pull/13895 https://github.com/SUSE/spacewalk/pull/13896

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
