### PR TITLE
[Port] Fix: Wrong renaming of a step

### DIFF
--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -825,7 +825,7 @@ When(/^I enter "([^"]*)" as the filtered XCCDF result type$/) do |input|
   find("input[placeholder='Filter by Result: ']").set(input)
 end
 
-When(/^I enter the package for "([^"]*)" as the filtered package states name$/) do |host|
+When(/^I enter the package for "([^"]*)" as the filtered package name$/) do |host|
   step %(I enter "#{PACKAGE_BY_CLIENT[host]}" as the filtered package name)
 end
 


### PR DESCRIPTION
## What does this PR change?

Fix a wrongly renamed step definition.

So we keep:
```
When(/^I enter the package for "([^"]*)" as the filtered package name$/) do |host|
  step %(I enter "#{PACKAGE_BY_CLIENT[host]}" as the filtered package name)
end

When(/^I enter "([^"]*)" as the filtered package name$/) do |input|
  find("input[placeholder='Filter by Package Name: ']").set(input)
end
```

And we have as a new step, for last supported feature, like that:
```
When(/^I enter "([^"]*)" as the filtered package states name$/) do |input|
  find("input[placeholder='Search package']").set(input)
end
```

Screenshot of the section called when we use "package name" filter:
![image](https://user-images.githubusercontent.com/2827771/109638970-eaaffe00-7b4e-11eb-83b5-46c9045f8845.png)

Screenshot of the section called when we use "package states name" filter:
![image](https://user-images.githubusercontent.com/2827771/109639431-74f86200-7b4f-11eb-8bb7-b18b38721ae0.png)


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
 - Manager-4.0 https://github.com/SUSE/spacewalk/pull/14114
 - Manager-4.1 https://github.com/SUSE/spacewalk/pull/14112

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
