### PR TITLE
Add Require dig to susemanager, needed by mgr-setup

### DIFF
--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,5 @@
+- Require bind-utils so dig is available for mgr-setup
+
 -------------------------------------------------------------------
 Fri Mar 05 15:43:37 CET 2021 - jgonzalez@suse.com
 

--- a/susemanager/susemanager.spec
+++ b/susemanager/susemanager.spec
@@ -112,6 +112,8 @@ Requires:       postfix
 # mgr-setup want to call mksubvolume
 Requires:       reprepro
 Requires:       snapper
+# mgr-setup calls dig
+Requires:       bind-utils
 %define python_sitelib %(%{pythonX} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")
 %global pythonsmroot %{python_sitelib}/spacewalk
 


### PR DESCRIPTION
## What does this PR change?

Add Require dig to susemanager, needed by mgr-setup. Seems JeOS aarcch64 installations do not have it installed by default.

Problem reported by @ggardet at https://github.com/uyuni-project/uyuni/issues/2130#issuecomment-792844266 and https://github.com/uyuni-project/uyuni/issues/2130#issuecomment-793629846

I checked CentOS8, and dig is provided by `bind-utils` as well.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Bugfix

- [x] **DONE**

## Test coverage
- No tests: We don't have aarch64 specific tests for the Server at this moment.

- [x] **DONE**

## Links

Tracks https://github.com/uyuni-project/uyuni/issues/2130

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
