### PR TITLE
Bugfix: Check if the directory exists prior to modular data cleanup

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/task/ModularDataCleanup.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/ModularDataCleanup.java
@@ -49,8 +49,15 @@ public class ModularDataCleanup extends RhnJavaJob {
         Set<Path> usedModularDataAbsolutePaths = usedModularDataPaths.stream()
                 .map(relPath -> Path.of(MOUNT_POINT_PATH, relPath))
                 .collect(Collectors.toSet());
+
+        File modulesPath = Path.of(MOUNT_POINT_PATH, MODULES_REL_PATH).toFile();
+        if (!modulesPath.exists()) {
+            log.info(String.format("Modules directory " + modulesPath + " does not exist. Skipping cleanup"));
+            return;
+        }
+
         Collection<File> modularDataFiles = FileUtils.listFiles(
-                Path.of(MOUNT_POINT_PATH, MODULES_REL_PATH).toFile(),
+                modulesPath,
                 new SuffixFileFilter("modules.yaml"),
                 TrueFileFilter.TRUE);
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Check if the directory exists prior to modular data cleanup (bsc#1184311)
 - define dependencies for salt-netapi-client and DB schema version
 - assign right base product for res8 (bsc#1184005)
 - Fix docs link in my organization configuration (bsc#1184286)


### PR DESCRIPTION
## What does this PR change?

Previously, the code for modular data cleanup (`modules.yaml` files) didn't check if the directory exists.
This adds a simple check with a descriptive log message in case the directory is missing (can happen, if the user never synced modular channels).

## GUI diff

No difference.

- [x] **DONE**

## Documentation
bugfix

- [ ] **DONE**

## Test coverage
- No tests: no tests in this area


- [x] **DONE**

## Links


Tracks https://github.com/SUSE/spacewalk/issues/14463

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
