### PR TITLE
Fix a couple of spelling mistakes in monitoring-admin.js

### DIFF
--- a/web/html/src/manager/admin/config/monitoring-admin.tsx
+++ b/web/html/src/manager/admin/config/monitoring-admin.tsx
@@ -38,11 +38,11 @@ const msgMap = {
   ),
   taskomatic_msg_enable: t(
     "The Taskomatic Prometheus exporter is up but the JMX configuration is disabled. " +
-      "Click the Enable button to enable the JMX configuration of click Disable to stop the Prometheus exporter."
+      "Click the Enable button to enable the JMX configuration or click Disable to stop the Prometheus exporter."
   ),
   taskomatic_msg_disable: t(
     "The Taskomatic Prometheus exporter is down but the JMX configuration is enabled. " +
-      "Click the Disable button to disable the JMX configuration of click Enable to start the Prometheus exporter."
+      "Click the Disable button to disable the JMX configuration or click Enable to start the Prometheus exporter."
   ),
   tomcat_msg_restart: msgRestart,
   taskomatic_msg_restart: msgRestart,


### PR DESCRIPTION
## What does this PR change?
Fix a couple of spelling mistakes in monitoring-admin.js
**add description**

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
