### PR TITLE
Testsuite: Add regex anchors in step definitions

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -195,7 +195,7 @@ Given(/^I am on the Systems page$/) do
   )
 end
 
-Given(/cobblerd is running/) do
+Given(/^cobblerd is running$/) do
   ct = CobblerTest.new
   raise 'cobblerd is not running' unless ct.running?
 end
@@ -225,7 +225,7 @@ When(/^I trigger cobbler system record$/) do
   end
 end
 
-Given(/distro "([^"]*)" exists/) do |distro|
+Given(/^distro "([^"]*)" exists$/) do |distro|
   ct = CobblerTest.new
   raise 'distro ' + distro + ' does not exist' unless ct.distro_exists(distro)
 end


### PR DESCRIPTION
## What does this PR change?
Add missing regex anchors in some step definitions.

- testsuite/features/step_definitions/common_steps.rb:
Wrap the step in ^...$

## Links
### Ports
- Manager-4.1: https://github.com/SUSE/spacewalk/pull/14432
- Manager-4.0: https://github.com/SUSE/spacewalk/pull/14433

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)
