### PR TITLE
QA: Get rif of service_pack_migration tag, run it always

### DIFF
--- a/testsuite/features/init_clients/sle_minion.feature
+++ b/testsuite/features/init_clients/sle_minion.feature
@@ -38,7 +38,6 @@ Feature: Bootstrap a Salt minion via the GUI
     And I follow "Proxy" in the content area
     Then I should see "sle_minion" hostname
 
-@service_pack_migration
   Scenario: Migrate this minion to SLE 15 SP2
     Given I am on the Systems overview page of this "sle_spack_migrated_minion"
     When I follow "Software" in the content area
@@ -52,7 +51,6 @@ Feature: Bootstrap a Salt minion via the GUI
     And I click on "Confirm"
     Then I should see a "This system is scheduled to be migrated to" text
 
-@service_pack_migration
   Scenario: Check the migration is successful for this minion
     Given I am on the Systems overview page of this "sle_spack_migrated_minion"
     When I follow "Events"
@@ -62,7 +60,6 @@ Feature: Bootstrap a Salt minion via the GUI
     Then I should see a "SUSE Linux Enterprise Server 15 SP2" text
     And vendor change should be enabled for "SP migration" on "sle_spack_migrated_minion"
 
-@service_pack_migration
   Scenario: Install the latest Salt on this minion
     When I enable repositories before installing Salt on this "sle_spack_migrated_minion"
     And I install Salt packages from "sle_spack_migrated_minion"

--- a/testsuite/features/init_clients/sle_ssh_minion.feature
+++ b/testsuite/features/init_clients/sle_ssh_minion.feature
@@ -1,10 +1,10 @@
 # Copyright (c) 2016-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
+@ssh_minion
 Feature: Bootstrap a Salt host managed via salt-ssh
 
-@ssh_minion
-  Scenario: Bootstrap a SLES system managed via salt-ssh
+  Scenario: Register this SSH minion for service pack migration
     Given I am authorized
     And I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
@@ -34,7 +34,6 @@ Feature: Bootstrap a Salt host managed via salt-ssh
     And I follow "Proxy" in the content area
     Then I should see "ssh_minion" hostname
 
-@service_pack_migration
   Scenario: Migrate this SSH minion to SLE 15 SP2
     Given I am on the Systems overview page of this "ssh_spack_migrated_minion"
     When I follow "Software" in the content area
@@ -48,7 +47,6 @@ Feature: Bootstrap a Salt host managed via salt-ssh
     And I click on "Confirm"
     Then I should see a "This system is scheduled to be migrated to" text
 
-@service_pack_migration
   Scenario: Check the migration is successful for this SSH minion
     Given I am on the Systems overview page of this "ssh_spack_migrated_minion"
     When I follow "Events"
@@ -58,23 +56,20 @@ Feature: Bootstrap a Salt host managed via salt-ssh
     Then I should see a "SUSE Linux Enterprise Server 15 SP2" text
     And vendor change should be enabled for "SP migration" on "ssh_spack_migrated_minion"
 
-@service_pack_migration
-  Scenario: Check the migration is successful for this SSH minion
+@proxy
+  Scenario: Check connection from SSH minion to proxy
     Given I am on the Systems overview page of this "ssh_spack_migrated_minion"
     When I follow "Details" in the content area
-    Then I should see a "SUSE Linux Enterprise Server 15 SP2" text
-    And vendor change should be enabled for SP migration on "ssh_spack_migrated_minion"
+    And I follow "Connection" in the content area
+    Then I should see "proxy" short hostname
 
-@service_pack_migration
-@ssh_minion
-  Scenario: Install the latest Salt on this SSH-managed minion
+  Scenario: Install the latest Salt on this minion
     When I enable repositories before installing Salt on this "ssh_spack_migrated_minion"
     And I install Salt packages from "ssh_spack_migrated_minion"
     And I disable repositories after installing Salt on this "ssh_spack_migrated_minion"
 
-@ssh_minion
   Scenario: Subscribe the SSH-managed SLES minion to a base channel
-    Given I am on the Systems overview page of this "ssh_minion"
+    Given I am on the Systems overview page of this "ssh_spack_migrated_minion"
     When I follow "Software" in the content area
     And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text
@@ -86,7 +81,6 @@ Feature: Bootstrap a Salt host managed via salt-ssh
     Then I should see a "Changing the channels has been scheduled." text
     And I wait until event "Subscribe channels scheduled by admin" is completed
 
-@ssh_minion
   Scenario: Check events history for failures on SSH minion
-    Given I am on the Systems overview page of this "ssh_minion"
+    Given I am on the Systems overview page of this "ssh_spack_migrated_minion"
     Then I check for failed events on history event page

--- a/testsuite/features/reposync/srv_sync_products.feature
+++ b/testsuite/features/reposync/srv_sync_products.feature
@@ -43,6 +43,19 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I wait until I see "SUSE Linux Enterprise Server 12 SP5 x86_64" product has been added
     Then the SLE12 SP5 product should be added
 
+
+@scc_credentials
+  Scenario: Add the initial product for the service pack migration
+    Given I am on the Products page
+    When I enter "SUSE Linux Enterprise Server 15 SP1" as the filtered product description
+    And I select "x86_64" in the dropdown list of the architecture filter
+    And I open the sub-list of the product "SUSE Linux Enterprise Server 15 SP1 x86_64"
+    Then I should see a "Basesystem Module 15 SP1 x86_64" text
+    When I select "SUSE Linux Enterprise Server 15 SP1 x86_64" as a product
+    And I click the Add Product button
+    And I wait until I see "SUSE Linux Enterprise Server 15 SP1 x86_64" product has been added
+    Then the SLE15 SP1 products should be added
+
 @scc_credentials
   Scenario: Add a product with recommended enabled
     Given I am on the Products page
@@ -62,26 +75,8 @@ Feature: Synchronize products in the products page of the Setup Wizard
     Then the SLE15 SP2 product should be added
 
 @scc_credentials
-@service_pack_migration
-  Scenario: Add the initial product for the service pack migration
-    Given I am on the Products page
-    When I enter "SUSE Linux Enterprise Server 15 SP1" as the filtered product description
-    And I select "x86_64" in the dropdown list of the architecture filter
-    And I open the sub-list of the product "SUSE Linux Enterprise Server 15 SP1 x86_64"
-    Then I should see a "Basesystem Module 15 SP1 x86_64" text
-    When I select "SUSE Linux Enterprise Server 15 SP1 x86_64" as a product
-    And I click the Add Product button
-    And I wait until I see "SUSE Linux Enterprise Server 15 SP1 x86_64" product has been added
-    Then the SLE15 SP1 products should be added
-
-@service_pack_migration
-@scc_credentials
-  Scenario: Installer update channels got enabled when products were added for the SP migration
-    When I execute mgr-sync "list channels" with user "admin" and password "admin"
-    Then I should get "    [I] SLES12-SP5-Installer-Updates for x86_64 SUSE Linux Enterprise Server 12 SP5 x86_64 [sles12-sp5-installer-updates-x86_64]"
-    And I should get "    [I] SLE15-SP2-Installer-Updates for x86_64 SUSE Linux Enterprise Server 15 SP2 x86_64 [sle15-sp2-installer-updates-x86_64]"
-
-@scc_credentials
   Scenario: Installer update channels got enabled when products were added
     When I execute mgr-sync "list channels" with user "admin" and password "admin"
     Then I should get "    [I] SLES12-SP5-Installer-Updates for x86_64 SUSE Linux Enterprise Server 12 SP5 x86_64 [sles12-sp5-installer-updates-x86_64]"
+    And I should get "    [I] SLE15-SP1-Installer-Updates for x86_64 SUSE Linux Enterprise Server 15 SP1 x86_64 [sle15-sp1-installer-updates-x86_64]"
+    And I should get "    [I] SLE15-SP2-Installer-Updates for x86_64 SUSE Linux Enterprise Server 15 SP2 x86_64 [sle15-sp2-installer-updates-x86_64]"

--- a/testsuite/features/secondary/allcli_action_chain.feature
+++ b/testsuite/features/secondary/allcli_action_chain.feature
@@ -92,7 +92,6 @@ Feature: Action chains on several systems at once
     Then I should see a "Action Chain new action chain has been scheduled for execution." text
 
   Scenario: Verify that the action chain from the system set manager was executed successfully
-    Given I am authorized as "admin" with password "admin"
     When I run "rhn_check -vvv" on "sle_client"
     And I wait until file "/tmp/action_chain_done" exists on "sle_client"
     And I wait until file "/tmp/action_chain_done" exists on "sle_minion"

--- a/testsuite/features/secondary/trad_sp_migration.feature
+++ b/testsuite/features/secondary/trad_sp_migration.feature
@@ -5,6 +5,7 @@
 # only the alert warning message here for now.
 
 @scope_traditional_client
+@scope_sp_migration
 Feature: Service pack migration
 
   Scenario: Check the warning message on tab "Software" => "SP Migration"

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -84,10 +84,8 @@ def compute_list_to_leave_running
     raise "Can't build list of reposyncs to leave running" unless ['12-SP4', '12-SP5', '15-SP1', '15-SP2', '15-SP3'].include? os_version
     do_not_kill += CHANNEL_TO_SYNCH_BY_OS_VERSION[os_version]
   end
-  if $service_pack_migration_enabled
-    do_not_kill += CHANNEL_TO_SYNCH_BY_OS_VERSION[MIGRATE_SSH_MINION_FROM]
-    do_not_kill += CHANNEL_TO_SYNCH_BY_OS_VERSION[MIGRATE_SSH_MINION_TO]
-  end
+  do_not_kill += CHANNEL_TO_SYNCH_BY_OS_VERSION[MIGRATE_SSH_MINION_FROM]
+  do_not_kill += CHANNEL_TO_SYNCH_BY_OS_VERSION[MIGRATE_SSH_MINION_TO]
   do_not_kill.uniq
 end
 

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -20,8 +20,6 @@ server = ENV['SERVER']
 $debug_mode = true if ENV['DEBUG']
 $long_tests_enabled = true if ENV['LONG_TESTS'] == 'true'
 puts "Executing long running tests" if $long_tests_enabled
-$service_pack_migration_enabled = true if ENV['SERVICE_PACK_MIGRATION'] == 'true'
-puts "Executing service pack migrations" if $service_pack_migration_enabled
 
 # maximal wait before giving up
 # the tests return much before that delay in case of success
@@ -341,16 +339,6 @@ end
 # do test only if we want to run long tests
 Before('@long_test') do
   skip_this_scenario unless $long_tests_enabled
-end
-
-# do test only if we want to run service pack migration
-Before('@service_pack_migration') do
-  skip_this_scenario unless $service_pack_migration_enabled
-end
-
-# do test only if we don't want to run service pack migration
-Before('@skip_service_pack_migration') do
-  skip_this_scenario if $service_pack_migration_enabled
 end
 
 # have more infos about the errors


### PR DESCRIPTION
## What does this PR change?

Get rid of the service_pack_migration tag in our test framework and run it always.
It's causing troubles and a logic hard to maintain, we are making the wrong assumption that this tag is enabled in some other features like allcli_software_channels_dependencies.feature and srv_distro_cobbler.feature

Note: It doesn't depend on the Jenkins pipeline change, in order to remove the variable passed by the environment, but we will merge both together. (https://github.com/SUSE/susemanager-ci/pull/207 was reverted and we need to apply again)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
 - Manager-4.0
 - Manager-4.1

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_lint_checkstyle"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "ruby_rubocop"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
