### PR TITLE
Virtual network edit action

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -7327,6 +7327,12 @@ Follow this url to see the full list of inactive systems:
           <context context-type="sourcefile">com.redhat.rhn.domain.action.ActionFormatter.getActionType</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="virt.network_update" xml:space="preserve">
+        <source>Virtual network update</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">com.suse.manager.webui.controllers.virtualization.VirtualNetsController.edit</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="virt.volume_delete" xml:space="preserve">
         <source>Virtual storage volume deletion</source>
         <context-group name="ctx">

--- a/java/code/src/com/suse/manager/virtualization/DhcpHostDef.java
+++ b/java/code/src/com/suse/manager/virtualization/DhcpHostDef.java
@@ -14,6 +14,8 @@
  */
 package com.suse.manager.virtualization;
 
+import org.jdom.Element;
+
 import java.util.Optional;
 
 public class DhcpHostDef {
@@ -76,6 +78,20 @@ public class DhcpHostDef {
      */
     public void setName(Optional<String> nameIn) {
         name = nameIn;
+    }
+
+    /**
+     * Parse DHCP host XML node
+     * @param node node to parse
+     * @return the parsed DHCP host definition
+     */
+    public static DhcpHostDef parse(Element node) {
+        DhcpHostDef def = new DhcpHostDef();
+        def.setIp(node.getAttributeValue("ip"));
+        def.setId(Optional.ofNullable(node.getAttributeValue("id")));
+        def.setMac(Optional.ofNullable(node.getAttributeValue("mac")));
+        def.setName(Optional.ofNullable(node.getAttributeValue("name")));
+        return def;
     }
 }
 

--- a/java/code/src/com/suse/manager/virtualization/DnsDef.java
+++ b/java/code/src/com/suse/manager/virtualization/DnsDef.java
@@ -14,8 +14,11 @@
  */
 package com.suse.manager.virtualization;
 
+import org.jdom.Element;
+
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Represents a virtual network DNS definition
@@ -80,5 +83,36 @@ public class DnsDef {
      */
     public void setTxts(List<DnsTxtDef> txtsIn) {
         txts = txtsIn;
+    }
+
+    /**
+     * Parse dns XML node
+     *
+     * @param node the node to parse
+     *
+     * @return the parsed definition
+     */
+    public static Optional<DnsDef> parse(Element node) {
+        if (node == null) {
+            return Optional.empty();
+        }
+        DnsDef def = new DnsDef();
+        for (Object child : node.getChildren("forwarder")) {
+            def.forwarders.add(DnsForwarderDef.parse((Element)child));
+        }
+
+        for (Object child : node.getChildren("host")) {
+            def.hosts.add(DnsHostDef.parse((Element)child));
+        }
+
+        for (Object child : node.getChildren("srv")) {
+            def.srvs.add(DnsSrvDef.parse((Element)child));
+        }
+
+        for (Object child : node.getChildren("txt")) {
+            def.txts.add(DnsTxtDef.parse((Element)child));
+        }
+
+        return Optional.of(def);
     }
 }

--- a/java/code/src/com/suse/manager/virtualization/DnsForwarderDef.java
+++ b/java/code/src/com/suse/manager/virtualization/DnsForwarderDef.java
@@ -14,6 +14,8 @@
  */
 package com.suse.manager.virtualization;
 
+import org.jdom.Element;
+
 import java.util.Optional;
 
 /**
@@ -49,5 +51,18 @@ public class DnsForwarderDef {
      */
     public void setAddress(Optional<String> addressIn) {
         address = addressIn;
+    }
+
+    /**
+     * Parse dns forwarder node
+     *
+     * @param node the node to parse
+     * @return the parsed forwarder definition
+     */
+    public static DnsForwarderDef parse(Element node) {
+        DnsForwarderDef def = new DnsForwarderDef();
+        def.setAddress(Optional.ofNullable(node.getAttributeValue("addr")));
+        def.setDomain(Optional.ofNullable(node.getAttributeValue("domain")));
+        return def;
     }
 }

--- a/java/code/src/com/suse/manager/virtualization/DnsHostDef.java
+++ b/java/code/src/com/suse/manager/virtualization/DnsHostDef.java
@@ -14,11 +14,14 @@
  */
 package com.suse.manager.virtualization;
 
+import org.jdom.Element;
+
+import java.util.ArrayList;
 import java.util.List;
 
 public class DnsHostDef {
     private String address;
-    private List<String> names;
+    private List<String> names = new ArrayList<>();
 
     /**
      * @return value of address
@@ -46,5 +49,19 @@ public class DnsHostDef {
      */
     public void setNames(List<String> namesIn) {
         names = namesIn;
+    }
+
+    /**
+     * Parse DNS host node
+     * @param node the node to parse
+     * @return the parsed host definition
+     */
+    public static DnsHostDef parse(Element node) {
+        DnsHostDef def = new DnsHostDef();
+        def.setAddress(node.getAttributeValue("ip"));
+        for (Object child : node.getChildren("hostname")) {
+            def.names.add(((Element)child).getTextTrim());
+        }
+        return def;
     }
 }

--- a/java/code/src/com/suse/manager/virtualization/DnsSrvDef.java
+++ b/java/code/src/com/suse/manager/virtualization/DnsSrvDef.java
@@ -14,7 +14,10 @@
  */
 package com.suse.manager.virtualization;
 
+import org.jdom.Element;
+
 import java.util.Optional;
+import java.util.function.Function;
 
 /**
  * Represents a virtual network DNS SRV record definition
@@ -124,5 +127,26 @@ public class DnsSrvDef {
      */
     public void setWeight(Optional<Integer> weightIn) {
         weight = weightIn;
+    }
+
+    /**
+     * Parse a DNS srv XML node
+     *
+     * @param node the node to parse
+     * @return the parsed srv definition
+     */
+    public static DnsSrvDef parse(Element node) {
+        DnsSrvDef def = new DnsSrvDef();
+        def.setName(node.getAttributeValue("service"));
+        def.setProtocol(node.getAttributeValue("protocol"));
+
+        Function<String, Optional<Integer>> asInt = str -> Optional.ofNullable(str).map(Integer::parseInt);
+
+        def.setDomain(Optional.ofNullable(node.getAttributeValue("domain")));
+        def.setTarget(Optional.ofNullable(node.getAttributeValue("target")));
+        def.setPort(asInt.apply(node.getAttributeValue("port")));
+        def.setPriority(asInt.apply(node.getAttributeValue("priority")));
+        def.setWeight(asInt.apply(node.getAttributeValue("weight")));
+        return def;
     }
 }

--- a/java/code/src/com/suse/manager/virtualization/DnsTxtDef.java
+++ b/java/code/src/com/suse/manager/virtualization/DnsTxtDef.java
@@ -14,6 +14,8 @@
  */
 package com.suse.manager.virtualization;
 
+import org.jdom.Element;
+
 /**
  * Represents a virtual network DNS TXT record definition
  */
@@ -47,5 +49,17 @@ public class DnsTxtDef {
      */
     public void setValue(String valueIn) {
         value = valueIn;
+    }
+
+    /**
+     * Parse DNS TXT XML node
+     * @param node the node to parse
+     * @return the parsed TXT definition
+     */
+    public static DnsTxtDef parse(Element node) {
+        DnsTxtDef def = new DnsTxtDef();
+        def.setName(node.getAttributeValue("name"));
+        def.setValue(node.getAttributeValue("value"));
+        return def;
     }
 }

--- a/java/code/src/com/suse/manager/virtualization/NatDef.java
+++ b/java/code/src/com/suse/manager/virtualization/NatDef.java
@@ -14,6 +14,8 @@
  */
 package com.suse.manager.virtualization;
 
+import org.jdom.Element;
+
 import java.util.Optional;
 
 /**
@@ -49,5 +51,21 @@ public class NatDef {
      */
     public void setPort(Optional<Range<Integer>> portIn) {
         port = portIn;
+    }
+
+    /**
+     * Parse the nat element of the network XML definition
+     *
+     * @param node the XML node
+     * @return the created Nat definition
+     */
+    public static NatDef parseNat(Element node) {
+        NatDef def = null;
+        if (node != null) {
+            def = new NatDef();
+            def.setPort(Range.parse(node.getChild("port"), Integer::parseInt));
+            def.setAddress(Range.parse(node.getChild("address")));
+        }
+        return def;
     }
 }

--- a/java/code/src/com/suse/manager/virtualization/NetworkDefinition.java
+++ b/java/code/src/com/suse/manager/virtualization/NetworkDefinition.java
@@ -16,16 +16,26 @@ package com.suse.manager.virtualization;
 
 import com.google.gson.annotations.SerializedName;
 
+import org.apache.log4j.Logger;
+import org.jdom.Document;
+import org.jdom.Element;
+import org.jdom.input.SAXBuilder;
+
+import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 /**
  * Represents the virtual network create action request body structure.
  */
 public class NetworkDefinition {
+    private static final Logger LOG = Logger.getLogger(NetworkDefinition.class);
+
     private String type;
 
     @SerializedName("macvtapmode")
@@ -52,6 +62,10 @@ public class NetworkDefinition {
     private Optional<IpDef> ipv6 = Optional.empty();
     private Optional<String> domain = Optional.empty();
     private Optional<DnsDef> dns = Optional.empty();
+
+    // name and uuid will be empty when creating a new network
+    private Optional<String> name = Optional.empty();
+    private Optional<String> uuid = Optional.empty();
 
     /**
      * @return value of type
@@ -90,6 +104,29 @@ public class NetworkDefinition {
                 "macvtap", () -> getMacvtapMode().orElse("vepa")
         );
         return converters.getOrDefault(getType(), this::getType).get();
+    }
+
+    /**
+     * Set the forward mode
+     *
+     * @param modeIn the forward mode as found in the XML
+     */
+    public void setForwardMode(String modeIn) {
+        if (modeIn == null) {
+            setType("isolated");
+        }
+        else {
+            Consumer<String> macvtapSetter = mode -> {
+                setType("macvtap");
+                setMacvtapMode(Optional.of(mode));
+            };
+            Map<String, Consumer<String>> converters = Map.of(
+                    "private", macvtapSetter,
+                    "passthrough", macvtapSetter,
+                    "vepa", macvtapSetter
+            );
+            converters.getOrDefault(modeIn, this::setType).accept(modeIn);
+        }
     }
 
     /**
@@ -286,5 +323,126 @@ public class NetworkDefinition {
      */
     public void setDns(Optional<DnsDef> dnsIn) {
         dns = dnsIn;
+    }
+
+    /**
+     * @return value of name
+     */
+    public Optional<String> getName() {
+        return name;
+    }
+
+    /**
+     * @param nameIn value of name
+     */
+    public void setName(Optional<String> nameIn) {
+        name = nameIn;
+    }
+
+    /**
+     * @return value of uuid
+     */
+    public Optional<String> getUuid() {
+        return uuid;
+    }
+
+    /**
+     * @param uuidIn value of uuid
+     */
+    public void setUuid(Optional<String> uuidIn) {
+        uuid = uuidIn;
+    }
+
+    /**
+     * Parse libvirt network definition
+     *
+     * @param xml the libvirt definition XML string
+     *
+     * @return the created definition object
+     */
+    public static NetworkDefinition parse(String xml) {
+        NetworkDefinition def = null;
+        SAXBuilder builder = new SAXBuilder();
+        builder.setValidation(false);
+
+        try {
+            Document doc = builder.build(new StringReader(xml));
+            def = new NetworkDefinition();
+
+            Element netElement = doc.getRootElement();
+            Element forwardNode = netElement.getChild("forward");
+            def.setForwardMode(forwardNode != null ? forwardNode.getAttributeValue("mode") : null);
+
+            def.setName(Optional.ofNullable(netElement.getChildText("name")));
+            def.setUuid(Optional.ofNullable(netElement.getChildText("uuid")));
+
+            if (forwardNode != null) {
+                for (Object child : forwardNode.getChildren()) {
+                    Element node = (Element) child;
+                    switch (node.getName()) {
+                        case "nat": def.setNat(Optional.of(NatDef.parseNat(node))); break;
+                        case "pf": def.setPhysicalFunction(Optional.of(node.getAttributeValue("dev"))); break;
+                        case "interface": def.interfaces.add(node.getAttributeValue("dev")); break;
+                        case "address": def.virtualFunctions.add(NetworkDefinition.getPCIAddress(node)); break;
+                        default: LOG.error("Unexpected forward mode: " + node.getName());
+                    }
+                }
+            }
+            Element bridgeNode = netElement.getChild("bridge");
+            if (bridgeNode != null) {
+                def.setBridge(Optional.ofNullable(bridgeNode.getAttributeValue("name")));
+            }
+            Element mtuNode = netElement.getChild("mtu");
+            if (mtuNode != null) {
+                def.setMtu(Optional.of(Integer.parseInt(mtuNode.getAttributeValue("size"))));
+            }
+            def.setVirtualPort(VirtualPortDef.parse(netElement.getChild("virtualport")));
+            Element vlanNode = netElement.getChild("vlan");
+            if (vlanNode != null) {
+                String trunk = vlanNode.getAttributeValue("trunk");
+                if (trunk != null) {
+                    def.setVlanTrunk(Optional.of(trunk.equals("yes")));
+                }
+                for (Object tag : vlanNode.getChildren("tag")) {
+                    def.vlans.add(VlanDef.parse((Element)tag));
+                }
+            }
+            Element domainNode = netElement.getChild("domain");
+            if (domainNode != null) {
+                def.setDomain(Optional.ofNullable(domainNode.getAttributeValue("name")));
+            }
+            def.setDns(DnsDef.parse(netElement.getChild("dns")));
+            for (Object child : netElement.getChildren("ip")) {
+                Element ipNode = (Element)child;
+                String family = ipNode.getAttributeValue("family", "ipv4");
+                if ("ipv4".equals(family) && def.getIpv4().isEmpty()) {
+                    def.setIpv4(IpDef.parse(ipNode));
+                }
+                else if ("ipv6".equals(family) && def.getIpv6().isEmpty()) {
+                    def.setIpv6(IpDef.parse(ipNode));
+                }
+            }
+        }
+        catch (Exception e) {
+            LOG.error("failed to parse libvirt network XML definition: " + e.getMessage());
+            def = null;
+        }
+
+        return def;
+    }
+
+    private static String getPCIAddress(Element node) {
+        List<String> attributes = List.of("domain", "bus", "slot", "function");
+        List<Integer> parts = attributes.stream().map(
+                attr -> parseNumber(node.getAttributeValue(attr))
+        ).collect(Collectors.toList());
+        return String.format("%04x:%02x:%02x.%x", parts.get(0), parts.get(1), parts.get(2), parts.get(3)).toUpperCase();
+    }
+
+    private static int parseNumber(String value) {
+        if (value.startsWith("0x")) {
+            return Integer.parseInt(value.substring(2), 16);
+        }
+        return Integer.parseInt(value);
     }
 }

--- a/java/code/src/com/suse/manager/virtualization/Range.java
+++ b/java/code/src/com/suse/manager/virtualization/Range.java
@@ -14,22 +14,31 @@
  */
 package com.suse.manager.virtualization;
 
-public class Range<T> {
-    private T start;
-    private T end;
+import org.jdom.Element;
 
+import java.util.Optional;
+import java.util.function.Function;
+
+public class Range<T> {
+    private final T start;
+    private final T end;
+
+    /**
+     * Construct a range object.
+     *
+     * @param startIn the start value of the range
+     * @param endIn the end value of the range
+     *
+     */
+    public Range(T startIn, T endIn) {
+        this.start = startIn;
+        this.end = endIn;
+    }
     /**
      * @return start value of the range
      */
     public T getStart() {
         return start;
-    }
-
-    /**
-     * @param startIn start value of the range
-     */
-    public void setStart(T startIn) {
-        start = startIn;
     }
 
     /**
@@ -40,9 +49,33 @@ public class Range<T> {
     }
 
     /**
-     * @param endIn end value of the range
+     * Parse a range XML node
+     *
+     * @param node the node to parse
+     *
+     * @return the Range definition
      */
-    public void setEnd(T endIn) {
-        end = endIn;
+    public static Optional<Range<String>> parse(Element node) {
+        return parse(node, Function.identity());
+    }
+
+    /**
+     * Parse a range XML node
+     *
+     * @param node the node to parse
+     * @param converter function converting the string representation to the destination type
+     * @param <T> The type of the range to create
+     *
+     * @return the Range definition
+     */
+    public static <T> Optional<Range<T>> parse(Element node, Function<String, T> converter) {
+        if (node == null) {
+            return Optional.empty();
+        }
+        Range<T> def = new Range<T>(
+            converter.apply(node.getAttributeValue("start")),
+            converter.apply(node.getAttributeValue("end"))
+        );
+        return Optional.of(def);
     }
 }

--- a/java/code/src/com/suse/manager/virtualization/VirtualPortDef.java
+++ b/java/code/src/com/suse/manager/virtualization/VirtualPortDef.java
@@ -16,12 +16,18 @@ package com.suse.manager.virtualization;
 
 import com.google.gson.annotations.SerializedName;
 
+import org.apache.log4j.Logger;
+import org.jdom.Attribute;
+import org.jdom.Element;
+
 import java.util.Optional;
 
 /**
  * Represents the virtual network virtualport configuration
  */
 public class VirtualPortDef {
+    private static final Logger LOG = Logger.getLogger(VirtualPortDef.class);
+
     private String type;
 
     @SerializedName("profileid")
@@ -138,5 +144,36 @@ public class VirtualPortDef {
      */
     public void setInstanceId(Optional<String> instanceIdIn) {
         instanceId = instanceIdIn;
+    }
+
+    /**
+     * Extract information from virtualport JDOM XML Node
+     *
+     * @param node the node to parse
+     *
+     * @return the virtual port definition
+     */
+    public static Optional<VirtualPortDef> parse(Element node) {
+        if (node == null) {
+            return Optional.empty();
+        }
+        VirtualPortDef def = new VirtualPortDef();
+        def.setType(node.getAttributeValue("type"));
+        Element parametersNode = node.getChild("parameters");
+        if (parametersNode != null) {
+            for (Object attribute : parametersNode.getAttributes()) {
+                Attribute attr = (Attribute)attribute;
+                switch (attr.getName()) {
+                    case "interfaceid":     def.setInterfaceId(Optional.of(attr.getValue())); break;
+                    case "instanceid":      def.setInstanceId(Optional.of(attr.getValue())); break;
+                    case "managerid":       def.setManagerId(Optional.of(attr.getValue())); break;
+                    case "profileid":       def.setProfileId(Optional.of(attr.getValue())); break;
+                    case "typeid":          def.setTypeId(Optional.of(attr.getValue())); break;
+                    case "typeidversion":   def.setTypeIdVersion(Optional.of(attr.getValue())); break;
+                    default:                LOG.error("Unexpected virtual port attribute: " + attr.getName());
+                }
+            }
+        }
+        return Optional.of(def);
     }
 }

--- a/java/code/src/com/suse/manager/virtualization/VlanDef.java
+++ b/java/code/src/com/suse/manager/virtualization/VlanDef.java
@@ -16,6 +16,8 @@ package com.suse.manager.virtualization;
 
 import com.google.gson.annotations.SerializedName;
 
+import org.jdom.Element;
+
 import java.util.Optional;
 
 /**
@@ -53,5 +55,18 @@ public class VlanDef {
      */
     public void setNativeMode(Optional<String> nativeModeIn) {
         nativeMode = nativeModeIn;
+    }
+
+    /**
+     * Parse tag XML node
+     *
+     * @param node the non-null node
+     * @return the parsed VlanDef
+     */
+    public static VlanDef parse(Element node) {
+        VlanDef def = new VlanDef();
+        def.setTag(Integer.parseInt(node.getAttributeValue("id")));
+        def.setNativeMode(Optional.ofNullable(node.getAttributeValue("nativeMode")));
+        return def;
     }
 }

--- a/java/code/src/com/suse/manager/virtualization/test/NetworkDefinitionTest.java
+++ b/java/code/src/com/suse/manager/virtualization/test/NetworkDefinitionTest.java
@@ -1,0 +1,219 @@
+/**
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.virtualization.test;
+
+import com.suse.manager.virtualization.DnsDef;
+import com.suse.manager.virtualization.IpDef;
+import com.suse.manager.virtualization.NetworkDefinition;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import junit.framework.TestCase;
+
+public class NetworkDefinitionTest extends TestCase {
+
+    public void testParseBridge() {
+        String xml = "<network>\n" +
+                     "  <name>default</name>\n" +
+                     "  <uuid>8b612d0f-25b3-4bf5-b6f8-19cbd918fa11</uuid>\n" +
+                     "  <forward mode='bridge'/>\n" +
+                     "  <bridge name='br0'/>\n" +
+                     "</network>\n";
+        NetworkDefinition def = NetworkDefinition.parse(xml);
+        assertEquals(Optional.of("default"), def.getName());
+        assertEquals(Optional.of("8b612d0f-25b3-4bf5-b6f8-19cbd918fa11"), def.getUuid());
+        assertEquals("bridge", def.getForwardMode());
+        assertEquals(Optional.of("br0"), def.getBridge());
+    }
+
+    public void testParseNat() {
+        String xml = "<network connections='2'>\n" +
+                "  <name>default</name>\n" +
+                "  <uuid>d6c95a31-16a2-473a-b8cd-7ad2fe2dd855</uuid>\n" +
+                "  <mtu size='7000'/>\n" +
+                "  <forward mode='nat'>\n" +
+                "    <nat>\n" +
+                "      <port start='1024' end='65535'/>\n" +
+                "      <address start='192.168.122.5' end='192.168.122.6'/>\n" +
+                "    </nat>\n" +
+                "  </forward>\n" +
+                "  <bridge name='virbr0' stp='on' delay='0'/>\n" +
+                "  <mac address='52:54:00:cd:49:6b'/>\n" +
+                "  <domain name='tf.local' localOnly='yes'/>\n" +
+                "  <ip address='192.168.122.1' netmask='255.255.255.0'>\n" +
+                "    <dhcp>\n" +
+                "      <range start='192.168.122.2' end='192.168.122.254'/>\n" +
+                "      <host mac='2A:C3:A7:A6:01:00' name='dev-srv' ip='192.168.122.110'/>\n" +
+                "      <bootp file='pxelinux.0' server='192.168.122.110'/>\n" +
+                "    </dhcp>\n" +
+                "  </ip>\n" +
+                "  <ip family='ipv6' address='2001:db8:ac10:fd01::1' prefix='64'>\n" +
+                "    <dhcp>\n" +
+                "      <range start='2001:db8:ac10:fd01::1:10' end='2001:db8:ac10:fd01::1:ff'/>\n" +
+                "      <host id='0:3:0:1:0:16:3e:11:22:33' name='peter.xyz' ip='2001:db8:ac10:fd01::1:22'/>\n" +
+                "    </dhcp>\n" +
+                "  </ip>\n" +
+                "</network>";
+        NetworkDefinition def = NetworkDefinition.parse(xml);
+        assertEquals("nat", def.getForwardMode());
+        assertEquals(Optional.of(7000), def.getMtu());
+        assertEquals(Integer.valueOf(1024), def.getNat().orElseThrow().getPort().orElseThrow().getStart());
+        assertEquals(Integer.valueOf(65535), def.getNat().orElseThrow().getPort().orElseThrow().getEnd());
+        assertEquals("192.168.122.5", def.getNat().orElseThrow().getAddress().orElseThrow().getStart());
+        assertEquals("192.168.122.6", def.getNat().orElseThrow().getAddress().orElseThrow().getEnd());
+        assertEquals(Optional.of("virbr0"), def.getBridge());
+        assertEquals(Optional.of("tf.local"), def.getDomain());
+
+        IpDef ipv4 = def.getIpv4().orElseThrow();
+        assertEquals("192.168.122.0", ipv4.getAddress());
+        assertEquals(Integer.valueOf(24), ipv4.getPrefix());
+        assertEquals("192.168.122.2", ipv4.getDhcpRanges().get(0).getStart());
+        assertEquals("192.168.122.254", ipv4.getDhcpRanges().get(0).getEnd());
+        assertEquals(Optional.of("2A:C3:A7:A6:01:00"), ipv4.getHosts().get(0).getMac());
+        assertEquals("192.168.122.110", ipv4.getHosts().get(0).getIp());
+        assertEquals(Optional.of("dev-srv"), ipv4.getHosts().get(0).getName());
+        assertEquals(Optional.of("pxelinux.0"), ipv4.getBootpFile());
+        assertEquals(Optional.of("192.168.122.110"), ipv4.getBootpServer());
+
+        IpDef ipv6 = def.getIpv6().orElseThrow();
+        assertEquals("2001:db8:ac10:fd01:0:0:0:0", ipv6.getAddress());
+        assertEquals(Integer.valueOf(64), ipv6.getPrefix());
+        assertEquals(Optional.of("0:3:0:1:0:16:3e:11:22:33"), ipv6.getHosts().get(0).getId());
+        assertEquals(Optional.of("peter.xyz"), ipv6.getHosts().get(0).getName());
+    }
+
+    public void testParseDns() {
+        String xml = "<network>\n" +
+                "  <name>default</name>\n" +
+                "  <uuid>81ff0d90-c91e-6742-64da-4a736edb9a9c</uuid>\n" +
+                "  <forward dev='eth0' mode='nat'/>\n" +
+                "  <bridge name='virbr0' stp='on' delay='0'/>\n" +
+                "  <dns forwardPlainNames='no'>\n" +
+                "    <host ip='192.168.122.1'>\n" +
+                "      <hostname>host</hostname>\n" +
+                "      <hostname>gateway</hostname>\n" +
+                "    </host>\n" +
+                "    <srv service='name' protocol='tcp' domain='test-domain-name.com' target='test.example.com' port='1111' priority='11' weight='111'/>\n" +
+                "    <srv service='name2' protocol='tcp'/>\n" +
+                "    <txt name='example' value='example value'/>\n" +
+                "    <forwarder addr='8.8.4.4'/>\n" +
+                "    <forwarder domain='example.com' addr='192.168.1.1'/>\n" +
+                "    <forwarder domain='www.example.com'/>\n" +
+                "  </dns>\n" +
+                "  <ip address='192.168.122.1' netmask='255.255.255.0'/>" +
+                "</network>";
+        NetworkDefinition def = NetworkDefinition.parse(xml);
+        DnsDef dnsDef = def.getDns().orElseThrow();
+        assertEquals("192.168.122.1", dnsDef.getHosts().get(0).getAddress());
+        assertEquals(Arrays.asList("host", "gateway"), dnsDef.getHosts().get(0).getNames());
+        assertEquals("name", dnsDef.getSrvs().get(0).getName());
+        assertEquals("tcp", dnsDef.getSrvs().get(0).getProtocol());
+        assertEquals(Optional.of("test-domain-name.com"), dnsDef.getSrvs().get(0).getDomain());
+        assertEquals(Optional.of("test.example.com"), dnsDef.getSrvs().get(0).getTarget());
+        assertEquals(Optional.of(1111), dnsDef.getSrvs().get(0).getPort());
+        assertEquals(Optional.of(11), dnsDef.getSrvs().get(0).getPriority());
+        assertEquals(Optional.of(111), dnsDef.getSrvs().get(0).getWeight());
+        assertEquals("name2", dnsDef.getSrvs().get(1).getName());
+        assertEquals("tcp", dnsDef.getSrvs().get(1).getProtocol());
+        assertTrue(dnsDef.getSrvs().get(1).getDomain().isEmpty());
+        assertEquals("example", dnsDef.getTxts().get(0).getName());
+        assertEquals("example value", dnsDef.getTxts().get(0).getValue());
+        assertEquals(Optional.of("8.8.4.4"), dnsDef.getForwarders().get(0).getAddress());
+        assertTrue(dnsDef.getForwarders().get(0).getDomain().isEmpty());
+        assertEquals(Optional.of("192.168.1.1"), dnsDef.getForwarders().get(1).getAddress());
+        assertEquals(Optional.of("example.com"), dnsDef.getForwarders().get(1).getDomain());
+        assertEquals(Optional.of("www.example.com"), dnsDef.getForwarders().get(2).getDomain());
+        assertTrue(dnsDef.getForwarders().get(2).getAddress().isEmpty());
+    }
+
+    public void testParseOpenVSwitch() {
+        String xml = "<network>\n" +
+                "  <name>ovs-net</name>\n" +
+                "  <forward mode='bridge'/>\n" +
+                "  <bridge name='ovsbr0'/>\n" +
+                "  <virtualport type='openvswitch'>\n" +
+                "    <parameters interfaceid='09b11c53-8b5c-4eeb-8f00-d84eaa0aaa4f'/>\n" +
+                "  </virtualport>\n" +
+                "  <vlan trunk='yes'>\n" +
+                "    <tag id='42' nativeMode='untagged'/>\n" +
+                "    <tag id='47'/>\n" +
+                "  </vlan>\n" +
+                "</network>";
+        NetworkDefinition def = NetworkDefinition.parse(xml);
+        assertEquals("openvswitch", def.getVirtualPort().orElseThrow().getType());
+        assertEquals(Optional.of("09b11c53-8b5c-4eeb-8f00-d84eaa0aaa4f"),
+                def.getVirtualPort().orElseThrow().getInterfaceId());
+        assertTrue(def.getVlanTrunk().orElseThrow());
+        assertEquals(42, def.getVlans().get(0).getTag());
+        assertEquals(Optional.of("untagged"), def.getVlans().get(0).getNativeMode());
+        assertEquals(47, def.getVlans().get(1).getTag());
+    }
+
+    public void testParseIsolated() {
+        String xml = "<network>\n" +
+                "  <name>private</name>\n" +
+                "  <uuid>81ff0d90-c91e-6742-64da-4a736edb9a9b</uuid>\n" +
+                "  <ip address='192.168.152.1' netmask='255.255.255.0' />\n" +
+                "</network>";
+        NetworkDefinition def = NetworkDefinition.parse(xml);
+        assertEquals("isolated", def.getType());
+        assertTrue(def.getBridge().isEmpty());
+    }
+
+    public void testParsePassthrough() {
+        String xml = "<network>\n" +
+                "  <name>test</name>\n" +
+                "  <uuid>81ff0d90-c91e-6742-64da-4a736edb9a9b</uuid>\n" +
+                "  <forward mode='passthrough'>\n" +
+                "    <interface dev='eth10'/>\n" +
+                "    <interface dev='eth11'/>\n" +
+                "  </forward>\n" +
+                "</network>";
+        NetworkDefinition def = NetworkDefinition.parse(xml);
+        assertEquals("macvtap", def.getType());
+        assertEquals(Optional.of("passthrough"), def.getMacvtapMode());
+        assertEquals(Arrays.asList("eth10", "eth11"), def.getInterfaces());
+    }
+
+    public void testParsePrivate() {
+        String xml = "<network>\n" +
+                "  <name>test</name>\n" +
+                "  <uuid>81ff0d90-c91e-6742-64da-4a736edb9a9b</uuid>\n" +
+                "  <forward mode='private'>\n" +
+                "    <pf dev='eth0'/>\n" +
+                "  </forward>\n" +
+                "</network>";
+        NetworkDefinition def = NetworkDefinition.parse(xml);
+        assertEquals("macvtap", def.getType());
+        assertEquals(Optional.of("private"), def.getMacvtapMode());
+        assertEquals(Optional.of("eth0"), def.getPhysicalFunction());
+    }
+
+    public void testParseHostdev() {
+        String xml = "<network>\n" +
+                "  <name>test</name>\n" +
+                "  <uuid>81ff0d90-c91e-6742-64da-4a736edb9a9b</uuid>\n" +
+                "  <forward mode='hostdev'>\n" +
+                "    <driver name='vfio'/>\n" +
+                "    <address type='pci' domain='0x000A' bus='0x12' slot='0x1' function='0x6'/>\n" +
+                "    <address type='pci' domain='0' bus='16' slot='4' function='3'/>" +
+                "  </forward>\n" +
+                "</network>";
+        NetworkDefinition def = NetworkDefinition.parse(xml);
+        assertEquals("hostdev", def.getType());
+        assertEquals(Arrays.asList("000A:12:01.6", "0000:10:04.3"), def.getVirtualFunctions());
+    }
+}

--- a/java/code/src/com/suse/manager/virtualization/test/TestVirtManager.java
+++ b/java/code/src/com/suse/manager/virtualization/test/TestVirtManager.java
@@ -17,6 +17,7 @@ package com.suse.manager.virtualization.test;
 import com.redhat.rhn.domain.server.MinionServer;
 
 import com.suse.manager.virtualization.GuestDefinition;
+import com.suse.manager.virtualization.NetworkDefinition;
 import com.suse.manager.virtualization.PoolCapabilitiesJson;
 import com.suse.manager.virtualization.PoolDefinition;
 import com.suse.manager.webui.services.iface.VirtManager;
@@ -58,6 +59,11 @@ public class TestVirtManager implements VirtManager {
 
     @Override
     public Map<String, JsonObject> getNetworks(String minionId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Optional<NetworkDefinition> getNetworkDefinition(String minionId, String netName) {
         throw new UnsupportedOperationException();
     }
 

--- a/java/code/src/com/suse/manager/webui/controllers/virtualization/AbstractVirtualizationController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/virtualization/AbstractVirtualizationController.java
@@ -65,7 +65,7 @@ import spark.Spark;
 public abstract class AbstractVirtualizationController {
     private static final Logger LOG = Logger.getLogger(AbstractVirtualizationController.class);
 
-    private static final Gson GSON = new GsonBuilder()
+    protected static final Gson GSON = new GsonBuilder()
             .registerTypeAdapter(Date.class, new ECMAScriptDateAdapter())
             .registerTypeAdapter(LocalDateTime.class, new LocalDateTimeISOAdapter())
             .registerTypeAdapterFactory(new OptionalTypeAdapterFactory())

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -2150,6 +2150,7 @@ public class SaltServerActionService {
                                 }
                                 pillar.put("dns", dns);
                             });
+                            pillar.put("action_type", def.getUuid().isPresent() ? "defined" : "running");
 
                             return State.apply(
                                     Collections.singletonList("virt.network-create"),

--- a/java/code/src/com/suse/manager/webui/services/iface/VirtManager.java
+++ b/java/code/src/com/suse/manager/webui/services/iface/VirtManager.java
@@ -17,6 +17,7 @@ package com.suse.manager.webui.services.iface;
 import com.redhat.rhn.domain.server.MinionServer;
 
 import com.suse.manager.virtualization.GuestDefinition;
+import com.suse.manager.virtualization.NetworkDefinition;
 import com.suse.manager.virtualization.PoolCapabilitiesJson;
 import com.suse.manager.virtualization.PoolDefinition;
 import com.suse.manager.webui.utils.salt.custom.VmInfo;
@@ -84,6 +85,15 @@ public interface VirtManager {
      * @return a list of the network names
      */
     Map<String, JsonObject> getNetworks(String minionId);
+
+    /**
+     * Query virtual network definition
+     *
+     * @param minionId the host minion ID
+     * @param netName the domain name to look for
+     * @return the XML definition or an empty Optional
+     */
+    Optional<NetworkDefinition> getNetworkDefinition(String minionId, String netName);
 
     /**
      * Query the virtual host devices that can be either passed through or used for direct networks

--- a/java/code/src/com/suse/manager/webui/templates/virtualization/nets/edit.jade
+++ b/java/code/src/com/suse/manager/webui/templates/virtualization/nets/edit.jade
@@ -1,0 +1,22 @@
+include ../../system-common.jade
+#virtualnets-edit
+
+script(src='/javascript/momentjs/moment-with-langs.min.js?cb=#{webBuildtimestamp}', type='text/javascript')
+
+script(type='text/javascript').
+    window.csrfToken = "#{csrf_token}";
++userPreferences
+
+script(type='text/javascript').
+    spaImportReactPage('virtualization/nets/edit/nets-edit')
+        .then(function(module) {
+            module.renderer(
+              'virtualnets-edit',
+              {
+                  serverId: "#{server.id}",
+                  actionChains: !{actionChains},
+                  timezone: "#{h.renderTimezone()}",
+                  localTime: "#{h.renderLocalTime()}",
+                  netName: "#{netName}",
+              }
+        )});

--- a/java/code/src/com/suse/utils/Ip.java
+++ b/java/code/src/com/suse/utils/Ip.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.utils;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+
+/**
+ * Ip addresses computation utilities
+ */
+public class Ip {
+
+    private Ip() {
+    }
+
+    /**
+     * Convert a netmask into the corresponding prefix number
+     *
+     * @param mask the netmask as a string, e.g. "255.255.255.0"
+     * @return the prefix, e.g. 24
+     *
+     * @throws UnknownHostException if the netmask can't be parsed to an IP address
+     */
+    public static int netmaskToPrefix(String mask) throws UnknownHostException {
+        int prefix = 0;
+        InetAddress addr = InetAddress.getByName(mask);
+        byte[] data = addr.getAddress();
+        for (byte b : data) {
+            prefix += countSetBits(b);
+        }
+        return prefix;
+    }
+
+    /**
+     * Compute the network address from a IP address and its prefix
+     *
+     * @param address the IP address
+     * @param prefix the network prefix
+     * @return the network IP address as a string
+     *
+     * @throws UnknownHostException if the IP address can't be parsed
+     */
+    public static String getNetworkAddress(String address, int prefix) throws UnknownHostException {
+        InetAddress hostAddr = InetAddress.getByName(address);
+        byte[] mask = prefixToNetmask(prefix, hostAddr.getAddress().length);
+        byte[] netAddr = hostAddr.getAddress();
+        for (int i = 0; i < netAddr.length; i++) {
+            netAddr[i] = (byte)(Byte.toUnsignedInt(netAddr[i]) & Byte.toUnsignedInt(mask[i]));
+        }
+        return InetAddress.getByAddress(netAddr).getHostAddress();
+    }
+
+    /**
+     * Convert a network prefix into the corresponding netmask address data.
+     *
+     * @param mask the prefix, e.g. 24
+     * @param size the size of the expected address (depending whether IPv4 or IPv6 is expected)
+     *
+     * @return the computed data
+     */
+    public static byte[] prefixToNetmask(int mask, int size) {
+        byte[] addr = new byte[size];
+        int b = 0;
+        for (int i = 0; i < mask; i++) {
+            b += 1 << (7 - i % Byte.SIZE);
+            if (i % Byte.SIZE == 7 || i == mask - 1) {
+                addr[(i / Byte.SIZE)] = (byte)b;
+                b = 0;
+            }
+        }
+        return addr;
+    }
+
+    /**
+     * Count the number of 1 bits in a byte
+     *
+     * @param value the byte to count the bits in
+     * @return the number of set bits.
+     */
+    private static int countSetBits(byte value) {
+        int bits = Byte.toUnsignedInt(value);
+        int count = 0;
+        while (bits > 0) {
+            count += bits & 1;
+            bits >>= 1;
+        }
+        return count;
+    }
+}

--- a/java/code/src/com/suse/utils/test/IpTest.java
+++ b/java/code/src/com/suse/utils/test/IpTest.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.utils.test;
+
+import com.suse.utils.Ip;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import junit.framework.TestCase;
+
+public class IpTest extends TestCase {
+
+    public void testPrefixConversion() throws UnknownHostException {
+        assertEquals(24, Ip.netmaskToPrefix("255.255.255.0"));
+        assertEquals(17, Ip.netmaskToPrefix("255.255.128.0"));
+        assertEquals(64, Ip.netmaskToPrefix("ffff:ffff:ffff:ffff::"));
+    }
+
+    public void testPrefixToNetmask() throws UnknownHostException {
+        assertEquals("255.255.255.0",
+                InetAddress.getByAddress(Ip.prefixToNetmask(24, 4)).getHostAddress());
+        assertEquals("255.255.128.0",
+                InetAddress.getByAddress(Ip.prefixToNetmask(17, 4)).getHostAddress());
+    }
+
+    public void testGetNetworkAddress() throws UnknownHostException {
+        assertEquals("192.168.129.0", Ip.getNetworkAddress("192.168.129.12", 24));
+        assertEquals("192.168.128.0", Ip.getNetworkAddress("192.168.129.12", 17));
+        assertEquals("2a01:cb10:87cb:4e00:0:0:0:0",
+                Ip.getNetworkAddress("2a01:cb10:87cb:4e00:23a0:6566:5ebc:2cff", 64));
+    }
+}

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- add virtual network edit action
 - Lower case fqdn comparation when calculating minion connection path (bsc#1184849)
 
 -------------------------------------------------------------------

--- a/susemanager-utils/susemanager-sls/salt/virt/network-create.sls
+++ b/susemanager-utils/susemanager-sls/salt/virt/network-create.sls
@@ -1,3 +1,5 @@
+{% set active = salt.virt.network_info(pillar['network_name']).get(pillar['network_name'], {}).get('active') %}
+{% set state = 'running' if active else pillar['action_type'] %}
 {% macro optional(name) -%}
   {%- if pillar[name]|default(none) %}
     - {{ name }}: {{ pillar[name] }}
@@ -6,8 +8,8 @@
 
 {% set  optional_props = ['bridge', 'mtu', 'domain', 'physical_function', 'addresses',
                           'interfaces', 'tag', 'vport', 'nat', 'ipv4_config', 'ipv6_config', 'dns'] -%}
-network_running:
-  virt.network_running:
+network_{{ state }}:
+  virt.network_{{ state }}:
     - name: {{ pillar['network_name'] }}
     - forward: {{ pillar['forward']|default('null') }}
     - bridge: {{ pillar['bridge']|default('null') }}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,5 @@
+- add virtual network edit action
+
 -------------------------------------------------------------------
 Fri Apr 16 13:35:25 CEST 2021 - jgonzalez@suse.com
 

--- a/testsuite/features/secondary/minkvm_guests.feature
+++ b/testsuite/features/secondary/minkvm_guests.feature
@@ -365,6 +365,21 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I should see a "test-net2" virtual network on "kvm_server"
     And "test-net2" virtual network on "kvm_server" should have "192.168.128.1" IPv4 address with 24 prefix
 
+@virthost_kvm
+  Scenario: Edit a virtual network
+    Given I am on the "Virtualization" page of this "kvm_server"
+    When I follow "Networks"
+    And I click on "Stop" in row "test-net2"
+    And I click on "Stop" in "Stop Network" modal
+    Then I wait until table row for "test-net2" contains button "Start"
+    When I click on "Edit" in row "test-net2"
+    And I wait until option "bridge" appears in list "type"
+    And I enter "192.168.130.0" as "ipv4def_address"
+    And I click on "remove_ipv4def_dhcpranges0"
+    And I click on "Update"
+    Then I should see a "Virtual Networks" text
+    And "test-net2" virtual network on "kvm_server" should have "192.168.130.1" IPv4 address with 24 prefix
+
 # Start provisioning scenarios
 
 @long_test

--- a/web/html/src/manager/virtualization/index.js
+++ b/web/html/src/manager/virtualization/index.js
@@ -8,5 +8,6 @@ export default {
   'virtualization/pools/edit/pools-edit': () => import('./pools/edit/pools-edit.renderer'),
   'virtualization/nets/list/nets-list': () => import('./nets/list/nets-list.renderer'),
   'virtualization/nets/create/nets-create': () => import('./nets/create/nets-create.renderer'),
+  'virtualization/nets/edit/nets-edit': () => import('./nets/edit/nets-edit.renderer'),
 }
 

--- a/web/html/src/manager/virtualization/nets/edit/nets-edit.js
+++ b/web/html/src/manager/virtualization/nets/edit/nets-edit.js
@@ -1,0 +1,71 @@
+// @flow
+import type { ActionChain } from 'components/action-schedule';
+
+import * as React from 'react';
+import { TopPanel } from 'components/panels/TopPanel';
+import { Loading } from 'components/utils/Loading';
+import { SimpleActionApi } from '../../SimpleActionApi';
+import { VirtualizationNetworkDefinitionApi } from '../virtualization-network-definition-api';
+import { NetworkProperties } from '../network-properties';
+
+type Props = {
+  serverId: string,
+  netName: string,
+  localTime: string,
+  timezone: string,
+  actionChains: Array<ActionChain>,
+};
+
+export function NetsEdit(props: Props) {
+  return (
+    <SimpleActionApi
+      urlType="nets"
+      idName="names"
+      hostid={props.serverId}
+      bounce={`/rhn/manager/systems/details/virtualization/nets/${props.serverId}`}
+    >
+    {
+      ({
+        onAction,
+        messages: actionMessages
+      }) => (
+        <VirtualizationNetworkDefinitionApi
+          hostid={props.serverId}
+          networkName={props.netName}
+        >
+        {
+          ({
+            definition,
+            messages: definitionMessages,
+          }) => {
+            if (definition == null) {
+              return <Loading />;
+            }
+
+            const onSubmit = (model: Object) => onAction('edit', [model.definition.name], model);
+
+            return (
+              <TopPanel
+                title={props.netName}
+              >
+                <NetworkProperties
+                  serverId={props.serverId}
+                  submitText={t('Update')}
+                  submit={onSubmit}
+                  initialModel={definition}
+                  messages={actionMessages.concat(definitionMessages)}
+                  timezone={props.timezone}
+                  localTime={props.localTime}
+                  actionChains={props.actionChains}
+                />
+              </TopPanel>
+            );
+          }
+        }
+        </VirtualizationNetworkDefinitionApi>
+      )
+    }
+    </SimpleActionApi>
+  );
+}
+

--- a/web/html/src/manager/virtualization/nets/edit/nets-edit.renderer.js
+++ b/web/html/src/manager/virtualization/nets/edit/nets-edit.renderer.js
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { NetsEdit } from './nets-edit';
+import SpaRenderer from "core/spa/spa-renderer";
+
+export const renderer = (id, { serverId, actionChains, timezone, localTime, netName }) => {
+  SpaRenderer.renderNavigationReact(
+    <NetsEdit
+      serverId={serverId}
+      netName={netName}
+      actionChains={actionChains}
+      timezone={timezone}
+      localTime={localTime}
+    />,
+    document.getElementById(id),
+  );
+};
+

--- a/web/html/src/manager/virtualization/nets/list/nets-list.js
+++ b/web/html/src/manager/virtualization/nets/list/nets-list.js
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 import { Column } from 'components/table/Column';
 import { Utils } from 'utils/functions';
-import { AsyncButton } from 'components/buttons';
+import { LinkButton, AsyncButton } from 'components/buttons';
 import { Utils as MessagesUtils } from 'components/messages';
 import { Utils as ListUtils } from '../../list.utils';
 import { ListTab } from '../../ListTab';
@@ -96,6 +96,14 @@ export function NetsList(props: Props) {
                   )
                 }
                 { row.active && createModalButton('stop', modalsData, row) }
+                { props.allow_changing && (
+                  <LinkButton
+                    title={t('Edit')}
+                    className="btn-default btn-sm"
+                    icon="fa-edit"
+                    href={`/rhn/manager/systems/details/virtualization/nets/${props.serverId}/edit/${row.name}`}
+                  />
+                )}
                 { createModalButton('delete', modalsData, row) }
                 </div>
               );

--- a/web/html/src/manager/virtualization/nets/virtualization-network-definition-api.tsx
+++ b/web/html/src/manager/virtualization/nets/virtualization-network-definition-api.tsx
@@ -1,0 +1,51 @@
+import * as React from "react";
+import Network from "utils/network";
+import * as Messages from "components/messages";
+
+import { MessageType } from "components/messages";
+
+type Props = {
+  /** Virtual host server ID */
+  hostid: string;
+
+  /** Name of the network for which to get the defintion*/
+  networkName: string;
+
+  /** Children function rendering the content depending on the request result */
+  children: (arg0: { definition: any; messages: MessageType[] }) => React.ReactNode;
+};
+
+/** Component calling the Uyuni REST API to get the XML definition of a virtual storage pool */
+export function VirtualizationNetworkDefinitionApi(props: Props) {
+  const [messages, setMessages] = React.useState<MessageType[]>([]);
+  const [definition, setDefinition] = React.useState(null);
+
+  React.useEffect(() => {
+    Network.get(
+      `/rhn/manager/api/systems/details/virtualization/nets/${props.hostid}/net/${props.networkName}`,
+      "application/json"
+    ).promise.then(
+      response => {
+        setDefinition(response);
+      },
+      xhr => {
+        const errMessages =
+          xhr.status === 0
+            ? Messages.Utils.error(
+                t("Request interrupted or invalid response received from the server. Please try again.")
+              )
+            : Messages.Utils.error(Network.errorMessageByStatus(xhr.status));
+        setMessages(errMessages);
+      }
+    );
+  }, [props.hostid, props.networkName]);
+
+  return (
+    <>
+      {props.children({
+        definition: definition,
+        messages: messages,
+      })}
+    </>
+  );
+}

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,5 @@
+- virtual network edit action
+
 -------------------------------------------------------------------
 Mon Apr 19 14:52:24 CEST 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Add editing action for virtual networks.

## GUI diff

Before:
![before](https://user-images.githubusercontent.com/397931/110490320-79dd8880-80f0-11eb-9d48-a9c2f45d3af3.png)


After:
![after](https://user-images.githubusercontent.com/397931/110490329-7d710f80-80f0-11eb-9224-37c3fb9f2f8e.png)


- [X] **DONE**

## Documentation
- [PR](https://github.com/uyuni-project/uyuni-docs/issues/844)

- [X] **DONE**

## Test coverage
- Unit tests were added
- Cucumber tests were added

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/14068

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
