### PR TITLE
VM memory display fix

### DIFF
--- a/backend/server/rhnVirtualization.py
+++ b/backend/server/rhnVirtualization.py
@@ -494,7 +494,7 @@ class VirtualizationEventHandler:
                 rvi.confirmed         as confirmed,
                 rvii.name             as name,
                 rvit.label            as instance_type,
-                rvii.memory_size_k    as memory_size_k,
+                rvii.memory_size      as memory_size,
                 rvii.instance_id      as instance_id,
                 rvii.vcpus            as vcpus,
                 rvis.label            as state
@@ -562,7 +562,7 @@ class VirtualizationEventHandler:
                 (instance_id,
                  name,
                  vcpus,
-                 memory_size_k,
+                 memory_size,
                  instance_type,
                  state)
             SELECT
@@ -644,8 +644,8 @@ class VirtualizationEventHandler:
             bindings['vcpus'] = properties[PropertyType.VCPUS]
 
         if PropertyType.MEMORY in properties and \
-           existing_row['memory_size_k'] != properties[PropertyType.MEMORY]:
-            new_values_array.append('memory_size_k=:memory')
+           existing_row['memory_size'] != properties[PropertyType.MEMORY]:
+            new_values_array.append('memory_size=:memory')
             bindings['memory'] = properties[PropertyType.MEMORY]
 
         if PropertyType.TYPE in properties and \

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,5 @@
+- Rename rhnVirtualInstanceInfo memory_size_k column
+
 -------------------------------------------------------------------
 Fri Feb 12 14:27:27 CET 2021 - jgonzalez@suse.com
 

--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
@@ -1032,7 +1032,7 @@ SELECT PI.server_id ID, S.name,
          COALESCE(VIS.name, '(unknown)') AS STATE_NAME,
          COALESCE(VIS.label, 'unknown') AS STATE_LABEL,
      COALESCE(VII.vcpus, 0) AS VCPUS,
-     COALESCE(VII.memory_size_k, 0) AS MEMORY,
+     COALESCE(VII.memory_size, 0) AS MEMORY,
      COALESCE(((SELECT 1 FROM rhnUserServerPerms USP WHERE USP.user_id = :user_id AND USP.server_id = VI.virtual_system_id)), 0 ) as accessible,
          rhn_channel.user_role_check((select channel_id from rhnServerOverview where server_id = VI.virtual_system_id), :user_id, 'subscribe') AS subscribable,
          1 AS selectable

--- a/java/code/src/com/redhat/rhn/domain/server/VirtualInstance.java
+++ b/java/code/src/com/redhat/rhn/domain/server/VirtualInstance.java
@@ -223,18 +223,18 @@ public class VirtualInstance extends BaseDomainHelper {
     }
 
     /**
-     * Returns the total memory in KB allocated to the virtual instance.
+     * Returns the total memory in MiB allocated to the virtual instance.
      *
-     * @return The total memory in KB allocated to the virtual instance.
+     * @return The total memory in MiB allocated to the virtual instance.
      */
     public Long getTotalMemory() {
         return getInfo().getTotalMemory();
     }
 
     /**
-     * Sets the total memory in KB allocated to the virtual instance.
+     * Sets the total memory in MiB allocated to the virtual instance.
      *
-     * @param memory The total memory in KB
+     * @param memory The total memory in MiB
      */
     public void setTotalMemory(Long memory) {
         initInfo().setTotalMemory(memory);

--- a/java/code/src/com/redhat/rhn/domain/server/VirtualInstanceInfo.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/VirtualInstanceInfo.hbm.xml
@@ -12,7 +12,7 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         </id>
 
         <property name="name" column="NAME" type="string" length="128"/>
-        <property name="totalMemory" column="MEMORY_SIZE_K" type="long"/>
+        <property name="totalMemory" column="memory_size" type="long"/>
         <property name="numberOfCPUs" column="VCPUS" type="integer"/>
         <property name="created" column="CREATED" type="timestamp" insert="false" update="false"/>
         <property name="modified" column="MODIFIED" type="timestamp" insert="false" update="false"/>

--- a/java/code/src/com/redhat/rhn/domain/server/VirtualInstanceInfo.java
+++ b/java/code/src/com/redhat/rhn/domain/server/VirtualInstanceInfo.java
@@ -73,18 +73,18 @@ public class VirtualInstanceInfo extends BaseDomainHelper {
     }
 
     /**
-     * Returns the total memory in KB allocated to the virtual instance.
+     * Returns the total memory in MiB allocated to the virtual instance.
      *
-     * @return The total memory in KB allocated to the virtual instance.
+     * @return The total memory in MiB allocated to the virtual instance.
      */
     public Long getTotalMemory() {
         return totalMemory;
     }
 
     /**
-     * Sets the total memory in KB for the virtual instance.
+     * Sets the total memory in MiB for the virtual instance.
      *
-     * @param memory The total memory in KB.
+     * @param memory The total memory in MiB.
      */
     public void setTotalMemory(Long memory) {
         totalMemory = memory;

--- a/java/code/src/com/suse/manager/reactor/messaging/LibvirtEngineDomainLifecycleMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/LibvirtEngineDomainLifecycleMessageAction.java
@@ -84,7 +84,7 @@ public class LibvirtEngineDomainLifecycleMessageAction implements MessageAction 
                         LOG.debug("Adding VM " + def.getName() + " with state to " + state.getLabel());
                         VirtualInstanceManager.addGuestVirtualInstance(def.getUuid().replaceAll("-", ""),
                                 def.getName(), def.getVirtualInstanceType(), state, minion, null,
-                                def.getVcpu().getMax(), def.getMaxMemory());
+                                def.getVcpu().getMax(), def.getMaxMemory() / 1024);
 
                         // Check if the defined VM will require a manual restart
                         if (def.isRequiresRestart()) {
@@ -134,7 +134,7 @@ public class LibvirtEngineDomainLifecycleMessageAction implements MessageAction 
                                     updatedDef.get().getVcpu().getMax() :
                                     vm.getNumberOfCPUs();
                             Long memory = updatedDef.isPresent() ?
-                                    updatedDef.get().getMaxMemory() :
+                                    updatedDef.get().getMaxMemory() / 1024 :
                                     vm.getTotalMemory();
                             VirtualInstanceManager.updateGuestVirtualInstanceProperties(
                                     vm, name, "updated".equals(message.getDetail()) ? vm.getState() : state,

--- a/java/code/src/com/suse/manager/reactor/messaging/test/LibvirtEngineDomainLifecycleMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/LibvirtEngineDomainLifecycleMessageActionTest.java
@@ -244,7 +244,7 @@ public class LibvirtEngineDomainLifecycleMessageActionTest extends JMockBaseTest
 
 
         assertEquals(Long.valueOf(2), matchingGuests.get(0).getVcpus());
-        assertEquals(Long.valueOf(1048576), matchingGuests.get(0).getMemory());
+        assertEquals(Long.valueOf(1024), matchingGuests.get(0).getMemory());
     }
 
     protected Optional<String> getSaltResponse(String filename, Map<String, String> placeholders) throws Exception {

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -1665,6 +1665,7 @@ public class SaltUtils {
         HardwareMapper hwMapper = new HardwareMapper(server,
                 new ValueMap(result.getGrains()));
         hwMapper.mapCpuInfo(new ValueMap(result.getCpuInfo()));
+        server.setRam(hwMapper.getTotalMemory());
         if (CpuArchUtil.isDmiCapable(hwMapper.getCpuArch())) {
             hwMapper.mapDmiInfo(
                     result.getSmbiosRecordsBios().orElse(Collections.emptyMap()),

--- a/java/code/src/com/suse/manager/virtualization/VirtManagerSalt.java
+++ b/java/code/src/com/suse/manager/virtualization/VirtManagerSalt.java
@@ -228,7 +228,7 @@ public class VirtManagerSalt implements VirtManager {
                         Map<String, Object> vm = entry.getValue();
                         String state = vm.get("state").toString();
                         GuestProperties props = new GuestProperties(
-                                ((Double)vm.get("maxMem")).longValue(),
+                                ((Double)vm.get("maxMem")).longValue() / 1024,
                                 entry.getKey(),
                                 "shutdown".equals(state) ? "stopped" : state,
                                 vm.get("uuid").toString(),

--- a/java/code/src/com/suse/manager/virtualization/test/VirtManagerSaltTest.java
+++ b/java/code/src/com/suse/manager/virtualization/test/VirtManagerSaltTest.java
@@ -62,7 +62,7 @@ public class VirtManagerSaltTest extends TestCase {
                 .filter(info -> info.getGuestProperties() != null && info.getGuestProperties().getName().equals("vm01"))
                 .findFirst().get();
         assertEquals(2, vm1infos.getGuestProperties().getVcpus());
-        assertEquals(1048576, vm1infos.getGuestProperties().getMemorySize());
+        assertEquals(1024, vm1infos.getGuestProperties().getMemorySize());
         assertEquals("stopped", vm1infos.getGuestProperties().getState());
         assertEquals("b99a8176-4f40-498d-8e61-2f6ade654fe2", vm1infos.getGuestProperties().getUuid());
         assertEquals(VirtualInstanceManager.EVENT_TYPE_EXISTS, vm1infos.getEventType());
@@ -71,7 +71,7 @@ public class VirtManagerSaltTest extends TestCase {
                 .filter(info -> info.getGuestProperties() != null && info.getGuestProperties().getName().equals("vm02"))
                 .findFirst().get();
         assertEquals(12, vm2infos.getGuestProperties().getVcpus());
-        assertEquals(2097152L, vm2infos.getGuestProperties().getMemorySize());
+        assertEquals(2048L, vm2infos.getGuestProperties().getMemorySize());
         assertEquals("running", vm2infos.getGuestProperties().getState());
         assertEquals("98eef4f7-eb7f-4be8-859d-11658506c496", vm2infos.getGuestProperties().getUuid());
         assertEquals(VirtualInstanceManager.EVENT_TYPE_EXISTS, vm2infos.getEventType());

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Rename rhnVirtualInstanceInfo memory_size_k column
 - Cleanup sessions via SQL query instead of SQL function (bsc#1180224)
 - Do not call page decorator in HEAD requests (bsc#1181228)
 - Allow to configure request timeout (bsc#1178767)

--- a/schema/spacewalk/common/tables/rhnVirtualInstanceInfo.sql
+++ b/schema/spacewalk/common/tables/rhnVirtualInstanceInfo.sql
@@ -24,7 +24,7 @@ CREATE TABLE rhnVirtualInstanceInfo
     instance_type  NUMERIC NOT NULL
                        CONSTRAINT rhn_vii_it_fk
                            REFERENCES rhnVirtualInstanceType (id),
-    memory_size_k  NUMERIC,
+    memory_size    NUMERIC,
     vcpus          NUMERIC,
     state          NUMERIC NOT NULL
                        CONSTRAINT rhn_vii_state_fk

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- Rename rhnVirtualInstanceInfo memory_size_k column
 - Drop "pxt_session_cleanup" function (bsc#1180224)
 
 -------------------------------------------------------------------

--- a/schema/spacewalk/upgrade/susemanager-schema-4.2.7-to-susemanager-schema-4.2.8/001-rename-memory-size.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.2.7-to-susemanager-schema-4.2.8/001-rename-memory-size.sql
@@ -1,0 +1,9 @@
+DO $$
+BEGIN
+  IF EXISTS(SELECT *
+    FROM information_schema.columns
+    WHERE table_name='rhnvirtualinstanceinfo' and column_name='memory_size_k')
+  THEN
+      ALTER TABLE rhnVirtualInstanceInfo RENAME COLUMN memory_size_k TO memory_size;
+  END IF;
+END $$;

--- a/web/html/src/manager/virtualization/guests/list/guests-list.js
+++ b/web/html/src/manager/virtualization/guests/list/guests-list.js
@@ -120,7 +120,7 @@ export function GuestsList(props: Props) {
                 columnKey="memory"
                 comparator={Utils.sortByNumber}
                 header={t('Current Memory')}
-                cell={row => `${row.memory / 1024} MiB`}
+                cell={row => `${row.memory} MiB`}
               />,
               <Column
                 columnKey="vcpus"


### PR DESCRIPTION
## What does this PR change?

Displaying the memory amount of a VM in the virtualization page is fine... as long as the VM is not registered as a system. The fun comes when registering the VM because Uyuni gets a different memory amount coming from the guest OS during the hardware update.

In order to always display the memory amount allocated on the host, the virtualization page now gets the memory value from `salt.vm_info`.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: displayed value fix

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
