### PR TITLE
Fix metadata steps

### DIFF
--- a/testsuite/features/support/client_stack.rb
+++ b/testsuite/features/support/client_stack.rb
@@ -1,28 +1,12 @@
-# Copyright (c) 2010-2020 SUSE LLC.
+# Copyright (c) 2010-2021 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 require 'nokogiri'
 require 'timeout'
 
-def client_is_zypp?
-  $client.run('test -x /usr/bin/zypper', false)
-end
-
-def client_refresh_metadata
-  if client_is_zypp?
-    $client.run('zypper --non-interactive ref -s', true, 500, 'root')
-  else
-    $client.run('yum clean all', true, 600, 'root')
-    $client.run('yum makecache', true, 600, 'root')
-  end
-end
-
 def client_raw_repodata_dir(channel)
-  if client_is_zypp?
-    "/var/cache/zypp/raw/spacewalk:#{channel}/repodata"
-  else
-    "/var/cache/yum/#{channel}"
-  end
+  "/var/cache/zypp/raw/spacewalk:#{channel}/repodata"
+  # it would be "/var/cache/yum/#{channel}" for CentOS
 end
 
 def client_system_id_to_i


### PR DESCRIPTION
## What does this PR change?

This PR refreshes metadata properly:
* CentOS and Ubuntu are not traditional clients anymore, no need to `rhn_check` first
* on all traditional clients, there's no need to `rhn_check` first anyway, this is orthogonal to refreshing metadata
* on Ubuntu and debian, it's `apt_get` and not `yum`

It also removes useless code: `client_is_zypp` would always return `true`, because `$client` always uses `zypper`.
(I think SLE 11 SP3 was using `yum` but that client is long dead and buried :latin_cross: )


## Links

Ports:
* 4.0
* 4.1


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
