### PR TITLE
QA: Make sure that a package state is shown before continue

### DIFF
--- a/testsuite/features/build_validation/init_clients/sle11sp4_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle11sp4_ssh_minion.feature
@@ -35,6 +35,7 @@ Feature: Bootstrap a SLES 11 SP4 Salt SSH Minion
     And I wait until button "Search" becomes enabled
     And I enter "sle-manager-tools-release" as the filtered package states name
     And I click on "Search" in element "search-row"
+    And I wait until I see "sle-manager-tools-release" text
     And I remove package "sle-manager-tools-release" from highstate
 
   # WORKAROUND bsc#1181847

--- a/testsuite/features/build_validation/init_clients/sle12sp4_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle12sp4_ssh_minion.feature
@@ -35,6 +35,7 @@ Feature: Bootstrap a SLES 12 SP4 Salt SSH Minion
     And I wait until button "Search" becomes enabled
     And I enter "sle-manager-tools-release" as the filtered package states name
     And I click on "Search" in element "search-row"
+    And I wait until I see "sle-manager-tools-release" text
     And I remove package "sle-manager-tools-release" from highstate
 
   # WORKAROUND bsc#1181847

--- a/testsuite/features/build_validation/init_clients/sle15_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15_ssh_minion.feature
@@ -35,6 +35,7 @@ Feature: Bootstrap a SLES 15 Salt SSH Minion
     And I wait until button "Search" becomes enabled
     And I enter "sle-manager-tools-release" as the filtered package states name
     And I click on "Search" in element "search-row"
+    And I wait until I see "sle-manager-tools-release" text
     And I remove package "sle-manager-tools-release" from highstate
 
   # WORKAROUND bsc#1181847

--- a/testsuite/features/build_validation/init_clients/sle15sp1_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp1_ssh_minion.feature
@@ -35,6 +35,7 @@ Feature: Bootstrap a SLES 15 SP1 Salt SSH Minion
     And I wait until button "Search" becomes enabled
     And I enter "sle-manager-tools-release" as the filtered package states name
     And I click on "Search" in element "search-row"
+    And I wait until I see "sle-manager-tools-release" text
     And I remove package "sle-manager-tools-release" from highstate
 
   # WORKAROUND bsc#1181847

--- a/testsuite/features/build_validation/init_clients/sle15sp2_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp2_ssh_minion.feature
@@ -35,6 +35,7 @@ Feature: Bootstrap a SLES 15 SP2 Salt SSH Minion
     And I wait until button "Search" becomes enabled
     And I enter "sle-manager-tools-release" as the filtered package states name
     And I click on "Search" in element "search-row"
+    And I wait until I see "sle-manager-tools-release" text
     And I remove package "sle-manager-tools-release" from highstate
 
   # WORKAROUND bsc#1181847

--- a/testsuite/features/build_validation/init_clients/sle15sp3_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp3_ssh_minion.feature
@@ -35,6 +35,7 @@ Feature: Bootstrap a SLES 15 SP3 Salt SSH Minion
     And I wait until button "Search" becomes enabled
     And I enter "sle-manager-tools-release" as the filtered package states name
     And I click on "Search" in element "search-row"
+    And I wait until I see "sle-manager-tools-release" text
     And I remove package "sle-manager-tools-release" from highstate
 
   # WORKAROUND bsc#1181847

--- a/testsuite/features/init_clients/sle_ssh_minion.feature
+++ b/testsuite/features/init_clients/sle_ssh_minion.feature
@@ -35,6 +35,7 @@ Feature: Bootstrap a Salt host managed via salt-ssh
     And I wait until button "Search" becomes enabled
     And I enter "sle-manager-tools-release" as the filtered package states name
     And I click on "Search" in element "search-row"
+    And I wait until I see "sle-manager-tools-release" text
     And I remove package "sle-manager-tools-release" from highstate
 
 @proxy

--- a/testsuite/features/secondary/minssh_bootstrap_xmlrpc.feature
+++ b/testsuite/features/secondary/minssh_bootstrap_xmlrpc.feature
@@ -43,6 +43,7 @@ Feature: Register a salt-ssh system via XML-RPC
     And I wait until button "Search" becomes enabled
     And I enter "sle-manager-tools-release" as the filtered package states name
     And I click on "Search" in element "search-row"
+    And I wait until I see "sle-manager-tools-release" text
     And I remove package "sle-manager-tools-release" from highstate
 
 @ssh_minion


### PR DESCRIPTION
## What does this PR change?

Sometimes, we try to remove the package too fast, before the package is shown, and it causes that when we iterate through the list of elements in the list, the package still not there.
To avoid it, we will wait for a text during a timeout.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Ports:
- Manager-4.0
- Manager-4.1

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
