### PR TITLE
Ensure new files are synced just after writing them (bsc#1175660)

### DIFF
--- a/java/code/src/com/redhat/rhn/common/util/FileUtils.java
+++ b/java/code/src/com/redhat/rhn/common/util/FileUtils.java
@@ -23,13 +23,13 @@ import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
-import java.io.Writer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -61,12 +61,13 @@ public class FileUtils {
                 file.delete();
             }
             file.createNewFile();
-            Writer output = new BufferedWriter(new FileWriter(file));
-            try {
-              output.write(contents);
-            }
-            finally {
-              output.close();
+            try (FileOutputStream fos = new FileOutputStream(file);
+                 FileWriter fw = new FileWriter(fos.getFD());
+                 BufferedWriter output = new BufferedWriter(fw)) {
+                output.write(contents);
+                output.flush();
+                fw.flush();
+                fos.getFD().sync();
             }
         }
         catch (Exception e) {

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Ensure new files are synced just after writing them (bsc#1175660)
 - Add 'mgr_origin_server' to Salt pillar data (bsc#1180439)
 - enable openscap auditing for salt systems in SSM (bsc#1157711)
 - Removed "Software Crashes" feature


### PR DESCRIPTION
## What does this PR change?

This PR fixes a race condition that happens on scenarios where there are lot of SSH minions and SSH actions being executed. When the SSH workers from Java are managing SSH actions for minions, involving "salt-ssh", those workers generates the custom roster file to be used and starts the "salt-ssh" subprocess.

When there are lot of actions happening at the same time it might happen that those roster files created by the SSH workers are not yet synced on the filesystem at the time the corresponding "salt-ssh" subprocess tries to read that roster file. If that's the case, the "salt-ssh" can stuck or raise a 500 error:

```
2020-12-05 21:45:00,469 [Thread-10925] ERROR com.redhat.rhn.taskomatic.task.SSHPush - com.suse.salt.netapi.exception.SaltException: Response code: 500
java.lang.RuntimeException: com.suse.salt.netapi.exception.SaltException: Response code: 500
	at com.suse.manager.webui.services.impl.SaltService.callSync(SaltService.java:244)
	at com.suse.manager.webui.services.impl.SaltService.ping(SaltService.java:253)
	at com.redhat.rhn.taskomatic.task.sshpush.SSHPushWorkerSalt.performCheckin(SSHPushWorkerSalt.java:337)
	at com.redhat.rhn.taskomatic.task.sshpush.SSHPushWorkerSalt.lambda$run$0(SSHPushWorkerSalt.java:122)
	at java.base/java.util.Optional.ifPresent(Optional.java:183)
	at com.redhat.rhn.taskomatic.task.sshpush.SSHPushWorkerSalt.run(SSHPushWorkerSalt.java:110)
	at EDU.oswego.cs.dl.util.concurrent.PooledExecutor$Worker.run(PooledExecutor.java:732)
	at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: com.suse.salt.netapi.exception.SaltException: Response code: 500
	at com.suse.salt.netapi.client.impl.HttpAsyncClientImpl.createSaltException(HttpAsyncClientImpl.java:145)
	at com.suse.salt.netapi.client.impl.HttpAsyncClientImpl.access$000(HttpAsyncClientImpl.java:27)
	at com.suse.salt.netapi.client.impl.HttpAsyncClientImpl$1.completed(HttpAsyncClientImpl.java:121)
	at com.suse.salt.netapi.client.impl.HttpAsyncClientImpl$1.completed(HttpAsyncClientImpl.java:101)
	at org.apache.http.concurrent.BasicFuture.completed(BasicFuture.java:123)
	at org.apache.http.impl.nio.client.DefaultClientExchangeHandlerImpl.responseCompleted(DefaultClientExchangeHandlerImpl.java:181)
	at org.apache.http.nio.protocol.HttpAsyncRequestExecutor.processResponse(HttpAsyncRequestExecutor.java:442)
	at org.apache.http.nio.protocol.HttpAsyncRequestExecutor.inputReady(HttpAsyncRequestExecutor.java:332)
	at org.apache.http.impl.nio.DefaultNHttpClientConnection.consumeInput(DefaultNHttpClientConnection.java:265)
	at org.apache.http.impl.nio.client.InternalIODispatch.onInputReady(InternalIODispatch.java:81)
	at org.apache.http.impl.nio.client.InternalIODispatch.onInputReady(InternalIODispatch.java:39)
	at org.apache.http.impl.nio.reactor.AbstractIODispatch.inputReady(AbstractIODispatch.java:121)
	at org.apache.http.impl.nio.reactor.BaseIOReactor.readable(BaseIOReactor.java:162)
	at org.apache.http.impl.nio.reactor.AbstractIOReactor.processEvent(AbstractIOReactor.java:337)
	at org.apache.http.impl.nio.reactor.AbstractIOReactor.processEvents(AbstractIOReactor.java:315)
	at org.apache.http.impl.nio.reactor.AbstractIOReactor.execute(AbstractIOReactor.java:276)
	at org.apache.http.impl.nio.reactor.BaseIOReactor.execute(BaseIOReactor.java:104)
	at org.apache.http.impl.nio.reactor.AbstractMultiworkerIOReactor$Worker.run(AbstractMultiworkerIOReactor.java:588)
	... 1 more
```   

This PR fixes the way Java generates the roster files to ensure those files are actually synced in the filesystem just after we created them instead of delegating the syncing to the underlying Java stack. This seems to avoid the race condition from happening.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **bugfix**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/12238

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
