### PR TITLE
AlmaLinux8 as a supported client

### DIFF
--- a/spacewalk/certs-tools/rhn_bootstrap_strings.py
+++ b/spacewalk/certs-tools/rhn_bootstrap_strings.py
@@ -382,6 +382,9 @@ if [ "$INSTALLER" == yum ]; then
         if [ -L /usr/share/doc/sles_es-release ]; then
             BASE="res"
             VERSION=6
+        elif [ -f /etc/almalinux-release ]; then
+            grep -v '^#' /etc/almalinux-release | grep -q '\(AlmaLinux\)' && BASE="almalinux"
+            VERSION=`grep -v '^#' /etc/almalinux-release | grep -Po '(?<=release )\d+'`
         elif [ -f /etc/oracle-release ]; then
             grep -v '^#' /etc/oracle-release | grep -q '\(Oracle\)' && BASE="oracle"
             VERSION=`grep -v '^#' /etc/oracle-release | grep -Po '(?<=release )\d+'`

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,4 @@
+- Prepare the bootstrap script generator for AlmaLinux 8
 - Prepare the bootstrap script generator for Amazon Linux 2
 - Prepare the bootstrap script generator for Alibaba Cloud Linux 2
 

--- a/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
@@ -42,6 +42,9 @@ mgr_server_localhost_alias_absent:
 {%- elif salt['file.file_exists']('/etc/system-release') %}
 {% set bootstrap_repo_url = 'https://' ~ salt['pillar.get']('mgr_server') ~ '/pub/repositories/amzn/' ~ grains['osmajorrelease'] ~ '/bootstrap/' %}
 
+{%- elif salt['file.file_exists']('/etc/almalinux-release') %}
+{% set bootstrap_repo_url = 'https://' ~ salt['pillar.get']('mgr_server') ~ '/pub/repositories/almalinux/' ~ grains['osmajorrelease'] ~ '/bootstrap/' %}
+
 {%- elif salt['file.file_exists']('/etc/centos-release') %}
 {# We try CentOS bootstrap repository first, if not available then fallback to RES #}
 {% set bootstrap_repo_url = 'https://' ~ salt['pillar.get']('mgr_server') ~ '/pub/repositories/centos/' ~ grains['osmajorrelease'] ~ '/bootstrap/' %}

--- a/susemanager-utils/susemanager-sls/salt/certs/AlmaLinux8.sls
+++ b/susemanager-utils/susemanager-sls/salt/certs/AlmaLinux8.sls
@@ -1,0 +1,1 @@
+RedHat8.sls

--- a/susemanager-utils/susemanager-sls/salt/packages/redhatproductinfo.sls
+++ b/susemanager-utils/susemanager-sls/salt/packages/redhatproductinfo.sls
@@ -19,6 +19,10 @@ amazonrelease:
   cmd.run:
     - name: cat /etc/system-release
     - onlyif: test -f /etc/system-release
+almalinux:
+  cmd.run:
+    - name: cat /etc/almalinux-release
+    - onlyif: test -f /etc/almalinux-release
 respkgquery:
   cmd.run:
     - name: rpm -q --whatprovides 'sles_es-release-server'

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Add support for AlmaLinux 8
 - Provide Custom Info as Pillar data
 - Add support for Amazon Linux 2
 - Add support for Alibaba Cloud Linux 2

--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -1237,11 +1237,6 @@ DATA = {
         'BASECHANNEL' : 'oraclelinux8-x86_64', 'PKGLIST' : RES8 + RES8_X86,
         'DEST' : '/srv/www/htdocs/pub/repositories/oracle/8/bootstrap/'
     },
-    'amazonlinux-2-x86_64' : {
-        # We will need to update the IDs when we have the definitions for SUSE Manager
-        'PDID' : [-14, 1683], 'BETAPDID' : [2065], 'PKGLIST' : RES7 + RES7_X86 + AMAZONLINUX2,
-        'DEST' : '/srv/www/htdocs/pub/repositories/amzn/2/bootstrap/'
-    },
     'amazonlinux-2-x86_64-uyuni' : {
         'BASECHANNEL' : 'amazonlinux2-core-x86_64', 'PKGLIST' : RES7 + RES7_X86 + AMAZONLINUX2,
         'DEST' : '/srv/www/htdocs/pub/repositories/amzn/2/bootstrap/'
@@ -1269,6 +1264,10 @@ DATA = {
     'alibaba-2-x86_64-uyuni': {
         'BASECHANNEL': 'alibaba-2-x86_64', 'PKGLIST': RES7 + RES7_X86,
         'DEST': '/srv/www/htdocs/pub/repositories/alibaba/2/bootstrap/'
+    },
+    'almalinux-8-x86_64-uyuni' : {
+        'BASECHANNEL' : 'almalinux8-x86_64', 'PKGLIST' : RES8 + RES8_X86,
+        'DEST' : '/srv/www/htdocs/pub/repositories/almalinux/8/bootstrap/'
     },
     'ubuntu-16.04-amd64' : {
         'PDID' : [-2, 1917], 'BETAPDID' : [2061], 'PKGLIST' : PKGLISTUBUNTU1604,

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- Add bootstrap repository definitions for AlmaLinux8
 - Add bootstrap repository for Amazon Linux 2
 - Add bootstrap repository for Alibaba Cloud Linux 2
 - Add bootstrap repository definition for SUSE Manager Proxy 4.2 (bsc#1183645)

--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -2313,3 +2313,58 @@ gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/CentOS7-Uyuni-Client-Tools/CentOS_7/
+
+[almalinux8]
+archs    = x86_64
+name     = AlmaLinux 8 (%(arch)s)
+gpgkey_url = https://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux
+gpgkey_id = 3ABB34F8
+gpgkey_fingerprint = 5E9B 8F56 17B5 066C E920 57C3 488F CF7C 3ABB 34F8
+repo_url = https://repo.almalinux.org/almalinux/8/BaseOS/%(arch)s/os/
+dist_map_release = 8
+
+[almalinux8-appstream]
+label    = %(base_channel)s-appstream
+archs    = x86_64
+name     = AlmaLinux 8 AppStream (%(arch)s)
+base_channels = almalinux8-%(arch)s
+repo_url = https://repo.almalinux.org/almalinux/8/AppStream/%(arch)s/os/
+
+[almalinux8-extras]
+label    = %(base_channel)s-extras
+archs    = x86_64
+name     = AlmaLinux 8 Extras (%(arch)s)
+base_channels = almalinux8-%(arch)s
+repo_url = https://repo.almalinux.org/almalinux/8/extras/%(arch)s/os/
+
+[almalinux8-powertools]
+label    = %(base_channel)s-powertools
+archs    = x86_64
+name     = AlmaLinux 8 PowerTools (%(arch)s)
+base_channels = almalinux8-%(arch)s
+repo_url = https://repo.almalinux.org/almalinux/8/PowerTools/%(arch)s/os/
+
+[almalinux8-ha]
+label    = %(base_channel)s-extras
+archs    = x86_64
+name     = AlmaLinux 8 Extras (%(arch)s)
+base_channels = almalinux8-%(arch)s
+repo_url = https://repo.almalinux.org/almalinux/8/HighAvailability/%(arch)s/os/
+
+[almalinux8-uyuni-client]
+name     = Uyuni Client Tools for %(base_channel_name)s
+archs    = %(_x86_archs)s
+base_channels = almalinux8-%(arch)s
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS8-Uyuni-Client-Tools/CentOS_8/repodata/repomd.xml.key
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS8-Uyuni-Client-Tools/CentOS_8/
+
+[almalinux8-uyuni-client-devel]
+name     = Uyuni Client Tools for %(base_channel_name)s (Development)
+archs    = %(_x86_archs)s
+base_channels = almalinux8-%(arch)s
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/CentOS8-Uyuni-Client-Tools/CentOS_8/repodata/repomd.xml.key
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/CentOS8-Uyuni-Client-Tools/CentOS_8/

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,4 @@
+- Add AlmaLinux 8 repositories
 - Add Amazon Linux 2 repositories
 - Add Alibaba Cloud Linux 2 repositories
 - Add current UEK repos to Oracle Linux


### PR DESCRIPTION
## What does this PR change?

AlmaLinux8 as a supported client

`uyuni-build-keys` at https://build.opensuse.org/project/show/home:juliogonzalezgil:branches:systemsmanagement:Uyuni:Master:Alma (will require a SR to `systemsmanagement:Uyuni:Master`

### What DOES NOT work

- Reposync (using the mirrorlist: https://github.com/SUSE/spacewalk/issues/14388)
- salt ssh minions do NOT trust the AlmaLinux automatically (as regular salt minions do, probably by accident). Seems the java code needs to be changed, and maybe the database, but it's unclear for me how to do it. Will talk to @mcalmer about it.
- After onboarding salt ssh minions if AlmaLinux GPG key is not accepted already, package installation/update will fail. This happens with CentOS8 as well.

### What was TESTED and DOES work.

- Reposync (using the mirrorlist: https://github.com/SUSE/spacewalk/issues/14388)
- Bootstrap repo generator
- Bootstrap script generator
- Bootstrapping as salt minion from WebUI (with an activation key)
- Bootstrapping as salt minion from bootstrap script (with an activation key)
- salt minion: Detect Packages requiring an update
- salt minion: CVE audit, was able to found that the instance vulnerable to CVE-2020-25632
- salt minion: Applying patches
- salt minion: Applying package updates
- salt minion: Installing a package
- salt minion: Removing a package
- salt minion: Running a salt command
- salt minion: Enabled locale and cpu-mitigations formulas and applied highstate
- Bootstrapping as salt ssh minion from WebUI (with an activation key)
- salt ssh minion: Detect Packages requiring an update
- salt ssh minion: CVE audit, was able to found that the instance vulnerable to CVE-2020-25632
 - salt minion: Applying patches
- salt minion: Applying package updates
- salt minion: Installing a package
- salt minion: Removing a package
- salt ssh minion: Running a salt command
- salt ssh minion: Enabled locale and cpu-mitigations formulas and applied highstate

### Conclusion

If our tests are fine, we could add it to both Uyuni and SUSE Manager (this last one via sumatoolbox)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- PR: https://github.com/uyuni-project/uyuni-docs/pull/868

- [x] **DONE**

## Test coverage
- No tests: We don't have them for unsupported distributions.

- [x] **DONE**

## Links

https://hackweek.suse.com/20/projects/testing-gnu-slash-linux-distributions-on-uyuni

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"		 
- [ ] Re-run test "java_pgsql_tests"		 
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"		 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"		 
- [ ] Re-run test "spacecmd_unittests"
