### PR TITLE
Log shell command output on failure when checking known_hosts file permissions

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -9205,6 +9205,15 @@ Alternatively, you will want to download &lt;strong&gt;Incremental Channel Conte
       <trans-unit id="maintenance.action.assign.error.systemnotfound" xml:space="preserve">
         <source>Some of the specified servers cannot be found</source>
       </trans-unit>
+      <trans-unit id="bootstrap.minion.error.noperm">
+        <source>Cannot read/write '{0}'. Please check permissions.</source>
+      </trans-unit>
+      <trans-unit id="bootstrap.minion.error.permcmdexec">
+        <source>Error when checking permissions on '{0}'. Please check server logs for more information.</source>
+      </trans-unit>
+      <trans-unit id="bootstrap.minion.error.salt">
+        <source>Error during applying the bootstrap state, message: {0}</source>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/java/code/src/com/suse/manager/webui/controllers/utils/AbstractMinionBootstrapper.java
+++ b/java/code/src/com/suse/manager/webui/controllers/utils/AbstractMinionBootstrapper.java
@@ -15,6 +15,7 @@
 package com.suse.manager.webui.controllers.utils;
 
 import com.redhat.rhn.common.conf.ConfigDefaults;
+import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.domain.server.ContactMethod;
 import com.redhat.rhn.domain.server.MinionServerFactory;
 import com.redhat.rhn.domain.server.ServerFactory;
@@ -59,6 +60,7 @@ public abstract class AbstractMinionBootstrapper {
     private static final int KEY_LENGTH_LIMIT = 1_000_000;
 
     private static final Logger LOG = Logger.getLogger(AbstractMinionBootstrapper.class);
+    private static final LocalizationService LOC = LocalizationService.getInstance();
 
     /**
      * Constructor
@@ -166,13 +168,14 @@ public abstract class AbstractMinionBootstrapper {
                 String responseMessage = "Cannot read/write '" + SALT_SSH_DIR_PATH + "/known_hosts'. " +
                         "Please check permissions.";
                 LOG.error("Error during bootstrap: " + responseMessage);
-                return new BootstrapResult(false, Optional.of(contactMethod), responseMessage.split("\\r?\\n"));
+                return new BootstrapResult(false, Optional.of(contactMethod),
+                        LOC.getMessage("bootstrap.minion.error.noperm", SALT_SSH_DIR_PATH + "/known_hosts"));
             }
         }
         catch (CommandExecutionException | IOException e) {
             LOG.error(e);
-            return new BootstrapResult(false, Optional.of(contactMethod), "Error when checking permissions on '" +
-                    SALT_SSH_DIR_PATH + "/known_hosts'. Please check server logs for more information.");
+            return new BootstrapResult(false, Optional.of(contactMethod),
+                    LOC.getMessage("bootstrap.minion.error.permcmdexec", SALT_SSH_DIR_PATH + "/known_hosts"));
         }
 
         try {
@@ -203,12 +206,10 @@ public abstract class AbstractMinionBootstrapper {
         catch (SaltException e) {
             LOG.error("Exception during bootstrap: " + e.getMessage(), e);
             return new BootstrapResult(false, Optional.empty(),
-                    "Error during applying the bootstrap" +
-                    " state, message: " + e.getMessage());
+                    LOC.getMessage("bootstrap.minion.error.salt", e.getMessage()));
         }
         catch (Exception e) {
-            return new BootstrapResult(false, Optional.empty(),
-                    e.getMessage());
+            return new BootstrapResult(false, Optional.empty(), e.getMessage());
         }
     }
 

--- a/java/code/src/com/suse/manager/webui/controllers/utils/CommandExecutionException.java
+++ b/java/code/src/com/suse/manager/webui/controllers/utils/CommandExecutionException.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.webui.controllers.utils;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.StringJoiner;
+
+/**
+ * Exception class that provides detailed information on a shell command execution
+ */
+public class CommandExecutionException extends Exception {
+
+    private Integer exitValue;
+    private String stdout;
+    private String stderr;
+
+    /**
+     * Create an exception with a message and a subprocess handle. Detailed output will only be appended if the command
+     * has already returned.
+     *
+     * @param message the exception message
+     * @param execProcess the handle for the subprocess that runs the shell command
+     */
+    public CommandExecutionException(String message, Process execProcess) {
+        this(message, execProcess, null);
+    }
+
+    /**
+     * Create an exception with a message, a subprocess handle and a cause. Detailed output will only be appended if the
+     * command has already returned.
+     *
+     * @param message the exception message
+     * @param execProcess the handle for the subprocess that runs the shell command
+     * @param cause the cause
+     */
+    public CommandExecutionException(String message, Process execProcess, Throwable cause) {
+        super(message, cause);
+
+        // Fill in output details if the process is finished
+        if (!execProcess.isAlive()) {
+            this.exitValue = execProcess.exitValue();
+            try {
+                this.stdout = IOUtils.toString(execProcess.getInputStream(), StandardCharsets.UTF_8);
+            }
+            catch (IOException ignored) {
+            }
+            try {
+                this.stderr = IOUtils.toString(execProcess.getErrorStream(), StandardCharsets.UTF_8);
+            }
+            catch (IOException ignored) {
+            }
+        }
+    }
+
+    /**
+     * Returns the exeption message with exit code and output information on the command's result appended
+     *
+     * @return the message
+     */
+    @Override
+    public String getMessage() {
+        StringJoiner sj = new StringJoiner("\n");
+        if (StringUtils.isNotEmpty(super.getMessage())) {
+            sj.add(super.getMessage());
+        }
+        if (exitValue != null) {
+            sj.add("Process exited with code: " + exitValue);
+        }
+        if (StringUtils.isNotEmpty(stdout)) {
+            sj.add("STDOUT: " + stdout);
+        }
+        if (StringUtils.isNotEmpty(stderr)) {
+            sj.add("STDERR: " + stderr);
+        }
+
+        return sj.toString();
+    }
+}

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Log shell command output on failure when checking known_hosts file permissions
 - adapt logging for testing accessability of URLs (bsc#1182817)
 - add warning about missing salt feature for virtual networks
 - add virtual network create action


### PR DESCRIPTION
In some cases, the `sudo ls` command we run to check ownership of Salt's `known_hosts` file fails with some error. Currently SUMA reports these errors incorrectly as wrong ownership/permissions. This PR adds deeper logging to provide more detailed information on the command execution.

See: https://bugzilla.suse.com/1182487

## GUI diff
**Case in hand:** `sudo` command cannot be executed because of some misconfiguration in the `sudoers` file.

Before:
![sudo-cmd-error-before](https://user-images.githubusercontent.com/1103552/109692169-7eea8700-7b88-11eb-88e7-0965390cba07.png)

After:
![sudo-cmd-error-after](https://user-images.githubusercontent.com/1103552/109695247-f53cb880-7b8b-11eb-9e3b-f50502093163.png)
rhn_web_ui.log:
```
ERROR com.suse.manager.webui.controllers.utils.AbstractMinionBootstrapper - com.suse.manager.webui.controllers.utils.CommandExecutionException: Error running command: sudo /usr/bin/ls -la /var/lib/salt/.ssh/known_hosts
Process exited with code: 1
STDERR: sudo: sorry, you must have a tty to run sudo
```

## Documentation
- No documentation needed: bugfix

## Test coverage
- No tests: logging enhancements

## Links

Tracks https://github.com/SUSE/spacewalk/pull/14159

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
