### PR TITLE
Reinstall salt broker after cleanup on proxy

### DIFF
--- a/testsuite/features/build_validation/init_clients/proxy.feature
+++ b/testsuite/features/build_validation/init_clients/proxy.feature
@@ -11,7 +11,11 @@ Feature: Setup SUSE Manager proxy
   I want to register the proxy to the server and configure it also as branch server
 
   Scenario: Clean up sumaform leftovers on a SUSE Manager proxy
-    When I perform a full salt minion cleanup on "proxy"
+    When I remove package "spacewalk-proxy-salt" from this "proxy" without error control
+    And I perform a full salt minion cleanup on "proxy"
+
+  Scenario: Install proxy pattern on the proxy
+    When I install pattern "suma_proxy" on this "proxy"
     # WORKAROUND to set proper product when JeOS image for SLE15SP2 is used
     And I set correct product for "proxy"
     # End of WORKAROUND

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -691,9 +691,6 @@ When(/^I perform a full salt minion cleanup on "([^"]*)"$/) do |host|
   end
   node.run('rm -Rf /var/cache/salt/minion /var/run/salt /var/log/salt /etc/salt', false)
   step %(I disable the repositories "tools_update_repo tools_pool_repo" on this "#{host}" without error control)
-  if host.include? 'proxy'
-    step %(I disable the repositories "proxy_module_pool_repo proxy_product_pool_repo proxy_product_update_repo" on this "#{host}" without error control)
-  end
 end
 
 When(/^I install a salt pillar top file for "([^"]*)" with target "([^"]*)" on the server$/) do |file, host|


### PR DESCRIPTION
## What does this PR change?

Removing file `/etc/salt/broker` may break transmission of Salt protocol between server and minions.

This PR reinstalls `spacewalk-proxy-salt` package after the salt cleanup in order to recreate that file.


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
