### PR TITLE
Revert "Update github actions checkout"

### DIFF
--- a/.github/workflows/add_pr_reviewer.yml
+++ b/.github/workflows/add_pr_reviewer.yml
@@ -8,7 +8,9 @@ jobs:
   add_pr_reviewer:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v1
+      with:
+        fetch-depth: 1
     - uses: actions/setup-ruby@v1
     - name: "Check if there are test framework changes"
       id: review_step

--- a/.github/workflows/changelog_checker.yml
+++ b/.github/workflows/changelog_checker.yml
@@ -10,7 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v1
+      with:
+        fetch-depth: 1
     - uses: actions/setup-ruby@v1
     - name: Run a changelog checker
       run: |


### PR DESCRIPTION
## What does this PR change?

This PR reverts commit eb3f1f310080f9c8e6d5329c69cefe53ad79b99e introduced in PR https://github.com/uyuni-project/uyuni/pull/3399 because it breaks the `changelog check` with the following error:

![Screenshot from 2021-03-17 10-45-44](https://user-images.githubusercontent.com/14297426/111455726-0ea63e80-870e-11eb-9dd6-84489a97afb8.png)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
