### PR TITLE
Revert "QA: Hold the browser session and page between scenarios"

### DIFF
--- a/testsuite/features/secondary/minkvm_guests.feature
+++ b/testsuite/features/secondary/minkvm_guests.feature
@@ -79,7 +79,6 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I click on "Graphical Console" in row "test-vm"
     And I switch to last opened window
     Then I wait until I see the VNC graphical console
-    And I close the last opened window
 
 @virthost_kvm
   Scenario: Suspend a KVM virtual machine
@@ -221,7 +220,6 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I click on "Graphical Console" in row "test-vm2"
     And I switch to last opened window
     Then I wait until I see the spice graphical console
-    And I close the last opened window
 
 @virthost_kvm
   Scenario: Show the virtual storage pools and volumes for KVM
@@ -405,7 +403,6 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I wait until I see the VNC graphical console
     Then I wait at most 500 seconds until I see modal containing "Disconnected" text
     And I wait at most 500 seconds until Salt master sees "test-vm2" as "unaccepted"
-    And I close the last opened window
 
 @long_test
 @virthost_kvm

--- a/testsuite/features/secondary/minxen_guests.feature
+++ b/testsuite/features/secondary/minxen_guests.feature
@@ -195,7 +195,6 @@ Feature: Be able to manage XEN virtual machines via the GUI
     And I click on "Graphical Console" in row "test-vm2"
     And I switch to last opened window
     And I wait until I see the VNC graphical console
-    And I close the last opened window
 
 @virthost_xen
   Scenario: Create a Xen fully virtualized guest
@@ -221,7 +220,6 @@ Feature: Be able to manage XEN virtual machines via the GUI
     And I click on "Graphical Console" in row "test-vm3"
     And I switch to last opened window
     And I wait until I see the spice graphical console
-    And I close the last opened window
 
 @virthost_xen
   Scenario: Show the virtual storage pools and volumes for Xen

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -131,10 +131,6 @@ When(/^I switch to last opened window$/) do
   page.driver.browser.switch_to.window(page.driver.browser.window_handles.last)
 end
 
-When(/^I close the last opened window$/) do
-  page.driver.browser.close
-end
-
 #
 # Check a checkbox of the given id
 #
@@ -353,7 +349,6 @@ end
 #
 
 Given(/^I am not authorized$/) do
-  page.reset!
   visit Capybara.app_host
   raise "Button 'Sign In' not visible" unless find_button('Sign In').visible?
 end

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -105,16 +105,6 @@ After do |scenario|
       debug_server_on_realtime_failure
     end
   end
-  page.instance_variable_set(:@touched, false)
-end
-
-# Reset the page if it's running the first scenario of a feature
-$first_scenario = true
-Before do
-  next unless $first_scenario
-
-  page.reset!
-  $first_scenario = false
 end
 
 AfterStep do


### PR DESCRIPTION
Reverts uyuni-project/uyuni#3361

I tried it first, and apparently, it was good, but I was wrong.
I will need to think deeper about this change. It's very disruptive.

Revert this before https://github.com/uyuni-project/uyuni/pull/3371, please

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

