### PR TITLE
Usage of "edit" icon on Content Lifecycle Management

### DIFF
--- a/web/html/src/components/panels/CreatorPanel.js
+++ b/web/html/src/components/panels/CreatorPanel.js
@@ -22,6 +22,7 @@ type Props = {
   disableDelete?: boolean,
   disableOperations?: boolean,
   collapsible?: boolean,
+  icon?: string,
   customIconClass?: string,
 };
 
@@ -55,7 +56,7 @@ const CreatorPanel = (props: Props) => {
           !props.disableEditing &&
           <ModalLink
             id={`${props.id}-modal-link`}
-            icon="fa-plus"
+            icon={props.icon ? props.icon : "fa-plus"}
             className="btn-link"
             text={props.creatingText}
             target={modalNameId}

--- a/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment-lifecycle.js
+++ b/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment-lifecycle.js
@@ -95,6 +95,7 @@ const EnvironmentLifecycle = (props: Props) => {
                     <CreatorPanel
                       id={`environment${environment.label}`}
                       title={environment.name}
+                      icon="fa-pencil"
                       creatingText="Edit"
                       panelLevel="3"
                       disableEditing={!hasEditingPermissions}

--- a/web/html/src/manager/content-management/shared/components/panels/properties/properties-edit.js
+++ b/web/html/src/manager/content-management/shared/components/panels/properties/properties-edit.js
@@ -53,6 +53,7 @@ const PropertiesEdit = (props: Props) => {
         disableEditing={!hasEditingPermissions}
         title={t('Project Properties')}
         collapsible
+        icon="fa-pencil"
         customIconClass="fa-small"
         onOpen={({ setItem, setErrors }) => {
             setItem(props.properties);

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,5 @@
+- Usage of "edit" icon on Content Lifecycle Management
+
 -------------------------------------------------------------------
 Mon Feb 01 10:22:21 CET 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

On CLM, use the `edit` icon for editing and the `add` icon for adding, instead of always using the `add` icon.

## GUI diff

No difference.

Before:

![Screenshot from 2021-02-08 10-39-42](https://user-images.githubusercontent.com/14297426/107232238-17259e00-6a19-11eb-9d1b-9811a9fa87e2.png)

![Screenshot from 2021-02-08 10-39-49](https://user-images.githubusercontent.com/14297426/107232248-1bea5200-6a19-11eb-9940-de0984c397fd.png)


After:

![Screenshot from 2021-02-08 10-39-06](https://user-images.githubusercontent.com/14297426/107232288-299fd780-6a19-11eb-86ff-1822e02155bf.png)

![Screenshot from 2021-02-08 10-38-51](https://user-images.githubusercontent.com/14297426/107232397-45a37900-6a19-11eb-95fd-8261e5d821e6.png)

- [x] **DONE**

## Documentation
- No documentation needed: Just changing an icon

- [x] **DONE**

## Test coverage
- No tests: Not applicable 

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
