### PR TITLE
Wait for reposync, including in Build Validation

### DIFF
--- a/testsuite/features/reposync/srv_wait_for_reposync.feature
+++ b/testsuite/features/reposync/srv_wait_for_reposync.feature
@@ -1,8 +1,9 @@
-# Copyright (c) 2019 SUSE LLC
+# Copyright (c) 2019-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-Feature: Abort all reposync activity
+Feature: Wait for reposync activity to finish
 
+@regular_ci
   Scenario: Delete scheduled reposyncs
     Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Admin > Task Schedules"
@@ -11,5 +12,10 @@ Feature: Abort all reposync activity
     And I click on "Update Schedule"
     And I click on "Delete Schedule"
 
+@continuous_integration
   Scenario: Kill running reposyncs
-    When I make sure no spacewalk-repo-sync is executing, excepted the ones needed to bootstrap
+    When I kill all running spacewalk-repo-sync, excepted the ones needed to bootstrap
+
+@build_validation
+  Scenario: Wait for running reposyncs to finish
+    When I wait until all spacewalk-repo-sync finished

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -66,8 +66,8 @@ def compute_image_name
 end
 
 # If we for example
-#  - start a reposync in reposync/srv_sync_channels.feature.
-#  - then kill it in reposync/srv_abort_all_sync.feature
+#  - start a reposync in reposync/srv_sync_channels.feature
+#  - then kill it in reposync/srv_wait_for_reposync.feature
 #  - then restart it later on in init_clients/sle_minion.feature
 # then the channel will be in an inconsistent state.
 #

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -286,6 +286,14 @@ Before('@sle15sp3_client') do
   skip_this_scenario unless $sle15sp3_client
 end
 
+Before('@build_validation') do
+  skip_this_scenario unless $build_validation
+end
+
+Before('@continuous_integration') do
+  skip_this_scenario if $build_validation
+end
+
 Before('@skip_for_ubuntu') do |scenario|
   skip_this_scenario if scenario.feature.location.file.include? 'ubuntu'
 end

--- a/testsuite/run_sets/build_validation_reposync.yml
+++ b/testsuite/run_sets/build_validation_reposync.yml
@@ -10,6 +10,7 @@
 
 - features/build_validation/reposync/srv_sync_all_products.feature
 - features/build_validation/reposync/srv_common_channels.feature
+- features/reposync/srv_wait_for_reposync.feature
 
 ## Channels and Product synchronization features END ###
 

--- a/testsuite/run_sets/refhost.yml
+++ b/testsuite/run_sets/refhost.yml
@@ -28,7 +28,7 @@
 - features/reposync/srv_sync_products.feature
 - features/reposync/srv_enable_sync_products.feature
   # we let the synchronization run
-  # - features/reposync/srv_abort_all_sync.feature
+  # - features/reposync/srv_wait_for_reposync.feature
 - features/reposync/srv_check_reposync.feature
 
 ## Core features END ###

--- a/testsuite/run_sets/reposync.yml
+++ b/testsuite/run_sets/reposync.yml
@@ -12,7 +12,7 @@
 - features/reposync/srv_sync_channels.feature
 - features/reposync/srv_sync_products.feature
 - features/reposync/srv_enable_sync_products.feature
-- features/reposync/srv_abort_all_sync.feature
+- features/reposync/srv_wait_for_reposync.feature
 - features/reposync/srv_check_reposync.feature
 
 ## Channels and Product synchronization features END ###

--- a/testsuite/run_sets/virtualization.yml
+++ b/testsuite/run_sets/virtualization.yml
@@ -21,7 +21,7 @@
 - features/reposync/srv_sync_channels.feature
 - features/reposync/srv_sync_products.feature
 - features/reposync/srv_enable_sync_products.feature
-- features/reposync/srv_abort_all_sync.feature
+- features/reposync/srv_wait_for_reposync.feature
 - features/reposync/srv_check_reposync.feature
 
 ## Core features END ###


### PR DESCRIPTION
## What does this PR change?

This PR waits for all reposyncs to finish, even when we are in Build Validation case


## Links

Solves SUSE/spacewalk#14055

Ports:
* 4.0: SUSE/spacewalk#14176
* 4.1: SUSE/spacewalk#14175


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)
