### PR TITLE
assign right res base product for version >=8 (bsc#1184005)

### DIFF
--- a/java/code/src/com/suse/manager/reactor/utils/RhelUtils.java
+++ b/java/code/src/com/suse/manager/reactor/utils/RhelUtils.java
@@ -14,6 +14,7 @@
  */
 package com.suse.manager.reactor.utils;
 
+import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.image.ImageInfo;
 import com.redhat.rhn.domain.product.SUSEProduct;
 import com.redhat.rhn.domain.product.SUSEProductFactory;
@@ -21,6 +22,7 @@ import com.redhat.rhn.domain.server.Server;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.Optional;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -198,7 +200,8 @@ public class RhelUtils {
      * 5) is it a centos system? check if /etc/centos-release file exists
      * 6) finally we can say it is a original RHEL (maybe:-)
      *
-     * @param server the minion
+     * @param channels channels assigned to the target
+     * @param arch the architecture string of the target
      * @param resReleasePackage the package that provides 'sles_es-release'
      * @param rhelReleaseFile the content of /etc/redhat-release
      * @param centosReleaseFile the content of /etc/centos-release
@@ -207,13 +210,12 @@ public class RhelUtils {
      * @return the {@link RhelProduct}
      */
     public static Optional<RhelProduct> detectRhelProduct(
-            Server server, Optional<String> resReleasePackage,
+            Set<Channel> channels, String arch, Optional<String> resReleasePackage,
             Optional<String> rhelReleaseFile, Optional<String> centosReleaseFile,
             Optional<String> oracleReleaseFile, Optional<String> alibabaReleaseFile) {
-        String arch = server.getServerArch().getLabel().replace("-redhat-linux", "");
 
         // check first if it has RES channels assigned or the RES release package installed
-        boolean hasRESChannels = server.getChannels().stream()
+        boolean hasRESChannels = channels.stream()
                 .filter(ch -> ch.getProductName() != null &&
                         "RES".equalsIgnoreCase(ch.getProductName().getName()))
                 .count() > 0;
@@ -230,7 +232,17 @@ public class RhelUtils {
             String release = releaseFile.map(ReleaseFile::getRelease).orElse("unknown");
 
             Optional<SUSEProduct> suseProduct = Optional.ofNullable(SUSEProductFactory
-                    .findSUSEProduct("RES", majorVersion, release, arch, true));
+                    .findSUSEProduct("RES", majorVersion, release, arch, true))
+                    .flatMap(resProduct -> {
+                        if (resProduct.isBase()) {
+                            return Optional.of(resProduct);
+                        }
+                        else {
+                            return Optional.ofNullable(SUSEProductFactory
+                                    .findSUSEProduct("rhel-base", majorVersion, release, arch, true));
+                        }
+                    })
+                    .filter(SUSEProduct::isBase);
 
             return Optional.of(new RhelProduct(suseProduct, name,
                     majorVersion, release, arch));
@@ -266,6 +278,40 @@ public class RhelUtils {
      *    assigned to a system it is a RES system
      * 2) if a RES release package (sles_es-release) is installed it is a RES.
      * 3) otherwise it is not a RES system
+     * 4) if /etc/oracle-release exists, it is OracleLinux
+     * 5) is it a centos system? check if /etc/centos-release file exists
+     * 6) finally we can say it is a original RHEL (maybe:-)
+     *
+     * @param server the minion
+     * @param resReleasePackage the package that provides 'sles_es-release'
+     * @param rhelReleaseFile the content of /etc/redhat-release
+     * @param centosReleaseFile the content of /etc/centos-release
+     * @param oracleReleaseFile the content of /etc/oracle-release
+     * @param alibabaReleaseFile the content of /etc/alinux-release
+     * @return the {@link RhelProduct}
+     */
+    public static Optional<RhelProduct> detectRhelProduct(
+            Server server, Optional<String> resReleasePackage,
+            Optional<String> rhelReleaseFile, Optional<String> centosReleaseFile,
+            Optional<String> oracleReleaseFile, Optional<String> alibabaReleaseFile) {
+        return detectRhelProduct(
+                server.getChannels(),
+                server.getServerArch().getLabel().replace("-redhat-linux", ""),
+                resReleasePackage,
+                rhelReleaseFile,
+                centosReleaseFile,
+                oracleReleaseFile,
+                alibabaReleaseFile
+        );
+    }
+
+    /**
+     * Guess the SUSE product for the RedHat minion and parse the
+     * /etc/redhat,centos-release file.
+     * 1) if the RES channel or a clone of the RES channel is
+     *    assigned to a system it is a RES system
+     * 2) if a RES release package (sles_es-release) is installed it is a RES.
+     * 3) otherwise it is not a RES system
      * 4) if /etc/oracle-release exists it is a OracleLinux
      * 5) if /etc/alinlux-release exists it is an Alibaba Cloud Linux
      * 6) is it a centos system? check if /etc/centos-release file exists
@@ -283,52 +329,15 @@ public class RhelUtils {
             ImageInfo image, Optional<String> resReleasePackage,
             Optional<String> rhelReleaseFile, Optional<String> centosReleaseFile,
             Optional<String> oracleReleaseFile, Optional<String> alibabaReleaseFile) {
-        String arch = image.getImageArch().getLabel().replace("-redhat-linux", "");
-
-        // check first if it has RES channels assigned or the RES release package installed
-        boolean hasRESChannels = image.getChannels().stream()
-                .filter(ch -> ch.getProductName() != null &&
-                        "RES".equalsIgnoreCase(ch.getProductName().getName()))
-                .count() > 0;
-        boolean hasRESReleasePackage = resReleasePackage
-                .filter(pkg -> StringUtils.startsWith(pkg, "sles_es-release")).isPresent();
-        if (hasRESChannels || hasRESReleasePackage) {
-            // we got a RES. find the corresponding SUSE product
-            Optional<ReleaseFile> releaseFile = rhelReleaseFile.or(() -> centosReleaseFile)
-                    .flatMap(RhelUtils::parseReleaseFile);
-            // Find the corresponding SUSEProduct in the database
-            String name = releaseFile.map(ReleaseFile::getName).orElse("RES");
-            String majorVersion = releaseFile.map(ReleaseFile::getMajorVersion)
-                    .orElse("unknown");
-            String release = releaseFile.map(ReleaseFile::getRelease).orElse("unknown");
-
-            Optional<SUSEProduct> suseProduct = Optional.ofNullable(SUSEProductFactory
-                    .findSUSEProduct("RES", majorVersion, release, arch, true));
-            return Optional.of(new RhelProduct(suseProduct, name,
-                    majorVersion, release, arch));
-        }
-
-        // next check if OracleLinux
-        if (oracleReleaseFile.filter(StringUtils::isNotBlank).isPresent()) {
-            return oracleReleaseFile.map(v -> detectPlainRHEL(v, arch, "OracleLinux"));
-        }
-
-        // next check if Alibaba Cloud Linux
-        if (alibabaReleaseFile.filter(StringUtils::isNotBlank).isPresent()) {
-            return alibabaReleaseFile.map(v -> detectPlainRHEL(v, arch, "Alibaba"));
-        }
-
-        // next check if Centos
-        if (centosReleaseFile.filter(StringUtils::isNotBlank).isPresent()) {
-            return centosReleaseFile.map(v -> detectPlainRHEL(v, arch, "CentOS"));
-        }
-
-        // if neither RES nor Centos then we probably got a plain RHEL
-        if (rhelReleaseFile.filter(StringUtils::isNotBlank).isPresent()) {
-            return rhelReleaseFile.map(v -> detectPlainRHEL(v, arch, "RedHatEnterprise"));
-        }
-
-        return Optional.empty();
+        return detectRhelProduct(
+                image.getChannels(),
+                image.getImageArch().getLabel().replace("-redhat-linux", ""),
+                resReleasePackage,
+                rhelReleaseFile,
+                centosReleaseFile,
+                oracleReleaseFile,
+                alibabaReleaseFile
+        );
     }
 
     private static RhelProduct detectPlainRHEL(String releaseFileContent,

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- assign right base product for res8 (bsc#1184005)
 - Fix docs link in my organization configuration (bsc#1184286)
 - Provide Custom Info as Pillar data
 - remove deprecated xmlrpc functions


### PR DESCRIPTION
## What does this PR change?

In case a system is detected to be a res system we currently only lookup res products as our base product which only works for versions < 8 where 8 is now a extension with rhel-base being the base product. The code change does a fallback search für rhel-base in case res returns an extension product.

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

Fixes #https://github.com/SUSE/spacewalk/issues/14416

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
