### PR TITLE
Add vendor change option to SP migration cucumber tests 

### DIFF
--- a/testsuite/features/init_clients/sle_minion.feature
+++ b/testsuite/features/init_clients/sle_minion.feature
@@ -49,6 +49,7 @@ Feature: Bootstrap a Salt minion via the GUI
     And I follow "SP Migration" in the content area
     And I wait until I see "Target Products:" text, refreshing the page
     And I click on "Select Channels"
+    And I check "allowVendorChange"
     And I wait until I see "SUSE Linux Enterprise Server 15 SP2 x86_64" text
     And I click on "Schedule Migration"
     And I should see a "Service Pack Migration - Confirm" text
@@ -63,6 +64,13 @@ Feature: Bootstrap a Salt minion via the GUI
     And I wait at most 600 seconds until event "Service Pack Migration scheduled by admin" is completed
     And I follow "Details" in the content area
     Then I should see a "SUSE Linux Enterprise Server 15 SP2" text
+
+@service_pack_migration
+  Scenario: Check the migration is successful for this minion
+    Given I am on the Systems overview page of this "sle_spack_migrated_minion"
+    When I follow "Details" in the content area
+    Then I should see a "SUSE Linux Enterprise Server 15 SP2" text
+    And vendor change should be enabled for SP migration on "sle_spack_migrated_minion"
 
 @service_pack_migration
   Scenario: Install the latest Salt on this minion

--- a/testsuite/features/init_clients/sle_ssh_minion.feature
+++ b/testsuite/features/init_clients/sle_ssh_minion.feature
@@ -60,6 +60,7 @@ Feature: Bootstrap a Salt host managed via salt-ssh
     And I follow "SP Migration" in the content area
     And I wait until I see "Target Products:" text, refreshing the page
     And I click on "Select Channels"
+    And I check "allowVendorChange"
     And I wait until I see "SUSE Linux Enterprise Server 15 SP2 x86_64" text
     And I click on "Schedule Migration"
     And I should see a "Service Pack Migration - Confirm" text
@@ -74,6 +75,13 @@ Feature: Bootstrap a Salt host managed via salt-ssh
     And I wait at most 600 seconds until event "Service Pack Migration scheduled by admin" is completed
     And I follow "Details" in the content area
     Then I should see a "SUSE Linux Enterprise Server 15 SP2" text
+
+@service_pack_migration
+  Scenario: Check the migration is successful for this SSH minion
+    Given I am on the Systems overview page of this "ssh_spack_migrated_minion"
+    When I follow "Details" in the content area
+    Then I should see a "SUSE Linux Enterprise Server 15 SP2" text
+    And vendor change should be enabled for SP migration on "ssh_spack_migrated_minion"
 
 @service_pack_migration
 @ssh_minion

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -188,6 +188,12 @@ When(/^I query latest Salt changes on ubuntu system "(.*?)"$/) do |host|
   end
 end
 
+When(/^vendor change should be enabled for SP migration on "([^"]*)"$/) do |host|
+  node = get_target(host)
+  _result, return_code = node.run("grep -- --allow-vendor-change /var/log/zypper.log")
+  raise 'Vendor change option not found in logs' unless return_code.zero?
+end
+
 When(/^I apply highstate on "([^"]*)"$/) do |host|
   system_name = get_system_name(host)
   if host.include? 'ssh_minion'


### PR DESCRIPTION
## What does this PR change?

Port of spacewalk PR#
This adds the allow vendor change option to the SP migration cucumber tests for the sle minion + ssh minion. 

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed:  
- 
- [ ] **DONE**

## Test coverage

- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
