### PR TITLE
Fix: python3 compat

### DIFF
--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,5 @@
+- Fix spacecmd compat with Python 3
+
 -------------------------------------------------------------------
 Fri Feb 12 14:26:48 CET 2021 - jgonzalez@suse.com
 

--- a/spacecmd/src/spacecmd/misc.py
+++ b/spacecmd/src/spacecmd/misc.py
@@ -754,7 +754,7 @@ def load_caches(self, server, username):
 
 def get_system_names(self):
     self.generate_system_cache()
-    return self.all_systems.values()
+    return list(self.all_systems.values())
 
 
 def get_system_names_ids(self):


### PR DESCRIPTION
## What does this PR change?

Fixes spacecmd compat with Python3:

```
spacecmd {SSM:0}> report_duplicates
ERROR: 'dict_values' object has no attribute 'count'
```

This is because `dict_values` returns a view - fix is to convert to a list.
Also checked if there were other occurrences of this problem:

```
% rg "return .*\.values()" -l
src/spacecmd/misc.py OK
src/spacecmd/softwarechannel.py OK
```

## GUI diff

- [X] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage

- No tests: already covered

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
