### PR TITLE
Avoid conflicts with running ioloop on mgr_events engine (bsc#1172711)

### DIFF
--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Avoid conflicts with running ioloop on mgr_events engine (bsc#1172711)
 - Require new kiwi-systemdeps packages (bsc#1184271)
 - keep salt-minion when it is installed to prevent update problems with
   dependend packages not available in the bootstrap repo (bsc#1183573)


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue with our custom `mgr_events` Salt engine at the time of dealing with the Tornado IOLoop.

Before this PR, the `mgr_events` engine is not properly instantiating the IOLoop to be used by this process, so it clashes when there is an already running tornado IOLoop, for example, when SaltStack Enterprise is running:

```console
Jan 16 15:01:59 suma-hostname salt-master[16536]: [CRITICAL] Engine 'mgr_events' could not be started!
Jan 16 15:01:59 suma-hostname salt-master[16536]: Traceback (most recent call last):
Jan 16 15:01:59 suma-hostname salt-master[16536]: File "/usr/lib/python3.6/site-packages/salt/engines/__init__.py", line 132, in run
Jan 16 15:01:59 suma-hostname salt-master[16536]: self.engine[self.fun](**kwargs)
Jan 16 15:01:59 suma-hostname salt-master[16536]: File "/usr/share/susemanager/modules/engines/mgr_events.py", line 214, in start
Jan 16 15:01:59 suma-hostname salt-master[16536]: io_loop.start()
Jan 16 15:01:59 suma-hostname salt-master[16536]: File "/usr/lib64/python3.6/site-packages/tornado/ioloop.py", line 754, in start
Jan 16 15:01:59 suma-hostname salt-master[16536]: raise RuntimeError("IOLoop is already running")
```

With this PR, we properly instantiate a new IOLoop and make it the current, as it's done for other engines included in Salt codebase.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**

- [x] **DONE**

## Test coverage
- No tests: **bugfix**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/11767

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
