### PR TITLE
Automatically start networks and pools when starting / creating a VM

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/virt/create-vm.sls
+++ b/susemanager-utils/susemanager-sls/salt/virt/create-vm.sls
@@ -12,6 +12,26 @@ initrd_cached:
     - makedirs: True
 {%- endif %}
 
+{%- if 'interfaces' in pillar %}
+nets-{{ pillar['name'] }}:
+  virt_utils.network_running:
+    - networks:
+    {%- for nic in pillar['interfaces'] %}
+      - {{ nic['source'] }}
+    {%- endfor %}
+{%- endif %}
+
+{%- if 'disks' in pillar %}
+pools-{{ pillar['name'] }}:
+  virt_utils.pool_running:
+    - pools:
+  {%- for disk in pillar['disks'] %}
+    {%- if 'pool' in disk %}
+      - {{ disk['pool'] }}
+    {%- endif %}
+  {%- endfor %}
+{%- endif %}
+
 {% macro domain_params() -%}
     - name: {{ pillar['name'] }}
     - cpu: {{ pillar['vcpus'] }}
@@ -75,6 +95,12 @@ domain_first_boot_define:
     - require:
       - file: kernel_cached
       - file: initrd_cached
+  {%- if 'interfaces' in pillar %}
+      - virt_utils: nets-{{ pillar['name'] }}
+  {%- endif %}
+  {%- if 'disks' in pillar %}
+      - virt_utils: pools-{{ pillar['name'] }}
+  {%- endif %}
 {%- endif %}
 
 {%- if cdrom_boot or ks_boot %}

--- a/susemanager-utils/susemanager-sls/salt/virt/statechange.sls
+++ b/susemanager-utils/susemanager-sls/salt/virt/statechange.sls
@@ -1,2 +1,10 @@
 {{ pillar['domain_name'] }}:
-    virt.{{ pillar['domain_state'] }}
+{%- if pillar['domain_state'] == 'running' %}
+  virt_utils.vm_resources_running:
+    - name: {{ pillar['domain_name'] }}
+  virt.running:
+    - require:
+      - virt_utils: {{ pillar['domain_name'] }}
+{%- else %}
+  virt.{{ pillar['domain_state'] }}
+{%- endif %}

--- a/susemanager-utils/susemanager-sls/src/states/virt_utils.py
+++ b/susemanager-utils/susemanager-sls/src/states/virt_utils.py
@@ -1,0 +1,156 @@
+"""
+virt utility functions
+"""
+
+import libvirt
+import re
+
+__virtualname__ = "virt_utils"
+
+
+def __virtual__():
+    """
+    Only if the virt module is loaded
+    """
+    return (
+        __virtualname__
+        if "virt.vm_info" in __salt__
+        else (False, "Module virt_utils: virt module can't be loaded")
+    )
+
+
+def _all_running(name, kind, names, is_running):
+    ret = {
+        "name": name,
+        "changes": {},
+        "result": True if not __opts__["test"] else None,
+        "comment": "",
+    }
+
+    stopped = []
+    missing = []
+    try:
+        info = __salt__["virt.{}_info".format(kind)]()
+        for obj_name in names:
+            obj_info = info.get(obj_name)
+            if not obj_info:
+                missing.append(obj_name)
+                continue
+
+            if not is_running(obj_info):
+                stopped.append(obj_name)
+
+        if missing:
+            ret["result"] = False
+            ret["comment"] = "{} {}{} not defined".format(
+                ", ".join(missing), kind, "s are" if len(missing) > 1 else " is"
+            )
+            return ret
+
+        if not stopped:
+            ret["comment"] = "all {}s are already running".format(kind)
+            return ret
+
+        for obj_name in stopped:
+            if not __opts__["test"]:
+                __salt__["virt.{}_start".format(kind)](obj_name)
+            change = "started"
+            ret["changes"][obj_name] = change
+
+        ret["comment"] = "{} {}{} been started".format(
+            ", ".join(stopped), kind, "s have" if len(stopped) > 1 else " has"
+        )
+
+    except libvirt.libvirtError as err:
+        ret["result"] = False
+        ret["comment"] = err.get_error_message()
+
+    return ret
+
+
+def network_running(name, networks=None):
+    """
+    Ensure one or more already defined virtual networks are running.
+
+    :param name: the name of one network to get running
+    :param networks: the list of network names to get running
+    """
+    return _all_running(
+        name, "network", networks or [name], lambda info: info.get("active", False)
+    )
+
+
+def pool_running(name, pools=None):
+    """
+    Ensure one or more already defined virtual storage pool are running.
+
+    :param name: the name of one pool to get running
+    :param pools: the list of pool names to get running
+    """
+    names = pools or [name]
+    ret = _all_running(name, "pool", names, lambda info: info["state"] == "running")
+    if ret["result"] is False:
+        return ret
+
+    # Refresh all pools
+    for pool_name in names:
+        try:
+            # No need to refresh a pool that has just been started
+            if pool_name in ret["changes"]:
+                continue
+            if not __opts__["test"]:
+                __salt__["virt.pool_refresh"](pool_name)
+            ret["changes"][pool_name] = "refreshed"
+
+        except libvirt.libvirtError as err:
+            ret["result"] = False
+            ret["comment"] = err.get_error_message()
+
+    return ret
+
+
+def vm_resources_running(name):
+    """
+    :param name: name of the VM for which to ensure networks and storage pools are running
+    """
+    ret = {
+        "name": name,
+        "changes": {},
+        "result": True if not __opts__["test"] else None,
+        "comment": "",
+    }
+    try:
+        infos = __salt__["virt.vm_info"](name)
+        if not infos.get(name):
+            ret["result"] = False
+            ret["comment"] = "Virtual machine {} does not exist".format(name)
+            return ret
+
+        vm_infos = infos.get(name)
+
+        # Ensure all the networks are started
+        networks = [
+            nic["source"]["network"]
+            for nic in vm_infos.get("nics", {}).values()
+            if nic["type"] == "network"
+        ]
+        net_ret = network_running(name="{}_nets".format(name), networks=networks)
+
+        # Ensure all the pools are started
+        pools = [
+            disk["file"].split("/")[0]
+            for disk in vm_infos.get("disks", {}).values()
+            if re.match("^[^/:]+/", disk["file"])
+        ]
+        pool_ret = pool_running(name="{}_pools".format(name), pools=pools)
+
+        failed = any([net_ret["result"] is False, pool_ret["result"] is False])
+        ret["result"] = False if failed else net_ret["result"]
+        ret["comment"] = "{}, {}".format(net_ret["comment"], pool_ret["comment"])
+        ret["changes"] = {"networks": net_ret["changes"], "pools": pool_ret["changes"]}
+
+    except libvirt.libvirtError as err:
+        ret["result"] = False
+        ret["comment"] = err.get_error_message()
+
+    return ret

--- a/susemanager-utils/susemanager-sls/src/tests/test_state_virt_utils.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_state_virt_utils.py
@@ -1,0 +1,237 @@
+from mock import MagicMock, patch, call
+from . import mockery
+
+mockery.setup_environment()
+import pytest
+
+from ..states import virt_utils
+
+# Mock globals
+virt_utils.log = MagicMock()
+virt_utils.__salt__ = {}
+virt_utils.__grains__ = {}
+virt_utils.__opts__ = {}
+
+TEST_NETS = {
+    "net0": {"active": True},
+    "net1": {"active": True},
+    "net2": {"active": False},
+    "net3": {"active": False},
+}
+
+TEST_POOLS = {
+    "pool0": {"state": "running"},
+    "pool1": {"state": "running"},
+    "pool2": {"state": "stopped"},
+    "pool3": {"state": "stopped"},
+}
+
+
+@pytest.mark.parametrize("test", [False, True])
+def test_network_running(test):
+    """
+    test the network_running function with only one name
+    """
+    with patch.dict(virt_utils.__opts__, {"test": test}):
+        start_mock = MagicMock(return_value=True)
+        with patch.dict(
+            virt_utils.__salt__,
+            {
+                "virt.network_info": MagicMock(return_value=TEST_NETS),
+                "virt.network_start": start_mock,
+            },
+        ):
+            ret = virt_utils.network_running(name="net2")
+            if test:
+                assert ret["result"] is None
+                start_mock.assert_not_called()
+            else:
+                assert ret["result"]
+                start_mock.assert_called_with("net2")
+            assert ret["comment"] == "net2 network has been started"
+
+
+@pytest.mark.parametrize("test", [False, True])
+def test_network_multiple(test):
+    """
+    test the network_running function with several names
+    """
+    with patch.dict(virt_utils.__opts__, {"test": test}):
+        start_mock = MagicMock(return_value=True)
+        with patch.dict(
+            virt_utils.__salt__,
+            {
+                "virt.network_info": MagicMock(return_value=TEST_NETS),
+                "virt.network_start": start_mock,
+            },
+        ):
+            ret = virt_utils.network_running(
+                name="the-state-id", networks=["net0", "net1", "net2", "net3"]
+            )
+            if test:
+                assert ret["result"] is None
+                start_mock.assert_not_called()
+            else:
+                assert ret["result"]
+                assert start_mock.mock_calls == [
+                    call("net2"),
+                    call("net3"),
+                ]
+            assert ret["comment"] == "net2, net3 networks have been started"
+            assert ret["changes"] == {"net2": "started", "net3": "started"}
+
+
+def test_network_missing():
+    """
+    test the network_running function with names of missing networks
+    """
+    with patch.dict(virt_utils.__opts__, {"test": True}):
+        start_mock = MagicMock(return_value=True)
+        with patch.dict(
+            virt_utils.__salt__,
+            {
+                "virt.network_info": MagicMock(return_value=TEST_NETS),
+                "virt.network_start": start_mock,
+            },
+        ):
+            ret = virt_utils.network_running(
+                name="the-state-id", networks=["net0", "net1", "net2", "net5"]
+            )
+            assert not ret["result"]
+            start_mock.assert_not_called()
+            assert ret["comment"] == "net5 network is not defined"
+            assert ret["changes"] == {}
+
+
+@pytest.mark.parametrize("test", [False, True])
+def test_pool_running(test):
+    """
+    test the pool_running function with only one name
+    """
+    with patch.dict(virt_utils.__opts__, {"test": test}):
+        start_mock = MagicMock(return_value=True)
+        refresh_mock = MagicMock(return_value=True)
+        with patch.dict(
+            virt_utils.__salt__,
+            {
+                "virt.pool_info": MagicMock(return_value=TEST_POOLS),
+                "virt.pool_start": start_mock,
+                "virt.pool_refresh": refresh_mock,
+            },
+        ):
+            ret = virt_utils.pool_running(name="pool2")
+            if test:
+                assert ret["result"] is None
+                start_mock.assert_not_called()
+            else:
+                assert ret["result"]
+                start_mock.assert_called_with("pool2")
+            refresh_mock.assert_not_called()
+            assert ret["comment"] == "pool2 pool has been started"
+            assert ret["changes"] == {"pool2": "started"}
+
+
+@pytest.mark.parametrize("test", [False, True])
+def test_pool_multiple(test):
+    """
+    test the pool_running function with several names
+    """
+    with patch.dict(virt_utils.__opts__, {"test": test}):
+        start_mock = MagicMock(return_value=True)
+        refresh_mock = MagicMock(return_value=True)
+        with patch.dict(
+            virt_utils.__salt__,
+            {
+                "virt.pool_info": MagicMock(return_value=TEST_POOLS),
+                "virt.pool_start": start_mock,
+                "virt.pool_refresh": refresh_mock,
+            },
+        ):
+            ret = virt_utils.pool_running(
+                name="the-state-id", pools=["pool0", "pool1", "pool2", "pool3"]
+            )
+            if test:
+                assert ret["result"] is None
+                start_mock.assert_not_called()
+            else:
+                assert ret["result"]
+                assert start_mock.mock_calls == [
+                    call("pool2"),
+                    call("pool3"),
+                ]
+                assert refresh_mock.mock_calls == [
+                    call("pool0"),
+                    call("pool1"),
+                ]
+            assert ret["comment"] == "pool2, pool3 pools have been started"
+            assert ret["changes"] == {
+                "pool0": "refreshed",
+                "pool1": "refreshed",
+                "pool2": "started",
+                "pool3": "started",
+            }
+
+
+def test_pool_missing():
+    """
+    test the pool_running function with names of undefined pools
+    """
+    with patch.dict(virt_utils.__opts__, {"test": True}):
+        start_mock = MagicMock(return_value=True)
+        with patch.dict(
+            virt_utils.__salt__,
+            {
+                "virt.pool_info": MagicMock(return_value=TEST_POOLS),
+                "virt.pool_start": start_mock,
+            },
+        ):
+            ret = virt_utils.pool_running(
+                name="the-state-id", pools=["pool0", "pool1", "pool2", "pool5"]
+            )
+            assert not ret["result"]
+            start_mock.assert_not_called()
+            assert ret["comment"] == "pool5 pool is not defined"
+            assert ret["changes"] == {}
+
+
+def test_vm_resources_running():
+    """
+    test the vm_resources_running function
+    """
+    with patch.dict(virt_utils.__opts__, {"test": False}):
+        start_net_mock = MagicMock(return_value=True)
+        start_pool_mock = MagicMock(return_value=True)
+        refresh_pool_mock = MagicMock(return_value=True)
+        test_vm_info = {
+           "vm1": {
+               "nics": {
+                   "nic0": {"type": "network", "source": {"network": "net0"}},
+                   "nic1": {"type": "network", "source": {"network": "net3"}},
+                },
+               "disks": {
+                   "disk0": {"file": "pool0/system"},
+                   "disk1": {"file": "pool2/data"},
+                   "disk2": {"file": "/foo/bar.qcow2"},
+               }
+            },
+        }
+        with patch.dict(
+            virt_utils.__salt__,
+            {
+                "virt.network_info": MagicMock(return_value=TEST_NETS),
+                "virt.pool_info": MagicMock(return_value=TEST_POOLS),
+                "virt.network_start": start_net_mock,
+                "virt.pool_start": start_pool_mock,
+                "virt.pool_refresh": refresh_pool_mock,
+                "virt.vm_info": MagicMock(return_value=test_vm_info)
+            },
+        ):
+            ret = virt_utils.vm_resources_running("vm1")
+            assert ret["result"]
+            assert ret["changes"] == {
+                "networks": {"net3": "started"},
+                "pools": {"pool0": "refreshed", "pool2": "started"},
+            }
+            assert start_net_mock.mock_calls == [call("net3")]
+            assert start_pool_mock.mock_calls == [call("pool2")]
+            assert refresh_pool_mock.mock_calls == [call("pool0")]

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Automatically start needed networks and storage pools when creating/starting a VM
 - Avoid conflicts with running ioloop on mgr_events engine (bsc#1172711)
 - Require new kiwi-systemdeps packages (bsc#1184271)
 - keep salt-minion when it is installed to prevent update problems with

--- a/susemanager-utils/susemanager-sls/susemanager-sls.spec
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.spec
@@ -101,9 +101,8 @@ cp src/modules/mgrclusters.py %{buildroot}/usr/share/susemanager/salt/_modules
 cp src/modules/mgr_caasp_manager.py %{buildroot}/usr/share/susemanager/salt/_modules
 cp src/modules/ssh_agent.py %{buildroot}/usr/share/susemanager/salt/_modules
 cp src/modules/uyuni_config.py %{buildroot}/usr/share/susemanager/salt/_modules
-cp src/states/product.py %{buildroot}/usr/share/susemanager/salt/_states
-cp src/states/mgrcompat.py %{buildroot}/usr/share/susemanager/salt/_states
-cp src/states/uyuni_config.py %{buildroot}/usr/share/susemanager/salt/_states
+cp src/states/*.py %{buildroot}/usr/share/susemanager/salt/_states
+rm %{buildroot}/usr/share/susemanager/salt/_states/__init__.py
 
 # Install doc, examples
 mkdir -p %{buildroot}/usr/share/doc/packages/uyuni-config-modules/examples/ldap


### PR DESCRIPTION
## What does this PR change?

Creating or starting a VM using a storage pool or network that is stopped will cause a failure. This change automatically starts those and ensures the storage pools are refreshed.

Getting pools refreshed may be useful after restarting the virtual host since the mount could happen after the `libvirtd` start and thus no volume would be listed in the started pool.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- Unit tests were added

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/9340

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
