### PR TITLE
Add reactivation key support to bootstrap script

### DIFF
--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,5 @@
+- Add reactivation key support to bootstrap script (bsc#1181580)
+
 -------------------------------------------------------------------
 Wed Jan 27 13:02:05 CET 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Reactivation key can now be set in bootstrap script or passed as
environmental variable to the script.
Reactivation key is saved as `management_key` in susemanager.conf.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- Documentation issue was created: https://github.com/SUSE/spacewalk/issues/13942
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [X] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/13958
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
