### PR TITLE
Solve spacewalk-common-channel problems for Leap 15.2 aarch64

### DIFF
--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -904,20 +904,21 @@ repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/
 [opensuse_leap15_1-aarch64]
 checksum = sha256
 archs    = aarch64
+label    = opensuse_leap15_1-%(arch)s
 name     = openSUSE Leap 15.1 (%(arch)s)
 gpgkey_url =  http://download.opensuse.org/ports/aarch64/distribution/leap/15.1/repo/oss/repodata/repomd.xml.key
 gpgkey_id = 3DBDC284
 gpgkey_fingerprint = 22C0 7BA5 3417 8CD0 2EFE  22AA B88B 2FD4 3DBD C284
-repo_url = http://download.opensuse.org/distribution/leap/15.1/repo/oss/
+repo_url = http://download.opensuse.org/ports/aarch64/distribution/leap/15.1/repo/oss/
 dist_map_release = 15.1
 
 [opensuse_leap15_1-updates-aarch64]
-label    = %(base_channel)s-updates
+label    = opensuse_leap15_1-updates-%(arch)s
 name     = openSUSE Leap 15.1 Updates (%(arch)s)
 archs    = aarch64
 checksum = sha256
 base_channels = opensuse_leap15_1-%(arch)s
-repo_url = http://download.opensuse.org/ports/update/leap/15.1/
+repo_url = http://download.opensuse.org/ports/update/leap/15.1/oss/
 
 # This is expected. openSUSE Leap 15.0 client tools are valid for all openSUSE Leap 15.X releases
 [opensuse_leap15_1-uyuni-client-aarch64]
@@ -1000,6 +1001,7 @@ repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/
 [opensuse_leap15_2-aarch64]
 checksum = sha256
 archs    = aarch64
+label    = opensuse_leap15_2-%(arch)s
 name     = openSUSE Leap 15.2 (%(arch)s)
 gpgkey_url = http://download.opensuse.org/ports/aarch64/distribution/leap/15.2/repo/oss/repodata/repomd.xml.key
 gpgkey_id = 3DBDC284
@@ -1008,12 +1010,12 @@ repo_url = http://download.opensuse.org/ports/aarch64/distribution/leap/15.2/rep
 dist_map_release = 15.2
 
 [opensuse_leap15_2-updates-aarch64]
-label    = %(base_channel)s-updates
+label    = opensuse_leap15_2-updates-%(arch)s
 name     = openSUSE Leap 15.2 Updates (%(arch)s)
 archs    = aarch64
 checksum = sha256
 base_channels = opensuse_leap15_2-%(arch)s
-repo_url = http://download.opensuse.org/ports/update/leap/15.2/
+repo_url = http://download.opensuse.org/ports/update/leap/15.2/oss/
 
 # This is expected. openSUSE Leap 15.0 client tools are valid for all openSUSE Leap 15.X releases
 [opensuse_leap15_2-uyuni-client-aarch64]


### PR DESCRIPTION
## What does this PR change?

We can't trust the default label created by `spacewalk-common-channels` for the GA repo, and we can't also use `base_parent` for the updates repo. All of this happens because the URLs for aarch64 do not follow the same standard as for `x86_64`

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed: Not documented yet.

- [x] **DONE**

## Test coverage
- No tests: No automated tests (but @Bischoff is testing it, kudos for that!)

- [x] **DONE**

## Links

None.

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
