### PR TITLE
Add openSUSE Leap 15.3

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -1181,6 +1181,18 @@ DATA = {
         'BASECHANNEL' : 'opensuse_leap15_2-aarch64', 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15SP0SP1_SALT + PKGLIST15_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/opensuse/15/2/bootstrap/'
     },
+    'openSUSE-Leap-15.3-x86_64' : {
+        'PDID' : [2236], 'PKGLIST' : PKGLIST15_SALT + PKGLIST15_X86_ARM,
+        'DEST' : '/srv/www/htdocs/pub/repositories/opensuse/15/3/bootstrap/'
+    },
+    'openSUSE-Leap-15.3-x86_64-uyuni' : {
+        'BASECHANNEL' : 'opensuse_leap15_3-x86_64', 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15SP0SP1_SALT + PKGLIST15_X86_ARM,
+        'DEST' : '/srv/www/htdocs/pub/repositories/opensuse/15/3/bootstrap/'
+    },
+    'openSUSE-Leap-15.3-aarch64-uyuni' : {
+        'BASECHANNEL' : 'opensuse_leap15_3-aarch64', 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15SP0SP1_SALT + PKGLIST15_X86_ARM,
+        'DEST' : '/srv/www/htdocs/pub/repositories/opensuse/15/3/bootstrap/'
+    },
     'centos-6-x86_64' : {
         'PDID' : [-11, 1682], 'BETAPDID' : [2064], 'PKGLIST' : RES6,
         'DEST' : '/srv/www/htdocs/pub/repositories/centos/6/bootstrap/'

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- Enable bootstrap repository creation for openSUSE Leap 15.3 for Uyuni
 - Enable aarch64 for CentOS7/8, Oracle 7/8, Amazon Linux 2
   and Alibaba Linux 2
 - Fix condition in mgr-setup to prevent noise messages during setup

--- a/utils/spacewalk-common-channels
+++ b/utils/spacewalk-common-channels
@@ -471,7 +471,7 @@ Create everything as well as unlimited activation key for every channel:
         if options.verbose:
             # an empty line after channel group
             sys.stdout.write("\n")
-
+        existing_repo_urls = get_existing_repos(client)
     if client is not None:
         # logout
         xmlrpc_logout(client, key)

--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -1039,6 +1039,62 @@ gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
 
+[opensuse_leap15_3]
+checksum = sha256
+archs    = x86_64, aarch64
+name     = openSUSE Leap 15.3 (%(arch)s)
+gpgkey_url = http://download.opensuse.org/distribution/leap/15.3/repo/oss/repodata/repomd.xml.key
+gpgkey_id = 3DBDC284
+gpgkey_fingerprint = 22C0 7BA5 3417 8CD0 2EFE  22AA B88B 2FD4 3DBD C284
+repo_url = http://download.opensuse.org/distribution/leap/15.3/repo/oss/
+dist_map_release = 15.3
+
+[opensuse_leap15_3-non-oss]
+label    = %(base_channel)s-non-oss
+name     = openSUSE 15.3 non oss (%(arch)s)
+archs    = x86_64, aarch64
+checksum = sha256
+base_channels = opensuse_leap15_3-%(arch)s
+repo_url = http://download.opensuse.org/distribution/leap/15.3/repo/non-oss/
+
+[opensuse_leap15_3-updates]
+label    = %(base_channel)s-updates
+name     = openSUSE Leap 15.3 Updates (%(arch)s)
+archs    = x86_64, aarch64
+checksum = sha256
+base_channels = opensuse_leap15_3-%(arch)s
+repo_url = http://download.opensuse.org/update/leap/15.3/oss/
+
+[opensuse_leap15_3-non-oss-updates]
+label    = %(base_channel)s-non-oss-updates
+name     = openSUSE Leap 15.3 non oss Updates (%(arch)s)
+archs    = x86_64, aarch64
+checksum = sha256
+base_channels = opensuse_leap15_3-%(arch)s
+repo_url = http://download.opensuse.org/update/leap/15.3/non-oss/
+
+# This is expected. openSUSE Leap 15.0 client tools are valid for all openSUSE Leap 15.X releases
+[opensuse_leap15_3-uyuni-client]
+name     = Uyuni Client Tools for %(base_channel_name)s
+archs    = x86_64, aarch64
+base_channels = opensuse_leap15_3-%(arch)s
+checksum = sha256
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/repodata/repomd.xml.key
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
+
+# This is expected. openSUSE Leap 15.0 client tools are valid for all openSUSE Leap 15.X releases
+[opensuse_leap15_3-uyuni-client-devel]
+name     = Uyuni Client Tools for %(base_channel_name)s (Development)
+archs    = x86_64, aarch64
+base_channels = opensuse_leap15_3-%(arch)s
+checksum = sha256
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/repodata/repomd.xml.key
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
+
 [sles12-sp3-uyuni-client]
 name     = Uyuni Client Tools for SLES12 SP3 %(arch)s
 archs    =  x86_64, s390x, aarch64, ppc64le
@@ -1534,6 +1590,16 @@ gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Server-POOL-x86_64-Media1/
 
+[uyuni-server-stable-leap-153]
+name     = Uyuni Server Stable for %(base_channel_name)s
+archs    = x86_64, aarch64
+base_channels = opensuse_leap15_3-%(arch)s
+checksum = sha256
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Server-POOL-x86_64-Media1/repodata/repomd.xml.key
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Server-POOL-x86_64-Media1/
+
 [uyuni-server-devel-leap]
 name     = Uyuni Server Devel for %(base_channel_name)s (Development)
 archs    = x86_64
@@ -1558,6 +1624,16 @@ repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/
 name     = Uyuni Proxy Stable for %(base_channel_name)s
 archs    = x86_64
 base_channels = opensuse_leap15_2-%(arch)s
+checksum = sha256
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Proxy-POOL-x86_64-Media1/repodata/repomd.xml.key
+gpgkey_id = %(_uyuni_gpgkey_id)s
+gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Proxy-POOL-x86_64-Media1/
+
+[uyuni-proxy-stable-leap-153]
+name     = Uyuni Proxy Stable for %(base_channel_name)s
+archs    = x86_64, aarch64
+base_channels = opensuse_leap15_3-%(arch)s
 checksum = sha256
 gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Proxy-POOL-x86_64-Media1/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,4 @@
+- Add openSUSE Leap 15.3
 - Add aarch64 for CentOS7/8 and Oracle7/8
 - Add AlmaLinux 8 repositories
 - Add Amazon Linux 2 repositories


### PR DESCRIPTION
## What does this PR change?

bootstrap data and common-channels for leap 15.3
a fix for being able to adding 2 channels, at the same time, with same repo url 

## GUI diff

No difference.

- [X] **DONE**

## Documentation
https://github.com/SUSE/spacewalk/issues/14440

- [X] **DONE**

## Test coverage

* add leap 15.3 for x86 and aarch64 with `spacewalk-common-channels` (both archs at the same time)
* trigger sincronization with `spacewalk-repo-sync -p <parent> via CLI)`
* check that we can generate bootstrap repos with `mgr-create-bootstrap-repo`

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/14339

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
