### PR TITLE
QA: Change the default page size

### DIFF
--- a/testsuite/features/core/srv_admin_preferences.feature
+++ b/testsuite/features/core/srv_admin_preferences.feature
@@ -1,0 +1,14 @@
+# Copyright (c) 2021 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+Feature: Change personal preferences
+  In order to set up my personal preferences
+  As a sysadmin
+  I want to navigate through "Home" submenus changing some settings
+
+  Scenario: Change page size to 100 per page
+    Given I am authorized as "admin" with password "admin"
+    When I follow the left menu "Home > My Preferences"
+    And I select "100" from "pagesize"
+    And I click on "Save Preferences"
+    Then I should see a "Preferences modified" text

--- a/testsuite/run_sets/build_validation_core.yml
+++ b/testsuite/run_sets/build_validation_core.yml
@@ -10,6 +10,7 @@
 # IMMUTABLE ORDER
 
 - features/core/first_settings.feature
+- features/core/srv_admin_preferences.feature
 
 # Configuration channel and configuration file for smoke tests
 - features/build_validation/srv_add_configuration_channel_and_file.feature

--- a/testsuite/run_sets/core.yml
+++ b/testsuite/run_sets/core.yml
@@ -10,6 +10,7 @@
 
 - features/core/first_settings.feature
 - features/core/srv_organization_credentials.feature
+- features/core/srv_admin_preferences.feature
 
 # initialize SUSE Manager server
 - features/core/srv_channels_add.feature


### PR DESCRIPTION
## What does this PR change?

This PR aims to fix a corner case happening when we have more elements in a list than the maximum per page in a list, so if we look for an element hidden on the next page, we must first filter by this element and then look for it.
The improvement, to prevent this extra filter step is to increase the page size by 100.

## Links

Ports:
 - Manager-4.0 https://github.com/SUSE/spacewalk/pull/14149
 - Manager-4.1 https://github.com/SUSE/spacewalk/pull/14184

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed