### PR TITLE
Require backports ssl

### DIFF
--- a/client/rhel/rhnlib/rhnlib.changes
+++ b/client/rhel/rhnlib/rhnlib.changes
@@ -1,3 +1,5 @@
+- require missing python-backports.ssl_match_hostname on SLE 11 (bsc#1183959)
+
 -------------------------------------------------------------------
 Wed Feb 17 12:16:30 CET 2021 - jgonzalez@suse.com
 

--- a/client/rhel/rhnlib/rhnlib.spec
+++ b/client/rhel/rhnlib/rhnlib.spec
@@ -76,6 +76,7 @@ BuildRequires:  python-devel
 Requires:       python-pyOpenSSL
 %else
 Requires:       python-openssl
+Requires:       python-backports.ssl_match_hostname
 %endif # 0{?suse_version} > 1200
 %else
 Requires:       pyOpenSSL


### PR DESCRIPTION
## What does this PR change?

On SLE 11 we need to require python-backports.ssl_match_hostname to make the new stack work.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/14392

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
