### PR TITLE
Replace CRLF in ssh priv key when bootstrapping (bsc#1182685)

### DIFF
--- a/web/html/src/manager/systems/bootstrap/bootstrap-minions.js
+++ b/web/html/src/manager/systems/bootstrap/bootstrap-minions.js
@@ -80,7 +80,8 @@ class BootstrapMinions extends React.Component {
 
     privKeyLoaded(keyString) {
         this.setState({
-            privKey: keyString,
+            // replace CRLF from Windows
+            privKey: keyString.replace(/\r\n/g, "\n"),
             privKeyLoading: false
         });
     }

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Replace CRLF in ssh priv key when bootstrapping (bsc#1182685)
 - Inform user when a request timeout happens (bsc#1178767)
 - Allow to configure request timeout (bsc#1178767)
 - Usage of "edit" icon on Content Lifecycle Management


### PR DESCRIPTION
Files generated on M$ Windows can contain these line terminators.


## GUI diff

No difference.

## Documentation
bugfix

## Test coverage
- No tests

- [x] **DONE**

## Links
https://github.com/SUSE/spacewalk/issues/14090

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"