### PR TITLE
VM Autoinstallation: don't create re-activation key

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/events/test/SsmPowerManagementActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/events/test/SsmPowerManagementActionTest.java
@@ -75,7 +75,7 @@ public class SsmPowerManagementActionTest extends BaseTestCaseWithUser {
 
         for (Server server : servers) {
             String cobblerName = CobblerSystemCreateCommand
-                .getCobblerSystemRecordName(server);
+                .getCobblerSystemRecordName(server.getName(), server.getOrgId());
             SystemRecord systemRecord = SystemRecord.lookupByName(connection, cobblerName);
             assertContains(MockConnection.getPowerCommands(), "power_system on " +
                 systemRecord.getId());

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerPowerSettingsUpdateCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerPowerSettingsUpdateCommand.java
@@ -126,7 +126,7 @@ public class CobblerPowerSettingsUpdateCommand extends CobblerCommand {
                 CobblerConnection connection = getCobblerConnection();
                 Image image = createDummyImage(connection);
                 systemRecord = SystemRecord.create(connection,
-                    CobblerSystemCreateCommand.getCobblerSystemRecordName(server), image);
+                    CobblerSystemCreateCommand.getCobblerSystemRecordName(server.getName(), server.getOrgId()), image);
                 systemRecord.enableNetboot(false);
                 server.setCobblerId(systemRecord.getId());
             }

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerVirtualSystemCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerVirtualSystemCommand.java
@@ -14,6 +14,7 @@
  */
 package com.redhat.rhn.manager.kickstart.cobbler;
 
+import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.validator.ValidatorError;
 import com.redhat.rhn.domain.action.kickstart.KickstartGuestAction;
 import com.redhat.rhn.domain.action.kickstart.KickstartGuestActionDetails;
@@ -44,6 +45,7 @@ public class CobblerVirtualSystemCommand extends CobblerSystemCreateCommand {
             .getLogger(CobblerVirtualSystemCommand.class);
 
     private String guestName;
+    private String hostName;
 
     /**
      * Constructor
@@ -57,6 +59,24 @@ public class CobblerVirtualSystemCommand extends CobblerSystemCreateCommand {
             String cobblerProfileName, String guestNameIn, KickstartData ksData) {
         super(serverIn, cobblerProfileName, ksData);
         guestName = guestNameIn;
+        hostName = serverIn.getName();
+    }
+
+    /**
+     * Constructor for VMs on Salt Virtual hosts
+     *
+     * @param userIn the user creating the VM
+     * @param cobblerProfileName to use
+     * @param guestNameIn the guest name to create
+     * @param ksData the kickstart data to associate system with
+     * @param hostNameIn the name of the virtual host system
+     * @param orgId the organization ID the system will belong to
+     */
+    public CobblerVirtualSystemCommand(User userIn, String cobblerProfileName, String guestNameIn, KickstartData ksData,
+                                       String hostNameIn, Long orgId) {
+        super(userIn, cobblerProfileName, ksData, guestNameIn, orgId);
+        guestName = guestNameIn;
+        hostName = hostNameIn;
     }
 
     /**
@@ -74,6 +94,7 @@ public class CobblerVirtualSystemCommand extends CobblerSystemCreateCommand {
             String activationKeysIn, String guestNameIn) {
         super(userIn, serverIn, ksDataIn, mediaPathIn, activationKeysIn);
         guestName = guestNameIn;
+        hostName = serverIn.getName();
     }
 
     /**
@@ -85,6 +106,7 @@ public class CobblerVirtualSystemCommand extends CobblerSystemCreateCommand {
     public CobblerVirtualSystemCommand(User userIn, Server serverIn,
             String nameIn) {
         super(userIn, serverIn, nameIn);
+        hostName = serverIn.getName();
     }
 
     /**
@@ -92,7 +114,9 @@ public class CobblerVirtualSystemCommand extends CobblerSystemCreateCommand {
      */
     @Override
     public String getCobblerSystemRecordName() {
-        return super.getCobblerSystemRecordName() + ":" + guestName.replace(' ', '_');
+        String sep = ConfigDefaults.get().getCobblerNameSeparator();
+        return CobblerVirtualSystemCommand.getCobblerSystemRecordName(hostName, getOrgId()) + sep +
+                guestName.replace(' ', '_').replaceAll("[^a-zA-Z0-9_\\-\\.]", "");
     }
 
     @Override

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/test/CobblerPowerCommandTest.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/test/CobblerPowerCommandTest.java
@@ -53,7 +53,7 @@ public class CobblerPowerCommandTest extends BaseTestCaseWithUser {
             assertNull(new CobblerPowerCommand(user, server, operation).store());
 
             String cobblerName = CobblerSystemCreateCommand
-                .getCobblerSystemRecordName(server);
+                .getCobblerSystemRecordName(server.getName(), server.getOrgId());
             SystemRecord systemRecord = SystemRecord.lookupByName(connection, cobblerName);
             String cobblerCommand = null;
             switch (operation) {

--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -19,7 +19,6 @@ import static java.util.Optional.empty;
 import static java.util.Optional.of;
 import static java.util.Optional.ofNullable;
 
-import com.google.gson.reflect.TypeToken;
 import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.common.messaging.EventMessage;
 import com.redhat.rhn.common.messaging.MessageAction;
@@ -56,15 +55,17 @@ import com.redhat.rhn.manager.system.SystemManager;
 
 import com.suse.manager.reactor.utils.ValueMap;
 import com.suse.manager.webui.services.iface.SaltApi;
+import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.manager.webui.services.impl.MinionPendingRegistrationService;
 import com.suse.manager.webui.services.pillar.MinionPillarManager;
 import com.suse.manager.webui.utils.salt.custom.MinionStartupGrains;
-import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.salt.netapi.datatypes.target.MinionList;
 import com.suse.salt.netapi.errors.SaltError;
 import com.suse.salt.netapi.exception.SaltException;
 import com.suse.salt.netapi.results.Result;
 import com.suse.utils.Opt;
+
+import com.google.gson.reflect.TypeToken;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -216,7 +217,9 @@ public class RegisterMinionEventMessageAction implements MessageAction {
             },
             ak -> {
                 if (Objects.isNull(ak.getServer())) {
-                    LOG.error("Management Key is not a reactivation key: " + ak.getKey());
+                    if (Objects.isNull(ak.getKickstartSession())) {
+                        LOG.error("Management Key is not a reactivation key: " + ak.getKey());
+                    }
                     return false;
                 }
                 //considered valid reactivation key only in this case

--- a/java/code/src/com/suse/manager/webui/controllers/virtualization/VirtualGuestsController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/virtualization/VirtualGuestsController.java
@@ -528,8 +528,8 @@ public class VirtualGuestsController extends AbstractVirtualizationController {
                     CobblerXMLRPCHelper.getConnection(user), data.getCobblerId());
             KickstartData ksData = KickstartFactory.
                     lookupKickstartDataByCobblerIdAndOrg(user.getOrg(), cobblerProfile.getId());
-            CobblerVirtualSystemCommand cobblerCmd = new CobblerVirtualSystemCommand(host, cobblerProfile.getName(),
-                    data.getName(), ksData);
+            CobblerVirtualSystemCommand cobblerCmd = new CobblerVirtualSystemCommand(user, cobblerProfile.getName(),
+                    data.getName(), ksData, host.getName(), host.getOrgId());
             String ksHost = helper.getKickstartHost();
             cobblerCmd.setKickstartHost(ksHost);
             cobblerCmd.store();

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix registration of VM created with cobbler profile on Salt minion
 - Cleanup sessions via SQL query instead of SQL function (bsc#1180224)
 - Do not call page decorator in HEAD requests (bsc#1181228)
 - Allow to configure request timeout (bsc#1178767)


### PR DESCRIPTION
## What does this PR change?

When creating a virtual machine cobbler profile, the activation key is
created for the virtualization host since the VM doesn't exist yet.

In order to avoid the VM to be registered as a reactivation of its host,
don't generate the reactivation key.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: bug fix

- [X] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"  
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
