### PR TITLE
QA: Support multiple Cucumber profiles

### DIFF
--- a/testsuite/Rakefile
+++ b/testsuite/Rakefile
@@ -14,8 +14,12 @@ namespace :cucumber do
       timestamp = Time.now.strftime('%Y%m%d%H%M%S')
       json_results = "-f json -o output_#{timestamp}-#{filename}.json"
       html_results = "-f html -o output_#{timestamp}-#{filename}.html"
-      profile = ENV['PROFILE'] || 'default'
-      cucumber_opts = %W[#{html_results} #{json_results} #{junit_results} -f rerun --profile #{profile} --out failed.txt -f pretty -r features]
+      profiles = ENV['PROFILE'] || 'default'
+      include_profiles = ""
+      profiles.split(',').each do |profile|
+        include_profiles << "--profile #{profile} "
+      end
+      cucumber_opts = %W[#{html_results} #{json_results} #{junit_results} -f rerun #{include_profiles} --out failed.txt -f pretty -r features]
       features = YAML.safe_load(File.read(entry))
       t.cucumber_opts = cucumber_opts + features unless features.nil?
     end
@@ -29,8 +33,12 @@ namespace :parallel do
     task "#{run_set}" do
       timestamp = Time.now.strftime('%Y%m%d%H%M%S')
       features = YAML.safe_load(File.read(File.join(Dir.pwd, 'run_sets', "#{run_set}.yml"))).join(' ')
-      profile = ENV['PROFILE'] || 'default'
-      cucumber_opts = "--profile #{profile}  -f html -o output_#{timestamp}-#{run_set}-$TEST_ENV_NUMBER.html -f json -o output_#{timestamp}-#{run_set}-$TEST_ENV_NUMBER.json #{junit_results} -f rerun --out failed.txt -f CustomFormatter::PrettyFormatter -r features "
+      profiles = ENV['PROFILE'] || 'default'
+      include_profiles = ""
+      profiles.split(',').each do |profile|
+        include_profiles << "--profile #{profile} "
+      end
+      cucumber_opts = "#{include_profiles}  -f html -o output_#{timestamp}-#{run_set}-$TEST_ENV_NUMBER.html -f json -o output_#{timestamp}-#{run_set}-$TEST_ENV_NUMBER.json #{junit_results} -f rerun --out failed.txt -f CustomFormatter::PrettyFormatter -r features "
       sh "bundle exec parallel_cucumber -n 6 -o '#{cucumber_opts}' #{features}"
     end
   end

--- a/testsuite/documentation/guidelines.md
+++ b/testsuite/documentation/guidelines.md
@@ -16,6 +16,7 @@ In order to filter by team focus areas our test suite, we have a list of cucumbe
 
 You can see in the file `testsuite/config/cucumber.yml` the list of profiles.
 
+If you run the tests using the rake tasks, you can pass a list of profiles using the environment variable `PROFILE`. Example: `onboarding,spacecmd` 
 
 ### Grouping steps
 


### PR DESCRIPTION
## What does this PR change?

Add support to run multiple cucumber profiles

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
