### PR TITLE
improve fromdir with better mapping of URL to local files

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -2226,7 +2226,9 @@ public class ContentSyncManager {
 
             // Build full URL to test
             if (uri.getScheme().equals("file")) {
-                return Files.isReadable(testUrlPath);
+                boolean readable = Files.isReadable(testUrlPath);
+                log.debug(String.format("Test file URL %s: readable %s", testUrlPath, readable));
+                return readable;
             }
             else {
                 URI testUri = new URI(uri.getScheme(), null, uri.getHost(),

--- a/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -1012,9 +1012,6 @@ public class ContentSyncManager {
      * @throws URISyntaxException in case of an error
      */
     public List<String> buildRepoFileUrl(String url, SCCRepository repo) throws URISyntaxException {
-        if (url.contains("mirrorlist")) {
-            return Arrays.asList(url);
-        }
         URI uri = new URI(url);
         List<String> relFiles = new LinkedList<>();
         List<String> urls = new LinkedList<>();

--- a/java/code/src/com/redhat/rhn/manager/content/MgrSyncUtils.java
+++ b/java/code/src/com/redhat/rhn/manager/content/MgrSyncUtils.java
@@ -31,12 +31,8 @@ import org.apache.log4j.Logger;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -216,19 +212,18 @@ public class MgrSyncUtils {
         String host = "";
         String path = "/";
         try {
-            URL url = new URL(urlString);
-            host = url.getHost();
-            path = url.getPath();
+            URI uri = new URI(urlString);
+            host = uri.getHost();
+            path = uri.getPath();
 
             // Case 1
             if ("localhost".equals(host)) {
-                return url.toURI();
+                return uri;
             }
-            String qPath = Arrays.stream(Optional.ofNullable(url.getQuery()).orElse("").split("&"))
+            String qPath = Arrays.stream(Optional.ofNullable(uri.getQuery()).orElse("").split("&"))
                     .filter(p -> p.contains("=")) // filter out possible auth tokens
                     .map(p ->
                         Arrays.stream(p.split("=", 2))
-                            .map(s -> URLDecoder.decode(s, StandardCharsets.UTF_8))
                             .collect(Collectors.joining("/"))
                     )
                     .sorted()
@@ -237,7 +232,7 @@ public class MgrSyncUtils {
                 path = new File(path, qPath).getAbsolutePath();
             }
         }
-        catch (MalformedURLException | URISyntaxException e) {
+        catch (URISyntaxException e) {
             log.warn("Unable to parse URL: " + urlString);
         }
         String sccDataPath = Config.get().getString(ContentSyncManager.RESOURCE_PATH, null);

--- a/java/code/src/com/redhat/rhn/manager/content/test/ContentSyncManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/content/test/ContentSyncManagerTest.java
@@ -1477,7 +1477,7 @@ public class ContentSyncManagerTest extends BaseTestCaseWithUser {
                     ContentSource cs = bestAuth.getContentSource();
                     assertNotNull(cs);
                     assertEquals(bestAuth.getUrl(), cs.getSourceUrl());
-                    assertContains(cs.getSourceUrl(), "file:" + fromdir.toString() + "/SUSE/");
+                    assertContains(cs.getSourceUrl(), "file://" + fromdir.toString() + "/SUSE/");
                 });
             slewe.getRepositories().stream()
             .filter(pr -> pr.isMandatory())
@@ -1488,10 +1488,10 @@ public class ContentSyncManagerTest extends BaseTestCaseWithUser {
                 assertNotNull(cs);
                 assertEquals(bestAuth.getUrl(), cs.getSourceUrl());
                 if (pr.getChannelName().toLowerCase().contains("nvidia")) {
-                    assertContains(cs.getSourceUrl(), "file:" + fromdir.toString() + "/repo/RPMMD/");
+                    assertContains(cs.getSourceUrl(), "file://" + fromdir.toString() + "/repo/RPMMD/");
                 }
                 else {
-                    assertContains(cs.getSourceUrl(), "file:" + fromdir.toString() + "/SUSE/");
+                    assertContains(cs.getSourceUrl(), "file://" + fromdir.toString() + "/SUSE/");
                 }
             });
         }

--- a/java/code/src/com/redhat/rhn/manager/content/test/MgrSyncUtilsTest.java
+++ b/java/code/src/com/redhat/rhn/manager/content/test/MgrSyncUtilsTest.java
@@ -56,7 +56,7 @@ public class MgrSyncUtilsTest extends BaseTestCaseWithUser {
         String name = "SLE-Module-Basesystem15-SP3-x86_64";
 
         URI opath = MgrSyncUtils.urlToFSPath(url, name);
-        URI expected = new URI(String.format("file:%s/SUSE/Updates/SLE-Module-Basesystem/15-SP3/x86_64/update", fromdir));
+        URI expected = new URI(String.format("file://%s/SUSE/Updates/SLE-Module-Basesystem/15-SP3/x86_64/update", fromdir));
         assertContains(opath.toString(), expected.toString());
     }
 
@@ -66,7 +66,7 @@ public class MgrSyncUtilsTest extends BaseTestCaseWithUser {
         String name = "SLE-Module-Basesystem15-SP3-x86_64";
 
         URI opath = MgrSyncUtils.urlToFSPath(url, name);
-        URI expected = new URI(String.format("file:%s/SUSE/Updates/SLE-Module-Basesystem/15-SP3/x86_64/update", fromdir));
+        URI expected = new URI(String.format("file://%s/SUSE/Updates/SLE-Module-Basesystem/15-SP3/x86_64/update", fromdir));
         assertContains(opath.toString(), expected.toString());
     }
 
@@ -76,7 +76,7 @@ public class MgrSyncUtilsTest extends BaseTestCaseWithUser {
         String name = "ubuntu-2004-amd64-main-amd64";
 
         URI opath = MgrSyncUtils.urlToFSPath(url, name);
-        URI expected = new URI(String.format("file:%s/archive.ubuntu.com/ubuntu/dists/focal/main/binary-amd64", fromdir));
+        URI expected = new URI(String.format("file://%s/archive.ubuntu.com/ubuntu/dists/focal/main/binary-amd64", fromdir));
         assertContains(opath.toString(), expected.toString());
     }
 
@@ -86,8 +86,19 @@ public class MgrSyncUtilsTest extends BaseTestCaseWithUser {
         String name = "centos-7-appstream-x86_64";
 
         URI opath = MgrSyncUtils.urlToFSPath(url, name);
-        URI expected = new URI(String.format("file:%s/mirrorlist.centos.org/arch/x86_64/infra/stock/release/8/repo/AppStream", fromdir));
+        URI expected = new URI(String.format("file://%s/mirrorlist.centos.org/arch/x86_64/infra/stock/release/8/repo/AppStream", fromdir));
         assertContains(opath.toString(), expected.toString());
+    }
+
+    public void testurlToFSPathMirrorlistNormalize() throws Exception {
+
+        String url = "http://mirrorlist.centos.org/../?release=8&arch=x86_64&repo=AppStream&infra=stock&..=..&x=%2E%2E";
+        String name = "centos-7-appstream-x86_64";
+
+        URI opath = MgrSyncUtils.urlToFSPath(url, name);
+        URI expected = new URI(String.format("file://%s", fromdir));
+        assertContains(opath.toString(), expected.toString());
+        assertFalse("Decoding error: " + opath.toString(), opath.toString().contains("%"));
     }
 
     public void testurlToFSPathLegacy() throws Exception {
@@ -97,7 +108,42 @@ public class MgrSyncUtilsTest extends BaseTestCaseWithUser {
         String name = "SLE-12-GA-Desktop-NVIDIA-Driver";
 
         URI opath = MgrSyncUtils.urlToFSPath(url, name);
-        URI expected = new URI(String.format("file:%s/repo/RPMMD/SLE-12-GA-Desktop-NVIDIA-Driver", fromdir));
+        URI expected = new URI(String.format("file://%s/repo/RPMMD/SLE-12-GA-Desktop-NVIDIA-Driver", fromdir));
         assertContains(opath.toString(), expected.toString());
+    }
+
+    public void testurlToFSPathLegacyNormalize() throws Exception {
+        Files.createDirectories(new File(fromdir + "/repo/RPMMD/SLE-12-GA-Desktop-NVIDIA-Driver/repodata/").toPath());
+        new File(fromdir + "/repo/RPMMD/SLE-12-GA-Desktop-NVIDIA-Driver/repodata/repomd.xml").createNewFile();
+        String url = "https://download.nvidia.com/suse/sle12sp4";
+        String name = "../../../etc/passwd SLE-12-GA-Desktop-NVIDIA-Driver";
+
+        URI opath = MgrSyncUtils.urlToFSPath(url, name);
+        URI expected = new URI(String.format("file://%s/download.nvidia.com/suse/sle12sp4", fromdir));
+        assertContains(opath.toString(), expected.toString());
+    }
+
+    public void testurlToFSPathLegacyQuoteNormalize() throws Exception {
+        Files.createDirectories(new File(fromdir + "/repo/RPMMD/SLE-12-GA-Desktop-NVIDIA-Driver/repodata/").toPath());
+        new File(fromdir + "/repo/RPMMD/SLE-12-GA-Desktop-NVIDIA-Driver/repodata/repomd.xml").createNewFile();
+        String url = "https://download.nvidia.com/suse/sle12sp4";
+        String name = "%2F%2E%2E%2Fetc/passwd SLE-12-GA-Desktop-NVIDIA-Driver";
+
+        URI opath = MgrSyncUtils.urlToFSPath(url, name);
+        URI expected = new URI(String.format("file://%s/download.nvidia.com/suse/sle12sp4", fromdir));
+        assertContains(opath.toString(), expected.toString());
+        assertFalse("Decoding error: " + opath.toString(), opath.toString().contains("%"));
+    }
+
+    public void testurlToFSPathLegacyQuoteNormalize2() throws Exception {
+        Files.createDirectories(new File(fromdir + "/repo/RPMMD/SLE-12-GA-Desktop-NVIDIA-Driver/repodata/").toPath());
+        new File(fromdir + "/repo/RPMMD/SLE-12-GA-Desktop-NVIDIA-Driver/repodata/repomd.xml").createNewFile();
+        String url = "https://download.nvidia.com/suse/sle12sp4%2F%2E%2E%2F%2E%2E%2F%2E%2E%2F%2E%2E%2F%2E%2E/etc/passwd";
+        String name = "SLE-12-GA-Desktop-NVIDIA-Driver";
+
+        URI opath = MgrSyncUtils.urlToFSPath(url, name);
+        URI expected = new URI(String.format("file://%s", fromdir));
+        assertContains(opath.toString(), expected.toString());
+        assertFalse("Decoding error: " + opath.toString(), opath.toString().contains("%"));
     }
 }

--- a/java/code/src/com/redhat/rhn/manager/content/test/MgrSyncUtilsTest.java
+++ b/java/code/src/com/redhat/rhn/manager/content/test/MgrSyncUtilsTest.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.manager.content.test;
+
+import com.redhat.rhn.common.conf.Config;
+import com.redhat.rhn.manager.content.ContentSyncManager;
+import com.redhat.rhn.manager.content.MgrSyncUtils;
+import com.redhat.rhn.testing.BaseTestCaseWithUser;
+
+import org.apache.commons.io.FileUtils;
+
+import java.io.File;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+
+public class MgrSyncUtilsTest extends BaseTestCaseWithUser {
+
+    private static Path fromdir;
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        fromdir = Files.createTempDirectory("sumatest");
+        Config.get().setString(ContentSyncManager.RESOURCE_PATH, fromdir.toString());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        Config.get().remove(ContentSyncManager.RESOURCE_PATH);
+        FileUtils.deleteDirectory(fromdir.toFile());
+    }
+
+    public void testurlToFSPathSLE() throws Exception {
+
+        String url = "https://updates.suse.com/SUSE/Updates/SLE-Module-Basesystem/15-SP3/x86_64/update/";
+        String name = "SLE-Module-Basesystem15-SP3-x86_64";
+
+        URI opath = MgrSyncUtils.urlToFSPath(url, name);
+        URI expected = new URI(String.format("file:%s/SUSE/Updates/SLE-Module-Basesystem/15-SP3/x86_64/update", fromdir));
+        assertContains(opath.toString(), expected.toString());
+    }
+
+    public void testurlToFSPathSLEWithToken() throws Exception {
+
+        String url = "https://updates.suse.com/SUSE/Updates/SLE-Module-Basesystem/15-SP3/x86_64/update/?123456789abcde";
+        String name = "SLE-Module-Basesystem15-SP3-x86_64";
+
+        URI opath = MgrSyncUtils.urlToFSPath(url, name);
+        URI expected = new URI(String.format("file:%s/SUSE/Updates/SLE-Module-Basesystem/15-SP3/x86_64/update", fromdir));
+        assertContains(opath.toString(), expected.toString());
+    }
+
+    public void testurlToFSPathUbuntu() throws Exception {
+
+        String url = "http://archive.ubuntu.com/ubuntu/dists/focal/main/binary-amd64/";
+        String name = "ubuntu-2004-amd64-main-amd64";
+
+        URI opath = MgrSyncUtils.urlToFSPath(url, name);
+        URI expected = new URI(String.format("file:%s/archive.ubuntu.com/ubuntu/dists/focal/main/binary-amd64", fromdir));
+        assertContains(opath.toString(), expected.toString());
+    }
+
+    public void testurlToFSPathMirrorlist() throws Exception {
+
+        String url = "http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=AppStream&infra=stock";
+        String name = "centos-7-appstream-x86_64";
+
+        URI opath = MgrSyncUtils.urlToFSPath(url, name);
+        URI expected = new URI(String.format("file:%s/mirrorlist.centos.org/arch/x86_64/infra/stock/release/8/repo/AppStream", fromdir));
+        assertContains(opath.toString(), expected.toString());
+    }
+
+    public void testurlToFSPathLegacy() throws Exception {
+        Files.createDirectories(new File(fromdir + "/repo/RPMMD/SLE-12-GA-Desktop-NVIDIA-Driver/repodata/").toPath());
+        new File(fromdir + "/repo/RPMMD/SLE-12-GA-Desktop-NVIDIA-Driver/repodata/repomd.xml").createNewFile();
+        String url = "https://download.nvidia.com/suse/sle12sp4";
+        String name = "SLE-12-GA-Desktop-NVIDIA-Driver";
+
+        URI opath = MgrSyncUtils.urlToFSPath(url, name);
+        URI expected = new URI(String.format("file:%s/repo/RPMMD/SLE-12-GA-Desktop-NVIDIA-Driver", fromdir));
+        assertContains(opath.toString(), expected.toString());
+    }
+}

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- improve fromdir with better mapping of URL to local files
+
 -------------------------------------------------------------------
 Thu Feb 25 12:06:49 CET 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

To be able to use Uyuni with a local mirror we had to improve the conversion of http URLs to local Files.
This fixes two problems:
1. Ubuntu/Debian URLs which requires multiple subdirs to work. supporting apt-mirror standard config
2. map mirrorlist using query parameters into a path (centos case)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- Documentation issue was created: https://github.com/SUSE/spacewalk/issues/14071

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/13719
Fixes https://github.com/SUSE/spacewalk/issues/13432
Tracks https://github.com/SUSE/spacewalk/pull/14126 https://github.com/SUSE/spacewalk/pull/14127

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
