### PR TITLE
Require the next rhnlib version that will come after #3250 is merged

### DIFF
--- a/client/rhel/spacewalk-client-tools/spacewalk-client-tools.spec
+++ b/client/rhel/spacewalk-client-tools/spacewalk-client-tools.spec
@@ -174,7 +174,7 @@ Obsoletes:      python-%{name} < %{version}-%{release}
 Provides:       python2-rhn-client-tools = %{version}-%{release}
 Obsoletes:      python2-rhn-client-tools < %{version}-%{release}
 Requires:       %{name} = %{version}-%{release}
-Requires:       rhnlib >= 2.5.78
+Requires:       rhnlib >= 4.2.2
 
 %if "%{_vendor}" != "debbuild"
 Requires:       rpm-python
@@ -282,7 +282,7 @@ Requires:       python3-dmidecode
 %endif
 Requires:       python3-hwdata
 Requires:       python3-netifaces
-Requires:       python3-rhnlib >= 2.5.78
+Requires:       python3-rhnlib >= 4.2.2
 Requires:       python3-rpm
 Requires:       python3-uyuni-common-libs
 

--- a/client/tools/mgr-osad/mgr-osad.spec
+++ b/client/tools/mgr-osad/mgr-osad.spec
@@ -122,7 +122,7 @@ Requires:       python
 Requires:       python-jabberpy
 Requires:       python2-mgr-osa-common = %{version}
 Requires:       python2-rhn-client-tools >= 2.8.4
-Requires:       rhnlib >= 2.8.3
+Requires:       rhnlib >= 4.2.2
 Requires:       python2-uyuni-common-libs
 %if 0%{?rhel} && 0%{?rhel} <= 5
 Requires:       python-hashlib
@@ -144,7 +144,7 @@ Requires:       python3
 Requires:       python3-jabberpy
 Requires:       python3-mgr-osa-common = %{version}
 Requires:       python3-rhn-client-tools >= 2.8.4
-Requires:       python3-rhnlib >= 2.8.3
+Requires:       python3-rhnlib >= 4.2.2
 Requires:       python3-uyuni-common-libs
 BuildRequires:  python3-devel
 

--- a/proxy/proxy/spacewalk-proxy.spec
+++ b/proxy/proxy/spacewalk-proxy.spec
@@ -159,7 +159,7 @@ Spacewalk Proxy components.
 Summary:        Custom Channel Package Manager for the Spacewalk Proxy Server
 Group:          Applications/Internet
 Requires:       python3
-Requires:       python3-rhnlib >= 2.5.56
+Requires:       python3-rhnlib >= 4.2.2
 Requires:       mgr-push >= 4.0.0
 Requires:       spacewalk-backend >= 1.7.24
 # proxy isn't Python 3 yet


### PR DESCRIPTION
## What does this PR change?

Adapts the three packages to the new rhnlib version that will include the changes for the ssl implementation from #3250

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Bugfix

- [x] **DONE**

## Test coverage
No tests: Media install tests will test the change.

- [x] **DONE**

## Links

Related: https://github.com/SUSE/spacewalk/issues/13902
Tracks: https://github.com/SUSE/spacewalk/pull/13994 and https://github.com/SUSE/spacewalk/pull/13996

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
