### PR TITLE
Fix: increase password length in the database (bsc#1182687)

### DIFF
--- a/schema/spacewalk/common/tables/suseCredentials.sql
+++ b/schema/spacewalk/common/tables/suseCredentials.sql
@@ -26,7 +26,7 @@ CREATE TABLE suseCredentials
                  REFERENCES suseCredentialsType (id),
     url      VARCHAR(256),
     username VARCHAR(64) NOT NULL,
-    password VARCHAR(64) NOT NULL,
+    password VARCHAR(4096) NOT NULL,
     created  TIMESTAMPTZ DEFAULT (current_timestamp) NOT NULL,
     modified TIMESTAMPTZ DEFAULT (current_timestamp) NOT NULL
 )

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,5 @@
+- Fix: increase password length in the database (bsc#1182687)
+
 -------------------------------------------------------------------
 Thu Feb 25 12:12:06 CET 2021 - jgonzalez@suse.com
 

--- a/schema/spacewalk/upgrade/susemanager-schema-4.2.8-to-susemanager-schema-4.2.9/100-password-length.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.2.8-to-susemanager-schema-4.2.9/100-password-length.sql
@@ -1,0 +1,1 @@
+alter table susecredentials alter column password type varchar(4096);


### PR DESCRIPTION
## What does this PR change?

This commit increases the password length for the susecredentials table.
Without this commit, the error of password length overflown in the
database field is happening when using a JWT Token (760 chars) as the
password.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Tracks TBD

- [] **DONE**

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
