### PR TITLE
Testsuite - updated kiwi profiles

### DIFF
--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS6_40/config.xml
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS6_40/config.xml
@@ -4,7 +4,7 @@
     <description type="system">
         <author>Admin User</author>
         <contact>noemail@example.com</contact>
-        <specification>SUSE Linux Enterprise 12 SP3 JeOS</specification>
+        <specification>SUSE Linux Enterprise 12 SP5 JeOS</specification>
     </description>
     <preferences>
         <version>6.0.0</version>
@@ -32,10 +32,10 @@
     </drivers>
 
     <repository type="rpm-md">  <!-- product -->
-        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-SERVER/12-SP3/x86_64/product/"/>
+        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-SERVER/12-SP5/x86_64/product/"/>
     </repository>
     <repository type="rpm-md">
-        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-SERVER/12-SP3/x86_64/update/"/>
+        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-SERVER/12-SP5/x86_64/update/"/>
     </repository>
     <repository type="rpm-md">  <!-- manager tools -->
         <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Manager-Tools/12/x86_64/product/"/>
@@ -43,7 +43,7 @@
     <repository type="rpm-md">
         <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Manager-Tools/12/x86_64/update/"/>
     </repository>
-    <repository type="rpm-md">  <!-- 4.0 development client tools -->
+    <repository type="rpm-md">  <!-- 4.0 client tools -->
         <source path="http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.0:/SLE12-SUSE-Manager-Tools/SLE_12/"/>
     </repository>
 

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS6_head/config.xml
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS6_head/config.xml
@@ -4,7 +4,7 @@
     <description type="system">
         <author>Admin User</author>
         <contact>noemail@example.com</contact>
-        <specification>SUSE Linux Enterprise 12 SP3 JeOS</specification>
+        <specification>SUSE Linux Enterprise 12 SP5 JeOS</specification>
     </description>
     <preferences>
         <version>6.0.0</version>
@@ -32,10 +32,10 @@
     </drivers>
 
     <repository type="rpm-md">  <!-- product -->
-        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-SERVER/12-SP3/x86_64/product/"/>
+        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-SERVER/12-SP5/x86_64/product/"/>
     </repository>
     <repository type="rpm-md">
-        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-SERVER/12-SP3/x86_64/update/"/>
+        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-SERVER/12-SP5/x86_64/update/"/>
     </repository>
     <repository type="rpm-md">
         <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Manager-Tools/12/x86_64/product/"/>


### PR DESCRIPTION
## What does this PR change?

PR updates currently used kiwi profiles for SLE12 to SP5.

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
