### PR TITLE
Feat: add logrotate conf for mgr-create-bootstrap-repo

### DIFF
--- a/backend/common/rhnLog.py
+++ b/backend/common/rhnLog.py
@@ -106,10 +106,7 @@ def initLOG(log_file="stderr", level=0):
 
         try:
             os.makedirs(log_path)
-            if os.getuid() == 0:
-                os.chown(log_path, apache_uid, apache_gid)
-            else:
-                os.chown(log_path, apache_uid, apache_gid)
+            os.chown(log_path, apache_uid, apache_gid)
         except:
             log_stderr("ERROR: unable to create log file path %s" % log_path,
                        sys.exc_info()[:2])

--- a/backend/common/rhnLog.py
+++ b/backend/common/rhnLog.py
@@ -107,7 +107,7 @@ def initLOG(log_file="stderr", level=0):
         try:
             os.makedirs(log_path)
             if os.getuid() == 0:
-                os.chown(log_path, apache_uid, 0)
+                os.chown(log_path, apache_uid, apache_gid)
             else:
                 os.chown(log_path, apache_uid, apache_gid)
         except:

--- a/susemanager/etc/logrotate.d/susemanager-tools
+++ b/susemanager/etc/logrotate.d/susemanager-tools
@@ -19,6 +19,5 @@
     missingok
     notifempty
     rotate 30
-    size 4096k
     su wwwrun www
 }

--- a/susemanager/etc/logrotate.d/susemanager-tools
+++ b/susemanager/etc/logrotate.d/susemanager-tools
@@ -1,6 +1,6 @@
 # logrotation file for susemanager
 
-/var/log/rhn/mgr-sync.log /var/log/rhn/mgr-create-bootstrap-repo.log {
+/var/log/rhn/mgr-sync.log {
     compress
     dateext
     maxage 365
@@ -11,4 +11,14 @@
     su wwwrun www
 }
 
-
+/var/log/rhn/mgr-create-bootstrap-repo/mgr-create-bootstrap-repo.log {
+    compress
+    dateext
+    daily
+    maxage 30
+    missingok
+    notifempty
+    rotate 30
+    size 4096k
+    su wwwrun www
+}

--- a/susemanager/src/mgr-create-bootstrap-repo
+++ b/susemanager/src/mgr-create-bootstrap-repo
@@ -20,9 +20,9 @@ initCFG('server.susemanager')
 rhnSQL.initDB()
 
 basepath = CFG.MOUNT_POINT or '/var/spacewalk'
-logfile = '/var/log/rhn/mgr-create-bootstrap-repo.log'
 LOCK  = None
 BETA  = None
+logfile = '/var/log/rhn/mgr-create-bootstrap-repo/mgr-create-bootstrap-repo.log'
 UYUNI = None
 
 _sql_synced_proucts = rhnSQL.Statement("""
@@ -259,7 +259,7 @@ def cli():
     parser = OptionParser(usage=usage, description=""
             "Tool to generate repositories containing the required software to "
             "register at SUSE Manager Server. Logs are written to "
-            "/var/log/rhn/mgr-create-bootstrap-repo.log .")
+            "/var/log/rhn/mgr-create-bootstrap-repo/mgr-create-bootstrap-repo.log .")
 
     parser.add_option('-n', '--dryrun', action='store_true', dest='dryrun',
                       help='Dry run. Show only changes - do not execute them')

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,5 @@
+- Feat: make mgr-create-bootstrap-repo log to another directory and logrotate it
+
 -------------------------------------------------------------------
 Thu Feb 25 12:10:50 CET 2021 - jgonzalez@suse.com
 

--- a/susemanager/susemanager.spec
+++ b/susemanager/susemanager.spec
@@ -267,6 +267,10 @@ if [[ -f /SWAPFILE && $(stat -c "%a" "/SWAPFILE") != "600" ]]; then
     chmod 600 /SWAPFILE
 fi
 
+%if !0%{?suse_version}
+sed -i 's/su wwwrun www/su apache apache/' /etc/logrotate.d/susemanager-tools
+%endif
+
 %posttrans
 # make sure our database will use correct encoding
 . /etc/sysconfig/postgresql


### PR DESCRIPTION
## What does this PR change?

* make mgr-create-bootstrap-repo log into a new separate directory /var/log/rhn/mgr-create-bootstrap-repo/ (for reviewers: the directory is created by `rhnLog.initLOG`)
* `log`-rotate those files by day.

NOTE: one minor problem: existing users that upgrade the package will not have the already existing files in /var/log/rhn/mgr-create-bootstrap-repo.* cleaned up.
Reviewers: is cleaning up those files needed? (Maybe in the specfile)

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: https://github.com/uyuni-project/uyuni-docs/blob/master/modules/reference/pages/command-line-tools.adoc does not mention log location
- [X] **DONE**

## Test coverage
- No tests: already covered by Cucumber

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/12990

- [x] **DONE**

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
