### PR TITLE
Notify beacon for Debian/Ubuntu systems

### DIFF
--- a/java/code/src/com/suse/manager/webui/services/pillar/MinionGeneralPillarGenerator.java
+++ b/java/code/src/com/suse/manager/webui/services/pillar/MinionGeneralPillarGenerator.java
@@ -43,12 +43,19 @@ public class MinionGeneralPillarGenerator implements MinionPillarGenerator {
 
     public static final MinionGeneralPillarGenerator INSTANCE = new MinionGeneralPillarGenerator();
 
-    private static final Map<String, Object> PKGSET_BEACON_PROPS = new HashMap<>();
-    private static final String PKGSET_COOKIE_PATH = "/var/cache/salt/minion/rpmdb.cookie";
     private static final int PKGSET_INTERVAL = 5;
+
+    private static final Map<String, Object> RPM_PKGSET_BEACON_PROPS = new HashMap<>();
+    private static final String RPM_PKGSET_COOKIE_PATH = "/var/cache/salt/minion/rpmdb.cookie";
     static {
-        PKGSET_BEACON_PROPS.put("cookie", PKGSET_COOKIE_PATH);
-        PKGSET_BEACON_PROPS.put("interval", PKGSET_INTERVAL);
+        RPM_PKGSET_BEACON_PROPS.put("cookie", RPM_PKGSET_COOKIE_PATH);
+        RPM_PKGSET_BEACON_PROPS.put("interval", PKGSET_INTERVAL);
+    }
+    private static final Map<String, Object> DPK_PKGSET_BEACON_PROPS = new HashMap<>();
+    private static final String DPK_PKGSET_COOKIE_PATH = "/var/cache/salt/minion/dpkg.cookie";
+    static {
+        DPK_PKGSET_BEACON_PROPS.put("cookie", DPK_PKGSET_COOKIE_PATH);
+        DPK_PKGSET_BEACON_PROPS.put("interval", PKGSET_INTERVAL);
     }
 
     /**
@@ -81,7 +88,10 @@ public class MinionGeneralPillarGenerator implements MinionPillarGenerator {
         // minion packages are modified locally
         if (minion.getOsFamily().toLowerCase().equals("suse") ||
                 minion.getOsFamily().toLowerCase().equals("redhat")) {
-            beaconConfig.put("pkgset", PKGSET_BEACON_PROPS);
+            beaconConfig.put("pkgset", RPM_PKGSET_BEACON_PROPS);
+        }
+        if (minion.getOsFamily().toLowerCase().equals("debian")) {
+            beaconConfig.put("pkgset", DPK_PKGSET_BEACON_PROPS);
         }
         if (!beaconConfig.isEmpty()) {
             pillar.add("beacons", beaconConfig);

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add support for notify beacon for Debian/Ubuntu systems
 - Check if the directory exists prior to modular data cleanup (bsc#1184311)
 - define dependencies for salt-netapi-client and DB schema version
 - assign right base product for res8 (bsc#1184005)

--- a/susemanager-utils/susemanager-sls/src/beacons/pkgset.py
+++ b/susemanager-utils/susemanager-sls/src/beacons/pkgset.py
@@ -17,9 +17,7 @@ __virtualname__ = 'pkgset'
 
 def __virtual__():
     return (
-        os.path.exists("/usr/lib/zypp/plugins/commit/susemanager") or  # Remove this once 2015.8.7 not in use
         os.path.exists("/usr/lib/zypp/plugins/commit/zyppnotify") or
-        os.path.exists("/usr/share/yum-plugins/susemanagerplugin.py") or  # Remove this once 2015.8.7 not in use
         os.path.exists("/usr/share/yum-plugins/yumnotify.py") or
         os.path.exists("/usr/bin/dpkgnotify")
     ) and __virtualname__ or False

--- a/susemanager-utils/susemanager-sls/src/beacons/pkgset.py
+++ b/susemanager-utils/susemanager-sls/src/beacons/pkgset.py
@@ -20,7 +20,8 @@ def __virtual__():
         os.path.exists("/usr/lib/zypp/plugins/commit/susemanager") or  # Remove this once 2015.8.7 not in use
         os.path.exists("/usr/lib/zypp/plugins/commit/zyppnotify") or
         os.path.exists("/usr/share/yum-plugins/susemanagerplugin.py") or  # Remove this once 2015.8.7 not in use
-        os.path.exists("/usr/share/yum-plugins/yumnotify.py")
+        os.path.exists("/usr/share/yum-plugins/yumnotify.py") or
+        os.path.exists("/usr/bin/dpkgnotify")
     ) and __virtualname__ or False
 
 

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Add support for notify beacon for Debian/Ubuntu systems
 - Automatically start needed networks and storage pools when creating/starting a VM
 - Avoid conflicts with running ioloop on mgr_events engine (bsc#1172711)
 - Require new kiwi-systemdeps packages (bsc#1184271)
@@ -7,7 +8,7 @@
 - Provide Custom Info as Pillar data
 - Add support for Amazon Linux 2
 - Add support for Alibaba Cloud Linux 2
-- add allow vendor change option to pathing via salt 
+- add allow vendor change option to pathing via salt
 - Prevent useless package list refresh actions on zypper minions (bsc#1183661)
 - Skip removed product classes with satellite-sync
 - add grain for virt module features


### PR DESCRIPTION
DO NOT MERGE UNTIL openSUSE/salt#347 IS MERGED

## What does this PR change?

This PR addapts Uyuni to support the aptnotify introduced on https://github.com/openSUSE/salt/pull/347
this 

And updated version of: https://github.com/uyuni-project/uyuni/pull/3442

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/11561

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
