### PR TITLE
Do a zypper ref before installing a pattern

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -814,7 +814,7 @@ When(/^I install pattern "([^"]*)" on this "([^"]*)"$/) do |pattern, host|
     pattern.gsub! "suma", "uyuni"
   end
   node = get_target(host)
-  raise 'Not found: zypper' unless file_exists?(node, '/usr/bin/zypper')
+  node.run('zypper ref')
   cmd = "zypper --non-interactive install -t pattern #{pattern}"
   node.run(cmd, true, DEFAULT_TIMEOUT, 'root', [0, 100, 101, 102, 103, 106])
 end
@@ -824,7 +824,7 @@ When(/^I remove pattern "([^"]*)" from this "([^"]*)"$/) do |pattern, host|
     pattern.gsub! "suma", "uyuni"
   end
   node = get_target(host)
-  raise 'Not found: zypper' unless file_exists?(node, '/usr/bin/zypper')
+  node.run('zypper ref')
   cmd = "zypper --non-interactive remove -t pattern #{pattern}"
   node.run(cmd, true, DEFAULT_TIMEOUT, 'root', [0, 100, 101, 102, 103, 104, 106])
 end


### PR DESCRIPTION
## What does this PR change?

This PR makes sure to do a `zypper ref` before installing (or removing) a pattern.

Technical notes:
 * we need to call `run()` twice because of different handling of error codes
 * we don't need to test for existence of `/usr/bin/zypper` as `zypper` will fail if it's not available


## Links

Ports:
* 4.0: SUSE/spacewalk#14350
* 4.1: SUSE/spacewalk#14349


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
