### PR TITLE
Fix condition in mgr-setup to prevent noise messages during setup

### DIFF
--- a/susemanager/bin/mgr-setup
+++ b/susemanager/bin/mgr-setup
@@ -7,7 +7,7 @@ DEFAULT_RHN_CONF="/usr/share/rhn/config-defaults/rhn.conf"
 if [ -f "$DEFAULT_RHN_CONF" ]; then
     while read -r name value
     do
-        if [ $name == "product_name" ]; then
+        if [ "$name" == "product_name" ]; then
             PRODUCT_NAME=$value
         fi
     done < $DEFAULT_RHN_CONF

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- Fix condition in mgr-setup to prevent noise messages during setup
 - Add bootstrap repository definitions for AlmaLinux8
 - Add bootstrap repository for Amazon Linux 2
 - Add bootstrap repository for Alibaba Cloud Linux 2


### PR DESCRIPTION
## What does this PR change?

There are a list of messages:
```
/usr/lib/susemanager/bin/mgr-setup: line 10: [: ==: unary operator expected
/usr/lib/susemanager/bin/mgr-setup: line 10: [: ==: unary operator expected
...
```
During Uyuni setup in YaST

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Changelogs

- Fix condition in mgr-setup to prevent noise messages during setup

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "susemanager_unittests"
