### PR TITLE
Add Typescript support to the po makefile

### DIFF
--- a/web/po/Makefile
+++ b/web/po/Makefile
@@ -33,9 +33,17 @@ gettextsrcdir = $(datadir)/gettext/po
 INSTALL = /usr/bin/install -c
 INSTALL_DATA = ${INSTALL} -m 644
 
-GMSGFMT = /usr/bin/msgfmt
-MSGFMT = /usr/bin/msgfmt
-MSGMERGE = /usr/bin/intltool-update -x --gettext-package=$(PACKAGE) --dist
+# macOS uses readonly system directories and has different paths for external tools
+uname_s = $(shell uname -s)
+ifeq ($(uname_s),Darwin)
+	BIN = /usr/local/bin
+else
+	BIN = /usr/bin
+endif
+
+GMSGFMT = ${BIN}/msgfmt
+MSGFMT = ${BIN}/msgfmt
+MSGMERGE = ${BIN}/intltool-update -x --gettext-package=$(PACKAGE) --dist
 
 INCLUDES = -I.. -I$(top_srcdir)/intl
 
@@ -46,7 +54,7 @@ DISTFILES = POTFILES.in $(PACKAGE).pot $(POFILES) $(GMOFILES)
 POTFILES = \
 	$(shell find ../html/javascript/ -name spacewalk\*.js | sort) \
 	$(shell find ../html/javascript/ -name susemanager\*.js | sort) \
-	$(shell find ../html/src/ -type f \( -name \*.js ! -path "*/dist/*" ! -path "*/node_modules/*" \) | sort)
+	$(shell find ../html/src/ -type f \( \( -name \*.js -o -name \*.jsx -o -name \*.ts -o -name \*.tsx \) ! -path "*/dist/*" ! -path "*/node_modules/*" \) | sort)
 
 CATALOGS = $(GMOFILES)
 
@@ -81,7 +89,7 @@ POTFILES.in:
 	done >> $@
 
 $(srcdir)/$(PACKAGE).pot: $(POTFILES) POTFILES.in
-	/usr/bin/intltool-update --gettext-package=$(PACKAGE) --pot
+	${BIN}/intltool-update --gettext-package=$(PACKAGE) --pot
 	rm -f POTFILES.in
 
 install: install-exec install-data


### PR DESCRIPTION
## What does this PR change?

Currently, we only generate the po files based on `.js` files, we should however include all of the following file extensions: `.js`, `.jsx`, `.ts`, `.tsx`  

This PR addresses that issue (and also the fact that the makefile couldn't be used on macOS because of the hardcoded paths).

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: only internal and user invisible changes

- [x] **DONE**

## Links

Fixes: https://github.com/SUSE/spacewalk/issues/13970

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
