### PR TITLE
Configchannel at group enhancements

### DIFF
--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,4 @@
+- Add group_addconfigchannel and group_removeconfigchannel
 - Add group_listconfigchannels and configchannel_listgroups
 - Handle SIGPIPE without user-visible Exception (bsc#1181124)
 - Fix spacecmd compat with Python 3

--- a/spacecmd/src/spacecmd/group.py
+++ b/spacecmd/src/spacecmd/group.py
@@ -523,3 +523,82 @@ def do_group_listconfigchannels(self, args):
             print(_('Type:        %s') % details.get('configChannelType', {}).get('label'))
 
     return 0
+
+####################
+
+
+def help_group_addconfigchannels(self):
+    print(_('group_addconfigchannels: Add config channels to a group'))
+    print(_('''usage: group_addconfigchannels <GROUP> <CHANNEL ...>'''))
+    print('')
+    print(self.HELP_SYSTEM_OPTS)
+
+
+def complete_group_addconfigchannels(self, text, line, beg, end):
+    parts = line.split(' ')
+
+    if len(parts) == 2:
+        return self.tab_completer(self.do_group_list('', True), text)
+    elif len(parts) > 2:
+        return tab_completer(self.do_configchannel_list('', True),
+                             text)
+
+
+def do_group_addconfigchannels(self, args):
+    if not self.check_api_version('25.0'):
+        logging.warning(_N("This version of the API doesn't support this method"))
+        return 1
+
+    arg_parser = get_argument_parser()
+    (args, options) = parse_command_arguments(args, arg_parser)
+
+    if not args:
+        self.help_group_addconfigchannels()
+        return 1
+
+    add_separator = False
+
+    group = args.pop(0)
+    channels = args
+    self.client.systemgroup.subscribeConfigChannel(self.session, group, channels)
+    return 0
+
+####################
+
+
+def help_group_removeconfigchannels(self):
+    print(_('group_removeconfigchannels: Remove config channels from a group'))
+    print(_('''usage: group_removeconfigchannels <GROUP> <CHANNEL ...>'''))
+    print('')
+    print(self.HELP_SYSTEM_OPTS)
+
+
+def complete_group_removeconfigchannels(self, text, line, beg, end):
+    parts = line.split(' ')
+
+    if len(parts) == 2:
+        return self.tab_completer(self.do_group_list('', True), text)
+    elif len(parts) > 2:
+        return tab_completer(self.do_configchannel_list('', True),
+                             text)
+
+
+def do_group_removeconfigchannels(self, args):
+    if not self.check_api_version('25.0'):
+        logging.warning(_N("This version of the API doesn't support this method"))
+        return 1
+
+    arg_parser = get_argument_parser()
+    (args, options) = parse_command_arguments(args, arg_parser)
+
+    if not args:
+        self.help_group_removeconfigchannels()
+        return 1
+
+    add_separator = False
+
+    group = args.pop(0)
+    channels = args
+    self.client.systemgroup.unsubscribeConfigChannel(self.session, group, channels)
+    return 0
+

--- a/spacecmd/src/spacecmd/group.py
+++ b/spacecmd/src/spacecmd/group.py
@@ -501,7 +501,7 @@ def do_group_listconfigchannels(self, args):
     (args, _options) = parse_command_arguments(args, arg_parser)
 
     if not args:
-        self.help_group_details()
+        self.help_group_listconfigchannels()
         return 1
 
     add_separator = False


### PR DESCRIPTION
## What does this PR change?

Fix a display correct help text and add two new calls.
- group_addconfigchannel()
- group_removeconfigchannel()

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **no docs for spacecmd**

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Enhances https://github.com/uyuni-project/uyuni/pull/3402

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
