### PR TITLE
Speed up susemanager-nodejs-sdk-devel RPM build

### DIFF
--- a/susemanager-frontend/susemanager-nodejs-sdk-devel/susemanager-nodejs-sdk-devel.changes
+++ b/susemanager-frontend/susemanager-nodejs-sdk-devel/susemanager-nodejs-sdk-devel.changes
@@ -1,3 +1,5 @@
+- Speed up the RPM build
+
 -------------------------------------------------------------------
 Fri Feb 12 14:34:08 CET 2021 - jgonzalez@suse.com
 

--- a/susemanager-frontend/susemanager-nodejs-sdk-devel/susemanager-nodejs-sdk-devel.spec
+++ b/susemanager-frontend/susemanager-nodejs-sdk-devel/susemanager-nodejs-sdk-devel.spec
@@ -56,17 +56,23 @@ mkdir -p %{buildroot}%{_bindir}
 cp -pr node_modules/* %{buildroot}%{nodejs_sitelib}
 
 chmod +x %{buildroot}%{nodejs_sitelib}/webpack/bin/*
-ln -sf %{nodejs_sitelib}/webpack/bin/webpack.js %{buildroot}%{_bindir}/webpack
+ln -sf ./webpack.js %{buildroot}/%{nodejs_sitelib}/webpack/bin/webpack
 
 find %{buildroot}%{nodejs_sitelib} -name "*~" -delete
 find %{buildroot}%{nodejs_sitelib} -name ".*" -type d -exec rm -rf {} +
 find %{buildroot}%{nodejs_sitelib} -name ".*" -delete
 %fdupes %{buildroot}%{nodejs_sitelib}
 
+# Compress all the node modules to reduce the huge number of files to package
+pushd %{buildroot}%{nodejs_sitelib}
+tar czf ../all_modules.tar.gz *
+tar tf ../all_modules.tar.gz | cut -d '/' -f1 | sort | uniq | while read -r MODULE; do rm -rf $MODULE; done
+mv ../all_modules.tar.gz .
+popd
+
 %files
 %defattr(-,root,root,-)
 %dir %{nodejs_modulesdir}
 %{nodejs_sitelib}/*
-%{_bindir}/*
 
 %changelog

--- a/web/spacewalk-web.spec
+++ b/web/spacewalk-web.spec
@@ -193,8 +193,9 @@ database.
 %build
 make -f Makefile.spacewalk-web PERLARGS="INSTALLDIRS=vendor" %{?_smp_mflags}
 pushd html/src
-ln -sf %{nodejs_sitelib} .
-BUILD_VALIDATION=false node build.js
+mkdir node_modules
+tar x -C node_modules -f %{nodejs_sitelib}/all_modules.tar.gz
+PATH=node_modules/webpack/bin:$PATH BUILD_VALIDATION=false node build.js
 popd
 sed -i -r "s/^(web.buildtimestamp *= *)_OBS_BUILD_TIMESTAMP_$/\1$(date +'%%Y%%m%%d%%H%%M%%S')/" conf/rhn_web.conf
 


### PR DESCRIPTION
## What does this PR change?

That package has about 40000 files in the node_modules folder, and it takes about 1.5h for rpmbuild to go over them on most IBS / OBS workers.

The speedup idea is to reduce the number of files by grouping them in an archive. That archive is then uncompressed when building the `spacewalk-web` package where it is actually used.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: rpm build speedup

- [X] **DONE**

## Test coverage
- No tests:  rpm build speedup

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
