### PR TITLE
Change client tools products names in CI to match SCC

### DIFF
--- a/testsuite/features/reposync/srv_sync_channels.feature
+++ b/testsuite/features/reposync/srv_sync_channels.feature
@@ -35,8 +35,8 @@ Feature: Be able to list available channels and enable them
     When I execute mgr-sync "list products --expand"
     Then I should get "[ ] SUSE Linux Enterprise Server 12 SP4 x86_64"
     And I should get "[ ] SUSE Manager Proxy 4.0 x86_64"
-    And I should get "  [ ] (R) SUSE Linux Enterprise Client Tools RES 7 x86_64"
-    And I should get "  [ ] (R) SUSE Manager Tools 15 x86_64"
+    And I should get "  [ ] (R) SUSE Manager Client Tools for RHEL and ES 7 x86_64"
+    And I should get "  [ ] (R) SUSE Manager Client Tools for SLE 15 x86_64"
 
 @scc_credentials
   Scenario: List products with filter

--- a/testsuite/features/reposync/srv_sync_products.feature
+++ b/testsuite/features/reposync/srv_sync_products.feature
@@ -54,7 +54,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     When I select "SUSE Linux Enterprise Server 15 SP2 x86_64" as a product
     # Drop following 2 lines if you wish to re-enable testing with beta client tools for SLE15
     And I open the sub-list of the product "Basesystem Module 15 SP2 x86_64"
-    And I deselect "SUSE Manager Tools 15 x86_64 (BETA)" as a SUSE Manager product
+    And I deselect "SUSE Manager Client Tools Beta for SLE 15 x86_64 (BETA)" as a SUSE Manager product
     Then I should see the "SUSE Linux Enterprise Server 15 SP2 x86_64" selected
     Then I should see the "Basesystem Module 15 SP2 x86_64" selected
     And I click the Add Product button


### PR DESCRIPTION
## What does this PR change?

Change client tools products names to match SCC, related to https://bugzilla.suse.com/show_bug.cgi?id=1152503#c20 and https://github.com/SUSE/spacewalk/issues/14079

## GUI diff

No difference.



- [x] **DONE**

## Documentation
- No documentation needed: **Changed to match already products in GUI, testsuite changes**

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/14079
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
