### PR TITLE
Testsuite: Test the Retracted Patches feature

### DIFF
--- a/testsuite/config/cucumber.yml
+++ b/testsuite/config/cucumber.yml
@@ -36,3 +36,4 @@ proxy: --tags @scope_proxy
 traditional_client: --tags @scope_traditional_client
 xmlrpc: --tags @scope_xmlrpc
 power_management: --tags @scope_power_management
+retracted_patches: --tags @scope_retracted_patches

--- a/testsuite/features/secondary/min_retracted_patches.feature
+++ b/testsuite/features/secondary/min_retracted_patches.feature
@@ -1,19 +1,19 @@
-# Copyright (c) 2015-2021 SUSE LLC
+# Copyright (c) 2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @scope_retracted_patches
-Feature: The Retracted Patches
+Feature: Retracted patches
 
   Scenario: Installed retracted package should show icon in the system packages list
     Given I am authorized as "admin" with password "admin"
     When I install package "rute-dummy-2.1-1.1.x86_64" on this "sle_minion"
-    When I am on the "Software" page of this "sle_minion"
+    And I am on the "Software" page of this "sle_minion"
     And I follow "Packages"
     And I follow "List / Remove"
     And I enter "rute-dummy" as the filtered package name
     And I click on the filter button until page does contain "rute-dummy" text
-    Then the table row for "rute-dummy-2.1-1.1" should contain "errata-retracted" icon
-    Then I remove package "rute-dummy" from this "sle_minion"
+    Then the table row for "rute-dummy-2.1-1.1" should contain "retracted" icon
+    When I remove package "rute-dummy" from this "sle_minion"
     And I wait until refresh package list on "sle_minion" is finished
 
   Scenario: Retracted package should not be available for installation
@@ -30,11 +30,11 @@ Feature: The Retracted Patches
     And I am on the "Software" page of this "sle_minion"
     And I follow "Packages"
     And I follow "Upgrade"
-    And I should not see a "rute-dummy-2.1-1.1" text
-    Then I remove package "rute-dummy" from this "sle_minion"
+    Then I should not see a "rute-dummy-2.1-1.1" text
+    When I remove package "rute-dummy" from this "sle_minion"
     And I wait until refresh package list on "sle_minion" is finished
 
-  Scenario: Retracted patch should not affect any systems
+  Scenario: Retracted patch should not affect any system
     Given I am authorized as "admin" with password "admin"
     When I install package "rute-dummy-2.0-1.2.x86_64" on this "sle_minion"
     And I follow the left menu "Software > Channel List > All"
@@ -43,7 +43,7 @@ Feature: The Retracted Patches
     And I follow "rute-dummy-0817"
     And I follow "Affected Systems"
     Then I should see a "No systems." text
-    Then I remove package "rute-dummy" from this "sle_minion"
+    When I remove package "rute-dummy" from this "sle_minion"
     And I wait until refresh package list on "sle_minion" is finished
    
   Scenario: Target systems for stable packages should not be empty
@@ -79,27 +79,27 @@ Feature: The Retracted Patches
   Scenario: Retracted packages in the patches list
     Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Patches > Patch List > All"
-    Then the table row for "rute-dummy-0815" should contain "errata-retracted" icon
-    Then the table row for "rute-dummy-0816" should not contain "errata-retracted" icon
-    Then the table row for "rute-dummy-0817" should contain "errata-retracted" icon
+    Then the table row for "rute-dummy-0815" should contain "retracted" icon
+    And the table row for "rute-dummy-0816" should not contain "retracted" icon
+    And the table row for "rute-dummy-0817" should contain "retracted" icon
 
   Scenario: Retracted patches in the channel patches list
     Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Software > Channel List > All"
     And I follow "Test-Channel-x86_64"
     And I follow "Patches" in the content area
-    Then the table row for "rute-dummy-0815" should contain "errata-retracted" icon
-    Then the table row for "rute-dummy-0816" should not contain "errata-retracted" icon
-    Then the table row for "rute-dummy-0817" should contain "errata-retracted" icon
+    Then the table row for "rute-dummy-0815" should contain "retracted" icon
+    And the table row for "rute-dummy-0816" should not contain "retracted" icon
+    And the table row for "rute-dummy-0817" should contain "retracted" icon
  
   Scenario: Retracted packages in the channel packages list
     Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Software > Channel List > All"
     And I follow "Test-Channel-x86_64"
     And I follow "Packages" in the content area
-    Then the table row for "rute-dummy-2.0-1.1.x86_64" should contain "errata-retracted" icon
-    Then the table row for "rute-dummy-2.0-1.2.x86_64" should not contain "errata-retracted" icon
-    Then the table row for "rute-dummy-2.1-1.1.x86_64" should contain "errata-retracted" icon
+    Then the table row for "rute-dummy-2.0-1.1.x86_64" should contain "retracted" icon
+    Then the table row for "rute-dummy-2.0-1.2.x86_64" should not contain "retracted" icon
+    Then the table row for "rute-dummy-2.1-1.1.x86_64" should contain "retracted" icon
 
   Scenario: SSM: Retracted package should not be available for installation
     Given I am authorized as "admin" with password "admin"
@@ -111,5 +111,5 @@ Feature: The Retracted Patches
     And I follow "Install"
     And I follow "Test-Channel-x86_64"
     Then I should see a "rute-dummy-2.0-1.2" text
-    Then I should not see a "rute-dummy-2.1-1.1" text
-
+    And I should not see a "rute-dummy-2.1-1.1" text
+    And I follow "Clear"

--- a/testsuite/features/secondary/srv_retracted_patches.feature
+++ b/testsuite/features/secondary/srv_retracted_patches.feature
@@ -1,0 +1,115 @@
+# Copyright (c) 2015-2021 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+@scope_retracted_patches
+Feature: The Retracted Patches
+
+  Scenario: Installed retracted package should show icon in the system packages list
+    Given I am authorized as "admin" with password "admin"
+    When I install package "rute-dummy-2.1-1.1.x86_64" on this "sle_minion"
+    When I am on the "Software" page of this "sle_minion"
+    And I follow "Packages"
+    And I follow "List / Remove"
+    And I enter "rute-dummy" as the filtered package name
+    And I click on the filter button until page does contain "rute-dummy" text
+    Then the table row for "rute-dummy-2.1-1.1" should contain "errata-retracted" icon
+    Then I remove package "rute-dummy" from this "sle_minion"
+    And I wait until refresh package list on "sle_minion" is finished
+
+  Scenario: Retracted package should not be available for installation
+    Given I am authorized as "admin" with password "admin"
+    When I am on the "Software" page of this "sle_minion"
+    And I follow "Packages"
+    And I follow "Install"
+    Then I should see a "rute-dummy-2.0-1.2" text
+    And I should not see a "rute-dummy-2.1-1.1" text
+
+  Scenario: Retracted package should not be available for upgrade
+    Given I am authorized as "admin" with password "admin"
+    When I install package "rute-dummy-2.0-1.2.x86_64" on this "sle_minion"
+    And I am on the "Software" page of this "sle_minion"
+    And I follow "Packages"
+    And I follow "Upgrade"
+    And I should not see a "rute-dummy-2.1-1.1" text
+    Then I remove package "rute-dummy" from this "sle_minion"
+    And I wait until refresh package list on "sle_minion" is finished
+
+  Scenario: Retracted patch should not affect any systems
+    Given I am authorized as "admin" with password "admin"
+    When I install package "rute-dummy-2.0-1.2.x86_64" on this "sle_minion"
+    And I follow the left menu "Software > Channel List > All"
+    And I follow "Test-Channel-x86_64"
+    And I follow "Patches" in the content area
+    And I follow "rute-dummy-0817"
+    And I follow "Affected Systems"
+    Then I should see a "No systems." text
+    Then I remove package "rute-dummy" from this "sle_minion"
+    And I wait until refresh package list on "sle_minion" is finished
+   
+  Scenario: Target systems for stable packages should not be empty
+    Given I am authorized as "admin" with password "admin"
+    When I follow the left menu "Software > Channel List > All"
+    And I follow "Test-Channel-x86_64"
+    And I follow "Packages" in the content area
+    And I follow "rute-dummy-2.0-1.2.x86_64"
+    And I follow "Target Systems"
+    Then I should see "sle_minion" hostname
+   
+  Scenario: Target systems for retracted packages should be empty
+    Given I am authorized as "admin" with password "admin"
+    When I follow the left menu "Software > Channel List > All"
+    And I follow "Test-Channel-x86_64"
+    And I follow "Packages" in the content area
+    And I follow "rute-dummy-2.1-1.1.x86_64"
+    And I follow "Target Systems"
+    Then I should not see "sle_minion" hostname
+
+  Scenario: Retracted packages in the patch detail
+    Given I am authorized as "admin" with password "admin"
+    When I follow the left menu "Patches > Patch List > All"
+    And I follow "rute-dummy-0815"
+    Then I should see a "Status: Retracted" text
+    When I go back
+    And I follow "rute-dummy-0816"
+    Then I should see a "Status: Stable" text
+    When I go back
+    And I follow "rute-dummy-0817"
+    Then I should see a "Status: Retracted" text
+
+  Scenario: Retracted packages in the patches list
+    Given I am authorized as "admin" with password "admin"
+    When I follow the left menu "Patches > Patch List > All"
+    Then the table row for "rute-dummy-0815" should contain "errata-retracted" icon
+    Then the table row for "rute-dummy-0816" should not contain "errata-retracted" icon
+    Then the table row for "rute-dummy-0817" should contain "errata-retracted" icon
+
+  Scenario: Retracted patches in the channel patches list
+    Given I am authorized as "admin" with password "admin"
+    When I follow the left menu "Software > Channel List > All"
+    And I follow "Test-Channel-x86_64"
+    And I follow "Patches" in the content area
+    Then the table row for "rute-dummy-0815" should contain "errata-retracted" icon
+    Then the table row for "rute-dummy-0816" should not contain "errata-retracted" icon
+    Then the table row for "rute-dummy-0817" should contain "errata-retracted" icon
+ 
+  Scenario: Retracted packages in the channel packages list
+    Given I am authorized as "admin" with password "admin"
+    When I follow the left menu "Software > Channel List > All"
+    And I follow "Test-Channel-x86_64"
+    And I follow "Packages" in the content area
+    Then the table row for "rute-dummy-2.0-1.1.x86_64" should contain "errata-retracted" icon
+    Then the table row for "rute-dummy-2.0-1.2.x86_64" should not contain "errata-retracted" icon
+    Then the table row for "rute-dummy-2.1-1.1.x86_64" should contain "errata-retracted" icon
+
+  Scenario: SSM: Retracted package should not be available for installation
+    Given I am authorized as "admin" with password "admin"
+    When I am on the System Overview page
+    And I follow "Clear"
+    And I check the "sle_minion" client 
+    And I am on System Set Manager Overview
+    And I follow "Packages" in the content area
+    And I follow "Install"
+    And I follow "Test-Channel-x86_64"
+    Then I should see a "rute-dummy-2.0-1.2" text
+    Then I should not see a "rute-dummy-2.1-1.1" text
+

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -223,6 +223,11 @@ When(/^I enter the URI of the registry as "([^"]*)"$/) do |arg1|
   fill_in arg1, with: $no_auth_registry
 end
 
+# Go back in the browser history
+When(/^I go back$/) do
+  page.driver.go_back
+end
+
 #
 # Click on a button
 #
@@ -468,6 +473,14 @@ Then(/^I wait until table row for "([^"]*)" contains "([^"]*)"$/) do |arg1, arg2
   xpath_query = "//div[@class=\"table-responsive\"]/table/tbody/tr[.//*[contains(.,'#{arg1}')]]"
   within(:xpath, xpath_query) do
     raise "xpath: #{xpath_query} has no content #{arg2}" unless has_content?(arg2, wait: DEFAULT_TIMEOUT)
+  end
+end
+
+Then(/^the table row for "([^"]*)" should( not)? contain "([^"]*)" icon$/) do |row, should_not, icon_class|
+  xpath_query = "//div[@class=\"table-responsive\"]/table/tbody/tr[.//*[contains(.,'#{row}')]]"
+  within(:xpath, xpath_query) do
+    func = should_not ? :has_no_css? : :has_css?
+    raise "xpath: #{xpath_query} has no content #{icon_class}" unless send(func, "i[class*='#{icon_class}']", wait: DEFAULT_TIMEOUT)
   end
 end
 

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -477,7 +477,8 @@ Then(/^I wait until table row for "([^"]*)" contains "([^"]*)"$/) do |arg1, arg2
 end
 
 Then(/^the table row for "([^"]*)" should( not)? contain "([^"]*)" icon$/) do |row, should_not, icon|
-  if icon == 'retracted'
+  case icon
+  when 'retracted'
     content_selector = "i[class*='errata-retracted']"
   else
     raise "Unsupported icon '#{icon}' in the step definition"

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -476,11 +476,20 @@ Then(/^I wait until table row for "([^"]*)" contains "([^"]*)"$/) do |arg1, arg2
   end
 end
 
-Then(/^the table row for "([^"]*)" should( not)? contain "([^"]*)" icon$/) do |row, should_not, icon_class|
+Then(/^the table row for "([^"]*)" should( not)? contain "([^"]*)" icon$/) do |row, should_not, icon|
+  if icon == 'retracted'
+    content_selector = "i[class*='errata-retracted']"
+  else
+    raise "Unsupported icon '#{icon}' in the step definition"
+  end
+
   xpath_query = "//div[@class=\"table-responsive\"]/table/tbody/tr[.//*[contains(.,'#{row}')]]"
   within(:xpath, xpath_query) do
-    func = should_not ? :has_no_css? : :has_css?
-    raise "xpath: #{xpath_query} has no content #{icon_class}" unless send(func, "i[class*='#{icon_class}']", wait: DEFAULT_TIMEOUT)
+    if should_not
+      raise "xpath: #{xpath_query} has no icon #{icon}" unless has_no_css?(content_selector, wait: DEFAULT_TIMEOUT)
+    else
+      raise "xpath: #{xpath_query} has no icon #{icon}" unless has_css?(content_selector, wait: DEFAULT_TIMEOUT)
+    end
   end
 end
 

--- a/testsuite/run_sets/secondary.yml
+++ b/testsuite/run_sets/secondary.yml
@@ -52,5 +52,6 @@
 - features/secondary/min_change_software_channel.feature
 - features/secondary/srv_test_maintenance_windows.feature
 - features/secondary/srv_user_configuration_salt_states.feature
+- features/secondary/srv_retracted_patches.feature
 
 ## Secondary features END ##

--- a/testsuite/run_sets/secondary.yml
+++ b/testsuite/run_sets/secondary.yml
@@ -52,6 +52,6 @@
 - features/secondary/min_change_software_channel.feature
 - features/secondary/srv_test_maintenance_windows.feature
 - features/secondary/srv_user_configuration_salt_states.feature
-- features/secondary/srv_retracted_patches.feature
+- features/secondary/min_retracted_patches.feature
 
 ## Secondary features END ##


### PR DESCRIPTION
Do not merge before https://github.com/uyuni-project/uyuni/pull/3110!

The PR adds various scenarios related to the Retracted Patches feature.
It also adds/extends existing step definitions according to its needs.

To me it looks cleaner to keep the feature in a separate feature file, but I'd happy to hear other suggestions from the reviewers.


## TODO
- [x] Agree on the structure: a new feature or merge into existing? Seems nobody had objection about a new feature.
- [x] Wait until the #3110 is merged
- [ ] Currently, the `SSM: Retracted package should not be available for installation` is failing. This might be a bug in Uyuni. Check this on a test environment


## Documentation
- No documentation needed: testsuite
- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/13252

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"