### PR TITLE
Do not hide navigation steps in implementation

### DIFF
--- a/testsuite/features/build_validation/init_clients/sle11sp4_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle11sp4_ssh_minion.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 SUSE LLC
+# Copyright (c) 2020-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @sle11sp4_ssh_minion
@@ -20,13 +20,20 @@ Feature: Bootstrap a SLES 11 SP4 Salt SSH Minion
     Then I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "sle11sp4_ssh_minion"
 
-# WORKAROUD for bsc#1124634
+# HACK
 # Package 'sle-manager-tools-release' is automatically installed during bootstrap and
 # stays installed after removal of channel containing it. So it is not possible to update it.
 # Package needs to be removed from highstate to avoid failure when updating it.
   Scenario: Remove sle-manager-tools-release from state after SLES 11 SP4 bootstrap
     Given I am on the Systems overview page of this "sle11sp4_ssh_minion"
-    When I remove package "sle-manager-tools-release" from highstate
+    When I wait until I see "States" text
+    And I follow "States" in the content area
+    And I wait until I see "Highstate" text
+    And I follow "Packages" in the content area
+    Then I should see a "Package States" text
+    When I follow "Search" in the content area
+    And I wait until button "Search" becomes enabled
+    And I remove package "sle-manager-tools-release" from highstate
 
   Scenario: Import the GPG keys for SLES 11 SP4 Salt SSH Minion
     When I import the GPG keys for "sle11sp4_ssh_minion"

--- a/testsuite/features/build_validation/init_clients/sle12sp4_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle12sp4_ssh_minion.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 SUSE LLC
+# Copyright (c) 2020-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @sle12sp4_ssh_minion
@@ -20,13 +20,20 @@ Feature: Bootstrap a SLES 12 SP4 Salt SSH Minion
     Then I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "sle12sp4_ssh_minion"
 
-# WORKAROUD for bsc#1124634
+# HACK
 # Package 'sle-manager-tools-release' is automatically installed during bootstrap and
 # stays installed after removal of channel containing it. So it is not possible to update it.
 # Package needs to be removed from highstate to avoid failure when updating it.
   Scenario: Remove sle-manager-tools-release from state after SLES 12 SP4 bootstrap
     Given I am on the Systems overview page of this "sle12sp4_ssh_minion"
-    When I remove package "sle-manager-tools-release" from highstate
+    When I wait until I see "States" text
+    And I follow "States" in the content area
+    And I wait until I see "Highstate" text
+    And I follow "Packages" in the content area
+    Then I should see a "Package States" text
+    When I follow "Search" in the content area
+    And I wait until button "Search" becomes enabled
+    And I remove package "sle-manager-tools-release" from highstate
 
   Scenario: Import the GPG keys for SLES 12 SP4 SSH Minion
     When I import the GPG keys for "sle12sp4_ssh_minion"

--- a/testsuite/features/build_validation/init_clients/sle15_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15_ssh_minion.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 SUSE LLC
+# Copyright (c) 2020-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @sle15_ssh_minion
@@ -20,13 +20,20 @@ Feature: Bootstrap a SLES 15 Salt SSH Minion
     Then I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "sle15_ssh_minion"
 
-  # WORKAROUD for bsc#1124634
+  # HACK
   # Package 'sle-manager-tools-release' is automatically installed during bootstrap and
   # stays installed after removal of channel containing it. So it is not possible to update it.
   # Package needs to be removed from highstate to avoid failure when updating it.
   Scenario: Remove sle-manager-tools-release from state after SLES 15 bootstrap
     Given I am on the Systems overview page of this "sle15_ssh_minion"
-    When I remove package "sle-manager-tools-release" from highstate
+    When I wait until I see "States" text
+    And I follow "States" in the content area
+    And I wait until I see "Highstate" text
+    And I follow "Packages" in the content area
+    Then I should see a "Package States" text
+    When I follow "Search" in the content area
+    And I wait until button "Search" becomes enabled
+    And I remove package "sle-manager-tools-release" from highstate
 
   Scenario: Import the GPG keys for SLES 15 Salt SSH Minion
     When I import the GPG keys for "sle15_ssh_minion"

--- a/testsuite/features/build_validation/init_clients/sle15sp1_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp1_ssh_minion.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 SUSE LLC
+# Copyright (c) 2020-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @sle15sp1_ssh_minion
@@ -20,13 +20,20 @@ Feature: Bootstrap a SLES 15 SP1 Salt SSH Minion
     Then I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "sle15sp1_ssh_minion"
 
-  # WORKAROUD for bsc#1124634
+  # HACK
   # Package 'sle-manager-tools-release' is automatically installed during bootstrap and
   # stays installed after removal of channel containing it. So it is not possible to update it.
   # Package needs to be removed from highstate to avoid failure when updating it.
   Scenario: Remove sle-manager-tools-release from state after SLES 15 SP1 bootstrap
     Given I am on the Systems overview page of this "sle15sp1_ssh_minion"
-    When I remove package "sle-manager-tools-release" from highstate
+    When I wait until I see "States" text
+    And I follow "States" in the content area
+    And I wait until I see "Highstate" text
+    And I follow "Packages" in the content area
+    Then I should see a "Package States" text
+    When I follow "Search" in the content area
+    And I wait until button "Search" becomes enabled
+    And I remove package "sle-manager-tools-release" from highstate
 
   Scenario: Import the GPG keys for SLES 15 SP1 Salt SSH Minion
     When I import the GPG keys for "sle15sp1_ssh_minion"

--- a/testsuite/features/build_validation/init_clients/sle15sp2_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp2_ssh_minion.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 SUSE LLC
+# Copyright (c) 2020-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @sle15sp2_ssh_minion
@@ -20,13 +20,20 @@ Feature: Bootstrap a SLES 15 SP2 Salt SSH Minion
     Then I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "sle15sp2_ssh_minion"
 
-  # WORKAROUD for bsc#1124634
+  # HACK
   # Package 'sle-manager-tools-release' is automatically installed during bootstrap and
   # stays installed after removal of channel containing it. So it is not possible to update it.
   # Package needs to be removed from highstate to avoid failure when updating it.
   Scenario: Remove sle-manager-tools-release from state after SLES 15 SP2 bootstrap
     Given I am on the Systems overview page of this "sle15sp2_ssh_minion"
-    When I remove package "sle-manager-tools-release" from highstate
+    When I wait until I see "States" text
+    And I follow "States" in the content area
+    And I wait until I see "Highstate" text
+    And I follow "Packages" in the content area
+    Then I should see a "Package States" text
+    When I follow "Search" in the content area
+    And I wait until button "Search" becomes enabled
+    And I remove package "sle-manager-tools-release" from highstate
 
   Scenario: Import the GPG keys for SLES 15 SP2 Salt SSH Minion
     When I import the GPG keys for "sle15sp2_ssh_minion"

--- a/testsuite/features/build_validation/init_clients/sle15sp3_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp3_ssh_minion.feature
@@ -20,13 +20,20 @@ Feature: Bootstrap a SLES 15 SP3 Salt SSH Minion
     Then I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "sle15sp3_ssh_minion"
 
-  # WORKAROUD for bsc#1124634
+  # HACK
   # Package 'sle-manager-tools-release' is automatically installed during bootstrap and
   # stays installed after removal of channel containing it. So it is not possible to update it.
   # Package needs to be removed from highstate to avoid failure when updating it.
   Scenario: Remove sle-manager-tools-release from state after SLES 15 SP3 bootstrap
     Given I am on the Systems overview page of this "sle15sp3_ssh_minion"
-    When I remove package "sle-manager-tools-release" from highstate
+    When I wait until I see "States" text
+    And I follow "States" in the content area
+    And I wait until I see "Highstate" text
+    And I follow "Packages" in the content area
+    Then I should see a "Package States" text
+    When I follow "Search" in the content area
+    And I wait until button "Search" becomes enabled
+    And I remove package "sle-manager-tools-release" from highstate
 
   Scenario: Import the GPG keys for SLES 15 SP3 Salt SSH Minion
     When I import the GPG keys for "sle15sp3_ssh_minion"

--- a/testsuite/features/init_clients/sle_ssh_minion.feature
+++ b/testsuite/features/init_clients/sle_ssh_minion.feature
@@ -18,7 +18,7 @@ Feature: Bootstrap a Salt host managed via salt-ssh
     And I wait until I see the name of "ssh_minion", refreshing the page
     And I wait until onboarding is completed for "ssh_minion"
 
-# WORKAROUD for bsc#1124634
+# HACK
 # Package 'sle-manager-tools-release' is automatically installed during bootstrap and
 # stays installed after removal of channel containing it. So it is not possible to update it.
 # Package needs to be removed from highstate to avoid failure when updating it.
@@ -26,7 +26,14 @@ Feature: Bootstrap a Salt host managed via salt-ssh
 @ssh_minion
   Scenario: Remove sle-manager-tools-release from state after bootstrap
     Given I am on the Systems overview page of this "ssh_minion"
-    When I remove package "sle-manager-tools-release" from highstate
+    When I wait until I see "States" text
+    And I follow "States" in the content area
+    And I wait until I see "Highstate" text
+    And I follow "Packages" in the content area
+    Then I should see a "Package States" text
+    When I follow "Search" in the content area
+    And I wait until button "Search" becomes enabled
+    And I remove package "sle-manager-tools-release" from highstate
 
 @proxy
 @ssh_minion

--- a/testsuite/features/secondary/minssh_bootstrap_xmlrpc.feature
+++ b/testsuite/features/secondary/minssh_bootstrap_xmlrpc.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 SUSE LLC.
+# Copyright (c) 2017-2021 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 @scope_salt_ssh
@@ -27,14 +27,21 @@ Feature: Register a salt-ssh system via XML-RPC
      And I wait until I see the name of "ssh_minion", refreshing the page
      And I wait until onboarding is completed for "ssh_minion"
 
-# WORKAROUD for bsc#1124634
+# HACK
 # Package 'sle-manager-tools-release' is automatically installed during bootstrap and
 # stays installed after removal of channel containing it. So it is not possible to update it.
 # Package needs to be removed from highstate to avoid failure when updating it.
 @ssh_minion
   Scenario: Remove sle-manager-tools-release from state after bootstrap via XML-RPC
     Given I am on the Systems overview page of this "ssh_minion"
-    When I remove package "sle-manager-tools-release" from highstate
+    When I wait until I see "States" text
+    And I follow "States" in the content area
+    And I wait until I see "Highstate" text
+    And I follow "Packages" in the content area
+    Then I should see a "Package States" text
+    When I follow "Search" in the content area
+    And I wait until button "Search" becomes enabled
+    And I remove package "sle-manager-tools-release" from highstate
 
 @ssh_minion
   Scenario: Check contact method of this Salt SSH system

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -1109,15 +1109,6 @@ And(/^I mark as read it via the "([^"]*)" button$/) do |target_button|
 end
 
 When(/^I remove package "([^"]*)" from highstate$/) do |package|
-  steps %(
-    When I wait until I see "States" text
-    And I follow "States" in the content area
-    And I wait until I see "Highstate" text
-    And I follow "Packages" in the content area
-    Then I should see a "Package States" text
-    When I follow "Search" in the content area
-    And I wait until button "Search" becomes enabled
-  )
   event_table_xpath = "//div[@class='table-responsive']/table/tbody"
   rows = find(:xpath, event_table_xpath)
   rows.all('tr').each do |tr|


### PR DESCRIPTION
## What does this PR change?

This PR does two things:

- it removes reference to bsc#1124634. Since this is an INVALID bug, I prefer we do not mention it.
  We need this scenario because of the way SUSE products work starting with SLES 15, that's all.

- it moves navigation steps from the ruby implementation to the feature. Rationale:
  * makes test suite execution easier to follow (more details)
  * it makes reading and understanding of scenario easier
  * it makes debugging easier when it fails at one of these steps
  * it is better if all our scenarios more or less follow a common pattern

Tested to work in 4.1 branch.


## Links

Ports:
* 4.0: SUSE/spacewalk#13894
* 4.1: SUSE/spacewalk#13893


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
