### PR TITLE
QA: Get rid of sles12 sp5 from CI tests

### DIFF
--- a/testsuite/features/reposync/srv_enable_sync_products.feature
+++ b/testsuite/features/reposync/srv_enable_sync_products.feature
@@ -8,8 +8,7 @@ Feature: Be able to list available products and enable them
 
   Scenario: List available products
     When I execute mgr-sync "list products" with user "admin" and password "admin"
-    Then I should get "[I] SUSE Linux Enterprise Server 12 SP5 x86_64"
-    And I should get "[ ] SUSE Linux Enterprise Desktop 15 SP2 x86_64"
+    Then I should get "[ ] SUSE Linux Enterprise Desktop 15 SP2 x86_64"
 
   Scenario: List all available products
     When I execute mgr-sync "list products -e"

--- a/testsuite/features/secondary/srv_content_lifecycle.feature
+++ b/testsuite/features/secondary/srv_content_lifecycle.feature
@@ -36,9 +36,9 @@ Feature: Content lifecycle
     When I follow the left menu "Content Lifecycle > Projects"
     And I follow "clp_name"
     And I click on "Attach/Detach Sources"
-    And I select "SLES12-SP5-Pool for x86_64" from "selectedBaseChannel"
+    And I select "SLES15-SP2-Pool for x86_64" from "selectedBaseChannel"
     And I click on "Save"
-    Then I wait until I see "SLES12-SP5-Pool for x86_64" text
+    Then I wait until I see "SLES15-SP2-Pool for x86_64" text
     And I should see a "Version 1: (draft - not built) - Check the changes below" text
 
 @uyuni
@@ -46,7 +46,7 @@ Feature: Content lifecycle
     Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Content Lifecycle > Projects"
     And I follow "clp_name"
-    And I should see a "SLES12-SP5-Updates for x86_64" text
+    And I should see a "SLES15-SP2-Updates for x86_64" text
     And I should see a "Build (2)" text
 
 @susemanager
@@ -54,9 +54,9 @@ Feature: Content lifecycle
     Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Content Lifecycle > Projects"
     And I follow "clp_name"
-    And I should see a "SLE-Manager-Tools12-Updates for x86_64 SP5" text
-    And I should see a "SLES12-SP5-Updates for x86_64" text
-    And I should see a "SLE-Manager-Tools12-Pool for x86_64 SP5" text
+    And I should see a "SLE-Manager-Tools15-Updates for x86_64 SP2" text
+    And I should see a "SLES15-SP2-Updates for x86_64" text
+    And I should see a "SLE-Manager-Tools15-Pool for x86_64 SP2" text
     And I should see a "Build (6)" text
 
   Scenario: Add environments to the project

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -526,15 +526,6 @@ When(/^I click the Add Product button$/) do
   raise "xpath: button#addProducts not found" unless find('button#addProducts').click
 end
 
-Then(/^the SLE12 SP5 product should be added$/) do
-  output = sshcmd('echo -e "admin\nadmin\n" | mgr-sync list channels', ignore_err: true)
-  raise unless output[:stdout].include? '[I] SLES12-SP5-Pool for x86_64 SUSE Linux Enterprise Server 12 SP5 x86_64 [sles12-sp5-pool-x86_64]'
-  if $product != 'Uyuni'
-    raise unless output[:stdout].include? '[I] SLE-Manager-Tools12-Pool for x86_64 SP5 SUSE Linux Enterprise Server 12 SP5 x86_64 [sle-manager-tools12-pool-x86_64-sp5]'
-  end
-  raise unless output[:stdout].include? '[I] SLE-Module-Legacy12-Updates for x86_64 Legacy Module 12 x86_64 [sle-module-legacy12-updates-x86_64-sp5]'
-end
-
 Then(/^the SLE15 SP2 product should be added$/) do
   output = sshcmd('echo -e "admin\nadmin\n" | mgr-sync list channels', ignore_err: true)
   raise unless output[:stdout].include? '[I] SLE-Product-SLES15-SP2-Pool for x86_64 SUSE Linux Enterprise Server 15 SP2 x86_64 [sle-product-sles15-sp2-pool-x86_64]'


### PR DESCRIPTION
## What does this PR change?

Get rid of sles12 sp5 from CI tests

## Links

Ports:
- Manager-4.0
- Manager-4.1

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
