### PR TITLE
Add python3-distro to bootstrap repo definitions

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -381,7 +381,8 @@ RES8 = [
     "python3-chardet",
     "python3-pysocks",
     "python3-pytz",
-    "python3-setuptools"
+    "python3-setuptools",
+    "python3-distro"
 ]
 
 RES8_X86 = [
@@ -395,6 +396,7 @@ PKGLIST15_SALT = [
     "python3-Babel",
     "python3-certifi",
     "python3-chardet",
+    "python3-distro",
     "python3-idna",
     "python3-Jinja2",
     "python3-MarkupSafe",
@@ -572,6 +574,7 @@ PKGLISTUBUNTU2004 = [
     "libzmq5",
     "python3-crypto",
     "python3-dateutil",
+    "python3-distro",
     "python3-jinja2",
     "python3-markupsafe",
     "python3-msgpack",
@@ -651,6 +654,7 @@ PKGLISTDEBIAN10 = [
     "python3-chardet",
     "python3-six",
     "python3-dateutil",
+    "python3-distro",
     "python3-tz",
     "python3-croniter",
     "python3-crypto",

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,6 @@
+- Add python3-distro to RES8, SLE15, Ubuntu20.04 and Debian 10 bootstrap
+  repositories to fix bootstrapping issues
+
 -------------------------------------------------------------------
 Fri Feb 12 14:32:42 CET 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Salt 3002.2 requires python3-distro. SLE 15, Ubuntu 20.04, Debian 10 and RES8 do not have python3-distro in the bootstrap repository yet.

## GUI diff

No difference.

## Documentation
- No documentation needed: Only ensures Salt 3002 from bootstrap repos is installable


## Test coverage
- No tests: Only bootstrap_data was touched, no test needed



## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
