### PR TITLE
Add aarch64 for CentOS7/8, Oracle7/8, Amazon Linux2 and Alibaba Linux 2

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -1205,12 +1205,20 @@ DATA = {
         'BASECHANNEL' : 'centos7-ppc64le', 'PKGLIST' : RES7,
         'DEST' : '/srv/www/htdocs/pub/repositories/centos/7/bootstrap/'
     },
+    'centos-7-aarch64-uyuni' : {
+        'BASECHANNEL' : 'centos7-aarch64', 'PKGLIST' : RES7,
+        'DEST' : '/srv/www/htdocs/pub/repositories/centos/7/bootstrap/'
+    },
     'centos-8-x86_64-uyuni' : {
         'BASECHANNEL' : 'centos8-x86_64', 'PKGLIST' : RES8 + RES8_X86,
         'DEST' : '/srv/www/htdocs/pub/repositories/centos/8/bootstrap/'
     },
     'centos-8-ppc64le-uyuni' : {
         'BASECHANNEL' : 'centos8-ppc64le', 'PKGLIST' : RES8,
+        'DEST' : '/srv/www/htdocs/pub/repositories/centos/8/bootstrap/'
+    },
+    'centos-8-aarch64-uyuni' : {
+        'BASECHANNEL' : 'centos8-aarch64', 'PKGLIST' : RES8,
         'DEST' : '/srv/www/htdocs/pub/repositories/centos/8/bootstrap/'
     },
     'oracle-6-x86_64' : {
@@ -1233,12 +1241,24 @@ DATA = {
         'BASECHANNEL' : 'oraclelinux7-x86_64', 'PKGLIST' : RES7 + RES7_X86,
         'DEST' : '/srv/www/htdocs/pub/repositories/oracle/7/bootstrap/'
     },
+    'oracle-7-aarch64-uyuni' : {
+        'BASECHANNEL' : 'oraclelinux7-aarch64', 'PKGLIST' : RES7 + RES7_X86,
+        'DEST' : '/srv/www/htdocs/pub/repositories/oracle/7/bootstrap/'
+    },
     'oracle-8-x86_64-uyuni' : {
         'BASECHANNEL' : 'oraclelinux8-x86_64', 'PKGLIST' : RES8 + RES8_X86,
         'DEST' : '/srv/www/htdocs/pub/repositories/oracle/8/bootstrap/'
     },
+    'oracle-8-aarch64-uyuni' : {
+        'BASECHANNEL' : 'oraclelinux8-aarch64', 'PKGLIST' : RES8,
+        'DEST' : '/srv/www/htdocs/pub/repositories/oracle/8/bootstrap/'
+    },
     'amazonlinux-2-x86_64-uyuni' : {
         'BASECHANNEL' : 'amazonlinux2-core-x86_64', 'PKGLIST' : RES7 + RES7_X86 + AMAZONLINUX2,
+        'DEST' : '/srv/www/htdocs/pub/repositories/amzn/2/bootstrap/'
+    },
+    'amazonlinux-2-aarch64-uyuni' : {
+        'BASECHANNEL' : 'amazonlinux2-core-aarch64', 'PKGLIST' : RES7 + AMAZONLINUX2,
         'DEST' : '/srv/www/htdocs/pub/repositories/amzn/2/bootstrap/'
     },
     'RHEL6-x86_64' : {
@@ -1263,6 +1283,10 @@ DATA = {
     },
     'alibaba-2-x86_64-uyuni': {
         'BASECHANNEL': 'alibaba-2-x86_64', 'PKGLIST': RES7 + RES7_X86,
+        'DEST': '/srv/www/htdocs/pub/repositories/alibaba/2/bootstrap/'
+    },
+    'alibaba-2-aarch64-uyuni': {
+        'BASECHANNEL': 'alibaba-2-aarch64', 'PKGLIST': RES7,
         'DEST': '/srv/www/htdocs/pub/repositories/alibaba/2/bootstrap/'
     },
     'almalinux-8-x86_64-uyuni' : {

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,5 @@
+- Enable aarch64 for CentOS7/8, Oracle 7/8, Amazon Linux 2
+  and Alibaba Linux 2
 - Fix condition in mgr-setup to prevent noise messages during setup
 - Add bootstrap repository definitions for AlmaLinux8
 - Add bootstrap repository for Amazon Linux 2

--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -151,7 +151,7 @@ base_channels = fedora30-%(arch)s
 repo_url = https://mirrors.fedoraproject.org/metalink?repo=updates-released-debug-f30&arch=%(arch)s
 
 [centos8]
-archs    = x86_64, ppc64le
+archs    = x86_64, ppc64le, aarch64
 name     = CentOS 8 (%(arch)s)
 gpgkey_url = http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-Official
 gpgkey_id = 8483C65D
@@ -161,49 +161,49 @@ dist_map_release = 8
 
 [centos8-appstream]
 label    = %(base_channel)s-appstream
-archs    = x86_64, ppc64le
+archs    = x86_64, ppc64le, aarch64
 name     = CentOS 8 AppStream (%(arch)s)
 base_channels = centos8-%(arch)s
 repo_url = http://mirrorlist.centos.org/?release=8&arch=%(arch)s&repo=AppStream&infra=stock
 
 [centos8-centosplus]
 label    = %(base_channel)s-centosplus
-archs    = x86_64, ppc64le
+archs    = x86_64, ppc64le, aarch64
 name     = CentOS 8 Plus (%(arch)s)
 base_channels = centos8-%(arch)s
 repo_url = http://mirrorlist.centos.org/?release=8&arch=%(arch)s&repo=centosplus&infra=stock
 
 [centos8-cr]
 label    = %(base_channel)s-cr
-archs    = x86_64, ppc64le
+archs    = x86_64, ppc64le, aarch64
 name     = CentOS 8 CR (%(arch)s)
 base_channels = centos8-%(arch)s
 repo_url = http://mirrorlist.centos.org/?release=8&arch=%(arch)s&repo=cr&infra=stock
 
 [centos8-extras]
 label    = %(base_channel)s-extras
-archs    = x86_64, ppc64le
+archs    = x86_64, ppc64le, aarch64
 name     = CentOS 8 Extras (%(arch)s)
 base_channels = centos8-%(arch)s
 repo_url = http://mirrorlist.centos.org/?release=8&arch=%(arch)s&repo=extras&infra=stock
 
 [centos8-fasttrack]
 label    = %(base_channel)s-fasttrack
-archs    = x86_64, ppc64le
+archs    = x86_64, ppc64le, aarch64
 name     = CentOS 8 FastTrack (%(arch)s)
 base_channels = centos8-%(arch)s
 repo_url = http://mirrorlist.centos.org/?release=8&arch=%(arch)s&repo=fasttrack&infra=stock
 
 [centos8-powertools]
 label    = %(base_channel)s-powertools
-archs    = x86_64, ppc64le
+archs    = x86_64, ppc64le, aarch64
 name     = CentOS 8 PowerTools (%(arch)s)
 base_channels = centos8-%(arch)s
 repo_url = http://mirrorlist.centos.org/?release=8&arch=%(arch)s&repo=PowerTools&infra=stock
 
 [centos8-uyuni-client]
 name     = Uyuni Client Tools for %(base_channel_name)s
-archs    = %(_x86_archs)s, ppc64le
+archs    = %(_x86_archs)s, ppc64le, aarch64
 base_channels = centos8-%(arch)s
 gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS8-Uyuni-Client-Tools/CentOS_8/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
@@ -212,7 +212,7 @@ repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/
 
 [centos8-uyuni-client-devel]
 name     = Uyuni Client Tools for %(base_channel_name)s (Development)
-archs    = %(_x86_archs)s, ppc64le
+archs    = %(_x86_archs)s, ppc64le, aarch64
 base_channels = centos8-%(arch)s
 gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/CentOS8-Uyuni-Client-Tools/CentOS_8/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
@@ -222,7 +222,7 @@ repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/
 [epel8]
 label    = epel8-%(base_channel)s
 name     = EPEL 8 for %(base_channel_name)s
-archs    = x86_64, ppc64le
+archs    = x86_64, ppc64le, aarch64
 base_channels = centos8-%(arch)s
 gpgkey_url = http://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8
 gpgkey_id = 2F86D6A1
@@ -299,7 +299,7 @@ gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/CentOS8-Uyuni-Client-Tools/CentOS_8/
 
 [centos7]
-archs    = x86_64, ppc64le
+archs    = x86_64, ppc64le, aarch64
 name     = CentOS 7 (%(arch)s)
 gpgkey_url = http://mirror.centos.org/centos/RPM-GPG-KEY-CentOS-7
 gpgkey_id = F4A80EB5
@@ -316,7 +316,7 @@ repo_url = http://mirror.centos.org/centos-7/7/atomic/%(arch)s
 
 [centos7-centosplus]
 label    = %(base_channel)s-centosplus
-archs    = x86_64, ppc64le
+archs    = x86_64, ppc64le, aarch64
 name     = CentOS 7 Plus (%(arch)s)
 base_channels = centos7-%(arch)s
 repo_url = http://mirrorlist.centos.org/?release=7&arch=%(arch)s&repo=centosplus
@@ -330,21 +330,21 @@ repo_url = http://mirror.centos.org/centos-7/7/cloud/%(arch)s
 
 [centos7-cr]
 label    = %(base_channel)s-cr
-archs    = x86_64, ppc64le
+archs    = x86_64, ppc64le, aarch64
 name     = CentOS 7 CR (%(arch)s)
 base_channels = centos7-%(arch)s
 repo_url = http://mirrorlist.centos.org/?release=7&arch=%(arch)s&repo=cr
 
 [centos7-extras]
 label    = %(base_channel)s-extras
-archs    = x86_64, ppc64le
+archs    = x86_64, ppc64le, aarch64
 name     = CentOS 7 Extras (%(arch)s)
 base_channels = centos7-%(arch)s
 repo_url = http://mirrorlist.centos.org/?release=7&arch=%(arch)s&repo=extras
 
 [centos7-fasttrack]
 label    = %(base_channel)s-fasttrack
-archs    = x86_64, ppc64le
+archs    = x86_64, ppc64le, aarch64
 name     = CentOS 7 FastTrack (%(arch)s)
 base_channels = centos7-%(arch)s
 repo_url = http://mirrorlist.centos.org/?release=7&arch=%(arch)s&repo=fasttrack
@@ -386,7 +386,7 @@ repo_url = http://mirror.centos.org/centos-7/7/storage/%(arch)s
 
 [centos7-updates]
 label    = %(base_channel)s-updates
-archs    = x86_64, ppc64le
+archs    = x86_64, ppc64le, aarch64
 name     = CentOS 7 Updates (%(arch)s)
 base_channels = centos7-%(arch)s
 repo_url = http://mirrorlist.centos.org/?release=7&arch=%(arch)s&repo=updates
@@ -400,7 +400,7 @@ repo_url = http://mirror.centos.org/centos-7/7/virt/%(arch)s
 
 [centos7-uyuni-client]
 name     = Uyuni Client Tools for %(base_channel_name)s
-archs    = %(_x86_archs)s, ppc64le
+archs    = %(_x86_archs)s, ppc64le, aarch64
 base_channels = centos7-%(arch)s
 gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS7-Uyuni-Client-Tools/CentOS_7/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
@@ -409,7 +409,7 @@ repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/
 
 [centos7-uyuni-client-devel]
 name     = Uyuni Client Tools for %(base_channel_name)s (Development)
-archs    = %(_x86_archs)s, ppc64le
+archs    = %(_x86_archs)s, ppc64le, aarch64
 base_channels = centos7-%(arch)s
 gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/CentOS7-Uyuni-Client-Tools/CentOS_7/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
@@ -419,7 +419,7 @@ repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/
 [epel7]
 label    = epel7-%(base_channel)s
 name     = EPEL 7 for %(base_channel_name)s
-archs    = x86_64, ppc64, ppc64le
+archs    = x86_64, ppc64, ppc64le, aarch64
 base_channels = centos7-%(arch)s scientific7-%(arch)s
 gpgkey_url = http://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
 gpgkey_id = 352C64E5
@@ -1140,7 +1140,7 @@ gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/SLE15-Uyuni-Client-Tools/SLE_15/
 
 [oraclelinux8]
-archs    = x86_64
+archs    = x86_64, aarch64
 name     = Oracle Linux 8 (%(arch)s)
 checksum = sha256
 gpgkey_url = https://yum.oracle.com/RPM-GPG-KEY-oracle-ol8
@@ -1150,7 +1150,7 @@ repo_url = https://yum.oracle.com/repo/OracleLinux/OL8/baseos/latest/%(arch)s/
 dist_map_release = 8
 
 [oraclelinux8-appstream]
-archs    = x86_64
+archs    = x86_64, aarch64
 name     = Oracle Linux 8 AppStream (%(arch)s)
 base_channels = oraclelinux8-%(arch)s
 checksum = sha256
@@ -1162,28 +1162,28 @@ dist_map_release = 8
 
 [oraclelinux8-addons]
 label    = %(base_channel)s-addons
-archs    = x86_64
+archs    = x86_64, aarch64
 name     = Addons for Oracle Linux 8 (%(arch)s)
 base_channels = oraclelinux8-%(arch)s
 repo_url = https://yum.oracle.com/repo/OracleLinux/OL8/addons/%(arch)s/
 
 [oraclelinux8-codereadybuilder]
 label    = %(base_channel)s-codereadybuilder
-archs    = x86_64
+archs    = x86_64, aarch64
 name     = Latest CodeReady Builder packages for Oracle Linux 8 (%(arch)s)
 base_channels = oraclelinux8-%(arch)s
 repo_url = https://yum.oracle.com/repo/OracleLinux/OL8/codeready/builder/%(arch)s/
 
 [oraclelinux8-developer-uek-r6]
 label    = %(base_channel)s-uek-r6
-archs    = x86_64
+archs    = x86_64, aarch64
 name     = Latest Unbreakable Enterprise Kernel Release 6 for Oracle Linux 8 (%(arch)s)
 base_channels = oraclelinux8-%(arch)s
 repo_url = https://yum.oracle.com/repo/OracleLinux/OL8/developer/UEKR6/%(arch)s/
 
 [oraclelinux8-developer]
 label    = %(base_channel)s-developer
-archs    = x86_64
+archs    = x86_64, aarch64
 name     = Packages for test and development - Oracle Linux 8 (%(arch)s)
 base_channels = oraclelinux8-%(arch)s
 repo_url = https://yum.oracle.com/repo/OracleLinux/OL8/developer/%(arch)s/
@@ -1197,7 +1197,7 @@ repo_url = https://yum.oracle.com/repo/OracleLinux/OL8/UEKR6/RDMA/%(arch)s/
 
 [oraclelinux8-uyuni-client]
 name     = Uyuni Client Tools for %(base_channel_name)s
-archs    = %(_x86_archs)s
+archs    = %(_x86_archs)s, aarch64
 base_channels = oraclelinux8-%(arch)s
 gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS8-Uyuni-Client-Tools/CentOS_8/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
@@ -1206,7 +1206,7 @@ repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/
 
 [oraclelinux8-uyuni-client-devel]
 name     = Uyuni Client Tools for %(base_channel_name)s (Development)
-archs    = %(_x86_archs)s
+archs    = %(_x86_archs)s, aarch64
 base_channels = oraclelinux8-%(arch)s
 gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/CentOS8-Uyuni-Client-Tools/CentOS_8/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
@@ -1214,7 +1214,7 @@ gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/CentOS8-Uyuni-Client-Tools/CentOS_8/
 
 [oraclelinux7]
-archs    = x86_64
+archs    = x86_64, aarch64
 name     = Oracle Linux 7 (%(arch)s)
 checksum = sha256
 gpgkey_url = https://yum.oracle.com/RPM-GPG-KEY-oracle-ol7
@@ -1225,7 +1225,7 @@ dist_map_release = 7
 
 [oraclelinux7-optional]
 label    = %(base_channel)s-optional
-archs    = x86_64
+archs    = x86_64, aarch64
 name     = Optional Packages for Oracle Linux 7 (%(arch)s)
 base_channels = oraclelinux7-%(arch)s
 repo_url = https://yum.oracle.com/repo/OracleLinux/OL7/optional/latest/%(arch)s/
@@ -1358,7 +1358,7 @@ repo_url = https://yum.oracle.com/repo/OracleLinux/OL7/openstack_extras/%(arch)s
 
 [oraclelinux7-scl]
 label     = %(base_channel)s-scl
-archs    = x86_64
+archs    = x86_64, aarch64
 name      = Software Collection Library packages for Oracle Linux 7 (%(arch)s)
 base_channels = oraclelinux7-%(arch)s
 repo_url = https://yum.oracle.com/repo/OracleLinux/OL7/SoftwareCollections/%(arch)s/
@@ -1372,7 +1372,7 @@ repo_url = https://yum.oracle.com/repo/OracleLinux/OL7/ceph/%(arch)s/
 
 [oraclelinux7-uyuni-client]
 name     = Uyuni Client Tools for %(base_channel_name)s
-archs    = %(_x86_archs)s
+archs    = %(_x86_archs)s, aarch64
 base_channels = oraclelinux7-%(arch)s
 gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS7-Uyuni-Client-Tools/CentOS_7/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
@@ -1381,7 +1381,7 @@ repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/
 
 [oraclelinux7-uyuni-client-devel]
 name     = Uyuni Client Tools for %(base_channel_name)s (Development)
-archs    = %(_x86_archs)s
+archs    = %(_x86_archs)s, aarch64
 base_channels = oraclelinux7-%(arch)s
 gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/CentOS7-Uyuni-Client-Tools/CentOS_7/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,4 @@
+- Add aarch64 for CentOS7/8 and Oracle7/8
 - Add AlmaLinux 8 repositories
 - Add Amazon Linux 2 repositories
 - Add Alibaba Cloud Linux 2 repositories


### PR DESCRIPTION
## What does this PR change?

Add aarch64 for CentOS7/8, Oracle7/8, Amazon Linux2 and Alibaba Linux 2

It will NOT be "supported" for Uyuni 2021.04. Requires testing first.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- Documentation issue was created: https://github.com/SUSE/spacewalk/issues/14440

- [x] **DONE**

## Test coverage
- No tests: https://github.com/SUSE/spacewalk/issues/14398

- [x] **DONE**

## Links

Tracks: https://github.com/SUSE/spacewalk/issues/14398

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
