### PR TITLE
Disable centos 8 from run_sets

### DIFF
--- a/testsuite/run_sets/build_validation_init_clients.yml
+++ b/testsuite/run_sets/build_validation_init_clients.yml
@@ -8,8 +8,8 @@
 - features/build_validation/init_clients/ceos7_minion.feature
 - features/build_validation/init_clients/ceos7_ssh_minion.feature
 - features/build_validation/init_clients/ceos7_client.feature
-- features/build_validation/init_clients/ceos8_minion.feature
-- features/build_validation/init_clients/ceos8_ssh_minion.feature
+#- features/build_validation/init_clients/ceos8_minion.feature
+#- features/build_validation/init_clients/ceos8_ssh_minion.feature
 
 - features/build_validation/init_clients/sle11sp4_minion.feature
 - features/build_validation/init_clients/sle11sp4_ssh_minion.feature


### PR DESCRIPTION
## What does this PR change?

Disable centos 8 from run_sets not only from renaming the files in the features folder.

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes: No issue created, direct fix from BV testsuite review
Tracks 
4.1: https://github.com/SUSE/spacewalk/pull/14493
4.0: https://github.com/SUSE/spacewalk/pull/14494

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
