### PR TITLE
No timeout for BV reposyncs

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -267,11 +267,11 @@ end
 # This function waits for all the reposyncs to complete.
 #
 # This function is written as a state machine. It bails out if no process is seen during
-# 30 seconds in a row, or if the reposyncs last more than 7200 seconds in a row.
+# 30 seconds in a row.
 When(/^I wait until all spacewalk\-repo\-sync finished$/) do
   reposync_not_running_streak = 0
   reposync_left_running_streak = 0
-  while reposync_not_running_streak <= 30 && reposync_left_running_streak <= 7200
+  while reposync_not_running_streak <= 30
     command_output, _code = $server.run('ps axo pid,cmd | grep spacewalk-repo-sync | grep -v grep', false)
     if command_output.empty?
       reposync_not_running_streak += 1


### PR DESCRIPTION
## What does this PR change?

In the context of Build Validation test suite, do not timeout when reposyncs take a lot of time, as this is expected.

## Links

Ports:
* 4.0: SUSE/spacewalk#14231
* 4.1: SUSE/spacewalk#14232


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
