### PR TITLE
Prevent useless package list refresh actions on zypper minions (bsc#1183661)

### DIFF
--- a/spacewalk/setup/salt/susemanager.conf
+++ b/spacewalk/setup/salt/susemanager.conf
@@ -90,3 +90,10 @@ rosters:
 
 # Allow minions to upload files to master
 file_recv: True
+
+# Define SALT_RUNNING env variable for pkg modules
+system-environment:
+  modules:
+    pkg:
+      _:
+        SALT_RUNNING: 1

--- a/spacewalk/setup/spacewalk-setup.changes
+++ b/spacewalk/setup/spacewalk-setup.changes
@@ -1,3 +1,4 @@
+- Prevent useless package list refresh actions on zypper minions (bsc#1183661)
 - set AJP parameters differently to prevent AH00992, AH00877 and
   AH01030: ajp_ilink_receive() can't receive header errors (bsc#1179271)
 - Use syslinux folder for cobbler loaders.

--- a/susemanager-utils/susemanager-sls/salt/services/salt-minion.sls
+++ b/susemanager-utils/susemanager-sls/salt/services/salt-minion.sls
@@ -20,6 +20,18 @@ mgr_remove_activation_key_grains:
     - repl: ''
     - onlyif: grep 'activation_key:' /etc/salt/minion.d/susemanager.conf
 
+{# add SALT_RUNNING env variable in case it's not present on the configuration #}
+mgr_append_salt_running_env_configuration:
+  file.append:
+    - name: /etc/salt/minion.d/susemanager.conf
+    - text: |
+        system-environment:
+          modules:
+            pkg:
+              _:
+                SALT_RUNNING: 1
+    - unless: grep 'system-environment' /etc/salt/minion.d/susemanager.conf
+
 mgr_salt_minion:
   pkg.installed:
     - name: salt-minion

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Add SALT_RUNNING config in case it's not present on the minion (bsc#1183661)
 - Skip removed product classes with satellite-sync
 - add grain for virt module features
 - add virtual network creation action


### PR DESCRIPTION
## What does this PR change?

This PR prevents useless package list refresh actions to be triggered by Uyuni when scheduling a package installation from the UI, or even when applying states that are calling the "zypperpkg" Salt module.

The `SALT_RUNNING` environment variable is expected to be injected by "zypperpkg" module when calling Zypper, but this is not happening after some refactor on the "zypperpkg" module.

This PR makes use of the new env variable mechanism via Salt minion configuration, so the `SALT_RUNNING` variable is injected when calling Zypper.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **bugfix**
- 
- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
