### PR TITLE
Remove SSL download from push package

### DIFF
--- a/testsuite/features/secondary/srv_push_package.feature
+++ b/testsuite/features/secondary/srv_push_package.feature
@@ -9,10 +9,6 @@ Feature: Push a package with unset vendor
   Background:
     Given I am authorized as "admin" with password "admin"
 
-  Scenario: Download the SSL certificate
-    When I download the SSL certificate
-    And I make the SSL certificate available to zypper
-
   Scenario: Push a package with unset vendor
     When I push package "/root/subscription-tools-1.0-0.noarch.rpm" into "test_base_channel" channel
     Then I should see package "subscription-tools-1.0-0.noarch" in channel "Test Base Channel"

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -22,20 +22,6 @@ When(/^I mount as "([^"]+)" the ISO from "([^"]+)" in the server$/) do |name, ur
   $server.run("umount #{iso_path}; mount #{iso_path}")
 end
 
-When(/^I download the SSL certificate$/) do
-  cert_path = '/usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT'
-  wget = 'wget --no-check-certificate -O'
-  $client.run("#{wget} #{cert_path} http://#{$server.ip}/pub/RHN-ORG-TRUSTED-SSL-CERT", true, 500, 'root')
-  $client.run("ls #{cert_path}")
-end
-
-When(/^I make the SSL certificate available to zypper$/) do
-  cert_path = '/usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT'
-  trust_path = '/etc/pki/trust/anchors'
-  $client.run("cd #{trust_path} && ln -sf #{cert_path}")
-  $client.run('update-ca-certificates')
-end
-
 Then(/^I can see all system information for "([^"]*)"$/) do |host|
   node = get_target(host)
   step %(I should see a "#{node.hostname}" text)


### PR DESCRIPTION
https://github.com/SUSE/spacewalk/issues/14358

- [x] No changelog needed


After investigation, the certificate doesn't seem needed anymore. I could run `rhnpush` command to push the package on the server side without any certificate issue.

Test suite have been run without the ssl downloaded without new error.

The SSL download should not be a test by itself because it's not part of SUMA project.

Discution : https://github.com/uyuni-project/uyuni/pull/3318#issuecomment-800077153
