### PR TITLE
QA: Fix selection of a snippet

### DIFF
--- a/testsuite/features/secondary/srv_distro_cobbler.feature
+++ b/testsuite/features/secondary/srv_distro_cobbler.feature
@@ -111,7 +111,8 @@ Feature: Cobbler and distribution autoinstallation
   Scenario: Check default snippets
     When I follow the left menu "Systems > Autoinstallation > Autoinstallation Snippets"
     And I follow "Default Snippets"
-    And I click on "Next Page"
+    And I enter "spacewalk/sles_no_signature_checks" as the filtered snippet name
+    And I click on the filter button
     And I follow "spacewalk/sles_no_signature_checks"
     Then I should see "<signature-handling>" in the textarea
 

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -825,6 +825,10 @@ When(/^I enter "([^"]*)" as the filtered XCCDF result type$/) do |input|
   find("input[placeholder='Filter by Result: ']").set(input)
 end
 
+When(/^I enter "([^"]*)" as the filtered snippet name$/) do |input|
+  find("input[placeholder='Filter by Snippet Name: ']").set(input)
+end
+
 When(/^I enter the package for "([^"]*)" as the filtered package name$/) do |host|
   step %(I enter "#{PACKAGE_BY_CLIENT[host]}" as the filtered package name)
 end


### PR DESCRIPTION

## What does this PR change?

It fixes an issue in our test suite when expecting to find a button, but the browser window has not the button element visible, as we increased the entries per page to 100. As the best way to find an entry is not about expecting it on the next page, but filtering it, this is what this proposal does.

<img width="918" src="https://user-images.githubusercontent.com/2827771/113046563-83fb2000-91a0-11eb-9404-8c1ef4de3611.png">

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.1
- Manager-4.0

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
