### PR TITLE
QA: Fix "has react select" field and value

### DIFF
--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -897,9 +897,8 @@ Then(/^option "([^"]*)" is selected as "([^"]*)"$/) do |option, field|
   next if has_select?(field, selected: option)
 
   # Custom React selector
-  within(:xpath, "//*[@name='#{field}']/..") do
-    next if has_xpath?(".//*[contains(text(),'#{option}')]")
-  end
+  next if has_xpath?("//*[@name='#{field}']/..//*[contains(text(),'#{option}')]")
+
   raise "#{option} is not selected as #{field}"
 end
 
@@ -911,9 +910,7 @@ When(/^I wait until option "([^"]*)" appears in list "([^"]*)"$/) do |option, fi
     break if has_select?(field, with_options: [option])
 
     # Custom React selector
-    within(:xpath, "//*[@name='#{field}']/..") do
-      break if has_xpath?(".//*[contains(text(),'#{option}')]")
-    end
+    break if has_xpath?("//*[@name='#{field}']/..//*[contains(text(),'#{option}')]")
   end
 end
 


### PR DESCRIPTION
## What does this PR change?

Still, a case that my test did not catch before. Here we fix the case to check if an option is selected on a React Select component.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
