### PR TITLE
Virt network: add warning if Salt feature is missing

### DIFF
--- a/java/code/src/com/suse/manager/virtualization/VirtManagerSalt.java
+++ b/java/code/src/com/suse/manager/virtualization/VirtManagerSalt.java
@@ -23,6 +23,7 @@ import com.suse.manager.webui.services.iface.VirtManager;
 import com.suse.manager.webui.utils.salt.custom.GuestProperties;
 import com.suse.manager.webui.utils.salt.custom.VmInfo;
 import com.suse.salt.netapi.calls.LocalCall;
+import com.suse.salt.netapi.calls.modules.Grains;
 import com.suse.salt.netapi.calls.modules.State;
 
 import com.google.gson.JsonElement;
@@ -147,7 +148,7 @@ public class VirtManagerSalt implements VirtManager {
         LocalCall<List<JsonObject>> call =
                 new LocalCall<>("virt.node_devices", Optional.empty(), Optional.empty(),
                         new TypeToken<List<JsonObject>>() { });
-        return saltApi.callSync(call, minionId).orElse(null);
+        return saltApi.callSync(call, minionId).orElse(new ArrayList<>());
     }
 
     /**
@@ -251,5 +252,13 @@ public class VirtManagerSalt implements VirtManager {
                 return plan;
             }
         );
+    }
+
+    @Override
+    public Optional<Map<String, Boolean>> getFeatures(String minionId) {
+        String grainName = "virt_features";
+        Optional<Map<String, Map<String, Boolean>>> data = saltApi.callSync(Grains.item(false,
+                new TypeToken<Map<String, Map<String, Boolean>>>() { }, grainName), minionId);
+        return data.map(features -> features.get(grainName));
     }
 }

--- a/java/code/src/com/suse/manager/virtualization/test/TestVirtManager.java
+++ b/java/code/src/com/suse/manager/virtualization/test/TestVirtManager.java
@@ -90,4 +90,9 @@ public class TestVirtManager implements VirtManager {
     public Optional<List<VmInfo>> getGuestsUpdatePlan(String minionId) {
         throw new UnsupportedOperationException();
     }
+
+    @Override
+    public Optional<Map<String, Boolean>> getFeatures(String minionId) {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/java/code/src/com/suse/manager/virtualization/test/VirtManagerSaltTest.java
+++ b/java/code/src/com/suse/manager/virtualization/test/VirtManagerSaltTest.java
@@ -28,6 +28,7 @@ import com.google.gson.reflect.TypeToken;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import junit.framework.TestCase;
@@ -75,5 +76,20 @@ public class VirtManagerSaltTest extends TestCase {
         assertEquals("running", vm2infos.getGuestProperties().getState());
         assertEquals("98eef4f7-eb7f-4be8-859d-11658506c496", vm2infos.getGuestProperties().getUuid());
         assertEquals(VirtualInstanceManager.EVENT_TYPE_EXISTS, vm2infos.getEventType());
+    }
+
+    public void testGetFeatures() {
+        SaltApi testSaltApi = new TestSaltApi() {
+            @Override
+            public <R> Optional<R> callSync(LocalCall<R> call, String minionId) {
+                return SaltTestUtils.<R>getSaltResponse(
+                        "/com/suse/manager/virtualization/test/virt.features.json",
+                        Collections.emptyMap(),
+                        new TypeToken<R>() { });
+            }
+        };
+        VirtManager virtManager = new VirtManagerSalt(testSaltApi);
+        Optional<Map<String, Boolean>> actual = virtManager.getFeatures("minion0");
+        assertTrue(actual.get().get("enhanced_network"));
     }
 }

--- a/java/code/src/com/suse/manager/virtualization/test/virt.features.json
+++ b/java/code/src/com/suse/manager/virtualization/test/virt.features.json
@@ -1,0 +1,5 @@
+{
+  "virt_features": {
+    "enhanced_network": true
+  }
+}

--- a/java/code/src/com/suse/manager/webui/controllers/virtualization/VirtualNetsController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/virtualization/VirtualNetsController.java
@@ -98,11 +98,14 @@ public class VirtualNetsController extends AbstractVirtualizationController {
      */
     public ModelAndView show(Request request, Response response, User user) {
         Server host = getServer(request, user);
+        String minionId = host.asMinionServer().orElseThrow(NotFoundException::new).getMinionId();
+        Map<String, Boolean> features = virtManager.getFeatures(minionId).orElse(new HashMap<>());
         return renderPage(request, response, user, "show", () -> {
             Map<String, Object> extra = new HashMap<>();
             extra.put("hypervisor", host.hasVirtualizationEntitlement() ?
                     virtManager.getHypervisor(host.getMinionId()).orElse("") :
                     "");
+            extra.put("support_enhanced_network", features.getOrDefault("enhanced_network", false));
             return extra;
         });
     }

--- a/java/code/src/com/suse/manager/webui/services/iface/VirtManager.java
+++ b/java/code/src/com/suse/manager/webui/services/iface/VirtManager.java
@@ -132,4 +132,13 @@ public interface VirtManager {
      * @return the plan to pass to VirtualInstanceManager.updateGuestsVirtualInstances
      */
     Optional<List<VmInfo>> getGuestsUpdatePlan(String minionId);
+
+    /**
+     * Get a list of virtual features the minion supports.
+     *
+     * @param minionId the minion id
+     *
+     * @return the map of features.
+     */
+    Optional<Map<String, Boolean>> getFeatures(String minionId);
 }

--- a/java/code/src/com/suse/manager/webui/templates/virtualization/nets/show.jade
+++ b/java/code/src/com/suse/manager/webui/templates/virtualization/nets/show.jade
@@ -15,7 +15,8 @@ script(type='text/javascript').
               {
                   serverId: "#{server.id}",
                   pageSize: "#{pageSize}",
-                  hypervisor: "#{hypervisor}"
+                  hypervisor: "#{hypervisor}",
+                  support_enhanced_network: #{support_enhanced_network}
               }
             )
         });

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- add warning about missing salt feature for virtual networks
 - add virtual network create action
 
 -------------------------------------------------------------------

--- a/susemanager-utils/susemanager-sls/src/grains/virt.py
+++ b/susemanager-utils/susemanager-sls/src/grains/virt.py
@@ -1,0 +1,14 @@
+import salt.modules.virt
+
+
+def __virtual__():
+    return salt.modules.virt.__virtual__()
+
+
+def features():
+    """returns the features map of the virt module"""
+    return {
+        "virt_features": {
+            "enhanced_network": "network_update" in salt.modules.virt.__dict__,
+        },
+    }

--- a/susemanager-utils/susemanager-sls/src/tests/mockery.py
+++ b/susemanager-utils/susemanager-sls/src/tests/mockery.py
@@ -21,6 +21,7 @@ def setup_environment():
         sys.modules['salt.utils.minions'] = MagicMock()
         sys.modules['salt.modules'] = MagicMock()
         sys.modules['salt.modules.cmdmod'] = MagicMock()
+        sys.modules['salt.modules.virt'] = MagicMock()
         sys.modules['salt.states'] = MagicMock()
         sys.modules['salt.exceptions'] = MagicMock(CommandExecutionError=Exception)
 

--- a/susemanager-utils/susemanager-sls/src/tests/test_grains_virt.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_grains_virt.py
@@ -1,0 +1,17 @@
+import pytest
+from mock import MagicMock, patch
+from . import mockery
+mockery.setup_environment()
+
+from ..grains import virt
+
+@pytest.mark.parametrize("network", [True, False])
+def test_features(network):
+    """
+    test the features function
+    """
+    virt_funcs = {}
+    if network:
+        virt_funcs["network_update"] = MagicMock(return_value = True)
+    with patch.dict(virt.salt.modules.virt.__dict__, virt_funcs):
+        assert virt.features()["virt_features"]["enhanced_network"] == network

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- add grain for virt module features
 - add virtual network creation action
 
 -------------------------------------------------------------------

--- a/web/html/src/manager/virtualization/ListTab.js
+++ b/web/html/src/manager/virtualization/ListTab.js
@@ -45,6 +45,7 @@ type Props = {
   getCreateActionsKeys: (actionResults: Object) => Array<string>,
   idName: string,
   panelButtons: React.Node,
+  messages?: Array<MessageType>,
 };
 
 export function ListTab(props: Props) {
@@ -208,21 +209,18 @@ export function ListTab(props: Props) {
                   refreshError,
                 }) => {
                   const {columns, actionsProvider} = props.children(createModalButton, onAction);
+                  const allMessages = [].concat(
+                    errors.map(msg => MessagesUtils.error(msg)[0]),
+                    getCreationActionMessages(),
+                    props.messages,
+                    messages,
+                  );
                   return (
                     <div>
                       {panelButtons}
                       <h2>{props.title}</h2>
                       <p>{props.description}</p>
-                      <Messages
-                        items={
-                          [].concat(
-                            errors.map(msg => MessagesUtils.error(msg)[0]),
-                            getCreationActionMessages()
-                          )
-                        }
-                      />
-                      { refreshError && <Messages items={refreshError} /> }
-                      { messages && <Messages items={messages} /> }
+                      <Messages items={allMessages}/>
                       <Table
                         data={data != null ? Object.keys(data).map(id => data[id]): []}
                         emptyText={t(`No virtual ${props.type} to show.`)}
@@ -290,4 +288,5 @@ ListTab.defaultProps = {
   getCreateActionsKeys: (actions) => Object.keys(actions).filter(key => key.startsWith("new-")),
   modalsData: [],
   panelButtons: [],
+  messages: [],
 }

--- a/web/html/src/manager/virtualization/nets/list/nets-list.js
+++ b/web/html/src/manager/virtualization/nets/list/nets-list.js
@@ -4,6 +4,7 @@ import * as React from 'react';
 import { Column } from 'components/table/Column';
 import { Utils } from 'utils/functions';
 import { AsyncButton } from 'components/buttons';
+import { Utils as MessagesUtils } from 'components/messages';
 import { Utils as ListUtils } from '../../list.utils';
 import { ListTab } from '../../ListTab';
 import { HypervisorCheck } from '../../HypervisorCheck';
@@ -13,6 +14,7 @@ type Props = {
   serverId: string,
   pageSize: number,
   hypervisor: string,
+  allow_changing: boolean,
 };
 
 export function NetsList(props: Props) {
@@ -39,6 +41,8 @@ export function NetsList(props: Props) {
         description={t('This is a list of virtual networks which are configured to run on this host.')}
         modalsData={modalsData}
         idName="name"
+        canCreate={props.allow_changing}
+        messages={props.allow_changing ? [] : MessagesUtils.warning(t("Salt minion doesn't support virtual network creation and editing"))}
       >
         {
           (createModalButton, onAction) => {

--- a/web/html/src/manager/virtualization/nets/list/nets-list.renderer.js
+++ b/web/html/src/manager/virtualization/nets/list/nets-list.renderer.js
@@ -2,12 +2,13 @@ import * as React from 'react';
 import { NetsList } from './nets-list';
 import SpaRenderer from "core/spa/spa-renderer";
 
-export const renderer = (id, { serverId, pageSize, hypervisor }) => {
+export const renderer = (id, { serverId, pageSize, hypervisor, support_enhanced_network }) => {
   SpaRenderer.renderNavigationReact(
     <NetsList
       serverId={serverId}
       pageSize={pageSize}
       hypervisor={hypervisor}
+      allow_changing={support_enhanced_network}
     />,
     document.getElementById(id),
   );

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- add warning about missing salt feature for virtual networks
 - add virtual network create action
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Add a warning in the UI if the salt minion doesn't support virtual network creation or editing

## GUI diff

Warning in the UI as shown in the screenshot:
![Screen Shot 2021-03-10 at 16 33 17](https://user-images.githubusercontent.com/397931/110654481-757fa100-81be-11eb-8ec9-0bfecfc35ef6.png)

- [X] **DONE**

## Documentation
- No documentation needed: no need to document a warning

- [X] **DONE**

## Test coverage
- Unit tests were added
- No cucumber test added, but the warning will help understanding the failures on current Uyuni

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
