### PR TITLE
Accessible better logging

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -2205,7 +2205,7 @@ public class ContentSyncManager {
             return accessibleUrl(url, username, password);
         }
         catch (URISyntaxException e) {
-            log.warn(e.getMessage());
+            log.error("accessibleUrl: " + url + " URISyntaxException " + e.getMessage());
         }
         return false;
     }
@@ -2226,9 +2226,9 @@ public class ContentSyncManager {
 
             // Build full URL to test
             if (uri.getScheme().equals("file")) {
-                boolean readable = Files.isReadable(testUrlPath);
-                log.debug(String.format("Test file URL %s: readable %s", testUrlPath, readable));
-                return readable;
+                boolean res = Files.isReadable(testUrlPath);
+                log.debug("accessibleUrl:" + testUrlPath.toString() + " " + res);
+                return res;
             }
             else {
                 URI testUri = new URI(uri.getScheme(), null, uri.getHost(),
@@ -2236,19 +2236,15 @@ public class ContentSyncManager {
                 // Verify the mirrored repo by sending a HEAD request
                 int status = MgrSyncUtils.sendHeadRequest(testUri.toString(),
                         user, password).getStatusLine().getStatusCode();
-                if (status == HttpURLConnection.HTTP_OK) {
-                    return true;
-                }
-                else {
-                    log.warn("accessibleUrl: " + testUri.toString() + " returned status " + status);
-                }
+                log.debug("accessibleUrl: " + testUri.toString() + " returned status " + status);
+                return (status == HttpURLConnection.HTTP_OK);
             }
         }
         catch (IOException e) {
-            log.warn(e.getMessage());
+            log.error("accessibleUrl: " + url + " IOException " + e.getMessage());
         }
         catch (URISyntaxException e) {
-            log.warn(e.getMessage());
+            log.error("accessibleUrl: " + url + " URISyntaxException " + e.getMessage());
         }
         return false;
     }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- adapt logging for testing accessability of URLs (bsc#1182817)
 - add warning about missing salt feature for virtual networks
 - add virtual network create action
 


### PR DESCRIPTION
## What does this PR change?

Changing logging - better messages and do not spam the logs with a standard configuration.
As we now have to test a lot of URL where it is expected that some are not available we cannot log a "failed" anymore with a warning. Changed this to debug.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **just logging**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/14182

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
