### PR TITLE
QA: Filter by Non-Critical patches before select the first

### DIFF
--- a/testsuite/features/build_validation/smoke_tests/smoke_tests.template
+++ b/testsuite/features/build_validation/smoke_tests/smoke_tests.template
@@ -22,8 +22,10 @@ Feature: Smoke tests for <client>
 @skip_for_ubuntu
   Scenario: Install a patch on the <client>
     Given I am on the Systems overview page of this "<client>"
-    And I follow "Software" in the content area
+    When I follow "Software" in the content area
     And I follow "Patches" in the content area
+    And I select "Non-Critical" from "type"
+    And I click on "Show"
     When I check the first patch in the list
     And I click on "Apply Patches"
     And I click on "Confirm"


### PR DESCRIPTION
## What does this PR change?

Filter by Non-Critical patches before selecting the first, so we skip Kernel patches.

![image](https://user-images.githubusercontent.com/2827771/110857100-b956d100-82b8-11eb-9921-6af017a80163.png)


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Ports:
- Manager-4.0
- Manager-4.1

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
