### PR TITLE
Testsuite - adapt testsuite to select by react component

### DIFF
--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -147,7 +147,7 @@ When(/^I check "([^"]*)" if not checked$/) do |arg1|
 end
 
 When(/^I select "([^"]*)" from "([^"]*)"$/) do |arg1, arg2|
-  xpath = "//input[@id='#{arg2}']/../../../../.."
+  xpath = "//input[@name='#{arg2}']/.."
   if all(:xpath, xpath, wait: 0).any?
     find(:xpath, xpath).click
     find(:xpath, "#{xpath}/div/div/div[normalize-space(text())='#{arg1}']", match: :first).click


### PR DESCRIPTION
## What does this PR change?

This PR adapts testsuite to select as a react component. There are currently two features with failures caused by react component replacing select:

1) Maintenance Windows
2) Content lifecycle

This PR works correctly with `Maintenance Windows` feature and doesn't break `Build OS images` (also using this select).

~~This change **must be tested with full testsuite run** before merging.~~ DONE

## Links

https://github.com/SUSE/spacewalk/issues/14194

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
