### PR TITLE
Add new step clean up all bootstrap repositories on the server

### DIFF
--- a/testsuite/features/build_validation/create_bootstrap_repositories/srv_create_bootstrap_repositories.feature
+++ b/testsuite/features/build_validation/create_bootstrap_repositories/srv_create_bootstrap_repositories.feature
@@ -3,7 +3,7 @@
 
 Feature: Create bootstrap repositories
 
-Scenario: Clean up all bootstrap repositories on the server
+  Scenario: Clean up all bootstrap repositories on the server
     When I clean up all bootstrap repositories on the server
 
 @proxy

--- a/testsuite/features/build_validation/create_bootstrap_repositories/srv_create_bootstrap_repositories.feature
+++ b/testsuite/features/build_validation/create_bootstrap_repositories/srv_create_bootstrap_repositories.feature
@@ -3,6 +3,9 @@
 
 Feature: Create bootstrap repositories
 
+Scenario: Clean up all bootstrap repositories on the server
+    When I clean up all bootstrap repositories on the server
+
 @proxy
   Scenario: Create the bootstrap repository for the SUSE Manager proxy
     When I create the bootstrap repository for "proxy" on the server

--- a/testsuite/features/build_validation/create_bootstrap_repositories/srv_create_bootstrap_repositories.feature
+++ b/testsuite/features/build_validation/create_bootstrap_repositories/srv_create_bootstrap_repositories.feature
@@ -3,6 +3,7 @@
 
 Feature: Create bootstrap repositories
 
+# WORKAROUND: --flush option does not seem to work in case of hash mismatch with same version
   Scenario: Clean up all bootstrap repositories on the server
     When I clean up all bootstrap repositories on the server
 

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -925,6 +925,10 @@ When(/^I wait until the package "(.*?)" has been cached on this "(.*?)"$/) do |p
   end
 end
 
+When(/^I clean up all bootstrap repositories on the server$/) do
+  $server.run('rm -rf /srv/www/htdocs/pub/repositories/')
+end
+
 When(/^I create the bootstrap repository for "([^"]*)" on the server$/) do |host|
   base_channel = BASE_CHANNEL_BY_CLIENT[host]
   channel = CHANNEL_TO_SYNC_BY_BASE_CHANNEL[base_channel]

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -926,7 +926,7 @@ When(/^I wait until the package "(.*?)" has been cached on this "(.*?)"$/) do |p
 end
 
 When(/^I clean up all bootstrap repositories on the server$/) do
-  $server.run('rm -rf /srv/www/htdocs/pub/repositories/')
+  $server.run('rm -rf /srv/www/htdocs/pub/repositories/*')
 end
 
 When(/^I create the bootstrap repository for "([^"]*)" on the server$/) do |host|

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -925,6 +925,7 @@ When(/^I wait until the package "(.*?)" has been cached on this "(.*?)"$/) do |p
   end
 end
 
+# WORKAROUND: --flush option does not seem to work in case of hash mismatch with same version
 When(/^I clean up all bootstrap repositories on the server$/) do
   $server.run('rm -rf /srv/www/htdocs/pub/repositories/*')
 end


### PR DESCRIPTION
## What does this PR change?

Adds new step in testsuite and uses it before we create the bootstrap repos to avoid any conflicts with packages that have same version but different hash.


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes #
Tracks 4.1: https://github.com/SUSE/spacewalk/pull/14329
            4.0: https://github.com/SUSE/spacewalk/pull/14330

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
