### PR TITLE
enhance server group API with config channel and formula access methods

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/state/StateFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/state/StateFactory.java
@@ -18,7 +18,6 @@ import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.config.ConfigChannel;
 import com.redhat.rhn.domain.org.Org;
 import com.redhat.rhn.domain.server.MinionServer;
-
 import com.redhat.rhn.domain.server.ServerGroup;
 
 import org.apache.log4j.Logger;
@@ -245,5 +244,16 @@ public class StateFactory extends HibernateFactory {
             }
         }
         return usage;
+    }
+
+    /**
+     * List group ids where a given channel is assigned to
+     * @param channel the channel
+     * @return list of group ids
+     */
+    public static List<Long> listConfigChannelsSubscribedGroupIds(ConfigChannel channel) {
+        return getSession().getNamedQuery("StateRevision.findGroupsAssignedToChannel")
+                .setParameter("channelId", channel.getId())
+                .list();
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/state/StateRevision.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/state/StateRevision.hbm.xml
@@ -82,4 +82,15 @@
         where cc.org_id= :orgId and cc.id = :channelId
         and (srvrev.entity_id is not null or grprev.entity_id is not null or orgrev.entity_id is not null)
     </sql-query>
+
+    <sql-query name="StateRevision.findGroupsAssignedToChannel">
+        <return-scalar column="group_id" type="long"/>
+        select latest.group_id
+          from (
+                select max(gsr.state_revision_id) state_revision_id, gsr.group_id
+                  from suseServerGroupStateRevision gsr
+              group by gsr.group_id) latest
+          join susestaterevisionconfigchannel cc on latest.state_revision_id = cc.state_revision_id
+         where cc.config_channel_id = :channelId
+    </sql-query>
 </hibernate-mapping>

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/configchannel/ConfigChannelHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/configchannel/ConfigChannelHandler.java
@@ -14,6 +14,8 @@
  */
 package com.redhat.rhn.frontend.xmlrpc.configchannel;
 
+import static java.util.Optional.empty;
+
 import com.redhat.rhn.FaultException;
 import com.redhat.rhn.common.db.datasource.DataResult;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
@@ -65,8 +67,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import static java.util.Optional.empty;
 
 /**
  * ConfigHandler
@@ -158,7 +158,7 @@ public class ConfigChannelHandler extends BaseHandler {
             ConfigChannel cc = helper.create(user, ct);
             helper.update(cc, name, label, description);
             ConfigurationManager.getInstance().save(cc, empty());
-            cc  = (ConfigChannel) HibernateFactory.reload(cc);
+            cc  = HibernateFactory.reload(cc);
             String contents = "";
             if (data.containsKey(ConfigRevisionSerializer.CONTENTS)) {
                 try {
@@ -244,7 +244,7 @@ public class ConfigChannelHandler extends BaseHandler {
                 "Could not find configuration file with filePath=: " + filePath);
         }
 
-        return (ArrayList<ConfigRevision>) cm.lookupConfigRevisions(cf);
+        return cm.lookupConfigRevisions(cf);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/FormulaSerializer.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/FormulaSerializer.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.frontend.xmlrpc.serializer;
+
+
+import com.redhat.rhn.domain.formula.Formula;
+import com.redhat.rhn.frontend.xmlrpc.serializer.util.SerializerHelper;
+
+import java.io.IOException;
+import java.io.Writer;
+
+import redstone.xmlrpc.XmlRpcException;
+import redstone.xmlrpc.XmlRpcSerializer;
+
+/**
+*
+* FormulaSerializer
+*
+* @xmlrpc.doc
+*
+* #struct_begin("formula")
+*     #prop("string", "name")
+*     #prop("string", "description")
+*     #prop("string", "formula_group")
+* #struct_end()
+*/
+public class FormulaSerializer extends RhnXmlRpcCustomSerializer {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Class getSupportedClass() {
+        return Formula.class;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected void doSerialize(Object value, Writer output, XmlRpcSerializer serializer)
+        throws XmlRpcException, IOException {
+        Formula formula = (Formula) value;
+        SerializerHelper helper = new SerializerHelper(serializer);
+        helper.add("name", formula.getName());
+        helper.add("description", formula.getDescription());
+        helper.add("formula_group", formula.getGroup());
+
+        helper.writeTo(output);
+    }
+}

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/SerializerRegistry.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/SerializerRegistry.java
@@ -1,6 +1,6 @@
 /**
  * Copyright (c) 2009--2017 Red Hat, Inc.
- * Copyright (c) 2020 SUSE LLC
+ * Copyright (c) 2020--2021 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -68,6 +68,7 @@ public class SerializerRegistry {
         SERIALIZER_CLASSES.add(ShortSystemInfoSerializer.class);
         SERIALIZER_CLASSES.add(SystemGroupsDTOSerializer.class);
         SERIALIZER_CLASSES.add(FormulaDataSerializer.class);
+        SERIALIZER_CLASSES.add(FormulaSerializer.class);
         SERIALIZER_CLASSES.add(EmptySystemProfileSerializer.class);
         SERIALIZER_CLASSES.add(UserSerializer.class);
         SERIALIZER_CLASSES.add(KickstartTreeSerializer.class);

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/ServerGroupHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/ServerGroupHandlerTest.java
@@ -16,6 +16,7 @@ package com.redhat.rhn.frontend.xmlrpc.system.test;
 
 import com.redhat.rhn.FaultException;
 import com.redhat.rhn.domain.config.ConfigChannel;
+import com.redhat.rhn.domain.formula.Formula;
 import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.domain.server.ManagedServerGroup;
 import com.redhat.rhn.domain.server.Server;
@@ -451,5 +452,16 @@ public class ServerGroupHandlerTest extends BaseHandlerTestCase {
         assignedChannels1 = handler.listAssignedConfigChannels(admin, group1.getName());
         assertContains(assignedChannels1, cc2);
         assertFalse("Unexpected channel found", assignedChannels1.contains(cc1));
+    }
+
+    /*
+     * Just check that we do not crash
+     */
+    public void testListAssignedFormulas() throws Exception {
+        ManagedServerGroup group = ServerGroupTestUtils.createManaged(admin);
+
+        List<Formula> assignedFormulas = handler.listAssignedFormuals(admin, group.getName());
+
+        assertTrue("Unexpected assigned formulas found", assignedFormulas.isEmpty());
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/ServerGroupHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/ServerGroupHandlerTest.java
@@ -15,6 +15,7 @@
 package com.redhat.rhn.frontend.xmlrpc.system.test;
 
 import com.redhat.rhn.FaultException;
+import com.redhat.rhn.domain.config.ConfigChannel;
 import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.domain.server.ManagedServerGroup;
 import com.redhat.rhn.domain.server.Server;
@@ -24,6 +25,7 @@ import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.domain.user.UserFactory;
 import com.redhat.rhn.frontend.xmlrpc.ServerGroupAccessChangeException;
 import com.redhat.rhn.frontend.xmlrpc.ServerNotInGroupException;
+import com.redhat.rhn.frontend.xmlrpc.configchannel.ConfigChannelHandler;
 import com.redhat.rhn.frontend.xmlrpc.system.XmlRpcSystemHelper;
 import com.redhat.rhn.frontend.xmlrpc.systemgroup.ServerGroupHandler;
 import com.redhat.rhn.frontend.xmlrpc.test.BaseHandlerTestCase;
@@ -365,5 +367,89 @@ public class ServerGroupHandlerTest extends BaseHandlerTestCase {
         assertEquals(server.getId().toString(), list.get(0).toString());
     }
 
+    public void testSubscribeAndListAssignedConfigChannels() throws Exception {
+        ConfigChannelHandler ccHandler = new ConfigChannelHandler();
+        String ccLabel1 = "CC-LABEL-1-" + TestUtils.randomString();
+        String ccLabel2 = "CC-LABEL-2-" + TestUtils.randomString();
 
+        ConfigChannel cc1 = ccHandler.create(admin,
+                ccLabel1,
+                "CC NAME " + TestUtils.randomString(),
+                "CC DESCRIPTION " + TestUtils.randomString(),
+                "state");
+        ConfigChannel cc2 = ccHandler.create(admin,
+                ccLabel2,
+                "CC NAME " + TestUtils.randomString(),
+                "CC DESCRIPTION " + TestUtils.randomString(),
+                "state");
+
+        ManagedServerGroup group1 = ServerGroupTestUtils.createManaged(admin);
+        ManagedServerGroup group2 = ServerGroupTestUtils.createManaged(admin);
+
+        handler.subscribeConfigChannel(admin, group1.getName(), Arrays.asList(ccLabel1));
+        handler.subscribeConfigChannel(admin, group2.getName(), Arrays.asList(ccLabel2));
+        List<ConfigChannel> assignedChannels1 = handler.listAssignedConfigChannels(admin, group1.getName());
+        List<ConfigChannel> assignedChannels2 = handler.listAssignedConfigChannels(admin, group2.getName());
+
+        assertContains(assignedChannels1, cc1);
+        assertContains(assignedChannels2, cc2);
+    }
+
+    public void testSubscribeAndListAssignedConfigChannels2() throws Exception {
+        ConfigChannelHandler ccHandler = new ConfigChannelHandler();
+        String ccLabel1 = "CC-LABEL-1-" + TestUtils.randomString();
+        String ccLabel2 = "CC-LABEL-2-" + TestUtils.randomString();
+
+        ConfigChannel cc1 = ccHandler.create(admin,
+                ccLabel1,
+                "CC NAME " + TestUtils.randomString(),
+                "CC DESCRIPTION " + TestUtils.randomString(),
+                "state");
+        ConfigChannel cc2 = ccHandler.create(admin,
+                ccLabel2,
+                "CC NAME " + TestUtils.randomString(),
+                "CC DESCRIPTION " + TestUtils.randomString(),
+                "state");
+
+        ManagedServerGroup group1 = ServerGroupTestUtils.createManaged(admin);
+        ManagedServerGroup group2 = ServerGroupTestUtils.createManaged(admin);
+
+        handler.subscribeConfigChannel(admin, group1.getName(), Arrays.asList(ccLabel1, ccLabel2));
+        List<ConfigChannel> assignedChannels1 = handler.listAssignedConfigChannels(admin, group1.getName());
+        List<ConfigChannel> assignedChannels2 = handler.listAssignedConfigChannels(admin, group2.getName());
+
+        assertContains(assignedChannels1, cc1);
+        assertContains(assignedChannels1, cc2);
+        assertTrue("Unexpected assigned channels", assignedChannels2.isEmpty());
+    }
+
+    public void testUnsubscribeConfigChannels() throws Exception {
+        ConfigChannelHandler ccHandler = new ConfigChannelHandler();
+        String ccLabel1 = "CC-LABEL-1-" + TestUtils.randomString();
+        String ccLabel2 = "CC-LABEL-2-" + TestUtils.randomString();
+
+        ConfigChannel cc1 = ccHandler.create(admin,
+                ccLabel1,
+                "CC NAME " + TestUtils.randomString(),
+                "CC DESCRIPTION " + TestUtils.randomString(),
+                "state");
+        ConfigChannel cc2 = ccHandler.create(admin,
+                ccLabel2,
+                "CC NAME " + TestUtils.randomString(),
+                "CC DESCRIPTION " + TestUtils.randomString(),
+                "state");
+
+        ManagedServerGroup group1 = ServerGroupTestUtils.createManaged(admin);
+
+        handler.subscribeConfigChannel(admin, group1.getName(), Arrays.asList(ccLabel1, ccLabel2));
+        List<ConfigChannel> assignedChannels1 = handler.listAssignedConfigChannels(admin, group1.getName());
+
+        assertContains(assignedChannels1, cc1);
+        assertContains(assignedChannels1, cc2);
+
+        handler.unsubscribeConfigChannel(admin, group1.getName(), Arrays.asList(ccLabel1));
+        assignedChannels1 = handler.listAssignedConfigChannels(admin, group1.getName());
+        assertContains(assignedChannels1, cc2);
+        assertFalse("Unexpected channel found", assignedChannels1.contains(cc1));
+    }
 }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,6 @@
+- enhance config channel API with list assigned groups
+- enhance server group API with config channel and formula
+  access methods
 - Fix: populate docker-registries on inspection (bsc#1178179)
 - Raise length limit for kernel options (bsc#1182916)
 - optionally allow vendor change when patching

--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,4 @@
+- Add group_listconfigchannels and configchannel_listgroups
 - Handle SIGPIPE without user-visible Exception (bsc#1181124)
 - Fix spacecmd compat with Python 3
 

--- a/spacecmd/src/spacecmd/configchannel.py
+++ b/spacecmd/src/spacecmd/configchannel.py
@@ -100,6 +100,41 @@ def do_configchannel_listsystems(self, args):
 ####################
 
 
+def help_configchannel_listgroups(self):
+    print(_('configchannel_listgroups: List the groups subscribed to a'))
+    print(_('                           configuration channel'))
+    print(_('usage: configchannel_listgroups CHANNEL'))
+
+
+def complete_configchannel_listgroups(self, text, line, beg, end):
+    return tab_completer(self.do_configchannel_list('', True), text)
+
+
+def do_configchannel_listgroups(self, args):
+    if not self.check_api_version('25.0'):
+        logging.warning(_N("This version of the API doesn't support this method"))
+        return 1
+
+    arg_parser = get_argument_parser()
+    (args, _options) = parse_command_arguments(args, arg_parser)
+
+    if not args:
+        self.help_configchannel_listgroups()
+        return 1
+
+    channel = args[0]
+    groups = self.client.configchannel.listAssignedSystemGroups(self.session, channel)
+    groups = sorted([g.get('name') for g in groups])
+
+    if groups:
+        print('\n'.join(groups))
+        return 0
+    else:
+        return 1
+
+####################
+
+
 def help_configchannel_listfiles(self):
     print(_('configchannel_listfiles: List the files in a config channel'))
     print(_('usage: configchannel_listfiles CHANNEL ...'))

--- a/spacecmd/src/spacecmd/group.py
+++ b/spacecmd/src/spacecmd/group.py
@@ -481,3 +481,45 @@ def do_group_details(self, args, short=False):
             print('\n'.join(sorted(systems)))
 
     return 0
+
+####################
+
+def help_group_listconfigchannels(self):
+    print(_('group_listconfigchannels: List configuration channels assigned to a system group'))
+    print(_('usage: group_listconfigchannels GROUP'))
+
+def complete_group_listconfigchannels(self, text, line, beg, end):
+    return tab_completer(self.do_group_list('', True), text)
+
+def do_group_listconfigchannels(self, args):
+    if not self.check_api_version('25.0'):
+        logging.warning(_N("This version of the API doesn't support this method"))
+        return 1
+
+    arg_parser = get_argument_parser()
+
+    (args, _options) = parse_command_arguments(args, arg_parser)
+
+    if not args:
+        self.help_group_details()
+        return 1
+
+    add_separator = False
+
+    for group in args:
+        try:
+            channels = self.client.systemgroup.listAssignedConfigChannels(self.session, group)
+        except xmlrpclib.Fault:
+            logging.warning(_N('The group "%s" is invalid') % group)
+            return 1
+        for details in channels:
+            if add_separator:
+                print(self.SEPARATOR)
+            add_separator = True
+
+            print(_('Label:       %s') % details.get('label'))
+            print(_('Name:        %s') % details.get('name'))
+            print(_('Description: %s') % details.get('description'))
+            print(_('Type:        %s') % details.get('configChannelType', {}).get('label'))
+
+    return 0


### PR DESCRIPTION
## What does this PR change?

Add missing API functions for handling Config Channels @ System Groups

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- API doc added

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/13710

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
