### PR TITLE
Handle the caches update correctly for retracted patches in CLM

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/ErrataCache_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/ErrataCache_queries.xml
@@ -117,7 +117,10 @@ DELETE FROM rhnOrgErrataCacheQueue WHERE org_id = :org_id
                 WHERE
                          SC.channel_id = :channel_id
                   AND    SC.server_id = S.id
-              AND    p.id in (%s)
+                  AND    p.id in (%s)
+                  AND    p.id NOT IN (SELECT EP.package_id FROM rhnErrataPackage EP INNER JOIN rhnErrata E
+                                      ON EP.errata_id = E.id
+                                      WHERE EP.package_id = p.id AND E.advisory_status = 'retracted')
                   AND    p.package_arch_id = spac.package_arch_id
                   AND    spac.server_arch_id = s.server_arch_id
                   AND    SP_EVR.id = SP.evr_id

--- a/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
@@ -266,9 +266,8 @@ public class ServerFactory extends HibernateFactory {
      *
      * @param serverId the server ID
      */
-    public static void updateServerNeededCache(Long serverId) {
-        CallableMode m = ModeFactory.getCallableMode(
-                "System_queries", "update_needed_cache");
+    public static void updateServerNeededCache(long serverId) {
+        CallableMode m = ModeFactory.getCallableMode("System_queries", "update_needed_cache");
         Map inParams = new HashMap();
         inParams.put("server_id", serverId);
 

--- a/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
@@ -262,6 +262,20 @@ public class ServerFactory extends HibernateFactory {
     }
 
     /**
+     * Regenerate the package needed cache for the server
+     *
+     * @param serverId the server ID
+     */
+    public static void updateServerNeededCache(Long serverId) {
+        CallableMode m = ModeFactory.getCallableMode(
+                "System_queries", "update_needed_cache");
+        Map inParams = new HashMap();
+        inParams.put("server_id", serverId);
+
+        m.execute(inParams, new HashMap());
+    }
+
+    /**
      * Get the Logger for the derived class so log messages show up on the
      * correct class
      */

--- a/java/code/src/com/redhat/rhn/manager/errata/cache/UpdateErrataCacheCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/cache/UpdateErrataCacheCommand.java
@@ -23,6 +23,7 @@ import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.errata.ErrataFactory;
 import com.redhat.rhn.domain.org.Org;
 import com.redhat.rhn.domain.org.OrgFactory;
+import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.manager.BaseTransactionCommand;
 import org.apache.log4j.Logger;
 
@@ -195,12 +196,7 @@ public class UpdateErrataCacheCommand extends BaseTransactionCommand {
     }
 
     private void processServer(Long serverId) {
-        CallableMode m = ModeFactory.getCallableMode(
-                "System_queries", "update_needed_cache");
-        Map inParams = new HashMap();
-        inParams.put("server_id", serverId);
-
-        m.execute(inParams, new HashMap());
+        ServerFactory.updateServerNeededCache(serverId);
     }
 
     private void processImage(Long imageId) {

--- a/java/code/src/com/redhat/rhn/manager/errata/cache/test/RetractedPatchesCacheManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/cache/test/RetractedPatchesCacheManagerTest.java
@@ -1,0 +1,164 @@
+/**
+ * Copyright (c) 2009--2014 Red Hat, Inc.
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.manager.errata.cache.test;
+
+import com.redhat.rhn.common.db.datasource.DataResult;
+import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.domain.errata.AdvisoryStatus;
+import com.redhat.rhn.domain.errata.Errata;
+import com.redhat.rhn.domain.errata.test.ErrataFactoryTest;
+import com.redhat.rhn.domain.rhnpackage.Package;
+import com.redhat.rhn.domain.rhnpackage.PackageEvr;
+import com.redhat.rhn.domain.rhnpackage.PackageEvrFactory;
+import com.redhat.rhn.domain.rhnpackage.test.PackageTest;
+import com.redhat.rhn.domain.server.InstalledPackage;
+import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerFactory;
+import com.redhat.rhn.domain.server.test.ServerFactoryTest;
+import com.redhat.rhn.frontend.dto.ErrataCacheDto;
+import com.redhat.rhn.manager.errata.cache.ErrataCacheManager;
+import com.redhat.rhn.manager.system.SystemManager;
+import com.redhat.rhn.testing.BaseTestCaseWithUser;
+import com.redhat.rhn.testing.ChannelTestUtils;
+
+import java.util.List;
+
+/**
+ * ErrataFactoryTest
+ */
+public class RetractedPatchesCacheManagerTest extends BaseTestCaseWithUser {
+
+    private Server server;
+    private Channel subscribedChannel;
+
+    // 3 ascending versions of the same package
+    private Package oldPkg;
+    private Package newerPkg;
+    private Package newestPkg;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+
+        server = ServerFactoryTest.createTestServer(user);
+
+        List<Package> generatedPackages = createSubsequentPackages();
+        oldPkg = generatedPackages.get(0);
+        newerPkg = generatedPackages.get(1);
+        newestPkg = generatedPackages.get(2);
+
+        subscribedChannel = ChannelTestUtils.createBaseChannel(user);
+        SystemManager.subscribeServerToChannel(user, server, subscribedChannel);
+    }
+
+    /**
+     * Test that inserting a retracted package with higher version to the cache has no effect.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    public void testRetractedPatchesInCache() throws Exception {
+        // channel has all packages
+        subscribedChannel.getPackages().addAll(List.of(oldPkg, newerPkg, newestPkg));
+
+        // oldest is installed on the server
+        installPackageOnServer(oldPkg, server);
+
+        // newest is retracted
+        Errata retracted = ErrataFactoryTest.createTestErrata(user.getOrg().getId());
+        retracted.setAdvisoryStatus(AdvisoryStatus.RETRACTED);
+        retracted.addPackage(newestPkg);
+        subscribedChannel.addErrata(retracted);
+
+        // insert newer & newest
+        ErrataCacheManager.insertCacheForChannelPackages(subscribedChannel.getId(), retracted.getId(), List.of(newestPkg.getId()));
+        ErrataCacheManager.insertCacheForChannelPackages(subscribedChannel.getId(), null, List.of(newerPkg.getId()));
+
+        // only the newer should be in the cache since newest is retracted
+        DataResult needingUpdates = ErrataCacheManager.packagesNeedingUpdates(server.getId());
+        assertEquals(1, needingUpdates.size());
+        assertEquals(newerPkg.getId(), ((ErrataCacheDto) needingUpdates.get(0)).getPackageId());
+
+        // just to be sure, recompute the cache and verify that the results are same
+        ServerFactory.updateServerNeededCache(server.getId());
+        needingUpdates = ErrataCacheManager.packagesNeedingUpdates(server.getId());
+        assertEquals(1, needingUpdates.size());
+        assertEquals(newerPkg.getId(), ((ErrataCacheDto) needingUpdates.get(0)).getPackageId());
+    }
+
+    /**
+     * Similar as testRetractedPatchesInCache, but here we also attempt to insert the retracted errata id to the cache.
+     * The result should be the same: no new row in the cache.
+     *
+     * @throws Exception if anything goes wrong
+     */
+    public void testRetractedPackagesInCache() throws Exception {
+        // channel has all packages
+        subscribedChannel.getPackages().addAll(List.of(oldPkg, newerPkg, newestPkg));
+
+        // oldest is installed on the server
+        installPackageOnServer(oldPkg, server);
+
+        // newest is retracted
+        Errata retracted = ErrataFactoryTest.createTestErrata(user.getOrg().getId());
+        retracted.setAdvisoryStatus(AdvisoryStatus.RETRACTED);
+        retracted.addPackage(newestPkg);
+        subscribedChannel.addErrata(retracted);
+
+        // insert newer & newest packages with no reference to errata
+        ErrataCacheManager.insertCacheForChannelPackages(subscribedChannel.getId(), null, List.of(newestPkg.getId()));
+        ErrataCacheManager.insertCacheForChannelPackages(subscribedChannel.getId(), null, List.of(newerPkg.getId()));
+
+        // only the newer should be in the cache since newest is retracted
+        DataResult needingUpdates = ErrataCacheManager.packagesNeedingUpdates(server.getId());
+        assertEquals(1, needingUpdates.size());
+        assertEquals(newerPkg.getId(), ((ErrataCacheDto) needingUpdates.get(0)).getPackageId());
+
+        // just to be sure, recompute the cache and verify that the results are same
+        ServerFactory.updateServerNeededCache(server.getId());
+        needingUpdates = ErrataCacheManager.packagesNeedingUpdates(server.getId());
+        assertEquals(1, needingUpdates.size());
+        assertEquals(newerPkg.getId(), ((ErrataCacheDto) needingUpdates.get(0)).getPackageId());
+    }
+
+    private static void installPackageOnServer(Package pkg, Server server) {
+        InstalledPackage installedNewerPkg = createInstalledPackage(pkg);
+        installedNewerPkg.setServer(server);
+        server.getPackages().add(installedNewerPkg);
+    }
+
+    private static InstalledPackage createInstalledPackage(Package pkg) {
+        InstalledPackage installedNewerPkg = new InstalledPackage();
+        installedNewerPkg.setEvr(pkg.getPackageEvr());
+        installedNewerPkg.setArch(pkg.getPackageArch());
+        installedNewerPkg.setName(pkg.getPackageName());
+        return installedNewerPkg;
+    }
+
+    private List<Package> createSubsequentPackages() throws Exception {
+        Package pkg1 = PackageTest.createTestPackage(user.getOrg());
+        PackageEvr evr = pkg1.getPackageEvr();
+        evr.setVersion("1.0.0");
+
+        Package pkg2 = PackageTest.createTestPackage(user.getOrg());
+        pkg2.setPackageName(pkg1.getPackageName());
+        pkg2.setPackageEvr(PackageEvrFactory.lookupOrCreatePackageEvr(evr.getEpoch(), "2.0.0", evr.getRelease(), pkg1.getPackageType()));
+
+        Package pkg3 = PackageTest.createTestPackage(user.getOrg());
+        pkg3.setPackageName(pkg1.getPackageName());
+        pkg3.setPackageEvr(PackageEvrFactory.lookupOrCreatePackageEvr(evr.getEpoch(), "3.0.0", evr.getRelease(), pkg1.getPackageType()));
+
+        return List.of(pkg1, pkg2, pkg3);
+    }
+}

--- a/java/code/src/com/redhat/rhn/manager/errata/cache/test/RetractedPatchesCacheManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/cache/test/RetractedPatchesCacheManagerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2009--2014 Red Hat, Inc.
+ * Copyright (c) 2021 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/schema/spacewalk/upgrade/susemanager-schema-4.2.5-to-susemanager-schema-4.2.6/013-ignore-retracted-pkgs-in-newest-pkgs-view.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.2.5-to-susemanager-schema-4.2.6/013-ignore-retracted-pkgs-in-newest-pkgs-view.sql
@@ -1,5 +1,5 @@
 --
--- Copyright (c) 2008--2012 Red Hat, Inc.
+-- Copyright (c) 2021 SUSE LLC
 --
 -- This software is licensed to you under the GNU General Public License,
 -- version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -8,14 +8,6 @@
 -- along with this software; if not, see
 -- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 --
--- Red Hat trademarks are not licensed under GPLv2. No permission is
--- granted to use or replicate Red Hat trademarks that are incorporated
--- in this software or its documentation.
---
---
---
---
--- this is much more readable with ts=4, enjoy!
 
 create or replace view
 rhnChannelNewestPackageView


### PR DESCRIPTION
Make sure the following caches are aligned correctly when dealing with retracted patches:

- `rhnServerNeeded`
- `rhnChannelNewestPackage`

The changes are also relevant for non-CLM scenarios.

Review commit-by-commit.

TODO
- [x] DB Migration

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: more or less a bugfix :smile:

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"