### PR TITLE
Cherry-pick migration doc update

### DIFF
--- a/web/html/src/TYPESCRIPT_MIGRATION.md
+++ b/web/html/src/TYPESCRIPT_MIGRATION.md
@@ -26,6 +26,18 @@ $ yarn tsc
 # Get a list of remaining errors that need to be resolved manually
 ```
 
+## Configuring your editor
+
+If you're using VS Code, the editor config is already included.  
+For other editors, Typescript has integration plugins for more or less all popular editors.  
+
+Usually, you will only need to specify where the Typescript SDK is, how to configure this depends on your editor:  
+```json
+{
+    "typescript.tsdk": "./web/html/src/node_modules/typescript/lib"
+}
+```
+
 ## Common problems you may encounter:
 
 ### `Argument of type 'Foo' is not assignable to parameter of type 'never'` when pushing into an empty array


### PR DESCRIPTION
## What does this PR change?

Cherry-pick Typescript migration docs update.  

This is already present in a larger PR, but if anyone wants to start working with Typescript today, would be nice to have this information large and center.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: only internal and user invisible changes

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
