### PR TITLE
Fix JSON serialization in function 'list_modules' of mgr-libmod (bsc#1182492)

### DIFF
--- a/susemanager-utils/mgr-libmod/mgr-libmod.changes
+++ b/susemanager-utils/mgr-libmod/mgr-libmod.changes
@@ -1,3 +1,5 @@
+- Fix 'list_modules' JSON serialization (bsc#1182492)
+
 -------------------------------------------------------------------
 Wed Jan 27 12:53:13 CET 2021 - jgonzalez@suse.com
 

--- a/susemanager-utils/mgr-libmod/mgrlibmod/mllib.py
+++ b/susemanager-utils/mgr-libmod/mgrlibmod/mllib.py
@@ -273,7 +273,7 @@ class MLLibmodAPI:
             d_mod = mod.get_defaults()
             mobj[m_name] = {
                 "default": d_mod.get_default_stream() if d_mod else None,
-                "streams": set([s.get_stream_name() for s in mod.get_all_streams()])
+                "streams": list(set([s.get_stream_name() for s in mod.get_all_streams()]))
             }
 
         modules["modules"] = mobj

--- a/susemanager-utils/mgr-libmod/tests/data/not_found.json
+++ b/susemanager-utils/mgr-libmod/tests/data/not_found.json
@@ -9,6 +9,6 @@
                 {
                         "name": "notfound",
                         "stream": "mystream"
-                },
+                }
 	]
 }

--- a/susemanager-utils/mgr-libmod/tests/test_libmodapi.py
+++ b/susemanager-utils/mgr-libmod/tests/test_libmodapi.py
@@ -158,6 +158,8 @@ class TestLibmodProc:
         for key, value in result['modules'].items():
             assert 'default' in value
             assert 'streams' in value
+            # Assert that streams is a list (serializable)
+            assert type(value['streams']) is list
             # Assert that there are no duplicates in stream names
             assert len(value['streams']) == len(set(value['streams']))
 

--- a/susemanager-utils/mgr-libmod/tests/test_libmodapi.py
+++ b/susemanager-utils/mgr-libmod/tests/test_libmodapi.py
@@ -3,6 +3,7 @@ Unit test for LibmodProc class.
 """
 from mgrlibmod.mllib import MLLibmodProc, MLLibmodAPI
 from mgrlibmod.mlerrcode import MlConflictingStreams, MlModuleNotFound
+import json
 import pytest
 from unittest import mock
 from unittest.mock import mock_open
@@ -24,6 +25,32 @@ class TestLibmodProc:
 
     def teardown_method(self):
         del self.libmodproc
+
+    def test_to_json(self):
+        """
+        test_to_json -- test if the output is successfully serialized into JSON
+        """
+
+        # Test module_packages output
+        self.libmodapi.set_repodata(open("tests/data/module_packages-1.json", "r").read()).run()
+        result_dict = self.libmodapi._result
+        json_str = self.libmodapi.to_json()
+
+        assert result_dict == json.loads(json_str)
+
+        # Test list_modules output
+        self.libmodapi.set_repodata(open("tests/data/list_modules.json", "r").read()).run()
+        result_dict = self.libmodapi._result
+        json_str = self.libmodapi.to_json()
+
+        assert result_dict == json.loads(json_str)
+
+        # Test list_packages output
+        self.libmodapi.set_repodata(open("tests/data/list_packages.json", "r").read()).run()
+        result_dict = self.libmodapi._result
+        json_str = self.libmodapi.to_json()
+
+        assert result_dict == json.loads(json_str)
 
     def test_meta_compressed(self):
         """


### PR DESCRIPTION
In `list_modules` output, every `module` dict has a list of `streams` implemented as a Set. Since Set is not serializable, it cannot be output as JSON. This PR changes the type of the `streams` to be a list instead.

See: https://bugzilla.suse.com/1182492

## Documentation
- No documentation needed: bugfix

## Test coverage
- Unit tests were added

## Links

Port of https://github.com/SUSE/spacewalk/pull/14048

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
