### PR TITLE
Set up Java logging with level TRACE in testsuite

### DIFF
--- a/testsuite/features/core/first_settings.feature
+++ b/testsuite/features/core/first_settings.feature
@@ -52,6 +52,11 @@ Feature: Very first settings
   Scenario: Wait for refresh of list of products to finish
     When I wait until mgr-sync refresh is finished
 
+  Scenario: Set up Java logging with level TRACE
+    When I increase Java log level to "trace" on server
+    And I restart the tomcat service
+    And I wait until tomcat restart is finished
+
 @server_http_proxy
   Scenario: Setup HTTP proxy
     Given I am authorized for the "Admin" section

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -383,6 +383,27 @@ Then(/^the tomcat logs should not contain errors$/) do
   end
 end
 
+When(/^I increase Java log level to "([^"]*)" on server$/) do |log_level|
+  $server.run(
+    "cat >>/srv/tomcat/webapps/rhn/WEB-INF/classes/log4j.properties <<CONFIG
+log4j.logger.com.suse.manager.reactor=#{log_level.upcase}
+log4j.logger.com.suse.manager.webui.services.impl=#{log_level.upcase}
+CONFIG"
+  )
+end
+
+When(/^I restart the tomcat service$/) do
+  $server.run('systemctl restart tomcat.service')
+end
+
+When(/^I wait until tomcat restart is finished/) do
+  repeat_until_timeout(timeout: 300, message: "tomcat did not restart in 5 minutes.") do
+    _, code = $server.run("curl -k https://#{$server.full_hostname}")
+    break if code.zero?
+    sleep 20
+  end
+end
+
 When(/^I restart the spacewalk service$/) do
   $server.run('spacewalk-service restart')
 end


### PR DESCRIPTION
Round No. 2 :) I've tried to test it locally, but I don't know if the waiting works correctly. The step is finishing pretty quickly in my local testsuite setup.

## What does this PR change?
Set up Java logging with level TRACE in testsuite, uses curl to wait for tomcat to restart completely

**Will be reverted after https://github.com/SUSE/spacewalk/issues/14057 is done**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
