### PR TITLE
Prevent several AJP errors (bsc#1179271)

### DIFF
--- a/spacewalk/setup/share/server.xml.xsl
+++ b/spacewalk/setup/share/server.xml.xsl
@@ -15,7 +15,8 @@
     <xsl:attribute name="URIEncoding">UTF-8</xsl:attribute>
     <xsl:attribute name="address">127.0.0.1</xsl:attribute>
     <xsl:attribute name="maxThreads">150</xsl:attribute>
-    <xsl:attribute name="connectionTimeout">20000</xsl:attribute>
+    <xsl:attribute name="connectionTimeout">900000</xsl:attribute>
+    <xsl:attribute name="keepAliveTimeout">300000</xsl:attribute>
     <xsl:attribute name="secretRequired">false</xsl:attribute>
   </xsl:element>
   <xsl:if test="not(../Connector[@port='8009' and @address='::1'])">
@@ -25,7 +26,8 @@
     <xsl:attribute name="URIEncoding">UTF-8</xsl:attribute>
     <xsl:attribute name="address">::1</xsl:attribute>
     <xsl:attribute name="maxThreads">150</xsl:attribute>
-    <xsl:attribute name="connectionTimeout">20000</xsl:attribute>
+    <xsl:attribute name="connectionTimeout">900000</xsl:attribute>
+    <xsl:attribute name="keepAliveTimeout">300000</xsl:attribute>
     <xsl:attribute name="secretRequired">false</xsl:attribute>
   </xsl:element>
   </xsl:if>
@@ -37,7 +39,8 @@
     <xsl:attribute name="URIEncoding">UTF-8</xsl:attribute>
     <xsl:attribute name="address">::1</xsl:attribute>
     <xsl:attribute name="maxThreads">150</xsl:attribute>
-    <xsl:attribute name="connectionTimeout">20000</xsl:attribute>
+    <xsl:attribute name="connectionTimeout">900000</xsl:attribute>
+    <xsl:attribute name="keepAliveTimeout">300000</xsl:attribute>
     <xsl:attribute name="secretRequired">false</xsl:attribute>
   </xsl:element>
 </xsl:template>
@@ -54,7 +57,8 @@
       <xsl:attribute name="URIEncoding">UTF-8</xsl:attribute>
       <xsl:attribute name="address">127.0.0.1</xsl:attribute>
       <xsl:attribute name="maxThreads">150</xsl:attribute>
-      <xsl:attribute name="connectionTimeout">20000</xsl:attribute>
+      <xsl:attribute name="connectionTimeout">900000</xsl:attribute>
+      <xsl:attribute name="keepAliveTimeout">300000</xsl:attribute>
       <xsl:attribute name="secretRequired">false</xsl:attribute>
     </xsl:element>
     <xsl:text>
@@ -66,7 +70,8 @@
       <xsl:attribute name="URIEncoding">UTF-8</xsl:attribute>
       <xsl:attribute name="address">::1</xsl:attribute>
       <xsl:attribute name="maxThreads">150</xsl:attribute>
-      <xsl:attribute name="connectionTimeout">20000</xsl:attribute>
+      <xsl:attribute name="connectionTimeout">900000</xsl:attribute>
+      <xsl:attribute name="keepAliveTimeout">300000</xsl:attribute>
       <xsl:attribute name="secretRequired">false</xsl:attribute>
     </xsl:element>
   <xsl:apply-templates select="node()"/>

--- a/spacewalk/setup/spacewalk-setup.changes
+++ b/spacewalk/setup/spacewalk-setup.changes
@@ -1,3 +1,5 @@
+- set AJP parameters differently to prevent AH00992, AH00877 and
+  AH01030: ajp_ilink_receive() can't receive header errors (bsc#1179271)
 - Use syslinux folder for cobbler loaders.
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Tomcat tuning parameters to prevent rare errors in high load scenarios.

### Background

AJP is a TCP-based protocol for fast communication between httpd and Tomcat, and it is used at every http request that involves the Java stack.

There is an optional watchdog mechanism to kill AJP connections if they are inactive for too long.

The JVM might not respond to such keepalive messages if it's too loaded, or during GC pauses. The keepalive time is configurable via the `keepAliveTimeout` `server.xml` variable:

https://tomcat.apache.org/tomcat-8.5-doc/config/http.html

We did not set it, so it got the default value, which is equal to `connectionTimeout`. We did set `connectionTimeout` to 20s to prevent AJP connection runaways (which were observed, for example, under QUALYS scans hammering the Server).

When this happens, the following errors appear in Apache's error logs:

```
[proxy_ajp:error] [pid 25957] [client 10.87.154.220:56452] AH00992: ajp_read_header: ajp_ilink_receive failed
[proxy_ajp:error] [pid 25957] (120006)APR does not understand this error code: [client 10.87.154.220:56452] AH00878: read response failed from 127.0.0.1:8009 (localhost)
[proxy_ajp:error] [pid 25957] [client 10.87.154.220:56452] AH00877: read zero bytes, expecting 386 bytes
[proxy_ajp:error] [pid 26934] (70014)End of file found: AH01030: ajp_ilink_receive() can't receive header
[proxy_ajp:error] [pid 26934] [client 10.87.154.220:56678] AH00992: ajp_read_header: ajp_ilink_receive failed
[proxy_ajp:error] [pid 26934] (120006)APR does not understand this error code: [client 10.87.154.220:56678] AH00878: read response failed from 127.0.0.1:8009 (localhost)
[proxy_ajp:error] [pid 26934] [client 10.87.154.220:56678] AH00877: read zero bytes, expecting 293 bytes
```

This patch changes the AJP watchdog time to be more tolerant (5 minutes instead of 20 seconds) and the connection timeout to prevent runaways as well (15 minutes instead of 20 seconds).

Expectation is that ajp errors will appear less frequently even in cases of high load/low responsiveness from the JVM, while still preventing runaways effectively (the one case we had observed accumulated over several days).


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pull/850)

- [x] **DONE**

## Test coverage
- No tests: **only happens at high load. Not really possible to simulate at this time**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/13267
Tracks https://github.com/SUSE/spacewalk/pull/14298 https://github.com/SUSE/spacewalk/pull/14299

- [x] **DONE**

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
