### PR TITLE
Openscap dependencies metadata

### DIFF
--- a/testsuite/features/secondary/min_centos_openscap_audit.feature
+++ b/testsuite/features/secondary/min_centos_openscap_audit.feature
@@ -12,6 +12,7 @@ Feature: OpenSCAP audit of CentOS Salt minion
   Scenario: Install the OpenSCAP packages on the CentOS minion
     Given I am on the Systems overview page of this "ceos_minion"
     When I enable repository "CentOS-Base" on this "ceos_minion"
+    And I refresh the metadata for "ceos_minion"
     And I install OpenSCAP dependencies on "ceos_minion"
     And I fix CentOS 7 OpenSCAP files on "ceos_minion"
     And I follow "Software" in the content area

--- a/testsuite/features/secondary/min_salt_openscap_audit.feature
+++ b/testsuite/features/secondary/min_salt_openscap_audit.feature
@@ -10,6 +10,7 @@ Feature: OpenSCAP audit of Salt minion
   Scenario: Install the OpenSCAP packages on the SLE minion
     Given I am on the Systems overview page of this "sle_minion"
     When I enable repository "os_pool_repo os_update_repo" on this "sle_minion"
+    And I refresh the metadata for "sle_minion"
     And I install OpenSCAP dependencies on "sle_minion"
     And I follow "Software" in the content area
     And I click on "Update Package List"

--- a/testsuite/features/secondary/min_ubuntu_openscap_audit.feature
+++ b/testsuite/features/secondary/min_ubuntu_openscap_audit.feature
@@ -12,6 +12,7 @@ Feature: OpenSCAP audit of Ubuntu Salt minion
   Scenario: Install the OpenSCAP packages on the Ubuntu minion
     Given I am on the Systems overview page of this "ubuntu_minion"
     When I enable universe repositories on "ubuntu_minion"
+    And I refresh the metadata for "ubuntu_minion"
     And I install OpenSCAP dependencies on "ubuntu_minion"
     And I follow "Software" in the content area
     And I click on "Update Package List"

--- a/testsuite/features/secondary/trad_openscap_audit.feature
+++ b/testsuite/features/secondary/trad_openscap_audit.feature
@@ -11,6 +11,7 @@ Feature: OpenSCAP audit of traditional client
   Scenario: Install the OpenSCAP packages on the traditional client
     When I enable repository "os_pool_repo os_update_repo" on this "sle_client"
     And I enable SUSE Manager tools repositories on "sle_client"
+    And I refresh the metadata for "sle_client"
     And I install OpenSCAP dependencies on "sle_client"
 
   Scenario: Schedule an OpenSCAP audit job on the traditional client using SUSE profile

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1343,9 +1343,11 @@ end
 
 When(/^I refresh packages list via spacecmd on "([^"]*)"$/) do |client|
   node = get_system_name(client)
-  $server.run("spacecmd -u admin -p admin clear_caches")
+  result, code = $server.run("spacecmd -u admin -p admin clear_caches")
+  STDOUT.puts "clear caches: rc=#{code} output=#{result}"
   command = "spacecmd -u admin -p admin system_schedulepackagerefresh #{node}"
-  $server.run(command)
+  result, code = $server.run(command)
+  STDOUT.puts "schedule package refresh: rc=#{code} output=#{result}"
 end
 
 Then(/^I wait until refresh package list on "(.*?)" is finished$/) do |client|
@@ -1369,6 +1371,7 @@ When(/^spacecmd should show packages "([^"]*)" installed on "([^"]*)"$/) do |pac
   $server.run("spacecmd -u admin -p admin clear_caches")
   command = "spacecmd -u admin -p admin system_listinstalledpackages #{node}"
   result, code = $server.run(command, false)
+  STDOUT.puts "list installed packages: rc=#{code} output=#{result}"
   packages.split(' ').each do |package|
     pkg = package.strip
     raise "package #{pkg} is not installed" unless result.include? pkg
@@ -1381,6 +1384,7 @@ When(/^I wait until package "([^"]*)" is installed on "([^"]*)" via spacecmd$/) 
   command = "spacecmd -u admin -p admin system_listinstalledpackages #{node}"
   repeat_until_timeout(timeout: 600, message: "package #{pkg} is not installed yet") do
     result, code = $server.run(command, false)
+    STDOUT.puts "list installed packages: rc=#{code} output=#{result}"
     break if result.include? pkg
     sleep 1
   end


### PR DESCRIPTION
## What does this PR change?

This PR makes sure to zypper ref before we install openscap packages, in order to avoid:
```
And I install OpenSCAP dependencies on "sle_client" 
(...)
Media source 'http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head:/SLE15-SUSE-Manager-Tools/images/repo/SLE-15-Manager-Tools-POOL-x86_64-Media1/' does not contain the desired medium
```

It also temporarily adds debugging information to understand why we get:
```
 When I refresh packages list via spacecmd on "ubuntu_minion"
 And I wait until refresh package list on "ubuntu_minion" is finished
 Then spacecmd should show packages "virgo-dummy-1.0" installed on "ubuntu_minion"
                                            
 package virgo-dummy-1.0 is not installed (RuntimeError)
```

## Links

Ports:
* 4.0:
* 4.1:

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
