### PR TITLE
QA: Speed up select step definition

### DIFF
--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -148,7 +148,7 @@ end
 
 When(/^I select "([^"]*)" from "([^"]*)"$/) do |arg1, arg2|
   xpath = "//input[@id='#{arg2}']/../../../../.."
-  if has_xpath?(xpath)
+  if all(:xpath, xpath, wait: 0).any?
     find(:xpath, xpath).click
     find(:xpath, "#{xpath}/div/div/div[normalize-space(text())='#{arg1}']", match: :first).click
   else


### PR DESCRIPTION
## What does this PR change?

Speed up select step definition, by using a different method to identify if we have to React component or not, that will not wait default timeout of 10 seconds.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Ports:
- Manager-4.0
- Manager-4.1

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
