### PR TITLE
Bootstrap repositories must be generated sequentially

### DIFF
--- a/testsuite/features/build_validation/create_bootstrap_repositories/srv_create_bootstrap_repositories.feature
+++ b/testsuite/features/build_validation/create_bootstrap_repositories/srv_create_bootstrap_repositories.feature
@@ -1,0 +1,136 @@
+# Copyright (c) 2021 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+Feature: Create bootstrap repositories
+
+@proxy
+  Scenario: Create the bootstrap repository for the SUSE Manager proxy
+    When I create the bootstrap repository for "proxy" on the server
+
+@sle11sp4_client
+  Scenario: Create the bootstrap repository for a SLES 11 SP4 traditional client
+    When I create the bootstrap repository for "sle11sp4_client" on the server
+
+@sle11sp4_minion
+  Scenario: Create the bootstrap repository for a SLES 11 SP4 minion
+    When I create the bootstrap repository for "sle11sp4_minion" on the server
+
+@sle11sp4_ssh_minion
+  Scenario: Create the bootstrap repository for a SLES 11 SP4 Salt SSH minion
+    When I create the bootstrap repository for "sle11sp4_ssh_minion" on the server
+
+@sle12sp4_client
+  Scenario: Create the bootstrap repository for a SLES 12 SP4 traditional client
+    When I create the bootstrap repository for "sles12sp4_client" on the server
+
+@sle12sp4_minion
+  Scenario: Create the bootstrap repository for a SLES 12 SP4 minion
+    When I create the bootstrap repository for "sle12sp4_minion" on the server
+
+@sle12sp4_ssh_minion
+  Scenario: Create the bootstrap repository for a SLES 12 SP4 Salt SSH minion
+    When I create the bootstrap repository for "sle12sp4_minion" on the server
+
+@sle15_client
+  Scenario: Create the bootstrap repository for a SLES 15 traditional client
+    When I create the bootstrap repository for "sle15_client" on the server
+
+@sle15_minion
+  Scenario: Create the bootstrap repository for a SLES 15 minion
+    When I create the bootstrap repository for "sle15_minion" on the server
+
+@sle15_ssh_minion
+  Scenario: Create the bootstrap repository for a SLES 15 Salt SSH minion
+    When I create the bootstrap repository for "sle15_ssh_minion" on the server
+
+@sle15sp1_client
+  Scenario: Create the bootstrap repository for a SLES 15 SP1 traditional client
+    When I create the bootstrap repository for "sle15sp1_client" on the server
+
+@sle15sp1_minion
+  Scenario: Create the bootstrap repository for a SLES 15 SP1 minion
+    When I create the bootstrap repository for "sle15sp1_minion" on the server
+
+@sle15sp1_ssh_minion
+  Scenario: Create the bootstrap repository for a SLES 15 SP1 Salt SSH minion
+    When I create the bootstrap repository for "sle15sp1_ssh_minion" on the server
+
+@sle15sp2_client
+  Scenario: Create the bootstrap repository for a SLES 15 SP2 traditional client
+    When I create the bootstrap repository for "sle15sp2_client" on the server
+
+@sle15sp2_minion
+  Scenario: Create the bootstrap repository for a SLES 15 SP2 minion
+    When I create the bootstrap repository for "sle15sp2_minion" on the server
+
+@sle15sp2_ssh_minion
+  Scenario: Create the bootstrap repository for a SLES 15 SP2 Salt SSH minion
+    When I create the bootstrap repository for "sle15sp2_ssh_minion" on the server
+
+@sle15sp3_client
+  Scenario: Create the bootstrap repository for a SLES 15 SP3 traditional client
+    When I create the bootstrap repository for "sle15sp3_client" on the server
+
+@sle15sp3_minion
+  Scenario: Create the bootstrap repository for a SLES 15 SP3 minion
+    When I create the bootstrap repository for "sle15sp3_minion" on the server
+
+@sle15sp3_ssh_minion
+  Scenario: Create the bootstrap repository for a SLES 15 SP3 Salt SSH minion
+    When I create the bootstrap repository for "sle15sp3_ssh_minion" on the server
+
+@ceos6_client
+  Scenario: Create the bootstrap repository for a CentOS 6 traditional client
+    When I create the bootstrap repository for "ceos6_client" on the server
+
+@ceos6_minion
+  Scenario: Create the bootstrap repository for a CentOS 6 Salt minion
+    When I create the bootstrap repository for "ceos6_minion" on the server
+
+@ceos6_ssh_minion
+  Scenario: Create the bootstrap repository for a CentOS 6 Salt SSH minion
+    When I create the bootstrap repository for "ceos6_ssh_minion" on the server
+
+@ceos7_client
+  Scenario: Create the bootstrap repository for a CentOS 7 traditional client
+    When I create the bootstrap repository for "ceos7_client" on the server
+
+@ceos7_minion
+  Scenario: Create the bootstrap repository for a CentOS 7 Salt minion
+    When I create the bootstrap repository for "ceos7_minion" on the server
+
+@ceos7_ssh_minion
+  Scenario: Create the bootstrap repository for a CentOS 7 Salt SSH minion
+    When I create the bootstrap repository for "ceos7_ssh_minion" on the server
+
+@ceos8_minion
+  Scenario: Create the bootstrap repository for a CentOS 8 Salt minion
+    When I create the bootstrap repository for "ceos8_minion" on the server
+
+@ceos8_ssh_minion
+  Scenario: Create the bootstrap repository for a CentOS 8 Salt SSH minion
+    When I create the bootstrap repository for "ceos8_ssh_minion" on the server
+
+@ubuntu1604_minion
+  Scenario: Create the bootstrap repository for a Ubuntu 16.04 Salt minion
+    When I create the bootstrap repository for "ubuntu1604_minion" on the server
+
+@ubuntu1604_ssh_minion
+  Scenario: Create the bootstrap repository for a Ubuntu 16.04 Salt SSH minion
+    When I create the bootstrap repository for "ubuntu1604_ssh_minion" on the server
+
+@ubuntu1804_minion
+  Scenario: Create the bootstrap repository for a Ubuntu 18.04 Salt minion
+    When I create the bootstrap repository for "ubuntu1804_minion" on the server
+
+@ubuntu1804_ssh_minion
+  Scenario: Create the bootstrap repository for a Ubuntu 18.04 Salt SSH minion
+    When I create the bootstrap repository for "ubuntu1804_ssh_minion" on the server
+
+@ubuntu2004_minion
+  Scenario: Create the bootstrap repository for a Ubuntu 20.04 minion
+    When I create the bootstrap repository for "ubuntu2004_minion" on the server
+
+@ubuntu2004_ssh_minion
+  Scenario: Create the bootstrap repository for a Ubuntu 20.04 Salt SSH minion
+    When I create the bootstrap repository for "ubuntu2004_ssh_minion" on the server

--- a/testsuite/features/build_validation/init_clients/ceos6_client.feature
+++ b/testsuite/features/build_validation/init_clients/ceos6_client.feature
@@ -7,10 +7,6 @@ Feature: Bootstrap a CentOS 6 traditional client
   Scenario: Clean up sumaform leftovers on a CentOS 6 traditional client
     When I perform a full salt minion cleanup on "ceos6_client"
 
-  Scenario: Create the bootstrap repository for a CentOS 6 traditional client
-    Given I am authorized
-    When I create the bootstrap repository for "ceos6_client" on the server
-
   Scenario: Prepare a CentOS 6 traditional client
     When I enable the repositories "centos_base_backup centos_updates_backup tools_pool_repo" on this "ceos6_client" without error control
     And I run "/usr/bin/update-ca-trust force-enable" on "ceos6_client"

--- a/testsuite/features/build_validation/init_clients/ceos6_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ceos6_minion.feature
@@ -10,10 +10,6 @@ Feature: Bootstrap a CentOS 6 Salt minion
   Scenario: Clean up sumaform leftovers on a CentOS 6 Salt minion
     When I perform a full salt minion cleanup on "ceos6_minion"
 
-  Scenario: Create the bootstrap repository for a CentOS 6 Salt minion
-    Given I am authorized
-    When I create the bootstrap repository for "ceos6_minion" on the server
-
   Scenario: Bootstrap a CentOS 6 Salt minion
     Given I am authorized
     When I go to the bootstrapping page

--- a/testsuite/features/build_validation/init_clients/ceos6_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ceos6_ssh_minion.feature
@@ -10,10 +10,6 @@ Feature: Bootstrap a CentOS 6 Salt SSH minion
   Scenario: Clean up sumaform leftovers on a CentOS 6 Salt SSH minion
     When I perform a full salt minion cleanup on "ceos6_ssh_minion"
 
-  Scenario: Create the bootstrap repository for a CentOS 6 Salt SSH minion 
-    Given I am authorized
-    When I create the bootstrap repository for "ceos6_ssh_minion" on the server
-
   Scenario: Bootstrap a CentOS 6 Salt SSH minion
     Given I am authorized
     When I go to the bootstrapping page

--- a/testsuite/features/build_validation/init_clients/ceos7_client.feature
+++ b/testsuite/features/build_validation/init_clients/ceos7_client.feature
@@ -7,10 +7,6 @@ Feature: Bootstrap a CentOS 7 traditional client
   Scenario: Clean up sumaform leftovers on a CentOS 7 traditional client
     When I perform a full salt minion cleanup on "ceos7_client"
 
-  Scenario: Create the bootstrap repository for a CentOS 7 traditional client
-    Given I am authorized
-    When I create the bootstrap repository for "ceos7_client" on the server
-
   Scenario: Prepare a CentOS 7 traditional client
     When I enable repository "CentOS-Base tools_pool_repo" on this "ceos7_client" without error control
     And I bootstrap traditional client "ceos7_client" using bootstrap script with activation key "1-ceos7_client_key" from the proxy

--- a/testsuite/features/build_validation/init_clients/ceos7_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ceos7_minion.feature
@@ -10,10 +10,6 @@ Feature: Bootstrap a CentOS 7 Salt minion
   Scenario: Clean up sumaform leftovers on a  CentOS 7 Salt minion
     When I perform a full salt minion cleanup on "ceos7_minion"
 
-  Scenario: Create the bootstrap repository for a CentOS 7 Salt minion
-    Given I am authorized
-    When I create the bootstrap repository for "ceos7_minion" on the server
-
   Scenario: Bootstrap a CentOS 7 Salt minion
     Given I am authorized
     When I go to the bootstrapping page

--- a/testsuite/features/build_validation/init_clients/ceos7_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ceos7_ssh_minion.feature
@@ -10,10 +10,6 @@ Feature: Bootstrap a CentOS 7 Salt SSH minion
   Scenario: Clean up sumaform leftovers on a CentOS 7 Salt SSH minion
     When I perform a full salt minion cleanup on "ceos7_ssh_minion"
 
-  Scenario: Create the bootstrap repository for a CentOS 7 Salt SSH minion 
-    Given I am authorized
-    When I create the bootstrap repository for "ceos7_ssh_minion" on the server
-
   Scenario: Bootstrap a CentOS 7 Salt SSH minion
     Given I am authorized
     When I go to the bootstrapping page

--- a/testsuite/features/build_validation/init_clients/ceos8_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ceos8_minion.feature
@@ -10,10 +10,6 @@ Feature: Bootstrap a CentOS 8 Salt minion
   Scenario: Clean up sumaform leftovers on a CentOS 8 Salt minion
     When I perform a full salt minion cleanup on "ceos8_minion"
 
-  Scenario: Create the bootstrap repository for a CentOS 8 Salt minion
-    Given I am authorized
-    When I create the bootstrap repository for "ceos8_minion" on the server
-
   Scenario: Bootstrap a CentOS 8 Salt minion
     Given I am authorized
     When I go to the bootstrapping page

--- a/testsuite/features/build_validation/init_clients/ceos8_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ceos8_ssh_minion.feature
@@ -10,10 +10,6 @@ Feature: Bootstrap a CentOS 8 Salt SSH minion
   Scenario: Clean up sumaform leftovers on a CentOS 8 Salt SSH minion
     When I perform a full salt minion cleanup on "ceos8_ssh_minion"
 
-  Scenario: Create the bootstrap repository for a CentOS 8 Salt SSH minion
-    Given I am authorized
-    When I create the bootstrap repository for "ceos8_ssh_minion" on the server
-
   Scenario: Bootstrap a CentOS 8 Salt SSH minion
     Given I am authorized
     When I go to the bootstrapping page

--- a/testsuite/features/build_validation/init_clients/disabled/ubuntu2004_minion.feature
+++ b/testsuite/features/build_validation/init_clients/disabled/ubuntu2004_minion.feature
@@ -10,10 +10,6 @@ Feature: Bootstrap a Ubuntu 20.04 Salt minion
   Scenario: Clean up sumaform leftovers on a Ubuntu 20.04 minion
     When I perform a full salt minion cleanup on "ubuntu2004_minion"
 
-  Scenario: Create the bootstrap repository for a Ubuntu 20.04 minion
-    Given I am authorized
-    When I create the bootstrap repository for "ubuntu2004_minion" on the server
-
   Scenario: Bootstrap a Ubuntu 20.04 minion
     Given I am authorized
     When I go to the bootstrapping page

--- a/testsuite/features/build_validation/init_clients/disabled/ubuntu2004_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/disabled/ubuntu2004_ssh_minion.feature
@@ -10,10 +10,6 @@ Feature: Bootstrap a Ubuntu 20.04 Salt SSH minion
   Scenario: Clean up sumaform leftovers on a Ubuntu 20.04 Salt SSH minion
     When I perform a full salt minion cleanup on "ubuntu2004_ssh_minion"
 
-  Scenario: Create the bootstrap repository for a Ubuntu 20.04 Salt SSH minion
-    Given I am authorized
-    When I create the bootstrap repository for "ubuntu2004_ssh_minion" on the server
-
   Scenario: Bootstrap a SSH-managed Ubuntu 20.04 minion
     Given I am authorized
     When I go to the bootstrapping page

--- a/testsuite/features/build_validation/init_clients/proxy.feature
+++ b/testsuite/features/build_validation/init_clients/proxy.feature
@@ -16,10 +16,6 @@ Feature: Setup SUSE Manager proxy
     And I set correct product for "proxy"
     # End of WORKAROUND
 
-  Scenario: Create the bootstrap repository for the SUSE Manager proxy
-    Given I am authorized
-    When I create the bootstrap repository for "proxy" on the server
-
   Scenario: Bootstrap the proxy as a Salt minion
     Given I am authorized
     When I go to the bootstrapping page

--- a/testsuite/features/build_validation/init_clients/sle11sp4_client.feature
+++ b/testsuite/features/build_validation/init_clients/sle11sp4_client.feature
@@ -7,10 +7,6 @@ Feature: Bootstrap a SLES 11 SP4 traditional client
   Scenario: Clean up sumaform leftovers on a SLES 11 SP4 traditional client
     When I perform a full salt minion cleanup on "sle11sp4_client"
 
-  Scenario: Create the bootstrap repository for a SLES 11 SP4 traditional client
-    Given I am authorized
-    When I create the bootstrap repository for "sle11sp4_client" on the server
-
   Scenario: Register a SLES 11 SP4 traditional client
     When I bootstrap traditional client "sle11sp4_client" using bootstrap script with activation key "1-sle11sp4_client_key" from the proxy
     And I install package "spacewalk-client-setup mgr-cfg-actions" on this "sle11sp4_client"

--- a/testsuite/features/build_validation/init_clients/sle11sp4_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle11sp4_minion.feature
@@ -7,10 +7,6 @@ Feature: Bootstrap a SLES 11 SP4 Salt minion
   Scenario: Clean up sumaform leftovers on a SLES 11 SP4 Salt minion
     When I perform a full salt minion cleanup on "sle11sp4_minion"
 
-  Scenario: Create the bootstrap repository for a SLES 11 SP4 minion
-    Given I am authorized
-    When I create the bootstrap repository for "sle11sp4_minion" on the server
-
   Scenario: Bootstrap a SLES 11 SP4 minion
     Given I am authorized
     When I go to the bootstrapping page

--- a/testsuite/features/build_validation/init_clients/sle11sp4_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle11sp4_ssh_minion.feature
@@ -7,10 +7,6 @@ Feature: Bootstrap a SLES 11 SP4 Salt SSH minion
   Scenario: Clean up sumaform leftovers on a SLES 11 SP4 Salt SSH minion
     When I perform a full salt minion cleanup on "sle11sp4_ssh_minion"
 
-  Scenario: Create the bootstrap repository for a SLES 11 SP4 Salt SSH minion
-    Given I am authorized
-    When I create the bootstrap repository for "sle11sp4_ssh_minion" on the server
-
   Scenario: Bootstrap a SLES 11 SP4 system managed via salt-ssh
     Given I am authorized
     When I go to the bootstrapping page

--- a/testsuite/features/build_validation/init_clients/sle12sp4_client.feature
+++ b/testsuite/features/build_validation/init_clients/sle12sp4_client.feature
@@ -7,10 +7,6 @@ Feature: Bootstrap a SLES 12 SP4 traditional client
   Scenario: Clean up sumaform leftovers on a SLES 12 SP4 traditional client
     When I perform a full salt minion cleanup on "sle12sp4_client"
 
-  Scenario: Create the bootstrap repository for a SLES 12 SP4 traditional client
-    Given I am authorized
-    When I create the bootstrap repository for "sles12sp4_client" on the server
-
   Scenario: Register a SLES 12 SP4 traditional client
     When I bootstrap traditional client "sle12sp4_client" using bootstrap script with activation key "1-sle12sp4_client_key" from the proxy
     And I install package "spacewalk-client-setup mgr-cfg-actions" on this "sle12sp4_client"

--- a/testsuite/features/build_validation/init_clients/sle12sp4_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle12sp4_minion.feature
@@ -7,10 +7,6 @@ Feature: Bootstrap a SLES 12 SP4 Salt minion
   Scenario: Clean up sumaform leftovers on a SLES 12 SP4 Salt minion
     When I perform a full salt minion cleanup on "sle12sp4_minion"
 
-  Scenario: Create the bootstrap repository for a SLES 12 SP4 minion
-    Given I am authorized
-    When I create the bootstrap repository for "sle12sp4_minion" on the server
-
   Scenario: Bootstrap a SLES 12 SP4 minion
     Given I am authorized
     When I go to the bootstrapping page

--- a/testsuite/features/build_validation/init_clients/sle12sp4_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle12sp4_ssh_minion.feature
@@ -7,10 +7,6 @@ Feature: Bootstrap a SLES 12 SP4 Salt SSH minion
   Scenario: Clean up sumaform leftovers on a SLES 12 SP4 Salt SSH minion
     When I perform a full salt minion cleanup on "sle12sp4_ssh_minion"
 
-  Scenario: Create the bootstrap repository for a SLES 12 SP4 Salt SSH minion
-    Given I am authorized
-    When I create the bootstrap repository for "sle12sp4_minion" on the server
-
   Scenario: Bootstrap a SLES 12 SP4 system managed via salt-ssh
     Given I am authorized
     When I go to the bootstrapping page

--- a/testsuite/features/build_validation/init_clients/sle15_client.feature
+++ b/testsuite/features/build_validation/init_clients/sle15_client.feature
@@ -7,10 +7,6 @@ Feature: Bootstrap a SLES 15 traditional client
   Scenario: Clean up sumaform leftovers on a SLES 15 traditional client
     When I perform a full salt minion cleanup on "sle15_client"
 
-  Scenario: Create the bootstrap repository for a SLES 15 traditional client
-    Given I am authorized
-    When I create the bootstrap repository for "sle15_client" on the server
-
   Scenario: Register a SLES 15 traditional client
     When I bootstrap traditional client "sle15_client" using bootstrap script with activation key "1-sle15_client_key" from the proxy
     And I install package "spacewalk-client-setup mgr-cfg-actions" on this "sle15_client"

--- a/testsuite/features/build_validation/init_clients/sle15_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15_minion.feature
@@ -7,10 +7,6 @@ Feature: Bootstrap a SLES 15 Salt minion
   Scenario: Clean up sumaform leftovers on a SLES 15 Salt minion
     When I perform a full salt minion cleanup on "sle15_minion"
 
-  Scenario: Create the bootstrap repository for a SLES 15 minion
-    Given I am authorized
-    When I create the bootstrap repository for "sle15_minion" on the server
-
   Scenario: Bootstrap a SLES 15 minion
     Given I am authorized
     When I go to the bootstrapping page

--- a/testsuite/features/build_validation/init_clients/sle15_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15_ssh_minion.feature
@@ -7,10 +7,6 @@ Feature: Bootstrap a SLES 15 Salt SSH minion
   Scenario: Clean up sumaform leftovers on a SLES 15 Salt SSH minion
     When I perform a full salt minion cleanup on "sle15_ssh_minion"
 
-  Scenario: Create the bootstrap repository for a SLES 15 Salt SSH minion
-    Given I am authorized
-    When I create the bootstrap repository for "sle15_ssh_minion" on the server
-
   Scenario: Bootstrap a SLES 15 system managed via salt-ssh
     Given I am authorized
     When I go to the bootstrapping page

--- a/testsuite/features/build_validation/init_clients/sle15sp1_client.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp1_client.feature
@@ -7,10 +7,6 @@ Feature: Bootstrap a SLES 15 SP1 traditional client
   Scenario: Clean up sumaform leftovers on a SLES 15 SP1 traditional client
     When I perform a full salt minion cleanup on "sle15sp1_client"
 
-  Scenario: Create the bootstrap repository for a SLES 15 SP1 traditional client
-    Given I am authorized
-    When I create the bootstrap repository for "sle15sp1_client" on the server
-
   Scenario: Register a SLES 15 SP1 traditional client
     When I bootstrap traditional client "sle15sp1_client" using bootstrap script with activation key "1-sle15sp1_client_key" from the proxy
     And I install package "spacewalk-client-setup mgr-cfg-actions" on this "sle15sp1_client"

--- a/testsuite/features/build_validation/init_clients/sle15sp1_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp1_minion.feature
@@ -7,10 +7,6 @@ Feature: Bootstrap a SLES 15 SP1 Salt minion
   Scenario: Clean up sumaform leftovers on a SLES 15 SP1 Salt minion
     When I perform a full salt minion cleanup on "sle15sp1_minion"
 
-  Scenario: Create the bootstrap repository for a SLES 15 SP1 minion
-    Given I am authorized
-    When I create the bootstrap repository for "sle15sp1_minion" on the server
-
   Scenario: Bootstrap a SLES 15 SP1 minion
     Given I am authorized
     When I go to the bootstrapping page

--- a/testsuite/features/build_validation/init_clients/sle15sp1_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp1_ssh_minion.feature
@@ -7,10 +7,6 @@ Feature: Bootstrap a SLES 15 SP1 Salt SSH minion
   Scenario: Clean up sumaform leftovers on a SLES 15 SP1 Salt SSH minion
     When I perform a full salt minion cleanup on "sle15sp1_ssh_minion"
 
-  Scenario: Create the bootstrap repository for a SLES 15 SP1 Salt SSH minion
-    Given I am authorized
-    When I create the bootstrap repository for "sle15sp1_ssh_minion" on the server
-
   Scenario: Bootstrap a SLES 15 SP1 system managed via salt-ssh
     Given I am authorized
     When I go to the bootstrapping page

--- a/testsuite/features/build_validation/init_clients/sle15sp2_client.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp2_client.feature
@@ -7,10 +7,6 @@ Feature: Bootstrap a SLES 15 SP2 traditional client
   Scenario: Clean up sumaform leftovers on a SLES 15 SP2 traditional client
     When I perform a full salt minion cleanup on "sle15sp2_client"
 
-  Scenario: Create the bootstrap repository for a SLES 15 SP2 traditional client
-    Given I am authorized
-    When I create the bootstrap repository for "sle15sp2_client" on the server
-
   Scenario: Register a SLES 15 SP2 traditional client
     When I bootstrap traditional client "sle15sp2_client" using bootstrap script with activation key "1-sle15sp2_client_key" from the proxy
     And I install package "spacewalk-client-setup mgr-cfg-actions" on this "sle15sp2_client"

--- a/testsuite/features/build_validation/init_clients/sle15sp2_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp2_minion.feature
@@ -7,10 +7,6 @@ Feature: Bootstrap a SLES 15 SP2 Salt minion
   Scenario: Clean up sumaform leftovers on a SLES 15 SP2 Salt minion
     When I perform a full salt minion cleanup on "sle15sp2_minion"
 
-  Scenario: Create the bootstrap repository for a SLES 15 SP2 minion
-    Given I am authorized
-    When I create the bootstrap repository for "sle15sp2_minion" on the server
-
   Scenario: Bootstrap a SLES 15 SP2 minion
     Given I am authorized
     When I go to the bootstrapping page

--- a/testsuite/features/build_validation/init_clients/sle15sp2_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp2_ssh_minion.feature
@@ -7,10 +7,6 @@ Feature: Bootstrap a SLES 15 SP2 Salt SSH minion
   Scenario: Clean up sumaform leftovers on a SLES 15 SP2 Salt SSH minion
     When I perform a full salt minion cleanup on "sle15sp2_ssh_minion"
 
-  Scenario: Create the bootstrap repository for a SLES 15 SP2 Salt SSH minion
-    Given I am authorized
-    When I create the bootstrap repository for "sle15sp2_ssh_minion" on the server
-
   Scenario: Bootstrap a SLES 15 SP2 system managed via salt-ssh
     Given I am authorized
     When I go to the bootstrapping page

--- a/testsuite/features/build_validation/init_clients/sle15sp3_client.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp3_client.feature
@@ -7,10 +7,6 @@ Feature: Bootstrap a SLES 15 SP3 traditional client
   Scenario: Clean up sumaform leftovers on a SLES 15 SP3 traditional client
     When I perform a full salt minion cleanup on "sle15sp3_client"
 
-  Scenario: Create the bootstrap repository for a SLES 15 SP3 traditional client
-    Given I am authorized
-    When I create the bootstrap repository for "sle15sp3_client" on the server
-
   Scenario: Register a SLES 15 SP3 traditional client
     When I bootstrap traditional client "sle15sp3_client" using bootstrap script with activation key "1-sle15sp3_client_key" from the proxy
     And I install package "spacewalk-client-setup mgr-cfg-actions" on this "sle15sp3_client"

--- a/testsuite/features/build_validation/init_clients/sle15sp3_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp3_minion.feature
@@ -7,10 +7,6 @@ Feature: Bootstrap a SLES 15 SP3 Salt minion
   Scenario: Clean up sumaform leftovers on a SLES 15 SP3 Salt minion
     When I perform a full salt minion cleanup on "sle15sp3_minion"
 
-  Scenario: Create the bootstrap repository for a SLES 15 SP3 minion
-    Given I am authorized
-    When I create the bootstrap repository for "sle15sp3_minion" on the server
-
   Scenario: Bootstrap a SLES 15 SP3 minion
     Given I am authorized
     When I go to the bootstrapping page

--- a/testsuite/features/build_validation/init_clients/sle15sp3_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp3_ssh_minion.feature
@@ -7,10 +7,6 @@ Feature: Bootstrap a SLES 15 SP3 Salt SSH minion
   Scenario: Clean up sumaform leftovers on a SLES 15 SP3 Salt SSH minion
     When I perform a full salt minion cleanup on "sle15sp3_ssh_minion"
 
-  Scenario: Create the bootstrap repository for a SLES 15 SP3 Salt SSH minion
-    Given I am authorized
-    When I create the bootstrap repository for "sle15sp3_ssh_minion" on the server
-
   Scenario: Bootstrap a SLES 15 SP3 system managed via salt-ssh
     Given I am authorized
     When I go to the bootstrapping page

--- a/testsuite/features/build_validation/init_clients/ubuntu1604_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ubuntu1604_minion.feature
@@ -10,10 +10,6 @@ Feature: Bootstrap a Ubuntu 16.04 Salt minion
   Scenario: Clean up sumaform leftovers on a Ubuntu 16.04 Salt minion
     When I perform a full salt minion cleanup on "ubuntu1604_minion"
 
-  Scenario: Create the bootstrap repository for a Ubuntu 16.04 Salt minion
-    Given I am authorized
-    When I create the bootstrap repository for "ubuntu1604_minion" on the server
-
   Scenario: Bootstrap a Ubuntu 16.04 minion
     Given I am authorized
     When I go to the bootstrapping page

--- a/testsuite/features/build_validation/init_clients/ubuntu1604_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ubuntu1604_ssh_minion.feature
@@ -10,10 +10,6 @@ Feature: Bootstrap a Ubuntu 16.04 Salt SSH minion
   Scenario: Clean up sumaform leftovers on a Ubuntu 16.04 Salt SSH minion
     When I perform a full salt minion cleanup on "ubuntu1604_ssh_minion"
 
-  Scenario: Create the bootstrap repository for a Ubuntu 16.04 Salt SSH minion
-    Given I am authorized
-    When I create the bootstrap repository for "ubuntu1604_ssh_minion" on the server
-
   Scenario: Bootstrap a SSH-managed Ubuntu 16.04 minion
     Given I am authorized
     When I go to the bootstrapping page

--- a/testsuite/features/build_validation/init_clients/ubuntu1804_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ubuntu1804_minion.feature
@@ -10,10 +10,6 @@ Feature: Bootstrap a Ubuntu 18.04 Salt minion
   Scenario: Clean up sumaform leftovers on a Ubuntu 18.04 Salt minion
     When I perform a full salt minion cleanup on "ubuntu1804_minion"
 
-  Scenario: Create the bootstrap repository for a Ubuntu 18.04 Salt minion
-    Given I am authorized
-    When I create the bootstrap repository for "ubuntu1804_minion" on the server
-
   Scenario: Bootstrap a Ubuntu 18.04 minion
     Given I am authorized
     When I go to the bootstrapping page

--- a/testsuite/features/build_validation/init_clients/ubuntu1804_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ubuntu1804_ssh_minion.feature
@@ -10,10 +10,6 @@ Feature: Bootstrap a Ubuntu 18.04 Salt SSH minion
   Scenario: Clean up sumaform leftovers on a 18.04 Salt SSH minion
     When I perform a full salt minion cleanup on "ubuntu1804_ssh_minion"
 
-  Scenario: Create the bootstrap repository for a Ubuntu 18.04 Salt SSH minion
-    Given I am authorized
-    When I create the bootstrap repository for "ubuntu1804_ssh_minion" on the server
-
   Scenario: Bootstrap a SSH-managed Ubuntu 18.04 minion
     Given I am authorized
     When I go to the bootstrapping page

--- a/testsuite/run_sets/build_validation_create_bootstrap_repositories.yml
+++ b/testsuite/run_sets/build_validation_create_bootstrap_repositories.yml
@@ -1,0 +1,5 @@
+## Create bootstrap repositories ###
+
+- features/build_validation/create_bootstrap_repositories/create_bootstrap_repositories.feature
+
+## Create bootstrap repositories ###


### PR DESCRIPTION
## What does this PR change?

See SUSE/susemanager-ci#202 (Add new stage for BV create bootstrap repos)

Move the creation of bootstrap repos away from parallel stages, as `mgr-create-bootstrap-repo` cannot run in parallel.


## Links

Ports:
* 4.0: SUSE/spacewalk#14300
* 4.1: SUSE/spacewalk#14301


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
