### PR TITLE
Close the <p> tags in several channel descriptions

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/content/test/data1/productsUnscoped.json
+++ b/java/code/src/com/redhat/rhn/manager/content/test/data1/productsUnscoped.json
@@ -527,7 +527,7 @@
         "product_class": "SLE-LP",
         "cpe": "cpe:/o:suse:sle-live-patching:12",
         "free": false,
-        "description": "<p> SUSE Linux Enterprise Live Patching provides packages to update critical kernel modules live in SUSE Linux Enterprise. With SUSE Linux Enterprise Live Patching, you can perform critical kernel patching without shutting down your system, reducing the need for planned downtime and increasing service availability. <p>",
+        "description": "<p> SUSE Linux Enterprise Live Patching provides packages to update critical kernel modules live in SUSE Linux Enterprise. With SUSE Linux Enterprise Live Patching, you can perform critical kernel patching without shutting down your system, reducing the need for planned downtime and increasing service availability. </p>",
         "release_stage": "released",
         "eula_url": "https://updates.suse.com/SUSE/Products/SLE-Live-Patching/12/x86_64/product.license/",
         "product_type": "extension",

--- a/java/code/src/com/redhat/rhn/manager/content/test/smallBase/productsUnscoped.json
+++ b/java/code/src/com/redhat/rhn/manager/content/test/smallBase/productsUnscoped.json
@@ -527,7 +527,7 @@
         "product_class": "SLE-LP",
         "cpe": "cpe:/o:suse:sle-live-patching:12",
         "free": false,
-        "description": "<p> SUSE Linux Enterprise Live Patching provides packages to update critical kernel modules live in SUSE Linux Enterprise. With SUSE Linux Enterprise Live Patching, you can perform critical kernel patching without shutting down your system, reducing the need for planned downtime and increasing service availability. <p>",
+        "description": "<p> SUSE Linux Enterprise Live Patching provides packages to update critical kernel modules live in SUSE Linux Enterprise. With SUSE Linux Enterprise Live Patching, you can perform critical kernel patching without shutting down your system, reducing the need for planned downtime and increasing service availability. </p>",
         "release_stage": "released",
         "eula_url": "https://updates.suse.com/SUSE/Products/SLE-Live-Patching/12/x86_64/product.license/",
         "product_type": "extension",


### PR DESCRIPTION
## What does this PR change?

Close the `<p>` tags in several channel descriptions.
Otherwise, the HTML tags are visible:

![close-html-tag-Screenshot from 2021-03-18 11-35-54](https://user-images.githubusercontent.com/13642261/111613753-24376900-87df-11eb-9f5c-45736085dc1e.png)


## Links
Found during manual test cycle for 4.2.0 Beta 1.
https://github.com/SUSE/spacewalk/issues/12722

### Ports
- Manager-4.1: https://github.com/SUSE/spacewalk/pull/14348
- Manager-4.0: https://github.com/SUSE/spacewalk/pull/14347

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)
