### PR TITLE
QA: Clean up the sumaform repositories for proxy host

### DIFF
--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -691,6 +691,9 @@ When(/^I perform a full salt minion cleanup on "([^"]*)"$/) do |host|
   end
   node.run('rm -Rf /var/cache/salt/minion /var/run/salt /var/log/salt /etc/salt', false)
   step %(I disable the repositories "tools_update_repo tools_pool_repo" on this "#{host}" without error control)
+  if host.include? 'proxy'
+    step %(I disable the repositories "proxy_module_pool_repo proxy_product_pool_repo proxy_product_update_repo" on this "#{host}" without error control)
+  end
 end
 
 When(/^I install a salt pillar top file for "([^"]*)" with target "([^"]*)" on the server$/) do |file, host|


### PR DESCRIPTION
## What does this PR change?

Clean up the sumaform repositories for proxy VM deployed with it.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.1 https://github.com/SUSE/spacewalk/pull/14143
- Manager-4.0 https://github.com/SUSE/spacewalk/pull/14144

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
