### PR TITLE
QAM: Fix CentOS6 repos, fix tools repos (#13871)

### DIFF
--- a/testsuite/features/build_validation/init_clients/ceos6_client.feature
+++ b/testsuite/features/build_validation/init_clients/ceos6_client.feature
@@ -8,8 +8,7 @@ Feature: Bootstrap a CentOS 6 traditional client
     When I perform a full salt minion cleanup on "ceos6_client"
 
   Scenario: Prepare a CentOS 6 traditional client
-    When I enable SUSE Manager tools repositories on "ceos6_client"
-    And I enable the repositories "CentOS-Base_backup CentOS-Updates_backup" on this "ceos6_client"
+    And I enable the repositories "centos_base_backup centos_updates_backup tools_pool_repo" on this "ceos6_client" without error control
     And I run "/usr/bin/update-ca-trust force-enable" on "ceos6_client"
     And I bootstrap traditional client "ceos6_client" using bootstrap script with activation key "1-ceos6_client_key" from the proxy
     And I install the traditional stack utils on "ceos6_client"

--- a/testsuite/features/build_validation/init_clients/ceos7_client.feature
+++ b/testsuite/features/build_validation/init_clients/ceos7_client.feature
@@ -8,8 +8,7 @@ Feature: Bootstrap a CentOS 7 traditional client
     When I perform a full salt minion cleanup on "ceos7_client"
 
   Scenario: Prepare a CentOS 7 traditional client
-    When I enable SUSE Manager tools repositories on "ceos7_client"
-    And I enable repository "CentOS-Base" on this "ceos7_client"
+    And I enable repository "CentOS-Base tools_pool_repo" on this "ceos7_client" without error control
     And I bootstrap traditional client "ceos7_client" using bootstrap script with activation key "1-ceos7_client_key" from the proxy
     And I install the traditional stack utils on "ceos7_client"
     And I run "mgr-actions-control --enable-all" on "ceos7_client"


### PR DESCRIPTION
## What does this PR change?

Fix CentOS6 repositories filename to be disabled.
Fix how to handle client tools repositories, and not fail the command if doesn't found the repo.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
 - Manager-4.1 https://github.com/SUSE/spacewalk/pull/13871

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
