### PR TITLE
Skip Install patch for 15sp3

### DIFF
--- a/testsuite/features/build_validation/smoke_tests/smoke_tests.template
+++ b/testsuite/features/build_validation/smoke_tests/smoke_tests.template
@@ -19,6 +19,7 @@ Feature: Smoke tests for <client>
     Given I am on the Systems overview page of this "<client>"
     Then I can see all system information for "<client>"
 
+@skip_for_sle15sp3
 @skip_for_ubuntu
   Scenario: Install a patch on the <client>
     Given I am on the Systems overview page of this "<client>"

--- a/testsuite/features/build_validation/smoke_tests/smoke_tests.template
+++ b/testsuite/features/build_validation/smoke_tests/smoke_tests.template
@@ -19,6 +19,7 @@ Feature: Smoke tests for <client>
     Given I am on the Systems overview page of this "<client>"
     Then I can see all system information for "<client>"
 
+# TODO: Remove the @skip_for_sle15sp3 when 15sp3 gets released and has patches
 @skip_for_sle15sp3
 @skip_for_ubuntu
   Scenario: Install a patch on the <client>

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -300,6 +300,7 @@ Before('@sle15sp3_client') do
   skip_this_scenario unless $sle15sp3_client
 end
 
+# TODO: Remove this when 15sp3 gets released and has patches
 Before('@skip_for_sle15sp3') do |scenario|
   skip_this_scenario if scenario.feature.location.file.include? '15sp3'
 end

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -300,6 +300,10 @@ Before('@sle15sp3_client') do
   skip_this_scenario unless $sle15sp3_client
 end
 
+Before('@skip_for_sle15sp3') do |scenario|
+  skip_this_scenario if scenario.feature.location.file.include? '15sp3'
+end
+
 Before('@skip_for_ubuntu') do |scenario|
   skip_this_scenario if scenario.feature.location.file.include? 'ubuntu'
 end


### PR DESCRIPTION
## What does this PR change?

Skip Install patch scenario for 15sp3 because it is not released yet and has no patches.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes No issue created, directly from BV testsuite review
Tracks 
4.1: https://github.com/SUSE/spacewalk/pull/14505
4.0: https://github.com/SUSE/spacewalk/pull/14508

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
