### PR TITLE
eslint: Unexpected string concatenation of literals (no-useless-concat)

### DIFF
--- a/web/html/src/manager/images/image-import.tsx
+++ b/web/html/src/manager/images/image-import.tsx
@@ -268,7 +268,7 @@ class ImageImport extends React.Component {
             invalidHint={
               <span>
                 Target Image Store is required.&nbsp;
-                <a href={"/rhn/manager/cm/imagestores/create" + "?url_bounce=" + this.getBounceUrl()}>
+                <a href={"/rhn/manager/cm/imagestores/create?url_bounce=" + this.getBounceUrl()}>
                   Create a new one
                 </a>
                 .


### PR DESCRIPTION
## What does this PR change?

This PR fixes all `no-useless-concat` eslint warnings.

**Before**
```
$ yarn lint
...
warning: Unexpected string concatenation of literals (no-useless-concat) at manager/images/image-import.tsx:271:63:
...
42 warnings found.
```

**After**
```
$ yarn lint
...
41 warnings found.
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
