### PR TITLE
Open repomd files as binary (bsc#1173893)

### DIFF
--- a/backend/server/repomd/view.py
+++ b/backend/server/repomd/view.py
@@ -365,7 +365,7 @@ class RepoMDView(object):
         self.repomd = repomd
 
     def get_file(self):
-        repomd_file = open(self.repomd.filename)
+        repomd_file = open(self.repomd.filename, "rb")
         return repomd_file
 
 

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Open repomd files as binary (bsc#1173893)
 - Rename rhnVirtualInstanceInfo memory_size_k column
 
 -------------------------------------------------------------------


### PR DESCRIPTION
This is related to serving comps.xml and modules.yaml files to
traditional clients. If the files weren't opened in the binary mode,
yum/dnf on clients was not working correctly (yum on CentOS7 was failing
silently, dnf on RHEL8 reported an error) and the following line appeared in
the SUMA apache error log, when client tried to download the file:

`TypeError: file like object yielded non string type`

Fixed by opening the files as binary. Then I noticed, we do this for the cached
files already (see db7f3a9f26141a3f27e17c8d0afd88b9fe851bf3).


## GUI diff

No difference.

## Documentation
bugfix

## Test coverage
No tests here AFAIK

## Links

Tracks https://github.com/SUSE/spacewalk/issues/11926

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"