### PR TITLE
Testsuite: Replace pidof with pgrep

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -493,8 +493,8 @@ When(/^the server starts mocking an IPMI host$/) do
 end
 
 When(/^the server stops mocking an IPMI host$/) do
-  $server.run('kill $(pidof ipmi_sim)')
-  $server.run('kill $(pidof -x fake_ipmi_host.sh)')
+  $server.run('pkill ipmi_sim')
+  $server.run('pkill fake_ipmi_host.sh || :')
 end
 
 When(/^the server starts mocking a Redfish host$/) do


### PR DESCRIPTION
## What does this PR change?
The current sles15sp3o image at the CI doesn't ship `pidof`; use `pgrep`
instead which is available.

- testsuite/features/step_definitions/command_steps.rb:
Replace pidof with pgrep.

## Links
### Ports:
- Manager4-.1: https://github.com/SUSE/spacewalk/pull/13923
- Manager-4.0: https://github.com/SUSE/spacewalk/pull/13924

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)
