### PR TITLE
Enable Ubuntu 20.04 syncing in testsuite

### DIFF
--- a/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
+++ b/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
@@ -22,13 +22,13 @@ Feature: Synchronize products in the products page of the Setup Wizard
     When I click the Add Product button
     And I wait until I see "Ubuntu 18.04" product has been added
 
-#  Scenario: Add Ubuntu 20.04
-#    Given I am on the Products page
-#    When I enter "Ubuntu 20.04" as the filtered product description
-#    And I select "Ubuntu 20.04" as a product
-#    Then I should see the "Ubuntu 20.04" selected
-#    When I click the Add Product button
-#    And I wait until I see "Ubuntu 20.04" product has been added
+  Scenario: Add Ubuntu 20.04
+    Given I am on the Products page
+    When I enter "Ubuntu 20.04" as the filtered product description
+    And I select "Ubuntu 20.04" as a product
+    Then I should see the "Ubuntu 20.04" selected
+    When I click the Add Product button
+    And I wait until I see "Ubuntu 20.04" product has been added
 
   Scenario: SUSE Linux Enterprise Server 11 SP3
     Given I am on the Products page


### PR DESCRIPTION
## What does this PR change?

Enable Ubuntu 20.04 syncing in testsuite now that we can

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes #13372
Tracks 
4.1: https://github.com/SUSE/spacewalk/pull/14335
4.0: https://github.com/SUSE/spacewalk/pull/14336

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
