### PR TITLE
Traditional stack change ssl implementation

### DIFF
--- a/client/rhel/rhnlib/rhn/connections.py
+++ b/client/rhel/rhnlib/rhn/connections.py
@@ -249,7 +249,7 @@ class HTTPSProxyConnection(HTTPProxyConnection):
             raise xmlrpclib.ProtocolError(host,
                 response.status, response.reason, response.msg)
         self.sock = SSL.SSLSocket(self.sock, self.trusted_certs)
-        self.sock.init_ssl()
+        self.sock.init_ssl(self.host)
 
     def putrequest(self, method, url, skip_host=0):
         return HTTPConnection.putrequest(self, method, url, skip_host=skip_host)

--- a/client/rhel/rhnlib/rhnlib.changes
+++ b/client/rhel/rhnlib/rhnlib.changes
@@ -1,3 +1,6 @@
+- change SSL implementation to python ssl for better SAN and
+  hostname matching support (bsc#1181807)
+
 -------------------------------------------------------------------
 Fri Sep 18 11:29:26 CEST 2020 - jgonzalez@suse.com
 

--- a/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes
+++ b/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes
@@ -1,3 +1,5 @@
+- adapt to new SSL implementation of rhnlib (bsc#1181807)
+
 -------------------------------------------------------------------
 Wed Jan 27 13:03:05 CET 2021 - jgonzalez@suse.com
 

--- a/client/rhel/spacewalk-client-tools/src/bin/rhn_check.py
+++ b/client/rhel/spacewalk-client-tools/src/bin/rhn_check.py
@@ -41,8 +41,6 @@ if not hasattr(t, 'ugettext'):
     t.ugettext = t.gettext
 _ = t.ugettext
 
-import OpenSSL
-
 # disable sgmlop module
 # it breaks rhn_check when loaded during xmlrpclib import
 sys.modules['sgmlop'] = None
@@ -141,7 +139,7 @@ class CheckCli(rhncli.RhnCli):
         except up2dateErrors.ServerCapabilityError:
             print(sys.exc_info()[1])
             sys.exit(1)
-        except OpenSSL.SSL.Error:
+        except SSL.SSL.SSLError:
             print("ERROR: SSL errors detected")
             print("%s" % sys.exc_info()[1])
             sys.exit(-1)
@@ -175,7 +173,7 @@ class CheckCli(rhncli.RhnCli):
         except up2dateErrors.ServerCapabilityError:
             print(sys.exc_info()[1])
             sys.exit(1)
-        except SSL.Error:
+        except SSL.SSL.SSLError:
             print("ERROR: SSL errors detected")
             print("%s" % sys.exc_info()[1])
             sys.exit(-1)

--- a/client/rhel/spacewalk-client-tools/src/up2date_client/rhncli.py
+++ b/client/rhel/spacewalk-client-tools/src/up2date_client/rhncli.py
@@ -38,10 +38,7 @@ import socket
 from optparse import Option
 from optparse import OptionParser
 
-from OpenSSL import SSL
-from OpenSSL import crypto
-
-from rhn import rpclib
+from rhn import rpclib, SSL
 from rhn.i18n import sstr
 
 try: # python2
@@ -107,15 +104,18 @@ class RhnCli(object):
         except IOError:
             sys.stderr.write(sstr(_("There was some sort of I/O error: %s\n") % sys.exc_info()[1]))
             sys.exit(1)
-        except SSL.Error:
+        except SSL.SSL.SSLError as err:
+            if err.args[0] == SSL.SSL_ERROR_SYSCALL:
+                sys.stderr.write(sstr("SSL.SSL.SSLSyscallError: %s\n" % str(sys.exc_info()[1])))
+                sys.exit(2)
             sys.stderr.write(sstr(_("There was an SSL error: %s\n") % sys.exc_info()[1]))
             sys.stderr.write(sstr(_("A common cause of this error is the system time being incorrect. " \
                                "Verify that the time on this system is correct.\n")))
             sys.exit(1)
-        except (SSL.SysCallError, socket.error):
-            sys.stderr.write(sstr("OpenSSL.SSL.SysCallError: %s\n" % str(sys.exc_info()[1])))
+        except (socket.error):
+            sys.stderr.write(sstr("SSL.SSL.SSLSyscallError: %s\n" % str(sys.exc_info()[1])))
             sys.exit(2)
-        except crypto.Error:
+        except SSL.crypto.Error:
             sys.stderr.write(sstr(_("There was a SSL crypto error: %s\n") % sys.exc_info()[1]))
         except SystemExit:
             raise

--- a/client/rhel/spacewalk-client-tools/src/up2date_client/rhnregGui.py
+++ b/client/rhel/spacewalk-client-tools/src/up2date_client/rhnregGui.py
@@ -65,7 +65,7 @@ from up2date_client import up2dateUtils
 from up2date_client import config
 import OpenSSL
 from up2date_client import up2dateLog
-from rhn import rpclib
+from rhn import rpclib, SSL
 from rhn.connections import idn_puny_to_unicode
 from up2date_client import rhnreg_constants
 from up2date_client.pmPlugin import PM_PLUGIN_NAME, PM_PLUGIN_CONF
@@ -960,7 +960,7 @@ class ProvideCertificatePage:
                     errorWindow(rhnreg_constants.SSL_CERT_ERROR_MSG % (certFile, server_url))
 
                 return ERROR_WAS_HANDLED
-            except OpenSSL.SSL.Error:
+            except (OpenSSL.SSL.Error, SSL.SSL.SSLError):
                 # TODO Modify rhnlib to raise a unique exception for the not a
                 # cert file case.
                 errorWindow(_("There was an SSL error. This could be because the file you picked was not a certificate file."))

--- a/client/rhel/spacewalk-client-tools/src/up2date_client/rhnserver.py
+++ b/client/rhel/spacewalk-client-tools/src/up2date_client/rhnserver.py
@@ -32,11 +32,11 @@
 
 
 from rhn.tb import raise_with_tb
+from rhn import SSL
 from up2date_client import rpcServer
 from up2date_client import up2dateErrors
 from up2date_client import capabilities
 import sys
-import OpenSSL
 
 try: # python2
     import xmlrpclib
@@ -67,7 +67,7 @@ class _DoCallWrapper(object):
             return rpcServer.doCall(method, *args, **kwargs)
         except xmlrpclib.Fault:
             raise_with_tb(self.__exception_from_fault(sys.exc_info()[1]))
-        except OpenSSL.SSL.Error:
+        except SSL.SSL.SSLError:
             # TODO This should probably be moved to rhnlib and raise an
             # exception that subclasses OpenSSL.SSL.Error
             # TODO Is there a better way to detect cert failures?

--- a/client/tools/mgr-osad/mgr-osad.changes
+++ b/client/tools/mgr-osad/mgr-osad.changes
@@ -1,3 +1,5 @@
+- adapt to new SSL implementation of rhnlib (bsc#1181807)
+
 -------------------------------------------------------------------
 Thu Dec 03 13:35:30 CET 2020 - jgonzalez@suse.com
 

--- a/client/tools/mgr-osad/mgr-osad.spec
+++ b/client/tools/mgr-osad/mgr-osad.spec
@@ -284,7 +284,7 @@ SELinux policy module supporting osa-dispatcher.
 %if 0%{?suse_version}
 cp prog.init.SUSE prog.init
 %endif
-%if 0%{?fedora} || 0%{?rhel}
+%if 0%{?fedora} || 0%{?rhel} >= 8
 sed -i 's@^#!/usr/bin/python$@#!/usr/bin/python3 -s@' invocation.py
 %endif
 

--- a/proxy/installer/rhn-proxy-activate.py
+++ b/proxy/installer/rhn-proxy-activate.py
@@ -198,7 +198,7 @@ def _errorHandler(pre='', post=''):
             errorString = errorString + s
         except xmlrpclib.Fault as e:
             errorCode, errorString = _getActivationError(e)
-        except SSL.SSL.Error as e:
+        except SSL.SSL.SSLError as e:
             errorCode = 13
             errorString = "ERROR: failed SSL connection - bad or expired cert?"
         except Exception as e:  # pylint: disable=E0012, W0703
@@ -282,7 +282,7 @@ def _deactivateProxy_api_v3_x(options, cfg):
             else:
                 errorString = "WARNING: upon deactivation attempt: %s" % errorString
                 sys.stderr.write("%s\n" % errorString)
-        except SSL.SSL.Error:
+        except SSL.SSL.SSLError:
             sys.stderr.write(errorString + '\n')
             sys.exit(errorCode)
         except (xmlrpclib.ProtocolError, socket.error):
@@ -314,7 +314,7 @@ def _activateProxy_api_v3_x(options, cfg):
         errorCode, errorString = _errorHandler()
         try:
             raise
-        except SSL.SSL.Error:
+        except SSL.SSL.SSLError:
             # let's force a system exit for this one.
             sys.stderr.write(errorString + '\n')
             sys.exit(errorCode)

--- a/proxy/installer/spacewalk-proxy-installer.changes
+++ b/proxy/installer/spacewalk-proxy-installer.changes
@@ -1,3 +1,5 @@
+- adapt to new SSL implementation of rhnlib (bsc#1181807)
+
 -------------------------------------------------------------------
 Wed Jan 27 13:04:41 CET 2021 - jgonzalez@suse.com
 

--- a/proxy/proxy/rhnProxyAuth.py
+++ b/proxy/proxy/rhnProxyAuth.py
@@ -283,9 +283,9 @@ problems, isn't running, or the token is somehow corrupt.
                 token = None
                 time.sleep(.25)
                 continue
-            except SSL.SSL.Error as e:
+            except SSL.SSL.SSLError as e:
                 token = None
-                error = ['rhn.SSL.SSL.Error', repr(e), str(e)]
+                error = ['rhn.SSL.SSL.SSLError', repr(e), str(e)]
                 log_error(error)
                 Traceback(mail=0)
                 time.sleep(.25)
@@ -330,7 +330,7 @@ problems, isn't running, or the token is somehow corrupt.
                     raise rhnFault(1000,
                                 _("SUSE Manager Proxy error (error: %s). "
                                   "Please contact your system administrator.") % error[0])
-                if error[0] in ('rhn.SSL.SSL.Error', 'socket.sslerror'):
+                if error[0] in ('rhn.SSL.SSL.SSLError', 'socket.sslerror'):
                     raise rhnFault(1000,
                                 _("SUSE Manager Proxy error (SSL issues? Error: %s). "
                                   "Please contact your system administrator.") % error[0])

--- a/proxy/proxy/spacewalk-proxy.changes
+++ b/proxy/proxy/spacewalk-proxy.changes
@@ -1,3 +1,5 @@
+- adapt to new SSL implementation of rhnlib (bsc#1181807)
+
 -------------------------------------------------------------------
 Wed Jan 27 13:19:10 CET 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Change rhnlib SSL implementation to use python ssl instead of pyOpenSSL. This brings us better SAN support and
better hostname matching during SSL handshake.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Issue: https://github.com/SUSE/spacewalk/issues/13902
Tracks https://github.com/SUSE/spacewalk/pull/13988 https://github.com/SUSE/spacewalk/pull/13989

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
