### PR TITLE
Add allow vendor change support for patching

### DIFF
--- a/backend/server/action/errata.py
+++ b/backend/server/action/errata.py
@@ -29,7 +29,7 @@ def update(serverId, actionId, dry_run=0):
     statement = """
         select r1.errata_id, r2.allow_vendor_change
         from rhnactionerrataupdate r1
-        join rhnactiondetails r2 on r1.action_id = r2.action_id
+        join rhnactionpackagedetails r2 on r1.action_id = r2.action_id
         where r1.action_id = :action_id
     """
     h = rhnSQL.prepare(statement)
@@ -41,7 +41,7 @@ def update(serverId, actionId, dry_run=0):
                             "%s for server %s" % (actionId, serverId))
 
     params = {
-        "errata_id" : [x['errata_id'] for x in ret],
+        "errata_ids" : [x['errata_id'] for x in ret],
         "allow_vendor_change" : (ret[0]['allow_vendor_change'] == 'Y')
     }
-    return (params)
+    return params

--- a/backend/server/action/errata.py
+++ b/backend/server/action/errata.py
@@ -29,7 +29,7 @@ def update(serverId, actionId, dry_run=0):
     statement = """
         select r1.errata_id, r2.allow_vendor_change
         from rhnactionerrataupdate r1
-        join rhnactionpackagedetails r2 on r1.action_id = r2.action_id
+        left join rhnactionpackagedetails r2 on r1.action_id = r2.action_id
         where r1.action_id = :action_id
     """
     h = rhnSQL.prepare(statement)
@@ -40,8 +40,10 @@ def update(serverId, actionId, dry_run=0):
         raise InvalidAction("errata.update: Unknown action id "
                             "%s for server %s" % (actionId, serverId))
 
-    params = {
+    if ret[0]['allow_vendor_change'] is null or ret[0]['allow_vendor_change'] is False:
+        return [x['errata_id'] for x in ret]
+
+    return {
         "errata_ids" : [x['errata_id'] for x in ret],
         "allow_vendor_change" : (ret[0]['allow_vendor_change'] == 'Y')
     }
-    return params

--- a/backend/server/action/errata.py
+++ b/backend/server/action/errata.py
@@ -27,9 +27,11 @@ __rhnexport__ = ['update']
 def update(serverId, actionId, dry_run=0):
     log_debug(3)
     statement = """
-        select errata_id
-        from rhnActionErrataUpdate
-        where action_id = :action_id"""
+        select r1.errata_id, r2.allow_vendor_change
+        from rhnactionerrataupdate r1
+        join rhnactiondetails r2 on r1.action_id = r2.action_id
+        where r1.action_id = :action_id
+    """
     h = rhnSQL.prepare(statement)
     h.execute(action_id=actionId)
     ret = h.fetchall_dict()
@@ -38,4 +40,8 @@ def update(serverId, actionId, dry_run=0):
         raise InvalidAction("errata.update: Unknown action id "
                             "%s for server %s" % (actionId, serverId))
 
-    return [x['errata_id'] for x in ret]
+    params = {
+        "errata_id" : [x['errata_id'] for x in ret],
+        "allow_vendor_change" : (ret[0]['allow_vendor_change'] == 'Y')
+    }
+    return (params)

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- add allow vendor change with patching via rhnstack 
 - Fixed kickstart tree permissions to a+r.
 - Avoid race condition due multiple reposync import threads (bsc#1183151)
 

--- a/client/rhel/dnf-plugin-spacewalk/actions/errata.py
+++ b/client/rhel/dnf-plugin-spacewalk/actions/errata.py
@@ -24,6 +24,8 @@ def __getErrataInfo(errata_id):
 
 def update(errataidlist, cache_only=None):
     packagelist = []
+    if type(errataidlist) == dict:
+        errataidlist = params['errata_ids']
 
     if type(errataidlist) not in [type([]), type(())]:
         errataidlist = [ errataidlist ]

--- a/client/rhel/dnf-plugin-spacewalk/dnf-plugin-spacewalk.changes
+++ b/client/rhel/dnf-plugin-spacewalk/dnf-plugin-spacewalk.changes
@@ -1,3 +1,5 @@
+- Make errata update compatible with new data structure sent by the server
+
 -------------------------------------------------------------------
 Wed Jan 27 12:51:51 CET 2021 - jgonzalez@suse.com
 

--- a/client/rhel/yum-rhn-plugin/actions/errata.py
+++ b/client/rhel/yum-rhn-plugin/actions/errata.py
@@ -23,6 +23,8 @@ def __getErrataInfo(errata_id):
 
 def update(errataidlist, cache_only=None):
     packagelist = []
+    if type(errataidlist) == dict:
+        errataidlist = params['errata_ids']
 
     if type(errataidlist) not in [type([]), type(())]:
         errataidlist = [ errataidlist ]

--- a/client/rhel/yum-rhn-plugin/yum-rhn-plugin.changes
+++ b/client/rhel/yum-rhn-plugin/yum-rhn-plugin.changes
@@ -1,3 +1,5 @@
+- Make errata update compatible with new data structure sent by the server
+
 -------------------------------------------------------------------
 Fri Feb 12 14:36:09 CET 2021 - jgonzalez@suse.com
 

--- a/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
@@ -51,6 +51,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
                                 <many-to-many column="errata_id" outer-join="false"
                                         class="com.redhat.rhn.domain.errata.Errata" />
                         </set>
+                         <one-to-one name="details"
+                class="com.redhat.rhn.domain.action.errata.ActionPackageDetails"
+                outer-join="false" cascade="all" constrained="false" property-ref="parentAction"/>
                 </subclass>
         <subclass name="com.redhat.rhn.domain.action.image.DeployImageAction"
             lazy="true" discriminator-value="500">

--- a/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
@@ -788,7 +788,6 @@ select sa.server_id
                              NULL as permission_owner,
                              NULL as permission_group,
                              NULL as permission_seclabel,
-                             NULL as allow_vendor_change,
                              NULL as source from dual) ra_16_,
                      (select NULL as pool_name,
                              NULL as volume_name from dual) ra_17_,

--- a/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
@@ -788,6 +788,7 @@ select sa.server_id
                              NULL as permission_owner,
                              NULL as permission_group,
                              NULL as permission_seclabel,
+                             NULL as allow_vendor_change,
                              NULL as source from dual) ra_16_,
                      (select NULL as pool_name,
                              NULL as volume_name from dual) ra_17_,

--- a/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
@@ -51,9 +51,9 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
                                 <many-to-many column="errata_id" outer-join="false"
                                         class="com.redhat.rhn.domain.errata.Errata" />
                         </set>
-                         <one-to-one name="details"
-                class="com.redhat.rhn.domain.action.errata.ActionPackageDetails"
-                outer-join="false" cascade="all" constrained="false" property-ref="parentAction"/>
+                        <one-to-one name="details"
+                            class="com.redhat.rhn.domain.action.errata.ActionPackageDetails"
+                            outer-join="false" cascade="all" constrained="false" property-ref="parentAction"/>
                 </subclass>
         <subclass name="com.redhat.rhn.domain.action.image.DeployImageAction"
             lazy="true" discriminator-value="500">

--- a/java/code/src/com/redhat/rhn/domain/action/errata/ActionPackageDetails.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/errata/ActionPackageDetails.hbm.xml
@@ -3,13 +3,15 @@
 PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
 "http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd">
 <hibernate-mapping>
-  <class name="com.redhat.rhn.domain.action.errata.rhnActionPackageDetails">"
-         table="rhnActionDup">
+  <class name="com.redhat.rhn.domain.action.errata.ActionPackageDetails" table="rhnActionPackageDetails">
     <id name="id" type="long" column="id">
       <meta attribute="scope-set">protected</meta>
+      <generator class="sequence">
+        <param name="sequence">rhn_actiondpd_id_seq</param>
+      </generator>
     </id>
     <!-- Reference to the parent action -->
-    <one-to-one name="parentAction" column="action_id"
+    <many-to-one name="parentAction" column="action_id"
                  class="com.redhat.rhn.domain.action.Action" outer-join="true"
                  not-null="true" insert="true" update="false" />
     <property name="allowVendorChange" column="allow_vendor_change" type="yes_no" />

--- a/java/code/src/com/redhat/rhn/domain/action/errata/ActionPackageDetails.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/errata/ActionPackageDetails.hbm.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE hibernate-mapping
+PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+"http://hibernate.sourceforge.net/hibernate-mapping-3.0.dtd">
+<hibernate-mapping>
+  <class name="com.redhat.rhn.domain.action.errata.rhnActionPackageDetails">"
+         table="rhnActionDup">
+    <id name="id" type="long" column="id">
+      <meta attribute="scope-set">protected</meta>
+    </id>
+    <!-- Reference to the parent action -->
+    <one-to-one name="parentAction" column="action_id"
+                 class="com.redhat.rhn.domain.action.Action" outer-join="true"
+                 not-null="true" insert="true" update="false" />
+    <property name="allowVendorChange" column="allow_vendor_change" type="yes_no" />
+  </class>
+</hibernate-mapping>

--- a/java/code/src/com/redhat/rhn/domain/action/errata/ActionPackageDetails.java
+++ b/java/code/src/com/redhat/rhn/domain/action/errata/ActionPackageDetails.java
@@ -1,15 +1,19 @@
 
 package com.redhat.rhn.domain.action.errata;
 
+import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionChild;
 
 public class ActionPackageDetails extends ActionChild {
      private Long id;
      private boolean allowVendorChange = false;
 
-     public ActionPackageDetails() {     }
+     public ActionPackageDetails(Action parentActionIn) {
+         super.setParentAction(parentActionIn);
+     }
 
-     public ActionPackageDetails(boolean allowVendorChangeIn) {
+     public ActionPackageDetails(Action parentActionIn, boolean allowVendorChangeIn) {
+         super.setParentAction(parentActionIn);
          this.allowVendorChange = allowVendorChangeIn;
      }
 

--- a/java/code/src/com/redhat/rhn/domain/action/errata/ActionPackageDetails.java
+++ b/java/code/src/com/redhat/rhn/domain/action/errata/ActionPackageDetails.java
@@ -1,9 +1,17 @@
 
 package com.redhat.rhn.domain.action.errata;
 
-public class ActionPackageDetails {
+import com.redhat.rhn.domain.action.ActionChild;
+
+public class ActionPackageDetails extends ActionChild {
      private Long id;
      private boolean allowVendorChange = false;
+
+     public ActionPackageDetails() {     }
+
+     public ActionPackageDetails(boolean allowVendorChangeIn) {
+         this.allowVendorChange = allowVendorChangeIn;
+     }
 
     /**
      * Return the ID.

--- a/java/code/src/com/redhat/rhn/domain/action/errata/ActionPackageDetails.java
+++ b/java/code/src/com/redhat/rhn/domain/action/errata/ActionPackageDetails.java
@@ -1,3 +1,17 @@
+/**
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
 
 package com.redhat.rhn.domain.action.errata;
 
@@ -8,10 +22,23 @@ public class ActionPackageDetails extends ActionChild {
      private Long id;
      private boolean allowVendorChange = false;
 
-     public ActionPackageDetails(Action parentActionIn) {
-         super.setParentAction(parentActionIn);
-     }
+    /**
+     * Constructor
+     */
+    public ActionPackageDetails() {  }
 
+    /**
+     * Constructor
+     * @param parentActionIn Action
+     */
+     public ActionPackageDetails(Action parentActionIn) {
+            super.setParentAction(parentActionIn);
+     }
+    /**
+     * Constructor
+     * @param parentActionIn Action
+     * @param allowVendorChangeIn boolean
+     */
      public ActionPackageDetails(Action parentActionIn, boolean allowVendorChangeIn) {
          super.setParentAction(parentActionIn);
          this.allowVendorChange = allowVendorChangeIn;

--- a/java/code/src/com/redhat/rhn/domain/action/errata/ActionPackageDetails.java
+++ b/java/code/src/com/redhat/rhn/domain/action/errata/ActionPackageDetails.java
@@ -18,8 +18,13 @@ package com.redhat.rhn.domain.action.errata;
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionChild;
 
+/**
+ * ActionPackageDetails
+ *
+ * Handles the vendor change flag for patching, upgrading, installing
+ */
 public class ActionPackageDetails extends ActionChild {
-     private Long id;
+     private long id;
      private boolean allowVendorChange = false;
 
     /**
@@ -27,13 +32,6 @@ public class ActionPackageDetails extends ActionChild {
      */
     public ActionPackageDetails() {  }
 
-    /**
-     * Constructor
-     * @param parentActionIn Action
-     */
-     public ActionPackageDetails(Action parentActionIn) {
-            super.setParentAction(parentActionIn);
-     }
     /**
      * Constructor
      * @param parentActionIn Action
@@ -48,7 +46,7 @@ public class ActionPackageDetails extends ActionChild {
      * Return the ID.
      * @return id
      */
-    public Long getId() {
+    public long getId() {
         return id;
     }
 
@@ -56,10 +54,9 @@ public class ActionPackageDetails extends ActionChild {
      * Set the ID.
      * @param idIn id
      */
-    public void setId(Long idIn) {
+    public void setId(long idIn) {
         this.id = idIn;
     }
-
 
     /**
      * @return Returns allow vendor change

--- a/java/code/src/com/redhat/rhn/domain/action/errata/ActionPackageDetails.java
+++ b/java/code/src/com/redhat/rhn/domain/action/errata/ActionPackageDetails.java
@@ -1,0 +1,38 @@
+
+package com.redhat.rhn.domain.action.errata;
+
+public class ActionPackageDetails {
+     private Long id;
+     private boolean allowVendorChange = false;
+
+    /**
+     * Return the ID.
+     * @return id
+     */
+    public Long getId() {
+        return id;
+    }
+
+    /**
+     * Set the ID.
+     * @param idIn id
+     */
+    public void setId(Long idIn) {
+        this.id = idIn;
+    }
+
+
+    /**
+     * @return Returns allow vendor change
+     */
+    public boolean getAllowVendorChange() {
+        return allowVendorChange;
+    }
+
+    /**
+     * @param allowVendorChangeIn Set allow vendor change flag.
+     */
+    public void setAllowVendorChange(boolean allowVendorChangeIn) {
+        this.allowVendorChange = allowVendorChangeIn;
+    }
+}

--- a/java/code/src/com/redhat/rhn/domain/action/errata/ErrataAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/errata/ErrataAction.java
@@ -30,6 +30,21 @@ import java.util.Set;
 public class ErrataAction extends Action {
 
     private Set<Errata> errata;
+    private ActionPackageDetails apd;
+
+    /**
+     * @return Returns ActionPackageDetails
+     */
+    public ActionPackageDetails getActionPackageDetails() {
+        return apd;
+    }
+
+    /**
+     * @param  Set ActionPackageDetails
+     */
+    public void setActionPackageDetails(ActionPackageDetails apdIn){
+        this.apd = apdIn;
+    }
 
     /**
      * @return Returns the errata.

--- a/java/code/src/com/redhat/rhn/domain/action/errata/ErrataAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/errata/ErrataAction.java
@@ -42,7 +42,7 @@ public class ErrataAction extends Action {
     /**
      * @param detailsIn ActionPackageDetails
      */
-    public void setDetails(ActionPackageDetails detailsIn){
+    public void setDetails(ActionPackageDetails detailsIn) {
         this.details = detailsIn;
     }
 

--- a/java/code/src/com/redhat/rhn/domain/action/errata/ErrataAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/errata/ErrataAction.java
@@ -30,20 +30,21 @@ import java.util.Set;
 public class ErrataAction extends Action {
 
     private Set<Errata> errata;
-    private ActionPackageDetails apd;
+    private ActionPackageDetails details;
 
     /**
      * @return Returns ActionPackageDetails
      */
-    public ActionPackageDetails getActionPackageDetails() {
-        return apd;
+    public ActionPackageDetails getDetails() {
+        return details;
     }
 
     /**
-     * @param  Set ActionPackageDetails
+     * @param detailsIn ActionPackageDetails
      */
-    public void setActionPackageDetails(ActionPackageDetails apdIn){
-        this.apd = apdIn;
+    public void setDetails(ActionPackageDetails detailsIn){
+        detailsIn.setParentAction(this);
+        this.details = detailsIn;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/action/errata/ErrataAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/errata/ErrataAction.java
@@ -43,7 +43,6 @@ public class ErrataAction extends Action {
      * @param detailsIn ActionPackageDetails
      */
     public void setDetails(ActionPackageDetails detailsIn){
-        detailsIn.setParentAction(this);
         this.details = detailsIn;
     }
 

--- a/java/code/src/com/redhat/rhn/domain/action/server/test/ServerActionTest.java
+++ b/java/code/src/com/redhat/rhn/domain/action/server/test/ServerActionTest.java
@@ -16,6 +16,8 @@ package com.redhat.rhn.domain.action.server.test;
 
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionFactory;
+import com.redhat.rhn.domain.action.errata.ActionPackageDetails;
+import com.redhat.rhn.domain.action.errata.ErrataAction;
 import com.redhat.rhn.domain.action.salt.ApplyStatesAction;
 import com.redhat.rhn.domain.action.server.ServerAction;
 import com.redhat.rhn.domain.action.test.ActionFactoryTest;
@@ -91,7 +93,8 @@ public class ServerActionTest extends RhnBaseTestCase {
     public void testCreate() throws Exception {
         User user = UserTestUtils.findNewUser("testUser",
                 "testOrg" + this.getClass().getSimpleName());
-        Action parent = ActionFactoryTest.createAction(user, ActionFactory.TYPE_ERRATA);
+        ErrataAction parent = (ErrataAction) ActionFactoryTest.createAction(user, ActionFactory.TYPE_ERRATA);
+        parent.setDetails(new ActionPackageDetails());
         ServerAction child = createServerAction(ServerFactoryTest
                 .createTestServer(user), parent);
 

--- a/java/code/src/com/redhat/rhn/domain/action/server/test/ServerActionTest.java
+++ b/java/code/src/com/redhat/rhn/domain/action/server/test/ServerActionTest.java
@@ -14,6 +14,7 @@
  */
 package com.redhat.rhn.domain.action.server.test;
 
+import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionFactory;
 import com.redhat.rhn.domain.action.errata.ActionPackageDetails;
@@ -94,7 +95,8 @@ public class ServerActionTest extends RhnBaseTestCase {
         User user = UserTestUtils.findNewUser("testUser",
                 "testOrg" + this.getClass().getSimpleName());
         ErrataAction parent = (ErrataAction) ActionFactoryTest.createAction(user, ActionFactory.TYPE_ERRATA);
-        parent.setDetails(new ActionPackageDetails());
+        //TODO: Save ActionPackageDetails
+        new ActionPackageDetails(parent);
         ServerAction child = createServerAction(ServerFactoryTest
                 .createTestServer(user), parent);
 

--- a/java/code/src/com/redhat/rhn/domain/action/server/test/ServerActionTest.java
+++ b/java/code/src/com/redhat/rhn/domain/action/server/test/ServerActionTest.java
@@ -95,7 +95,6 @@ public class ServerActionTest extends RhnBaseTestCase {
         User user = UserTestUtils.findNewUser("testUser",
                 "testOrg" + this.getClass().getSimpleName());
         ErrataAction parent = (ErrataAction) ActionFactoryTest.createAction(user, ActionFactory.TYPE_ERRATA);
-        //TODO: Save ActionPackageDetails
         new ActionPackageDetails(parent);
         ServerAction child = createServerAction(ServerFactoryTest
                 .createTestServer(user), parent);

--- a/java/code/src/com/redhat/rhn/domain/action/server/test/ServerActionTest.java
+++ b/java/code/src/com/redhat/rhn/domain/action/server/test/ServerActionTest.java
@@ -14,7 +14,6 @@
  */
 package com.redhat.rhn.domain.action.server.test;
 
-import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionFactory;
 import com.redhat.rhn.domain.action.errata.ActionPackageDetails;
@@ -28,7 +27,6 @@ import com.redhat.rhn.domain.server.test.ServerFactoryTest;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.testing.RhnBaseTestCase;
 import com.redhat.rhn.testing.UserTestUtils;
-
 import java.util.Date;
 
 /**
@@ -95,7 +93,7 @@ public class ServerActionTest extends RhnBaseTestCase {
         User user = UserTestUtils.findNewUser("testUser",
                 "testOrg" + this.getClass().getSimpleName());
         ErrataAction parent = (ErrataAction) ActionFactoryTest.createAction(user, ActionFactory.TYPE_ERRATA);
-        new ActionPackageDetails(parent);
+        new ActionPackageDetails();
         ServerAction child = createServerAction(ServerFactoryTest
                 .createTestServer(user), parent);
 

--- a/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
@@ -1138,7 +1138,7 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
         List<MinionSummary> minionSummaries = minions.stream().map(MinionSummary::new).collect(Collectors.toList());
 
         Map<LocalCall<?>, List<MinionSummary>> localCallListMap =
-                saltServerActionService.errataAction(minionSummaries, Collections.singleton(e1.getId()));
+                saltServerActionService.errataAction(minionSummaries, Collections.singleton(e1.getId()), false);
 
         assertEquals(1, localCallListMap.size());
         localCallListMap.entrySet().forEach(result -> {

--- a/java/code/src/com/redhat/rhn/frontend/action/errata/test/ErrataConfirmActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/errata/test/ErrataConfirmActionTest.java
@@ -49,6 +49,7 @@ public class ErrataConfirmActionTest extends RhnPostMockStrutsTestCase {
         RhnSetManager.store(updateMe); //save the set
 
         addRequestParameter("eid", e.getId().toString());
+        addRequestParameter("allowVendorChange", new String[]{"false"});
         // Execute the Action
         actionPerform();
         verifyForward("confirmed");

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/ErrataConfirmSetupAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/ErrataConfirmSetupAction.java
@@ -75,8 +75,6 @@ public class ErrataConfirmSetupAction extends RhnAction implements Listable, Mai
 
         RequestContext requestContext = new RequestContext(request);
         User user = requestContext.getCurrentUser();
-        DynaActionForm form = (DynaActionForm) formIn;
-
 
         Long sid = requestContext.getRequiredParam("sid");
         RhnSet set = ErrataSetupAction.getSetDecl(sid).get(user);
@@ -95,7 +93,7 @@ public class ErrataConfirmSetupAction extends RhnAction implements Listable, Mai
 
         //Setup the Action Chain widget
         ActionChainHelper.prepopulateActionChains(request);
-        boolean allowVendorChange = BooleanUtils.toBoolean(request.getParameterValues(ALLOW_VENDOR_CHANGE)[0]);
+        boolean allowVendorChange = BooleanUtils.toBoolean(request.getParameter(ALLOW_VENDOR_CHANGE));
         request.setAttribute("date", picker);
         request.setAttribute("system", server);
         request.setAttribute(ALLOW_VENDOR_CHANGE, allowVendorChange);

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/ErrataConfirmSetupAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/ErrataConfirmSetupAction.java
@@ -148,7 +148,7 @@ public class ErrataConfirmSetupAction extends RhnAction implements Listable, Mai
             List<Long> errataIds = new ArrayList<Long>(errataList);
             try {
                 ErrataManager.applyErrata(user, errataIds, earliest, actionChain,
-                        serverIds, allowVendorChange);
+                        serverIds, true, allowVendorChange);
 
                 ActionMessages msg = new ActionMessages();
                 Object[] args = null;

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/ErrataConfirmSetupAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/ErrataConfirmSetupAction.java
@@ -95,6 +95,7 @@ public class ErrataConfirmSetupAction extends RhnAction implements Listable, Mai
 
         request.setAttribute("date", picker);
         request.setAttribute("system", server);
+        request.setAttribute("allowVendorChange", request.getParameterValues("allowVendorChange") != null);
         request.setAttribute(ListTagHelper.PARENT_URL,
                 request.getRequestURI() + "?sid=" + sid);
 
@@ -133,7 +134,11 @@ public class ErrataConfirmSetupAction extends RhnAction implements Listable, Mai
 
         Server server = SystemManager.lookupByIdAndUser(sid, user);
         RhnSet set = ErrataSetupAction.getSetDecl(sid).get(user);
+<<<<<<< HEAD
 
+=======
+        boolean allowVendorChange = request.getParameterValues("allowVendorChange") != null;
+>>>>>>> 6fa1f87f876... Fix Hibernate issues
         // Get the errata IDs
         Set<Long> errataList = set.getElementValues();
         if (server != null && !errataList.isEmpty()) {

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/ErrataConfirmSetupAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/ErrataConfirmSetupAction.java
@@ -36,6 +36,7 @@ import com.redhat.rhn.manager.errata.ErrataManager;
 import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
 
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.log4j.Logger;
 import org.apache.struts.action.ActionErrors;
 import org.apache.struts.action.ActionForm;
@@ -61,6 +62,7 @@ import javax.servlet.http.HttpServletResponse;
  */
 public class ErrataConfirmSetupAction extends RhnAction implements Listable, MaintenanceWindowsAware {
 
+    public static final String ALLOW_VENDOR_CHANGE = "allowVendorChange";
     /** Logger instance */
     private static Logger log = Logger.getLogger(ErrataConfirmSetupAction.class);
 
@@ -73,6 +75,7 @@ public class ErrataConfirmSetupAction extends RhnAction implements Listable, Mai
 
         RequestContext requestContext = new RequestContext(request);
         User user = requestContext.getCurrentUser();
+        DynaActionForm form = (DynaActionForm) formIn;
 
 
         Long sid = requestContext.getRequiredParam("sid");
@@ -92,10 +95,10 @@ public class ErrataConfirmSetupAction extends RhnAction implements Listable, Mai
 
         //Setup the Action Chain widget
         ActionChainHelper.prepopulateActionChains(request);
-
+        boolean allowVendorChange = BooleanUtils.toBoolean(request.getParameterValues(ALLOW_VENDOR_CHANGE)[0]);
         request.setAttribute("date", picker);
         request.setAttribute("system", server);
-        request.setAttribute("allowVendorChange", request.getParameterValues("allowVendorChange") != null);
+        request.setAttribute(ALLOW_VENDOR_CHANGE, allowVendorChange);
         request.setAttribute(ListTagHelper.PARENT_URL,
                 request.getRequestURI() + "?sid=" + sid);
 
@@ -134,11 +137,8 @@ public class ErrataConfirmSetupAction extends RhnAction implements Listable, Mai
 
         Server server = SystemManager.lookupByIdAndUser(sid, user);
         RhnSet set = ErrataSetupAction.getSetDecl(sid).get(user);
-<<<<<<< HEAD
+        boolean allowVendorChange = BooleanUtils.toBoolean(request.getParameterValues(ALLOW_VENDOR_CHANGE)[0]);
 
-=======
-        boolean allowVendorChange = request.getParameterValues("allowVendorChange") != null;
->>>>>>> 6fa1f87f876... Fix Hibernate issues
         // Get the errata IDs
         Set<Long> errataList = set.getElementValues();
         if (server != null && !errataList.isEmpty()) {
@@ -148,7 +148,7 @@ public class ErrataConfirmSetupAction extends RhnAction implements Listable, Mai
             List<Long> errataIds = new ArrayList<Long>(errataList);
             try {
                 ErrataManager.applyErrata(user, errataIds, earliest, actionChain,
-                        serverIds);
+                        serverIds, allowVendorChange);
 
                 ActionMessages msg = new ActionMessages();
                 Object[] args = null;

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/ErrataSetupAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/ErrataSetupAction.java
@@ -86,7 +86,7 @@ public class ErrataSetupAction extends RhnAction implements Listable {
 
         Optional<MinionServer> minion = MinionServerFactory.lookupById(sid);
         // Check if this is a SUSE system
-        boolean isSUSEMinion = minion.isPresent() && minion.get().getOsFamily().equals("Suse");
+        boolean isSUSEMinion = minion.map(m -> m.getOsFamily().equals("Suse")).orElse(false);
         boolean zyppPluginInstalled = false;
         if (!isSUSEMinion) {
             Server server = ServerFactory.lookupById(sid);

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/ErrataSetupAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/ErrataSetupAction.java
@@ -178,6 +178,7 @@ public class ErrataSetupAction extends RhnAction implements Listable {
         Long sid = requestContext.getParamAsLong("sid");
         User user = requestContext.getCurrentUser();
         RhnSet set = getSetDecl(sid).get(user);
+        boolean allowVendorChange = request.getParameterValues(ALLOW_VENDOR_CHANGE) != null;
 
         //if they chose no errata, return to the same page with a message
         if (set.isEmpty()) {

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/test/ErrataActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/test/ErrataActionTest.java
@@ -58,6 +58,7 @@ public class ErrataActionTest extends RhnPostMockStrutsTestCase {
         addSubmitted();
         addRequestParameter(RequestContext.DISPATCH,
                 LocalizationService.getInstance().getMessage("errata.jsp.apply"));
+        addRequestParameter("allowVendorChange", "true");
 
         // Create System
         Server server = ServerFactoryTest.createTestServer(user, true);

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/test/ErrataConfirmActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/test/ErrataConfirmActionTest.java
@@ -76,7 +76,7 @@ public class ErrataConfirmActionTest extends RhnPostMockStrutsTestCase {
             UserFactory.save(user);
         }
         RhnSetManager.store(errata); //save the set
-        addRequestParameter("allowVendorChange", new String[]{ "false" });
+        addRequestParameter("allowVendorChange", new String("false"));
 
         addRequestParameter("sid", server.getId().toString());
         addSubmitted();
@@ -112,8 +112,8 @@ public class ErrataConfirmActionTest extends RhnPostMockStrutsTestCase {
         addRequestParameter("sid", server.getId().toString());
 
         addSubmitted();
-        addRequestParameter("allowVendorChange", new String[]{ "false" });
 
+        addRequestParameter("allowVendorChange", new String("false"));
         addRequestParameter("dispatch", "dispatch");
         // Execute the Action
         actionPerform();

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/test/ErrataConfirmActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/test/ErrataConfirmActionTest.java
@@ -76,6 +76,7 @@ public class ErrataConfirmActionTest extends RhnPostMockStrutsTestCase {
             UserFactory.save(user);
         }
         RhnSetManager.store(errata); //save the set
+        addRequestParameter("allowVendorChange", new String[]{ "false" });
 
         addRequestParameter("sid", server.getId().toString());
         addSubmitted();
@@ -111,6 +112,8 @@ public class ErrataConfirmActionTest extends RhnPostMockStrutsTestCase {
         addRequestParameter("sid", server.getId().toString());
 
         addSubmitted();
+        addRequestParameter("allowVendorChange", new String[]{ "false" });
+
         addRequestParameter("dispatch", "dispatch");
         // Execute the Action
         actionPerform();

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/test/ErrataConfirmSetupActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/test/ErrataConfirmSetupActionTest.java
@@ -30,7 +30,7 @@ public class ErrataConfirmSetupActionTest extends RhnMockStrutsTestCase {
         // Create Server
         Server server = ServerFactoryTest.createTestServer(user, true);
         addRequestParameter("sid", server.getId().toString());
-        addRequestParameter("allowVendorChange", new String[]{"false"});
+        addRequestParameter("allowVendorChange", new String( "false" ));
 
         //Note: 2 invocations of getParameter("schedule_type") will be called by DatePicker
         addRequestParameter(DatePicker.SCHEDULE_TYPE, DatePicker.ScheduleType.DATE.asString());

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/test/ErrataConfirmSetupActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/test/ErrataConfirmSetupActionTest.java
@@ -30,6 +30,7 @@ public class ErrataConfirmSetupActionTest extends RhnMockStrutsTestCase {
         // Create Server
         Server server = ServerFactoryTest.createTestServer(user, true);
         addRequestParameter("sid", server.getId().toString());
+        addRequestParameter("allowVendorChange", new String[]{"false"});
 
         //Note: 2 invocations of getParameter("schedule_type") will be called by DatePicker
         addRequestParameter(DatePicker.SCHEDULE_TYPE, DatePicker.ScheduleType.DATE.asString());

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/test/ErrataSetupActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/test/ErrataSetupActionTest.java
@@ -32,17 +32,16 @@ public class ErrataSetupActionTest extends RhnMockStrutsTestCase {
     public void setUp() throws Exception {
         super.setUp();
         setRequestPathInfo("/systems/details/ErrataList");
-
     }
     public void testInvalidParamCase() {
         addRequestParameter(RequestContext.SID, "-9999");
         actionPerform();
         assertPermissionException();
-
     }
 
     public void testNormalCase() throws Exception {
         Server server = ServerFactoryTest.createTestServer(user, true);
+        addRequestParameter("allowVendorChange", "false");
         addRequestParameter("sid", server.getId().toString());
         Errata e = ErrataFactoryTest.createTestErrata(user.getOrg().getId());
 
@@ -64,7 +63,7 @@ public class ErrataSetupActionTest extends RhnMockStrutsTestCase {
         assertTrue(request.getAttribute("showApplyErrata").equals("true"));
         clearRequestParameters();
         addRequestParameter("sid", server.getId().toString());
-
+        addRequestParameter("allowVendorChange", new String[]{ "false" });
         for (Iterator itr = e.getPackages().iterator(); itr.hasNext();) {
             Package pkg = (Package) itr.next();
             ErrataCacheManager.deleteNeededCache(server.getId(),

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -3216,7 +3216,29 @@ public class SystemHandler extends BaseHandler {
      */
     public List<Long> scheduleApplyErrata(User loggedInUser, List<Integer> serverIds,
             List<Integer> errataIds) {
-        return scheduleApplyErrata(loggedInUser, serverIds, errataIds, null, false);
+        return scheduleApplyErrata(loggedInUser, serverIds, errataIds, null, false, false);
+    }
+
+    /**
+     * Schedules an action to apply errata updates to multiple systems.
+     * @param loggedInUser The current user
+     * @param serverIds List of server IDs to apply the errata to (as Integers)
+     * @param errataIds List of errata IDs to apply (as Integers)
+     * @param allowVendorChange boolean
+     * @return list of action ids, exception thrown otherwise
+     * @since 24
+     *
+     * @xmlrpc.doc Schedules an action to apply errata updates to multiple systems.
+     * @xmlrpc.param #param("string", "sessionKey")
+     * @xmlrpc.param #array_single("int", "serverId")
+     * @xmlrpc.param #array_single("int", "errataId")
+     * @xmlrpc.param #param("boolean", "allowVendorChange")
+     * @xmlrpc.returntype #array_single("int", "actionId")
+     */
+    public List<Long> scheduleApplyErrata(User loggedInUser, List<Integer> serverIds,
+                                          List<Integer> errataIds, boolean allowVendorChange) {
+        return scheduleApplyErrata(loggedInUser, serverIds, errataIds, null,
+                false, allowVendorChange);
     }
 
     /**
@@ -3312,10 +3334,12 @@ public class SystemHandler extends BaseHandler {
      *          "Allow this API call, despite modular content being present")
      * @xmlrpc.param #param_desc("boolean", "onlyRelevant",
      *          "If true not all erratas are applied to all systems. Systems get only the erratas relevant for them.")
+     * @param allowVendorChange boolean
      * @xmlrpc.returntype #array_single("int", "actionId")
      */
     public List<Long> scheduleApplyErrata(User loggedInUser, List<Integer> serverIdsIn, List<Integer> errataIdsIn,
-                                          Date earliestOccurrence, Boolean allowModules, Boolean onlyRelevant) {
+                                          Date earliestOccurrence, Boolean allowModules,
+                                          Boolean onlyRelevant, boolean allowVendorChange) {
 
         // we need long values to pass to ErrataManager.applyErrataHelper
         List<Long> serverIds = serverIdsIn.stream()
@@ -3467,6 +3491,64 @@ public class SystemHandler extends BaseHandler {
         return scheduleApplyErrata(loggedInUser, serverIds, errataIds, earliestOccurrence, allowModules);
     }
 
+    /**
+     * Schedules an action to apply errata updates to a system at a specified time.
+     * @param loggedInUser The current user
+     * @param sid ID of the server
+     * @param errataIds List of errata IDs to apply (as Integers)
+     * @param earliestOccurrence Earliest occurrence of the errata update
+     * @param allowModules Allow this API call, despite modular content being present
+     * @param allowVendorChange boolean
+     * @return list of action ids, exception thrown otherwise
+     * @since 21
+     *
+     * @xmlrpc.doc Schedules an action to apply errata updates to a system at a
+     * given date/time.
+     * @xmlrpc.param #param("string", "sessionKey")
+     * @xmlrpc.param #param("int", "serverId")
+     * @xmlrpc.param #array_single("int", "errataId")
+     * @xmlrpc.param dateTime.iso8601 earliestOccurrence
+     * @xmlrpc.param #param_desc("boolean", "allowModules",
+     *          "Allow this API call, despite modular content being present")
+     * @xmlrpc.param #param("boolean", "allowVendorChange")
+     * @xmlrpc.returntype #array_single("int", "actionId")
+     */
+    public List<Long> scheduleApplyErrata(User loggedInUser, Integer sid, List<Integer> errataIds,
+                                          Date earliestOccurrence, Boolean allowModules, boolean allowVendorChange) {
+        List<Integer> serverIds = new ArrayList<Integer>();
+        serverIds.add(sid);
+        return scheduleApplyErrata(loggedInUser, sid, errataIds, earliestOccurrence, allowModules, allowVendorChange);
+    }
+
+
+   /**
+     * Schedules an action to apply errata updates to a a list of systems at a specified time.
+     * @param loggedInUser The current user
+     * @param sid ID of the server
+     * @param errataIds List of errata IDs to apply (as Integers)
+     * @param earliestOccurrence Earliest occurrence of the errata update
+     * @param allowModules Allow this API call, despite modular content being present
+     * @param allowVendorChange boolean
+     * @return list of action ids, exception thrown otherwise
+     * @since 24
+     *
+     * @xmlrpc.doc Schedules an action to apply errata updates to a system at a
+     * given date/time.
+     * @xmlrpc.param #param("string", "sessionKey")
+     * @xmlrpc.param #param("int", "serverId")
+     * @xmlrpc.param #array_single("int", "errataId")
+     * @xmlrpc.param dateTime.iso8601 earliestOccurrence
+     * @xmlrpc.param #param_desc("boolean", "allowModules",
+     *          "Allow this API call, despite modular content being present")
+     * @xmlrpc.param #param("boolean", "allowVendorChange")
+     * @xmlrpc.returntype #array_single("int", "actionId")
+     */
+    public List<Long> scheduleApplyErrata(User loggedInUser, List<Integer> sid, List<Integer> errataIds,
+                                         Date earliestOccurrence, Boolean allowModules, boolean allowVendorChange) {
+        return scheduleApplyErrata(loggedInUser, sid, errataIds, earliestOccurrence, allowModules,
+                false, allowVendorChange);
+
+}
     /**
      * Compares the packages installed on two systems.
      *

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -3216,29 +3216,7 @@ public class SystemHandler extends BaseHandler {
      */
     public List<Long> scheduleApplyErrata(User loggedInUser, List<Integer> serverIds,
             List<Integer> errataIds) {
-        return scheduleApplyErrata(loggedInUser, serverIds, errataIds, null, false, false);
-    }
-
-    /**
-     * Schedules an action to apply errata updates to multiple systems.
-     * @param loggedInUser The current user
-     * @param serverIds List of server IDs to apply the errata to (as Integers)
-     * @param errataIds List of errata IDs to apply (as Integers)
-     * @param allowVendorChange boolean
-     * @return list of action ids, exception thrown otherwise
-     * @since 24
-     *
-     * @xmlrpc.doc Schedules an action to apply errata updates to multiple systems.
-     * @xmlrpc.param #param("string", "sessionKey")
-     * @xmlrpc.param #array_single("int", "serverId")
-     * @xmlrpc.param #array_single("int", "errataId")
-     * @xmlrpc.param #param("boolean", "allowVendorChange")
-     * @xmlrpc.returntype #array_single("int", "actionId")
-     */
-    public List<Long> scheduleApplyErrata(User loggedInUser, List<Integer> serverIds,
-                                          List<Integer> errataIds, boolean allowVendorChange) {
-        return scheduleApplyErrata(loggedInUser, serverIds, errataIds, null,
-                false, allowVendorChange);
+        return scheduleApplyErrata(loggedInUser, serverIds, errataIds, null, false);
     }
 
     /**
@@ -3362,7 +3340,7 @@ public class SystemHandler extends BaseHandler {
 
         try {
             return ErrataManager.applyErrataHelper(loggedInUser,
-                    serverIds, errataIds, earliestOccurrence, onlyRelevant);
+                    serverIds, errataIds, earliestOccurrence, onlyRelevant, allowVendorChange);
         }
         catch (com.redhat.rhn.taskomatic.TaskomaticApiException e) {
             throw new TaskomaticApiException(e.getMessage());
@@ -3491,36 +3469,6 @@ public class SystemHandler extends BaseHandler {
         return scheduleApplyErrata(loggedInUser, serverIds, errataIds, earliestOccurrence, allowModules);
     }
 
-    /**
-     * Schedules an action to apply errata updates to a system at a specified time.
-     * @param loggedInUser The current user
-     * @param sid ID of the server
-     * @param errataIds List of errata IDs to apply (as Integers)
-     * @param earliestOccurrence Earliest occurrence of the errata update
-     * @param allowModules Allow this API call, despite modular content being present
-     * @param allowVendorChange boolean
-     * @return list of action ids, exception thrown otherwise
-     * @since 21
-     *
-     * @xmlrpc.doc Schedules an action to apply errata updates to a system at a
-     * given date/time.
-     * @xmlrpc.param #param("string", "sessionKey")
-     * @xmlrpc.param #param("int", "serverId")
-     * @xmlrpc.param #array_single("int", "errataId")
-     * @xmlrpc.param dateTime.iso8601 earliestOccurrence
-     * @xmlrpc.param #param_desc("boolean", "allowModules",
-     *          "Allow this API call, despite modular content being present")
-     * @xmlrpc.param #param("boolean", "allowVendorChange")
-     * @xmlrpc.returntype #array_single("int", "actionId")
-     */
-    public List<Long> scheduleApplyErrata(User loggedInUser, Integer sid, List<Integer> errataIds,
-                                          Date earliestOccurrence, Boolean allowModules, boolean allowVendorChange) {
-        List<Integer> serverIds = new ArrayList<Integer>();
-        serverIds.add(sid);
-        return scheduleApplyErrata(loggedInUser, sid, errataIds, earliestOccurrence, allowModules, allowVendorChange);
-    }
-
-
    /**
      * Schedules an action to apply errata updates to a a list of systems at a specified time.
      * @param loggedInUser The current user
@@ -3528,7 +3476,7 @@ public class SystemHandler extends BaseHandler {
      * @param errataIds List of errata IDs to apply (as Integers)
      * @param earliestOccurrence Earliest occurrence of the errata update
      * @param allowModules Allow this API call, despite modular content being present
-     * @param allowVendorChange boolean
+     * @param onlyRelevant boolean
      * @return list of action ids, exception thrown otherwise
      * @since 24
      *
@@ -3544,9 +3492,9 @@ public class SystemHandler extends BaseHandler {
      * @xmlrpc.returntype #array_single("int", "actionId")
      */
     public List<Long> scheduleApplyErrata(User loggedInUser, List<Integer> sid, List<Integer> errataIds,
-                                         Date earliestOccurrence, Boolean allowModules, boolean allowVendorChange) {
+                                         Date earliestOccurrence, Boolean allowModules, boolean onlyRelevant) {
         return scheduleApplyErrata(loggedInUser, sid, errataIds, earliestOccurrence, allowModules,
-                false, allowVendorChange);
+                onlyRelevant, false);
 
 }
     /**

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -38,6 +38,7 @@ import com.redhat.rhn.common.security.PermissionException;
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionChain;
 import com.redhat.rhn.domain.action.ActionChainFactory;
+import com.redhat.rhn.domain.action.errata.ActionPackageDetails;
 import com.redhat.rhn.domain.action.errata.ErrataAction;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.channel.ChannelFactory;
@@ -1837,11 +1838,13 @@ public class ErrataManager extends BaseManager {
         List<ErrataAction> minionErrataActions = minionActions.collect(toList());
         List<Action> minionTaskoActions = new ArrayList<>();
         traditionalErrataActions.stream().forEach(ea-> {
-            ea.getActionPackageDetails().setAllowVendorChange(allowVendorChange);
-            actionIds.add(ActionManager.storeAction(ea).getId());
+            ea.setDetails(new ActionPackageDetails(allowVendorChange));
+            Action action = ActionManager.storeAction(ea);
+            actionIds.add(action.getId());
         });
+
         minionErrataActions.stream().forEach(ea-> {
-           ea.getActionPackageDetails().setAllowVendorChange(allowVendorChange);
+           ea.setDetails(new ActionPackageDetails(allowVendorChange));
            Action action = ActionManager.storeAction(ea);
            minionTaskoActions.add(action);
            actionIds.add(action.getId());

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -1839,14 +1839,12 @@ public class ErrataManager extends BaseManager {
         List<Action> minionTaskoActions = new ArrayList<>();
         traditionalErrataActions.stream().forEach(ea-> {
             ea.setDetails(new ActionPackageDetails(ea, allowVendorChange));
-            //TODO: Save ActionPackageDetails directly, no save needed on Action itself
             Action action = ActionManager.storeAction(ea);
             actionIds.add(action.getId());
         });
 
         minionErrataActions.stream().forEach(ea-> {
            ea.setDetails(new ActionPackageDetails(ea, allowVendorChange));
-           //TODO: Save ActionPackageDetails directly, no save needed on Action itself
            Action action = ActionManager.storeAction(ea);
            minionTaskoActions.add(action);
            actionIds.add(action.getId());
@@ -1854,12 +1852,8 @@ public class ErrataManager extends BaseManager {
         //Taskomatic part is needed only for minionActions
         //and only if actions are not added to an action chain
         if (actionChain == null && !minionTaskoActions.isEmpty()) {
-            try {
                 taskomaticApi.scheduleMinionActionExecutions(minionTaskoActions, false);
                 MinionActionManager.scheduleStagingJobsForMinions(minionTaskoActions, user);
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
         }
         return actionIds;
     }

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -1,4 +1,5 @@
 /**
+ * Copyright (c) 2010--2021 SUSE LLC
  * Copyright (c) 2009--2018 Red Hat, Inc.
  *
  * This software is licensed to you under the GNU General Public License,
@@ -11,9 +12,6 @@
  * Red Hat trademarks are not licensed under GPLv2. No permission is
  * granted to use or replicate Red Hat trademarks that are incorporated
  * in this software or its documentation.
- */
-/*
- * Copyright (c) 2010 SUSE LLC
  */
 package com.redhat.rhn.manager.errata;
 
@@ -1663,7 +1661,7 @@ public class ErrataManager extends BaseManager {
     }
 
 
-        /**
+    /**
      * Apply a list of errata to a list of servers, with an optional Action
      * Chain.
      * Note that not all erratas are applied to all systems. Systems get
@@ -1852,8 +1850,8 @@ public class ErrataManager extends BaseManager {
         //Taskomatic part is needed only for minionActions
         //and only if actions are not added to an action chain
         if (actionChain == null && !minionTaskoActions.isEmpty()) {
-                taskomaticApi.scheduleMinionActionExecutions(minionTaskoActions, false);
-                MinionActionManager.scheduleStagingJobsForMinions(minionTaskoActions, user);
+            taskomaticApi.scheduleMinionActionExecutions(minionTaskoActions, false);
+            MinionActionManager.scheduleStagingJobsForMinions(minionTaskoActions, user);
         }
         return actionIds;
     }

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -1610,7 +1610,26 @@ public class ErrataManager extends BaseManager {
      * (typically: Taskomatic is down)
      */
     public static List<Long> applyErrataHelper(User loggedInUser, List<Long> systemIds,
-            List<Long> errataIds, Date earliestOccurrence, boolean onlyRelevant)
+                                               List<Long> errataIds, Date earliestOccurrence, boolean onlyRelevant)
+            throws TaskomaticApiException {
+        return applyErrataHelper(loggedInUser, systemIds, errataIds, earliestOccurrence, onlyRelevant, false);
+    }
+
+    /**
+     * Apply errata updates to a system list at a specified time.
+     * @param loggedInUser The logged in user
+     * @param systemIds list of system IDs
+     * @param errataIds List of errata IDs to apply (as Integers)
+     * @param earliestOccurrence Earliest occurrence of the errata update
+     * @param onlyRelevant If true not all erratas are applied to all systems.
+     *        Systems get only the erratas relevant for them.
+     * @param allowVendorChange If true not all erratas are applied to all systems.
+     * @return list of action ids
+     * @throws TaskomaticApiException if there was a Taskomatic error
+     * (typically: Taskomatic is down)
+     */
+    public static List<Long> applyErrataHelper(User loggedInUser, List<Long> systemIds,
+            List<Long> errataIds, Date earliestOccurrence, boolean onlyRelevant, boolean allowVendorChange)
         throws TaskomaticApiException {
 
         if (systemIds.isEmpty()) {
@@ -1622,7 +1641,7 @@ public class ErrataManager extends BaseManager {
 
         // at this point all errata is applicable to all systems, so let's apply
         return applyErrata(loggedInUser, errataIds, earliestOccurrence,
-                null, systemIds, onlyRelevant);
+                null, systemIds, onlyRelevant, allowVendorChange);
     }
 
     /**
@@ -1657,9 +1676,8 @@ public class ErrataManager extends BaseManager {
     public static List<Long> applyErrata(User user, List errataIds, Date earliest,
             ActionChain actionChain, List<Long> serverIds)
         throws TaskomaticApiException {
-        return applyErrata(user, errataIds, earliest, actionChain, serverIds, true);
+        return applyErrata(user, errataIds, earliest, actionChain, serverIds, true, false);
     }
-
 
     /**
      * Apply a list of errata to a list of servers, with an optional Action
@@ -1671,15 +1689,18 @@ public class ErrataManager extends BaseManager {
      * @param earliest schedule time
      * @param actionChain the action chain to add the action to or null
      * @param serverIds server ids
-     * @param allowVendorChange allow vendor change boolean
+     * @param onlyRelevant If true not all erratas are applied to all systems.
+     *        Systems get only the erratas relevant for them.
+     *        If false, InvalidErrataException is thrown if an errata does not apply
+     *        to a system.
      * @return list of action ids
      * @throws TaskomaticApiException if there was a Taskomatic error
      * (typically: Taskomatic is down)
      */
     public static List<Long> applyErrata(User user, List<Long> errataIds, Date earliest,
-                                         ActionChain actionChain, List<Long> serverIds, boolean allowVendorChange)
-        throws TaskomaticApiException {
-        return applyErrata(user, errataIds, earliest, actionChain, serverIds, true, allowVendorChange);
+                                         ActionChain actionChain, List<Long> serverIds, boolean onlyRelevant)
+            throws TaskomaticApiException {
+        return applyErrata(user, errataIds, earliest, actionChain, serverIds, onlyRelevant, false);
     }
 
     /**
@@ -1702,7 +1723,7 @@ public class ErrataManager extends BaseManager {
      * @throws TaskomaticApiException if there was a Taskomatic error
      * (typically: Taskomatic is down)
      */
-    private static List<Long> applyErrata(User user, List<Long> errataIds, Date earliest,
+    public static List<Long> applyErrata(User user, List<Long> errataIds, Date earliest,
             ActionChain actionChain, List<Long> serverIds, boolean onlyRelevant, boolean allowVendorChange)
         throws TaskomaticApiException {
 

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -1838,13 +1838,15 @@ public class ErrataManager extends BaseManager {
         List<ErrataAction> minionErrataActions = minionActions.collect(toList());
         List<Action> minionTaskoActions = new ArrayList<>();
         traditionalErrataActions.stream().forEach(ea-> {
-            ea.setDetails(new ActionPackageDetails(allowVendorChange));
+            ea.setDetails(new ActionPackageDetails(ea, allowVendorChange));
+            //TODO: Save ActionPackageDetails directly, no save needed on Action itself
             Action action = ActionManager.storeAction(ea);
             actionIds.add(action.getId());
         });
 
         minionErrataActions.stream().forEach(ea-> {
-           ea.setDetails(new ActionPackageDetails(allowVendorChange));
+           ea.setDetails(new ActionPackageDetails(ea, allowVendorChange));
+           //TODO: Save ActionPackageDetails directly, no save needed on Action itself
            Action action = ActionManager.storeAction(ea);
            minionTaskoActions.add(action);
            actionIds.add(action.getId());

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -1623,7 +1623,7 @@ public class ErrataManager extends BaseManager {
      * @param earliestOccurrence Earliest occurrence of the errata update
      * @param onlyRelevant If true not all erratas are applied to all systems.
      *        Systems get only the erratas relevant for them.
-     * @param allowVendorChange If true not all erratas are applied to all systems.
+     * @param allowVendorChange true if vendor change allowed
      * @return list of action ids
      * @throws TaskomaticApiException if there was a Taskomatic error
      * (typically: Taskomatic is down)
@@ -1684,30 +1684,6 @@ public class ErrataManager extends BaseManager {
      * Chain.
      * Note that not all erratas are applied to all systems. Systems get
      * only the erratas relevant for them.
-     * @param user user
-     * @param errataIds errata ids
-     * @param earliest schedule time
-     * @param actionChain the action chain to add the action to or null
-     * @param serverIds server ids
-     * @param onlyRelevant If true not all erratas are applied to all systems.
-     *        Systems get only the erratas relevant for them.
-     *        If false, InvalidErrataException is thrown if an errata does not apply
-     *        to a system.
-     * @return list of action ids
-     * @throws TaskomaticApiException if there was a Taskomatic error
-     * (typically: Taskomatic is down)
-     */
-    public static List<Long> applyErrata(User user, List<Long> errataIds, Date earliest,
-                                         ActionChain actionChain, List<Long> serverIds, boolean onlyRelevant)
-            throws TaskomaticApiException {
-        return applyErrata(user, errataIds, earliest, actionChain, serverIds, onlyRelevant, false);
-    }
-
-    /**
-     * Apply a list of errata to a list of servers, with an optional Action
-     * Chain.
-     * Note that not all erratas are applied to all systems. Systems get
-     * only the erratas relevant for them.
      *
      * @param user user
      * @param errataIds errata ids
@@ -1718,7 +1694,7 @@ public class ErrataManager extends BaseManager {
      *        Systems get only the erratas relevant for them.
      *        If false, InvalidErrataException is thrown if an errata does not apply
      *        to a system.
-     * @param allowVendorChange If true not all erratas are applied to all systems.
+     * @param allowVendorChange true if vendor change allowed
      * @return list of action ids
      * @throws TaskomaticApiException if there was a Taskomatic error
      * (typically: Taskomatic is down)
@@ -1854,14 +1830,14 @@ public class ErrataManager extends BaseManager {
             concat(updateStackActions,
             nonUpdateStackActions))
             .collect(toList());
-        List<ErrataAction> minionErrataActions = minionActions.collect(toList());
-        List<Action> minionTaskoActions = new ArrayList<>();
         traditionalErrataActions.stream().forEach(ea-> {
             ea.setDetails(new ActionPackageDetails(ea, allowVendorChange));
             Action action = ActionManager.storeAction(ea);
             actionIds.add(action.getId());
         });
 
+        List<ErrataAction> minionErrataActions = minionActions.collect(toList());
+        List<Action> minionTaskoActions = new ArrayList<>();
         minionErrataActions.stream().forEach(ea-> {
            ea.setDetails(new ActionPackageDetails(ea, allowVendorChange));
            Action action = ActionManager.storeAction(ea);

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -1834,10 +1834,14 @@ public class ErrataManager extends BaseManager {
             concat(updateStackActions,
             nonUpdateStackActions))
             .collect(toList());
-        traditionalErrataActions.stream().forEach(ea-> actionIds.add(ActionManager.storeAction(ea).getId()));
         List<ErrataAction> minionErrataActions = minionActions.collect(toList());
         List<Action> minionTaskoActions = new ArrayList<>();
+        traditionalErrataActions.stream().forEach(ea-> {
+            ea.getActionPackageDetails().setAllowVendorChange(allowVendorChange);
+            actionIds.add(ActionManager.storeAction(ea).getId());
+        });
         minionErrataActions.stream().forEach(ea-> {
+           ea.getActionPackageDetails().setAllowVendorChange(allowVendorChange);
            Action action = ActionManager.storeAction(ea);
            minionTaskoActions.add(action);
            actionIds.add(action.getId());
@@ -1845,8 +1849,12 @@ public class ErrataManager extends BaseManager {
         //Taskomatic part is needed only for minionActions
         //and only if actions are not added to an action chain
         if (actionChain == null && !minionTaskoActions.isEmpty()) {
-            taskomaticApi.scheduleMinionActionExecutions(minionTaskoActions, false);
-            MinionActionManager.scheduleStagingJobsForMinions(minionTaskoActions, user);
+            try {
+                taskomaticApi.scheduleMinionActionExecutions(minionTaskoActions, false);
+                MinionActionManager.scheduleStagingJobsForMinions(minionTaskoActions, user);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
         }
         return actionIds;
     }

--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -1661,6 +1661,28 @@ public class ErrataManager extends BaseManager {
         return applyErrata(user, errataIds, earliest, actionChain, serverIds, true);
     }
 
+
+        /**
+     * Apply a list of errata to a list of servers, with an optional Action
+     * Chain.
+     * Note that not all erratas are applied to all systems. Systems get
+     * only the erratas relevant for them.
+     * @param user user
+     * @param errataIds errata ids
+     * @param earliest schedule time
+     * @param actionChain the action chain to add the action to or null
+     * @param serverIds server ids
+     * @param allowVendorChange allow vendor change boolean
+     * @return list of action ids
+     * @throws TaskomaticApiException if there was a Taskomatic error
+     * (typically: Taskomatic is down)
+     */
+    public static List<Long> applyErrata(User user, List<Long> errataIds, Date earliest,
+                                         ActionChain actionChain, List<Long> serverIds, boolean allowVendorChange)
+        throws TaskomaticApiException {
+        return applyErrata(user, errataIds, earliest, actionChain, serverIds, true, allowVendorChange);
+    }
+
     /**
      * Apply a list of errata to a list of servers, with an optional Action
      * Chain.
@@ -1676,12 +1698,13 @@ public class ErrataManager extends BaseManager {
      *        Systems get only the erratas relevant for them.
      *        If false, InvalidErrataException is thrown if an errata does not apply
      *        to a system.
+     * @param allowVendorChange If true not all erratas are applied to all systems.
      * @return list of action ids
      * @throws TaskomaticApiException if there was a Taskomatic error
      * (typically: Taskomatic is down)
      */
     private static List<Long> applyErrata(User user, List<Long> errataIds, Date earliest,
-            ActionChain actionChain, List<Long> serverIds, boolean onlyRelevant)
+            ActionChain actionChain, List<Long> serverIds, boolean onlyRelevant, boolean allowVendorChange)
         throws TaskomaticApiException {
 
         // compute server id to applicable errata id map

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -1031,7 +1031,7 @@ public class SaltServerActionService {
      *
      * @param minionSummaries list of minion summaries to target
      * @param errataIds list of errata ids
-     * @param allowVendorChange boolean if vendor change allowed
+     * @param allowVendorChange true if vendor change allowed
      * @return minion summaries grouped by local call
      */
     public Map<LocalCall<?>, List<MinionSummary>> errataAction(List<MinionSummary> minionSummaries,

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -221,6 +221,7 @@ public class SaltServerActionService {
 
     /** SLS pillar parameter name for the list of regular patch names. */
     public static final String PARAM_REGULAR_PATCHES = "param_regular_patches";
+    public static final String ALLOW_VENDOR_CHANGE = "allow_vendor_change";
 
     private boolean commitTransaction = true;
 
@@ -334,7 +335,7 @@ public class SaltServerActionService {
             return ImageProfileFactory.lookupById(details.getImageProfileId()).map(
                     ip -> imageBuildAction(
                             minions,
-                            ofNullable(details.getVersion()),
+                            Optional.ofNullable(details.getVersion()),
                             ip,
                             imageBuildAction.getSchedulerUser(),
                             imageBuildAction.getId())
@@ -467,7 +468,7 @@ public class SaltServerActionService {
                         (actionType != null ? actionType.getName() : "") +
                         " is not supported with Salt");
             }
-            return emptyMap();
+            return Collections.emptyMap();
         }
     }
 
@@ -1030,10 +1031,11 @@ public class SaltServerActionService {
      *
      * @param minionSummaries list of minion summaries to target
      * @param errataIds list of errata ids
+     * @param allowVendorChange boolean if vendor change allowed
      * @return minion summaries grouped by local call
      */
     public Map<LocalCall<?>, List<MinionSummary>> errataAction(List<MinionSummary> minionSummaries,
-            Set<Long> errataIds) {
+            Set<Long> errataIds, boolean allowVendorChange) {
         Set<Long> minionServerIds = minionSummaries.stream().map(MinionSummary::getServerId)
                 .collect(Collectors.toSet());
 
@@ -1060,6 +1062,7 @@ public class SaltServerActionService {
                         .sorted()
                         .collect(Collectors.toList())
                 );
+                params.put("allowVendorChange", allowVendorChange);
                 params.put(PARAM_UPDATE_STACK_PATCHES,
                     entry.getKey().stream()
                         .filter(e -> e.isUpdateStack())

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -291,7 +291,7 @@ public class SaltServerActionService {
             ErrataAction errataAction = (ErrataAction) actionIn;
             Set<Long> errataIds = errataAction.getErrata().stream()
                     .map(Errata::getId).collect(Collectors.toSet());
-            return errataAction(minions, errataIds);
+            return errataAction(minions, errataIds, errataAction.getActionPackageDetails().getAllowVendorChange());
         }
         else if (ActionFactory.TYPE_PACKAGES_UPDATE.equals(actionType)) {
             return packagesUpdateAction(minions, (PackageUpdateAction) actionIn);
@@ -334,7 +334,7 @@ public class SaltServerActionService {
             return ImageProfileFactory.lookupById(details.getImageProfileId()).map(
                     ip -> imageBuildAction(
                             minions,
-                            Optional.ofNullable(details.getVersion()),
+                            ofNullable(details.getVersion()),
                             ip,
                             imageBuildAction.getSchedulerUser(),
                             imageBuildAction.getId())
@@ -467,7 +467,7 @@ public class SaltServerActionService {
                         (actionType != null ? actionType.getName() : "") +
                         " is not supported with Salt");
             }
-            return Collections.emptyMap();
+            return emptyMap();
         }
     }
 

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -291,7 +291,7 @@ public class SaltServerActionService {
             ErrataAction errataAction = (ErrataAction) actionIn;
             Set<Long> errataIds = errataAction.getErrata().stream()
                     .map(Errata::getId).collect(Collectors.toSet());
-            return errataAction(minions, errataIds, errataAction.getActionPackageDetails().getAllowVendorChange());
+            return errataAction(minions, errataIds, errataAction.getDetails().getAllowVendorChange());
         }
         else if (ActionFactory.TYPE_PACKAGES_UPDATE.equals(actionType)) {
             return packagesUpdateAction(minions, (PackageUpdateAction) actionIn);

--- a/java/code/webapp/WEB-INF/pages/systems/errata.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/errata.jsp
@@ -35,10 +35,12 @@
                 </html:submit>
             </div>
             <div class="action-button-wrapper btn-group">
+                <c:if test="${supported}" >
                 <label>
                     <bean:message key="spmigration.jsp.allow.vendor.change" />
                 </label>
                 <input  name="allowVendorChange" type="checkbox" />
+                </c:if>
             </div>
         </div>
     </c:if>

--- a/java/code/webapp/WEB-INF/pages/systems/errata.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/errata.jsp
@@ -34,6 +34,12 @@
                     <bean:message key="errata.jsp.apply"/>
                 </html:submit>
             </div>
+            <div class="action-button-wrapper btn-group">
+                <label>
+                    <bean:message key="spmigration.jsp.allow.vendor.change" />
+                </label>
+                <input  name="allowVendorChange" type="checkbox" />
+            </div>
         </div>
     </c:if>
     <br/>

--- a/java/code/webapp/WEB-INF/pages/systems/errataconfirm.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/errataconfirm.jsp
@@ -17,6 +17,7 @@
         <rl:listset name="erratConfirmListSet">
             <rhn:csrf />
             <rhn:submitted />
+            <html:hidden property="allowVendorChange" value="${allowVendorChange}" />
             <div class="spacewalk-section-toolbar">
                 <div class="action-button-wrapper">
                     <html:submit styleClass="btn btn-success" property="dispatch">

--- a/java/code/webapp/WEB-INF/struts-config.xml
+++ b/java/code/webapp/WEB-INF/struts-config.xml
@@ -1080,7 +1080,6 @@
       <form-property name="allowVendorChange" type="java.lang.Boolean" />
     </form-bean>
 
-
     <form-bean name="servicePackMigrationForm"
                type="com.redhat.rhn.frontend.struts.ScrubbingDynaActionForm">
       <form-property name="step" type="java.lang.String" />

--- a/java/code/webapp/WEB-INF/struts-config.xml
+++ b/java/code/webapp/WEB-INF/struts-config.xml
@@ -1075,6 +1075,12 @@
       <form-property name="proxy_pass" type="java.lang.String" />
     </form-bean>
 
+    <form-bean name="ErrataInstallForm"
+               type="com.redhat.rhn.frontend.struts.ScrubbingDynaActionForm">
+      <form-property name="allowVendorChange" type="java.lang.Boolean" />
+    </form-bean>
+
+
     <form-bean name="servicePackMigrationForm"
                type="com.redhat.rhn.frontend.struts.ScrubbingDynaActionForm">
       <form-property name="step" type="java.lang.String" />
@@ -3087,6 +3093,7 @@
     </action>
 
     <action path="/systems/details/ErrataList"
+        name="ErrataInstallForm"
         scope="request"
         input="/WEB-INF/pages/systems/errata.jsp"
         type="com.redhat.rhn.frontend.action.systems.ErrataSetupAction"

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- optionally allow vendor change when patching
 - Speed up the system groups page (bsc#1182132)
 - Log shell command output on failure when checking known_hosts file permissions
 - adapt logging for testing accessability of URLs (bsc#1182817)

--- a/schema/spacewalk/common/tables/rhnActionDetails.sql
+++ b/schema/spacewalk/common/tables/rhnActionDetails.sql
@@ -1,0 +1,28 @@
+--
+-- Copyright (c) 2020 SUSE LLC 
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+--
+
+
+CREATE TABLE rhnActionDetails
+(
+    action_id  NUMERIC NOT NULL
+                   CONSTRAINT rhn_act_eu_act_fk
+                       REFERENCES rhnAction (id)
+                       ON DELETE CASCADE,
+    allow_vendor_change  CHAR(1) DEFAULT ('N') NOT NULL 
+    CONSTRAINT rhn_actdet_avc_ck CHECK (allow_vendor_change in ('Y','N'))
+);
+
+CREATE INDEX rhn_act_eud_aid_idx
+    ON rhnActionDetails (action_id);

--- a/schema/spacewalk/common/tables/rhnActionPackageDetails.sql
+++ b/schema/spacewalk/common/tables/rhnActionPackageDetails.sql
@@ -16,6 +16,8 @@
 
 CREATE TABLE rhnActionPackageDetails
 (
+    id         NUMERIC NOT NULL
+               CONSTRAINT rhn_actionpd_id_pk PRIMARY KEY,
     action_id  NUMERIC NOT NULL
                    CONSTRAINT rhn_act_eu_act_fk
                        REFERENCES rhnAction (id)
@@ -26,3 +28,5 @@ CREATE TABLE rhnActionPackageDetails
 
 CREATE INDEX rhn_act_eud_aid_idx
     ON rhnActionPackageDetails (action_id);
+
+CREATE SEQUENCE rhn_actiondpd_id_seq;

--- a/schema/spacewalk/common/tables/rhnActionPackageDetails.sql
+++ b/schema/spacewalk/common/tables/rhnActionPackageDetails.sql
@@ -24,7 +24,13 @@ CREATE TABLE rhnActionPackageDetails
                        ON DELETE CASCADE,
     allow_vendor_change  CHAR(1) DEFAULT ('N') NOT NULL 
     CONSTRAINT rhn_actdet_avc_ck CHECK (allow_vendor_change in ('Y','N'))
+
+    created   TIMESTAMPTZ
+                  DEFAULT (current_timestamp) NOT NULL,
+    modified  TIMESTAMPTZ
+                  DEFAULT (current_timestamp) NOT NULL
 );
+
 
 CREATE INDEX rhn_act_eud_aid_idx
     ON rhnActionPackageDetails (action_id);

--- a/schema/spacewalk/common/tables/rhnActionPackageDetails.sql
+++ b/schema/spacewalk/common/tables/rhnActionPackageDetails.sql
@@ -14,7 +14,7 @@
 --
 
 
-CREATE TABLE rhnActionDetails
+CREATE TABLE rhnActionPackageDetails
 (
     action_id  NUMERIC NOT NULL
                    CONSTRAINT rhn_act_eu_act_fk
@@ -25,4 +25,4 @@ CREATE TABLE rhnActionDetails
 );
 
 CREATE INDEX rhn_act_eud_aid_idx
-    ON rhnActionDetails (action_id);
+    ON rhnActionPackageDetails (action_id);

--- a/schema/spacewalk/common/tables/rhnActionPackageDetails.sql
+++ b/schema/spacewalk/common/tables/rhnActionPackageDetails.sql
@@ -1,5 +1,5 @@
 --
--- Copyright (c) 2020 SUSE LLC 
+-- Copyright (c) 2021 SUSE LLC
 --
 -- This software is licensed to you under the GNU General Public License,
 -- version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/schema/spacewalk/common/tables/rhnActionPackageDetails.sql
+++ b/schema/spacewalk/common/tables/rhnActionPackageDetails.sql
@@ -23,7 +23,7 @@ CREATE TABLE rhnActionPackageDetails
                        REFERENCES rhnAction (id)
                        ON DELETE CASCADE,
     allow_vendor_change  CHAR(1) DEFAULT ('N') NOT NULL 
-    CONSTRAINT rhn_actdet_avc_ck CHECK (allow_vendor_change in ('Y','N'))
+    CONSTRAINT rhn_actdet_avc_ck CHECK (allow_vendor_change in ('Y','N')),
 
     created   TIMESTAMPTZ
                   DEFAULT (current_timestamp) NOT NULL,

--- a/schema/spacewalk/postgres/triggers/rhnActionPackageDetails.sql
+++ b/schema/spacewalk/postgres/triggers/rhnActionPackageDetails.sql
@@ -1,0 +1,14 @@
+create or replace function rhn_actionpackagedetails_mod_trig_fun() returns trigger as
+$$
+begin
+	new.modified := current_timestamp;
+	return new;
+end;
+$$ language plpgsql;
+
+create trigger
+rhn_actionpackagedetails_mod_trig
+before insert or update on rhnActionPackageDetails
+for each row
+execute procedure rhn_actionpackagedetails_mod_trig_fun();
+

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- add rhnactiondetails table for handling allow vendor change for errata/install/upgrade actions
 - add virtual network create action
 
 -------------------------------------------------------------------

--- a/schema/spacewalk/upgrade/susemanager-schema-4.2.9-to-susemanager-schema-4.2.10/001-rhnaction-vendorchange.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.2.9-to-susemanager-schema-4.2.10/001-rhnaction-vendorchange.sql
@@ -1,5 +1,5 @@
 --
--- Copyright (c) 2020 SUSE LLC 
+-- Copyright (c) 2021 SUSE LLC
 --
 -- This software is licensed to you under the GNU General Public License,
 -- version 2 (GPLv2). There is NO WARRANTY for this software, express or

--- a/schema/spacewalk/upgrade/susemanager-schema-4.2.9-to-susemanager-schema-4.2.10/001-rhnaction-vendorchange.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.2.9-to-susemanager-schema-4.2.10/001-rhnaction-vendorchange.sql
@@ -23,9 +23,29 @@ CREATE TABLE IF NOT EXISTS rhnActionPackageDetails
                        ON DELETE CASCADE,
     allow_vendor_change  CHAR(1) DEFAULT ('N') NOT NULL 
     CONSTRAINT rhn_actdet_avc_ck CHECK (allow_vendor_change in ('Y','N'))
+
+    created   TIMESTAMPTZ
+                  DEFAULT (current_timestamp) NOT NULL,
+    modified  TIMESTAMPTZ
+                  DEFAULT (current_timestamp) NOT NULL
+
 );
 
 CREATE INDEX IF NOT EXISTS rhn_act_eud_aid_idx
     ON rhnActionPackageDetails (action_id);
 
 CREATE SEQUENCE IF NOT EXISTS rhn_actiondpd_id_seq;
+
+create or replace function rhn_actionpackagedetails_mod_trig_fun() returns trigger as
+$$
+begin
+        new.modified := current_timestamp;
+        return new;
+end;
+$$ language plpgsql;
+
+create trigger
+rhn_actionpackagedetails_mod_trig
+before insert or update on rhnActionPackageDetails
+for each row
+execute procedure rhn_actionpackagedetails_mod_trig_fun();

--- a/schema/spacewalk/upgrade/susemanager-schema-4.2.9-to-susemanager-schema-4.2.10/001-rhnaction-vendorchange.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.2.9-to-susemanager-schema-4.2.10/001-rhnaction-vendorchange.sql
@@ -1,0 +1,27 @@
+--
+-- Copyright (c) 2020 SUSE LLC 
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+--
+
+CREATE TABLE IF NOT EXISTS rhnActionDetails 
+(
+    action_id  NUMERIC NOT NULL
+                   CONSTRAINT rhn_act_eu_act_fk
+                       REFERENCES rhnAction (id)
+                       ON DELETE CASCADE,
+    allow_vendor_change  CHAR(1) DEFAULT ('N') NOT NULL 
+    CONSTRAINT rhn_actdet_avc_ck CHECK (allow_vendor_change in ('Y','N'))
+);
+
+CREATE INDEX IF NOT EXISTS rhn_act_eud_aid_idx
+    ON rhnActionDetails (action_id);

--- a/schema/spacewalk/upgrade/susemanager-schema-4.2.9-to-susemanager-schema-4.2.10/001-rhnaction-vendorchange.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.2.9-to-susemanager-schema-4.2.10/001-rhnaction-vendorchange.sql
@@ -15,6 +15,8 @@
 
 CREATE TABLE IF NOT EXISTS rhnActionPackageDetails
 (
+    id         NUMERIC NOT NULL
+               CONSTRAINT rhn_actionpd_id_pk PRIMARY KEY,
     action_id  NUMERIC NOT NULL
                    CONSTRAINT rhn_act_eu_act_fk
                        REFERENCES rhnAction (id)
@@ -25,3 +27,5 @@ CREATE TABLE IF NOT EXISTS rhnActionPackageDetails
 
 CREATE INDEX IF NOT EXISTS rhn_act_eud_aid_idx
     ON rhnActionPackageDetails (action_id);
+
+CREATE SEQUENCE IF NOT EXISTS rhn_actiondpd_id_seq;

--- a/schema/spacewalk/upgrade/susemanager-schema-4.2.9-to-susemanager-schema-4.2.10/001-rhnaction-vendorchange.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.2.9-to-susemanager-schema-4.2.10/001-rhnaction-vendorchange.sql
@@ -22,7 +22,7 @@ CREATE TABLE IF NOT EXISTS rhnActionPackageDetails
                        REFERENCES rhnAction (id)
                        ON DELETE CASCADE,
     allow_vendor_change  CHAR(1) DEFAULT ('N') NOT NULL 
-    CONSTRAINT rhn_actdet_avc_ck CHECK (allow_vendor_change in ('Y','N'))
+    CONSTRAINT rhn_actdet_avc_ck CHECK (allow_vendor_change in ('Y','N')),
 
     created   TIMESTAMPTZ
                   DEFAULT (current_timestamp) NOT NULL,
@@ -44,6 +44,7 @@ begin
 end;
 $$ language plpgsql;
 
+drop trigger if exists rhn_actionpackagedetails_mod_trig on rhnActionPackageDetails;
 create trigger
 rhn_actionpackagedetails_mod_trig
 before insert or update on rhnActionPackageDetails

--- a/schema/spacewalk/upgrade/susemanager-schema-4.2.9-to-susemanager-schema-4.2.10/001-rhnaction-vendorchange.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.2.9-to-susemanager-schema-4.2.10/001-rhnaction-vendorchange.sql
@@ -13,7 +13,7 @@
 -- in this software or its documentation.
 --
 
-CREATE TABLE IF NOT EXISTS rhnActionDetails 
+CREATE TABLE IF NOT EXISTS rhnActionPackageDetails
 (
     action_id  NUMERIC NOT NULL
                    CONSTRAINT rhn_act_eu_act_fk
@@ -24,4 +24,4 @@ CREATE TABLE IF NOT EXISTS rhnActionDetails
 );
 
 CREATE INDEX IF NOT EXISTS rhn_act_eud_aid_idx
-    ON rhnActionDetails (action_id);
+    ON rhnActionPackageDetails (action_id);

--- a/susemanager-utils/susemanager-sls/salt/packages/patchinstall.sls
+++ b/susemanager-utils/susemanager-sls/salt/packages/patchinstall.sls
@@ -21,6 +21,7 @@ mgr_regular_patches:
 {% if not pillar.get('param_update_stack_patches', []) %}
     - refresh: true
 {% endif %}
+   - novendorchange:  {% not pillar.get('allow_vendor_change', False) %}
     - advisory_ids:
 {%- for patch in pillar.get('param_regular_patches', []) %}
       - {{ patch }}

--- a/susemanager-utils/susemanager-sls/salt/packages/patchinstall.sls
+++ b/susemanager-utils/susemanager-sls/salt/packages/patchinstall.sls
@@ -21,7 +21,7 @@ mgr_regular_patches:
 {% if not pillar.get('param_update_stack_patches', []) %}
     - refresh: true
 {% endif %}
-   - novendorchange:  {% not pillar.get('allow_vendor_change', False) %}
+    - novendorchange:  {{ not pillar.get('allow_vendor_change', False) }}
     - advisory_ids:
 {%- for patch in pillar.get('param_regular_patches', []) %}
       - {{ patch }}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- add allow vendor change option to pathing via salt 
 - Add SALT_RUNNING config in case it's not present on the minion (bsc#1183661)
 - Skip removed product classes with satellite-sync
 - add grain for virt module features

--- a/testsuite/features/init_clients/sle_minion.feature
+++ b/testsuite/features/init_clients/sle_minion.feature
@@ -60,13 +60,7 @@ Feature: Bootstrap a Salt minion via the GUI
     And I wait at most 600 seconds until event "Service Pack Migration scheduled by admin" is completed
     And I follow "Details" in the content area
     Then I should see a "SUSE Linux Enterprise Server 15 SP2" text
-
-@service_pack_migration
-  Scenario: Check the migration is successful for this minion
-    Given I am on the Systems overview page of this "sle_spack_migrated_minion"
-    When I follow "Details" in the content area
-    Then I should see a "SUSE Linux Enterprise Server 15 SP2" text
-    And vendor change should be enabled for SP migration on "sle_spack_migrated_minion"
+    And vendor change should be enabled for "SP migration" on "sle_spack_migrated_minion"
 
 @service_pack_migration
   Scenario: Install the latest Salt on this minion

--- a/testsuite/features/init_clients/sle_ssh_minion.feature
+++ b/testsuite/features/init_clients/sle_ssh_minion.feature
@@ -56,6 +56,7 @@ Feature: Bootstrap a Salt host managed via salt-ssh
     And I wait at most 600 seconds until event "Service Pack Migration scheduled by admin" is completed
     And I follow "Details" in the content area
     Then I should see a "SUSE Linux Enterprise Server 15 SP2" text
+    And vendor change should be enabled for "SP migration" on "ssh_spack_migrated_minion"
 
 @service_pack_migration
   Scenario: Check the migration is successful for this SSH minion

--- a/testsuite/features/secondary/min_salt_install_package.feature
+++ b/testsuite/features/secondary/min_salt_install_package.feature
@@ -32,10 +32,12 @@ Feature: Install a patch on the client via Salt through the UI
     And I follow "Software" in the content area
     And I follow "Patches" in the content area
     When I check "virgo-dummy-3456" in the list
+    And I check "allowVendorChange"
     And I click on "Apply Patches"
     And I click on "Confirm"
     Then I should see a "1 patch update has been scheduled for" text
     And I wait for "virgo-dummy-2.0-1.1" to be installed on "sle_minion"
+    And vendor change should be enabled for "package actions" on "sle_minion"
 
   Scenario: Cleanup: remove virgo-dummy package from SLE minion
     When I disable repository "test_repo_rpm_pool" on this "sle_minion"

--- a/testsuite/features/secondary/trad_inst_package_and_patch.feature
+++ b/testsuite/features/secondary/trad_inst_package_and_patch.feature
@@ -41,12 +41,14 @@ Feature: Install a package to the traditional client
     When I follow "Software" in the content area
     And I follow "Patches" in the content area
     And I check "andromeda-dummy-6789" in the list
+    And I check "allowVendorChange"
     And I click on "Apply Patches"
     And I click on "Confirm"
     And I run "rhn_check -vvv" on "sle_client"
     Then I should see a "1 patch update has been scheduled for" text
     When I wait until event "Package Install/Upgrade scheduled by admin" is completed
     Then "andromeda-dummy-2.0-1.1" should be installed on "sle_client"
+    And vendor change should be enabled for "package actions" on "sle_client"
     And The metadata buildtime from package "andromeda-dummy" match the one in the rpm on "sle_client"
 
   Scenario: Cleanup: remove packages and restore non-update repo

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -188,7 +188,7 @@ When(/^I query latest Salt changes on ubuntu system "(.*?)"$/) do |host|
   end
 end
 
-When(/^vendor change should be enabled for SP migration on "([^"]*)"$/) do |host|
+When(/^vendor change should be enabled for "(?:[^"]*)" on "([^"]*)"$/) do |host|
   node = get_target(host)
   _result, return_code = node.run("grep -- --allow-vendor-change /var/log/zypper.log")
   raise 'Vendor change option not found in logs' unless return_code.zero?


### PR DESCRIPTION
## What does this PR change?
This PR is from 4.1 
https://github.com/SUSE/spacewalk/pull/13370 <- already approved but wont be merged into 4.1

Adds a UI/api handling of allowing vendor change when applying patches.  Supports both rhn/salt stack.  

Spacewalk issue #12047 12407
Depends also on: https://github.com/openSUSE/salt/pull/301 
https://github.com/openSUSE/zypp-plugin-spacewalk/pull/44
## GUI diff
After:

![image](https://user-images.githubusercontent.com/729087/101291032-2e23f600-3806-11eb-856f-6ea9aec0ff3b.png)

- [ ] **DONE**

## Documentation
- @Loquacity pinged.

- [ ] **DONE**

## Test coverage
- Unit tests were added

- [ ] **DONE**

## Links

Fixes #

Relevant branches (GitHub automatic links expected below):
 - Uyuni

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
