### PR TITLE
QA: KVM/XEN tests authorize always as admin

### DIFF
--- a/testsuite/features/secondary/minkvm_guests.feature
+++ b/testsuite/features/secondary/minkvm_guests.feature
@@ -6,7 +6,7 @@ Feature: Be able to manage KVM virtual machines via the GUI
 
 @virthost_kvm
   Scenario: Bootstrap KVM virtual host
-    Given I am authorized
+    Given I am authorized as "admin" with password "admin"
     When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "kvm_server" as "hostname"
@@ -387,7 +387,7 @@ Feature: Be able to manage KVM virtual machines via the GUI
 @virthost_kvm
 @scc_credentials
   Scenario: Create auto installation profile
-    Given I am authorized
+    Given I am authorized as "admin" with password "admin"
     And I follow the left menu "Systems > Autoinstallation > Profiles"
     And I follow "Upload Kickstart/Autoyast File"
     When I enter "15-sp2-kvm" as "kickstartLabel"
@@ -435,7 +435,7 @@ Feature: Be able to manage KVM virtual machines via the GUI
 @virthost_kvm
 @scc_credentials
   Scenario: Cleanup: remove the auto installation profile
-    Given I am authorized
+    Given I am authorized as "admin" with password "admin"
     And I follow the left menu "Systems > Autoinstallation > Profiles"
     When I follow "15-sp2-kvm"
     And I follow "Delete Autoinstallation"
@@ -446,7 +446,7 @@ Feature: Be able to manage KVM virtual machines via the GUI
 @virthost_kvm
 @scc_credentials
   Scenario: Cleanup: remove the auto installation distribution
-    Given I am authorized
+    Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Systems > Autoinstallation > Distributions"
     And I follow "SLE-15-SP2-TFTP"
     And I follow "Delete Distribution"

--- a/testsuite/features/secondary/minxen_guests.feature
+++ b/testsuite/features/secondary/minxen_guests.feature
@@ -6,7 +6,7 @@ Feature: Be able to manage XEN virtual machines via the GUI
 
 @virthost_xen
   Scenario: Bootstrap Xen virtual host
-    Given I am authorized
+    Given I am authorized as "admin" with password "admin"
     When I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "xen_server" as "hostname"


### PR DESCRIPTION
## What does this PR change?

KVM/XEN tests authorize always as admin, in order to avoid unexpected scenarios, let's use always the same user.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:

- Manager-4.0
- Manager-4.1

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
