### PR TITLE
QAM: Disable Sumaform client tools repositories (#13868)

### DIFF
--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -682,6 +682,7 @@ When(/^I perform a full salt minion cleanup on "([^"]*)"$/) do |host|
     node.run('zypper --non-interactive remove -y salt salt-minion', false)
   end
   node.run('rm -Rf /var/cache/salt/minion /var/run/salt /var/log/salt /etc/salt', false)
+  step %(I disable the repositories "tools_update_repo tools_pool_repo" on this "#{host}")
 end
 
 When(/^I install a salt pillar top file for "([^"]*)" with target "([^"]*)" on the server$/) do |file, host|


### PR DESCRIPTION
## What does this PR change?

We have a conflict with the repository used by SUMA when bootstrapping a minion, and the client tools repositories injected by Sumaform during the deployment; As in order to configure the basic stuff for those VMs, Sumaform convert every machine into a salt-minion and runs on it some salt states.

What we do in this PR, is to be sure that no client tools repositories are in our nodes before we bootstrap clients in our QAM/BV test suite.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
 - Manager-4.1 https://github.com/SUSE/spacewalk/pull/13868

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
