### PR TITLE
fix type mapping

### DIFF
--- a/backend/server/handlers/xmlrpc/queue.py
+++ b/backend/server/handlers/xmlrpc/queue.py
@@ -485,7 +485,7 @@ class Queue(rhnHandler):
                 rmsg = result["faultString"] + str(data)
         if type(rcode) in [type({}), type(()), type([])] \
                 or type(rcode) is not IntType:
-            rmsg = "%s [%s]" % (UnicodeType(message), UnicodeType(rcode))
+            rmsg = "%s [%s]" % (message, rcode)
             rcode = -1
         # map to db codes.
         status = self.status_for_action_type_code(action_type, rcode)


### PR DESCRIPTION
## What does this PR change?

In rare cases we saw execptions like this:

```
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/<CENSORED!>/server/apacheRequest.py", line 135, in call_function
    response = func(*params)
  File "/usr/share/rhn/server/handlers/xmlrpc/queue.py", line 488, in submit
    rmsg = "%s [%s]" % (UnicodeType(message), UnicodeType(rcode))
TypeError: string argument without an encoding
```

Introduced by https://github.com/uyuni-project/uyuni/pull/3252 .

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
