### PR TITLE
Fix: Populate docker-registries on inspection (bsc#1178179)

### DIFF
--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -113,6 +113,10 @@ import com.redhat.rhn.manager.kickstart.cobbler.CobblerXMLRPCHelper;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSyntaxException;
+import com.google.gson.reflect.TypeToken;
 import com.suse.manager.clusters.ClusterManager;
 import com.suse.manager.model.clusters.Cluster;
 import com.suse.manager.reactor.messaging.ApplyStatesEventMessage;
@@ -143,11 +147,6 @@ import com.suse.salt.netapi.results.Ret;
 import com.suse.salt.netapi.results.StateApplyResult;
 import com.suse.utils.Json;
 import com.suse.utils.Opt;
-
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonSyntaxException;
-import com.google.gson.reflect.TypeToken;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.io.FileUtils;
@@ -1370,6 +1369,10 @@ public class SaltServerActionService {
             return result;
         }
         else {
+            List<ImageStore> imageStores = new LinkedList<>();
+            imageStores.add(store);
+            Map<String, Object> dockerRegistries = dockerRegPillar(imageStores);
+            pillar.put("docker-registries", dockerRegistries);
             pillar.put("imagename", store.getUri() + "/" + details.getName() + ":" + details.getVersion());
             LocalCall<Map<String, ApplyResult>> apply = State.apply(
                     Collections.singletonList("images.profileupdate"),

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix: populate docker-registries on inspection (bsc#1178179)
 - Raise length limit for kernel options (bsc#1182916)
 - optionally allow vendor change when patching
 - Speed up the system groups page (bsc#1182132)


### PR DESCRIPTION
## What does this PR change?

When SUSE Manager issues a container image inspection, `images.profileupdate` is executed.
The corresponding SLS file issue the login on every container registry
found from the docker-registries pillar.
This PR makes sure that docker-registries pillar is populated also for
inspection actions.

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage

- No tests: already covered

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/12896
