### PR TITLE
Fix name of TOKEN because GH does not allow it to start with GITHUB

### DIFF
--- a/.github/workflows/add_pr_reviewer_for_test_framework.yml
+++ b/.github/workflows/add_pr_reviewer_for_test_framework.yml
@@ -22,47 +22,47 @@ jobs:
       if: steps.review_step.outputs.review == 'true' && github.actor == 'srbarrios'
       uses: kunihiko-t/review-request-action@v0.1.3
       with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        repo-token: "${{ secrets.TOKEN }}"
         reviewers: "atighineanu,maximenoel8,lkotek,ktsamis,Bischoff,calancha"
     - name: "Send Review Request from lkotek to QA squad"
       if: steps.review_step.outputs.review == 'true' && github.actor == 'lkotek'
       uses: kunihiko-t/review-request-action@v0.1.3
       with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        repo-token: "${{ secrets.TOKEN }}"
         reviewers: "atighineanu,maximenoel8,srbarrios,ktsamis,Bischoff,calancha"
     - name: "Send Review Request from Bischoff to QA Squad"
       if: steps.review_step.outputs.review == 'true' && github.actor == 'Bischoff'
       uses: kunihiko-t/review-request-action@v0.1.3
       with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        repo-token: "${{ secrets.TOKEN }}"
         reviewers: "atighineanu,maximenoel8,lkotek,ktsamis,srbarrios,calancha"
     - name: "Send Review Request from ktsamis to QA Squad"
       if: steps.review_step.outputs.review == 'true' && github.actor == 'ktsamis'
       uses: kunihiko-t/review-request-action@v0.1.3
       with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        repo-token: "${{ secrets.TOKEN }}"
         reviewers: "atighineanu,maximenoel8,lkotek,srbarrios,Bischoff,calancha"
     - name: "Send Review Request from calancha to QA Squad"
       if: steps.review_step.outputs.review == 'true' && github.actor == 'calancha'
       uses: kunihiko-t/review-request-action@v0.1.3
       with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        repo-token: "${{ secrets.TOKEN }}"
         reviewers: "atighineanu,maximenoel8,lkotek,srbarrios,Bischoff,ktsamis"
     - name: "Send Review Request from atighineanu to QA Squad"
       if: steps.review_step.outputs.review == 'true' && github.actor == 'atighineanu'
       uses: kunihiko-t/review-request-action@v0.1.3
       with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        repo-token: "${{ secrets.TOKEN }}"
         reviewers: "maximenoel8,lkotek,srbarrios,ktsamis,Bischoff,calancha"
     - name: "Send Review Request from maximenoel8 to QA Squad"
       if: steps.review_step.outputs.review == 'true' && github.actor == 'maximenoel8'
       uses: kunihiko-t/review-request-action@v0.1.3
       with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        repo-token: "${{ secrets.TOKEN }}"
         reviewers: "atighineanu,lkotek,srbarrios,ktsamis,Bischoff,calancha"
     - name: "Send Review Request from non-qa members to QA Squad"
       if: steps.review_step.outputs.review == 'true' && github.actor != 'maximenoel8' && github.actor != 'atighineanu' && github.actor != 'ktsamis' && github.actor != 'Bischoff' && github.actor != 'lkotek' && github.actor != 'srbarrios' && github.actor != 'calancha'
       uses: kunihiko-t/review-request-action@v0.1.3
       with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        repo-token: "${{ secrets.TOKEN }}"
         reviewers: "atighineanu,maximenoel8,lkotek,srbarrios,Bischoff,ktsamis,calancha"


### PR DESCRIPTION
## What does this PR change?

Fix name of TOKEN because GH does not allow it to start with GITHUB
See https://docs.github.com/en/actions/reference/encrypted-secrets#about-encrypted-secrets

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
