### PR TITLE
Add lock option in wait for build script

### DIFF
--- a/susemanager-utils/testing/automation/wait-for-builds.sh
+++ b/susemanager-utils/testing/automation/wait-for-builds.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 
 usage() {
-  echo "Usage: $0 -a api -c config_file -p project -l"
+  echo "Usage: $0 -a api -c config_file -p project -u"
   echo "project is mandatory. The rest are optionals."
-  echo "l option is for locking the package after the build has finished"
+  echo "u option is for unlocking the package after the build has finished"
 }
 
 api=https://api.opensuse.org
 config_file=$HOME/.oscrc
-lock="no"
+lock="yes"
 
-while getopts ":a:c:p:l" o;do
+while getopts ":a:c:p:u" o;do
     case "${o}" in
         a)
             api=${OPTARG}
@@ -21,8 +21,8 @@ while getopts ":a:c:p:l" o;do
         p)
             project=${OPTARG}
             ;;
-        l)
-            lock="yes"
+        u)
+            lock="no"
             ;;    
         :)
             echo "ERROR: Option -$OPTARG requires an argument"


### PR DESCRIPTION
## What does this PR change?

This way, we can prevent the package from being rebuild

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
