### PR TITLE
Testsuite - add new testsuite profile for kiwi images

### DIFF
--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_40/config.xml
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_40/config.xml
@@ -62,8 +62,8 @@
     <repository type="rpm-md">
         <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Manager-Tools/15/x86_64/update/"/>
     </repository>
-    <repository type="rpm-md">  <!-- 4.0 development client toools -->
-        <source path="http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.0:/SLE15-SUSE-Manager-Tools/SLE_15/"/>
+    <repository type="rpm-md">
+        <source path="http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.1:/SLE15-SUSE-Manager-Tools/SLE_15/"/>
     </repository>
 
     <packages type="image">

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_41/config.sh
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_41/config.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+# Copyright (c) 2019-2021 SUSE LLC
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+#======================================
+# Functions...
+#--------------------------------------
+test -f /.kconfig && . /.kconfig
+test -f /.profile && . /.profile
+
+mkdir /var/lib/misc/reconfig_system
+
+#======================================
+# Greeting...
+#--------------------------------------
+echo "Configure image: [$name]..."
+
+#======================================
+# add missing fonts
+#--------------------------------------
+CONSOLE_FONT="eurlatgr.psfu"
+
+#======================================
+# prepare for setting root pw, timezone
+#--------------------------------------
+echo ** "reset machine settings"
+
+# FIXME:
+#sed -i 's/^root:[^:]*:/root:*:/' /etc/shadow
+rm -f /etc/machine-id \
+      /var/lib/zypp/AnonymousUniqueId \
+      /var/lib/systemd/random-seed \
+      /var/lib/dbus/machine-id
+
+#======================================
+# SuSEconfig
+#--------------------------------------
+echo "** Running suseConfig..."
+suseConfig
+
+echo "** Running ldconfig..."
+/sbin/ldconfig
+
+#======================================
+# Setup baseproduct link
+#--------------------------------------
+suseSetupProduct
+
+#======================================
+# Specify default runlevel
+#--------------------------------------
+baseSetRunlevel 3
+
+#======================================
+# Add missing gpg keys to rpm
+#--------------------------------------
+suseImportBuildKey
+
+#======================================
+# Enable DHCP on eth0
+#--------------------------------------
+cat >/etc/sysconfig/network/ifcfg-eth0 <<EOF
+BOOTPROTO='dhcp'
+MTU=''
+REMOTE_IPADDR=''
+STARTMODE='auto'
+ETHTOOL_OPTIONS=''
+USERCONTROL='no'
+EOF
+
+#======================================
+# Enable sshd
+#--------------------------------------
+chkconfig sshd on
+
+#======================================
+# Remove doc files
+#--------------------------------------
+baseStripDocs
+
+#======================================
+# Sysconfig Update
+#--------------------------------------
+echo '** Update sysconfig entries...'
+
+baseUpdateSysConfig /etc/sysconfig/network/dhcp DHCLIENT_SET_HOSTNAME yes
+
+# Enable firewalld
+chkconfig firewalld on
+
+# Set GRUB2 to boot graphically (bsc#1097428)
+sed -Ei"" "s/#?GRUB_TERMINAL=.+$/GRUB_TERMINAL=gfxterm/g" /etc/default/grub
+sed -Ei"" "s/#?GRUB_GFXMODE=.+$/GRUB_GFXMODE=auto/g" /etc/default/grub
+
+# Systemd controls the console font now
+echo FONT="$CONSOLE_FONT" >> /etc/vconsole.conf
+
+#======================================
+# SSL Certificates Configuration
+#--------------------------------------
+echo '** Rehashing SSL Certificates...'
+update-ca-certificates
+
+if [ ! -s /var/log/zypper.log ]; then
+	> /var/log/zypper.log
+fi
+
+# only for debugging
+#systemctl enable debug-shell.service
+
+baseCleanMount
+
+exit 0

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_41/config.xml
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_41/config.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<image schemaversion="6.1" name="POS_Image_JeOS7_head">
+<image schemaversion="6.1" name="POS_Image_JeOS7_41">
     <description type="system">
         <author>Admin User</author>
         <contact>noemail@example.com</contact>
-        <specification>SUSE Linux Enterprise 15 SP3 JeOS</specification>
+        <specification>SUSE Linux Enterprise 15 SP2 JeOS</specification>
     </description>
     <preferences>
         <version>7.0.0</version>
@@ -21,6 +21,10 @@
         <type filesystem="ext3" image="pxe" initrd_system="dracut"/>
     </preferences>
 
+    <users group="root">
+      <user home="/root" name="root" password="linux" pwdformat="plain" shell="/bin/bash"/>
+    </users>
+
     <drivers>
       <file name="drivers/block/virtio_blk.ko" />
     </drivers>
@@ -29,28 +33,28 @@
          in that case, sync those repos in SUSE Manager, and add them to the activation key;
          finally, re-enable option  '- -ignore-repos-used-for-build' in file 'kiwi-image-build.sls' -->
     <repository type="rpm-md">  <!-- product -->
-        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP3/x86_64/product/"/>
+        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP2/x86_64/product/"/>
     </repository>
     <repository type="rpm-md">
-        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Product-SLES/15-SP3/x86_64/update/"/>
+        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Product-SLES/15-SP2/x86_64/update/"/>
     </repository>
     <repository type="rpm-md">  <!-- base system -->
-        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP3/x86_64/product/"/>
+        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15-SP2/x86_64/product/"/>
     </repository>
     <repository type="rpm-md">
-        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP3/x86_64/update/"/>
+        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15-SP2/x86_64/update/"/>
     </repository>
     <repository type="rpm-md">  <!-- desktop applications -->
-        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Module-Desktop-Applications/15-SP3/x86_64/product/"/>
+        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Module-Desktop-Applications/15-SP2/x86_64/product/"/>
     </repository>
     <repository type="rpm-md">
-        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Desktop-Applications/15-SP3/x86_64/update/"/>
+        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Desktop-Applications/15-SP2/x86_64/update/"/>
     </repository>
     <repository type="rpm-md">  <!-- development tools -->
-        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Module-Development-Tools/15-SP3/x86_64/product/"/>
+        <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Module-Development-Tools/15-SP2/x86_64/product/"/>
     </repository>
     <repository type="rpm-md">
-        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Development-Tools/15-SP3/x86_64/update/"/>
+        <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Development-Tools/15-SP2/x86_64/update/"/>
     </repository>
     <repository type="rpm-md">  <!-- manager tools -->
         <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Manager-Tools/15/x86_64/product/"/>
@@ -58,8 +62,8 @@
     <repository type="rpm-md">
         <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Manager-Tools/15/x86_64/update/"/>
     </repository>
-    <repository type="rpm-md">  <!-- head development client toools -->
-        <source path="http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head:/SLE15-SUSE-Manager-Tools/SLE_15/"/>
+    <repository type="rpm-md">
+        <source path="http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.1:/SLE15-SUSE-Manager-Tools/SLE_15/"/>
     </repository>
 
     <packages type="image">
@@ -116,9 +120,6 @@
         <package name="dosfstools"/>
         <package name="xfsprogs"/>
     </packages>
-    <users group="root">
-      <user home="/root" name="root" password="linux" pwdformat="plain" shell="/bin/bash"/>
-    </users>
 
     <packages type="bootstrap">
         <package name="udev"/>

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_41/images.sh
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_41/images.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Copyright (c) 2019-2021 SUSE LLC
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+test -f /.kconfig && . /.kconfig
+test -f /.profile && . /.profile
+
+systemctl enable salt-minion.service
+
+# notify SUSE Manager about newly deployed image
+systemctl enable image-deployed.service
+
+# install bootloader and generate boot menu
+systemctl enable install-local-bootloader.service

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_41/root/etc/multipath.conf
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_41/root/etc/multipath.conf
@@ -1,0 +1,4 @@
+# workaround for bsc#1069169
+defaults {
+  find_multipaths smart
+}

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_41/root/etc/sysconfig/bootloader
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_41/root/etc/sysconfig/bootloader
@@ -1,0 +1,34 @@
+
+## Path:	System/Bootloader
+## Description:	Bootloader configuration
+## Type:	list(grub,grub2,grub2-efi,none)
+## Default:	grub2
+#
+# Type of bootloader in use.
+# For making the change effect run bootloader configuration tool
+# and configure newly selected bootloader
+#
+#
+LOADER_TYPE="grub2"
+
+## Path:	System/Bootloader
+## Description:	Bootloader configuration
+## Type:	yesno
+## Default:	"no"
+#
+# Enable UEFI Secure Boot support
+# This setting is only relevant to UEFI which supports Secure Boot. It won't
+# take effect on any other firmware type.
+#
+#
+SECURE_BOOT="no"
+
+## Path:	System/Bootloader
+## Description:	Bootloader configuration
+## Type:	yesno
+## Default:	"no"
+#
+# Enable Trusted Boot support
+# Only available for legacy (non-UEFI) boot.
+#
+TRUSTED_BOOT="no"

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_41/root/etc/systemd/system/image-deployed.service
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_41/root/etc/systemd/system/image-deployed.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Notify SUSE Manager about newly deployed image
+Requires=salt-minion.service
+After=salt-minion.service
+
+# only if there are no susemanager channels configured
+ConditionPathExists=!/etc/zypp/repos.d/susemanager:channels.repo
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/salt-call event.send suse/manager/image_deployed with_grains=True
+
+[Install]
+WantedBy=multi-user.target

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_41/root/etc/systemd/system/install-local-bootloader.service
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_41/root/etc/systemd/system/install-local-bootloader.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Install bootloader for local boot
+
+# only if not configured yet
+ConditionPathExists=!/boot/grub2/grub.cfg
+
+[Service]
+Type=oneshot
+ExecStartPre=/bin/bash -c 'if [ -e /sys/firmware/efi ]; then sed -i -e "s|^LOADER_TYPE=.*|LOADER_TYPE=\\"grub2-efi\\"|" /etc/sysconfig/bootloader; fi'
+ExecStartPre=/bin/bash -c 'if [ ! -e /sys/firmware/efi ]; then sed -i -e "s|^LOADER_TYPE=.*|LOADER_TYPE=\\"grub2\\"|" /etc/sysconfig/bootloader; fi'
+ExecStart=/bin/bash -c 'pbl --install ; dracut -f ; pbl --config '
+
+[Install]
+WantedBy=multi-user.target

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -39,8 +39,11 @@ end
 # determine image for PXE boot tests
 def compute_image_filename
   case ENV['PXEBOOT_IMAGE']
-  when 'sles15sp2', 'sles15sp2o', 'sles15sp3o'
+  when 'sles15sp3', 'sles15sp3o'
     'Kiwi/POS_Image-JeOS7_head'
+  when 'sles15sp2', 'sles15sp2o'
+    # Same image version is used in case of 4.0 and 4.1
+    'Kiwi/POS_Image-JeOS7_41'
   when 'sles15sp1', 'sles15sp1o'
     raise 'This is not supported image version.'
   else
@@ -50,8 +53,11 @@ end
 
 def compute_image_name
   case ENV['PXEBOOT_IMAGE']
-  when 'sles15sp2', 'sles15sp2o', 'sles15sp3o'
+  when 'sles15sp3', 'sles15sp3o'
     'POS_Image_JeOS7_head'
+  when 'sles15sp2', 'sles15sp2o'
+    # Same kiwi image version is used in case of 4.0 and 4.1
+    'POS_Image_JeOS7_41'
   when 'sles15sp1', 'sles15sp1o'
     raise 'This is not supported image version.'
   else


### PR DESCRIPTION
## What does this PR change?

PR updates kiwi profile for head and creates separate profile used for 4.1 and 4.0 testsuite.

JeOS7 template for SLE15SP3 was tested and proved to be working.

## Links

https://github.com/SUSE/spacewalk/issues/13655

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
