### PR TITLE
BV: Fix an issue that not allow to select some systems because they are in second page of the list

### DIFF
--- a/testsuite/features/build_validation/add_activation_keys/add_activation_key.template
+++ b/testsuite/features/build_validation/add_activation_keys/add_activation_key.template
@@ -9,4 +9,3 @@ Feature: Create an activation key for <client>
 
   Scenario: Create an activation key with the channel and child channels for a <client>
     When I create an activation key including custom channels for "<client>" via XML-RPC
-

--- a/testsuite/features/build_validation/init_clients/ceos6_client.feature
+++ b/testsuite/features/build_validation/init_clients/ceos6_client.feature
@@ -16,7 +16,7 @@ Feature: Bootstrap a CentOS 6 traditional client
     Then I should see "ceos6_client" via spacecmd
 
   Scenario: The onboarding of CentOS 6 traditional client is completed
-    Given I am authorized
+    Given I am authorized as "admin" with password "admin"
     When I wait until onboarding is completed for "ceos6_client"
 
 @proxy

--- a/testsuite/features/build_validation/init_clients/ceos6_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ceos6_minion.feature
@@ -11,7 +11,7 @@ Feature: Bootstrap a CentOS 6 Salt minion
     When I perform a full salt minion cleanup on "ceos6_minion"
 
   Scenario: Bootstrap a CentOS 6 Salt minion
-    Given I am authorized
+    Given I am authorized as "admin" with password "admin"
     When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "ceos6_minion" as "hostname"

--- a/testsuite/features/build_validation/init_clients/ceos6_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ceos6_ssh_minion.feature
@@ -11,7 +11,7 @@ Feature: Bootstrap a CentOS 6 Salt SSH minion
     When I perform a full salt minion cleanup on "ceos6_ssh_minion"
 
   Scenario: Bootstrap a CentOS 6 Salt SSH minion
-    Given I am authorized
+    Given I am authorized as "admin" with password "admin"
     When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
     When I check "manageWithSSH"

--- a/testsuite/features/build_validation/init_clients/ceos7_client.feature
+++ b/testsuite/features/build_validation/init_clients/ceos7_client.feature
@@ -15,7 +15,7 @@ Feature: Bootstrap a CentOS 7 traditional client
     Then I should see "ceos7_client" via spacecmd
 
   Scenario: The onboarding of CentOS 7 traditional client is completed
-    Given I am authorized
+    Given I am authorized as "admin" with password "admin"
     When I wait until onboarding is completed for "ceos7_client"
 
 @proxy

--- a/testsuite/features/build_validation/init_clients/ceos7_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ceos7_minion.feature
@@ -11,7 +11,7 @@ Feature: Bootstrap a CentOS 7 Salt minion
     When I perform a full salt minion cleanup on "ceos7_minion"
 
   Scenario: Bootstrap a CentOS 7 Salt minion
-    Given I am authorized
+    Given I am authorized as "admin" with password "admin"
     When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "ceos7_minion" as "hostname"

--- a/testsuite/features/build_validation/init_clients/ceos7_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ceos7_ssh_minion.feature
@@ -11,7 +11,7 @@ Feature: Bootstrap a CentOS 7 Salt SSH minion
     When I perform a full salt minion cleanup on "ceos7_ssh_minion"
 
   Scenario: Bootstrap a CentOS 7 Salt SSH minion
-    Given I am authorized
+    Given I am authorized as "admin" with password "admin"
     When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
     When I check "manageWithSSH"

--- a/testsuite/features/build_validation/init_clients/ceos8_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ceos8_minion.feature
@@ -11,7 +11,7 @@ Feature: Bootstrap a CentOS 8 Salt minion
     When I perform a full salt minion cleanup on "ceos8_minion"
 
   Scenario: Bootstrap a CentOS 8 Salt minion
-    Given I am authorized
+    Given I am authorized as "admin" with password "admin"
     When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "ceos8_minion" as "hostname"

--- a/testsuite/features/build_validation/init_clients/ceos8_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ceos8_ssh_minion.feature
@@ -11,7 +11,7 @@ Feature: Bootstrap a CentOS 8 Salt SSH minion
     When I perform a full salt minion cleanup on "ceos8_ssh_minion"
 
   Scenario: Bootstrap a CentOS 8 Salt SSH minion
-    Given I am authorized
+    Given I am authorized as "admin" with password "admin"
     When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
     When I check "manageWithSSH"

--- a/testsuite/features/build_validation/init_clients/disabled/ubuntu2004_minion.feature
+++ b/testsuite/features/build_validation/init_clients/disabled/ubuntu2004_minion.feature
@@ -11,7 +11,7 @@ Feature: Bootstrap a Ubuntu 20.04 Salt minion
     When I perform a full salt minion cleanup on "ubuntu2004_minion"
 
   Scenario: Bootstrap a Ubuntu 20.04 minion
-    Given I am authorized
+    Given I am authorized as "admin" with password "admin"
     When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "ubuntu2004_minion" as "hostname"

--- a/testsuite/features/build_validation/init_clients/disabled/ubuntu2004_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/disabled/ubuntu2004_ssh_minion.feature
@@ -11,7 +11,7 @@ Feature: Bootstrap a Ubuntu 20.04 Salt SSH minion
     When I perform a full salt minion cleanup on "ubuntu2004_ssh_minion"
 
   Scenario: Bootstrap a SSH-managed Ubuntu 20.04 minion
-    Given I am authorized
+    Given I am authorized as "admin" with password "admin"
     When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "ubuntu2004_ssh_minion" as "hostname"

--- a/testsuite/features/build_validation/init_clients/proxy.feature
+++ b/testsuite/features/build_validation/init_clients/proxy.feature
@@ -17,7 +17,7 @@ Feature: Setup SUSE Manager proxy
     # End of WORKAROUND
 
   Scenario: Bootstrap the proxy as a Salt minion
-    Given I am authorized
+    Given I am authorized as "admin" with password "admin"
     When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "proxy" as "hostname"

--- a/testsuite/features/build_validation/init_clients/sle11sp4_client.feature
+++ b/testsuite/features/build_validation/init_clients/sle11sp4_client.feature
@@ -14,7 +14,7 @@ Feature: Bootstrap a SLES 11 SP4 traditional client
     Then I should see "sle11sp4_client" via spacecmd
 
   Scenario: The onboarding of SLES 11 SP4 traditional client is completed
-    Given I am authorized
+    Given I am authorized as "admin" with password "admin"
     When I wait until onboarding is completed for "sle11sp4_client"
 
   Scenario: Check registration values of SLES 11 SP4 traditional

--- a/testsuite/features/build_validation/init_clients/sle11sp4_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle11sp4_minion.feature
@@ -8,7 +8,7 @@ Feature: Bootstrap a SLES 11 SP4 Salt minion
     When I perform a full salt minion cleanup on "sle11sp4_minion"
 
   Scenario: Bootstrap a SLES 11 SP4 minion
-    Given I am authorized
+    Given I am authorized as "admin" with password "admin"
     When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "sle11sp4_minion" as "hostname"
@@ -22,7 +22,7 @@ Feature: Bootstrap a SLES 11 SP4 Salt minion
     And I wait until onboarding is completed for "sle11sp4_minion"
 
   Scenario: Check the new bootstrapped SLES 11 SP4 minion in System Overview page
-    Given I am authorized
+    Given I am authorized as "admin" with password "admin"
     When I go to the minion onboarding page
     Then I should see a "accepted" text
     And the Salt master can reach "sle11sp4_minion"

--- a/testsuite/features/build_validation/init_clients/sle11sp4_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle11sp4_ssh_minion.feature
@@ -8,7 +8,7 @@ Feature: Bootstrap a SLES 11 SP4 Salt SSH minion
     When I perform a full salt minion cleanup on "sle11sp4_ssh_minion"
 
   Scenario: Bootstrap a SLES 11 SP4 system managed via salt-ssh
-    Given I am authorized
+    Given I am authorized as "admin" with password "admin"
     When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
     When I check "manageWithSSH"

--- a/testsuite/features/build_validation/init_clients/sle12sp4_client.feature
+++ b/testsuite/features/build_validation/init_clients/sle12sp4_client.feature
@@ -14,7 +14,7 @@ Feature: Bootstrap a SLES 12 SP4 traditional client
     Then I should see "sle12sp4_client" via spacecmd
 
   Scenario: The onboarding of SLES 12 SP4 traditional client is completed
-    Given I am authorized
+    Given I am authorized as "admin" with password "admin"
     When I wait until onboarding is completed for "sle12sp4_client"
 
   Scenario: Check registration values of SLES 12 SP4 traditional client

--- a/testsuite/features/build_validation/init_clients/sle12sp4_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle12sp4_minion.feature
@@ -8,7 +8,7 @@ Feature: Bootstrap a SLES 12 SP4 Salt minion
     When I perform a full salt minion cleanup on "sle12sp4_minion"
 
   Scenario: Bootstrap a SLES 12 SP4 minion
-    Given I am authorized
+    Given I am authorized as "admin" with password "admin"
     When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "sle12sp4_minion" as "hostname"
@@ -22,7 +22,7 @@ Feature: Bootstrap a SLES 12 SP4 Salt minion
     And I wait until onboarding is completed for "sle12sp4_minion"
 
   Scenario: Check the new bootstrapped SLES 12 SP4 minion in System Overview page
-    Given I am authorized
+    Given I am authorized as "admin" with password "admin"
     When I go to the minion onboarding page
     Then I should see a "accepted" text
     And the Salt master can reach "sle12sp4_minion"

--- a/testsuite/features/build_validation/init_clients/sle12sp4_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle12sp4_ssh_minion.feature
@@ -8,7 +8,7 @@ Feature: Bootstrap a SLES 12 SP4 Salt SSH minion
     When I perform a full salt minion cleanup on "sle12sp4_ssh_minion"
 
   Scenario: Bootstrap a SLES 12 SP4 system managed via salt-ssh
-    Given I am authorized
+    Given I am authorized as "admin" with password "admin"
     When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
     When I check "manageWithSSH"

--- a/testsuite/features/build_validation/init_clients/sle15_client.feature
+++ b/testsuite/features/build_validation/init_clients/sle15_client.feature
@@ -14,7 +14,7 @@ Feature: Bootstrap a SLES 15 traditional client
     Then I should see "sle15_client" via spacecmd
 
   Scenario: The onboarding of SLES 15 traditional client is completed
-    Given I am authorized
+    Given I am authorized as "admin" with password "admin"
     When I wait until onboarding is completed for "sle15_client"
 
   Scenario: Check registration values of SLES 15 traditional client

--- a/testsuite/features/build_validation/init_clients/sle15_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15_minion.feature
@@ -8,7 +8,7 @@ Feature: Bootstrap a SLES 15 Salt minion
     When I perform a full salt minion cleanup on "sle15_minion"
 
   Scenario: Bootstrap a SLES 15 minion
-    Given I am authorized
+    Given I am authorized as "admin" with password "admin"
     When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "sle15_minion" as "hostname"
@@ -22,7 +22,7 @@ Feature: Bootstrap a SLES 15 Salt minion
     And I wait until onboarding is completed for "sle15_minion"
 
   Scenario: Check the new bootstrapped SLES 15 minion in System Overview page
-    Given I am authorized
+    Given I am authorized as "admin" with password "admin"
     When I go to the minion onboarding page
     Then I should see a "accepted" text
     And the Salt master can reach "sle15_minion"

--- a/testsuite/features/build_validation/init_clients/sle15_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15_ssh_minion.feature
@@ -8,7 +8,7 @@ Feature: Bootstrap a SLES 15 Salt SSH minion
     When I perform a full salt minion cleanup on "sle15_ssh_minion"
 
   Scenario: Bootstrap a SLES 15 system managed via salt-ssh
-    Given I am authorized
+    Given I am authorized as "admin" with password "admin"
     When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
     When I check "manageWithSSH"

--- a/testsuite/features/build_validation/init_clients/sle15sp1_client.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp1_client.feature
@@ -14,7 +14,7 @@ Feature: Bootstrap a SLES 15 SP1 traditional client
     Then I should see "sle15sp1_client" via spacecmd
 
   Scenario: The onboarding of SLES 15 SP1 traditional client is completed
-    Given I am authorized
+    Given I am authorized as "admin" with password "admin"
     When I wait until onboarding is completed for "sle15sp1_client"
 
   Scenario: Check registration values of SLES 15 SP1 traditional

--- a/testsuite/features/build_validation/init_clients/sle15sp1_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp1_minion.feature
@@ -8,7 +8,7 @@ Feature: Bootstrap a SLES 15 SP1 Salt minion
     When I perform a full salt minion cleanup on "sle15sp1_minion"
 
   Scenario: Bootstrap a SLES 15 SP1 minion
-    Given I am authorized
+    Given I am authorized as "admin" with password "admin"
     When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "sle15sp1_minion" as "hostname"
@@ -22,7 +22,7 @@ Feature: Bootstrap a SLES 15 SP1 Salt minion
     And I wait until onboarding is completed for "sle15sp1_minion"
 
   Scenario: Check the new bootstrapped SLES 15 SP1 minion in System Overview page
-    Given I am authorized
+    Given I am authorized as "admin" with password "admin"
     When I go to the minion onboarding page
     Then I should see a "accepted" text
     And the Salt master can reach "sle15sp1_minion"

--- a/testsuite/features/build_validation/init_clients/sle15sp1_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp1_ssh_minion.feature
@@ -8,7 +8,7 @@ Feature: Bootstrap a SLES 15 SP1 Salt SSH minion
     When I perform a full salt minion cleanup on "sle15sp1_ssh_minion"
 
   Scenario: Bootstrap a SLES 15 SP1 system managed via salt-ssh
-    Given I am authorized
+    Given I am authorized as "admin" with password "admin"
     When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
     When I check "manageWithSSH"

--- a/testsuite/features/build_validation/init_clients/sle15sp2_client.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp2_client.feature
@@ -14,7 +14,7 @@ Feature: Bootstrap a SLES 15 SP2 traditional client
     Then I should see "sle15sp2_client" via spacecmd
 
   Scenario: The onboarding of SLES 15 SP2 traditional client is completed
-    Given I am authorized
+    Given I am authorized as "admin" with password "admin"
     When I wait until onboarding is completed for "sle15sp2_client"
 
   Scenario: Check registration values of SLES 15 SP2 traditional

--- a/testsuite/features/build_validation/init_clients/sle15sp2_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp2_minion.feature
@@ -8,7 +8,7 @@ Feature: Bootstrap a SLES 15 SP2 Salt minion
     When I perform a full salt minion cleanup on "sle15sp2_minion"
 
   Scenario: Bootstrap a SLES 15 SP2 minion
-    Given I am authorized
+    Given I am authorized as "admin" with password "admin"
     When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "sle15sp2_minion" as "hostname"
@@ -22,7 +22,7 @@ Feature: Bootstrap a SLES 15 SP2 Salt minion
     And I wait until onboarding is completed for "sle15sp2_minion"
 
   Scenario: Check the new bootstrapped SLES 15 SP2 minion in System Overview page
-    Given I am authorized
+    Given I am authorized as "admin" with password "admin"
     When I go to the minion onboarding page
     Then I should see a "accepted" text
     And the Salt master can reach "sle15sp2_minion"

--- a/testsuite/features/build_validation/init_clients/sle15sp2_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp2_ssh_minion.feature
@@ -8,7 +8,7 @@ Feature: Bootstrap a SLES 15 SP2 Salt SSH minion
     When I perform a full salt minion cleanup on "sle15sp2_ssh_minion"
 
   Scenario: Bootstrap a SLES 15 SP2 system managed via salt-ssh
-    Given I am authorized
+    Given I am authorized as "admin" with password "admin"
     When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
     When I check "manageWithSSH"

--- a/testsuite/features/build_validation/init_clients/sle15sp3_client.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp3_client.feature
@@ -14,7 +14,7 @@ Feature: Bootstrap a SLES 15 SP3 traditional client
     Then I should see "sle15sp3_client" via spacecmd
 
   Scenario: The onboarding of SLES 15 SP3 traditional client is completed
-    Given I am authorized
+    Given I am authorized as "admin" with password "admin"
     When I wait until onboarding is completed for "sle15sp3_client"
 
   Scenario: Check registration values of SLES 15 SP3 traditional

--- a/testsuite/features/build_validation/init_clients/sle15sp3_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp3_minion.feature
@@ -8,7 +8,7 @@ Feature: Bootstrap a SLES 15 SP3 Salt minion
     When I perform a full salt minion cleanup on "sle15sp3_minion"
 
   Scenario: Bootstrap a SLES 15 SP3 minion
-    Given I am authorized
+    Given I am authorized as "admin" with password "admin"
     When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "sle15sp3_minion" as "hostname"
@@ -22,7 +22,7 @@ Feature: Bootstrap a SLES 15 SP3 Salt minion
     And I wait until onboarding is completed for "sle15sp3_minion"
 
   Scenario: Check the new bootstrapped SLES 15 SP3 minion in System Overview page
-    Given I am authorized
+    Given I am authorized as "admin" with password "admin"
     When I go to the minion onboarding page
     Then I should see a "accepted" text
     And the Salt master can reach "sle15sp3_minion"

--- a/testsuite/features/build_validation/init_clients/sle15sp3_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp3_ssh_minion.feature
@@ -8,7 +8,7 @@ Feature: Bootstrap a SLES 15 SP3 Salt SSH minion
     When I perform a full salt minion cleanup on "sle15sp3_ssh_minion"
 
   Scenario: Bootstrap a SLES 15 SP3 system managed via salt-ssh
-    Given I am authorized
+    Given I am authorized as "admin" with password "admin"
     When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
     When I check "manageWithSSH"

--- a/testsuite/features/build_validation/init_clients/ubuntu1604_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ubuntu1604_minion.feature
@@ -11,7 +11,7 @@ Feature: Bootstrap a Ubuntu 16.04 Salt minion
     When I perform a full salt minion cleanup on "ubuntu1604_minion"
 
   Scenario: Bootstrap a Ubuntu 16.04 minion
-    Given I am authorized
+    Given I am authorized as "admin" with password "admin"
     When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "ubuntu1604_minion" as "hostname"

--- a/testsuite/features/build_validation/init_clients/ubuntu1604_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ubuntu1604_ssh_minion.feature
@@ -11,7 +11,7 @@ Feature: Bootstrap a Ubuntu 16.04 Salt SSH minion
     When I perform a full salt minion cleanup on "ubuntu1604_ssh_minion"
 
   Scenario: Bootstrap a SSH-managed Ubuntu 16.04 minion
-    Given I am authorized
+    Given I am authorized as "admin" with password "admin"
     When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "ubuntu1604_ssh_minion" as "hostname"

--- a/testsuite/features/build_validation/init_clients/ubuntu1804_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ubuntu1804_minion.feature
@@ -11,7 +11,7 @@ Feature: Bootstrap a Ubuntu 18.04 Salt minion
     When I perform a full salt minion cleanup on "ubuntu1804_minion"
 
   Scenario: Bootstrap a Ubuntu 18.04 minion
-    Given I am authorized
+    Given I am authorized as "admin" with password "admin"
     When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "ubuntu1804_minion" as "hostname"

--- a/testsuite/features/build_validation/init_clients/ubuntu1804_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ubuntu1804_ssh_minion.feature
@@ -11,7 +11,7 @@ Feature: Bootstrap a Ubuntu 18.04 Salt SSH minion
     When I perform a full salt minion cleanup on "ubuntu1804_ssh_minion"
 
   Scenario: Bootstrap a SSH-managed Ubuntu 18.04 minion
-    Given I am authorized
+    Given I am authorized as "admin" with password "admin"
     When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "ubuntu1804_ssh_minion" as "hostname"

--- a/testsuite/features/build_validation/retail/deploy_sle11sp3_terminal.feature
+++ b/testsuite/features/build_validation/retail/deploy_sle11sp3_terminal.feature
@@ -15,11 +15,11 @@ Feature: PXE boot a SLES 11 SP3 retail terminal
     And I am on the System Overview page
     And I wait until I see the name of "sle11sp3_terminal", refreshing the page
     And I follow this "sle11sp3_terminal" link
-    And I wait until event "Apply states [util.syncstates, saltboot] scheduled by (none)" is completed
+    And I wait until event "Apply states [util.syncstates, saltboot] scheduled" is completed
     And I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until radio button "SLES11-SP3-Pool" is checked, refreshing the page
-    And I wait until event "Package List Refresh scheduled by (none)" is completed
+    And I wait until event "Package List Refresh scheduled" is completed
     Then the PXE boot minion should have been reformatted
 
   Scenario: Check connection from SLES 11 SP3 retail terminal to branch server
@@ -37,7 +37,7 @@ Feature: PXE boot a SLES 11 SP3 retail terminal
     And I click on "Install Selected Packages"
     And I click on "Confirm"
     Then I should see a "1 package install has been scheduled" text
-    When I wait until event "Package Install/Upgrade scheduled by admin" is completed
+    When I wait until event "Package Install/Upgrade scheduled" is completed
 
   Scenario: Remove a package on the SLES 11 SP3 retail terminal
     Given I am on the Systems overview page of this "sle11sp3_terminal"
@@ -49,4 +49,4 @@ Feature: PXE boot a SLES 11 SP3 retail terminal
     And I click on "Remove Packages"
     And I click on "Confirm"
     Then I should see a "1 package removal has been scheduled" text
-    When I wait until event "Package Removal scheduled by admin" is completed
+    When I wait until event "Package Removal scheduled" is completed

--- a/testsuite/features/build_validation/retail/deploy_sle12sp4_terminal.feature
+++ b/testsuite/features/build_validation/retail/deploy_sle12sp4_terminal.feature
@@ -17,11 +17,11 @@ Feature: PXE boot a SLES 12 SP4 retail terminal
     And I am on the System Overview page
     And I wait until I see the name of "sle12sp4_terminal", refreshing the page
     And I follow this "sle12sp4_terminal" link
-    And I wait until event "Apply states [util.syncstates, saltboot] scheduled by (none)" is completed
+    And I wait until event "Apply states [util.syncstates, saltboot] scheduled" is completed
     And I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until radio button "SLES12-SP4-Pool" is checked, refreshing the page
-    And I wait until event "Package List Refresh scheduled by (none)" is completed
+    And I wait until event "Package List Refresh scheduled" is completed
     Then the PXE boot minion should have been reformatted
 
   Scenario: Check connection from SLES 12 SP4 retail terminal to branch server
@@ -39,7 +39,7 @@ Feature: PXE boot a SLES 12 SP4 retail terminal
     And I click on "Install Selected Packages"
     And I click on "Confirm"
     Then I should see a "1 package install has been scheduled" text
-    When I wait until event "Package Install/Upgrade scheduled by admin" is completed
+    When I wait until event "Package Install/Upgrade scheduled" is completed
 
   Scenario: Remove a package on the SLES 12 SP4 retail terminal
     Given I am on the Systems overview page of this "sle12sp4_terminal"
@@ -51,4 +51,4 @@ Feature: PXE boot a SLES 12 SP4 retail terminal
     And I click on "Remove Packages"
     And I click on "Confirm"
     Then I should see a "1 package removal has been scheduled" text
-    When I wait until event "Package Removal scheduled by admin" is completed
+    When I wait until event "Package Removal scheduled" is completed

--- a/testsuite/features/build_validation/retail/deploy_sle15sp2_terminal.feature
+++ b/testsuite/features/build_validation/retail/deploy_sle15sp2_terminal.feature
@@ -15,11 +15,11 @@ Feature: PXE boot a SLES 15 SP2 retail terminal
     And I am on the System Overview page
     And I wait until I see the name of "sle15sp2_terminal", refreshing the page
     And I follow this "sle15sp2_terminal" link
-    And I wait until event "Apply states [util.syncstates, saltboot] scheduled by (none)" is completed
+    And I wait until event "Apply states [util.syncstates, saltboot] scheduled" is completed
     And I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until radio button "SLE-Product-SLES15-SP2-Pool" is checked, refreshing the page
-    And I wait until event "Package List Refresh scheduled by (none)" is completed
+    And I wait until event "Package List Refresh scheduled" is completed
     Then the PXE boot minion should have been reformatted
 
   Scenario: Check connection from SLES 15 SP2 retail terminal to branch server
@@ -37,7 +37,7 @@ Feature: PXE boot a SLES 15 SP2 retail terminal
     And I click on "Install Selected Packages"
     And I click on "Confirm"
     Then I should see a "1 package install has been scheduled" text
-    When I wait until event "Package Install/Upgrade scheduled by admin" is completed
+    When I wait until event "Package Install/Upgrade scheduled" is completed
 
   Scenario: Remove a package on the SLES 15 SP2 retail terminal
     Given I am on the Systems overview page of this "sle15sp2_terminal"
@@ -49,4 +49,4 @@ Feature: PXE boot a SLES 15 SP2 retail terminal
     And I click on "Remove Packages"
     And I click on "Confirm"
     Then I should see a "1 package removal has been scheduled" text
-    When I wait until event "Package Removal scheduled by admin" is completed
+    When I wait until event "Package Removal scheduled" is completed

--- a/testsuite/features/build_validation/retail/sle11sp4_kiwi_image_buildhost.feature
+++ b/testsuite/features/build_validation/retail/sle11sp4_kiwi_image_buildhost.feature
@@ -4,11 +4,11 @@
 Feature: Bootstrap a SLES 11 SP4 Salt build host via the GUI
 
   Scenario: Create the bootstrap repository for a SLES 11 SP4 build host
-     Given I am authorized
+     Given I am authorized as "admin" with password "admin"
      When I create the bootstrap repository for "sle11sp4_buildhost" on the server
 
   Scenario: Bootstrap a SLES 11 SP4 build host
-     Given I am authorized
+     Given I am authorized as "admin" with password "admin"
      When I go to the bootstrapping page
      Then I should see a "Bootstrap Minions" text
      When I enter the hostname of "sle11sp4_buildhost" as "hostname"
@@ -20,7 +20,7 @@ Feature: Bootstrap a SLES 11 SP4 Salt build host via the GUI
      And I wait until I see "Successfully bootstrapped host!" text
 
   Scenario: Check the new bootstrapped SLES 11 SP4 build host in System Overview page
-    Given I am authorized
+    Given I am authorized as "admin" with password "admin"
     When I go to the minion onboarding page
     Then I should see a "accepted" text
     When I am on the System Overview page

--- a/testsuite/features/build_validation/retail/sle12sp4_kiwi_image_buildhost.feature
+++ b/testsuite/features/build_validation/retail/sle12sp4_kiwi_image_buildhost.feature
@@ -4,11 +4,11 @@
 Feature: Bootstrap a SLES 12 SP4 Salt build host via the GUI
 
   Scenario: Create the bootstrap repository for a SLES 12 SP4 build host
-     Given I am authorized
+     Given I am authorized as "admin" with password "admin"
      When I create the bootstrap repository for "sle12sp4_buildhost" on the server
 
   Scenario: Bootstrap a SLES build host
-     Given I am authorized
+     Given I am authorized as "admin" with password "admin"
      When I go to the bootstrapping page
      Then I should see a "Bootstrap Minions" text
      When I enter the hostname of "sle12sp4_buildhost" as "hostname"
@@ -20,7 +20,7 @@ Feature: Bootstrap a SLES 12 SP4 Salt build host via the GUI
      And I wait until I see "Successfully bootstrapped host!" text
 
   Scenario: Check the new bootstrapped SLES 12 SP4 build host in System Overview page
-    Given I am authorized
+    Given I am authorized as "admin" with password "admin"
     When I go to the minion onboarding page
     Then I should see a "accepted" text
     When I am on the System Overview page

--- a/testsuite/features/build_validation/retail/sle15sp2_kiwi_image_buildhost.feature
+++ b/testsuite/features/build_validation/retail/sle15sp2_kiwi_image_buildhost.feature
@@ -4,11 +4,11 @@
 Feature: Bootstrap a SLES 15 SP2 Salt build host via the GUI
 
   Scenario: Create the bootstrap repository for a SLES 15 SP2 build host
-     Given I am authorized
+     Given I am authorized as "admin" with password "admin"
      When I create the bootstrap repository for "sle15sp2_buildhost" on the server
 
   Scenario: Bootstrap a SLES 15 SP2 build host
-     Given I am authorized
+     Given I am authorized as "admin" with password "admin"
      When I go to the bootstrapping page
      Then I should see a "Bootstrap Minions" text
      When I enter the hostname of "sle15sp2_buildhost" as "hostname"
@@ -20,7 +20,7 @@ Feature: Bootstrap a SLES 15 SP2 Salt build host via the GUI
      And I wait until I see "Successfully bootstrapped host!" text
 
   Scenario: Check the new bootstrapped SLES 15 SP2 build host in System Overview page
-    Given I am authorized
+    Given I am authorized as "admin" with password "admin"
     When I go to the minion onboarding page
     Then I should see a "accepted" text
     When I am on the System Overview page

--- a/testsuite/features/core/srv_user_preferences.feature
+++ b/testsuite/features/core/srv_user_preferences.feature
@@ -6,8 +6,15 @@ Feature: Change personal preferences
   As a sysadmin
   I want to navigate through "Home" submenus changing some settings
 
-  Scenario: Change page size to 100 per page
+  Scenario: Change page size to 100 per page in admin user
     Given I am authorized as "admin" with password "admin"
+    When I follow the left menu "Home > My Preferences"
+    And I select "100" from "pagesize"
+    And I click on "Save Preferences"
+    Then I should see a "Preferences modified" text
+
+  Scenario: Change page size to 100 per page in testing user
+    Given I am authorized as "testing" with password "testing"
     When I follow the left menu "Home > My Preferences"
     And I select "100" from "pagesize"
     And I click on "Save Preferences"

--- a/testsuite/run_sets/build_validation_core.yml
+++ b/testsuite/run_sets/build_validation_core.yml
@@ -10,7 +10,7 @@
 # IMMUTABLE ORDER
 
 - features/core/first_settings.feature
-- features/core/srv_admin_preferences.feature
+- features/core/srv_user_preferences.feature
 
 # Configuration channel and configuration file for smoke tests
 - features/build_validation/core/srv_add_configuration_channel_and_file.feature

--- a/testsuite/run_sets/core.yml
+++ b/testsuite/run_sets/core.yml
@@ -10,7 +10,7 @@
 
 - features/core/first_settings.feature
 - features/core/srv_organization_credentials.feature
-- features/core/srv_admin_preferences.feature
+- features/core/srv_user_preferences.feature
 
 # initialize SUSE Manager server
 - features/core/srv_channels_add.feature


### PR DESCRIPTION
## What does this PR change?

- Change the user preferences of the testing client, by increasing the pagination size to 100
- Change all the BV features to use admin user
- Simplify some checks in retail BV features, to don't have a dependency on the user triggering the events

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Ports:
- Manager-4.0
- Manager-4.1

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
