### PR TITLE
Update github actions checkout

### DIFF
--- a/.github/workflows/add_pr_reviewer.yml
+++ b/.github/workflows/add_pr_reviewer.yml
@@ -8,9 +8,7 @@ jobs:
   add_pr_reviewer:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-      with:
-        fetch-depth: 1
+    - uses: actions/checkout@v2
     - uses: actions/setup-ruby@v1
     - name: "Check if there are test framework changes"
       id: review_step

--- a/.github/workflows/changelog_checker.yml
+++ b/.github/workflows/changelog_checker.yml
@@ -10,9 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v1
-      with:
-        fetch-depth: 1
+    - uses: actions/checkout@v2
     - uses: actions/setup-ruby@v1
     - name: Run a changelog checker
       run: |


### PR DESCRIPTION
## What does this PR change?

checkout v1 has a bug which makes it not finding the latest git
reference and fail.

updating to v2 should fix it.

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed

- [X] **DONE**

## Test coverage
- No tests

- [X] **DONE**

## Links

No issue was created.

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed




## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
