### PR TITLE
delete scenario which delete product package from package state

### DIFF
--- a/testsuite/features/init_clients/sle_ssh_minion.feature
+++ b/testsuite/features/init_clients/sle_ssh_minion.feature
@@ -18,26 +18,6 @@ Feature: Bootstrap a Salt host managed via salt-ssh
     And I wait until I see the name of "ssh_minion", refreshing the page
     And I wait until onboarding is completed for "ssh_minion"
 
-# HACK
-# Package 'sle-manager-tools-release' is automatically installed during bootstrap and
-# stays installed after removal of channel containing it. So it is not possible to update it.
-# Package needs to be removed from highstate to avoid failure when updating it.
-@skip_service_pack_migration
-@ssh_minion
-  Scenario: Remove sle-manager-tools-release from state after bootstrap
-    Given I am on the Systems overview page of this "ssh_minion"
-    When I wait until I see "States" text
-    And I follow "States" in the content area
-    And I wait until I see "Highstate" text
-    And I follow "Packages" in the content area
-    Then I should see a "Package States" text
-    When I follow "Search" in the content area
-    And I wait until button "Search" becomes enabled
-    And I enter "sle-manager-tools-release" as the filtered package states name
-    And I click on "Search" in element "search-row"
-    And I wait until I see "sle-manager-tools-release" text
-    And I remove package "sle-manager-tools-release" from highstate
-
 @proxy
 @ssh_minion
   Scenario: Check connection from SSH minion to proxy


### PR DESCRIPTION
## What does this PR change?

This scenario should not be needed since round about a year now.
Adding the products to the package state was dropped in https://github.com/uyuni-project/uyuni/pull/2158

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/14287

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
