### PR TITLE
Filtered systems and packages

### DIFF
--- a/testsuite/documentation/cucumber-steps.md
+++ b/testsuite/documentation/cucumber-steps.md
@@ -324,8 +324,8 @@ The check box can be identified by name, id or label text.
 
 ```cucumber
   When I check the row with the "virgo-dummy-3456" link
-  When I check the row with the "sle_client" hostname
   When I check the row with the "suse_docker_admin" text
+  When I check the "sle_client" client
   When I check "New Test Channel" in the list
   When I uncheck "hoag-dummy-1.1-1.1" in the list
 ```

--- a/testsuite/features/build_validation/smoke_tests/smoke_tests.template
+++ b/testsuite/features/build_validation/smoke_tests/smoke_tests.template
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 SUSE LLC.
+# Copyright (c) 2020-2021 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 @<client>
@@ -35,7 +35,9 @@ Feature: Smoke tests for <client>
     Given I am on the Systems overview page of this "<client>"
     And I follow "Software" in the content area
     And I follow "Install"
-    And I check the "<client>" package in the list
+    And I enter the package for "<client>" as the filtered package name
+    And I click on the filter button
+    And I check the package for "<client>" in the list
     And I click on "Install Selected Packages"
     And I click on "Confirm"
     Then I should see a "1 package install has been scheduled for" text
@@ -46,7 +48,9 @@ Feature: Smoke tests for <client>
     Given I am on the Systems overview page of this "<client>"
     And I follow "Software" in the content area
     And I follow "List / Remove"
-    And I check the "<client>" package in the list
+    And I enter the package for "<client>" as the filtered package name
+    And I click on the filter button
+    And I check the package for "<client>" in the list
     And I click on "Remove Packages"
     And I click on "Confirm"
     Then I should see a "1 package removal has been scheduled" text
@@ -112,7 +116,9 @@ Feature: Smoke tests for <client>
     And I follow the left menu "Configuration > Channels"
     And I follow "Mixed Channel"
     And I follow "Deploy all configuration files to selected subscribed systems"
-    And I check the "<client>" host in the list
+    And I enter the hostname of "<client>" as the filtered system name
+    And I click on the filter button
+    And I check the "<client>" client
     And I click on "Confirm & Deploy to Selected Systems"
     Then I should see a "/etc/s-mgr/config" link
     When I click on "Deploy Files to Selected Systems"

--- a/testsuite/features/secondary/trad_cve_audit.feature
+++ b/testsuite/features/secondary/trad_cve_audit.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2020 SUSE LLC
+# Copyright (c) 2015-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @sle_client
@@ -69,8 +69,8 @@ Feature: CVE Audit on traditional clients
     And I select "1999" from "cveIdentifierYear"
     And I enter "9999" as "cveIdentifierId"
     And I click on "Audit Servers"
-    And I should see a "Affected, at least one patch available in an assigned channel" text
-    When I check the row with the "sle_client" hostname
+    Then I should see a "Affected, at least one patch available in an assigned channel" text
+    When I check the "sle_client" client
     Then I should see a "system selected" text
     When I am on the System Manager System Overview page
     Then I should see "sle_client" as link
@@ -95,7 +95,7 @@ Feature: CVE Audit on traditional clients
 
   Scenario: Apply patches
     Given I am on the Systems overview page of this "sle_client"
-    And I follow "Software" in the content area
+    When I follow "Software" in the content area
     And I follow "Patches" in the content area
     And I check "milkyway-dummy-2345" in the list
     And I click on "Apply Patches"

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2020 SUSE LLC.
+# Copyright (c) 2010-2021 SUSE LLC.
 # Licensed under the terms of the MIT license.
 
 #
@@ -763,11 +763,6 @@ Then(/^I check the row with the "([^"]*)" text$/) do |text|
   step %(I check "#{text}" in the list)
 end
 
-Then(/^I check the row with the "([^"]*)" hostname$/) do |host|
-  system_name = get_system_name(host)
-  step %(I check "#{system_name}" in the list)
-end
-
 When(/^I check the first patch in the list$/) do
   step %(I check the first row in the list)
 end
@@ -801,6 +796,11 @@ Then(/^I click on the filter button until page does contain "([^"]*)" text$/) do
   end
 end
 
+When(/^I enter the hostname of "([^"]*)" as the filtered system name$/) do |host|
+  system_name = get_system_name(host)
+  find("input[placeholder='Filter by System Name: ']").set(system_name)
+end
+
 When(/^I enter "([^"]*)" as the filtered package states name$/) do |input|
   find("input[placeholder='Search package']").set(input)
 end
@@ -825,20 +825,12 @@ When(/^I enter "([^"]*)" as the filtered XCCDF result type$/) do |input|
   find("input[placeholder='Filter by Result: ']").set(input)
 end
 
-When(/^I check the "([^"]*)" host in the list$/) do |host|
-  steps %(
-    When I enter "#{$node_by_host[host].hostname}" as the filtered system name
-    And I click on the filter button
-    And I check "#{$node_by_host[host].hostname}" in the list
-  )
+When(/^I enter the package for "([^"]*)" as the filtered package states name$/) do |host|
+  step %(I enter "#{PACKAGE_BY_CLIENT[host]}" as the filtered package name)
 end
 
-Then(/^I check (a|the) "([^"]*)" package in the list$/) do |_article, client|
-  steps %(
-    When I enter "#{PACKAGE_BY_CLIENT[client]}" as the filtered package name
-    And I click on the filter button
-    And I check "#{PACKAGE_BY_CLIENT[client]}" in the list
-  )
+When(/^I check the package for "([^"]*)" in the list$/) do |host|
+  step %(I check "#{PACKAGE_BY_CLIENT[host]}" in the list)
 end
 
 When(/^I check row with "([^"]*)" and arch of "([^"]*)"$/) do |text, client|


### PR DESCRIPTION
## What does this PR change?

On top of:
* Fix the deploy of config files, selecting the system #3289
* Filter by package state name #3227 

this PR:
* restores the step `I enter "..." as the filtered system name` which was destroyed by accident
* avoids using series of steps in step definitions (clarity of feature, easier debugging)
* removes duplicated step `I check the row with the "..." hostname`


## Links

Ports:
* 4.0: SUSE/spacewalk#14031
* 4.1: SUSE/spacewalk#14032


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
