### PR TITLE
We have 2 BETA channels in HEAD

### DIFF
--- a/testsuite/features/secondary/srv_content_lifecycle.feature
+++ b/testsuite/features/secondary/srv_content_lifecycle.feature
@@ -57,7 +57,7 @@ Feature: Content lifecycle
     And I should see a "SLE-Manager-Tools12-Updates for x86_64 SP5" text
     And I should see a "SLES12-SP5-Updates for x86_64" text
     And I should see a "SLE-Manager-Tools12-Pool for x86_64 SP5" text
-    And I should see a "Build (4)" text
+    And I should see a "Build (6)" text
 
   Scenario: Add environments to the project
     Given I am authorized as "admin" with password "admin"
@@ -106,7 +106,7 @@ Feature: Content lifecycle
     When I follow the left menu "Content Lifecycle > Projects"
     And I follow "clp_name"
     Then I should see a "not built" text in the environment "qa_name"
-    When I click on "Build (4)"
+    When I click on "Build (6)"
     Then I should see a "Version 1 history" text
     When I enter "test version message 1" as "message"
     And I click the environment build button


### PR DESCRIPTION
## What does this PR change?

In step `And I should see a "Build (4)" text`, the text `Build(6)` appears, because we have two extra channels:
* SLE-Manager-Tools12-BETA-Pool
* SLE-Manager-Tools12-BETA-Updates

This PR adapts the test. It will need to be reverted when we branch to 4.2.


## Links

No ports, HEAD only.


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
