### PR TITLE
Fix spacewalk-backend build after abrt removal

### DIFF
--- a/backend/server/handlers/xmlrpc/Makefile
+++ b/backend/server/handlers/xmlrpc/Makefile
@@ -5,7 +5,7 @@ TOP	= ../../..
 SUBDIR	= server/handlers/xmlrpc
 
 FILES	= __init__ country queue registration states up2date errata \
-	  getMethod proxy get_handler abrt scap
+	  getMethod proxy get_handler scap
 
 include $(TOP)/Makefile.defs
 


### PR DESCRIPTION
## What does this PR change?

PR https://github.com/uyuni-project/uyuni/pull/3122 removed `abrt` from xmlrpc, but `spacewalk-backend` build was not updated acordingly.

This PR fixes the following issue on OBS:

```
[  235s] make[3]: Entering directory '/home/abuild/rpmbuild/BUILD/spacewalk-backend-git-84.3957aa0/server/handlers/xmlrpc'
[  235s] make[3]: *** No rule to make target 'abrt.py', needed by 'all'.  Stop.
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
