### PR TITLE
Speedup system groups page

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/SystemGroup_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/SystemGroup_queries.xml
@@ -50,7 +50,7 @@ ORDER BY UPPER(NAME)
   <elaborator name="most_severe_errata" />
 </mode>
 <query name="most_severe_errata" params="">
-    WITH groupAdvisoryTypes AS NOT MATERIALIZED (
+    WITH groupAdvisoryTypes AS (
         SELECT sgm.server_group_id, e.advisory_type
           FROM rhnServerNeededCache snpc
               INNER JOIN rhnServerGroupMembers sgm ON sgm.server_id = snpc.server_id

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Speed up the system groups page (bsc#1182132)
 - Log shell command output on failure when checking known_hosts file permissions
 - adapt logging for testing accessability of URLs (bsc#1182817)
 - add warning about missing salt feature for virtual networks


### PR DESCRIPTION
## What does this PR change?

Speed up the system groups page by removing the `NOT MATERIALIZED` hint to prevent Postgres from recomputing the query at every use.

We observed a **36x speedup** on a particular user case bsc#1182132.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/13965

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
