### PR TITLE
check for directory existance

### DIFF
--- a/susemanager/bin/pg-migrate-10-to-12.sh
+++ b/susemanager/bin/pg-migrate-10-to-12.sh
@@ -8,6 +8,13 @@ if [ $# -gt 1 ]; then
     exit 1
 fi
 
+if [ -d "/var/lib/pgsql/data-pg10" ]; then
+    echo "/var/lib/pgsql/data-pg10 exists." 
+    echo "Maybe a previous migration was cancelled?"
+    echo "Please check and cleanup prior to running the script"
+    exit 1
+fi
+
 if [ $# == 1 ]; then
     if [ $1 == "fast" ]; then
         echo "`date +"%H:%M:%S"`   Performing fast upgrade..."

--- a/susemanager/bin/pg-migrate-12-to-13.sh
+++ b/susemanager/bin/pg-migrate-12-to-13.sh
@@ -11,6 +11,13 @@ if [ $# -gt 1 ]; then
     exit 1
 fi
 
+if [ -d "/var/lib/pgsql/data-pg$OLD_VERSION" ]; then
+    echo "/var/lib/pgsql/data-pg$OLD_VERSION exists." 
+    echo "Maybe a previous migration was cancelled?"
+    echo "Please check and cleanup prior to running the script"
+    exit 1
+fi
+
 if [ $# == 1 ]; then
     if [ $1 == "fast" ]; then
         echo "`date +"%H:%M:%S"`   Performing fast upgrade..."


### PR DESCRIPTION
## What does this PR change?

Check whether the data-pg10 directory exists when executing the script, otherwiese it will just move data into that directory in line 83

## GUI diff

No difference.

## Documentation
- No documentation needed: doesnt require docs imho, just to catch an error

- [x] **DONE**

## Test coverage
- No tests

## Changelogs

- [X] No changelog needed

Make the database migration script check for existance of the migration directory to avoid re-run after something went wrong with a migration.