### PR TITLE
Improve virtual network feature warning message

### DIFF
--- a/web/html/src/manager/virtualization/nets/list/nets-list.js
+++ b/web/html/src/manager/virtualization/nets/list/nets-list.js
@@ -42,7 +42,7 @@ export function NetsList(props: Props) {
         modalsData={modalsData}
         idName="name"
         canCreate={props.allow_changing}
-        messages={props.allow_changing ? [] : MessagesUtils.warning(t("Salt minion doesn't support virtual network creation and editing"))}
+        messages={props.allow_changing ? [] : MessagesUtils.warning(t("The Salt version on this system does not support virtual network creating and editing"))}
       >
         {
           (createModalButton, onAction) => {


### PR DESCRIPTION
## What does this PR change?

Follow up of PR #3387 improving a warning message

## GUI diff

Difference is too tiny to document.

- [X] **DONE**

## Documentation
- No documentation needed: message reworded

- [X] **DONE**

## Test coverage
- No tests: message reworded

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
