### PR TITLE
We test virtualization host enablement elsewhere

### DIFF
--- a/testsuite/features/core/srv_create_activationkey.feature
+++ b/testsuite/features/core/srv_create_activationkey.feature
@@ -12,7 +12,6 @@ Feature: Create activation keys
     And I follow "Create Key"
     And I enter "SUSE Test Key x86_64" as "description"
     And I enter "SUSE-KEY-x86_64" as "key"
-    And I check "virtualization_host"
     And I enter "20" as "usageLimit"
     And I select "Test-Channel-x86_64" from "selectedBaseChannel"
     And I click on "Create Activation Key"


### PR DESCRIPTION
## What does this PR change?

Fix small side effect of activation keys refactoring

We already test the virtualization enablement in the virtualization tests, no need to have it in core too.


## Links

Ports:
* 4.0: SUSE/spacewalk#13884
* 4.1: SUSE/spacewalk#13883

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
