### PR TITLE
XMLRPC does not know Long and comparing long with int result into errors

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -7365,7 +7365,7 @@ public class SystemHandler extends BaseHandler {
      * @xmlrpc.returntype #param("int", "actionId", "The action id of the scheduled action")
      */
     public Long scheduleApplyHighstate(User loggedInUser, Integer sid, Date earliestOccurrence, boolean test) {
-        return scheduleApplyHighstate(loggedInUser, Arrays.asList(sid.longValue()), earliestOccurrence, test);
+        return scheduleApplyHighstate(loggedInUser, Arrays.asList(sid), earliestOccurrence, test);
     }
 
     /**
@@ -7379,21 +7379,23 @@ public class SystemHandler extends BaseHandler {
      *
      * @xmlrpc.doc Schedule highstate application for a given system.
      * @xmlrpc.param #session_key()
-     * @xmlrpc.param #array_single("long", "systemIds")
+     * @xmlrpc.param #array_single("int", "systemIds")
      * @xmlrpc.param #param("dateTime.iso8601", "earliestOccurrence")
      * @xmlrpc.param #param_desc("boolean", "test", "Run states in test-only mode")
      * @xmlrpc.returntype #param("int", "actionId", "The action id of the scheduled action")
      */
-    public Long scheduleApplyHighstate(User loggedInUser, List<Long> sids, Date earliestOccurrence, boolean test) {
+    public Long scheduleApplyHighstate(User loggedInUser, List<Integer> sids, Date earliestOccurrence, boolean test) {
+        List<Long> sysids = sids.stream().map(Integer::longValue).collect(Collectors.toList());
         try {
             List<Long> visible = MinionServerFactory.lookupVisibleToUser(loggedInUser)
                     .map(m -> m.getId()).collect(Collectors.toList());
-            if (!visible.containsAll(sids)) {
-                sids.removeAll(visible);
-                throw new UnsupportedOperationException("Some System not managed with Salt: " + sids);
+            if (!visible.containsAll(sysids)) {
+                sysids.removeAll(visible);
+                throw new UnsupportedOperationException("Some System not managed with Salt: " + sysids);
             }
 
-            Action a = ActionManager.scheduleApplyHighstate(loggedInUser, sids, earliestOccurrence, Optional.of(test));
+            Action a = ActionManager.scheduleApplyHighstate(loggedInUser, sysids, earliestOccurrence,
+                    Optional.of(test));
             a = ActionFactory.save(a);
             taskomaticApi.scheduleActionExecution(a);
             return a.getId();
@@ -7426,7 +7428,7 @@ public class SystemHandler extends BaseHandler {
      */
     public Long scheduleApplyStates(User loggedInUser, Integer sid, List<String> stateNames,
             Date earliestOccurrence, boolean test) {
-        return scheduleApplyStates(loggedInUser, Arrays.asList(sid.longValue()), stateNames,
+        return scheduleApplyStates(loggedInUser, Arrays.asList(sid), stateNames,
                 earliestOccurrence, test);
     }
 
@@ -7442,23 +7444,24 @@ public class SystemHandler extends BaseHandler {
      *
      * @xmlrpc.doc Schedule highstate application for a given system.
      * @xmlrpc.param #session_key()
-     * @xmlrpc.param #array_single("long", "systemIds")
+     * @xmlrpc.param #array_single("int", "systemIds")
      * @xmlrpc.param #array_single("string", "state names")
      * @xmlrpc.param #param("dateTime.iso8601", "earliestOccurrence")
      * @xmlrpc.param #param_desc("boolean", "test", "Run states in test-only mode")
      * @xmlrpc.returntype #param("int", "actionId", "The action id of the scheduled action")
      */
-    public Long scheduleApplyStates(User loggedInUser, List<Long> sids, List<String> stateNames,
+    public Long scheduleApplyStates(User loggedInUser, List<Integer> sids, List<String> stateNames,
             Date earliestOccurrence, boolean test) {
+        List<Long> sysids = sids.stream().map(Integer::longValue).collect(Collectors.toList());
         try {
             List<Long> visible = MinionServerFactory.lookupVisibleToUser(loggedInUser)
                     .map(m -> m.getId()).collect(Collectors.toList());
-            if (!visible.containsAll(sids)) {
-                sids.removeAll(visible);
-                throw new UnsupportedOperationException("Some System not managed with Salt: " + sids);
+            if (!visible.containsAll(sysids)) {
+                sysids.removeAll(visible);
+                throw new UnsupportedOperationException("Some System not managed with Salt: " + sysids);
             }
 
-            Action a = ActionManager.scheduleApplyStates(loggedInUser, sids, stateNames, earliestOccurrence,
+            Action a = ActionManager.scheduleApplyStates(loggedInUser, sysids, stateNames, earliestOccurrence,
                     Optional.of(test));
             a = ActionFactory.save(a);
             taskomaticApi.scheduleActionExecution(a);

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
@@ -2673,8 +2673,8 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
         int preScheduleSize = ActionManager.recentlyScheduledActions(admin, null, 30).size();
         Date scheduleDate = new Date();
 
-        List<Long> sids = new LinkedList<Long>();
-        sids.add(testServer.getId());
+        List<Integer> sids = new LinkedList<>();
+        sids.add(testServer.getId().intValue());
 
         Long actionId = getMockedHandler().scheduleApplyHighstate(admin, sids, scheduleDate, true);
         assertNotNull(actionId);


### PR DESCRIPTION
## What does this PR change?

Even when specified `List<Long>` as input parameter, redstone XMLRPC lib give us `XmlRpcArray<Integer>`.
`containsAll` or `removeAll` on a Long list does not match.

To fix this, we have to specify `List<Integer>` as input parameter and convert it to `List<Long>` .

Bug introduced with https://github.com/uyuni-project/uyuni/pull/3234

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
