### PR TITLE
Add a retail tag, the feature is a dependency for buildhost_osimage_build_image.feature

### DIFF
--- a/testsuite/features/secondary/buildhost_osimage_build_image.feature
+++ b/testsuite/features/secondary/buildhost_osimage_build_image.feature
@@ -11,6 +11,7 @@
 
 @buildhost
 @long_test
+@scope_retail
 @scope_building_container_images
 Feature: Build OS images
 


### PR DESCRIPTION
## What does this PR change?

Add a retail tag as the feature `proxy_retail_pxeboot_and_mass_import` is a dependency for `buildhost_osimage_build_image`

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.1
- Manager-4.0

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
