### PR TITLE
more links changed to buttons

### DIFF
--- a/testsuite/features/build_validation/add_custom_repositories/add_ceos8_repositories.feature
+++ b/testsuite/features/build_validation/add_custom_repositories/add_ceos8_repositories.feature
@@ -75,18 +75,18 @@ Feature: Adding the CentOS 8 distribution custom repositories
     And I enter "no-appstream" as "label"
     And I click on "Create"
     Then I should see a "Content Lifecycle Project - Remove AppStream metadata" text
-    When I follow "Attach/Detach Sources"
+    When I click on "Attach/Detach Sources"
     And I select "RHEL8-Pool for x86_64" from "selectedBaseChannel"
     And I check "Custom Channel for CentOS 8 DVD"
     And I check "RES-AS-8-Updates for x86_64"
     And I click on "Save"
     Then I should see a "Custom Channel for CentOS 8 DVD" text
-    When I follow "Attach/Detach Filters"
+    When I click on "Attach/Detach Filters"
     And I check "python-3.8: enable module python38:3.8"
     And I check "ruby-2.7: enable module ruby:2.7"
     And I click on "Save"
     Then I should see a "python-3.8: enable module python38:3.8" text
-    When I follow "Add Environment"
+    When I click on "Add Environment"
     And I enter "result" as "name"
     And I enter "result" as "label"
     And I enter "Filtered channels without AppStream channels" as "description"

--- a/testsuite/features/secondary/srv_content_lifecycle.feature
+++ b/testsuite/features/secondary/srv_content_lifecycle.feature
@@ -35,7 +35,7 @@ Feature: Content lifecycle
     Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Content Lifecycle > Projects"
     And I follow "clp_name"
-    And I follow "Attach/Detach Sources"
+    And I click on "Attach/Detach Sources"
     And I select "SLES12-SP5-Pool for x86_64" from "selectedBaseChannel"
     And I click on "Save"
     Then I wait until I see "SLES12-SP5-Pool for x86_64" text
@@ -64,21 +64,21 @@ Feature: Content lifecycle
     When I follow the left menu "Content Lifecycle > Projects"
     And I follow "clp_name"
     Then I should see a "No environments created" text
-    When I follow "Add Environment"
+    When I click on "Add Environment"
     And I enter "dev_name" as "name"
     And I enter "dev_label" as "label"
     And I enter "dev_desc" as "description"
     And I click on "Save"
     Then I wait until I see "dev_name" text
     And I should see a "dev_desc" text
-    When I follow "Add Environment"
+    When I click on "Add Environment"
     And I enter "prod_name" as "name"
     And I enter "prod_label" as "label"
     And I enter "prod_desc" as "description"
     And I click on "Save"
     Then I wait until I see "prod_name" text
     And I should see a "prod_desc" text
-    When I follow "Add Environment"
+    When I click on "Add Environment"
     And I enter "qa_name" as "name"
     And I enter "qa_label" as "label"
     And I enter "qa_desc" as "description"
@@ -136,7 +136,7 @@ Feature: Content lifecycle
     When I follow the left menu "Content Lifecycle > Projects"
     And I follow "clp_name"
     Then I should see a "Build (0)" text
-    When I follow "Attach/Detach Sources"
+    When I click on "Attach/Detach Sources"
     And I add the "Test Base Channel" channel to sources
     And I click on "Save"
     Then I wait until I see "Test Base Channel" text

--- a/testsuite/features/secondary/trad_cve_audit.feature
+++ b/testsuite/features/secondary/trad_cve_audit.feature
@@ -48,8 +48,8 @@ Feature: CVE Audit on traditional clients
     And I should see a "Install a new patch on this system" link
     And I should see a "milkyway-dummy-2345" text
     And I should see a "Download CSV" link
-    And I should see a "Status" link
-    And I should see a "Name" link
+    And I should see a "Status" button
+    And I should see a "Name" button
     And I should see a "extra CVE data update" link
     Then I follow "Install a new patch on this system" on "sle_client" row
     And I should see a "Relevant Patches" text


### PR DESCRIPTION
## What does this PR change?

Found more links which changed into buttons in PR https://github.com/uyuni-project/uyuni/pull/3282
I wonder if this was really a good idea to do it.

@ricardoasmarques @ncounter @Etheryte - I wonder if this was intended or we we better rollback this change?

See examples below

## GUI diff

The column header texts are not links anymore, but buttons.:

![image](https://user-images.githubusercontent.com/1038917/108596340-b2f1cb00-7384-11eb-8bf7-4ee22c6a518c.png)


Here the right side actions `Attach/Detach Sources`, `Attach/Detach Filter`, etc are now also buttons:

![image](https://user-images.githubusercontent.com/1038917/108596360-d87ed480-7384-11eb-8b77-c605d8328917.png)


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
