### PR TITLE
Fix rare issues with reposync when there are errors with package checksums (bsc#1183151)

### DIFF
--- a/backend/satellite_tools/reposync.py
+++ b/backend/satellite_tools/reposync.py
@@ -1269,6 +1269,19 @@ class RepoSync(object):
                     # Set to_link to False, no need to link again
                     to_process[index] = (pack, True, False)
 
+            except KeyboardInterrupt:
+                raise
+            except rhnSQL.SQLError:
+                raise
+            except Exception:
+                failed_packages += 1
+                e = str(sys.exc_info()[1])
+                if e:
+                    log2(0, 1, e, stream=sys.stderr)
+                if self.fail:
+                    raise
+                to_process[index] = (pack, False, False)
+            finally:
                 # importing packages by batch or if the current packages is the last
                 if mpm_bin_batch and (import_count == to_download_count
                                       or len(mpm_bin_batch) % self.import_batch_size == 0):
@@ -1290,19 +1303,6 @@ class RepoSync(object):
                     del mpm_src_batch
                     mpm_src_batch = importLib.Collection()
 
-            except KeyboardInterrupt:
-                raise
-            except rhnSQL.SQLError:
-                raise
-            except Exception:
-                failed_packages += 1
-                e = str(sys.exc_info()[1])
-                if e:
-                    log2(0, 1, e, stream=sys.stderr)
-                if self.fail:
-                    raise
-                to_process[index] = (pack, False, False)
-            finally:
                 if is_non_local_repo and stage_path:
                     if os.path.exists(stage_path):
                         os.remove(stage_path)

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,5 @@
+- Check if batch needs to be imported even after failure (bsc#1183151)
+
 -------------------------------------------------------------------
 Fri Jun 18 15:18:58 CEST 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

This PR fixes a really anoying issue that might happen only in rare cases when there are issues with the checksum/metadata from a repository that is being synced with `spacewalk-repo-sync`.

The package import is done in parallel for different "batches" during a reposync execution. The code that handles the processing of each "batch" does some checking after processing each package to figure out if it's time to do the actual SQL import of the packages that have been already processed in this batch.

The problem this PR is fixing happens in cases when there are checksum/metadata issues on the repository that it's been synced:

```console
# spacewalk-repo-sync -c testchannel2 -u https://packages.microsoft.com/rhel/7/prod/
...
2021/03/23 11:11:17 +02:00     31/39 : msodbcsql17-17.7.1.1-1.x86_64.rpm
2021/03/23 11:11:18 +02:00     32/39 : mssql-tools-17.2.0.2-1.x86_64.rpm
2021/03/23 11:11:20 +02:00     33/39 : msodbcsql-13.1.9.1-1.x86_64.rpm
2021/03/23 11:11:20 +02:00     34/39 : mdatp_101.02.48.x86_64.rpm
2021/03/23 11:11:22 +02:00 ERROR: Download failed: https://packages.microsoft.com/rhel/7/prod/omi-1.6.4-0.ssl_100.ulinux.x64.rpm - Target file isn't valid. Checksum should be aeb801a2e2155848cdd07f44f9077b920e57ea04f1b550dc1070a07f0f53a106 (sha256).. Retrying...
2021/03/23 11:11:22 +02:00 ERROR: Download failed: https://packages.microsoft.com/rhel/7/prod/scx-1.6.4-7.universal.x64.rpm - Target file isn't valid. Checksum should be 7f4693c10b130ccfb40db6bcee88e98d5d67116b7984b1f5a81b721b86af4940 (sha256).. Retrying...
2021/03/23 11:11:25 +02:00 ERROR: Download failed: https://packages.microsoft.com/rhel/7/prod/scx-1.6.4-7.universal.x64.rpm - Target file isn't valid. Checksum should be 7f4693c10b130ccfb40db6bcee88e98d5d67116b7984b1f5a81b721b86af4940 (sha256).. Retrying...
2021/03/23 11:11:25 +02:00 ERROR: Download failed: https://packages.microsoft.com/rhel/7/prod/omi-1.6.4-0.ssl_100.ulinux.x64.rpm - Target file isn't valid. Checksum should be aeb801a2e2155848cdd07f44f9077b920e57ea04f1b550dc1070a07f0f53a106 (sha256).. Retrying...
2021/03/23 11:11:26 +02:00     35/39 : dotnet-runtime-3.1.0-x64.rpm
2021/03/23 11:11:26 +02:00 ERROR: Download failed: https://packages.microsoft.com/rhel/7/prod/scx-1.6.4-7.universal.x64.rpm - Target file isn't valid. Checksum should be 7f4693c10b130ccfb40db6bcee88e98d5d67116b7984b1f5a81b721b86af4940 (sha256)..
2021/03/23 11:11:26 +02:00     36/39 : scx-1.6.4-7.universal.x64.rpm (failed)
2021/03/23 11:11:27 +02:00 ERROR: Download failed: https://packages.microsoft.com/rhel/7/prod/omi-1.6.4-0.ssl_100.ulinux.x64.rpm - Target file isn't valid. Checksum should be aeb801a2e2155848cdd07f44f9077b920e57ea04f1b550dc1070a07f0f53a106 (sha256)..
2021/03/23 11:11:27 +02:00     37/39 : omi-1.6.4-0.ssl_100.ulinux.x64.rpm (failed)
2021/03/23 11:11:32 +02:00     38/39 : dotnet-runtime-5.0.4-x64.rpm
2021/03/23 11:11:37 +02:00     39/39 : mssql-zulu-jre-11.37.18-1.x86_64.rpm
2021/03/23 11:11:38 +02:00 Importing packages started.
2021/03/23 11:11:38 +02:00
2021/03/23 11:11:38 +02:00   Importing packages to DB:
2021/03/23 11:11:38 +02:00   Package batch #1 of 29 completed...
2021/03/23 11:11:38 +02:00   Package batch #3 of 29 completed...
...
2021/03/23 11:11:39 +02:00   Package batch #27 of 29 completed...
2021/03/23 11:11:39 +02:00   Package batch #29 of 29 completed...
2021/03/23 11:11:39 +02:00   Package batch #28 of 29 completed...
2021/03/23 11:11:40 +02:00 (50, 'checksums did not match aeb801a2e2155848cdd07f44f9077b920e57ea04f1b550dc1070a07f0f53a106 vs 33d64c8269e16daf7c2ed432fb7881976205d291bb38879fcf40cf6197bc7688', 'Invalid information uploaded to the server')
2021/03/23 11:11:40 +02:00   Package batch #23 of 29 completed...
2021/03/23 11:11:40 +02:00 (50, 'checksums did not match 7f4693c10b130ccfb40db6bcee88e98d5d67116b7984b1f5a81b721b86af4940 vs 42b8943a8bbb45a810d6656d9887cf14c480e1d7a4e3ba20fc3d42518787665a', 'Invalid information uploaded to the server')
2021/03/23 11:11:40 +02:00   Package batch #5 of 29 completed...
2021/03/23 11:11:40 +02:00 Importing packages finished.
2021/03/23 11:11:40 +02:00
2021/03/23 11:11:40 +02:00   Linking packages to the channel.
2021/03/23 11:11:40 +02:00 Unexpected error: <class 'spacewalk.server.importlib.importLib.InvalidPackageError'>
2021/03/23 11:11:40 +02:00 Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/spacewalk/satellite_tools/reposync.py", line 592, in sync
    ret = self.import_packages(plugin, data['id'], url, is_non_local_repo)
  File "/usr/lib/python3.6/site-packages/spacewalk/satellite_tools/reposync.py", line 1107, in import_packages
    importer.run()
  File "/usr/lib/python3.6/site-packages/spacewalk/server/importlib/importLib.py", line 777, in run
    self.submit()
  File "/usr/lib/python3.6/site-packages/spacewalk/server/importlib/packageImport.py", line 126, in submit
    self.backend.lookupPackages(self.batch, self.checksums)
  File "/usr/lib/python3.6/site-packages/spacewalk/server/importlib/backend.py", line 822, in lookupPackages
    raise_with_tb(not_found[0], not_found[1])
  File "/usr/lib/python3.6/site-packages/uyuni/common/usix.py", line 77, in raise_with_tb
    raise value
  File "/usr/lib/python3.6/site-packages/spacewalk/server/importlib/backend.py", line 814, in lookupPackages
    self.__lookupObjectCollection([package], 'rhnPackage')
  File "/usr/lib/python3.6/site-packages/spacewalk/server/importlib/backend.py", line 2493, in __lookupObjectCollection
    raise InvalidPackageError(object, "Could not find object %s in table %s" % (object, tableName))
spacewalk.server.importlib.importLib.InvalidPackageError: Could not find object [<<class 'spacewalk.server.importlib.importLib.IncompletePackage'> instance; attributes={'package_id': None, 'name': 'aadlogin', 'epoch': None, 'version': '1.0.004880001', 'release': '1', 'arch': 'x86_64', 'org_id': 1, 'package_size': None, 'last_modified': None, 'md5sum': None, 'channels': {104: 'testchannel2'}, 'checksum_list': None, 'checksum': '48ca97ee85fff7a02006c3f2bde8d9b996b7d3ea7e7317895c3866c59072ff44', 'checksum_type': 'sha256', 'checksums': {'sha256': '48ca97ee85fff7a02006c3f2bde8d9b996b7d3ea7e7317895c3866c59072ff44'}, 'name_id': 410, 'evr_id': 12299, 'package_arch_id': 120, 'nevra_id': 577, 'checksum_id': 72837}] in table rhnPackage
```

This can be now easily reproducible just by tying to sync ` https://packages.microsoft.com/rhel/7/prod/` repo, as there are some inconsistencies atm. 

The root cause of this issue is that the code that checks if it's time to import the processed packages from the current batch in the database is not running when an exception is produced, for example when verifying package checksum.

Therefore in such cases, there are chances that the entire batch is finally not imported in the database, so we got errors at the time of linking package from package that were not even failing to verify the checksum.

This PR just move this checks so they are also evaluated when a checksum issue is produced.

This is actually what we tried to fix in the past with: https://github.com/uyuni-project/uyuni/pull/671 (but was never tested / merged)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **bugfix**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/14212

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
