### PR TITLE
Fix action result string format

### DIFF
--- a/backend/server/handlers/xmlrpc/queue.py
+++ b/backend/server/handlers/xmlrpc/queue.py
@@ -24,6 +24,7 @@ except ImportError:
     import xmlrpc.client as xmlrpclib
 
 from uyuni.common.usix import IntType, TupleType, UnicodeType, raise_with_tb
+from rhn.i18n import sstr
 
 # Global modules
 from spacewalk.common import rhnFlags
@@ -433,10 +434,7 @@ class Queue(rhnHandler):
                 raise_with_tb(rhnFault(30, _("Invalid action value type %s (%s)") %
                                (action_id, type(action_id))), sys.exc_info()[2])
         # bring message into correct format
-        try:
-            message = message.encode('utf8')
-        except UnicodeEncodeError:
-            pass
+        message = sstr(message)
 
         # Authenticate the system certificate
         self.auth_system(system_id)

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- fix string conversion of action result
 - Fix requesting Release file in debian repos (bsc#1182006)
 - Removed "Software Crashes" feature
 


### PR DESCRIPTION
## What does this PR change?

The string conversion was made for python2. With python3 we produce a byte string. Until Postgresql 12 inserting a byte string into a TEXT column just worked and we got a human readable text. But with postgresql 13, it store an ASCII representation of the string.
This PR does the conversion correct using utility function of rhn.i18n.

## GUI diff

No difference.

Before:

![image](https://user-images.githubusercontent.com/1038917/107529320-0ad94680-6bbb-11eb-9db0-11e149b3db3f.png)


After:

![image](https://user-images.githubusercontent.com/1038917/107529230-f39a5900-6bba-11eb-848b-979adeb839e1.png)


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
