### PR TITLE
add bootstrap data for SLE 15 SP3 products

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -1087,6 +1087,22 @@ DATA = {
         'PDID' : [1946, 1712], 'BETAPDID' : [1928], 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/15/2/bootstrap/'
     },
+    'SLE-15-SP3-aarch64' : {
+        'PDID' : [2142, 1709], 'BETAPDID' : [1925], 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15_X86_ARM,
+        'DEST' : '/srv/www/htdocs/pub/repositories/sle/15/3/bootstrap/'
+    },
+    'SLE-15-SP3-ppc64le' : {
+        'PDID' : [2143, 1710], 'BETAPDID' : [1926], 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15_PPC,
+        'DEST' : '/srv/www/htdocs/pub/repositories/sle/15/3/bootstrap/'
+    },
+    'SLE-15-SP3-s390x' : {
+        'PDID' : [2144, 1711], 'BETAPDID' : [1927], 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15_Z,
+        'DEST' : '/srv/www/htdocs/pub/repositories/sle/15/3/bootstrap/'
+    },
+    'SLE-15-SP3-x86_64' : {
+        'PDID' : [2145, 1712], 'BETAPDID' : [1928], 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15_X86_ARM,
+        'DEST' : '/srv/www/htdocs/pub/repositories/sle/15/3/bootstrap/'
+    },
     'SUMA-41-PROXY-x86_64' : {
         'PDID' : [1946, 2015], 'BETAPDID' : [], 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/15/2/bootstrap/'

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- add SLE 15 SP3 bootstrap repository definitions (bsc#1182008)
 - python3-dbus-python and dependencies not installed by default
   on JeOS SLE15 images, add them to the bootstrap repository list
   of packages for traditional (bsc#1182071)


### PR DESCRIPTION

## What does this PR change?

Adss bootstrap data for SLE15SP3



## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed: this is an internal change to make sle15sp3 work (fixes an issue, is not a new feature)

- [ ] **DONE**

## Test coverage
- No tests: SLE15SP3 clients can be bootstrapped. I assume this is covered by our current testsuite already.

- [ ] **DONE**

## Links

fixes https://github.com/SUSE/spacewalk/issues/13819
fixes bsc#1182008

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
