### PR TITLE
Add universe security repositories to spacewalk-common-channels

### DIFF
--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -1593,6 +1593,15 @@ checksum = sha256
 base_channels = ubuntu-16.04-pool-amd64
 repo_url = http://archive.ubuntu.com/ubuntu/dists/xenial-updates/universe/binary-amd64/
 
+[ubuntu-1604-amd64-universe-security]
+label    = ubuntu-1604-amd64-universe-security
+name     = Ubuntu 16.04 LTS AMD64 Universe Security Updates
+archs    = amd64-deb
+repo_type = deb
+checksum = sha256
+base_channels = ubuntu-16.04-pool-amd64
+repo_url = http://archive.ubuntu.com/ubuntu/dists/xenial-security/universe/binary-amd64/
+
 [ubuntu-1604-pool-amd64-uyuni]
 label    = ubuntu-16.04-pool-amd64-uyuni
 checksum = sha256
@@ -1648,6 +1657,15 @@ repo_type = deb
 checksum = sha256
 base_channels = ubuntu-16.04-pool-amd64-uyuni
 repo_url = http://archive.ubuntu.com/ubuntu/dists/xenial-updates/universe/binary-amd64/
+
+[ubuntu-1604-amd64-universe-security-uyuni]
+label    = ubuntu-1604-amd64-universe-security-uyuni
+name     = Ubuntu 16.04 LTS AMD64 Universe Security Updates for Uyuni
+archs    = amd64-deb
+repo_type = deb
+checksum = sha256
+base_channels = ubuntu-16.04-pool-amd64-uyuni
+repo_url = http://archive.ubuntu.com/ubuntu/dists/xenial-security/universe/binary-amd64/
 
 [ubuntu-1604-amd64-uyuni-client]
 label    = ubuntu-1604-amd64-uyuni-client
@@ -1723,6 +1741,16 @@ checksum = sha256
 base_channels = ubuntu-18.04-pool-amd64
 repo_url = http://archive.ubuntu.com/ubuntu/dists/bionic-updates/universe/binary-amd64/
 
+[ubuntu-1804-amd64-universe-security]
+label    = ubuntu-1804-amd64-universe-security
+name     = Ubuntu 18.04 LTS AMD64 Universe Security Updates
+archs    = amd64-deb
+repo_type = deb
+checksum = sha256
+base_channels = ubuntu-18.04-pool-amd64
+repo_url = http://archive.ubuntu.com/ubuntu/dists/bionic-security/universe/binary-amd64/
+
+
 [ubuntu-1804-pool-amd64-uyuni]
 label    = ubuntu-18.04-pool-amd64-uyuni
 checksum = sha256
@@ -1778,6 +1806,15 @@ repo_type = deb
 checksum = sha256
 base_channels = ubuntu-18.04-pool-amd64-uyuni
 repo_url = http://archive.ubuntu.com/ubuntu/dists/bionic-updates/universe/binary-amd64/
+
+[ubuntu-1804-amd64-universe-security-uyuni]
+label    = ubuntu-1804-amd64-universe-security-uyuni
+name     = Ubuntu 18.04 LTS AMD64 Universe Security Updates for Uyuni
+archs    = amd64-deb
+repo_type = deb
+checksum = sha256
+base_channels = ubuntu-18.04-pool-amd64-uyuni
+repo_url = http://archive.ubuntu.com/ubuntu/dists/bionic-security/universe/binary-amd64/
 
 [ubuntu-1804-amd64-uyuni-client]
 label    = ubuntu-1804-amd64-uyuni-client
@@ -1852,6 +1889,15 @@ repo_type = deb
 checksum = sha256
 base_channels = ubuntu-20.04-pool-amd64-uyuni
 repo_url = http://archive.ubuntu.com/ubuntu/dists/focal-updates/universe/binary-amd64/
+
+[ubuntu-2004-amd64-universe-security-uyuni]
+label    = ubuntu-2004-amd64-universe-security-uyuni
+name     = Ubuntu 20.04 LTS AMD64 Universe Security Updates for Uyuni
+archs    = amd64-deb
+repo_type = deb
+checksum = sha256
+base_channels = ubuntu-20.04-pool-amd64-uyuni
+repo_url = http://archive.ubuntu.com/ubuntu/dists/focal-security/universe/binary-amd64/
 
 [ubuntu-2004-amd64-uyuni-client]
 label    = ubuntu-2004-amd64-uyuni-client

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,4 @@
+- Add the Universe Security repositories for Ubuntu
 - Complete the fix arch handling in spacewalk-common-channels
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Add universe security repositories to spacewalk-common-channels

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- PR: https://github.com/uyuni-project/uyuni-docs/pull/849

- [x] **DONE**

## Test coverage
- No tests: The testsuite does not test the list of repositories, as long as packages can install.

- [x] **DONE**

## Links

Related: https://github.com/SUSE/spacewalk/issues/14138

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
