### PR TITLE
Fix salt cleanup for proxy

### DIFF
--- a/testsuite/features/build_validation/init_clients/proxy.feature
+++ b/testsuite/features/build_validation/init_clients/proxy.feature
@@ -12,9 +12,12 @@ Feature: Setup SUSE Manager proxy
 
   Scenario: Clean up sumaform leftovers on a SUSE Manager proxy
     When I perform a full salt minion cleanup on "proxy"
-    # WORKAROUND to set proper product when JeOS image for SLE15SP2 is used
-    And I set correct product for "proxy"
-    # End of WORKAROUND
+
+  Scenario: Install proxy software
+    # uncomment when product is out:
+    # When I install "SUSE-Manager-Proxy" product on the proxy
+    And I install proxy pattern on the proxy
+    And I let squid use avahi on the proxy
 
   Scenario: Bootstrap the proxy as a Salt minion
     Given I am authorized as "admin" with password "admin"
@@ -50,23 +53,19 @@ Feature: Setup SUSE Manager proxy
     Given I am on the Systems overview page of this "proxy"
     Then I check for failed events on history event page
 
-@proxy
 @private_net
   Scenario: Install the Retail pattern on the server
     When I install pattern "suma_retail" on this "server"
     And I wait for "patterns-suma_retail" to be installed on "server"
 
-@proxy
 @private_net
   Scenario: Enable repositories for installing branch services
     When I install package "expect" on this "proxy"
 
-@proxy
 @private_net
   Scenario: Configure retail formulas using retail_branch_init command
     When I set "eth1" as NIC, "id" as prefix, "rbs" as branch server name and "branch.org" as domain
 
-@proxy
 @private_net
   Scenario: Parametrize empty-zones-enable section in DNS formula
     # retail_branch_init command is not able to configure this
@@ -81,12 +80,10 @@ Feature: Setup SUSE Manager proxy
     And I click on "Save Formula"
     Then I should see a "Formula saved" text
 
-@proxy
 @private_net
   Scenario: Let avahi work on the branch server
     When I open avahi port on the proxy
 
-@proxy
 @private_net
   Scenario: Apply the branch network formulas via the highstate
     Given I am on the Systems overview page of this "proxy"
@@ -99,4 +96,3 @@ Feature: Setup SUSE Manager proxy
     And service "named" is active on "proxy"
     And service "firewalld" is enabled on "proxy"
     And service "firewalld" is active on "proxy"
-

--- a/testsuite/features/core/proxy_register_as_minion_with_gui.feature
+++ b/testsuite/features/core/proxy_register_as_minion_with_gui.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 SUSE LLC
+# Copyright (c) 2017-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # The scenarios in this feature are skipped if there is no proxy
@@ -7,12 +7,18 @@
 # Alternative: Bootstrap the proxy as Salt minion from GUI
 
 @scope_proxy
+@proxy
 Feature: Setup SUSE Manager proxy
   In order to use a proxy with the SUSE manager server
   As the system administrator
   I want to register the proxy to the server
 
-@proxy
+  Scenario: Install proxy software
+    # uncomment when product is out:
+    # When I install "SUSE-Manager-Proxy" product on the proxy
+    And I install proxy pattern on the proxy
+    And I let squid use avahi on the proxy
+
   Scenario: Bootstrap the proxy as a Salt minion
     Given I am authorized
     When I go to the bootstrapping page
@@ -24,22 +30,18 @@ Feature: Setup SUSE Manager proxy
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text
 
-@proxy
   Scenario: Wait until the proxy appears
     Given I am authorized
     When I wait until onboarding is completed for "proxy"
 
-@proxy
   Scenario: Detect latest Salt changes on the proxy
     When I query latest Salt changes on "proxy"
 
-@proxy
   Scenario: Copy the keys and configure the proxy
     When I copy server's keys to the proxy
     And I configure the proxy
     Then I should see "proxy" via spacecmd
 
-@proxy
   Scenario: Check proxy system details
     When I am on the Systems overview page of this "proxy"
     Then I should see "proxy" hostname
@@ -47,13 +49,11 @@ Feature: Setup SUSE Manager proxy
     # When I wait until I see "$PRODUCT Proxy" text, refreshing the page
     Then I should see a "Proxy" link in the content area
 
-@proxy
   Scenario: Install expect package on proxy for bootstrapping minion with GUI
     When I enable repositories before installing branch server
     And I install package "expect" on this "proxy"
     And I disable repositories after installing branch server
 
-@proxy
   Scenario: Check events history for failures on the proxy
     Given I am on the Systems overview page of this "proxy"
     Then I check for failed events on history event page

--- a/testsuite/features/core/proxy_register_as_minion_with_script.feature
+++ b/testsuite/features/core/proxy_register_as_minion_with_script.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 SUSE LLC
+# Copyright (c) 2017-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # The scenarios in this feature are skipped if there is no proxy
@@ -7,12 +7,18 @@
 # Alternative: Bootstrap the proxy as a Salt minion from script
 
 @scope_proxy
+@proxy
 Feature: Setup SUSE Manager proxy
   In order to use a proxy with the SUSE manager server
   As the system administrator
   I want to register the proxy to the server
 
-@proxy
+  Scenario: Install proxy software
+    # uncomment when product is out:
+    # When I install "SUSE-Manager-Proxy" product on the proxy
+    And I install proxy pattern on the proxy
+    And I let squid use avahi on the proxy
+
   Scenario: Create the bootstrap script for the proxy and use it
     When I execute mgr-bootstrap "--script=bootstrap-proxy.sh --no-up2date"
     Then I should get "* bootstrap script (written):"
@@ -20,29 +26,24 @@ Feature: Setup SUSE Manager proxy
     When I fetch "pub/bootstrap/bootstrap-proxy.sh" to "proxy"
     And I run "sh ./bootstrap-proxy.sh" on "proxy"
 
-@proxy
   Scenario: Accept the key for the proxy
     Given I am authorized as "testing" with password "testing"
     When I go to the minion onboarding page
     And I wait until I see "pending" text, refreshing the page
     And I accept "proxy" key
 
-@proxy
   Scenario: Wait until the proxy appears
     Given I am authorized
     When I wait until onboarding is completed for "proxy"
 
-@proxy
   Scenario: Detect latest Salt changes on the proxy
     When I query latest Salt changes on "proxy"
 
-@proxy
   Scenario: Copy the keys and configure the proxy
     When I copy server's keys to the proxy
     And I configure the proxy
     Then I should see "proxy" via spacecmd
 
-@proxy
   Scenario: Check proxy system details
     When I am on the Systems overview page of this "proxy"
     Then I should see "proxy" hostname
@@ -50,13 +51,11 @@ Feature: Setup SUSE Manager proxy
     # When I wait until I see "$PRODUCT Proxy" text, refreshing the page
     Then I should see a "Proxy" link in the content area
 
-@proxy
   Scenario: Install expect package on proxy for bootstrapping minion via script
     When I enable repositories before installing branch server
     And I install package "expect" on this "proxy"
     And I disable repositories after installing branch server
 
-@proxy
   Scenario: Cleanup: remove proxy bootstrap scripts
     When I run "rm /srv/www/htdocs/pub/bootstrap/bootstrap-proxy.sh" on "server"
     And I run "rm /root/bootstrap-proxy.sh" on "proxy"

--- a/testsuite/features/core/proxy_register_as_trad_with_script.feature
+++ b/testsuite/features/core/proxy_register_as_trad_with_script.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2020 SUSE LLC
+# Copyright (c) 2017-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # The scenarios in this feature are skipped if there is no proxy
@@ -7,12 +7,18 @@
 # Alternative: Bootstrap the proxy as a traditional client from script
 
 @scope_proxy
+@proxy
 Feature: Setup SUSE Manager proxy
   In order to use a proxy with the SUSE manager server
   As the system administrator
   I want to register the proxy to the server
 
-@proxy
+  Scenario: Install proxy software
+    # uncomment when product is out:
+    # When I install "SUSE-Manager-Proxy" product on the proxy
+    And I install proxy pattern on the proxy
+    And I let squid use avahi on the proxy
+
   Scenario: Create the bootstrap script for the proxy and use it
     When I execute mgr-bootstrap "--script=bootstrap-proxy.sh --no-up2date --traditional"
     Then I should get "* bootstrap script (written):"
@@ -20,13 +26,11 @@ Feature: Setup SUSE Manager proxy
     When I fetch "pub/bootstrap/bootstrap-proxy.sh" to "proxy"
     And I run "sh ./bootstrap-proxy.sh" on "proxy"
 
-@proxy
   Scenario: Copy the keys and configure the proxy
     When I copy server's keys to the proxy
     And I configure the proxy
     Then I should see "proxy" via spacecmd
 
-@proxy
   Scenario: Check proxy system details
     When I am on the Systems overview page of this "proxy"
     Then I should see "proxy" hostname
@@ -34,13 +38,11 @@ Feature: Setup SUSE Manager proxy
     # When I wait until I see "$PRODUCT Proxy" text, refreshing the page
     Then I should see a "Proxy" link in the content area
 
-@proxy
   Scenario: Install expect package on proxy for bootstrapping client via script
     When I enable repositories before installing branch server
     And I install package "expect" on this "proxy"
     And I disable repositories after installing branch server
 
-@proxy
   Scenario: Cleanup: remove proxy bootstrap scripts
     When I run "rm /srv/www/htdocs/pub/bootstrap/bootstrap-proxy.sh" on "server"
     And I run "rm /root/bootstrap-proxy.sh" on "proxy"

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -798,15 +798,13 @@ When(/^I (enable|disable) (the repositories|repository) "([^"]*)" on this "([^"]
 end
 
 When(/^I enable source package syncing$/) do
-  node = get_target("server")
   cmd = "echo 'server.sync_source_packages = 1' >> /etc/rhn/rhn.conf"
-  node.run(cmd)
+  $server.run(cmd)
 end
 
 When(/^I disable source package syncing$/) do
-  node = get_target("server")
   cmd = "sed -i 's/^server.sync_source_packages = 1.*//g' /etc/rhn/rhn.conf"
-  node.run(cmd)
+  $server.run(cmd)
 end
 
 When(/^I install pattern "([^"]*)" on this "([^"]*)"$/) do |pattern, host|
@@ -872,13 +870,12 @@ When(/^I install package(?:s)? "([^"]*)" on this "([^"]*)"((?: without error con
 end
 
 When(/^I install package tftpboot-installation on the server$/) do
-  node = get_target("server")
-  output, _code = node.run("find /var/spacewalk/packages -name tftpboot-installation-SLE-15-SP2-x86_64-*.noarch.rpm")
+  output, _code = $server.run('find /var/spacewalk/packages -name tftpboot-installation-SLE-15-SP2-x86_64-*.noarch.rpm')
   packages = output.split("\n")
   pattern = '/tftpboot-installation-([^/]+)*.noarch.rpm'
   # Reverse sort the package name to get the latest version first and install it
   package = packages.min { |a, b| b.match(pattern)[0] <=> a.match(pattern)[0] }
-  node.run("rpm -i #{package}")
+  $server.run("rpm -i #{package}")
 end
 
 When(/^I install old package(?:s)? "([^"]*)" on this "([^"]*)"((?: without error control)?)$/) do |package, host, error_control|
@@ -942,6 +939,27 @@ When(/^I create the bootstrap repository for "([^"]*)" on the server$/) do |host
   STDOUT.puts 'Creating the boostrap repository on the server:'
   STDOUT.puts '  ' + cmd
   $server.run(cmd)
+end
+
+When(/^I install "([^"]*)" product on the proxy$/) do |product|
+  out, = $proxy.run("zypper ref && zypper --non-interactive install --auto-agree-with-licenses --force-resolution -t product #{product}")
+  STDOUT.puts "Installed #{product} product: #{out}"
+end
+
+When(/^I install proxy pattern on the proxy$/) do
+  pattern = $product == 'Uyuni' ? 'uyuni_proxy' : 'suma_proxy'
+  cmd = "zypper --non-interactive install -t pattern #{pattern}"
+  $proxy.run(cmd, true, 600, 'root', [0, 100, 101, 102, 103, 106])
+end
+
+When(/^I let squid use avahi on the proxy$/) do
+  file = '/usr/share/rhn/proxy-template/squid.conf'
+  key = 'dns_multicast_local'
+  val = 'on'
+  $proxy.run("grep '^#{key}' #{file} && sed -i -e 's/^#{key}.*$/#{key} #{val}/' #{file} || echo '#{key} #{val}' >> #{file}")
+  key = 'ignore_unknown_nameservers'
+  val = 'off'
+  $proxy.run("grep '^#{key}' #{file} && sed -i -e 's/^#{key}.*$/#{key} #{val}/' #{file} || echo '#{key} #{val}' >> #{file}")
 end
 
 When(/^I open avahi port on the proxy$/) do
@@ -1544,17 +1562,4 @@ When(/^I apply "([^"]*)" local salt state on "([^"]*)"$/) do |state, host|
   return_code = file_inject(node, source, remote_file)
   raise 'File injection failed' unless return_code.zero?
   node.run('salt-call --local --file-root=/usr/share/susemanager/salt --module-dirs=/usr/share/susemanager/salt/ --log-level=info --retcode-passthrough state.apply ' + state)
-end
-
-# WORKAROUND to set proper product when JeOS image for SLE15SP2 is used
-When(/^I set correct product for "(proxy|branch server)"$/) do |product|
-  if product.include? 'proxy'
-    prod = 'SUSE-Manager-Proxy'
-  elsif product.include? 'branch server'
-    prod = 'SUSE-Manager-Retail-Branch-Server'
-  else
-    raise 'Incorrect product used.'
-  end
-  out, = $proxy.run("zypper ref && zypper --non-interactive install --auto-agree-with-licenses --force-resolution -t product #{prod}")
-  puts "Setting proper product: #{out}"
 end

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -689,11 +689,8 @@ When(/^I perform a full salt minion cleanup on "([^"]*)"$/) do |host|
   else
     node.run('zypper --non-interactive remove -y salt salt-minion', false)
   end
-  node.run('rm -Rf /var/cache/salt/minion /var/run/salt /var/log/salt /etc/salt', false)
+  node.run('rm -Rf /var/cache/salt/minion /var/run/salt /var/log/salt /etc/salt /var/tmp/.root*', false)
   step %(I disable the repositories "tools_update_repo tools_pool_repo" on this "#{host}" without error control)
-  if host.include? 'proxy'
-    step %(I disable the repositories "proxy_module_pool_repo proxy_product_pool_repo proxy_product_update_repo" on this "#{host}" without error control)
-  end
 end
 
 When(/^I install a salt pillar top file for "([^"]*)" with target "([^"]*)" on the server$/) do |file, host|


### PR DESCRIPTION
## What does this PR change?

In build validation test suite, there was a conflict between sumaform, and the salt cleanup, that removes `/etc/salt/broker`.

Cleanest solution is to install the pattern ourselves **after** the cleanup (in all test suites).

We take the occasion to also clean up `/var/tmp/.rootXXX` directory used by sumaform to do some salt-ssh.

Plus some other code simplification.


## Links

Fixes SUSE/spacewalk#14421

Sumaform part uyuni-project/sumaform#870
susemanager-ci part SUSE/susemanager-ci#219

Ports:
* 4.0: SUSE/spacewalk#14431
* 4.1: SUSE/spacewalk#14429


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
