### PR TITLE
Improve translation automation

### DIFF
--- a/.github/workflows/update_translations.yml
+++ b/.github/workflows/update_translations.yml
@@ -11,6 +11,11 @@ jobs:
    if: github.repository == 'uyuni-project/uyuni'
    runs-on: ubuntu-latest
    steps:
+   - name: Cancel Previous Runs
+     uses: styfle/cancel-workflow-action@0.8.0
+     with:
+         access_token: ${{ github.token }}
+
    - name: Checkout repo
      uses: actions/checkout@v2
 

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_bn_IN.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_bn_IN.xml
@@ -4696,10 +4696,6 @@ organization. You may grant or remove the organization administrator role in the
         <source>Patches Management</source>
         <target>ত্রুটি-বিচ্যুতি পরিচালনা</target>
       </trans-unit>
-      <trans-unit id="erratalist.jsp.noerrata" xml:space="preserve">
-        <source>No Patches</source>
-        <target state="needs-adaptation">কোনো প্রকাশিত ত্রুটি-বিচ্যুতির তথ্য উপস্থিত নেই</target>
-      </trans-unit>
       <trans-unit id="erratalist.jsp.errata" xml:space="preserve">
         <source>Patches</source>
         <target state="needs-adaptation">প্রকাশিত ত্রুটি-বিচ্যুতির তথ্য</target>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ca.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ca.xml
@@ -4351,10 +4351,6 @@ organization. You may grant or remove the organization administrator role in the
       <trans-unit id="erratalist.jsp.erratamgmt" xml:space="preserve">
         <source>Patches Management</source>
       </trans-unit>
-      <trans-unit id="erratalist.jsp.noerrata" xml:space="preserve">
-        <source>No Patches</source>
-      <target state="needs-adaptation" />
-      </trans-unit>
       <trans-unit id="erratalist.jsp.errata" xml:space="preserve">
         <source>Patches</source>
       <target state="needs-adaptation" />

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_cs.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_cs.xml
@@ -4836,10 +4836,6 @@ organization. You may grant or remove the organization administrator role in the
         <source>Patches Management</source>
         <target />
       </trans-unit>
-      <trans-unit id="erratalist.jsp.noerrata" xml:space="preserve">
-        <source>No Patches</source>
-        <target state="needs-adaptation" />
-      </trans-unit>
       <trans-unit id="erratalist.jsp.errata" xml:space="preserve">
         <source>Patches</source>
         <target state="needs-adaptation" />

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_de.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_de.xml
@@ -4902,10 +4902,6 @@ die Organisations-Administrator Rolle im Abschnitt "Rollen" des Tab "Details" ge
         <source>Patches Management</source>
         <target>Errata-Management</target>
       </trans-unit>
-      <trans-unit id="erratalist.jsp.noerrata" xml:space="preserve">
-        <source>No Patches</source>
-        <target state="needs-adaptation">Keine veröffentlichten Errata</target>
-      </trans-unit>
       <trans-unit id="erratalist.jsp.errata" xml:space="preserve">
         <source>Patches</source>
         <target state="needs-adaptation">Veröffentlichte Errata</target>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_es.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_es.xml
@@ -4779,10 +4779,6 @@ administrador de la organización en la sección "Roles" de la pestaña
         <source>Patches Management</source>
         <target>Gestión de parches</target>
       </trans-unit>
-      <trans-unit id="erratalist.jsp.noerrata" xml:space="preserve">
-        <source>No Patches</source>
-        <target state="needs-adaptation">Ninguna errata publicada</target>
-      </trans-unit>
       <trans-unit id="erratalist.jsp.errata" xml:space="preserve">
         <source>Patches</source>
         <target state="needs-adaptation">Erratas publicada</target>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_fr.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_fr.xml
@@ -4902,10 +4902,6 @@ organisation. Vous pouvez accorder ou retirer le rôle d'administrateur d'organi
         <source>Patches Management</source>
         <target>Gestion des errata</target>
       </trans-unit>
-      <trans-unit id="erratalist.jsp.noerrata" xml:space="preserve">
-        <source>No Patches</source>
-        <target state="needs-adaptation">Aucun errata publié</target>
-      </trans-unit>
       <trans-unit id="erratalist.jsp.errata" xml:space="preserve">
         <source>Patches</source>
         <target state="needs-adaptation">Errata publiés</target>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_gu.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_gu.xml
@@ -4788,10 +4788,6 @@ organization. You may grant or remove the organization administrator role in the
         <source>Patches Management</source>
         <target>ત્રુટિસૂચી વ્યવસ્થાપન</target>
       </trans-unit>
-      <trans-unit id="erratalist.jsp.noerrata" xml:space="preserve">
-        <source>No Patches</source>
-        <target state="needs-adaptation">પ્રકાશિત થયેલ કોઈ ત્રુટિસૂચી નથી</target>
-      </trans-unit>
       <trans-unit id="erratalist.jsp.errata" xml:space="preserve">
         <source>Patches</source>
         <target state="needs-adaptation">પ્રકાશિત ત્રુટિસૂચી</target>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_hi.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_hi.xml
@@ -4788,10 +4788,6 @@ organization. You may grant or remove the organization administrator role in the
         <source>Patches Management</source>
         <target>इरेटा प्रबंधन</target>
       </trans-unit>
-      <trans-unit id="erratalist.jsp.noerrata" xml:space="preserve">
-        <source>No Patches</source>
-        <target state="needs-adaptation">कोई प्रकाशित इरेटा नहीं</target>
-      </trans-unit>
       <trans-unit id="erratalist.jsp.errata" xml:space="preserve">
         <source>Patches</source>
         <target state="needs-adaptation">प्रकाशित इरेटा</target>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_it.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_it.xml
@@ -4901,10 +4901,6 @@ amministratore dell'organizzazione all'interno della sezione "Ruoli" della tabel
         <source>Patches Management</source>
         <target>Gestione Errata</target>
       </trans-unit>
-      <trans-unit id="erratalist.jsp.noerrata" xml:space="preserve">
-        <source>No Patches</source>
-        <target state="needs-adaptation">Nessun Errata pubblicato</target>
-      </trans-unit>
       <trans-unit id="erratalist.jsp.errata" xml:space="preserve">
         <source>Patches</source>
         <target state="needs-adaptation">Errata pubblicato</target>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ja.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ja.xml
@@ -4951,10 +4951,6 @@ organization. You may grant or remove the organization administrator role in the
         <source>Patches Management</source>
         <target>パッチ管理</target>
       </trans-unit>
-      <trans-unit id="erratalist.jsp.noerrata" xml:space="preserve">
-        <source>No Patches</source>
-        <target state="translated">パッチはありません</target>
-      </trans-unit>
       <trans-unit id="erratalist.jsp.errata" xml:space="preserve">
         <source>Patches</source>
         <target state="translated">パッチ</target>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ko.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ko.xml
@@ -4835,10 +4835,6 @@ organization. You may grant or remove the organization administrator role in the
         <source>Patches Management</source>
         <target>에라타 관리</target>
       </trans-unit>
-      <trans-unit id="erratalist.jsp.noerrata" xml:space="preserve">
-        <source>No Patches</source>
-        <target state="needs-adaptation">발표된 에라타가 없습니다.</target>
-      </trans-unit>
       <trans-unit id="erratalist.jsp.errata" xml:space="preserve">
         <source>Patches</source>
         <target state="needs-adaptation">발표된 에라타</target>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_pa.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_pa.xml
@@ -4788,10 +4788,6 @@ organization. You may grant or remove the organization administrator role in the
         <source>Patches Management</source>
         <target>ਇਰੱਟਾ ਪਰਬੰਧਨ</target>
       </trans-unit>
-      <trans-unit id="erratalist.jsp.noerrata" xml:space="preserve">
-        <source>No Patches</source>
-        <target state="needs-adaptation">ਕੋਈ ਇਰੱਟਾ ਪਰਾਕਸ਼ਤ ਨਹੀਂ</target>
-      </trans-unit>
       <trans-unit id="erratalist.jsp.errata" xml:space="preserve">
         <source>Patches</source>
         <target state="needs-adaptation">ਪਰਕਾਸ਼ਤ ਇਰੱਟਾ</target>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_pt_BR.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_pt_BR.xml
@@ -4906,10 +4906,6 @@ permanecer sem modificações nesta página. Caso queira modificá-los, visite
         <source>Patches Management</source>
         <target>Administração de Errata</target>
       </trans-unit>
-      <trans-unit id="erratalist.jsp.noerrata" xml:space="preserve">
-        <source>No Patches</source>
-        <target state="needs-adaptation">Nenhuma Errata Publicada.</target>
-      </trans-unit>
       <trans-unit id="erratalist.jsp.errata" xml:space="preserve">
         <source>Patches</source>
         <target state="needs-adaptation">Erratas Publicadas</target>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ru.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ru.xml
@@ -4783,10 +4783,6 @@ organization. You may grant or remove the organization administrator role in the
         <source>Patches Management</source>
         <target>Управление исправлениями</target>
       </trans-unit>
-      <trans-unit id="erratalist.jsp.noerrata" xml:space="preserve">
-        <source>No Patches</source>
-        <target state="needs-adaptation">Нет опубликованных исправлений</target>
-      </trans-unit>
       <trans-unit id="erratalist.jsp.errata" xml:space="preserve">
         <source>Patches</source>
         <target state="needs-adaptation">Опубликованные исправления</target>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_sk.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_sk.xml
@@ -4836,10 +4836,6 @@ organization. You may grant or remove the organization administrator role in the
         <source>Patches Management</source>
         <target />
       </trans-unit>
-      <trans-unit id="erratalist.jsp.noerrata" xml:space="preserve">
-        <source>No Patches</source>
-        <target state="needs-adaptation" />
-      </trans-unit>
       <trans-unit id="erratalist.jsp.errata" xml:space="preserve">
         <source>Patches</source>
         <target state="needs-adaptation" />

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ta.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_ta.xml
@@ -4788,10 +4788,6 @@ organization. You may grant or remove the organization administrator role in the
         <source>Patches Management</source>
         <target>பிழைத்திருத்த மேலாண்மை</target>
       </trans-unit>
-      <trans-unit id="erratalist.jsp.noerrata" xml:space="preserve">
-        <source>No Patches</source>
-        <target state="needs-adaptation">வெளியிடப்பட்ட பிழைத்திருத்தங்கள் ஒன்றுமில்லை</target>
-      </trans-unit>
       <trans-unit id="erratalist.jsp.errata" xml:space="preserve">
         <source>Patches</source>
         <target state="needs-adaptation">வெளியிடப்பட்ட பிழைத்திருத்தங்கள்</target>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_uk.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_uk.xml
@@ -4584,10 +4584,6 @@ organization. You may grant or remove the organization administrator role in the
       <trans-unit id="erratalist.jsp.erratamgmt" xml:space="preserve">
         <source>Patches Management</source>
       </trans-unit>
-      <trans-unit id="erratalist.jsp.noerrata" xml:space="preserve">
-        <source>No Patches</source>
-      <target state="needs-adaptation" />
-      </trans-unit>
       <trans-unit id="erratalist.jsp.errata" xml:space="preserve">
         <source>Patches</source>
       <target state="needs-adaptation" />

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_zh_CN.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_zh_CN.xml
@@ -4952,10 +4952,6 @@ organization. You may grant or remove the organization administrator role in the
         <source>Patches Management</source>
         <target state="translated">补丁管理</target>
       </trans-unit>
-      <trans-unit id="erratalist.jsp.noerrata" xml:space="preserve">
-        <source>No Patches</source>
-        <target state="needs-adaptation">没有已发布补丁</target>
-      </trans-unit>
       <trans-unit id="erratalist.jsp.errata" xml:space="preserve">
         <source>Patches</source>
         <target state="needs-adaptation">已发布补丁</target>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_zh_TW.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_zh_TW.xml
@@ -4898,10 +4898,6 @@ organization. You may grant or remove the organization administrator role in the
         <source>Patches Management</source>
         <target>勘誤管理</target>
       </trans-unit>
-      <trans-unit id="erratalist.jsp.noerrata" xml:space="preserve">
-        <source>No Patches</source>
-        <target state="needs-adaptation">沒有已發佈的勘誤</target>
-      </trans-unit>
       <trans-unit id="erratalist.jsp.errata" xml:space="preserve">
         <source>Patches</source>
         <target state="needs-adaptation">已發佈的勘誤</target>

--- a/scripts/translation/update-all-translation-strings.sh
+++ b/scripts/translation/update-all-translation-strings.sh
@@ -40,13 +40,16 @@ function update_xliff() {
         return 1;
     fi
     $GIT_ROOT_DIR/scripts/translation/xliffmerger.py $GIT_ROOT_DIR/$XLIFF_DIR
-    for change in `git diff --numstat | awk '{print $1}'`; do
-        if [ $change -gt 1 ]; then
-            git add -u
-            git commit -m "update strings for translations in $XLIFF_DIR"
-            return 2
-        fi
-    done
+    if [ $? -ne 0 ]; then
+        echo "xliffmerger returned a fault code"
+        return 1
+    fi
+    MODIFIED=`git status --short --porcelain --untracked-files=no | wc -l`
+    if [ $MODIFIED -gt 0 ]; then
+        git add -u
+        git commit -m "update strings for translations in $XLIFF_DIR"
+        return 2
+    fi
     git reset --hard
     return 0
 }

--- a/scripts/translation/xliffmerger.py
+++ b/scripts/translation/xliffmerger.py
@@ -95,8 +95,10 @@ def process(original_file, translation_file):
         logging.info(f' These (id,new_source_value) -> {to_update}, will be updated in the {translation_file} ')
         update_trans_units(translation_body_element, trans_trans_units, to_update)
     else:
-        logging.info("Something went wrong, this should not have happend!")
-
+        logging.info((
+            "Something went wrong, this should not have happend! Count of original units: "
+            "%d, count of translation units: %d." % (len(orig_trans_units), len(trans_trans_units))))
+        raise Exception("Mismatching orig/trans lengths")
     for t in list(translation_body_element.findall('d:trans-unit', ns)):
         if not t.get('{http://www.w3.org/XML/1998/namespace}space'):
             t.set('xml:space', 'preserve')

--- a/scripts/translation/xliffmerger.py
+++ b/scripts/translation/xliffmerger.py
@@ -64,18 +64,20 @@ def process(original_file, translation_file):
     logging.debug(f'{trans_units_ids} trans_units in Ids translation file {translation_file}')
 
     # Delete the ones which are in translation file but not in original
-    logging.info("########## DELETING ORPHAN TRANS_UNITS ##########")
     to_remove = set(trans_units_ids).difference(set(org_trans_units_ids))
-    logging.info(f'Trans-units with these Ids : {to_remove}, will be deleted from the {translation_file}')
-    delete_trans_units(translation_body_element, trans_trans_units, to_remove)
-    logging.info("-------------------------------------------------\n")
+    if to_remove:
+      logging.info("########## DELETING ORPHAN TRANS_UNITS ##########")
+      logging.info(f'Trans-units with these Ids : {to_remove}, will be deleted from the {translation_file}')
+      delete_trans_units(translation_body_element, trans_trans_units, to_remove)
+      logging.info("-------------------------------------------------\n")
 
     # Add the ones which are not in translation file but exist in original
-    logging.info("########## ADDING MISSING TRANS_UNITS ##########")
     to_add = set(org_trans_units_ids).difference(set(trans_units_ids))
-    logging.info(f'Trans-units with these Ids : {to_add}, will be added to the {translation_file}')
-    add_trans_units(translation_body_element, orig_trans_units, to_add)
-    logging.info("-------------------------------------------------\n")
+    if to_add:
+      logging.info("########## ADDING MISSING TRANS_UNITS ##########")
+      logging.info(f'Trans-units with these Ids : {to_add}, will be added to the {translation_file}')
+      add_trans_units(translation_body_element, orig_trans_units, to_add)
+      logging.info("-------------------------------------------------\n")
 
     # Update() those trans_units where source has been changed but id remained same. We will be updating source text and
     # add the 'needs-adaptation' state attribute


### PR DESCRIPTION
This improves multiple things (see the commits one-by-one):
- make xliff merger a bit more silent, when there are no changes
- propagate an error from the xliff merger to the update all translations script
- propagate errors from xliff merger outside of the translation script (error in it should make the automation fail)
- remove the duplicate key in translation files `erratalist.jsp.noerrata` (we might need a validator job to prevent these situations in the future)
- when running the translation automation, cancel all pending runs of it

## Review
I've added multiple reviewers, so it'd be enough if you just review the part that belongs to your focus area.

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"