### PR TITLE
Debrand mgr-setup file

### DIFF
--- a/susemanager/bin/mgr-setup
+++ b/susemanager/bin/mgr-setup
@@ -1,5 +1,21 @@
 #!/bin/bash
 
+# get product name, default: SUSE Manager
+IFS=" = "
+DEFAULT_RHN_CONF="/usr/share/rhn/config-defaults/rhn.conf"
+
+if [ -f "$DEFAULT_RHN_CONF" ]; then
+    while read -r name value
+    do
+        if [ $name == "product_name" ]; then
+            PRODUCT_NAME=$value
+        fi
+    done < $DEFAULT_RHN_CONF
+fi
+if [ ! -n "$PRODUCT_NAME" ]; then
+    PRODUCT_NAME="SUSE Manager"
+fi
+
 DISTRIBUTION_ID="$(source /etc/os-release && echo ${ID})"
 case ${DISTRIBUTION_ID} in
     sles|suse-manager-server) JVM='/usr/lib64/jvm/jre-11-openjdk/bin/java';;

--- a/susemanager/bin/mgr-setup
+++ b/susemanager/bin/mgr-setup
@@ -34,7 +34,7 @@ fi
 HOSTNAME=`hostname -f`
 if [ "$HOSTNAME" != "$(echo $HOSTNAME | tr '[:upper:]' '[:lower:]')" ]
 then
-    echo "Uppercase characters are not allowed for SUSE Manager hostname."
+    echo "Uppercase characters are not allowed for $PRODUCT_NAME hostname."
     exit 1
 fi
 
@@ -90,14 +90,14 @@ DB_BACKEND="postgresql"
 function help() {
     echo "
 Usage: $0 [OPTION]
-helper script to do migration or setup of SUSE Manager
+helper script to do migration or setup of $PRODUCT_NAME
 
-  -m             full migration of an existing SUSE Manager
+  -m             full migration of an existing $PRODUCT_NAME
   -r             only sync remote files (useful for migration only)
-  -f             version of SUSE Manager to migrate from.
+  -f             version of $PRODUCT_NAME to migrate from.
                  Must be one of: 3.1 or 3.2
                  NOTE: Needs to be specified before '-r' or '-m'
-  -s             fresh setup of the SUSE Manager installation
+  -s             fresh setup of the $PRODUCT_NAME installation
   -w             wait between steps (in case you do -r -m)
   -l LOGFILE     write a log to LOGFILE
   -h             this help screen
@@ -301,7 +301,7 @@ if [ -f $MANAGER_COMPLETE ]; then
         echo "Delete existing salt minion keys"
         salt-key -D -y > /dev/null
     else
-        echo "SUSE Manager is already set up. Exit." >&2
+        echo "$PRODUCT_NAME is already set up. Exit." >&2
         exit 1
     fi
 fi
@@ -359,7 +359,7 @@ ssl-server-key = $SERVER_KEY" >> /root/spacewalk-answers
     fi
     if [ "x" = "x$MANAGER_MAIL_FROM" ]; then
         MY_DOMAIN=`hostname -d`
-        MANAGER_MAIL_FROM="SUSE Manager ($REALHOSTNAME) <root@$MY_DOMAIN>"
+        MANAGER_MAIL_FROM="$PRODUCT_NAME ($REALHOSTNAME) <root@$MY_DOMAIN>"
     fi
     if ! grep "^web.default_mail_from" /etc/rhn/rhn.conf > /dev/null; then
         echo "web.default_mail_from = $MANAGER_MAIL_FROM" >> /etc/rhn/rhn.conf
@@ -438,7 +438,7 @@ copy_remote_files() {
                /var/log/rhn
                /var/spacewalk"
 
-    echo "Copy files from old SUSE Manager..."
+    echo "Copy files from old $PRODUCT_NAME..."
 
     for DIR in $SUMAFILES; do
         DEST=`dirname "$DIR"`
@@ -527,10 +527,10 @@ remove_ssh_key() {
 check_remote_type() {
     case "$FROMVERSION" in
         3.1)
-            echo "Migrating from remote system SUSE Manager 3.1"
+            echo "Migrating from remote system $PRODUCT_NAME 3.1"
             ;;
         3.2)
-            echo "Migrating from remote system SUSE Manager 3.2"
+            echo "Migrating from remote system $PRODUCT_NAME 3.2"
             ;;
         *)
             echo
@@ -839,7 +839,7 @@ if [ "$DO_SETUP" = "1" ]; then
     if [ -f $MANAGER_COMPLETE_HOOK ]; then
         $MANAGER_COMPLETE_HOOK
     else
-        echo "You can access SUSE Manager via https://`hostname -f`" > /etc/motd
+        echo "You can access $PRODUCT_NAME via https://`hostname -f`" > /etc/motd
     fi
 fi
 wait_step
@@ -894,9 +894,9 @@ if [ "$DO_MIGRATION" = "1" ]; then
     echo
     echo "============================================================================"
     echo "Migration complete."
-    echo "Please shut down the old SUSE Manager server now."
+    echo "Please shut down the old $PRODUCT_NAME server now."
     echo "Reboot the new server and make sure it uses the same IP address and hostname"
-    echo "as the old SUSE Manager server!"
+    echo "as the old $PRODUCT_NAME server!"
     echo
     echo "IMPORTANT: Make sure, if applicable, that your external storage is mounted"
     echo "in the new server as well as the ISO images needed for distributions before"


### PR DESCRIPTION
## What does this PR change?

Use value of parameter `product_name` from `/usr/share/rhn/config-defaults/rhn.conf` instead hardcoded string `SUSE Manager` for visible output.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Cosmetic branding related Change

- [x] **DONE**

## Test coverage
- No tests: There doesn't seem to exist a test for mgr-setup

- [x] **DONE**

## Links

Fixes #1354

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
