### PR TITLE
Add python3-dbus-python and dependencies to SLE15 bootstrap repos (bsc#1182071)

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -421,7 +421,14 @@ PKGLIST15SP0SP1_SALT = [
 ]
 
 PKGLIST15_TRAD = [
+    "dbus-1-glib",
+    "glib2-tools",
+    "gio-branding-SLE",
+    "girepository-1_0",
     "libgudev-1_0-0",
+    "libgirepository-1_0-1",
+    "libgio-2_0-0",
+    "libgobject-2_0-0",
     "libnewt0_52",
     "libslang2",
     "newt",
@@ -429,7 +436,9 @@ PKGLIST15_TRAD = [
     "python3-cffi",
     "python3-cryptography",
     "python-dmidecode",
+    "python3-dbus-python",
     "python3-dmidecode",
+    "python3-gobject",
     "python3-libxml2-python",
     "python3-netifaces",
     "python3-newt",
@@ -452,6 +461,7 @@ PKGLIST15_TRAD = [
     "python3-spacewalk-client-tools",
     "python3-uyuni-common-libs*",
     "mgr-daemon|spacewalksd",
+    "shared-mime-info",
     "suseRegisterInfo",
     "python3-suseRegisterInfo",
     "zypp-plugin-spacewalk",

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,7 @@
+- python3-dbus-python and dependencies not installed by default
+  on JeOS SLE15 images, add them to the bootstrap repository list
+  of packages for traditional (bsc#1182071)
+
 -------------------------------------------------------------------
 Fri Jan 29 16:51:52 CET 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Fix bootstrap of JeOS SLE15 clients, as python3-dbus-python and dependencies are not available and do not work.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Bugfix

- [x] **DONE**

## Test coverage
- No tests: QAM testsuite covers it

- [x] **DONE**

## Links

Fix for https://github.com/SUSE/spacewalk/issues/13951 (master)
Tracks https://github.com/SUSE/spacewalk/pull/13954

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
