### PR TITLE
Log product detection error

### DIFF
--- a/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes
+++ b/client/rhel/spacewalk-client-tools/spacewalk-client-tools.changes
@@ -1,3 +1,5 @@
+- log an error when product detection failed (bsc#1182339)
+
 -------------------------------------------------------------------
 Thu Feb 25 12:05:05 CET 2021 - jgonzalez@suse.com
 

--- a/client/rhel/spacewalk-client-tools/src/up2date_client/up2dateUtils.py
+++ b/client/rhel/spacewalk-client-tools/src/up2date_client/up2dateUtils.py
@@ -9,6 +9,7 @@
 import os
 import gettext
 from up2date_client import up2dateErrors
+from up2date_client import up2dateLog
 from up2date_client import config
 from up2date_client.pkgplatform import getPlatform
 from rhn.i18n import sstr, bstr
@@ -84,6 +85,9 @@ else:
                             ts.ts.closeDB()
                             return osVersionRelease
 
+                log = up2dateLog.initLog()
+                log.log_me("Error: Could not determine what version of Linux you are running. "\
+                           "Check if the product is installed correctly. Aborting.")
                 raise up2dateErrors.RpmError(
                     "Could not determine what version of Linux you "\
                     "are running.\nIf you get this error, try running \n\n"\


### PR DESCRIPTION
## What does this PR change?

When the product detection failed, the raised exception is swallowed somehow in the deep of python code.
Write a log message that the info does not get lost and the user get a hint what is wrong.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/14136

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
