### PR TITLE
QA: Hold the browser session and page between scenarios

### DIFF
--- a/testsuite/features/secondary/minkvm_guests.feature
+++ b/testsuite/features/secondary/minkvm_guests.feature
@@ -79,6 +79,7 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I click on "Graphical Console" in row "test-vm"
     And I switch to last opened window
     Then I wait until I see the VNC graphical console
+    And I close the last opened window
 
 @virthost_kvm
   Scenario: Suspend a KVM virtual machine
@@ -220,6 +221,7 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I click on "Graphical Console" in row "test-vm2"
     And I switch to last opened window
     Then I wait until I see the spice graphical console
+    And I close the last opened window
 
 @virthost_kvm
   Scenario: Show the virtual storage pools and volumes for KVM
@@ -403,6 +405,7 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I wait until I see the VNC graphical console
     Then I wait at most 500 seconds until I see modal containing "Disconnected" text
     And I wait at most 500 seconds until Salt master sees "test-vm2" as "unaccepted"
+    And I close the last opened window
 
 @long_test
 @virthost_kvm

--- a/testsuite/features/secondary/minxen_guests.feature
+++ b/testsuite/features/secondary/minxen_guests.feature
@@ -195,6 +195,7 @@ Feature: Be able to manage XEN virtual machines via the GUI
     And I click on "Graphical Console" in row "test-vm2"
     And I switch to last opened window
     And I wait until I see the VNC graphical console
+    And I close the last opened window
 
 @virthost_xen
   Scenario: Create a Xen fully virtualized guest
@@ -220,6 +221,7 @@ Feature: Be able to manage XEN virtual machines via the GUI
     And I click on "Graphical Console" in row "test-vm3"
     And I switch to last opened window
     And I wait until I see the spice graphical console
+    And I close the last opened window
 
 @virthost_xen
   Scenario: Show the virtual storage pools and volumes for Xen

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -349,6 +349,7 @@ end
 #
 
 Given(/^I am not authorized$/) do
+  page.reset!
   visit Capybara.app_host
   raise "Button 'Sign In' not visible" unless find_button('Sign In').visible?
 end

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -131,6 +131,10 @@ When(/^I switch to last opened window$/) do
   page.driver.browser.switch_to.window(page.driver.browser.window_handles.last)
 end
 
+When(/^I close the last opened window$/) do
+  page.driver.browser.close
+end
+
 #
 # Check a checkbox of the given id
 #

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -109,12 +109,12 @@ After do |scenario|
 end
 
 # Reset the page if it's running the first scenario of a feature
-$first_scenario = true # This will be set every time we run a new feature
+$first_scenario = true
 Before do
-  if $first_scenario
-    page.reset!
-    $first_scenario = false
-  end
+  next unless $first_scenario
+
+  page.reset!
+  $first_scenario = false
 end
 
 AfterStep do

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -108,6 +108,15 @@ After do |scenario|
   page.instance_variable_set(:@touched, false)
 end
 
+# Reset the page if it's running the first scenario of a feature
+$first_scenario = true # This will be set every time we run a new feature
+Before do
+  if $first_scenario
+    page.reset!
+    $first_scenario = false
+  end
+end
+
 AfterStep do
   if all('.senna-loading').any?
     puts "WARN: Step ends with an ajax transition not finished, let's wait a bit!"

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -105,6 +105,7 @@ After do |scenario|
       debug_server_on_realtime_failure
     end
   end
+  page.instance_variable_set(:@touched, false)
 end
 
 AfterStep do


### PR DESCRIPTION
## What does this PR change?

Hold the browser session (and page) between Cucumber scenarios, but not between Cucumber Features.

Bonus:
This also fixes a problem in XEN/KVM tests, that were opening a graphical console in full-screen mode in a new tab and not taking into account to close the tab, coming back to the previous page before end the scenario. 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.0 https://github.com/SUSE/spacewalk/pull/14188
- Manager-4.1 https://github.com/SUSE/spacewalk/pull/14187

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
