### PR TITLE
Importing GPG keys manually on SSH minion could be a workaround

### DIFF
--- a/testsuite/features/build_validation/init_clients/ceos6_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ceos6_ssh_minion.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 SUSE LLC
+# Copyright (c) 2020-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 #  1) bootstrap a new CentOS minion via salt-ssh
@@ -23,6 +23,7 @@ Feature: Bootstrap a CentOS 6 Salt SSH minion
     Then I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "ceos6_ssh_minion"
 
+  # WORKAROUND bsc#1181847
   Scenario: Import the GPG keys for CentOS 6 Salt SSH minion
     When I import the GPG keys for "ceos6_ssh_minion"
 

--- a/testsuite/features/build_validation/init_clients/ceos7_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ceos7_ssh_minion.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 SUSE LLC
+# Copyright (c) 2020-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 #  1) bootstrap a new CentOS minion via salt-ssh
@@ -23,6 +23,7 @@ Feature: Bootstrap a CentOS 7 Salt SSH minion
     Then I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "ceos7_ssh_minion"
 
+  # WORKAROUND bsc#1181847
   Scenario: Import the GPG keys for CentOS 7 Salt SSH minion
     When I import the GPG keys for "ceos7_ssh_minion"
 

--- a/testsuite/features/build_validation/init_clients/ceos8_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ceos8_ssh_minion.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 SUSE LLC
+# Copyright (c) 2020-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 #  1) bootstrap a new CentOS minion via salt-ssh
@@ -23,6 +23,7 @@ Feature: Bootstrap a CentOS 8 Salt SSH minion
     Then I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "ceos8_ssh_minion"
 
+  # WORKAROUND bsc#1181847
   Scenario: Import the GPG keys for CentOS 8 Salt SSH minion
     When I import the GPG keys for "ceos8_ssh_minion"
 

--- a/testsuite/features/build_validation/init_clients/disabled/ubuntu2004_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/disabled/ubuntu2004_ssh_minion.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 SUSE LLC
+# Copyright (c) 2020-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 #  1) bootstrap a new Ubuntu minion via salt-ssh
@@ -25,6 +25,7 @@ Feature: Bootstrap a Ubuntu 20.04 Salt SSH Minion
     Then I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "ubuntu2004_ssh_minion"
 
+  # WORKAROUND bsc#1181847
   Scenario: Import the GPG keys for Ubuntu 20.04 Salt SSH Minion
     When I import the GPG keys for "ubuntu2004_ssh_minion"
 

--- a/testsuite/features/build_validation/init_clients/sle11sp4_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle11sp4_ssh_minion.feature
@@ -35,6 +35,7 @@ Feature: Bootstrap a SLES 11 SP4 Salt SSH Minion
     And I wait until button "Search" becomes enabled
     And I remove package "sle-manager-tools-release" from highstate
 
+  # WORKAROUND bsc#1181847
   Scenario: Import the GPG keys for SLES 11 SP4 Salt SSH Minion
     When I import the GPG keys for "sle11sp4_ssh_minion"
 

--- a/testsuite/features/build_validation/init_clients/sle12sp4_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle12sp4_ssh_minion.feature
@@ -35,6 +35,7 @@ Feature: Bootstrap a SLES 12 SP4 Salt SSH Minion
     And I wait until button "Search" becomes enabled
     And I remove package "sle-manager-tools-release" from highstate
 
+  # WORKAROUND bsc#1181847
   Scenario: Import the GPG keys for SLES 12 SP4 SSH Minion
     When I import the GPG keys for "sle12sp4_ssh_minion"
 

--- a/testsuite/features/build_validation/init_clients/sle15_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15_ssh_minion.feature
@@ -35,6 +35,7 @@ Feature: Bootstrap a SLES 15 Salt SSH Minion
     And I wait until button "Search" becomes enabled
     And I remove package "sle-manager-tools-release" from highstate
 
+  # WORKAROUND bsc#1181847
   Scenario: Import the GPG keys for SLES 15 Salt SSH Minion
     When I import the GPG keys for "sle15_ssh_minion"
 

--- a/testsuite/features/build_validation/init_clients/sle15sp1_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp1_ssh_minion.feature
@@ -35,6 +35,7 @@ Feature: Bootstrap a SLES 15 SP1 Salt SSH Minion
     And I wait until button "Search" becomes enabled
     And I remove package "sle-manager-tools-release" from highstate
 
+  # WORKAROUND bsc#1181847
   Scenario: Import the GPG keys for SLES 15 SP1 Salt SSH Minion
     When I import the GPG keys for "sle15sp1_ssh_minion"
 

--- a/testsuite/features/build_validation/init_clients/sle15sp2_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp2_ssh_minion.feature
@@ -35,6 +35,7 @@ Feature: Bootstrap a SLES 15 SP2 Salt SSH Minion
     And I wait until button "Search" becomes enabled
     And I remove package "sle-manager-tools-release" from highstate
 
+  # WORKAROUND bsc#1181847
   Scenario: Import the GPG keys for SLES 15 SP2 Salt SSH Minion
     When I import the GPG keys for "sle15sp2_ssh_minion"
 

--- a/testsuite/features/build_validation/init_clients/sle15sp3_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp3_ssh_minion.feature
@@ -35,6 +35,7 @@ Feature: Bootstrap a SLES 15 SP3 Salt SSH Minion
     And I wait until button "Search" becomes enabled
     And I remove package "sle-manager-tools-release" from highstate
 
+  # WORKAROUND bsc#1181847
   Scenario: Import the GPG keys for SLES 15 SP3 Salt SSH Minion
     When I import the GPG keys for "sle15sp3_ssh_minion"
 

--- a/testsuite/features/build_validation/init_clients/ubuntu1604_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ubuntu1604_ssh_minion.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 SUSE LLC
+# Copyright (c) 2020-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 #  1) bootstrap a new Ubuntu minion via salt-ssh
@@ -25,6 +25,7 @@ Feature: Bootstrap a Ubuntu 16.04 Salt SSH minion
     Then I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "ubuntu1604_ssh_minion"
 
+  # WORKAROUND bsc#1181847
   Scenario: Import the GPG keys for Ubuntu 16.04 Salt SSH minion
     When I import the GPG keys for "ubuntu1604_ssh_minion"
 

--- a/testsuite/features/build_validation/init_clients/ubuntu1804_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ubuntu1804_ssh_minion.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 SUSE LLC
+# Copyright (c) 2020-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 #  1) bootstrap a new Ubuntu minion via salt-ssh
@@ -25,6 +25,7 @@ Feature: Bootstrap a Ubuntu 18.04 Salt SSH Minion
     Then I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "ubuntu1804_ssh_minion"
 
+  # WORKAROUND bsc#1181847
   Scenario: Import the GPG keys for 18.04 Salt SSH Minion
     When I import the GPG keys for "ubuntu1804_ssh_minion"
 

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -472,6 +472,7 @@ When(/^I install the GPG key of the test packages repository on the PXE boot min
   $server.run("salt #{system_name} cmd.run 'rpmkeys --import #{dest}'")
 end
 
+# WORKAROUND bsc#1181847
 When(/^I import the GPG keys for "([^"]*)"$/) do |host|
   node = get_target(host)
   gpg_keys = get_gpg_keys(node)


### PR DESCRIPTION
## What does this PR change?

This PR adds a comment about a workaround we do for SSH minions. We import the GPG key manually.

If https://bugzilla.suse.com/show_bug.cgi?id=1181847 is not a bug, but a feature, then this comment will need to be ajusted again in a separate PR.


## Links

Ports:
* 4.0: SUSE/spacewalk#13934
* 4.1: SUSE/spacewalk#13933


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
