### PR TITLE
Gpg key for ssh minion

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
@@ -112,49 +112,20 @@ bootstrap_repo:
       - ([ {{ bootstrap_repo_exists }} = "True" ])
 {%- endif %}
 
-{%- if not grains['os_family'] == 'Debian' %}
-{%- if salt['pillar.get']('mgr_metadata_signing_enabled', false) %}
-mgr_trust_customer_gpg_key:
-  cmd.run:
-    - name: rpm --import https://{{ salt['pillar.get']('mgr_server') }}/pub/mgr-gpg-pub.key
-    - runas: root
-{%- endif %}
-{%- endif %}
-
 {%- if grains['os_family'] == 'RedHat' %}
-trust_suse_manager_tools_rhel_gpg_key:
-  cmd.run:
-{%- if grains['osmajorrelease']|int == 6 %}
-    - name: rpm --import https://{{ salt['pillar.get']('mgr_server') }}/pub/{{ salt['pillar.get']('gpgkeys:res6tools:file') }}
-    - unless: rpm -q {{ salt['pillar.get']('gpgkeys:res6tools:name') }}
-{%- elif grains['osmajorrelease']|int == 7 %}
-    - name: rpm --import https://{{ salt['pillar.get']('mgr_server') }}/pub/{{ salt['pillar.get']('gpgkeys:res7tools:file') }}
-    - unless: rpm -q {{ salt['pillar.get']('gpgkeys:res7tools:name') }}
-{%- elif grains['osmajorrelease']|int == 8 %}
-    - name: rpm --import https://{{ salt['pillar.get']('mgr_server') }}/pub/{{ salt['pillar.get']('gpgkeys:res8tools:file') }}
-    - unless: rpm -q {{ salt['pillar.get']('gpgkeys:res8tools:name') }}
-{% else %}
-    - name: /usr/bin/true
-{%- endif %}
-    - runas: root
-
 trust_res_gpg_key:
   cmd.run:
     - name: rpm --import https://{{ salt['pillar.get']('mgr_server') }}/pub/{{ salt['pillar.get']('gpgkeys:res:file') }}
     - unless: rpm -q {{ salt['pillar.get']('gpgkeys:res:name') }}
     - runas: root
-
 {%- elif grains['os_family'] == 'Debian' %}
-{%- include 'channels/debiankeyring.sls' %}
 install_gnupg_debian:
   pkg.latest:
     - pkgs:
       - gnupg
-trust_suse_manager_tools_deb_gpg_key:
-  mgrcompat.module_run:
-    - name: pkg.add_repo_key
-    - path: https://{{ salt['pillar.get']('mgr_server') }}/pub/{{ salt['pillar.get']('gpgkeys:ubuntutools:file') }}
 {%- endif %}
+
+{% include 'channels/gpg-keys.sls' %}
 
 salt-minion-package:
   pkg.latest:

--- a/susemanager-utils/susemanager-sls/salt/channels/debiankeyring.sls
+++ b/susemanager-utils/susemanager-sls/salt/channels/debiankeyring.sls
@@ -1,7 +1,0 @@
-{%- if pillar.get('mgr_metadata_signing_enabled', false) %}
-mgr_debian_repo_keyring:
-  file.managed:
-    - name: /usr/share/keyrings/mgr-archive-keyring.gpg
-    - source: salt://gpg/mgr-keyring.gpg
-    - mode: 644
-{%- endif %}

--- a/susemanager-utils/susemanager-sls/salt/channels/gpg-keys.sls
+++ b/susemanager-utils/susemanager-sls/salt/channels/gpg-keys.sls
@@ -1,0 +1,39 @@
+
+{%- if salt['pillar.get']('mgr_metadata_signing_enabled', false) %}
+{%- if grains['os_family'] == 'Debian' %}
+mgr_debian_repo_keyring:
+  file.managed:
+    - name: /usr/share/keyrings/mgr-archive-keyring.gpg
+    - source: salt://gpg/mgr-keyring.gpg
+    - mode: 644
+{% else %}
+mgr_trust_customer_gpg_key:
+  cmd.run:
+    - name: rpm --import https://{{ salt['pillar.get']('mgr_server') }}/pub/mgr-gpg-pub.key
+    - runas: root
+{%- endif %}
+{%- endif %}
+
+{%- if grains['os_family'] == 'RedHat' %}
+trust_suse_manager_tools_rhel_gpg_key:
+  cmd.run:
+{%- if grains['osmajorrelease']|int == 6 %}
+    - name: rpm --import https://{{ salt['pillar.get']('mgr_server') }}/pub/{{ salt['pillar.get']('gpgkeys:res6tools:file') }}
+    - unless: rpm -q {{ salt['pillar.get']('gpgkeys:res6tools:name') }}
+{%- elif grains['osmajorrelease']|int == 7 %}
+    - name: rpm --import https://{{ salt['pillar.get']('mgr_server') }}/pub/{{ salt['pillar.get']('gpgkeys:res7tools:file') }}
+    - unless: rpm -q {{ salt['pillar.get']('gpgkeys:res7tools:name') }}
+{%- elif grains['osmajorrelease']|int == 8 %}
+    - name: rpm --import https://{{ salt['pillar.get']('mgr_server') }}/pub/{{ salt['pillar.get']('gpgkeys:res8tools:file') }}
+    - unless: rpm -q {{ salt['pillar.get']('gpgkeys:res8tools:name') }}
+{% else %}
+    - name: /usr/bin/true
+{%- endif %}
+    - runas: root
+
+{%- elif grains['os_family'] == 'Debian' %}
+trust_suse_manager_tools_deb_gpg_key:
+  mgrcompat.module_run:
+    - name: pkg.add_repo_key
+    - path: https://{{ salt['pillar.get']('mgr_server') }}/pub/{{ salt['pillar.get']('gpgkeys:ubuntutools:file') }}
+{%- endif %}

--- a/susemanager-utils/susemanager-sls/salt/channels/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/channels/init.sls
@@ -122,6 +122,6 @@ mgrchannels_yum_clean_all:
        - file: "/etc/yum.repos.d/susemanager:channels.repo"
     -  unless: "/usr/bin/yum repolist | grep \"repolist: 0$\""
 {%- endif %}
-{%- elif grains['os_family'] == 'Debian' %}
-{%- include 'channels/debiankeyring.sls' %}
 {%- endif %}
+
+{% include 'channels/gpg-keys.sls' %}

--- a/susemanager-utils/susemanager-sls/salt/ssh_bootstrap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/ssh_bootstrap/init.sls
@@ -61,4 +61,18 @@ authorize_own_key:
       - file: ownership_own_ssh_key
       - ssh_auth: no_own_key_authorized
 
+{%- if grains['os_family'] == 'RedHat' %}
+trust_res_gpg_key:
+  cmd.run:
+    - name: rpm --import https://{{ salt['pillar.get']('mgr_server') }}/pub/{{ salt['pillar.get']('gpgkeys:res:file') }}
+    - unless: rpm -q {{ salt['pillar.get']('gpgkeys:res:name') }}
+    - runas: root
+{%- elif grains['os_family'] == 'Debian' %}
+install_gnupg_debian:
+  pkg.latest:
+    - pkgs:
+      - gnupg
+{%- endif %}
+
+{% include 'channels/gpg-keys.sls' %}
 {% include 'bootstrap/remove_traditional_stack.sls' %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,5 @@
+- handle GPG keys when bootstrapping ssh minions (bsc#1181847)
+
 -------------------------------------------------------------------
 Thu Feb 25 12:12:31 CET 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

When bootstrapping salt minions via salt-ssh, we use a different bootstrap state which do not work on GPG keys like the
standard bootstrap state.
This PR extract now the GPG key handling from various files, combine them in a new state file and include it from various places incl. the ssh bootstrap state.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/13922
Tracks https://github.com/SUSE/spacewalk/pull/14169 https://github.com/SUSE/spacewalk/pull/14170

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
