### PR TITLE
Fix typo in debrepo handling

### DIFF
--- a/backend/common/repo.py
+++ b/backend/common/repo.py
@@ -302,7 +302,7 @@ class DpkgRepo:
             release_file = self._get_parent_url(local_path, 2, "InRelease")
             self._flat = False
         elif os.access(self._get_parent_url(local_path, 2, "Release"), os.R_OK):
-            release_file = self._get_parent_url(local_path, 2, "InRelease")
+            release_file = self._get_parent_url(local_path, 2, "Release")
             self._flat = False
         else:
             self._flat = True

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Fix requesting Release file in debian repos (bsc#1182006)
 - Removed "Software Crashes" feature
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Checking for `Release` but requesting `InRelease` afterwards is just wrong.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes #
Tracks https://github.com/SUSE/spacewalk/pull/13938

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
