### PR TITLE
Testsuite: Fix check for env. vars set by terracumber

### DIFF
--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -18,12 +18,9 @@ require 'multi_test'
 
 server = ENV['SERVER']
 $debug_mode = true if ENV['DEBUG']
-$long_tests_enabled = true if ENV['LONG_TESTS']
+$long_tests_enabled = true if ENV['LONG_TESTS'] == 'true'
 puts "Executing long running tests" if $long_tests_enabled
-$service_pack_migration_enabled = true if ENV['SERVICE_PACK_MIGRATION']
-# To disable SP migration, comment the previous line, uncoment the next one
-# and adjust testsuite/run_sets/init_clients.yml
-# $service_pack_migration_enabled = false
+$service_pack_migration_enabled = true if ENV['SERVICE_PACK_MIGRATION'] == 'true'
 puts "Executing service pack migrations" if $service_pack_migration_enabled
 
 # maximal wait before giving up


### PR DESCRIPTION
## What does this PR change?
It fixes a few environment variable checks.

Terracumber sets them as the strings 'true' or 'false'.
At Ruby, `if 'false'` returns truthy.

- testsuite/features/support/env.rb:
Check explicitely for either 'true' or 'false'.

## Links
### Ports
- Manager-4.1: https://github.com/SUSE/spacewalk/pull/14044
- Manager-4.0: https://github.com/SUSE/spacewalk/pull/14045
## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)
