### PR TITLE
Detect working apt with auth.conf.d

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/channels/channels.repo
+++ b/susemanager-utils/susemanager-sls/salt/channels/channels.repo
@@ -6,10 +6,13 @@
 {%- set hostname = salt['pillar.get']('pkg_download_point_host', args['host'])%}
 {%- set port = salt['pillar.get']('pkg_download_point_port', args.get('port', 443))%}
 {%- if grains['os'] == 'Debian' or grains['os'] == 'Ubuntu' %}
-{%- if (grains['os'] == 'Debian' and grains['osmajorrelease']|int < 10) or (grains['os'] == 'Ubuntu' and grains['osmajorrelease']|int < 18) %}
-deb {{ '[trusted=yes]' if not pillar.get('mgr_metadata_signing_enabled', false) else '[signed-by=/usr/share/keyrings/mgr-archive-keyring.gpg]' }} {{protocol}}://{{ args['token'] }}@{{hostname}}:{{port}}/rhn/manager/download {{ chan }} main
-{%- else %}
+{%- set apt_version = salt['pkg.version']("apt") %}
+{%- set apt_support_acd = grains['os_family'] == 'Debian' and apt_version and salt['pkg.version_cmp'](apt_version, "1.6.10") > 0 %}
+
+{%- if apt_support_acd %}
 deb {{ '[trusted=yes]' if not pillar.get('mgr_metadata_signing_enabled', false) else '[signed-by=/usr/share/keyrings/mgr-archive-keyring.gpg]' }} {{protocol}}://{{hostname}}:{{port}}/rhn/manager/download {{ chan }} main
+{%- else %}
+deb {{ '[trusted=yes]' if not pillar.get('mgr_metadata_signing_enabled', false) else '[signed-by=/usr/share/keyrings/mgr-archive-keyring.gpg]' }} {{protocol}}://{{ args['token'] }}@{{hostname}}:{{port}}/rhn/manager/download {{ chan }} main
 {%- endif %}
 {%- else %}
 [{{ args['alias'] }}]

--- a/susemanager-utils/susemanager-sls/salt/channels/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/channels/init.sls
@@ -88,7 +88,10 @@ mgrchannels_repo:
 {%- endif %}
 {%- endif %}
 
-{%- if (grains['os'] == 'Debian' and grains['osmajorrelease']|int >= 10) or (grains['os'] == 'Ubuntu' and grains['osmajorrelease']|int >= 18) %}
+{%- set apt_version = salt['pkg.version']("apt") %}
+{%- set apt_support_acd = grains['os_family'] == 'Debian' and apt_version and salt['pkg.version_cmp'](apt_version, "1.6.10") > 0 %}
+
+{%- if apt_support_acd %}
 aptauth_conf:
   file.managed:
     - name: "/etc/apt/auth.conf.d/susemanager.conf"

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,7 @@
+- Ubuntu 18 has version of apt which does not correctly support
+  auth.conf.d directory. Detect the working version and use this feature
+  only when we have a higher version installed
+
 -------------------------------------------------------------------
 Wed Jan 27 13:11:15 CET 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Ubuntu 18.04 has an initial version of apt which does not support auth.conf.d directory. 
The first working version seems to be 1.6.10.
Check the apt version to decide whenever we want to use the feature or not.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **manual**

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/3281
Tracks 

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
