### PR TITLE
Fix docs link in my organization configuration (bsc#1184286)

### DIFF
--- a/java/code/webapp/WEB-INF/pages/multiorg/configuration.jsp
+++ b/java/code/webapp/WEB-INF/pages/multiorg/configuration.jsp
@@ -14,7 +14,7 @@
         miscImg="${img}"
         miscAlt="${text}"
         imgAlt="users.jsp.imgAlt"
-        helpUrl="/docs/${rhn:getDocsLocale(pageContext)}/reference/home/your-organization-configuration.html">
+        helpUrl="/docs/${rhn:getDocsLocale(pageContext)}/reference/home/my-organization-configuration.html">
       <c:out escapeXml="true" value="${org.name}" />
     </rhn:toolbar>
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix docs link in my organization configuration (bsc#1184286)
 - Provide Custom Info as Pillar data
 - remove deprecated xmlrpc functions
 - Add support for Alibaba Cloud Linux 2


### PR DESCRIPTION
## What does this PR change?

Fix broken docs link in `My Organization` -> `Configuraration`

**add description**

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: **Fix**

- [x] **DONE**

## Test coverage
- No tests: **Fix**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/14466

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
