### PR TITLE
Complete the fix arch handling in spacewalk-common-channels

### DIFF
--- a/utils/spacewalk-common-channels
+++ b/utils/spacewalk-common-channels
@@ -37,6 +37,7 @@ DEFAULT_CONFIG = '/etc/rhn/spacewalk-common-channels.ini'
 DEFAULT_REPO_TYPE = 'yum'
 
 CHANNEL_ARCH = {
+    'aarch64':      'channel-aarch64',
     'i386':         'channel-ia32',
     'ia64':         'channel-ia64',
     'sparc':        'channel-sparc',

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,5 @@
+- Complete the fix arch handling in spacewalk-common-channels
+
 -------------------------------------------------------------------
 Wed Jan 27 13:06:52 CET 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Complete the fix arch handling in spacewalk-common-channels

Without this:
```
uyuni-server:~ # spacewalk-common-channels opensuse_leap15_2-aarch64
SUSE Manager username: admin
SUSE Manager password: 
Traceback (most recent call last):
  File "/usr/bin/spacewalk-common-channels", line 347, in <module>
    base_info['summary'], CHANNEL_ARCH[base_info['arch']],
KeyError: 'aarch64'
```

With this:

```
uyuni-server:~ # spacewalk-common-channels opensuse_leap15_2-aarch64
SUSE Manager username: admin 
SUSE Manager password: 
uyuni-server:~ # 
```
And the channel and repo gets added, and I am able to launch a reposync

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Bugfix

- [x] **DONE**

## Test coverage
- No tests: No arm coverage for now.

- [x] **DONE**

## Links

Tracks https://github.com/uyuni-project/uyuni/issues/2130

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
