### PR TITLE
Rollback WebUI version to 2021.01

### DIFF
--- a/web/conf/rhn_web.conf
+++ b/web/conf/rhn_web.conf
@@ -70,7 +70,7 @@ web.version = 4.2.0 Alpha2
 # the version of Uyuni to show at the WebUI, it will be prepended
 # to web.version as version for the SPECs, when building them
 # for Uyuni
-web.version.uyuni =  2021.02
+web.version.uyuni =  2021.01
 
 web.buildtimestamp = _OBS_BUILD_TIMESTAMP_
 

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -2,7 +2,7 @@
 Mon Feb 01 10:22:21 CET 2021 - jgonzalez@suse.com
 
 - version 4.2.7-1
-- Uyuni 2021.02
+- Uyuni 2021.01
 
 -------------------------------------------------------------------
 Fri Jan 29 14:44:57 CET 2021 - jgonzalez@suse.com


### PR DESCRIPTION
## What does this PR change?

Rollback WebUI version to 2021.01

## GUI diff

No difference.

- [x ] **DONE**

## Documentation
- Documentation issue was created: Request submitted to @jcayouette on rocket.chat. Willl be ready by the end of the day

- [ ] **DONE**

## Test coverage
- No tests: Just a rollback on the WebUI version

- [x] **DONE**

## Links

None

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
