### PR TITLE
Remove unused variables in frontend code

### DIFF
--- a/web/html/src/components/datetimepicker.tsx
+++ b/web/html/src/components/datetimepicker.tsx
@@ -131,10 +131,10 @@ class TimePicker extends React.Component<TimePickerProps> {
       roundingFunction: (seconds, options) => seconds,
     });
     this._input?.on("change", () => {
-      const timepickerValue = this._input?.timepicker("getTime");
+      // Do nothing
     });
     this._input?.on("timeFormatError", () => {
-      const timepickerValue = this._input?.timepicker("getTime");
+      // Do nothing
     });
     this._input?.timepicker("setTime", this.props.value);
     this._input?.on("changeTime", () => {

--- a/web/html/src/components/formulas/FormulaComponentGenerator.tsx
+++ b/web/html/src/components/formulas/FormulaComponentGenerator.tsx
@@ -622,9 +622,6 @@ export class FormulaFormContextProvider extends React.Component<
   // TODO implement componentDidUpdate
 
   render() {
-    const layout = this.state.formulaLayout;
-    const values = this.state.formulaValues;
-
     const contextValue = {
       scope: this.props.scope,
       layout: this.state.formulaLayout,
@@ -1063,7 +1060,6 @@ export class FormulaFormContextProvider extends React.Component<
 
   clearValues = clearValuesConfirmation => {
     const layout = this.state.formulaLayout;
-    const values = this.state.formulaValues;
     if (clearValuesConfirmation()) {
       let clearValues: any = {};
       if (this.props.scope === "system") {


### PR DESCRIPTION
## What does this PR change?

This PR removes unused variables in frontend code, which reduces the number of `eslint` warnings.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
