### PR TITLE
Reduce the number of queries used to obtain the list of channel

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/channel/Channel.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/channel/Channel.hbm.xml
@@ -145,6 +145,41 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         -->
     </class>
 
+    <sql-query name="Channel.findAllByUserOrderByChild">
+        <![CDATA[
+    SELECT {channel.*}
+    FROM rhnChannel {channel}
+        LEFT OUTER JOIN rhnChannel parent ON channel.parent_channel = parent.id
+        LEFT OUTER JOIN rhnChannelCloned channel_1_ ON channel.id = channel_1_.id
+    WHERE EXISTS (
+        SELECT 1
+        FROM suseChannelUserRoleView scur
+        WHERE scur.channel_id = channel.id
+        AND scur.user_id = :userId
+        AND scur.deny_reason IS NULL
+    )
+    AND (
+        channel.parent_channel IS NULL
+        OR (
+            channel.parent_channel IS NOT NULL
+            AND EXISTS (
+                SELECT 1
+                FROM suseChannelUserRoleView scur
+                WHERE scur.channel_id = channel.parent_channel
+                AND scur.user_id = :userId
+                AND scur.deny_reason IS NULL
+            )
+        )
+    )
+    ORDER BY
+        channel.org_id NULLS FIRST,
+        COALESCE(parent.label, channel.label),
+        channel.parent_channel NULLS FIRST,
+        channel.label
+        ]]>
+        <return alias="channel" class="com.redhat.rhn.domain.channel.Channel" />
+    </sql-query>
+
     <query name="Channel.findRedHatBaseChannels">
         <![CDATA[
                 from com.redhat.rhn.domain.channel.Channel as c where c.org is null

--- a/java/code/src/com/redhat/rhn/domain/channel/ChannelFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/ChannelFactory.java
@@ -1041,6 +1041,24 @@ public class ChannelFactory extends HibernateFactory {
     }
 
     /**
+     * All channels (including children) based on the following rules
+     *
+     * 1) Base channels are listed first
+     * 2) Parent channels are ordered by label
+     * 3) Child channels are listed right after the corresponding parent, and ordered by label
+     * 4) Channels are included only if user has access to them
+     * 5) Child channels are included only if the user has access to the corresponding parent channel
+     *
+     * @param user The user to check channel access
+     * @return List of channels (including children) accessible for the provided user
+     */
+    public static List<Channel> findAllByUserOrderByChild(User user) {
+        Map<String, Object> params = new HashMap<String, Object>();
+        params.put("userId", user.getId());
+        return singleton.listObjectsByNamedQuery("Channel.findAllByUserOrderByChild", params);
+    }
+
+    /**
      * Get a list of channels with no org that are not a child
      * @return List of Channels
      */

--- a/java/code/src/com/redhat/rhn/domain/channel/test/ChannelFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/test/ChannelFactoryTest.java
@@ -486,4 +486,47 @@ public class ChannelFactoryTest extends RhnBaseTestCase {
         assertTrue(ChannelFactory.isAccessibleByUser(c.getLabel(), user2.getId()));
         assertFalse(ChannelFactory.isAccessibleByUser(c.getLabel(), user3.getId()));
     }
+
+    /**
+     * Test "ChannelFactory.findAllByUserOrderByChild"
+     * @throws Exception
+     */
+    public void testFindAllByUserOrderByChild() throws Exception {
+        User user1 = UserTestUtils.findNewUser("testuser1", "testorg1");
+        User user2 = UserTestUtils.findNewUser("testuser2", "testorg2");
+
+        Channel parent3 = ChannelFactoryTest.createTestChannel(user1);
+        parent3.setLabel("b_parent3");
+        ChannelFactory.save(parent3);
+
+        Channel parent2 = ChannelFactoryTest.createTestChannel(user2);
+        parent2.setLabel("b_parent2");
+        ChannelFactory.save(parent2);
+
+        Channel parent1 = ChannelFactoryTest.createTestChannel(user1);
+        parent1.setLabel("b_parent1");
+        ChannelFactory.save(parent1);
+
+        Channel child1 = ChannelFactoryTest.createTestChannel(user1);
+        child1.setLabel("a_child1");
+        child1.setParentChannel(parent1);
+        ChannelFactory.save(child1);
+
+        Channel base1 = ChannelFactoryTest.createTestChannel(user1);
+        base1.setLabel("z_base1");
+        base1.setOrg(null);
+        ChannelFactory.save(base1);
+
+        Channel base2 = ChannelFactoryTest.createTestChannel(user2);
+        base2.setLabel("z_base2");
+        base2.setOrg(null);
+        ChannelFactory.save(base2);
+
+        List<Channel> channels = ChannelFactory.findAllByUserOrderByChild(user1);
+        assertEquals(4, channels.size());
+        assertEquals("z_base1", channels.get(0).getLabel());
+        assertEquals("b_parent1", channels.get(1).getLabel());
+        assertEquals("a_child1", channels.get(2).getLabel());
+        assertEquals("b_parent3", channels.get(3).getLabel());
+    }
 }

--- a/java/code/src/com/redhat/rhn/frontend/action/channel/manage/ChannelPackagesBaseAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/channel/manage/ChannelPackagesBaseAction.java
@@ -21,8 +21,8 @@ import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.struts.RhnAction;
 import com.redhat.rhn.manager.user.UserManager;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * ChannelPackagesBaseAction
@@ -32,25 +32,9 @@ public class ChannelPackagesBaseAction extends RhnAction {
     protected final String listName = "packageList";
 
     protected List<SelectableChannel> findChannels(User user, Long selectedChan) {
-        //Add Red Hat Base Channels, and custom base channels
-        List<SelectableChannel> chanList = new ArrayList<SelectableChannel>();
-        for (Channel chanTmp : ChannelFactory.listRedHatBaseChannels()) {
-            if (canAccessChannel(user, chanTmp)) {
-                chanList.add(setSelected(chanTmp, selectedChan));
-                for (Channel chanChild : chanTmp.getAccessibleChildrenFor(user)) {
-                    chanList.add(setSelected(chanChild, selectedChan));
-                }
-            }
-        }
-        for (Channel chanTmp : ChannelFactory.listCustomBaseChannels(user)) {
-            if (canAccessChannel(user, chanTmp)) {
-                chanList.add(setSelected(chanTmp, selectedChan));
-                for (Channel chanChild : chanTmp.getAccessibleChildrenFor(user)) {
-                    chanList.add(setSelected(chanChild, selectedChan));
-                }
-            }
-        }
-        return chanList;
+        return ChannelFactory.findAllByUserOrderByChild(user).stream()
+                .map(c -> setSelected(c, selectedChan))
+                .collect(Collectors.toList());
     }
 
     protected boolean canAccessChannel(User user, Channel channel) {

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Speed up pages to compare or add packages to channels (bsc#1178767)
 - Remove validator.js from jade templates
 - Homogenizes style in filter buttons, facilitating testability
 - improve fromdir with better mapping of URL to local files


### PR DESCRIPTION
## What does this PR change?

The `Software > Manage > Channels > $CHANNEL > Packages > Add | Compare` pages were performing many queries for each "Channel"  in the dropdown, each time the `View Packages` button was clicked, which causes a `Request timeout` on environments with many channels.

This PR will obtain all channels (including children), check permissions, and sort in a single query to improve the performance of those pages.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Fixes: https://github.com/SUSE/spacewalk/issues/13117

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
