### PR TITLE
When using the clone-by-date tool, the modules.yaml of the target channel is not aligned to the source.

### DIFF
--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- XMLRPC: Endpoint for aligning channel metadata based on another channel (bsc#1182810)
 - forward registration data to SUSE Customer Center
 - Rename system migration to system transfer
 - Rename SP to product migration

--- a/utils/cloneByDate.py
+++ b/utils/cloneByDate.py
@@ -757,6 +757,12 @@ class ChannelCloner:
             pb.addTo(self.bunch_size)
             pb.printIncrement()
 
+        # align modular metadata
+        md_aligned = self.remote_api.align_modular_metadata(
+                self.from_label, self.to_label);
+        if md_aligned == 1:
+            print("\nModular metadata aligned")
+
         self.reset_new_pkgs()
         pb.printComplete()
 
@@ -907,6 +913,10 @@ class RemoteApi:
     def sync_errata(self, to_label):
         self.auth_check()
         self.client.channel.software.syncErrata(self.auth_token, to_label)
+
+    def align_modular_metadata(self, from_label, to_label):
+        return self.client.channel.software.alignMetadata(
+                self.auth_token, from_label, to_label, 'modules')
 
     def get_details(self, label):
         self.auth_check()

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,4 @@
+- Align the modules.yaml of target channel after cloning errata (bsc#1182810)
 - Add client tools for SLES12SP5 and SLES4SAP 12SP4/12SP5/15SP2/15SP3
 - Fix the URLs for SLE15 Stable client tools
 - Add openSUSE Tumbleweed/microOS


### PR DESCRIPTION
Not aligning the modules.yaml in this situation is wrong, since the source modules.yaml of the source can get updated, whereas the modules.yaml of the target still stays the same and might get incorrect for the new state of the channel.

Aligning the modules.yaml (this PR) is also wrong: if the clone-by-date tool is executed with a date "far in the past", then the modules.yaml of the source might be incorrect for the new state of the clone, since it contains references to packages that were filtered out when cloning.

While both approaches are wrokng, I believe aligning the metadata is "less wrong".

In general, this problem might be insolvable, since we don't control the generating of the modules.yaml.

## TODO
- [x] Check the DNF behavior of cloned channel created by `spacewalk-clone-by-date` (with a date far in the past) and new `modules.yaml`: it seems DNF displays the modules according to new `modules.yaml` (as expected), but installing a new module that is not present in the cloned channel fails.

## Documentation
Maybe instead of this fix, we only need to update the documentation.

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/14139

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"