### PR TITLE
Revert "Set up Java logging with level TRACE in testsuite"

### DIFF
--- a/testsuite/features/core/first_settings.feature
+++ b/testsuite/features/core/first_settings.feature
@@ -52,10 +52,6 @@ Feature: Very first settings
   Scenario: Wait for refresh of list of products to finish
     When I wait until mgr-sync refresh is finished
 
-  Scenario: Set up Java logging with level TRACE
-    When I increase Java log level to "trace" on server
-    And I restart the tomcat service
-
 @server_http_proxy
   Scenario: Setup HTTP proxy
     Given I am authorized for the "Admin" section

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -383,19 +383,6 @@ Then(/^the tomcat logs should not contain errors$/) do
   end
 end
 
-When(/^I increase Java log level to "([^"]*)" on server$/) do |log_level|
-  $server.run(
-    "cat >>/srv/tomcat/webapps/rhn/WEB-INF/classes/log4j.properties <<CONFIG
-log4j.logger.com.suse.manager.reactor=#{log_level.upcase}
-log4j.logger.com.suse.manager.webui.services.impl=#{log_level.upcase}
-CONFIG"
-  )
-end
-
-When(/^I restart the tomcat service$/) do
-  $server.run('systemctl restart tomcat.service')
-end
-
 When(/^I restart the spacewalk service$/) do
   $server.run('spacewalk-service restart')
 end


### PR DESCRIPTION
Reverts uyuni-project/uyuni#3484

We will do it differently, using sumaform.
As we will safe an extra restart of tomcat service.