### PR TITLE
Adding new labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -41,14 +41,41 @@ database:
 content-management: 
 - java/code/src/com/suse/manager/webui/controllers/contentmanagement/*
 - java/code/src/com/suse/manager/webui/controllers/contentmanagement/**/*
+spark-router:
+- java/code/src/com/suse/manager/webui/Router.java
+webui-templates:
+- java/code/src/com/suse/manager/webui/templates/*
+- java/code/src/com/suse/manager/webui/templates/**/*
+webui-controllers:
+- java/code/src/com/suse/manager/webui/controller/*
+- java/code/src/com/suse/manager/webui/controller/**/*
+salt-actions-implementations:
+- java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+salt-events-listener:
+- java/code/src/com/suse/manager/reactor/SaltReactor.java
+data-model:
+- java/code/src/com/redhat/rhn/domain/*
+- java/code/src/com/redhat/rhn/domain/**/*
+old-ui:
+- java/code/src/com/redhat/rhn/frontend/*
+- java/code/src/com/redhat/rhn/frontend/**/*
+xmlrpc:
+- java/code/src/com/redhat/rhn/frontend/xmlrpc/*
+- java/code/src/com/redhat/rhn/frontend/xmlrpc/**/*
 
 #QA Labels
 testing: 
 - testsuite/*
 - testsuite/**/*
+test-framework:
+- testsuite/features/support/*
+- testsuite/features/step_definitions/*
 core-features: 
 - testsuite/features/core/*
 - testsuite/features/core/**/*
+build-validation-features: 
+- testsuite/features/build_validation/*
+- testsuite/features/build_validation/**/*
 secondary-features: 
 - testsuite/features/secondary/*
 - testsuite/features/secondary/**/*


### PR DESCRIPTION
## What does this PR change?

Adding some new labels on the GitHub action Labeler.
The main purpose of these new labels is to identify better which part of the product could have an impact due to the PR changes.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

Nothing to be ported to Manager-4.1, until we clarify if we have support for GitHub actions there.

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
