### PR TITLE
QA: Avoid log out/log in on every scenario of kvm/xen tests

### DIFF
--- a/testsuite/features/secondary/minkvm_guests.feature
+++ b/testsuite/features/secondary/minkvm_guests.feature
@@ -6,7 +6,7 @@ Feature: Be able to manage KVM virtual machines via the GUI
 
 @virthost_kvm
   Scenario: Bootstrap KVM virtual host
-    Given I am authorized
+    Given I am authorized as "admin" with password "admin"
     When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "kvm_server" as "hostname"
@@ -31,7 +31,6 @@ Feature: Be able to manage KVM virtual machines via the GUI
 
 @virthost_kvm
   Scenario: Enable the virtualization host formula for KVM
-    Given I am on the Systems overview page of this "kvm_server"
     When I follow "Formulas" in the content area
     Then I should see a "Choose formulas" text
     And I should see a "Virtualization" text
@@ -41,7 +40,6 @@ Feature: Be able to manage KVM virtual machines via the GUI
 
 @virthost_kvm
   Scenario: Parametrize the KVM virtualization host
-    Given I am on the Systems overview page of this "kvm_server"
     When I follow "Formulas" in the content area
     And I follow first "Virtualization Host" in the content area
     And I select "NAT" in virtual network mode field
@@ -53,7 +51,6 @@ Feature: Be able to manage KVM virtual machines via the GUI
 
 @virthost_kvm
   Scenario: Apply the KVM virtualization host formula via the highstate
-    Given I am on the Systems overview page of this "kvm_server"
     When I follow "States" in the content area
     And I click on "Apply Highstate"
     And I wait until event "Apply highstate scheduled by admin" is completed
@@ -61,8 +58,8 @@ Feature: Be able to manage KVM virtual machines via the GUI
 
 @virthost_kvm
   Scenario: Prepare a KVM test virtual machine and list it
-    Given I am on the "Virtualization" page of this "kvm_server"
-    When I delete default virtual network on "kvm_server"
+    When I follow "Virtualization" in the content area
+    And I delete default virtual network on "kvm_server"
     And I create test-net0 virtual network on "kvm_server"
     And I create test-net1 virtual network on "kvm_server"
     And I delete default virtual storage pool on "kvm_server"
@@ -72,36 +69,36 @@ Feature: Be able to manage KVM virtual machines via the GUI
 
 @virthost_kvm
   Scenario: Start a KVM virtual machine
-    Given I am on the "Virtualization" page of this "kvm_server"
-    When I click on "Start" in row "test-vm"
+    When I follow "Virtualization" in the content area
+    And I click on "Start" in row "test-vm"
     Then I should see "test-vm" virtual machine running on "kvm_server"
 
 @virthost_kvm
   Scenario: Show the VNC graphical console for KVM
-    Given I am on the "Virtualization" page of this "kvm_server"
-    When I click on "Graphical Console" in row "test-vm"
+    When I follow "Virtualization" in the content area
+    And I click on "Graphical Console" in row "test-vm"
     And I switch to last opened window
     Then I wait until I see the VNC graphical console
 
 @virthost_kvm
   Scenario: Suspend a KVM virtual machine
-    Given I am on the "Virtualization" page of this "kvm_server"
-    When I wait until table row for "test-vm" contains button "Suspend"
+    When I follow "Virtualization" in the content area
+    And I wait until table row for "test-vm" contains button "Suspend"
     And I click on "Suspend" in row "test-vm"
     And I click on "Suspend" in "Suspend Guest" modal
     Then I should see "test-vm" virtual machine paused on "kvm_server"
 
 @virthost_kvm
   Scenario: Resume a KVM virtual machine
-    Given I am on the "Virtualization" page of this "kvm_server"
-    When I wait until table row for "test-vm" contains button "Resume"
+    When I follow "Virtualization" in the content area
+    And I wait until table row for "test-vm" contains button "Resume"
     And I click on "Resume" in row "test-vm"
     Then I should see "test-vm" virtual machine running on "kvm_server"
 
 @virthost_kvm
   Scenario: Shutdown a KVM virtual machine
-    Given I am on the "Virtualization" page of this "kvm_server"
-    When I wait until table row for "test-vm" contains button "Stop"
+    When I follow "Virtualization" in the content area
+    And I wait until table row for "test-vm" contains button "Stop"
     And I wait until virtual machine "test-vm" on "kvm_server" is started
     And I click on "Stop" in row "test-vm"
     And I click on "Stop" in "Stop Guest" modal
@@ -109,8 +106,8 @@ Feature: Be able to manage KVM virtual machines via the GUI
 
 @virthost_kvm
   Scenario: Edit a KVM virtual machine
-    Given I am on the "Virtualization" page of this "kvm_server"
-    When I click on "Edit" in row "test-vm"
+    When I follow "Virtualization" in the content area
+    And I click on "Edit" in row "test-vm"
     And I wait until I do not see "Loading..." text
     Then I should see "512" in field "memory"
     And I should see "1" in field "vcpu"
@@ -133,8 +130,8 @@ Feature: Be able to manage KVM virtual machines via the GUI
 
 @virthost_kvm
   Scenario: Add a network interface to a KVM virtual machine
-    Given I am on the "Virtualization" page of this "kvm_server"
-    When I click on "Edit" in row "test-vm"
+    When I follow "Virtualization" in the content area
+    And I click on "Edit" in row "test-vm"
     And I wait until I do not see "Loading..." text
     And I click on "add_network"
     And I select "test-net1" from "network1_source"
@@ -144,8 +141,8 @@ Feature: Be able to manage KVM virtual machines via the GUI
 
 @virthost_kvm
   Scenario: Delete a network interface from a KVM virtual machine
-    Given I am on the "Virtualization" page of this "kvm_server"
-    When I click on "Edit" in row "test-vm"
+    When I follow "Virtualization" in the content area
+    And I click on "Edit" in row "test-vm"
     And I wait until I do not see "Loading..." text
     And I click on "remove_network1"
     And I click on "Update"
@@ -154,8 +151,8 @@ Feature: Be able to manage KVM virtual machines via the GUI
 
 @virthost_kvm
   Scenario: Add a disk and a cdrom to a KVM virtual machine
-    Given I am on the "Virtualization" page of this "kvm_server"
-    When I click on "Edit" in row "test-vm"
+    When I follow "Virtualization" in the content area
+    And I click on "Edit" in row "test-vm"
     And I wait until I do not see "Loading..." text
     And I click on "add_disk"
     And I click on "add_disk"
@@ -168,8 +165,8 @@ Feature: Be able to manage KVM virtual machines via the GUI
 
 @virthost_kvm
   Scenario: Attach an image to a cdrom on a KVM virtual machine
-    Given I am on the "Virtualization" page of this "kvm_server"
-    When I click on "Edit" in row "test-vm"
+    When I follow "Virtualization" in the content area
+    And I click on "Edit" in row "test-vm"
     And I store "" into file "/tmp/test-image.iso" on "kvm_server"
     And I wait until I do not see "Loading..." text
     And I enter "/tmp/test-image.iso" as "disk2_source_file"
@@ -179,8 +176,8 @@ Feature: Be able to manage KVM virtual machines via the GUI
 
 @virthost_kvm
   Scenario: Delete a disk from a KVM virtual machine
-    Given I am on the "Virtualization" page of this "kvm_server"
-    When I click on "Edit" in row "test-vm"
+    When I follow "Virtualization" in the content area
+    And I click on "Edit" in row "test-vm"
     And I wait until I do not see "Loading..." text
     And I click on "remove_disk2"
     And I click on "Update"
@@ -189,17 +186,17 @@ Feature: Be able to manage KVM virtual machines via the GUI
 
 @virthost_kvm
   Scenario: Delete a KVM virtual machine
-    Given I am on the "Virtualization" page of this "kvm_server"
-    When I click on "Delete" in row "test-vm"
+    When I follow "Virtualization" in the content area
+    And I click on "Delete" in row "test-vm"
     And I click on "Delete" in "Delete Guest" modal
     Then I should not see a "test-vm" virtual machine on "kvm_server"
 
 @virthost_kvm
   Scenario: Create a KVM virtual machine
-    Given I am on the "Virtualization" page of this "kvm_server"
+    When I follow "Virtualization" in the content area
     And I create empty "/var/lib/libvirt/images/test-pool0/disk1.qcow2" qcow2 disk file on "kvm_server"
     And I refresh the "test-pool0" storage pool of this "kvm_server"
-    When I follow "Create Guest"
+    And I follow "Create Guest"
     And I wait until I see "General" text
     And I enter "test-vm2" as "name"
     And I enter "/var/testsuite-data/disk-image-template.qcow2" as "disk0_source_template"
@@ -219,51 +216,51 @@ Feature: Be able to manage KVM virtual machines via the GUI
 
 @virthost_kvm
   Scenario: Show the Spice graphical console for KVM
-    Given I am on the "Virtualization" page of this "kvm_server"
-    When I click on "Graphical Console" in row "test-vm2"
+    When I follow "Virtualization" in the content area
+    And I click on "Graphical Console" in row "test-vm2"
     And I switch to last opened window
     Then I wait until I see the spice graphical console
 
 @virthost_kvm
   Scenario: Show the virtual storage pools and volumes for KVM
-    Given I am on the "Virtualization" page of this "kvm_server"
-    When I refresh the "test-pool0" storage pool of this "kvm_server"
+    When I follow "Virtualization" in the content area
+    And I refresh the "test-pool0" storage pool of this "kvm_server"
     And I follow "Storage"
     And I open the sub-list of the product "test-pool0"
     Then I wait until I see "test-vm2_system" text
 
 @virthost_kvm
   Scenario: delete a running KVM virtual machine
-    Given I am on the "Virtualization" page of this "kvm_server"
-    When I click on "Delete" in row "test-vm2"
+    When I follow "Virtualization" in the content area
+    And I click on "Delete" in row "test-vm2"
     And I click on "Delete" in "Delete Guest" modal
     Then I should not see a "test-vm2" virtual machine on "kvm_server"
 
 @virthost_kvm
   Scenario: Refresh a virtual storage pool for KVM
-    Given I am on the "Virtualization" page of this "kvm_server"
-    When I follow "Storage"
+    When I follow "Virtualization" in the content area
+    And I follow "Storage"
     And I click on "Refresh" in tree item "test-pool0"
     And I wait until the tree item "test-pool0" has no sub-list
 
 @virthost_kvm
   Scenario: Stop a virtual storage pool for KVM
-    Given I am on the "Virtualization" page of this "kvm_server"
-    When I follow "Storage"
+    When I follow "Virtualization" in the content area
+    And I follow "Storage"
     And I click on "Stop" in tree item "test-pool0"
     And I wait until the tree item "test-pool0" contains "inactive" text
 
 @virthost_kvm
   Scenario: Start a virtual storage pool for KVM
-    Given I am on the "Virtualization" page of this "kvm_server"
-    When I follow "Storage"
+    When I follow "Virtualization" in the content area
+    And I follow "Storage"
     And I click on "Start" in tree item "test-pool0"
     And I wait until the tree item "test-pool0" contains "running" text
 
 @virthost_kvm
   Scenario: Delete a virtual storage pool for KVM
-    Given I am on the "Virtualization" page of this "kvm_server"
-    When I follow "Storage"
+    When I follow "Virtualization" in the content area
+    And I follow "Storage"
     And I click on "Delete" in tree item "test-pool0"
     And I check "purge"
     And I click on "Delete" in "Delete Virtual Storage Pool" modal
@@ -272,8 +269,8 @@ Feature: Be able to manage KVM virtual machines via the GUI
 
 @virthost_kvm
   Scenario: Create a virtual storage pool for KVM
-    Given I am on the "Virtualization" page of this "kvm_server"
-    When I follow "Storage"
+    When I follow "Virtualization" in the content area
+    And I follow "Storage"
     And I follow "Create Pool"
     And I wait until option "dir" appears in list "type"
     And I select "dir" from "type"
@@ -288,8 +285,8 @@ Feature: Be able to manage KVM virtual machines via the GUI
 
 @virthost_kvm
   Scenario: Edit a virtual storage pool for KVM
-    Given I am on the "Virtualization" page of this "kvm_server"
-    When I follow "Storage"
+    When I follow "Virtualization" in the content area
+    And I follow "Storage"
     And I click on "Edit Pool" in tree item "test-pool1"
     And I wait until I see "General" text
     And I enter "0711" as "target_mode"
@@ -301,8 +298,8 @@ Feature: Be able to manage KVM virtual machines via the GUI
 
 @virthost_kvm
   Scenario: Delete a virtual volume
-    Given I am on the "Virtualization" page of this "kvm_server"
-    When I follow "Storage"
+    When I follow "Virtualization" in the content area
+    And I follow "Storage"
     And I open the sub-list of the product "tmp"
     And I click on "Delete" in tree item "test-net0.xml"
     And I click on "Delete" in "Delete Virtual Storage Volume" modal
@@ -310,15 +307,15 @@ Feature: Be able to manage KVM virtual machines via the GUI
 
 @virthost_kvm
   Scenario: List virtual networks
-    Given I am on the "Virtualization" page of this "kvm_server"
-    When I follow "Networks"
+    When I follow "Virtualization" in the content area
+    And I follow "Networks"
     Then I wait until I see "test-net0" text
     And I should see a "test-net1" text
 
 @virthost_kvm
   Scenario: Stop virtual network
-    Given I am on the "Virtualization" page of this "kvm_server"
-    When I follow "Networks"
+    When I follow "Virtualization" in the content area
+    And I follow "Networks"
     Then table row for "test-net1" should contain "running"
     When I click on "Stop" in row "test-net1"
     And I click on "Stop" in "Stop Network" modal
@@ -327,16 +324,16 @@ Feature: Be able to manage KVM virtual machines via the GUI
 
 @virthost_kvm
   Scenario: Start virtual network
-    Given I am on the "Virtualization" page of this "kvm_server"
-    When I follow "Networks"
+    When I follow "Virtualization" in the content area
+    And I follow "Networks"
     And I click on "Start" in row "test-net1"
     Then I wait until table row for "test-net1" contains button "Stop"
     And table row for "test-net1" should contain "running"
 
 @virthost_kvm
   Scenario: Delete virtual network
-    Given I am on the "Virtualization" page of this "kvm_server"
-    When I follow "Networks"
+    When I follow "Virtualization" in the content area
+    And I follow "Networks"
     And I click on "Delete" in row "test-net1"
     And I click on "Delete" in "Delete Network" modal
     Then I wait until I do not see "test-net1" text
@@ -348,10 +345,9 @@ Feature: Be able to manage KVM virtual machines via the GUI
 @virthost_kvm
 @scc_credentials
   Scenario: Create auto installation distribution
-    Given I am authorized
-    And I install package tftpboot-installation on the server
+    When I install package tftpboot-installation on the server
     And I wait for "tftpboot-installation-SLE-15-SP2-x86_64" to be installed on "server"
-    When I follow the left menu "Systems > Autoinstallation > Distributions"
+    And I follow the left menu "Systems > Autoinstallation > Distributions"
     And I follow "Create Distribution"
     And I enter "SLE-15-SP2-TFTP" as "label"
     And I enter "/usr/share/tftpboot-installation/SLE-15-SP2-x86_64/" as "basepath"
@@ -366,8 +362,7 @@ Feature: Be able to manage KVM virtual machines via the GUI
 @virthost_kvm
 @scc_credentials
   Scenario: Create auto installation profile
-    Given I am authorized
-    And I follow the left menu "Systems > Autoinstallation > Profiles"
+    When I follow the left menu "Systems > Autoinstallation > Profiles"
     And I follow "Upload Kickstart/Autoyast File"
     When I enter "15-sp2-kvm" as "kickstartLabel"
     And I select "SLE-15-SP2-TFTP" from "kstreeId"
@@ -413,9 +408,8 @@ Feature: Be able to manage KVM virtual machines via the GUI
 @virthost_kvm
 @scc_credentials
   Scenario: Cleanup: remove the auto installation profile
-    Given I am authorized
-    And I follow the left menu "Systems > Autoinstallation > Profiles"
-    When I follow "15-sp2-kvm"
+    When I follow the left menu "Systems > Autoinstallation > Profiles"
+    And I follow "15-sp2-kvm"
     And I follow "Delete Autoinstallation"
     And I click on "Delete Autoinstallation"
     Then I should not see a "15-sp2-kvm" text
@@ -424,7 +418,6 @@ Feature: Be able to manage KVM virtual machines via the GUI
 @virthost_kvm
 @scc_credentials
   Scenario: Cleanup: remove the auto installation distribution
-    Given I am authorized
     When I follow the left menu "Systems > Autoinstallation > Distributions"
     And I follow "SLE-15-SP2-TFTP"
     And I follow "Delete Distribution"

--- a/testsuite/features/secondary/minxen_guests.feature
+++ b/testsuite/features/secondary/minxen_guests.feature
@@ -6,7 +6,7 @@ Feature: Be able to manage XEN virtual machines via the GUI
 
 @virthost_xen
   Scenario: Bootstrap Xen virtual host
-    Given I am authorized
+    Given I am authorized as "admin" with password "admin"
     When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "xen_server" as "hostname"
@@ -31,7 +31,6 @@ Feature: Be able to manage XEN virtual machines via the GUI
 
 @virthost_xen
   Scenario: Enable the virtualization host formula for Xen
-    Given I am on the Systems overview page of this "xen_server"
     When I follow "Formulas" in the content area
     Then I should see a "Choose formulas" text
     And I should see a "Virtualization" text
@@ -41,7 +40,6 @@ Feature: Be able to manage XEN virtual machines via the GUI
 
 @virthost_xen
   Scenario: Parametrize the Xen virtualization host
-    Given I am on the Systems overview page of this "xen_server"
     When I follow "Formulas" in the content area
     And I follow first "Virtualization Host" in the content area
     And I select "Xen" from "hypervisor"
@@ -54,7 +52,6 @@ Feature: Be able to manage XEN virtual machines via the GUI
 
 @virthost_xen
   Scenario: Apply the Xen virtualization host formula via the highstate
-    Given I am on the Systems overview page of this "xen_server"
     When I follow "States" in the content area
     And I click on "Apply Highstate"
     And I wait until event "Apply highstate scheduled by admin" is completed
@@ -62,8 +59,8 @@ Feature: Be able to manage XEN virtual machines via the GUI
 
 @virthost_xen
   Scenario: Prepare a Xen test virtual machine and list it
-    Given I am on the "Virtualization" page of this "xen_server"
-    When I delete default virtual network on "xen_server"
+    When I follow "Virtualization" in the content area
+    And I delete default virtual network on "xen_server"
     And I create test-net0 virtual network on "xen_server"
     And I create test-net1 virtual network on "xen_server"
     And I delete default virtual storage pool on "xen_server"
@@ -73,29 +70,29 @@ Feature: Be able to manage XEN virtual machines via the GUI
 
 @virthost_xen
   Scenario: Start a Xen virtual machine
-    Given I am on the "Virtualization" page of this "xen_server"
-    When I click on "Start" in row "test-vm"
+    When I follow "Virtualization" in the content area
+    And I click on "Start" in row "test-vm"
     Then I should see "test-vm" virtual machine running on "xen_server"
 
 @virthost_xen
   Scenario: Suspend a Xen virtual machine
-    Given I am on the "Virtualization" page of this "xen_server"
-    When I wait until table row for "test-vm" contains button "Suspend"
+    When I follow "Virtualization" in the content area
+    And I wait until table row for "test-vm" contains button "Suspend"
     And I click on "Suspend" in row "test-vm"
     And I click on "Suspend" in "Suspend Guest" modal
     Then I should see "test-vm" virtual machine paused on "xen_server"
 
 @virthost_xen
   Scenario: Resume a Xen virtual machine
-    Given I am on the "Virtualization" page of this "xen_server"
-    When I wait until table row for "test-vm" contains button "Resume"
+    When I follow "Virtualization" in the content area
+    And I wait until table row for "test-vm" contains button "Resume"
     And I click on "Resume" in row "test-vm"
     Then I should see "test-vm" virtual machine running on "xen_server"
 
 @virthost_xen
   Scenario: Shutdown a Xen virtual machine
-    Given I am on the "Virtualization" page of this "xen_server"
-    When I wait until table row for "test-vm" contains button "Stop"
+    When I follow "Virtualization" in the content area
+    And I wait until table row for "test-vm" contains button "Stop"
     And I wait until virtual machine "test-vm" on "xen_server" is started
     And I click on "Stop" in row "test-vm"
     And I click on "Stop" in "Stop Guest" modal
@@ -103,8 +100,8 @@ Feature: Be able to manage XEN virtual machines via the GUI
 
 @virthost_xen
   Scenario: Edit a Xen virtual machine
-    Given I am on the "Virtualization" page of this "xen_server"
-    When I click on "Edit" in row "test-vm"
+    When I follow "Virtualization" in the content area
+    And I click on "Edit" in row "test-vm"
     And I wait until I do not see "Loading..." text
     And I should see "1" in field "vcpu"
     And option "VNC" is selected as "graphicsType"
@@ -123,8 +120,8 @@ Feature: Be able to manage XEN virtual machines via the GUI
 
 @virthost_xen
   Scenario: Add a network interface to a Xen virtual machine
-    Given I am on the "Virtualization" page of this "xen_server"
-    When I click on "Edit" in row "test-vm"
+    When I follow "Virtualization" in the content area
+    And I click on "Edit" in row "test-vm"
     And I wait until I do not see "Loading..." text
     And I click on "add_network"
     And I select "test-net1" from "network1_source"
@@ -134,8 +131,8 @@ Feature: Be able to manage XEN virtual machines via the GUI
 
 @virthost_xen
   Scenario: Delete a network interface from a Xen virtual machine
-    Given I am on the "Virtualization" page of this "xen_server"
-    When I click on "Edit" in row "test-vm"
+    When I follow "Virtualization" in the content area
+    And I click on "Edit" in row "test-vm"
     And I wait until I do not see "Loading..." text
     And I click on "remove_network1"
     And I click on "Update"
@@ -144,8 +141,8 @@ Feature: Be able to manage XEN virtual machines via the GUI
 
 @virthost_xen
   Scenario: Add a disk and a cdrom to a Xen virtual machine
-    Given I am on the "Virtualization" page of this "xen_server"
-    When I click on "Edit" in row "test-vm"
+    When I follow "Virtualization" in the content area
+    And I click on "Edit" in row "test-vm"
     And I wait until I do not see "Loading..." text
     And I click on "add_disk"
     And I select "test-pool0" from "disk1_source_pool"
@@ -159,8 +156,8 @@ Feature: Be able to manage XEN virtual machines via the GUI
 
 @virthost_xen
   Scenario: Delete a disk from a Xen virtual machine
-    Given I am on the "Virtualization" page of this "xen_server"
-    When I click on "Edit" in row "test-vm"
+    When I follow "Virtualization" in the content area
+    And I click on "Edit" in row "test-vm"
     And I wait until I do not see "Loading..." text
     # The libvirt disk order is not the same than for KVM
     And I click on "remove_disk1"
@@ -170,15 +167,15 @@ Feature: Be able to manage XEN virtual machines via the GUI
 
 @virthost_xen
   Scenario: Delete a Xen virtual machine
-    Given I am on the "Virtualization" page of this "xen_server"
-    When I click on "Delete" in row "test-vm"
+    When I follow "Virtualization" in the content area
+    And I click on "Delete" in row "test-vm"
     And I click on "Delete" in "Delete Guest" modal
     Then I should not see a "test-vm" virtual machine on "xen_server"
 
 @virthost_xen
   Scenario: Create a Xen paravirtualized guest
-    Given I am on the "Virtualization" page of this "xen_server"
-    When I follow "Create Guest"
+    When I follow "Virtualization" in the content area
+    And I follow "Create Guest"
     And I wait until I see "General" text
     And I enter "test-vm2" as "name"
     And I enter "512" as "memory"
@@ -194,15 +191,15 @@ Feature: Be able to manage XEN virtual machines via the GUI
 
 @virthost_xen
   Scenario: Show the VNC graphical console for Xen
-    Given I am on the "Virtualization" page of this "xen_server"
-    When I click on "Graphical Console" in row "test-vm2"
+    When I follow "Virtualization" in the content area
+    And I click on "Graphical Console" in row "test-vm2"
     And I switch to last opened window
     And I wait until I see the VNC graphical console
 
 @virthost_xen
   Scenario: Create a Xen fully virtualized guest
-    Given I am on the "Virtualization" page of this "xen_server"
-    When I follow "Create Guest"
+    When I follow "Virtualization" in the content area
+    And I follow "Create Guest"
     And I wait until I see "General" text
     And I enter "test-vm3" as "name"
     And I select "Fully Virtualized" from "osType"
@@ -219,23 +216,23 @@ Feature: Be able to manage XEN virtual machines via the GUI
 
 @virthost_xen
   Scenario: Show the Spice graphical console for Xen
-    Given I am on the "Virtualization" page of this "xen_server"
-    When I click on "Graphical Console" in row "test-vm3"
+    When I follow "Virtualization" in the content area
+    And I click on "Graphical Console" in row "test-vm3"
     And I switch to last opened window
     And I wait until I see the spice graphical console
 
 @virthost_xen
   Scenario: Show the virtual storage pools and volumes for Xen
-    Given I am on the "Virtualization" page of this "xen_server"
-    When I refresh the "test-pool0" storage pool of this "xen_server"
+    When I follow "Virtualization" in the content area
+    And I refresh the "test-pool0" storage pool of this "xen_server"
     And I follow "Storage"
     And I open the sub-list of the product "test-pool0"
     Then I wait until I see "test-vm2_system" text
 
 @virthost_xen
   Scenario: delete a running Xen virtual machine
-    Given I am on the "Virtualization" page of this "xen_server"
-    When I click on "Delete" in row "test-vm3"
+    When I follow "Virtualization" in the content area
+    And I click on "Delete" in row "test-vm3"
     And I click on "Delete" in "Delete Guest" modal
     Then I should not see a "test-vm3" virtual machine on "xen_server"
 


### PR DESCRIPTION
## What does this PR change?

This is a minor improvement, to avoid log out/log it for each scenario on the Xen tests.

As currently, the step we as starting almost every scenario has implicit the step that logs in.

``` 
Given(/^I am on the "([^"]*)" page of this "([^"]*)"$/) do |page, host|
  steps %(
    Given I am on the Systems overview page of this "#{host}"
    And I follow "#{page}" in the content area
  )
end
```
```
Given(/^I am on the Systems overview page of this "([^"]*)"$/) do |host|
  system_name = get_system_name(host)
  steps %(
    Given I am on the Systems page
    When I follow "#{system_name}"
    And I wait until I see "System Status" text
  )
end
``` 
```
Given(/^I am on the Systems page$/) do
  steps %(
    When I am authorized as "admin" with password "admin"
    And I follow the left menu "Systems > Overview"
    And I wait until I see "System Overview" text
  )
end
```
As you can see, this is a case of step with TOO MUCH embedded steps.

Instead, for what it concerns to our scenarios, we will use directly the navigation step:
```
When(/^I follow "([^"]*)" in the (.+)$/) do |arg1, arg2|
  tag = case arg2
        when /tab bar|tabs/ then 'header'
        when /content area/ then 'section'
        else raise "Unknown element with description '#{arg2}'"
        end
  within(:xpath, "//#{tag}") do
    step %(I follow "#{arg1}")
  end
end
```

As the pre-requisites to perform this step are already accomplished in the first scenarios.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.0
- Manager-4.1

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
