### PR TITLE
Keep salt minion when installed

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
@@ -139,7 +139,7 @@ install_gnupg_debian:
 {% include 'channels/gpg-keys.sls' %}
 
 salt-minion-package:
-  pkg.latest:
+  pkg.installed:
     - name: salt-minion
     - install_recommends: False
     - require:

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,5 @@
+- keep salt-minion when it is installed to prevent update problems with
+  dependend packages not available in the bootstrap repo (bsc#1183573)
 - Add support for AlmaLinux 8
 - Provide Custom Info as Pillar data
 - Add support for Amazon Linux 2


### PR DESCRIPTION
## What does this PR change?

Keep salt-minion when it is installed to prevent update problems with dependend packages not available in the bootstrap repo.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/14426

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
