### PR TITLE
Add obs-project for creating build service projects for pull requests

### DIFF
--- a/susemanager-utils/testing/automation/obs-project.py
+++ b/susemanager-utils/testing/automation/obs-project.py
@@ -1,0 +1,106 @@
+#!/usr/bin/python3
+import argparse
+import os
+import sys
+import urllib.request
+import xml.etree.ElementTree as ET
+import datetime
+
+parser = argparse.ArgumentParser(description="This utility helps you manage an obs project for a Pull Request")
+parser.add_argument('--api', help="Build Service API, defaults to https://api.opensuse.org", default="https://api.opensuse.org")
+parser.add_argument('--project', help="Project from which to \"branch\" from, defaults to systemsmanagement:Uyuni:Master", default="systemsmanagement:Uyuni:Master")
+parser.add_argument('--prproject', help="Project to branch to \"branch\", defaults to systemsmanagement:Uyuni:Master:PR", default="systemsmanagement:Uyuni:Master:PR")
+parser.add_argument('pullnumber', help="Pull Request number, for example 1")
+parser.add_argument('--username', help="Username in the build service, defaults to OBS_USER environment variable", default="")
+parser.add_argument('--password', help="Password in the build service, defaults to OBS_PASSWORD environment variable", default="")
+parser.add_argument('--setmaintainer', help="Set maintainer", default="")
+
+args = parser.parse_args()
+api = args.api
+project = args.project
+pr_project = args.prproject
+pull_number = args.pullnumber
+auth_user = args.username
+if (auth_user == ""):
+    if ("OBS_USER" not in os.environ.keys()):
+        print("Please set OBS_USER environment variable or pass it as a parameter")
+        sys.exit(-1)
+    auth_user = os.environ["OBS_USER"]
+auth_passwd = args.password
+if (auth_passwd == ""):
+    if ("OBS_PASSWORD" not in os.environ.keys()):
+        print("Please set OBS_PASSWORD environment variable or pass it as a parameter")
+        sys.exit(-1)
+    auth_passwd = os.environ["OBS_PASSWORD"]
+maintainer=args.setmaintainer
+pr_project = pr_project + ":" + pull_number
+
+print("DEBUG: getting api version for debugging purposes")
+req = urllib.request.Request("{}/about".format(api))
+with urllib.request.urlopen(req) as response:
+    data = response.read()
+root = ET.fromstring(data)
+revision = root.find("revision").text
+print("DEBUG: API version: {}".format(revision))
+
+print("DEBUG: getting meta data from {}".format(project))
+passman = urllib.request.HTTPPasswordMgrWithDefaultRealm()
+url = api + "/source/" + project + "/_meta"
+passman.add_password(None, url, auth_user, auth_passwd)
+authhandler = urllib.request.HTTPBasicAuthHandler(passman)
+opener = urllib.request.build_opener(authhandler)
+urllib.request.install_opener(opener)
+req = urllib.request.Request(url)
+with urllib.request.urlopen(req) as response:
+    data = response.read()
+root = ET.fromstring(data)
+result = root.find("title").text
+print("DEBUG: found metadata for project with title {}".format(result))
+
+print("DEBUG: adapting project meta for new project {}".format(pr_project))
+root.set("name", pr_project)
+new_title = "Build for Pull Request #" + pull_number
+print("DEBUG: setting title to {}".format(new_title))
+root.find("title").text = new_title 
+
+if (maintainer!=""):
+    print("DEBUG: Adding user {} as maintainer".format(auth_user))
+    new_person = ET.fromstring("<person userid=\"{}\" role=\"maintainer\"/>".format(auth_user))
+    root.append(new_person)
+
+root.find("description").text=str(datetime.datetime.now())
+
+print("DEBUG: adapting list of repositories")
+for repo in root.findall("repository"):
+    if repo.get("name") == "images":
+        print("DEBUG: skipping images repo")
+        root.remove(repo)
+        continue
+    if repo.get("name") == "images_pxe":
+        print("DEBUG: skipping images_pxe repo")
+        root.remove(repo)
+        continue
+    for child in repo.findall("path"):
+        repo.remove(child)
+    for child in repo.findall("releasetarget"):
+        repo.remove(child)
+    print("DEBUG: Adding setting repository {} to use path {}".format(repo.get("name"), project))
+    new_path = ET.fromstring("<path project=\"{}\" repository=\"{}\" />".format(project, repo.get("name")))
+    repo.append(new_path)
+            
+
+print("DEBUG: creating new project: {}".format(pr_project))
+passman = urllib.request.HTTPPasswordMgrWithDefaultRealm()
+url = api + "/source/" + pr_project + "/_meta"
+passman.add_password(None, url, auth_user, auth_passwd)
+authhandler = urllib.request.HTTPBasicAuthHandler(passman)
+opener = urllib.request.build_opener(authhandler)
+urllib.request.install_opener(opener)
+data = ET.tostring(root)
+req = urllib.request.Request(url, data = data, method="PUT")
+with urllib.request.urlopen(req) as response:
+    data = response.read()
+root = ET.fromstring(data)
+print("DEBUG: result: {}".format(root.get("code")))
+
+

--- a/susemanager-utils/testing/automation/obs-project.py
+++ b/susemanager-utils/testing/automation/obs-project.py
@@ -39,7 +39,7 @@ except IOError as e:
 auth_user = config[api]["user"]
 auth_passwd = config[api]["pass"]
 
-if (auth_user == "" || auth_passwd == ""):
+if (auth_user == "" or auth_passwd == ""):
     print("ERROR: could not find user or password in config file")
     sys.exit(-1)
 

--- a/susemanager-utils/testing/automation/obs-project.py
+++ b/susemanager-utils/testing/automation/obs-project.py
@@ -83,6 +83,10 @@ def add(args):
             continue
         for child in repo.findall("path"):
             repo.remove(child)
+        for child in repo.findall("arch"):
+            if child.text != "x86_64":
+                print("DEBUG skipping arch " + child.text)
+                repo.remove(child)
         for child in repo.findall("releasetarget"):
             repo.remove(child)
         print("DEBUG: Adding setting repository {} to use path {}".format(repo.get("name"), project))

--- a/susemanager-utils/testing/automation/obs-project.py
+++ b/susemanager-utils/testing/automation/obs-project.py
@@ -88,7 +88,6 @@ def add(args):
         print("DEBUG: Adding setting repository {} to use path {}".format(repo.get("name"), project))
         new_path = ET.fromstring("<path project=\"{}\" repository=\"{}\" />".format(project, repo.get("name")))
         repo.append(new_path)
-                
 
     print("DEBUG: creating new project: {}".format(pr_project))
     passman = urllib.request.HTTPPasswordMgrWithDefaultRealm()
@@ -110,7 +109,7 @@ def print_usage(args):
 
 parser = argparse.ArgumentParser(description="This utility helps you manage an obs project for a Pull Request")
 parser.add_argument('--api', help="Build Service API, defaults to https://api.opensuse.org", default="https://api.opensuse.org")
-parser.add_argument('--configfile', help="Config file where username and password are store, by default ~/.oscrc", default="~/.oscrc")
+parser.add_argument('--configfile', help="Config file where username and password are store, by default $HOME/.oscrc", default=os.environ["HOME"] + "/.oscrc")
 parser.set_defaults(func=print_usage)
 
 

--- a/susemanager-utils/testing/automation/obs-project.py
+++ b/susemanager-utils/testing/automation/obs-project.py
@@ -112,6 +112,7 @@ def remove(args):
     pull_number = args.pullnumber
     pr_project = pr_project + ":" + pull_number
     config_file = args.configfile
+    interactive = not args.noninteractive
 
     if (not os.path.exists(config_file)):
         print("ERROR: config file {} not found".format(config_file))
@@ -141,11 +142,12 @@ def remove(args):
 
     print("DEBUG: removing project {}".format(pr_project))
     answer = ""
-    while (answer!="y" and answer!="n"):
-        answer = input("Are you sure you want to remove it?(y/n)")
-    if (answer == "n"):
-        print("OK. Maybe another day. Bye!")
-        sys.exit(-1)
+    if (interactive):
+        while (answer!="y" and answer!="n"):
+            answer = input("Are you sure you want to remove it?(y/n)")
+        if (answer == "n"):
+            print("OK. Maybe another day. Bye!")
+            sys.exit(-1)
     passman = urllib.request.HTTPPasswordMgrWithDefaultRealm()
     url = api + "/source/" + pr_project 
     passman.add_password(None, url, auth_user, auth_passwd)
@@ -176,6 +178,7 @@ parser_add.set_defaults(func=add)
 
 parser_remove = subparser.add_parser("remove", help="remove project")
 parser_remove.add_argument('pullnumber', help="Pull Request number, for example 1")
+parser_remove.add_argument('--noninteractive', help="Non interactive. This is yes by default!", action="store_true", default=False)
 parser_remove.set_defaults(func=remove)
 
 

--- a/susemanager-utils/testing/automation/obs-project.py
+++ b/susemanager-utils/testing/automation/obs-project.py
@@ -21,7 +21,6 @@ api = args.api
 project = args.project
 pr_project = args.prproject
 pull_number = args.pullnumber
-auth_user = args.username
 maintainer=args.setmaintainer
 pr_project = pr_project + ":" + pull_number
 config_file = args.configfile

--- a/susemanager-utils/testing/automation/obs-project.py
+++ b/susemanager-utils/testing/automation/obs-project.py
@@ -7,108 +7,120 @@ import xml.etree.ElementTree as ET
 import datetime
 import configparser
 
+
+
+def add(args):
+    api = args.api
+    project = args.project
+    pr_project = args.prproject
+    pull_number = args.pullnumber
+    maintainer=args.setmaintainer
+    pr_project = pr_project + ":" + pull_number
+    config_file = args.configfile
+
+    if (not os.path.exists(config_file)):
+        print("ERROR: config file {} not found".format(config_file))
+        sys.exit(-1)
+
+    config = configparser.ConfigParser()
+    try:
+        config.read(config_file)
+    except IOError as e:
+        print("ERROR: Can't read config file ".format(e))
+        sys.exit(-1)
+
+    auth_user = config[api]["user"]
+    auth_passwd = config[api]["pass"]
+
+    if (auth_user == "" or auth_passwd == ""):
+        print("ERROR: could not find user or password in config file")
+        sys.exit(-1)
+
+    print("DEBUG: getting api version for debugging purposes")
+    req = urllib.request.Request("{}/about".format(api))
+    with urllib.request.urlopen(req) as response:
+        data = response.read()
+    root = ET.fromstring(data)
+    revision = root.find("revision").text
+    print("DEBUG: API version: {}".format(revision))
+
+    print("DEBUG: getting meta data from {}".format(project))
+    passman = urllib.request.HTTPPasswordMgrWithDefaultRealm()
+    url = api + "/source/" + project + "/_meta"
+    passman.add_password(None, url, auth_user, auth_passwd)
+    authhandler = urllib.request.HTTPBasicAuthHandler(passman)
+    opener = urllib.request.build_opener(authhandler)
+    urllib.request.install_opener(opener)
+    req = urllib.request.Request(url)
+    with urllib.request.urlopen(req) as response:
+        data = response.read()
+    root = ET.fromstring(data)
+    result = root.find("title").text
+    print("DEBUG: found metadata for project with title {}".format(result))
+
+    print("DEBUG: adapting project meta for new project {}".format(pr_project))
+    root.set("name", pr_project)
+    new_title = "Build for Pull Request #" + pull_number
+    print("DEBUG: setting title to {}".format(new_title))
+    root.find("title").text = new_title 
+
+    if (maintainer!=""):
+        print("DEBUG: Adding user {} as maintainer".format(auth_user))
+        new_person = ET.fromstring("<person userid=\"{}\" role=\"maintainer\"/>".format(auth_user))
+        root.append(new_person)
+
+    root.find("description").text=str(datetime.datetime.now())
+
+    print("DEBUG: adapting list of repositories")
+    for repo in root.findall("repository"):
+        if repo.get("name") == "images":
+            print("DEBUG: skipping images repo")
+            root.remove(repo)
+            continue
+        if repo.get("name") == "images_pxe":
+            print("DEBUG: skipping images_pxe repo")
+            root.remove(repo)
+            continue
+        for child in repo.findall("path"):
+            repo.remove(child)
+        for child in repo.findall("releasetarget"):
+            repo.remove(child)
+        print("DEBUG: Adding setting repository {} to use path {}".format(repo.get("name"), project))
+        new_path = ET.fromstring("<path project=\"{}\" repository=\"{}\" />".format(project, repo.get("name")))
+        repo.append(new_path)
+                
+
+    print("DEBUG: creating new project: {}".format(pr_project))
+    passman = urllib.request.HTTPPasswordMgrWithDefaultRealm()
+    url = api + "/source/" + pr_project + "/_meta"
+    passman.add_password(None, url, auth_user, auth_passwd)
+    authhandler = urllib.request.HTTPBasicAuthHandler(passman)
+    opener = urllib.request.build_opener(authhandler)
+    urllib.request.install_opener(opener)
+    data = ET.tostring(root)
+    req = urllib.request.Request(url, data = data, method="PUT")
+    with urllib.request.urlopen(req) as response:
+        data = response.read()
+    root = ET.fromstring(data)
+    print("DEBUG: result: {}".format(root.get("code")))
+
+def print_usage(args):
+    print("Use -h for help")
+
+
 parser = argparse.ArgumentParser(description="This utility helps you manage an obs project for a Pull Request")
 parser.add_argument('--api', help="Build Service API, defaults to https://api.opensuse.org", default="https://api.opensuse.org")
-parser.add_argument('--project', help="Project from which to \"branch\" from, defaults to systemsmanagement:Uyuni:Master", default="systemsmanagement:Uyuni:Master")
-parser.add_argument('--prproject', help="Project to branch to \"branch\", defaults to systemsmanagement:Uyuni:Master:PR", default="systemsmanagement:Uyuni:Master:PR")
-parser.add_argument('pullnumber', help="Pull Request number, for example 1")
 parser.add_argument('--configfile', help="Config file where username and password are store, by default ~/.oscrc", default="~/.oscrc")
-parser.add_argument('--setmaintainer', help="Set maintainer", default="")
+parser.set_defaults(func=print_usage)
 
+
+subparser = parser.add_subparsers()
+parser_add = subparser.add_parser("add", help="add project")
+parser_add.add_argument('--project', help="Project from which to \"branch\" from, defaults to systemsmanagement:Uyuni:Master", default="systemsmanagement:Uyuni:Master")
+parser_add.add_argument('--prproject', help="Project to branch to \"branch\", defaults to systemsmanagement:Uyuni:Master:PR", default="systemsmanagement:Uyuni:Master:PR")
+parser_add.add_argument('pullnumber', help="Pull Request number, for example 1")
+parser_add.add_argument('--setmaintainer', help="Set maintainer", default="")
+parser_add.set_defaults(func=add)
 
 args = parser.parse_args()
-api = args.api
-project = args.project
-pr_project = args.prproject
-pull_number = args.pullnumber
-maintainer=args.setmaintainer
-pr_project = pr_project + ":" + pull_number
-config_file = args.configfile
-
-if (not os.path.exists(config_file)):
-    print("ERROR: config file {} not found".format(config_file))
-    sys.exit(-1)
-
-config = configparser.ConfigParser()
-try:
-    config.read(config_file)
-except IOError as e:
-    print("ERROR: Can't read config file ".format(e))
-    sys.exit(-1)
-
-auth_user = config[api]["user"]
-auth_passwd = config[api]["pass"]
-
-if (auth_user == "" or auth_passwd == ""):
-    print("ERROR: could not find user or password in config file")
-    sys.exit(-1)
-
-print("DEBUG: getting api version for debugging purposes")
-req = urllib.request.Request("{}/about".format(api))
-with urllib.request.urlopen(req) as response:
-    data = response.read()
-root = ET.fromstring(data)
-revision = root.find("revision").text
-print("DEBUG: API version: {}".format(revision))
-
-print("DEBUG: getting meta data from {}".format(project))
-passman = urllib.request.HTTPPasswordMgrWithDefaultRealm()
-url = api + "/source/" + project + "/_meta"
-passman.add_password(None, url, auth_user, auth_passwd)
-authhandler = urllib.request.HTTPBasicAuthHandler(passman)
-opener = urllib.request.build_opener(authhandler)
-urllib.request.install_opener(opener)
-req = urllib.request.Request(url)
-with urllib.request.urlopen(req) as response:
-    data = response.read()
-root = ET.fromstring(data)
-result = root.find("title").text
-print("DEBUG: found metadata for project with title {}".format(result))
-
-print("DEBUG: adapting project meta for new project {}".format(pr_project))
-root.set("name", pr_project)
-new_title = "Build for Pull Request #" + pull_number
-print("DEBUG: setting title to {}".format(new_title))
-root.find("title").text = new_title 
-
-if (maintainer!=""):
-    print("DEBUG: Adding user {} as maintainer".format(auth_user))
-    new_person = ET.fromstring("<person userid=\"{}\" role=\"maintainer\"/>".format(auth_user))
-    root.append(new_person)
-
-root.find("description").text=str(datetime.datetime.now())
-
-print("DEBUG: adapting list of repositories")
-for repo in root.findall("repository"):
-    if repo.get("name") == "images":
-        print("DEBUG: skipping images repo")
-        root.remove(repo)
-        continue
-    if repo.get("name") == "images_pxe":
-        print("DEBUG: skipping images_pxe repo")
-        root.remove(repo)
-        continue
-    for child in repo.findall("path"):
-        repo.remove(child)
-    for child in repo.findall("releasetarget"):
-        repo.remove(child)
-    print("DEBUG: Adding setting repository {} to use path {}".format(repo.get("name"), project))
-    new_path = ET.fromstring("<path project=\"{}\" repository=\"{}\" />".format(project, repo.get("name")))
-    repo.append(new_path)
-            
-
-print("DEBUG: creating new project: {}".format(pr_project))
-passman = urllib.request.HTTPPasswordMgrWithDefaultRealm()
-url = api + "/source/" + pr_project + "/_meta"
-passman.add_password(None, url, auth_user, auth_passwd)
-authhandler = urllib.request.HTTPBasicAuthHandler(passman)
-opener = urllib.request.build_opener(authhandler)
-urllib.request.install_opener(opener)
-data = ET.tostring(root)
-req = urllib.request.Request(url, data = data, method="PUT")
-with urllib.request.urlopen(req) as response:
-    data = response.read()
-root = ET.fromstring(data)
-print("DEBUG: result: {}".format(root.get("code")))
-
-
+args.func(args)

--- a/susemanager-utils/testing/automation/obs-project.py
+++ b/susemanager-utils/testing/automation/obs-project.py
@@ -168,7 +168,6 @@ parser.add_argument('--configfile', help="Config file where username and passwor
 parser.add_argument('--prproject', help="Parent project for Pull Requests, defaults to systemsmanagement:Uyuni:Master:PR", default="systemsmanagement:Uyuni:Master:PR")
 parser.set_defaults(func=print_usage)
 
-
 subparser = parser.add_subparsers()
 parser_add = subparser.add_parser("add", help="add project")
 parser_add.add_argument('--project', help="Project from which to \"branch\" from, defaults to systemsmanagement:Uyuni:Master", default="systemsmanagement:Uyuni:Master")

--- a/susemanager-utils/testing/automation/obs-project.py
+++ b/susemanager-utils/testing/automation/obs-project.py
@@ -175,7 +175,6 @@ parser_add.add_argument('--setmaintainer', help="Set maintainer", default="")
 parser_add.set_defaults(func=add)
 
 parser_remove = subparser.add_parser("remove", help="remove project")
-parser_add.add_argument('--prproject', help="Project to remove from, defaults to systemsmanagement:Uyuni:Master:PR", default="systemsmanagement:Uyuni:Master:PR")
 parser_remove.add_argument('pullnumber', help="Pull Request number, for example 1")
 parser_remove.set_defaults(func=remove)
 

--- a/susemanager-utils/testing/automation/obs-project.py
+++ b/susemanager-utils/testing/automation/obs-project.py
@@ -5,15 +5,16 @@ import sys
 import urllib.request
 import xml.etree.ElementTree as ET
 import datetime
+import configparser
 
 parser = argparse.ArgumentParser(description="This utility helps you manage an obs project for a Pull Request")
 parser.add_argument('--api', help="Build Service API, defaults to https://api.opensuse.org", default="https://api.opensuse.org")
 parser.add_argument('--project', help="Project from which to \"branch\" from, defaults to systemsmanagement:Uyuni:Master", default="systemsmanagement:Uyuni:Master")
 parser.add_argument('--prproject', help="Project to branch to \"branch\", defaults to systemsmanagement:Uyuni:Master:PR", default="systemsmanagement:Uyuni:Master:PR")
 parser.add_argument('pullnumber', help="Pull Request number, for example 1")
-parser.add_argument('--username', help="Username in the build service, defaults to OBS_USER environment variable", default="")
-parser.add_argument('--password', help="Password in the build service, defaults to OBS_PASSWORD environment variable", default="")
+parser.add_argument('--configfile', help="Config file where username and password are store, by default ~/.oscrc", default="~/.oscrc")
 parser.add_argument('--setmaintainer', help="Set maintainer", default="")
+
 
 args = parser.parse_args()
 api = args.api
@@ -21,19 +22,26 @@ project = args.project
 pr_project = args.prproject
 pull_number = args.pullnumber
 auth_user = args.username
-if (auth_user == ""):
-    if ("OBS_USER" not in os.environ.keys()):
-        print("Please set OBS_USER environment variable or pass it as a parameter")
-        sys.exit(-1)
-    auth_user = os.environ["OBS_USER"]
-auth_passwd = args.password
-if (auth_passwd == ""):
-    if ("OBS_PASSWORD" not in os.environ.keys()):
-        print("Please set OBS_PASSWORD environment variable or pass it as a parameter")
-        sys.exit(-1)
-    auth_passwd = os.environ["OBS_PASSWORD"]
 maintainer=args.setmaintainer
 pr_project = pr_project + ":" + pull_number
+config_file = args.configfile
+
+if (not os.path.exists(config_file)):
+    print("ERROR: config file {} not found".format(config_file))
+    sys.exit(-1)
+
+try:
+    config.read(config_file)
+except IOError as e:
+    print("ERROR: Can't read config file ".format(e))
+    sys.exit(-1)
+
+auth_user = config[api]["user"]
+auth_passwd = config[api]["pass"]
+
+if (auth_user == "" || auth_passwd == ""):
+    print("ERROR: could not find user or password in config file")
+    sys.exit(-1)
 
 print("DEBUG: getting api version for debugging purposes")
 req = urllib.request.Request("{}/about".format(api))

--- a/susemanager-utils/testing/automation/obs-project.py
+++ b/susemanager-utils/testing/automation/obs-project.py
@@ -106,20 +106,29 @@ def add(args):
 def print_usage(args):
     print("Use -h for help")
 
+def remove(args):
+    print("TO BE IMPLEMENTED")
+
 
 parser = argparse.ArgumentParser(description="This utility helps you manage an obs project for a Pull Request")
 parser.add_argument('--api', help="Build Service API, defaults to https://api.opensuse.org", default="https://api.opensuse.org")
 parser.add_argument('--configfile', help="Config file where username and password are store, by default $HOME/.oscrc", default=os.environ["HOME"] + "/.oscrc")
+parser.add_argument('--prproject', help="Parent project for Pull Requests, defaults to systemsmanagement:Uyuni:Master:PR", default="systemsmanagement:Uyuni:Master:PR")
 parser.set_defaults(func=print_usage)
 
 
 subparser = parser.add_subparsers()
 parser_add = subparser.add_parser("add", help="add project")
 parser_add.add_argument('--project', help="Project from which to \"branch\" from, defaults to systemsmanagement:Uyuni:Master", default="systemsmanagement:Uyuni:Master")
-parser_add.add_argument('--prproject', help="Project to branch to \"branch\", defaults to systemsmanagement:Uyuni:Master:PR", default="systemsmanagement:Uyuni:Master:PR")
 parser_add.add_argument('pullnumber', help="Pull Request number, for example 1")
 parser_add.add_argument('--setmaintainer', help="Set maintainer", default="")
 parser_add.set_defaults(func=add)
+
+parser_remove = subparser.add_parser("remove", help="remove project")
+parser_add.add_argument('--prproject', help="Project to remove from, defaults to systemsmanagement:Uyuni:Master:PR", default="systemsmanagement:Uyuni:Master:PR")
+parser_remove.add_argument('pullnumber', help="Pull Request number, for example 1")
+parser_remove.set_defaults(func=remove)
+
 
 args = parser.parse_args()
 args.func(args)

--- a/susemanager-utils/testing/automation/obs-project.py
+++ b/susemanager-utils/testing/automation/obs-project.py
@@ -29,6 +29,7 @@ if (not os.path.exists(config_file)):
     print("ERROR: config file {} not found".format(config_file))
     sys.exit(-1)
 
+config = configparser.ConfigParser()
 try:
     config.read(config_file)
 except IOError as e:

--- a/susemanager-utils/testing/automation/wait-for-builds.sh
+++ b/susemanager-utils/testing/automation/wait-for-builds.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+usage() {
+  echo "Usage: $0 -a api -c config_file -p project"
+  echo "project is mandatory. The rest are optionals."
+}
+
+api=https://api.opensuse.org
+config_file=$HOME/.oscrc
+
+while getopts ":a:c:p:" o;do
+    case "${o}" in
+        a)
+            api=${OPTARG}
+            ;;
+        c)
+            config_file=${OPTARG}
+            ;;
+        p)
+            project=${OPTARG}
+            ;;
+        :)
+            echo "ERROR: Option -$OPTARG requires an argument"
+            ;;
+        \?)
+            echo "ERROR: Invalid option -$OPTARG"
+            usage
+            ;;
+    esac
+done
+shift $((OPTIND-1))
+
+echo "DEBUG: api: $api ; config_file: $config_file ; project $project"
+
+if [ -z "${project}" ];then
+    usage
+    exit -1
+fi 
+
+for i in $(osc -A $api -c $config_file ls $project);do
+    echo "Checking $project/$i"
+    osc -A $api -c $config_file results $project $i -w
+done


### PR DESCRIPTION
## What does this PR change?

Adds obs-proejct for creating buildservice projects for pull requests

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
