### PR TITLE
Fix bugged checkbox in formula-selection

### DIFF
--- a/web/html/src/components/formula-selection.tsx
+++ b/web/html/src/components/formula-selection.tsx
@@ -118,7 +118,7 @@ class FormulaSelection extends React.Component<Props, State> {
 
   getListIcon(state) {
     if (!state) return "fa fa-lg fa-square-o";
-    else if (state === 1) return "fa fa-lg fa-check-square-o";
+    else if (DEPRECATED_unsafeEquals(state, 1)) return "fa fa-lg fa-check-square-o";
     else return "fa fa-lg fa-minus-square-o";
   }
 


### PR DESCRIPTION
## What does this PR change?

In https://github.com/uyuni-project/uyuni/pull/3242, I introduced a regression in the checkbox logic in formula selection: https://ci.suse.de/view/Manager/view/Uyuni/job/uyuni-master-cucumber-NUE/1223/testReport/(root)/Setup%20SUSE%20Manager%20for%20Retail%20branch%20network/Enable_the_branch_network_formulas_on_the_branch_server/
  
Essentially, the problem boils down to the existing code relying on `"1" == 1` in non-strict Javascript.  
This PR fixes the problem.

## GUI diff

Before: checkbox not checking

After: checkbox checking

- [x] **DONE**

## Documentation
- No documentation needed: bugfix

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
