### PR TITLE
Move Salt pkg environ settings to minion config file

### DIFF
--- a/spacewalk/setup/salt/susemanager.conf
+++ b/spacewalk/setup/salt/susemanager.conf
@@ -90,10 +90,3 @@ rosters:
 
 # Allow minions to upload files to master
 file_recv: True
-
-# Define SALT_RUNNING env variable for pkg modules
-system-environment:
-  modules:
-    pkg:
-      _:
-        SALT_RUNNING: 1

--- a/spacewalk/setup/spacewalk-setup.changes
+++ b/spacewalk/setup/spacewalk-setup.changes
@@ -1,4 +1,3 @@
-- Prevent useless package list refresh actions on zypper minions (bsc#1183661)
 - set AJP parameters differently to prevent AH00992, AH00877 and
   AH01030: ajp_ilink_receive() can't receive header errors (bsc#1179271)
 - Use syslinux folder for cobbler loaders.

--- a/susemanager-utils/susemanager-sls/salt/bootstrap/susemanager.conf
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/susemanager.conf
@@ -12,3 +12,10 @@ start_event_grains:
   - machine_id
   - saltboot_initrd
   - susemanager
+
+# Define SALT_RUNNING env variable for pkg modules
+system-environment:
+  modules:
+    pkg:
+      _:
+        SALT_RUNNING: 1

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,5 +1,5 @@
 - add allow vendor change option to pathing via salt 
-- Add SALT_RUNNING config in case it's not present on the minion (bsc#1183661)
+- Prevent useless package list refresh actions on zypper minions (bsc#1183661)
 - Skip removed product classes with satellite-sync
 - add grain for virt module features
 - add virtual network creation action


### PR DESCRIPTION
## What does this PR change?

This PR moves the Salt "pkg" environment settings to the minion config file instead. This settings were wrongly pushed to the master configuration file by https://github.com/uyuni-project/uyuni/pull/3431 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **bugfix**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
