### PR TITLE
Remove "Updates" column from system groups table

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/SystemGroup_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/SystemGroup_queries.xml
@@ -47,51 +47,7 @@ ORDER BY UPPER(NAME)
     ) x
     ORDER BY UPPER(NAME)
   </query>
-  <elaborator name="most_severe_errata" />
 </mode>
-<query name="most_severe_errata" params="">
-    WITH groupAdvisoryTypes AS NOT MATERIALIZED (
-        SELECT sgm.server_group_id, e.advisory_type
-          FROM rhnServerNeededCache snpc
-              INNER JOIN rhnServerGroupMembers sgm ON sgm.server_id = snpc.server_id
-              INNER JOIN rhnServerFeaturesView sfv ON sgm.server_id = sfv.server_id
-              LEFT JOIN rhnErrata e ON e.id = snpc.errata_id
-          WHERE sfv.label = 'ftr_system_grouping'
-    )
-    SELECT rhnServerGroup.id,
-        CASE (
-            SELECT EXISTS (SELECT 1
-                FROM groupAdvisoryTypes gat
-                    WHERE gat.server_group_id = rhnServerGroup.id
-                    AND gat.advisory_type = 'Security Advisory')
-        )
-        WHEN TRUE THEN 'Security Advisory'
-        ELSE CASE (
-            SELECT EXISTS (SELECT 1
-                FROM groupAdvisoryTypes gat
-                    WHERE gat.server_group_id = rhnServerGroup.id
-                    AND gat.advisory_type = 'Bug Fix Advisory')
-        )
-        WHEN TRUE THEN 'Bug Fix Advisory'
-        ELSE CASE (
-            SELECT EXISTS (SELECT 1
-                FROM groupAdvisoryTypes gat
-                    WHERE gat.server_group_id = rhnServerGroup.id
-                    AND gat.advisory_type = 'Product Enhancement Advisory')
-        )
-        WHEN TRUE THEN 'Product Enhancement Advisory'
-        ELSE CASE (
-            SELECT EXISTS (SELECT 1
-                FROM groupAdvisoryTypes gat
-                    WHERE gat.server_group_id = rhnServerGroup.id
-                    AND gat.advisory_type IS NULL)
-        )
-        WHEN TRUE THEN 'Outdated Packages'
-        ELSE NULL
-        END END END END AS most_severe_errata
-    FROM rhnServerGroup
-    WHERE rhnServerGroup.id IN (%s)
-</query>
 <mode name="is_visible">
         <query  params="sgid, user_id">
                 SELECT 1
@@ -107,7 +63,6 @@ ORDER BY UPPER(NAME)
 <mode name="visible_to_user" class="com.redhat.rhn.frontend.dto.SystemGroupOverview">
   <query name="visible_to_user_ids" />
   <elaborator name="visible_to_user_overview_fast" />
-  <elaborator name="most_severe_errata" />
 </mode>
 
 <mode name="managed_system_groups_by_system">

--- a/java/code/webapp/WEB-INF/pages/common/fragments/systems/group_listdisplay.jspf
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/systems/group_listdisplay.jspf
@@ -27,23 +27,6 @@
   <rl:decorator name="PageSizeDecorator" />
 
   <rl:selectablecolumn value="${current.id}" selected="${current.selected}" disabled="${not current.selectable}" />
-  
-  <!--Updates Column -->
-  <rl:column sortable="false" bound="false" headerkey="grouplist.jsp.status" styleclass="center" headerclass="thin-column">
-
-    <a href="/rhn/groups/ListErrata.do?sgid=${current.id}" class="js-spa">
-    <c:choose>
-      <c:when test="${current.mostSevereErrata == 'Security Advisory'}">
-        <rhn:icon type="system-crit" title="grouplist.jsp.security" />
-      </c:when>
-      <c:when test="${current.mostSevereErrata == 'Bug Fix Advisory' or current.mostSevereErrata == 'Product Enhancement Advisory' or current.mostSevereErrata == 'Outdated Packages'}">
-        <rhn:icon type="system-warn" title="grouplist.jsp.updates" />
-      </c:when>
-      <c:otherwise>
-        <rhn:icon type="system-ok" title="grouplist.jsp.noerrata" />
-      </c:otherwise>
-    </c:choose>
-  </rl:column>
 
   <!--Name Column -->
   <rl:column sortable="true" bound="false" headerkey="grouplist.jsp.name" sortattr="name">

--- a/java/code/webapp/WEB-INF/pages/common/fragments/yourrhn/systemGroups.jsp
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/yourrhn/systemGroups.jsp
@@ -14,22 +14,6 @@
                  hidepagenums="true"
                  emptykey="yourrhn.jsp.systemgroups.none">
 
-                <rl:column headerkey="grouplist.jsp.status">
-                <a class="js-spa" href="/rhn/groups/ListErrata.do?sgid=${current.id}">
-                                <c:choose>
-                                        <c:when test="${current.mostSevereErrata == 'Security Advisory'}">
-                                        <rhn:icon type="system-crit" title="grouplist.jsp.security" />
-                                        </c:when>
-                                        <c:when test="${current.mostSevereErrata == 'Bug Fix Advisory' or current.mostSevereErrata == 'Product Enhancement Advisory' or current.mostSevereErrata == 'Outdated Packages'}">
-                                        <rhn:icon type="system-warn" title="grouplist.jsp.updates" />
-                                </c:when>
-                                        <c:otherwise>
-                                        <rhn:icon type="system-ok" title="grouplist.jsp.noerrata" />
-                                        </c:otherwise>
-                                        </c:choose>
-                                </a>
-                </rl:column>
-
                         <rl:column headerkey="yourrhn.jsp.systemgroups">
                 <a class="js-spa" href="/rhn/groups/GroupDetail.do?sgid=${current.id}">
                 <c:out value="${current.name}"/></a>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Remove "Updates" column from system groups table (bsc#1182132)
 - add virtual network create action
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

This PR removes the "Updates" column from the system groups table, which will speed up the "System Groups" page loading.

## GUI diff

Before:

![Screenshot from 2021-03-09 09-06-34](https://user-images.githubusercontent.com/14297426/110465834-d8910b00-80cc-11eb-8d4a-46aae3437f88.png)


After:

![Screenshot from 2021-03-09 09-09-48](https://user-images.githubusercontent.com/14297426/110465845-dc249200-80cc-11eb-9d41-ffb4f104493d.png)


- [x] **DONE**

## Documentation
- Documentation issue was created: https://github.com/SUSE/spacewalk/issues/14217

- [x] **DONE**

## Test coverage
- No tests: This PR removes a feature, so no new tests were added.

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/14215
Fixes https://github.com/SUSE/spacewalk/issues/13965

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
