### PR TITLE
Enhance state api

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/server/MinionServerFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/server/MinionServerFactory.java
@@ -62,9 +62,9 @@ public class MinionServerFactory extends HibernateFactory {
     }
 
     /**
-     * Lookup all Servers that belong to an org
+     * Lookup all Minion Servers that can be managed by the given user
      * @param user the user servers are visible to
-     * @return the Server found
+     * @return stream of MinionServer found
      */
     public static Stream<MinionServer> lookupVisibleToUser(User user) {
         return user.getServers().stream().flatMap(

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- enahance schedule states XMLRPC API
 - Cleanup sessions via SQL query instead of SQL function (bsc#1180224)
 - Do not call page decorator in HEAD requests (bsc#1181228)
 - Allow to configure request timeout (bsc#1178767)


### PR DESCRIPTION
## What does this PR change?

Enhance the SystemHandler  and add more schedule states API calls.
Call Highstate for multiple systems and call an individual list of states for one or multiple systems.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- XMLRPC API doc added

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
