### PR TITLE
Testsuite - gpg key name for SLE11 corrected #14277

### DIFF
--- a/testsuite/features/support/client_stack.rb
+++ b/testsuite/features/support/client_stack.rb
@@ -76,6 +76,8 @@ def get_gpg_keys(node, target = $server)
   if os_family =~ /^sles/
     # HACK: SLE 15 uses SLE 12 GPG key
     os_version = 12 if os_version =~ /^15/
+    # SLE11 key doesn't contain service pack string
+    os_version = 11 if os_version =~ /^11/
     gpg_keys, _code = target.run("cd /srv/www/htdocs/pub/ && ls -1 sle#{os_version}*", false)
   elsif os_family =~ /^centos/
     gpg_keys, _code = target.run("cd /srv/www/htdocs/pub/ && ls -1 #{os_family}#{os_version}* res*", false)


### PR DESCRIPTION
## What does this PR change?

GPG key for SLE11 doesn't contain string with information about service pack version. 
This change prevents failure of bootstrap in case of SLE11SP4 systems in QAM testsuite.

## Links 

https://github.com/SUSE/spacewalk/issues/14194
Tracks https://github.com/SUSE/spacewalk/pull/14256

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
