### PR TITLE
Fix CI cucumber tag

### DIFF
--- a/testsuite/features/reposync/srv_wait_for_reposync.feature
+++ b/testsuite/features/reposync/srv_wait_for_reposync.feature
@@ -3,7 +3,7 @@
 
 Feature: Wait for reposync activity to finish
 
-@regular_ci
+@continuous_integration
   Scenario: Delete scheduled reposyncs
     Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Admin > Task Schedules"


### PR DESCRIPTION
## What does this PR change?

This PR fixes a previous PR where we introduced the `continuous_integration` tag.


## Links

Ports:
* 4.0: SUSE/spacewalk#14209
* 4.1: SUSE/spacewalk#14210


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
