### PR TITLE
[WIP] Notify beacon for Debian/Ubuntu systems

### DIFF
--- a/java/code/src/com/suse/manager/webui/services/pillar/MinionGeneralPillarGenerator.java
+++ b/java/code/src/com/suse/manager/webui/services/pillar/MinionGeneralPillarGenerator.java
@@ -80,7 +80,8 @@ public class MinionGeneralPillarGenerator implements MinionPillarGenerator {
         // this add the configuration for the beacon that tell us when the
         // minion packages are modified locally
         if (minion.getOsFamily().toLowerCase().equals("suse") ||
-                minion.getOsFamily().toLowerCase().equals("redhat")) {
+                minion.getOsFamily().toLowerCase().equals("redhat") ||
+                minion.getOsFamily().toLowerCase().equals("debian")) {
             beaconConfig.put("pkgset", PKGSET_BEACON_PROPS);
         }
         if (!beaconConfig.isEmpty()) {

--- a/susemanager-utils/susemanager-sls/src/beacons/pkgset.py
+++ b/susemanager-utils/susemanager-sls/src/beacons/pkgset.py
@@ -20,7 +20,8 @@ def __virtual__():
         os.path.exists("/usr/lib/zypp/plugins/commit/susemanager") or  # Remove this once 2015.8.7 not in use
         os.path.exists("/usr/lib/zypp/plugins/commit/zyppnotify") or
         os.path.exists("/usr/share/yum-plugins/susemanagerplugin.py") or  # Remove this once 2015.8.7 not in use
-        os.path.exists("/usr/share/yum-plugins/yumnotify.py")
+        os.path.exists("/usr/share/yum-plugins/yumnotify.py") or
+        os.path.exists("/usr/bin/aptnotify")
     ) and __virtualname__ or False
 
 


### PR DESCRIPTION
## DO NOT MERGE UNTIL https://github.com/openSUSE/salt/pull/337 IS MERGED

## What does this PR change?

This PR addapts Uyuni to support the `aptnotify` introduced on https://github.com/openSUSE/salt/pull/337.

**TODO**

- [ ] How to update "Debian" minion pillar to include the new "beacon" without removing and adding the systems?

**Before:**
```
server:~ # cat /srv/susemanager/pillar_data/pillar_minionu.tf.local.yml
channels: {
    }
contact_method: default
machine_password: 6091329cc0f342369a78a5a7e5fe4b7d7abdf0d0f840f26fa5025a2b754cdbc8
mgr_origin_server: server.tf.local
mgr_server: server.tf.local
org_id: 1
```
**After removing, and adding the system again:**
```
server:~ # cat /srv/susemanager/pillar_data/pillar_minionu.tf.local.yml
beacons:
    pkgset:
        cookie: /var/cache/salt/minion/rpmdb.cookie
        interval: 5
channels: {
    }
contact_method: default
machine_password: 489325da5ba03766e546d682939a0ce24a015ea3269ed6d7d35d6ae8329299b0
mgr_origin_server: server.tf.local
mgr_server: server.tf.local
org_id: 1
```


- [ ] How to automatically "refresh" pillar on "Debian" minion to activate the new "beacon"?

```
salt '*' saltutil.refresh_pillar
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/11561

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
