### PR TITLE
Testsuite: Ensure we get the lastest Salt after SP migration

### DIFF
--- a/testsuite/features/init_clients/sle_minion.feature
+++ b/testsuite/features/init_clients/sle_minion.feature
@@ -56,17 +56,19 @@ Feature: Bootstrap a Salt minion via the GUI
     Then I should see a "This system is scheduled to be migrated to" text
 
 @service_pack_migration
-  Scenario: Check the migration status for this minion
+  Scenario: Check the migration is successful for this minion
     Given I am on the Systems overview page of this "sle_spack_migrated_minion"
     When I follow "Events"
     And I follow "History"
     And I wait at most 600 seconds until event "Service Pack Migration scheduled by admin" is completed
+    And I follow "Details" in the content area
+    Then I should see a "SUSE Linux Enterprise Server 15 SP2" text
 
 @service_pack_migration
-  Scenario: Check the migration is successful for this minion
-    Given I am on the Systems overview page of this "sle_spack_migrated_minion"
-    When I follow "Details" in the content area
-    Then I should see a "SUSE Linux Enterprise Server 15 SP2" text
+  Scenario: Install the latest Salt on this minion
+    When I enable repositories before installing Salt on this "sle_spack_migrated_minion"
+    And I install Salt packages from "sle_spack_migrated_minion"
+    And I disable repositories after installing Salt on this "sle_spack_migrated_minion"
 
   Scenario: Subscribe the SLES minion to a base channel
     Given I am on the Systems overview page of this "sle_minion"

--- a/testsuite/features/init_clients/sle_ssh_minion.feature
+++ b/testsuite/features/init_clients/sle_ssh_minion.feature
@@ -67,17 +67,20 @@ Feature: Bootstrap a Salt host managed via salt-ssh
     Then I should see a "This system is scheduled to be migrated to" text
 
 @service_pack_migration
-  Scenario: Check the migration status for this SSH minion
+  Scenario: Check the migration is successful for this SSH minion
     Given I am on the Systems overview page of this "ssh_spack_migrated_minion"
     When I follow "Events"
     And I follow "History"
     And I wait at most 600 seconds until event "Service Pack Migration scheduled by admin" is completed
+    And I follow "Details" in the content area
+    Then I should see a "SUSE Linux Enterprise Server 15 SP2" text
 
 @service_pack_migration
-  Scenario: Check the migration is successful for this SSH minion
-    Given I am on the Systems overview page of this "ssh_spack_migrated_minion"
-    When I follow "Details" in the content area
-    Then I should see a "SUSE Linux Enterprise Server 15 SP2" text
+@ssh_minion
+  Scenario: Install the latest Salt on this SSH-managed minion
+    When I enable repositories before installing Salt on this "ssh_spack_migrated_minion"
+    And I install Salt packages from "ssh_spack_migrated_minion"
+    And I disable repositories after installing Salt on this "ssh_spack_migrated_minion"
 
 @ssh_minion
   Scenario: Subscribe the SSH-managed SLES minion to a base channel

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -659,6 +659,14 @@ When(/^I install Salt packages from "(.*?)"$/) do |host|
   end
 end
 
+When(/^I enable repositories before installing Salt on this "([^"]*)"$/) do |host|
+  step %(I enable repository "tools_additional_repo" on this "#{host}" without error control)
+end
+
+When(/^I disable repositories after installing Salt on this "([^"]*)"$/) do |host|
+  step %(I disable repository "tools_additional_repo" on this "#{host}" without error control)
+end
+
 # minion bootstrap steps
 Then(/^I run spacecmd listevents for "([^"]*)"$/) do |host|
   system_name = get_system_name(host)


### PR DESCRIPTION
## What does this PR change?
Ensure we use the latest Salt version available after the SP migration.

After the SP migration, the Salt version installed in the
SLE minion is the one from SCC; instead, we want to
test the latest Salt version available.

- testsuite/features/init_clients/sle_minion.feature
- testsuite/features/init_clients/sle_ssh_minion.feature
Install the latest Salt version in the SP migrated minion.
Combine the two steps checking the result of the SP migration in just one.
- testsuite/features/step_definitions/salt_steps.rb: Step definitions.


## Links

Fixes https://github.com/SUSE/spacewalk/issues/14030
### Ports
- Manager-4.1: https://github.com/SUSE/spacewalk/pull/14051
and https://github.com/SUSE/spacewalk/pull/14078
## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)
