### PR TITLE
[Port] QAM: CLM scenario needs to set a label text (#13876)

### DIFF
--- a/testsuite/features/build_validation/add_custom_repositories/add_ceos8_repositories.feature
+++ b/testsuite/features/build_validation/add_custom_repositories/add_ceos8_repositories.feature
@@ -88,6 +88,7 @@ Feature: Adding the CentOS 8 distribution custom repositories
     Then I should see a "python-3.8: enable module python38:3.8" text
     When I follow "Add Environment"
     And I enter "result" as "name"
+    And I enter "result" as "label"
     And I enter "Filtered channels without AppStream channels" as "description"
     And I click on "Save"
     Then I should see a "not built" text


### PR DESCRIPTION
## What does this PR change?

Fix: CLM scenario on QAM missed a step to set a label.
Note: CI scenarios are ok, they contain the step already.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed 

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
 - Manager-4.1 https://github.com/SUSE/spacewalk/pull/13876

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
