### PR TITLE
Move push_package feature from core to secondary

### DIFF
--- a/testsuite/features/secondary/srv_push_package.feature
+++ b/testsuite/features/secondary/srv_push_package.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2015-2019 SUSE LLC
+# Copyright (c) 2015-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: Push a package with unset vendor

--- a/testsuite/features/secondary/srv_push_package.feature
+++ b/testsuite/features/secondary/srv_push_package.feature
@@ -9,10 +9,6 @@ Feature: Push a package with unset vendor
   Background:
     Given I am authorized as "admin" with password "admin"
 
-  Scenario: Download the SSL certificate
-    When I download the SSL certificate
-    And I make the SSL certificate available to zypper
-
   Scenario: Push a package with unset vendor
     When I push package "/root/subscription-tools-1.0-0.noarch.rpm" into "test_base_channel" channel
     Then I should see package "subscription-tools-1.0-0.noarch" in channel "Test Base Channel"

--- a/testsuite/features/secondary/srv_push_package.feature
+++ b/testsuite/features/secondary/srv_push_package.feature
@@ -9,6 +9,10 @@ Feature: Push a package with unset vendor
   Background:
     Given I am authorized as "admin" with password "admin"
 
+  Scenario: Download the SSL certificate
+    When I download the SSL certificate
+    And I make the SSL certificate available to zypper
+
   Scenario: Push a package with unset vendor
     When I push package "/root/subscription-tools-1.0-0.noarch.rpm" into "test_base_channel" channel
     Then I should see package "subscription-tools-1.0-0.noarch" in channel "Test Base Channel"

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -20,20 +20,6 @@ When(/^I mount as "([^"]+)" the ISO from "([^"]+)" in the server$/) do |mountpoi
   $server.run("mount -o loop #{iso_path} /srv/www/htdocs/#{mountpoint}", true, 500, 'root')
 end
 
-When(/^I download the SSL certificate$/) do
-  cert_path = '/usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT'
-  wget = 'wget --no-check-certificate -O'
-  $client.run("#{wget} #{cert_path} http://#{$server.ip}/pub/RHN-ORG-TRUSTED-SSL-CERT", true, 500, 'root')
-  $client.run("ls #{cert_path}")
-end
-
-When(/^I make the SSL certificate available to zypper$/) do
-  cert_path = '/usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT'
-  trust_path = '/etc/pki/trust/anchors'
-  $client.run("cd #{trust_path} && ln -sf #{cert_path}")
-  $client.run('update-ca-certificates')
-end
-
 Then(/^I can see all system information for "([^"]*)"$/) do |host|
   node = get_target(host)
   step %(I should see a "#{node.hostname}" text)

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -20,6 +20,20 @@ When(/^I mount as "([^"]+)" the ISO from "([^"]+)" in the server$/) do |mountpoi
   $server.run("mount -o loop #{iso_path} /srv/www/htdocs/#{mountpoint}", true, 500, 'root')
 end
 
+When(/^I download the SSL certificate$/) do
+  cert_path = '/usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT'
+  wget = 'wget --no-check-certificate -O'
+  $client.run("#{wget} #{cert_path} http://#{$server.ip}/pub/RHN-ORG-TRUSTED-SSL-CERT", true, 500, 'root')
+  $client.run("ls #{cert_path}")
+end
+
+When(/^I make the SSL certificate available to zypper$/) do
+  cert_path = '/usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT'
+  trust_path = '/etc/pki/trust/anchors'
+  $client.run("cd #{trust_path} && ln -sf #{cert_path}")
+  $client.run('update-ca-certificates')
+end
+
 Then(/^I can see all system information for "([^"]*)"$/) do |host|
   node = get_target(host)
   step %(I should see a "#{node.hostname}" text)

--- a/testsuite/run_sets/core.yml
+++ b/testsuite/run_sets/core.yml
@@ -14,7 +14,6 @@
 
 # initialize SUSE Manager server
 - features/core/srv_channels_add.feature
-- features/core/srv_push_package.feature
 - features/core/srv_create_repository.feature
 - features/core/srv_create_activationkey.feature
 - features/core/srv_osimage.feature

--- a/testsuite/run_sets/refhost.yml
+++ b/testsuite/run_sets/refhost.yml
@@ -12,7 +12,6 @@
 - features/core/first_settings.feature
 # initialize SUSE Manager server
 - features/core/srv_channels_add.feature
-- features/core/srv_push_package.feature
 - features/core/srv_create_repository.feature
 - features/core/srv_create_activationkey.feature
 - features/core/srv_docker.feature

--- a/testsuite/run_sets/secondary_parallelizable.yml
+++ b/testsuite/run_sets/secondary_parallelizable.yml
@@ -74,5 +74,6 @@
 - features/secondary/trad_check_patches_install.feature
 - features/secondary/trad_sp_migration.feature
 - features/secondary/trad_check_registration.feature
+- features/secondary/srv_push_package.feature
 
 ## Parallelizable Secondary features END ##

--- a/testsuite/run_sets/secondary_parallelizable.yml
+++ b/testsuite/run_sets/secondary_parallelizable.yml
@@ -34,6 +34,7 @@
 - features/secondary/srv_change_task_schedule.feature
 - features/secondary/srv_notifications.feature
 - features/secondary/srv_monitoring.feature
+- features/secondary/srv_push_package.feature
 
 - features/secondary/proxy_retail_pxeboot_and_mass_import.feature
 - features/secondary/allcli_overview_systems_details.feature
@@ -74,6 +75,5 @@
 - features/secondary/trad_check_patches_install.feature
 - features/secondary/trad_sp_migration.feature
 - features/secondary/trad_check_registration.feature
-- features/secondary/srv_push_package.feature
 
 ## Parallelizable Secondary features END ##

--- a/testsuite/run_sets/sle-updates.yml
+++ b/testsuite/run_sets/sle-updates.yml
@@ -11,7 +11,6 @@
 - features/core/first_settings.feature
 # initialize SUSE Manager server
 - features/core/srv_channels_add.feature
-- features/core/srv_push_package.feature
 - features/core/srv_create_repository.feature
 - features/core/srv_create_activationkey.feature
 - features/core/srv_osimage.feature

--- a/testsuite/run_sets/virtualization.yml
+++ b/testsuite/run_sets/virtualization.yml
@@ -12,7 +12,6 @@
 - features/core/first_settings.feature
 # initialize SUSE Manager server
 - features/core/srv_channels_add.feature
-- features/core/srv_push_package.feature
 - features/core/srv_create_repository.feature
 - features/core/srv_create_activationkey.feature
 - features/core/srv_osimage.feature


### PR DESCRIPTION
Move push_package feature from core to secondary

The changes have been tested

https://github.com/SUSE/spacewalk/issues/13559

- [x] No changelog needed