### PR TITLE
BV: refactor waits for reposync

### DIFF
--- a/testsuite/features/build_validation/reposync/srv_wait_for_product_reposync.feature
+++ b/testsuite/features/build_validation/reposync/srv_wait_for_product_reposync.feature
@@ -1,0 +1,7 @@
+# Copyright (c) 2021 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+Feature: Wait for reposync activity to finish after adding products
+
+  Scenario: Wait for running reposyncs to finish after adding products
+    When I wait until all spacewalk-repo-sync finished

--- a/testsuite/features/reposync/srv_wait_for_reposync.feature
+++ b/testsuite/features/reposync/srv_wait_for_reposync.feature
@@ -1,9 +1,8 @@
 # Copyright (c) 2019-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-Feature: Wait for reposync activity to finish
+Feature: Wait for reposync activity to finish in CI context
 
-@continuous_integration
   Scenario: Delete scheduled reposyncs
     Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Admin > Task Schedules"
@@ -12,10 +11,5 @@ Feature: Wait for reposync activity to finish
     And I click on "Update Schedule"
     And I click on "Delete Schedule"
 
-@continuous_integration
-  Scenario: Kill running reposyncs
+  Scenario: Kill running reposyncs or wait for them to finish
     When I kill all running spacewalk-repo-sync, excepted the ones needed to bootstrap
-
-@build_validation
-  Scenario: Wait for running reposyncs to finish
-    When I wait until all spacewalk-repo-sync finished

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -37,7 +37,7 @@ if File.exist?(custom_repos_path)
   $custom_repositories = JSON.parse(custom_repos_file)
   $build_validation = true
   # HACK
-  # QAM and Build Validations will require longer timeouts due to the low performance of our VMs
+  # Build Validations will require longer timeouts due to the low performance of our VMs
   # if we ever improve this fact, we can reduce these timeouts.
   Capybara.default_max_wait_time = 30
   DEFAULT_TIMEOUT = 1800
@@ -284,14 +284,6 @@ end
 
 Before('@sle15sp3_client') do
   skip_this_scenario unless $sle15sp3_client
-end
-
-Before('@build_validation') do
-  skip_this_scenario unless $build_validation
-end
-
-Before('@continuous_integration') do
-  skip_this_scenario if $build_validation
 end
 
 Before('@skip_for_ubuntu') do |scenario|

--- a/testsuite/run_sets/build_validation_reposync.yml
+++ b/testsuite/run_sets/build_validation_reposync.yml
@@ -9,7 +9,7 @@
 ## Channels and Product synchronization features BEGIN ###
 
 - features/build_validation/reposync/srv_sync_all_products.feature
-- features/reposync/srv_wait_for_reposync.feature
+- features/build_validation/reposync/srv_wait_for_product_reposync.feature
 
 ## Channels and Product synchronization features END ###
 


### PR DESCRIPTION
## What does this PR change?

This PR simplifies the waiting for reposync, by dropping the @build_validation and @continuous_integration tags.


## Links

Ports:
* 4.0: SUSE/spacewalk#14295
* 4.1: SUSE/spacewalk#14296


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
