### PR TITLE
Testsuite - change of name for SLE12 key

### DIFF
--- a/testsuite/features/support/client_stack.rb
+++ b/testsuite/features/support/client_stack.rb
@@ -69,15 +69,14 @@ def get_os_version(node)
     ['6', 'centos']
   end
 end
-# rubocop:enable Metrics/AbcSize
 
 def get_gpg_keys(node, target = $server)
   os_version, os_family = get_os_version(node)
   if os_family =~ /^sles/
     # HACK: SLE 15 uses SLE 12 GPG key
     os_version = 12 if os_version =~ /^15/
-    # SLE11 key doesn't contain service pack string
-    os_version = 11 if os_version =~ /^11/
+    # SLE11 and SLE12 gpg keys don't contain service pack strings
+    os_version = os_version.split('-')[0] if os_version =~ /^1[12]/
     gpg_keys, _code = target.run("cd /srv/www/htdocs/pub/ && ls -1 sle#{os_version}*", false)
   elsif os_family =~ /^centos/
     gpg_keys, _code = target.run("cd /srv/www/htdocs/pub/ && ls -1 #{os_family}#{os_version}* res*", false)
@@ -86,6 +85,7 @@ def get_gpg_keys(node, target = $server)
   end
   gpg_keys.lines.map(&:strip)
 end
+# rubocop:enable Metrics/AbcSize
 
 def sle11family?(node)
   _out, code = node.run('pidof systemd', false)


### PR DESCRIPTION
## What does this PR change?

GPG key for SLE12 doesn't contain string with information about service pack version.
This change prevents failure of bootstrap in case of SLE12SP4 systems in QAM testsuite.

Same problem was already resolved by https://github.com/uyuni-project/uyuni/pull/3400 for SLE11 systems

## Links

https://github.com/SUSE/spacewalk/issues/14194

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
