### PR TITLE
QA: Capybara hold the web browser session

### DIFF
--- a/testsuite/features/secondary/minkvm_guests.feature
+++ b/testsuite/features/secondary/minkvm_guests.feature
@@ -82,6 +82,7 @@ Feature: Be able to manage KVM virtual machines via the GUI
     When I click on "Graphical Console" in row "test-vm"
     And I switch to last opened window
     Then I wait until I see the VNC graphical console
+    When I close the last opened window
 
 @virthost_kvm
   Scenario: Suspend a KVM virtual machine
@@ -223,6 +224,7 @@ Feature: Be able to manage KVM virtual machines via the GUI
     When I click on "Graphical Console" in row "test-vm2"
     And I switch to last opened window
     Then I wait until I see the spice graphical console
+    When I close the last opened window
 
 @virthost_kvm
   Scenario: Show the virtual storage pools and volumes for KVM
@@ -430,6 +432,7 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I wait until I see the VNC graphical console
     Then I wait at most 500 seconds until I see modal containing "Disconnected" text
     And I wait at most 500 seconds until Salt master sees "test-vm2" as "unaccepted"
+    When I close the last opened window
 
 @long_test
 @virthost_kvm

--- a/testsuite/features/secondary/minxen_guests.feature
+++ b/testsuite/features/secondary/minxen_guests.feature
@@ -198,6 +198,7 @@ Feature: Be able to manage XEN virtual machines via the GUI
     When I click on "Graphical Console" in row "test-vm2"
     And I switch to last opened window
     And I wait until I see the VNC graphical console
+    And I close the last opened window
 
 @virthost_xen
   Scenario: Create a Xen fully virtualized guest
@@ -223,6 +224,7 @@ Feature: Be able to manage XEN virtual machines via the GUI
     When I click on "Graphical Console" in row "test-vm3"
     And I switch to last opened window
     And I wait until I see the spice graphical console
+    And I close the last opened window
 
 @virthost_xen
   Scenario: Show the virtual storage pools and volumes for Xen

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -131,6 +131,11 @@ When(/^I switch to last opened window$/) do
   page.driver.browser.switch_to.window(page.driver.browser.window_handles.last)
 end
 
+When(/^I close the last opened window$/) do
+  page.driver.browser.close
+  page.driver.browser.switch_to.window(page.driver.browser.window_handles.first)
+end
+
 #
 # Check a checkbox of the given id
 #
@@ -353,6 +358,7 @@ end
 #
 
 Given(/^I am not authorized$/) do
+  page.reset!
   visit Capybara.app_host
   raise "Button 'Sign In' not visible" unless find_button('Sign In').visible?
 end

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -103,6 +103,16 @@ After do |scenario|
       debug_server_on_realtime_failure
     end
   end
+  page.instance_variable_set(:@touched, false)
+end
+
+# Reset the page if it's running the first scenario of a feature
+$first_scenario = true
+Before do
+  next unless $first_scenario
+
+  page.reset!
+  $first_scenario = false
 end
 
 AfterStep do


### PR DESCRIPTION
## What does this PR change?

This code changes the actual behavior of our test suite, currently, we open a new web session for each scenario, so we require a log-in for each scenario. This PR aims to keep open the browser for the whole feature, resetting the session only when a new Cucumber feature starts.

Some scenarios rely on the current behavior, so they expect that we have a reset page on every scenario, but if we change that by holding the session, we must assure that the scenarios don't rely anymore on this.

So, this PR also includes a change in the KVM/XEN tests where we open a new tab, and we expect to have it closed when a new scenario starts. What we do in this case is to assure that we close the tab and we move to the first tab.

**Note:** 
This PR will speed up the test suite "per se", but holding the session by default will help to speed up the tests if we start removing the logout and log-in actions that we do every time we start a scenario. I will proceed to these refactors in next PRs.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.0
- Manager-4.1

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
