### PR TITLE
QAM: Get rid of BUILD_VALIDATION env. variable

### DIFF
--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -18,7 +18,6 @@ require 'multi_test'
 
 server = ENV['SERVER']
 $debug_mode = true if ENV['DEBUG']
-$build_validation = true if ENV['BUILD_VALIDATION']
 $long_tests_enabled = true if ENV['LONG_TESTS']
 puts "Executing long running tests" if $long_tests_enabled
 $service_pack_migration_enabled = true if ENV['SERVICE_PACK_MIGRATION']
@@ -34,17 +33,17 @@ STARTTIME = Time.new.to_i
 Capybara.default_max_wait_time = 10
 DEFAULT_TIMEOUT = 250
 
-# Build Validations will require longer timeouts and some concrete tweaks
-if $build_validation
-  Capybara.default_max_wait_time = 30
-  DEFAULT_TIMEOUT = 1800
-end
-
-# QAM test suite will provide a json file including all client repositories
+# QAM and Build Validation pipelines will provide a json file including all custom (MI) repositories
 custom_repos_path = File.dirname(__FILE__) + '/../upload_files/' + 'custom_repositories.json'
 if File.exist?(custom_repos_path)
   custom_repos_file = File.read(custom_repos_path)
   $custom_repositories = JSON.parse(custom_repos_file)
+  $build_validation = true
+  # HACK
+  # QAM and Build Validations will require longer timeouts due to the low performance of our VMs
+  # if we ever improve this fact, we can reduce these timeouts.
+  Capybara.default_max_wait_time = 30
+  DEFAULT_TIMEOUT = 1800
 end
 
 def enable_assertions


### PR DESCRIPTION
## What does this PR change?

Get rid of BUILD_VALIDATION env. variable

As both QAM and BV needs a json to provide the MI repos, we have enough by checking the existence of this file, as we did before introducing this variable. This variable was only introduced because I wrongly understood that BVs like Alpha, Betas and GMCs will not have MI repos.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.1
- Manager-4.0

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
