### PR TITLE
QAM: Fix the deploy of config files, selecting the system

### DIFF
--- a/testsuite/features/build_validation/smoke_tests/smoke_tests.template
+++ b/testsuite/features/build_validation/smoke_tests/smoke_tests.template
@@ -111,7 +111,9 @@ Feature: Smoke tests for <client>
     Given I am authorized as "admin" with password "admin"
     And I follow the left menu "Configuration > Channels"
     And I follow "Mixed Channel"
-    And I follow "Deploy all configuration files to all subscribed systems"
+    And I follow "Deploy all configuration files to selected subscribed systems"
+    And I check the "<client>" host in the list
+    And I click on "Confirm & Deploy to Selected Systems"
     Then I should see a "/etc/s-mgr/config" link
     When I click on "Deploy Files to Selected Systems"
     Then I should see a "being scheduled" text

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -801,6 +801,10 @@ Then(/^I click on the filter button until page does contain "([^"]*)" text$/) do
   end
 end
 
+When(/^I enter "([^"]*)" as the filtered system name$/) do |input|
+  find("input[placeholder='Filter by System Name: ']").set(input)
+end
+
 When(/^I enter "([^"]*)" as the filtered package name$/) do |input|
   find("input[placeholder='Filter by Package Name: ']").set(input)
 end
@@ -819,6 +823,14 @@ end
 
 When(/^I enter "([^"]*)" as the filtered XCCDF result type$/) do |input|
   find("input[placeholder='Filter by Result: ']").set(input)
+end
+
+When(/^I check the "([^"]*)" host in the list$/) do |host|
+  steps %(
+    When I enter "#{$node_by_host[host].hostname}" as the filtered system name
+    And I click on the filter button
+    And I check "#{$node_by_host[host].hostname}" in the list
+  )
 end
 
 Then(/^I check (a|the) "([^"]*)" package in the list$/) do |_article, client|


### PR DESCRIPTION
## What does this PR change?

We were not selecting the system properly from the list when deploying configuration files in a system.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
 - Manager-4.1 https://github.com/SUSE/spacewalk/pull/13914
 - Manager-4.0 https://github.com/SUSE/spacewalk/pull/14019
 
- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
