### PR TITLE
Fix: provide migration for rhnActionImageBuild

### DIFF
--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- Provide migration for rhnActionImageBuild
 - Rename rhnVirtualInstanceInfo memory_size_k column
 - Drop "pxt_session_cleanup" function (bsc#1180224)
 

--- a/schema/spacewalk/upgrade/susemanager-schema-4.2.7-to-susemanager-schema-4.2.8/500-rhnbuild-version.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.2.7-to-susemanager-schema-4.2.8/500-rhnbuild-version.sql
@@ -1,0 +1,1 @@
+alter table rhnActionImageBuild alter COLUMN version TYPE VARCHAR(128);


### PR DESCRIPTION
## What does this PR change?

The field 'version' in rhnActionImageBuild is a VARCHAR(128)
Initially, the field was called 'tag' and it was a VARCHAR(30).
Then the field was changed to a VARCHAR(128) in:

https://github.com/SUSE/spacewalk/commit/26e579530a0c332ef3c3ba04624c2c52b873e2e3#diff-52648bc84fdf1a8d6b28731a95979a144fba64064ffb6a84f7212e5bb541d95eR28

but the migration for this change was missing.
The field is now called 'version'.

## Documentation
- No documentation needed: only internal and user invisible changes
- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
