### PR TITLE
Filter by package state name

### DIFF
--- a/testsuite/features/build_validation/init_clients/sle11sp4_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle11sp4_ssh_minion.feature
@@ -33,6 +33,8 @@ Feature: Bootstrap a SLES 11 SP4 Salt SSH Minion
     Then I should see a "Package States" text
     When I follow "Search" in the content area
     And I wait until button "Search" becomes enabled
+    And I enter "sle-manager-tools-release" as the filtered package states name
+    And I click on "Search" in element "search-row"
     And I remove package "sle-manager-tools-release" from highstate
 
   # WORKAROUND bsc#1181847

--- a/testsuite/features/build_validation/init_clients/sle12sp4_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle12sp4_ssh_minion.feature
@@ -33,6 +33,8 @@ Feature: Bootstrap a SLES 12 SP4 Salt SSH Minion
     Then I should see a "Package States" text
     When I follow "Search" in the content area
     And I wait until button "Search" becomes enabled
+    And I enter "sle-manager-tools-release" as the filtered package states name
+    And I click on "Search" in element "search-row"
     And I remove package "sle-manager-tools-release" from highstate
 
   # WORKAROUND bsc#1181847

--- a/testsuite/features/build_validation/init_clients/sle15_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15_ssh_minion.feature
@@ -33,6 +33,8 @@ Feature: Bootstrap a SLES 15 Salt SSH Minion
     Then I should see a "Package States" text
     When I follow "Search" in the content area
     And I wait until button "Search" becomes enabled
+    And I enter "sle-manager-tools-release" as the filtered package states name
+    And I click on "Search" in element "search-row"
     And I remove package "sle-manager-tools-release" from highstate
 
   # WORKAROUND bsc#1181847

--- a/testsuite/features/build_validation/init_clients/sle15sp1_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp1_ssh_minion.feature
@@ -33,6 +33,8 @@ Feature: Bootstrap a SLES 15 SP1 Salt SSH Minion
     Then I should see a "Package States" text
     When I follow "Search" in the content area
     And I wait until button "Search" becomes enabled
+    And I enter "sle-manager-tools-release" as the filtered package states name
+    And I click on "Search" in element "search-row"
     And I remove package "sle-manager-tools-release" from highstate
 
   # WORKAROUND bsc#1181847

--- a/testsuite/features/build_validation/init_clients/sle15sp2_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp2_ssh_minion.feature
@@ -33,6 +33,8 @@ Feature: Bootstrap a SLES 15 SP2 Salt SSH Minion
     Then I should see a "Package States" text
     When I follow "Search" in the content area
     And I wait until button "Search" becomes enabled
+    And I enter "sle-manager-tools-release" as the filtered package states name
+    And I click on "Search" in element "search-row"
     And I remove package "sle-manager-tools-release" from highstate
 
   # WORKAROUND bsc#1181847

--- a/testsuite/features/build_validation/init_clients/sle15sp3_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp3_ssh_minion.feature
@@ -33,6 +33,8 @@ Feature: Bootstrap a SLES 15 SP3 Salt SSH Minion
     Then I should see a "Package States" text
     When I follow "Search" in the content area
     And I wait until button "Search" becomes enabled
+    And I enter "sle-manager-tools-release" as the filtered package states name
+    And I click on "Search" in element "search-row"
     And I remove package "sle-manager-tools-release" from highstate
 
   # WORKAROUND bsc#1181847

--- a/testsuite/features/init_clients/sle_ssh_minion.feature
+++ b/testsuite/features/init_clients/sle_ssh_minion.feature
@@ -33,6 +33,8 @@ Feature: Bootstrap a Salt host managed via salt-ssh
     Then I should see a "Package States" text
     When I follow "Search" in the content area
     And I wait until button "Search" becomes enabled
+    And I enter "sle-manager-tools-release" as the filtered package states name
+    And I click on "Search" in element "search-row"
     And I remove package "sle-manager-tools-release" from highstate
 
 @proxy

--- a/testsuite/features/secondary/minssh_bootstrap_xmlrpc.feature
+++ b/testsuite/features/secondary/minssh_bootstrap_xmlrpc.feature
@@ -41,6 +41,8 @@ Feature: Register a salt-ssh system via XML-RPC
     Then I should see a "Package States" text
     When I follow "Search" in the content area
     And I wait until button "Search" becomes enabled
+    And I enter "sle-manager-tools-release" as the filtered package states name
+    And I click on "Search" in element "search-row"
     And I remove package "sle-manager-tools-release" from highstate
 
 @ssh_minion

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -801,8 +801,8 @@ Then(/^I click on the filter button until page does contain "([^"]*)" text$/) do
   end
 end
 
-When(/^I enter "([^"]*)" as the filtered system name$/) do |input|
-  find("input[placeholder='Filter by System Name: ']").set(input)
+When(/^I enter "([^"]*)" as the filtered package states name$/) do |input|
+  find("input[placeholder='Search package']").set(input)
 end
 
 When(/^I enter "([^"]*)" as the filtered package name$/) do |input|


### PR DESCRIPTION
## What does this PR change?

In our QAM and BV tests, we have a long list of package states in the table, so we need to first filter by name to be able to remove one of them.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.0 https://github.com/SUSE/spacewalk/pull/14015
- Manager-4.1 https://github.com/SUSE/spacewalk/pull/14018

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
