### PR TITLE
BV: Create the bootstrap repositories with custom channels

### DIFF
--- a/testsuite/documentation/cucumber-steps.md
+++ b/testsuite/documentation/cucumber-steps.md
@@ -504,7 +504,7 @@ Note that the text area variant handles the new lines characters while the other
 * Execute mgr-create-bootstrap-repo
 
 ```cucumber
-  When I create the "x86_64" bootstrap repository for "sle_minion" on the server
+  When I create the bootstrap repository for "sle_minion" on the server
 ```
 
 * Execute spacewalk-channel

--- a/testsuite/features/build_validation/init_clients/ceos6_client.feature
+++ b/testsuite/features/build_validation/init_clients/ceos6_client.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 SUSE LLC
+# Copyright (c) 2020-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @ceos6_client
@@ -7,8 +7,12 @@ Feature: Bootstrap a CentOS 6 traditional client
   Scenario: Clean up sumaform leftovers on a CentOS 6 traditional client
     When I perform a full salt minion cleanup on "ceos6_client"
 
+  Scenario: Create the bootstrap repository for a CentOS 6 traditional client
+    Given I am authorized
+    When I create the bootstrap repository for "ceos6_client" on the server
+
   Scenario: Prepare a CentOS 6 traditional client
-    And I enable the repositories "centos_base_backup centos_updates_backup tools_pool_repo" on this "ceos6_client" without error control
+    When I enable the repositories "centos_base_backup centos_updates_backup tools_pool_repo" on this "ceos6_client" without error control
     And I run "/usr/bin/update-ca-trust force-enable" on "ceos6_client"
     And I bootstrap traditional client "ceos6_client" using bootstrap script with activation key "1-ceos6_client_key" from the proxy
     And I install the traditional stack utils on "ceos6_client"
@@ -17,7 +21,7 @@ Feature: Bootstrap a CentOS 6 traditional client
 
   Scenario: The onboarding of CentOS 6 traditional client is completed
     Given I am authorized
-    And I wait until onboarding is completed for "ceos6_client"
+    When I wait until onboarding is completed for "ceos6_client"
 
 @proxy
   Scenario: Check connection from CentOS 6 traditional client to proxy

--- a/testsuite/features/build_validation/init_clients/ceos6_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ceos6_minion.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 SUSE LLC
+# Copyright (c) 2020-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 #  1) bootstrap a new CentOS 6 minion via salt-ssh
@@ -10,16 +10,20 @@ Feature: Bootstrap a CentOS 6 Salt minion
   Scenario: Clean up sumaform leftovers on a CentOS 6 Salt minion
     When I perform a full salt minion cleanup on "ceos6_minion"
 
+  Scenario: Create the bootstrap repository for a CentOS 6 Salt minion
+    Given I am authorized
+    When I create the bootstrap repository for "ceos6_minion" on the server
+
   Scenario: Bootstrap a CentOS 6 Salt minion
     Given I am authorized
     When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
-    And I enter the hostname of "ceos6_minion" as "hostname"
+    When I enter the hostname of "ceos6_minion" as "hostname"
     And I enter "linux" as "password"
     And I select "1-ceos6_minion_key" from "activationKeys"
     And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
-    Then I wait until I see "Successfully bootstrapped host!" text
+    And I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "ceos6_minion"
 
 @proxy

--- a/testsuite/features/build_validation/init_clients/ceos6_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ceos6_ssh_minion.feature
@@ -10,6 +10,10 @@ Feature: Bootstrap a CentOS 6 Salt SSH minion
   Scenario: Clean up sumaform leftovers on a CentOS 6 Salt SSH minion
     When I perform a full salt minion cleanup on "ceos6_ssh_minion"
 
+  Scenario: Create the bootstrap repository for a CentOS 6 Salt SSH minion 
+    Given I am authorized
+    When I create the bootstrap repository for "ceos6_ssh_minion" on the server
+
   Scenario: Bootstrap a CentOS 6 Salt SSH minion
     Given I am authorized
     When I go to the bootstrapping page
@@ -20,7 +24,7 @@ Feature: Bootstrap a CentOS 6 Salt SSH minion
     And I select "1-ceos6_ssh_minion_key" from "activationKeys"
     And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
-    Then I wait until I see "Successfully bootstrapped host!" text
+    And I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "ceos6_ssh_minion"
 
   # WORKAROUND bsc#1181847

--- a/testsuite/features/build_validation/init_clients/ceos7_client.feature
+++ b/testsuite/features/build_validation/init_clients/ceos7_client.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 SUSE LLC
+# Copyright (c) 2020-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @ceos7_client
@@ -7,8 +7,12 @@ Feature: Bootstrap a CentOS 7 traditional client
   Scenario: Clean up sumaform leftovers on a CentOS 7 traditional client
     When I perform a full salt minion cleanup on "ceos7_client"
 
+  Scenario: Create the bootstrap repository for a CentOS 7 traditional client
+    Given I am authorized
+    When I create the bootstrap repository for "ceos7_client" on the server
+
   Scenario: Prepare a CentOS 7 traditional client
-    And I enable repository "CentOS-Base tools_pool_repo" on this "ceos7_client" without error control
+    When I enable repository "CentOS-Base tools_pool_repo" on this "ceos7_client" without error control
     And I bootstrap traditional client "ceos7_client" using bootstrap script with activation key "1-ceos7_client_key" from the proxy
     And I install the traditional stack utils on "ceos7_client"
     And I run "mgr-actions-control --enable-all" on "ceos7_client"
@@ -16,7 +20,7 @@ Feature: Bootstrap a CentOS 7 traditional client
 
   Scenario: The onboarding of CentOS 7 traditional client is completed
     Given I am authorized
-    And I wait until onboarding is completed for "ceos7_client"
+    When I wait until onboarding is completed for "ceos7_client"
 
 @proxy
   Scenario: Check connection from CentOS 7 traditional client to proxy

--- a/testsuite/features/build_validation/init_clients/ceos7_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ceos7_minion.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 SUSE LLC
+# Copyright (c) 2020-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 #  1) bootstrap a new CentOS 7 minion via salt-ssh
@@ -10,16 +10,20 @@ Feature: Bootstrap a CentOS 7 Salt minion
   Scenario: Clean up sumaform leftovers on a  CentOS 7 Salt minion
     When I perform a full salt minion cleanup on "ceos7_minion"
 
+  Scenario: Create the bootstrap repository for a CentOS 7 Salt minion
+    Given I am authorized
+    When I create the bootstrap repository for "ceos7_minion" on the server
+
   Scenario: Bootstrap a CentOS 7 Salt minion
     Given I am authorized
     When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
-    And I enter the hostname of "ceos7_minion" as "hostname"
+    When I enter the hostname of "ceos7_minion" as "hostname"
     And I enter "linux" as "password"
     And I select "1-ceos7_minion_key" from "activationKeys"
     And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
-    Then I wait until I see "Successfully bootstrapped host!" text
+    And I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "ceos7_minion"
 
 @proxy

--- a/testsuite/features/build_validation/init_clients/ceos7_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ceos7_ssh_minion.feature
@@ -10,6 +10,10 @@ Feature: Bootstrap a CentOS 7 Salt SSH minion
   Scenario: Clean up sumaform leftovers on a CentOS 7 Salt SSH minion
     When I perform a full salt minion cleanup on "ceos7_ssh_minion"
 
+  Scenario: Create the bootstrap repository for a CentOS 7 Salt SSH minion 
+    Given I am authorized
+    When I create the bootstrap repository for "ceos7_ssh_minion" on the server
+
   Scenario: Bootstrap a CentOS 7 Salt SSH minion
     Given I am authorized
     When I go to the bootstrapping page
@@ -20,7 +24,7 @@ Feature: Bootstrap a CentOS 7 Salt SSH minion
     And I select "1-ceos7_ssh_minion_key" from "activationKeys"
     And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
-    Then I wait until I see "Successfully bootstrapped host!" text
+    And I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "ceos7_ssh_minion"
 
   # WORKAROUND bsc#1181847

--- a/testsuite/features/build_validation/init_clients/ceos8_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ceos8_minion.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 SUSE LLC
+# Copyright (c) 2020-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 #  1) bootstrap a new CentOS 8 minion via salt-ssh
@@ -10,16 +10,20 @@ Feature: Bootstrap a CentOS 8 Salt minion
   Scenario: Clean up sumaform leftovers on a CentOS 8 Salt minion
     When I perform a full salt minion cleanup on "ceos8_minion"
 
+  Scenario: Create the bootstrap repository for a CentOS 8 Salt minion
+    Given I am authorized
+    When I create the bootstrap repository for "ceos8_minion" on the server
+
   Scenario: Bootstrap a CentOS 8 Salt minion
     Given I am authorized
     When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
-    And I enter the hostname of "ceos8_minion" as "hostname"
+    When I enter the hostname of "ceos8_minion" as "hostname"
     And I enter "linux" as "password"
     And I select "1-ceos8_minion_key" from "activationKeys"
     And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
-    Then I wait until I see "Successfully bootstrapped host!" text
+    And I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "ceos8_minion"
 
 @proxy

--- a/testsuite/features/build_validation/init_clients/ceos8_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ceos8_ssh_minion.feature
@@ -10,6 +10,10 @@ Feature: Bootstrap a CentOS 8 Salt SSH minion
   Scenario: Clean up sumaform leftovers on a CentOS 8 Salt SSH minion
     When I perform a full salt minion cleanup on "ceos8_ssh_minion"
 
+  Scenario: Create the bootstrap repository for a CentOS 8 Salt SSH minion
+    Given I am authorized
+    When I create the bootstrap repository for "ceos8_ssh_minion" on the server
+
   Scenario: Bootstrap a CentOS 8 Salt SSH minion
     Given I am authorized
     When I go to the bootstrapping page
@@ -20,7 +24,7 @@ Feature: Bootstrap a CentOS 8 Salt SSH minion
     And I select "1-ceos8_ssh_minion_key" from "activationKeys"
     And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
-    Then I wait until I see "Successfully bootstrapped host!" text
+    And I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "ceos8_ssh_minion"
 
   # WORKAROUND bsc#1181847

--- a/testsuite/features/build_validation/init_clients/disabled/ubuntu2004_minion.feature
+++ b/testsuite/features/build_validation/init_clients/disabled/ubuntu2004_minion.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 SUSE LLC
+# Copyright (c) 2020-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 #  1) bootstrap a new Ubuntu minion
@@ -9,6 +9,10 @@ Feature: Bootstrap a Ubuntu 20.04 Salt minion
 
   Scenario: Clean up sumaform leftovers on a Ubuntu 20.04 minion
     When I perform a full salt minion cleanup on "ubuntu2004_minion"
+
+  Scenario: Create the bootstrap repository for a Ubuntu 20.04 minion
+    Given I am authorized
+    When I create the bootstrap repository for "ubuntu2004_minion" on the server
 
   Scenario: Bootstrap a Ubuntu 20.04 minion
     Given I am authorized
@@ -22,7 +26,7 @@ Feature: Bootstrap a Ubuntu 20.04 Salt minion
     And I select "1-ubuntu2004_minion_key" from "activationKeys"
     And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
-    Then I wait until I see "Successfully bootstrapped host!" text
+    And I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "ubuntu2004_minion"
 
 @proxy

--- a/testsuite/features/build_validation/init_clients/disabled/ubuntu2004_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/disabled/ubuntu2004_ssh_minion.feature
@@ -5,10 +5,14 @@
 #  2) subscribe it to a base channel for testing
 
 @ubuntu2004_ssh_minion
-Feature: Bootstrap a Ubuntu 20.04 Salt SSH Minion
+Feature: Bootstrap a Ubuntu 20.04 Salt SSH minion
 
-  Scenario: Clean up sumaform leftovers on a Ubuntu 20.04 Salt SSH Minion
+  Scenario: Clean up sumaform leftovers on a Ubuntu 20.04 Salt SSH minion
     When I perform a full salt minion cleanup on "ubuntu2004_ssh_minion"
+
+  Scenario: Create the bootstrap repository for a Ubuntu 20.04 Salt SSH minion
+    Given I am authorized
+    When I create the bootstrap repository for "ubuntu2004_ssh_minion" on the server
 
   Scenario: Bootstrap a SSH-managed Ubuntu 20.04 minion
     Given I am authorized
@@ -22,11 +26,11 @@ Feature: Bootstrap a Ubuntu 20.04 Salt SSH Minion
     And I select the hostname of "proxy" from "proxies"
     And I check "manageWithSSH"
     And I click on "Bootstrap"
-    Then I wait until I see "Successfully bootstrapped host!" text
+    And I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "ubuntu2004_ssh_minion"
 
   # WORKAROUND bsc#1181847
-  Scenario: Import the GPG keys for Ubuntu 20.04 Salt SSH Minion
+  Scenario: Import the GPG keys for Ubuntu 20.04 Salt SSH minion
     When I import the GPG keys for "ubuntu2004_ssh_minion"
 
   Scenario: Check events history for failures on SSH-managed Ubuntu 20.04 minion

--- a/testsuite/features/build_validation/init_clients/proxy.feature
+++ b/testsuite/features/build_validation/init_clients/proxy.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 SUSE LLC
+# Copyright (c) 2020-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # The scenarios in this feature are skipped if there is no proxy
@@ -16,9 +16,12 @@ Feature: Setup SUSE Manager proxy
     And I set correct product for "proxy"
     # End of WORKAROUND
 
+  Scenario: Create the bootstrap repository for the SUSE Manager proxy
+    Given I am authorized
+    When I create the bootstrap repository for "proxy" on the server
+
   Scenario: Bootstrap the proxy as a Salt minion
     Given I am authorized
-    And I create the "x86_64" bootstrap repository for "proxy" on the server
     When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "proxy" as "hostname"

--- a/testsuite/features/build_validation/init_clients/sle11sp4_client.feature
+++ b/testsuite/features/build_validation/init_clients/sle11sp4_client.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 SUSE LLC
+# Copyright (c) 2017-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @sle11sp4_client
@@ -6,6 +6,10 @@ Feature: Bootstrap a SLES 11 SP4 traditional client
 
   Scenario: Clean up sumaform leftovers on a SLES 11 SP4 traditional client
     When I perform a full salt minion cleanup on "sle11sp4_client"
+
+  Scenario: Create the bootstrap repository for a SLES 11 SP4 traditional client
+    Given I am authorized
+    When I create the bootstrap repository for "sle11sp4_client" on the server
 
   Scenario: Register a SLES 11 SP4 traditional client
     When I bootstrap traditional client "sle11sp4_client" using bootstrap script with activation key "1-sle11sp4_client_key" from the proxy
@@ -15,7 +19,7 @@ Feature: Bootstrap a SLES 11 SP4 traditional client
 
   Scenario: The onboarding of SLES 11 SP4 traditional client is completed
     Given I am authorized
-    Then I wait until onboarding is completed for "sle11sp4_client"
+    When I wait until onboarding is completed for "sle11sp4_client"
 
   Scenario: Check registration values of SLES 11 SP4 traditional
     Given I update the profile of "sle11sp4_client"

--- a/testsuite/features/build_validation/init_clients/sle11sp4_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle11sp4_minion.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 SUSE LLC
+# Copyright (c) 2020-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @sle11sp4_minion
@@ -7,9 +7,9 @@ Feature: Bootstrap a SLES 11 SP4 Salt minion
   Scenario: Clean up sumaform leftovers on a SLES 11 SP4 Salt minion
     When I perform a full salt minion cleanup on "sle11sp4_minion"
 
-  Scenario: Create the bootstrap repository for a Salt client
+  Scenario: Create the bootstrap repository for a SLES 11 SP4 minion
     Given I am authorized
-    And I create the "x86_64" bootstrap repository for "sle11sp4_minion" on the server
+    When I create the bootstrap repository for "sle11sp4_minion" on the server
 
   Scenario: Bootstrap a SLES 11 SP4 minion
     Given I am authorized
@@ -27,7 +27,7 @@ Feature: Bootstrap a SLES 11 SP4 Salt minion
 
   Scenario: Check the new bootstrapped SLES 11 SP4 minion in System Overview page
     Given I am authorized
-    And I go to the minion onboarding page
+    When I go to the minion onboarding page
     Then I should see a "accepted" text
     And the Salt master can reach "sle11sp4_minion"
 

--- a/testsuite/features/build_validation/init_clients/sle11sp4_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle11sp4_ssh_minion.feature
@@ -2,22 +2,26 @@
 # Licensed under the terms of the MIT license.
 
 @sle11sp4_ssh_minion
-Feature: Bootstrap a SLES 11 SP4 Salt SSH Minion
+Feature: Bootstrap a SLES 11 SP4 Salt SSH minion
 
-  Scenario: Clean up sumaform leftovers on a SLES 11 SP4 Salt SSH Minion
+  Scenario: Clean up sumaform leftovers on a SLES 11 SP4 Salt SSH minion
     When I perform a full salt minion cleanup on "sle11sp4_ssh_minion"
+
+  Scenario: Create the bootstrap repository for a SLES 11 SP4 Salt SSH minion
+    Given I am authorized
+    When I create the bootstrap repository for "sle11sp4_ssh_minion" on the server
 
   Scenario: Bootstrap a SLES 11 SP4 system managed via salt-ssh
     Given I am authorized
-    And I go to the bootstrapping page
+    When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
-    And I check "manageWithSSH"
+    When I check "manageWithSSH"
     And I enter the hostname of "sle11sp4_ssh_minion" as "hostname"
     And I enter "linux" as "password"
     And I select "1-sle11sp4_ssh_minion_key" from "activationKeys"
     And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
-    Then I wait until I see "Successfully bootstrapped host!" text
+    And I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "sle11sp4_ssh_minion"
 
 # HACK
@@ -39,7 +43,7 @@ Feature: Bootstrap a SLES 11 SP4 Salt SSH Minion
     And I remove package "sle-manager-tools-release" from highstate
 
   # WORKAROUND bsc#1181847
-  Scenario: Import the GPG keys for SLES 11 SP4 Salt SSH Minion
+  Scenario: Import the GPG keys for SLES 11 SP4 Salt SSH minion
     When I import the GPG keys for "sle11sp4_ssh_minion"
 
 @proxy

--- a/testsuite/features/build_validation/init_clients/sle12sp4_client.feature
+++ b/testsuite/features/build_validation/init_clients/sle12sp4_client.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 SUSE LLC
+# Copyright (c) 2015-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @sle12sp4_client
@@ -6,6 +6,10 @@ Feature: Bootstrap a SLES 12 SP4 traditional client
 
   Scenario: Clean up sumaform leftovers on a SLES 12 SP4 traditional client
     When I perform a full salt minion cleanup on "sle12sp4_client"
+
+  Scenario: Create the bootstrap repository for a SLES 12 SP4 traditional client
+    Given I am authorized
+    When I create the bootstrap repository for "sles12sp4_client" on the server
 
   Scenario: Register a SLES 12 SP4 traditional client
     When I bootstrap traditional client "sle12sp4_client" using bootstrap script with activation key "1-sle12sp4_client_key" from the proxy
@@ -15,7 +19,7 @@ Feature: Bootstrap a SLES 12 SP4 traditional client
 
   Scenario: The onboarding of SLES 12 SP4 traditional client is completed
     Given I am authorized
-    Then I wait until onboarding is completed for "sle12sp4_client"
+    When I wait until onboarding is completed for "sle12sp4_client"
 
   Scenario: Check registration values of SLES 12 SP4 traditional client
     Given I update the profile of "sle12sp4_client"

--- a/testsuite/features/build_validation/init_clients/sle12sp4_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle12sp4_minion.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 SUSE LLC
+# Copyright (c) 2020-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @sle12sp4_minion
@@ -7,9 +7,9 @@ Feature: Bootstrap a SLES 12 SP4 Salt minion
   Scenario: Clean up sumaform leftovers on a SLES 12 SP4 Salt minion
     When I perform a full salt minion cleanup on "sle12sp4_minion"
 
-  Scenario: Create the bootstrap repository for a Salt client
+  Scenario: Create the bootstrap repository for a SLES 12 SP4 minion
     Given I am authorized
-    And I create the "x86_64" bootstrap repository for "sle12sp4_minion" on the server
+    When I create the bootstrap repository for "sle12sp4_minion" on the server
 
   Scenario: Bootstrap a SLES 12 SP4 minion
     Given I am authorized
@@ -27,7 +27,7 @@ Feature: Bootstrap a SLES 12 SP4 Salt minion
 
   Scenario: Check the new bootstrapped SLES 12 SP4 minion in System Overview page
     Given I am authorized
-    And I go to the minion onboarding page
+    When I go to the minion onboarding page
     Then I should see a "accepted" text
     And the Salt master can reach "sle12sp4_minion"
 

--- a/testsuite/features/build_validation/init_clients/sle12sp4_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle12sp4_ssh_minion.feature
@@ -2,22 +2,26 @@
 # Licensed under the terms of the MIT license.
 
 @sle12sp4_ssh_minion
-Feature: Bootstrap a SLES 12 SP4 Salt SSH Minion
+Feature: Bootstrap a SLES 12 SP4 Salt SSH minion
 
-  Scenario: Clean up sumaform leftovers on a SLES 12 SP4 Salt SSH Minion
+  Scenario: Clean up sumaform leftovers on a SLES 12 SP4 Salt SSH minion
     When I perform a full salt minion cleanup on "sle12sp4_ssh_minion"
+
+  Scenario: Create the bootstrap repository for a SLES 12 SP4 Salt SSH minion
+    Given I am authorized
+    When I create the bootstrap repository for "sle12sp4_minion" on the server
 
   Scenario: Bootstrap a SLES 12 SP4 system managed via salt-ssh
     Given I am authorized
-    And I go to the bootstrapping page
+    When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
-    And I check "manageWithSSH"
+    When I check "manageWithSSH"
     And I enter the hostname of "sle12sp4_ssh_minion" as "hostname"
     And I enter "linux" as "password"
     And I select "1-sle12sp4_ssh_minion_key" from "activationKeys"
     And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
-    Then I wait until I see "Successfully bootstrapped host!" text
+    And I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "sle12sp4_ssh_minion"
 
 # HACK
@@ -39,7 +43,7 @@ Feature: Bootstrap a SLES 12 SP4 Salt SSH Minion
     And I remove package "sle-manager-tools-release" from highstate
 
   # WORKAROUND bsc#1181847
-  Scenario: Import the GPG keys for SLES 12 SP4 SSH Minion
+  Scenario: Import the GPG keys for SLES 12 SP4 SSH minion
     When I import the GPG keys for "sle12sp4_ssh_minion"
 
 @proxy

--- a/testsuite/features/build_validation/init_clients/sle15_client.feature
+++ b/testsuite/features/build_validation/init_clients/sle15_client.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 SUSE LLC
+# Copyright (c) 2015-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @sle15_client
@@ -6,6 +6,10 @@ Feature: Bootstrap a SLES 15 traditional client
 
   Scenario: Clean up sumaform leftovers on a SLES 15 traditional client
     When I perform a full salt minion cleanup on "sle15_client"
+
+  Scenario: Create the bootstrap repository for a SLES 15 traditional client
+    Given I am authorized
+    When I create the bootstrap repository for "sle15_client" on the server
 
   Scenario: Register a SLES 15 traditional client
     When I bootstrap traditional client "sle15_client" using bootstrap script with activation key "1-sle15_client_key" from the proxy
@@ -15,7 +19,7 @@ Feature: Bootstrap a SLES 15 traditional client
 
   Scenario: The onboarding of SLES 15 traditional client is completed
     Given I am authorized
-    Then I wait until onboarding is completed for "sle15_client"
+    When I wait until onboarding is completed for "sle15_client"
 
   Scenario: Check registration values of SLES 15 traditional client
     Given I update the profile of "sle15_client"

--- a/testsuite/features/build_validation/init_clients/sle15_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15_minion.feature
@@ -1,15 +1,15 @@
-# Copyright (c) 2020 SUSE LLC
+# Copyright (c) 2020-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @sle15_minion
-Feature: Be able to bootstrap a SLES 15 Salt minion
+Feature: Bootstrap a SLES 15 Salt minion
 
   Scenario: Clean up sumaform leftovers on a SLES 15 Salt minion
     When I perform a full salt minion cleanup on "sle15_minion"
 
-  Scenario: Create the bootstrap repository for a Salt client
+  Scenario: Create the bootstrap repository for a SLES 15 minion
     Given I am authorized
-    And I create the "x86_64" bootstrap repository for "sle15_minion" on the server
+    When I create the bootstrap repository for "sle15_minion" on the server
 
   Scenario: Bootstrap a SLES 15 minion
     Given I am authorized
@@ -27,7 +27,7 @@ Feature: Be able to bootstrap a SLES 15 Salt minion
 
   Scenario: Check the new bootstrapped SLES 15 minion in System Overview page
     Given I am authorized
-    And I go to the minion onboarding page
+    When I go to the minion onboarding page
     Then I should see a "accepted" text
     And the Salt master can reach "sle15_minion"
 

--- a/testsuite/features/build_validation/init_clients/sle15_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15_ssh_minion.feature
@@ -2,22 +2,26 @@
 # Licensed under the terms of the MIT license.
 
 @sle15_ssh_minion
-Feature: Bootstrap a SLES 15 Salt SSH Minion
+Feature: Bootstrap a SLES 15 Salt SSH minion
 
-  Scenario: Clean up sumaform leftovers on a SLES 15 Salt SSH Minion
+  Scenario: Clean up sumaform leftovers on a SLES 15 Salt SSH minion
     When I perform a full salt minion cleanup on "sle15_ssh_minion"
+
+  Scenario: Create the bootstrap repository for a SLES 15 Salt SSH minion
+    Given I am authorized
+    When I create the bootstrap repository for "sle15_ssh_minion" on the server
 
   Scenario: Bootstrap a SLES 15 system managed via salt-ssh
     Given I am authorized
-    And I go to the bootstrapping page
+    When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
-    And I check "manageWithSSH"
+    When I check "manageWithSSH"
     And I enter the hostname of "sle15_ssh_minion" as "hostname"
     And I enter "linux" as "password"
     And I select "1-sle15_ssh_minion_key" from "activationKeys"
     And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
-    Then I wait until I see "Successfully bootstrapped host!" text
+    And I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "sle15_ssh_minion"
 
   # HACK
@@ -39,7 +43,7 @@ Feature: Bootstrap a SLES 15 Salt SSH Minion
     And I remove package "sle-manager-tools-release" from highstate
 
   # WORKAROUND bsc#1181847
-  Scenario: Import the GPG keys for SLES 15 Salt SSH Minion
+  Scenario: Import the GPG keys for SLES 15 Salt SSH minion
     When I import the GPG keys for "sle15_ssh_minion"
 
 @proxy

--- a/testsuite/features/build_validation/init_clients/sle15sp1_client.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp1_client.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 SUSE LLC
+# Copyright (c) 2020-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @sle15sp1_client
@@ -6,6 +6,10 @@ Feature: Bootstrap a SLES 15 SP1 traditional client
 
   Scenario: Clean up sumaform leftovers on a SLES 15 SP1 traditional client
     When I perform a full salt minion cleanup on "sle15sp1_client"
+
+  Scenario: Create the bootstrap repository for a SLES 15 SP1 traditional client
+    Given I am authorized
+    When I create the bootstrap repository for "sle15sp1_client" on the server
 
   Scenario: Register a SLES 15 SP1 traditional client
     When I bootstrap traditional client "sle15sp1_client" using bootstrap script with activation key "1-sle15sp1_client_key" from the proxy
@@ -15,7 +19,7 @@ Feature: Bootstrap a SLES 15 SP1 traditional client
 
   Scenario: The onboarding of SLES 15 SP1 traditional client is completed
     Given I am authorized
-    Then I wait until onboarding is completed for "sle15sp1_client"
+    When I wait until onboarding is completed for "sle15sp1_client"
 
   Scenario: Check registration values of SLES 15 SP1 traditional
     Given I update the profile of "sle15sp1_client"

--- a/testsuite/features/build_validation/init_clients/sle15sp1_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp1_minion.feature
@@ -1,15 +1,15 @@
-# Copyright (c) 2020 SUSE LLC
+# Copyright (c) 2020-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @sle15sp1_minion
-Feature: Be able to bootstrap a SLES 15 SP1 Salt minion
+Feature: Bootstrap a SLES 15 SP1 Salt minion
 
   Scenario: Clean up sumaform leftovers on a SLES 15 SP1 Salt minion
     When I perform a full salt minion cleanup on "sle15sp1_minion"
 
-  Scenario: Create the bootstrap repository for a Salt client
+  Scenario: Create the bootstrap repository for a SLES 15 SP1 minion
     Given I am authorized
-    And I create the "x86_64" bootstrap repository for "sle15sp1_minion" on the server
+    When I create the bootstrap repository for "sle15sp1_minion" on the server
 
   Scenario: Bootstrap a SLES 15 SP1 minion
     Given I am authorized
@@ -27,7 +27,7 @@ Feature: Be able to bootstrap a SLES 15 SP1 Salt minion
 
   Scenario: Check the new bootstrapped SLES 15 SP1 minion in System Overview page
     Given I am authorized
-    And I go to the minion onboarding page
+    When I go to the minion onboarding page
     Then I should see a "accepted" text
     And the Salt master can reach "sle15sp1_minion"
 

--- a/testsuite/features/build_validation/init_clients/sle15sp1_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp1_ssh_minion.feature
@@ -2,22 +2,26 @@
 # Licensed under the terms of the MIT license.
 
 @sle15sp1_ssh_minion
-Feature: Bootstrap a SLES 15 SP1 Salt SSH Minion
+Feature: Bootstrap a SLES 15 SP1 Salt SSH minion
 
-  Scenario: Clean up sumaform leftovers on a SLES 15 SP1 Salt SSH Minion
+  Scenario: Clean up sumaform leftovers on a SLES 15 SP1 Salt SSH minion
     When I perform a full salt minion cleanup on "sle15sp1_ssh_minion"
+
+  Scenario: Create the bootstrap repository for a SLES 15 SP1 Salt SSH minion
+    Given I am authorized
+    When I create the bootstrap repository for "sle15sp1_ssh_minion" on the server
 
   Scenario: Bootstrap a SLES 15 SP1 system managed via salt-ssh
     Given I am authorized
-    And I go to the bootstrapping page
+    When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
-    And I check "manageWithSSH"
+    When I check "manageWithSSH"
     And I enter the hostname of "sle15sp1_ssh_minion" as "hostname"
     And I enter "linux" as "password"
     And I select "1-sle15sp1_ssh_minion_key" from "activationKeys"
     And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
-    Then I wait until I see "Successfully bootstrapped host!" text
+    And I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "sle15sp1_ssh_minion"
 
   # HACK
@@ -39,7 +43,7 @@ Feature: Bootstrap a SLES 15 SP1 Salt SSH Minion
     And I remove package "sle-manager-tools-release" from highstate
 
   # WORKAROUND bsc#1181847
-  Scenario: Import the GPG keys for SLES 15 SP1 Salt SSH Minion
+  Scenario: Import the GPG keys for SLES 15 SP1 Salt SSH minion
     When I import the GPG keys for "sle15sp1_ssh_minion"
 
 @proxy

--- a/testsuite/features/build_validation/init_clients/sle15sp2_client.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp2_client.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 SUSE LLC
+# Copyright (c) 2020-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @sle15sp2_client
@@ -6,6 +6,10 @@ Feature: Bootstrap a SLES 15 SP2 traditional client
 
   Scenario: Clean up sumaform leftovers on a SLES 15 SP2 traditional client
     When I perform a full salt minion cleanup on "sle15sp2_client"
+
+  Scenario: Create the bootstrap repository for a SLES 15 SP2 traditional client
+    Given I am authorized
+    When I create the bootstrap repository for "sle15sp2_client" on the server
 
   Scenario: Register a SLES 15 SP2 traditional client
     When I bootstrap traditional client "sle15sp2_client" using bootstrap script with activation key "1-sle15sp2_client_key" from the proxy
@@ -15,7 +19,7 @@ Feature: Bootstrap a SLES 15 SP2 traditional client
 
   Scenario: The onboarding of SLES 15 SP2 traditional client is completed
     Given I am authorized
-    Then I wait until onboarding is completed for "sle15sp2_client"
+    When I wait until onboarding is completed for "sle15sp2_client"
 
   Scenario: Check registration values of SLES 15 SP2 traditional
     Given I update the profile of "sle15sp2_client"

--- a/testsuite/features/build_validation/init_clients/sle15sp2_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp2_minion.feature
@@ -1,15 +1,15 @@
-# Copyright (c) 2020 SUSE LLC
+# Copyright (c) 2020-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @sle15sp2_minion
-Feature: Be able to bootstrap a SLES 15 SP2 Salt minion
+Feature: Bootstrap a SLES 15 SP2 Salt minion
 
   Scenario: Clean up sumaform leftovers on a SLES 15 SP2 Salt minion
     When I perform a full salt minion cleanup on "sle15sp2_minion"
 
-  Scenario: Create the bootstrap repository for a Salt client
+  Scenario: Create the bootstrap repository for a SLES 15 SP2 minion
     Given I am authorized
-    And I create the "x86_64" bootstrap repository for "sle15sp2_minion" on the server
+    When I create the bootstrap repository for "sle15sp2_minion" on the server
 
   Scenario: Bootstrap a SLES 15 SP2 minion
     Given I am authorized
@@ -27,7 +27,7 @@ Feature: Be able to bootstrap a SLES 15 SP2 Salt minion
 
   Scenario: Check the new bootstrapped SLES 15 SP2 minion in System Overview page
     Given I am authorized
-    And I go to the minion onboarding page
+    When I go to the minion onboarding page
     Then I should see a "accepted" text
     And the Salt master can reach "sle15sp2_minion"
 

--- a/testsuite/features/build_validation/init_clients/sle15sp2_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp2_ssh_minion.feature
@@ -2,22 +2,26 @@
 # Licensed under the terms of the MIT license.
 
 @sle15sp2_ssh_minion
-Feature: Bootstrap a SLES 15 SP2 Salt SSH Minion
+Feature: Bootstrap a SLES 15 SP2 Salt SSH minion
 
-  Scenario: Clean up sumaform leftovers on a SLES 15 SP2 Salt SSH Minion
+  Scenario: Clean up sumaform leftovers on a SLES 15 SP2 Salt SSH minion
     When I perform a full salt minion cleanup on "sle15sp2_ssh_minion"
+
+  Scenario: Create the bootstrap repository for a SLES 15 SP2 Salt SSH minion
+    Given I am authorized
+    When I create the bootstrap repository for "sle15sp2_ssh_minion" on the server
 
   Scenario: Bootstrap a SLES 15 SP2 system managed via salt-ssh
     Given I am authorized
-    And I go to the bootstrapping page
+    When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
-    And I check "manageWithSSH"
+    When I check "manageWithSSH"
     And I enter the hostname of "sle15sp2_ssh_minion" as "hostname"
     And I enter "linux" as "password"
     And I select "1-sle15sp2_ssh_minion_key" from "activationKeys"
     And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
-    Then I wait until I see "Successfully bootstrapped host!" text
+    And I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "sle15sp2_ssh_minion"
 
   # HACK
@@ -39,7 +43,7 @@ Feature: Bootstrap a SLES 15 SP2 Salt SSH Minion
     And I remove package "sle-manager-tools-release" from highstate
 
   # WORKAROUND bsc#1181847
-  Scenario: Import the GPG keys for SLES 15 SP2 Salt SSH Minion
+  Scenario: Import the GPG keys for SLES 15 SP2 Salt SSH minion
     When I import the GPG keys for "sle15sp2_ssh_minion"
 
 @proxy

--- a/testsuite/features/build_validation/init_clients/sle15sp3_client.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp3_client.feature
@@ -7,6 +7,10 @@ Feature: Bootstrap a SLES 15 SP3 traditional client
   Scenario: Clean up sumaform leftovers on a SLES 15 SP3 traditional client
     When I perform a full salt minion cleanup on "sle15sp3_client"
 
+  Scenario: Create the bootstrap repository for a SLES 15 SP3 traditional client
+    Given I am authorized
+    When I create the bootstrap repository for "sle15sp3_client" on the server
+
   Scenario: Register a SLES 15 SP3 traditional client
     When I bootstrap traditional client "sle15sp3_client" using bootstrap script with activation key "1-sle15sp3_client_key" from the proxy
     And I install package "spacewalk-client-setup mgr-cfg-actions" on this "sle15sp3_client"
@@ -15,7 +19,7 @@ Feature: Bootstrap a SLES 15 SP3 traditional client
 
   Scenario: The onboarding of SLES 15 SP3 traditional client is completed
     Given I am authorized
-    Then I wait until onboarding is completed for "sle15sp3_client"
+    When I wait until onboarding is completed for "sle15sp3_client"
 
   Scenario: Check registration values of SLES 15 SP3 traditional
     Given I update the profile of "sle15sp3_client"

--- a/testsuite/features/build_validation/init_clients/sle15sp3_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp3_minion.feature
@@ -2,14 +2,14 @@
 # Licensed under the terms of the MIT license.
 
 @sle15sp3_minion
-Feature: Be able to bootstrap a SLES 15 SP3 Salt minion
+Feature: Bootstrap a SLES 15 SP3 Salt minion
 
   Scenario: Clean up sumaform leftovers on a SLES 15 SP3 Salt minion
     When I perform a full salt minion cleanup on "sle15sp3_minion"
 
-  Scenario: Create the bootstrap repository for a Salt client
+  Scenario: Create the bootstrap repository for a SLES 15 SP3 minion
     Given I am authorized
-    And I create the "x86_64" bootstrap repository for "sle15sp3_minion" on the server
+    When I create the bootstrap repository for "sle15sp3_minion" on the server
 
   Scenario: Bootstrap a SLES 15 SP3 minion
     Given I am authorized
@@ -27,7 +27,7 @@ Feature: Be able to bootstrap a SLES 15 SP3 Salt minion
 
   Scenario: Check the new bootstrapped SLES 15 SP3 minion in System Overview page
     Given I am authorized
-    And I go to the minion onboarding page
+    When I go to the minion onboarding page
     Then I should see a "accepted" text
     And the Salt master can reach "sle15sp3_minion"
 

--- a/testsuite/features/build_validation/init_clients/sle15sp3_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp3_ssh_minion.feature
@@ -2,22 +2,26 @@
 # Licensed under the terms of the MIT license.
 
 @sle15sp3_ssh_minion
-Feature: Bootstrap a SLES 15 SP3 Salt SSH Minion
+Feature: Bootstrap a SLES 15 SP3 Salt SSH minion
 
-  Scenario: Clean up sumaform leftovers on a SLES 15 SP3 Salt SSH Minion
+  Scenario: Clean up sumaform leftovers on a SLES 15 SP3 Salt SSH minion
     When I perform a full salt minion cleanup on "sle15sp3_ssh_minion"
+
+  Scenario: Create the bootstrap repository for a SLES 15 SP3 Salt SSH minion
+    Given I am authorized
+    When I create the bootstrap repository for "sle15sp3_ssh_minion" on the server
 
   Scenario: Bootstrap a SLES 15 SP3 system managed via salt-ssh
     Given I am authorized
-    And I go to the bootstrapping page
+    When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
-    And I check "manageWithSSH"
+    When I check "manageWithSSH"
     And I enter the hostname of "sle15sp3_ssh_minion" as "hostname"
     And I enter "linux" as "password"
     And I select "1-sle15sp3_ssh_minion_key" from "activationKeys"
     And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
-    Then I wait until I see "Successfully bootstrapped host!" text
+    And I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "sle15sp3_ssh_minion"
 
   # HACK
@@ -39,7 +43,7 @@ Feature: Bootstrap a SLES 15 SP3 Salt SSH Minion
     And I remove package "sle-manager-tools-release" from highstate
 
   # WORKAROUND bsc#1181847
-  Scenario: Import the GPG keys for SLES 15 SP3 Salt SSH Minion
+  Scenario: Import the GPG keys for SLES 15 SP3 Salt SSH minion
     When I import the GPG keys for "sle15sp3_ssh_minion"
 
 @proxy

--- a/testsuite/features/build_validation/init_clients/ubuntu1604_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ubuntu1604_minion.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 SUSE LLC
+# Copyright (c) 2020-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 #  1) bootstrap a new Ubuntu minion via salt-ssh
@@ -9,6 +9,10 @@ Feature: Bootstrap a Ubuntu 16.04 Salt minion
 
   Scenario: Clean up sumaform leftovers on a Ubuntu 16.04 Salt minion
     When I perform a full salt minion cleanup on "ubuntu1604_minion"
+
+  Scenario: Create the bootstrap repository for a Ubuntu 16.04 Salt minion
+    Given I am authorized
+    When I create the bootstrap repository for "ubuntu1604_minion" on the server
 
   Scenario: Bootstrap a Ubuntu 16.04 minion
     Given I am authorized
@@ -21,7 +25,7 @@ Feature: Bootstrap a Ubuntu 16.04 Salt minion
     And I select "1-ubuntu1604_minion_key" from "activationKeys"
     And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
-    Then I wait until I see "Successfully bootstrapped host!" text
+    And I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "ubuntu1604_minion"
 
 @proxy

--- a/testsuite/features/build_validation/init_clients/ubuntu1604_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ubuntu1604_ssh_minion.feature
@@ -10,6 +10,10 @@ Feature: Bootstrap a Ubuntu 16.04 Salt SSH minion
   Scenario: Clean up sumaform leftovers on a Ubuntu 16.04 Salt SSH minion
     When I perform a full salt minion cleanup on "ubuntu1604_ssh_minion"
 
+  Scenario: Create the bootstrap repository for a Ubuntu 16.04 Salt SSH minion
+    Given I am authorized
+    When I create the bootstrap repository for "ubuntu1604_ssh_minion" on the server
+
   Scenario: Bootstrap a SSH-managed Ubuntu 16.04 minion
     Given I am authorized
     When I go to the bootstrapping page
@@ -22,7 +26,7 @@ Feature: Bootstrap a Ubuntu 16.04 Salt SSH minion
     And I select the hostname of "proxy" from "proxies"
     And I check "manageWithSSH"
     And I click on "Bootstrap"
-    Then I wait until I see "Successfully bootstrapped host!" text
+    And I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "ubuntu1604_ssh_minion"
 
   # WORKAROUND bsc#1181847

--- a/testsuite/features/build_validation/init_clients/ubuntu1804_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ubuntu1804_minion.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 SUSE LLC
+# Copyright (c) 2020-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 #  1) bootstrap a new Ubuntu minion
@@ -9,6 +9,10 @@ Feature: Bootstrap a Ubuntu 18.04 Salt minion
 
   Scenario: Clean up sumaform leftovers on a Ubuntu 18.04 Salt minion
     When I perform a full salt minion cleanup on "ubuntu1804_minion"
+
+  Scenario: Create the bootstrap repository for a Ubuntu 18.04 Salt minion
+    Given I am authorized
+    When I create the bootstrap repository for "ubuntu1804_minion" on the server
 
   Scenario: Bootstrap a Ubuntu 18.04 minion
     Given I am authorized
@@ -21,7 +25,7 @@ Feature: Bootstrap a Ubuntu 18.04 Salt minion
     And I select "1-ubuntu1804_minion_key" from "activationKeys"
     And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
-    Then I wait until I see "Successfully bootstrapped host!" text
+    And I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "ubuntu1804_minion"
 
 @proxy

--- a/testsuite/features/build_validation/init_clients/ubuntu1804_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ubuntu1804_ssh_minion.feature
@@ -5,10 +5,14 @@
 #  2) subscribe it to a base channel for testing
 
 @ubuntu1804_ssh_minion
-Feature: Bootstrap a Ubuntu 18.04 Salt SSH Minion
+Feature: Bootstrap a Ubuntu 18.04 Salt SSH minion
 
-  Scenario: Clean up sumaform leftovers on a 18.04 Salt SSH Minion
+  Scenario: Clean up sumaform leftovers on a 18.04 Salt SSH minion
     When I perform a full salt minion cleanup on "ubuntu1804_ssh_minion"
+
+  Scenario: Create the bootstrap repository for a Ubuntu 18.04 Salt SSH minion
+    Given I am authorized
+    When I create the bootstrap repository for "ubuntu1804_ssh_minion" on the server
 
   Scenario: Bootstrap a SSH-managed Ubuntu 18.04 minion
     Given I am authorized
@@ -22,11 +26,11 @@ Feature: Bootstrap a Ubuntu 18.04 Salt SSH Minion
     And I select the hostname of "proxy" from "proxies"
     And I check "manageWithSSH"
     And I click on "Bootstrap"
-    Then I wait until I see "Successfully bootstrapped host!" text
+    And I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "ubuntu1804_ssh_minion"
 
   # WORKAROUND bsc#1181847
-  Scenario: Import the GPG keys for 18.04 Salt SSH Minion
+  Scenario: Import the GPG keys for 18.04 Salt SSH minion
     When I import the GPG keys for "ubuntu1804_ssh_minion"
 
   Scenario: Check events history for failures on SSH-managed Ubuntu 18.04 minion

--- a/testsuite/features/build_validation/retail/sle11sp4_kiwi_image_buildhost.feature
+++ b/testsuite/features/build_validation/retail/sle11sp4_kiwi_image_buildhost.feature
@@ -1,11 +1,11 @@
 # Copyright (c) 2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-Feature: Be able to bootstrap a SLES 11 SP4 salt build host via the GUI
+Feature: Bootstrap a SLES 11 SP4 Salt build host via the GUI
 
-  Scenario: Create the bootstrap repository for a SLES 11 SP4 salt build host
+  Scenario: Create the bootstrap repository for a SLES 11 SP4 build host
      Given I am authorized
-     When I create the "x86_64" bootstrap repository for "sle11sp4_buildhost" on the server
+     When I create the bootstrap repository for "sle11sp4_buildhost" on the server
 
   Scenario: Bootstrap a SLES 11 SP4 build host
      Given I am authorized

--- a/testsuite/features/build_validation/retail/sle12sp4_kiwi_image_buildhost.feature
+++ b/testsuite/features/build_validation/retail/sle12sp4_kiwi_image_buildhost.feature
@@ -1,11 +1,11 @@
 # Copyright (c) 2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-Feature: Be able to bootstrap a SLES 12 SP4 salt build host via the GUI
+Feature: Bootstrap a SLES 12 SP4 Salt build host via the GUI
 
-  Scenario: Create the bootstrap repository for a SLES 12 SP4 salt build host
+  Scenario: Create the bootstrap repository for a SLES 12 SP4 build host
      Given I am authorized
-     When I create the "x86_64" bootstrap repository for "sle12sp4_buildhost" on the server
+     When I create the bootstrap repository for "sle12sp4_buildhost" on the server
 
   Scenario: Bootstrap a SLES build host
      Given I am authorized

--- a/testsuite/features/build_validation/retail/sle15sp2_kiwi_image_buildhost.feature
+++ b/testsuite/features/build_validation/retail/sle15sp2_kiwi_image_buildhost.feature
@@ -1,11 +1,11 @@
 # Copyright (c) 2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-Feature: Be able to bootstrap a SLES 15 SP2 salt build host via the GUI
+Feature: Bootstrap a SLES 15 SP2 Salt build host via the GUI
 
   Scenario: Create the bootstrap repository for a SLES 15 SP2 build host
      Given I am authorized
-     When I create the "x86_64" bootstrap repository for "sle15sp2_buildhost" on the server
+     When I create the bootstrap repository for "sle15sp2_buildhost" on the server
 
   Scenario: Bootstrap a SLES 15 SP2 build host
      Given I am authorized

--- a/testsuite/features/init_clients/buildhost_bootstrap.feature
+++ b/testsuite/features/init_clients/buildhost_bootstrap.feature
@@ -4,11 +4,6 @@
 Feature: Bootstrap a Salt build host via the GUI
 
 @buildhost
-  Scenario: Create the bootstrap repository for a Salt client build host
-     Given I am authorized
-     When I create the "x86_64" bootstrap repository for "build_host" on the server
-
-@buildhost
   Scenario: Bootstrap a SLES build host
      Given I am authorized
      When I go to the bootstrapping page

--- a/testsuite/features/init_clients/sle_minion.feature
+++ b/testsuite/features/init_clients/sle_minion.feature
@@ -3,10 +3,6 @@
 
 Feature: Bootstrap a Salt minion via the GUI
 
-  Scenario: Create the bootstrap repository for a Salt client
-     Given I am authorized
-     And I create the "x86_64" bootstrap repository for "sle_minion" on the server
-
   Scenario: Bootstrap a SLES minion
      Given I am authorized
      When I go to the bootstrapping page

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -925,26 +925,18 @@ When(/^I wait until the package "(.*?)" has been cached on this "(.*?)"$/) do |p
   end
 end
 
-When(/^I create the "([^"]*)" bootstrap repository for "([^"]*)" on the server$/) do |arch, host|
-  node = get_target(host)
-  os_version, _os_family = get_os_version(node)
-  cmd = 'false'
-  if (os_version.include? '15') && (host.include? 'proxy')
-    proxy_version = '40'
-    if os_version.include? 'SP3'
-      proxy_version = '42'
-    elsif os_version.include? 'SP2'
-      proxy_version = '41'
-    end
-    cmd = "mgr-create-bootstrap-repo -c SUMA-#{proxy_version}-PROXY-#{arch}"
-  elsif (os_version.include? '12') || (os_version.include? '15')
-    cmd = "mgr-create-bootstrap-repo -c SLE-#{os_version}-#{arch}"
-  elsif os_version.include? '11'
-    sle11 = "#{os_version[0, 2]}-SP#{os_version[-1]}"
-    cmd = "mgr-create-bootstrap-repo -c SLE-#{sle11}-#{arch}"
-  end
-  puts 'Creating the boostrap repository on the server: ' + cmd
-  $server.run(cmd, false)
+When(/^I create the bootstrap repository for "([^"]*)" on the server$/) do |host|
+  base_channel = BASE_CHANNEL_BY_CLIENT[host]
+  channel = CHANNEL_TO_SYNC_BY_BASE_CHANNEL[base_channel]
+  parent_channel = PARENT_CHANNEL_TO_SYNC_BY_BASE_CHANNEL[base_channel]
+  cmd = if parent_channel.nil?
+          "mgr-create-bootstrap-repo --create #{channel} --with-custom-channels"
+        else
+          "mgr-create-bootstrap-repo --create #{channel} --with-parent-channel #{parent_channel} --with-custom-channels"
+        end
+  STDOUT.puts 'Creating the boostrap repository on the server:'
+  STDOUT.puts '  ' + cmd
+  $server.run(cmd)
 end
 
 When(/^I open avahi port on the proxy$/) do

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -205,6 +205,38 @@ LABEL_BY_BASE_CHANNEL = { 'SLE-Product-SUSE-Manager-Proxy-4.2-Pool' => 'sle-prod
                           'ubuntu-18.04-pool' => 'ubuntu-18.04-pool-amd64',
                           'ubuntu-20.04-pool' => 'ubuntu-20.04-pool-amd64' }.freeze
 
+CHANNEL_TO_SYNC_BY_BASE_CHANNEL = { 'SLE-Product-SUSE-Manager-Proxy-4.2-Pool' => 'SUMA-42-PROXY-x86_64',
+                                    'SLES11-SP3-Pool' => 'SLE-11-SP3-i586',
+                                    'SLES11-SP4-Pool' => 'SLE-11-SP4-x86_64',
+                                    'SLES12-SP4-Pool' => 'SLE-12-SP4-x86_64',
+                                    'SLES12-SP5-Pool' => 'SLE-12-SP5-x86_64',
+                                    'SLES15-Pool' => 'SLE-15-x86_64',
+                                    'SLES15-SP1-Pool' => 'SLE-15-SP1-x86_64',
+                                    'SLES15-SP2-Pool' => 'SLE-15-SP2-x86_64',
+                                    'SLES15-SP3-Pool' => 'SLE-15-SP3-x86_64',
+                                    'RHEL x86_64 Server 6' => 'RES6-x86_64',
+                                    'RHEL x86_64 Server 7' => 'RES7-x86_64',
+                                    'RHEL8-Pool for x86_64' => 'SLE-ES8-x86_64',
+                                    'ubuntu-16.04-pool' => 'ubuntu-16.04-amd64',
+                                    'ubuntu-18.04-pool' => 'ubuntu-18.04-amd64',
+                                    'ubuntu-20.04-pool' => 'ubuntu-18.04-amd64' }.freeze
+
+PARENT_CHANNEL_TO_SYNC_BY_BASE_CHANNEL = { 'SLE-Product-SUSE-Manager-Proxy-4.2-Pool' => 'sle-product-suse-manager-proxy-4.2-pool-x86_64',
+                                           'SLES11-SP3-Pool' => nil,
+                                           'SLES11-SP4-Pool' => nil,
+                                           'SLES12-SP4-Pool' => nil,
+                                           'SLES12-SP5-Pool' => nil,
+                                           'SLES15-Pool' => 'sle-product-sles15-pool-x86_64',
+                                           'SLES15-SP1-Pool' => 'sle-product-sles15-sp1-pool-x86_64',
+                                           'SLES15-SP2-Pool' => 'sle-product-sles15-sp2-pool-x86_64',
+                                           'SLES15-SP3-Pool' => 'sle-product-sles15-sp3-pool-x86_64',
+                                           'RHEL x86_64 Server 6' => 'rhel-x86_64-server-6',
+                                           'RHEL x86_64 Server 7' => 'rhel-x86_64-server-7',
+                                           'RHEL8-Pool for x86_64' => nil,
+                                           'ubuntu-16.04-pool' => nil,
+                                           'ubuntu-18.04-pool' => nil,
+                                           'ubuntu-20.04-pool' => nil }.freeze
+
 PKGARCH_BY_CLIENT = { 'proxy' => 'x86_64',
                       'sle_client' => 'x86_64',
                       'sle_minion' => 'x86_64',


### PR DESCRIPTION
@moio @juliogonzalez @mcalmer please review only the first commit (the short one, that removes existing stuff).

## What does this PR change?

This PR removes the creation of bootstrap repositories from normal CI test suite
* in most cases, we are not synchronizing the repositories used to boot,
   so it is not possible to create the corresponding bootstrap repositories
* it had every chance to fail, as it was not specifying the parent channels (failures were ignored)
* it was not called anyway from proxy, traditional client, SSH minion, CentOS, nor Ubuntu

This PR also adds the creation of bootstrap repositories to BV test suite
* in that test suite, we use Maintenance Incidents as custom channels;
   we must therefore make sure that the bootstrap repositories use these custom channels,
   using `--with-custom-channels` option.


## Links

Ports:
* 4.0: SUSE/spacewalk#14279
* 4.1: SUSE/spacewalk#14278


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
