### PR TITLE
Opening RPM file in binary mode

### DIFF
--- a/backend/satellite_tools/satsync.py
+++ b/backend/satellite_tools/satsync.py
@@ -1909,7 +1909,7 @@ class Syncer:
         if self.mountpoint:
             rpmFile = rpmsPath(package_id, self.mountpoint, sources)
             try:
-                stream = open(rpmFile)
+                stream = open(rpmFile, "rb")
             except IOError:
                 e = sys.exc_info()[1]
                 if e.errno != 2:  # No such file or directory

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,5 @@
+- Fix for UnicodeDecodeError in satellite-sync: Opening RPM file in binary mode (bsc#1181274)
+
 -------------------------------------------------------------------
 Thu Feb 25 12:03:17 CET 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Opening RPM files in text mode with Python3 can lead to
UnicodeDecodeErrors.

RPMs are now being opened in binary mode instead.

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Links

https://bugzilla.suse.com/show_bug.cgi?id=1181274

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
