### PR TITLE
eslint: The href attribute requires a valid value to be accessible (anchor-is-valid)

### DIFF
--- a/branding/css/tables.less
+++ b/branding/css/tables.less
@@ -133,14 +133,18 @@ tr.alphaResult td.sortedCol:before {
   font-family: 'FontAwesome';
 }
 
-th.ascSort a:after {
+th.ascSort a:after, th.ascSort button:after {
   content: "  \f160";
   font-family: 'FontAwesome';
 }
 
-th.descSort a:after {
+th.descSort a:after, th.descSort button:after {
   content: "  \f161";
   font-family: 'FontAwesome';
+}
+
+th button.btn-link{
+  font-weight: bold;
 }
 
 .table-striped > tbody > tr:nth-child(odd) > td, .table-striped > tbody > tr:nth-child(odd) > th {

--- a/web/html/src/.eslintrc.js
+++ b/web/html/src/.eslintrc.js
@@ -21,6 +21,7 @@ module.exports = {
   },
 
   rules: {
+    "jsx-a11y/anchor-is-valid": "error",
     "react-hooks/rules-of-hooks": "error",
     // TODO: This needs to be reworked with Typescript support in mind
     "no-use-before-define": "off",

--- a/web/html/src/components/dialog/ModalLink.tsx
+++ b/web/html/src/components/dialog/ModalLink.tsx
@@ -21,13 +21,11 @@ export function ModalLink(props: Props) {
   const margin = props.text ? "" : " no-margin";
   var icon = props.icon && <i className={"fa " + props.icon + margin} />;
 
-  // TODO: Using `href="#"` is bad for accessibility and semantics, this should be a `<button>` that looks like it needs to
   return (
-    <a
+    <button
       id={props.id}
-      href="#"
       title={props.title}
-      className={props.className}
+      className={'btn-link ' + (props.className || '')}
       onClick={() => {
         if (props.onClick) props.onClick(props.item);
         showDialog(props.target);
@@ -35,6 +33,6 @@ export function ModalLink(props: Props) {
     >
       {icon}
       {props.text}
-    </a>
+    </button>
   );
 }

--- a/web/html/src/components/panels/CreatorPanel.tsx
+++ b/web/html/src/components/panels/CreatorPanel.tsx
@@ -55,7 +55,6 @@ const CreatorPanel = (props: Props) => {
             <ModalLink
               id={`${props.id}-modal-link`}
               icon={props.icon ? props.icon : "fa-plus"}
-              className="btn-link"
               text={props.creatingText}
               target={modalNameId}
               onClick={() => {

--- a/web/html/src/components/table/Header.tsx
+++ b/web/html/src/components/table/Header.tsx
@@ -41,9 +41,9 @@ export function Header(props: HeaderProps) {
 
     return (
       <th style={thStyle} className={thClass}>
-        <a href="#" className="orderBy" onClick={() => props.onSortChange?.(props.columnKey || null, newDirection)}>
+        <button className="btn-link orderBy" onClick={() => props.onSortChange?.(props.columnKey || null, newDirection)}>
           {props.children}
-        </a>
+        </button>
       </th>
     );
   }

--- a/web/html/src/components/table/SearchPanel.tsx
+++ b/web/html/src/components/table/SearchPanel.tsx
@@ -46,16 +46,16 @@ export function SearchPanel(props: SearchPanelProps) {
         {props.selectable && props.selectedCount > 0 && (
           <span>
             {t("({0} selected)", props.selectedCount)}&nbsp;
-            <a href="#" onClick={props.onClear}>
+            <button className="btn-link" onClick={props.onClear}>
               {t("Clear")}
-            </a>
+            </button>
             &nbsp;/&nbsp;
           </span>
         )}
         {props.selectable && (
-          <a href="#" onClick={props.onSelectAll}>
+          <button className="btn-link" onClick={props.onSelectAll}>
             {t("Select All")}
-          </a>
+          </button>
         )}
       </div>
     </div>

--- a/web/html/src/manager/clusters/cluster/cluster-overview.tsx
+++ b/web/html/src/manager/clusters/cluster/cluster-overview.tsx
@@ -249,7 +249,6 @@ const ClusterOverview = (props: Props) => {
             <ModalLink
               target="cluster-edit-dialog"
               icon="fa-plus"
-              className="btn-link"
               text={t("Edit properties")}
               title={t("Edit cluster details")}
               onClick={() => setEditModel({ name: cluster.name, description: cluster.description })}

--- a/web/html/src/manager/content-management/list-filters/appstreams/appstreams.js
+++ b/web/html/src/manager/content-management/list-filters/appstreams/appstreams.js
@@ -29,9 +29,9 @@ export default function AppStreams() {
       <>
         <div className="form-group">
           <div className="col-md-offset-3 col-md-6">
-            <a href="#" onClick={enableBrowse}>
+            <button className="btn-link" onClick={enableBrowse}>
               {isLoading ? <i className="fa fa-refresh fa-spin fa-fw"/> : <i className="fa fa-search fa-fw"/>}
-              Browse available modules</a>
+              Browse available modules</button>
           </div>
         </div>
         <TextInput/>

--- a/web/html/src/manager/content-management/list-filters/filter-edit.tsx
+++ b/web/html/src/manager/content-management/list-filters/filter-edit.tsx
@@ -73,7 +73,6 @@ const FilterEdit = (props: FilterEditProps) => {
       <ModalLink
         id={`${props.id}-modal-link`}
         icon={props.icon}
-        className="btn-link"
         text={props.buttonText}
         target={modalNameId}
         onClick={() => {


### PR DESCRIPTION
## What does this PR change?

This PR fixes all `anchor-is-valid` eslint warnings.

**Before**
```
$ yarn lint
...
warning: The href attribute requires a valid value to be accessible. Provide a valid, navigable address as the href value. If you cannot provide a valid href, but still need the element to resemble a link, use a button and change it with appropriate styles. Learn more: https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-is-valid.md (jsx-a11y/anchor-is-valid) at components/table/Header.tsx:44:9:
...
42 warnings found.
```

**After**
```
$ yarn lint
...
37 warnings found.
```

Learn more: https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-is-valid.md

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
