### PR TITLE
Raise length limit for kernel options

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/kickstart/KickstartData.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/kickstart/KickstartData.hbm.xml
@@ -30,7 +30,7 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         <property name="created" column="created" not-null="true" type="timestamp" insert="false" update="false"/>
         <property name="modified" column="modified" not-null="true" type="timestamp" insert="false" update="false"/>
         <property name="isOrgDefault" column="is_org_default" not-null="true" type="yes_no" />
-        <property name="kernelParams" column="kernel_params"  type="string" length="128" />
+        <property name="kernelParams" column="kernel_params"  type="string" length="2048" />
         <property name="nonChrootPost" column="nonchrootpost" not-null="false" type="yes_no" />
         <property name="noBase" column="no_base" not-null="false" type="yes_no" />
         <property name="ignoreMissing" column="ignore_missing" not-null="false" type="yes_no" />

--- a/java/code/src/com/redhat/rhn/frontend/action/kickstart/KickstartTroubleshootingEditAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/kickstart/KickstartTroubleshootingEditAction.java
@@ -74,7 +74,7 @@ public class KickstartTroubleshootingEditAction extends BaseKickstartEditAction 
         tscmd.setBootloaderType(form.getString(BOOTLOADER));
 
         String kernelParams = form.getString(KERNEL_PARAMS);
-        if (kernelParams.length() > 128) {
+        if (kernelParams.length() > 2048) {
             retval = new ValidatorError("kickstart.troubleshooting." +
                                         "validation.kernelparams.too_long");
         }

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -5506,7 +5506,7 @@ Follow this url to see the full list of inactive systems:
         </context-group>
       </trans-unit>
       <trans-unit id="kickstart.troubleshooting.validation.kernelparams.too_long" xml:space="preserve">
-        <source>Extra kernel parameters can be no longer than 128 characters.</source>
+        <source>Extra kernel parameters can be no longer than 2048 characters.</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/kickstart/Troubleshooting.do</context>
         </context-group>

--- a/java/code/webapp/WEB-INF/pages/common/fragments/kickstart/advanced/details.jspf
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/kickstart/advanced/details.jspf
@@ -73,7 +73,7 @@
                 <bean:message key="kickstartdetails.jsp.kernel_options"/>
             </label>
             <div class="col-lg-6">
-                <html:text property="kernel_options" styleClass="form-control" maxlength="1024" size="32" />
+                <html:text property="kernel_options" styleClass="form-control" maxlength="2048" size="32" />
             </div>
         </div>
         <div class="form-group">
@@ -81,7 +81,7 @@
                 <bean:message key="kickstartdetails.jsp.post_kernel_options"/>
             </label>
             <div class="col-lg-6">
-                <html:text property="post_kernel_options" styleClass="form-control" maxlength="1024" size="32" />
+                <html:text property="post_kernel_options" styleClass="form-control" maxlength="2048" size="32" />
             </div>
         </div>
         <div class="form-group">

--- a/java/code/webapp/WEB-INF/pages/kickstart/kickstartdetails.jsp
+++ b/java/code/webapp/WEB-INF/pages/kickstart/kickstartdetails.jsp
@@ -115,7 +115,7 @@
                                 <bean:message key="kickstartdetails.jsp.kernel_options"/>
                             </label>
                             <div class="col-lg-6">
-                                <html:text property="kernel_options" maxlength="1024" size="32" styleClass="form-control"/>
+                                <html:text property="kernel_options" maxlength="2048" size="32" styleClass="form-control"/>
                             </div>
                         </div>
                         <div class="form-group">
@@ -123,7 +123,7 @@
                                 <bean:message key="kickstartdetails.jsp.post_kernel_options"/>
                             </label>
                             <div class="col-lg-6">
-                                <html:text property="post_kernel_options" maxlength="1024" size="32" styleClass="form-control"/>
+                                <html:text property="post_kernel_options" maxlength="2048" size="32" styleClass="form-control"/>
                             </div>
                         </div>
                         <div class="form-group">

--- a/java/code/webapp/WEB-INF/pages/kickstart/tree-form.jspf
+++ b/java/code/webapp/WEB-INF/pages/kickstart/tree-form.jspf
@@ -59,7 +59,7 @@
             <bean:message key="kickstartdetails.jsp.kernel_options"/>:
         </label>
         <div class="col-md-6">
-            <html:text property="kernelopts" maxlength="256" size="64" styleClass="form-control"/>
+            <html:text property="kernelopts" maxlength="2048" size="64" styleClass="form-control"/>
         </div>
     </div>
 
@@ -68,7 +68,7 @@
             <bean:message key="kickstartdetails.jsp.post_kernel_options"/>:
         </label>
         <div class="col-md-6">
-            <html:text property="postkernelopts" maxlength="256" size="64" styleClass="form-control"/>
+            <html:text property="postkernelopts" maxlength="2048" size="64" styleClass="form-control"/>
         </div>
     </div>
 </c:if>

--- a/java/code/webapp/WEB-INF/pages/kickstart/troubleshooting.jsp
+++ b/java/code/webapp/WEB-INF/pages/kickstart/troubleshooting.jsp
@@ -43,7 +43,7 @@
 
         <tr>
           <th><bean:message key="kickstart.troubleshooting.jsp.kernelparams" />:</th>
-          <td><html:text property="kernelParams" maxlength="64" size="32" /></td>
+          <td><html:text property="kernelParams" maxlength="2048" size="32" /></td>
         </tr>
 
         <tr>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Raise length limit for kernel options (bsc#1182916)
 - optionally allow vendor change when patching
 - Speed up the system groups page (bsc#1182132)
 - Log shell command output on failure when checking known_hosts file permissions

--- a/schema/spacewalk/common/tables/rhnActionVirtCreate.sql
+++ b/schema/spacewalk/common/tables/rhnActionVirtCreate.sql
@@ -33,7 +33,7 @@ CREATE TABLE rhnActionVirtCreate
     remove_interfaces    CHAR(1),
     cobbler_system       VARCHAR(256),
     kickstart_host       VARCHAR(256),
-    kernel_options       VARCHAR(256)
+    kernel_options       VARCHAR(2048)
 )
 
 ;

--- a/schema/spacewalk/common/tables/rhnKSData.sql
+++ b/schema/spacewalk/common/tables/rhnKSData.sql
@@ -52,7 +52,7 @@ CREATE TABLE rhnKSData
     nochroot_post   BYTEA,
     partition_data   BYTEA,
     static_device   VARCHAR(32),
-    kernel_params   VARCHAR(128),
+    kernel_params   VARCHAR(2048),
     verboseup2date  CHAR(1)
                         DEFAULT ('N') NOT NULL
                         CONSTRAINT rhn_ks_verbose_up2date_ck

--- a/schema/spacewalk/common/tables/rhnKickstartableTree.sql
+++ b/schema/spacewalk/common/tables/rhnKickstartableTree.sql
@@ -37,8 +37,8 @@ CREATE TABLE rhnKickstartableTree
     install_type    NUMERIC NOT NULL
                         CONSTRAINT rhn_kstree_it_fk
                             REFERENCES rhnKSInstallType (id),
-    kernel_options       VARCHAR(256),
-    kernel_options_post  VARCHAR(256),
+    kernel_options       VARCHAR(2048),
+    kernel_options_post  VARCHAR(2048),
     last_modified   TIMESTAMPTZ
                         DEFAULT (current_timestamp) NOT NULL,
     created         TIMESTAMPTZ

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- Raise length limit for kernel options (bsc#1182916)
 - add rhnactiondetails table for handling allow vendor change for errata/install/upgrade actions
 - add virtual network create action
 

--- a/schema/spacewalk/upgrade/susemanager-schema-4.2.2-to-susemanager-schema-4.2.3/001-add_rhnVirtCreateAction_cobblerid.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.2.2-to-susemanager-schema-4.2.3/001-add_rhnVirtCreateAction_cobblerid.sql
@@ -12,4 +12,4 @@
 ALTER TABLE rhnActionVirtCreate
     ADD COLUMN IF NOT EXISTS cobbler_system VARCHAR(256),
     ADD COLUMN IF NOT EXISTS kickstart_host VARCHAR(256),
-    ADD COLUMN IF NOT EXISTS kernel_options VARCHAR(256);
+    ADD COLUMN IF NOT EXISTS kernel_options VARCHAR(2048);

--- a/schema/spacewalk/upgrade/susemanager-schema-4.2.2-to-susemanager-schema-4.2.3/001-add_rhnVirtCreateAction_cobblerid.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.2.2-to-susemanager-schema-4.2.3/001-add_rhnVirtCreateAction_cobblerid.sql
@@ -12,4 +12,4 @@
 ALTER TABLE rhnActionVirtCreate
     ADD COLUMN IF NOT EXISTS cobbler_system VARCHAR(256),
     ADD COLUMN IF NOT EXISTS kickstart_host VARCHAR(256),
-    ADD COLUMN IF NOT EXISTS kernel_options VARCHAR(2048);
+    ADD COLUMN IF NOT EXISTS kernel_options VARCHAR(256);

--- a/schema/spacewalk/upgrade/susemanager-schema-4.2.9-to-susemanager-schema-4.2.10/100-increase-kernel-options-length.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.2.9-to-susemanager-schema-4.2.10/100-increase-kernel-options-length.sql
@@ -1,0 +1,4 @@
+ALTER TABLE rhnKickstartableTree ALTER COLUMN kernel_options TYPE VARCHAR(2048);
+ALTER TABLE rhnKickstartableTree ALTER COLUMN kernel_options_post TYPE VARCHAR(2048);
+ALTER TABLE rhnActionVirtCreate ALTER COLUMN kernel_options TYPE VARCHAR(2048);
+ALTER TABLE rhnKSData ALTER COLUMN kernel_params TYPE VARCHAR(2048);


### PR DESCRIPTION
## What does this PR change?

Port of https://github.com/SUSE/spacewalk/pull/14183

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1182916

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
