### PR TITLE
Simplify config states channels selection workflow by dropping and squashing tabs into one

### DIFF
--- a/branding/css/susemanager-dark-variables.less
+++ b/branding/css/susemanager-dark-variables.less
@@ -88,6 +88,7 @@
 @notification-badge:     @orange-light;
 @box-shadow:             @gray-light;
 @inactive:               @eos-gray-light-2;
+@table-row-selected:     lighten(@eos-yellow-light, 5%);
 
 /**
 * FONTS

--- a/branding/css/susemanager-light-variables.less
+++ b/branding/css/susemanager-light-variables.less
@@ -88,6 +88,7 @@
 @notification-badge:     @orange-light;
 @box-shadow:             @gray-light;
 @inactive:               @eos-gray-light-2;
+@table-row-selected:     lighten(@eos-yellow-light, 5%);
 
 /**
 * FONTS

--- a/branding/css/susemanager-theme.less
+++ b/branding/css/susemanager-theme.less
@@ -1326,3 +1326,7 @@ select.small-select {
   cursor: pointer;
   background-color: fadeout(@gray, 70%);
 }
+
+tr.changed > td {
+  background-color: @table-row-selected!important;
+}

--- a/branding/css/uyuni-theme.less
+++ b/branding/css/uyuni-theme.less
@@ -1329,3 +1329,7 @@ select.small-select {
   cursor: pointer;
   background-color: fadeout(@gray, 70%);
 }
+
+tr.changed > td {
+  background-color: @table-row-selected!important;
+}

--- a/branding/css/uyuni-variables.less
+++ b/branding/css/uyuni-variables.less
@@ -50,6 +50,7 @@
 @notification-badge:      @orange-light;
 @box-shadow:              @gray-light;
 @inactive:                @gray-light-2;
+@table-row-selected:      lighten(@yellow, 40%);
 
 /**
 * FONTS

--- a/branding/spacewalk-branding.changes
+++ b/branding/spacewalk-branding.changes
@@ -1,3 +1,5 @@
+- Simplify state channels selection
+
 -------------------------------------------------------------------
 Fri Apr 16 15:55:22 CEST 2021 - jgonzalez@suse.com
 

--- a/testsuite/features/secondary/min_config_state_channel_subscriptions.feature
+++ b/testsuite/features/secondary/min_config_state_channel_subscriptions.feature
@@ -69,8 +69,8 @@ Feature: State Configuration channels
     When I am on the Systems overview page of this "sle_minion"
     And I follow "States" in the content area
     And I follow "Configuration Channels" in the content area
-    Then I should see a "Apply" button
-    When I click on "Apply"
+    Then I should see a "Execute States" button
+    When I click on "Execute States"
     Then I should see a "Applying the config channels has been scheduled" text
     When I wait until event "Apply states [custom] scheduled by admin" is completed
     And I wait until file "/root/statechannel" exists on "sle_minion"

--- a/testsuite/features/secondary/min_config_state_channel_subscriptions.feature
+++ b/testsuite/features/secondary/min_config_state_channel_subscriptions.feature
@@ -53,8 +53,6 @@ Feature: State Configuration channels
     When I am on the Systems overview page of this "sle_minion"
     And I follow "States" in the content area
     And I follow "Configuration Channels" in the content area
-    And I follow "Search" in element "config-channels-tabs"
-    And I click on "Search" in element "search-row"
     Then I should see a "My State Channel" text
     And I should see a "statechannel" text
     And I should see a "statechannel2" text
@@ -82,8 +80,6 @@ Feature: State Configuration channels
     When I am on the Systems overview page of this "sle_minion"
     And I follow "States" in the content area
     And I follow "Configuration Channels" in the content area
-    And I follow "Search" in element "config-channels-tabs"
-    And I click on "Search" in element "search-row"
     Then I should see a "My State Channel" text
     And I should see a "statechannel3" text
     And I check "statechannel3-cbox"

--- a/testsuite/features/secondary/min_config_state_channel_subscriptions.feature
+++ b/testsuite/features/secondary/min_config_state_channel_subscriptions.feature
@@ -53,6 +53,7 @@ Feature: State Configuration channels
     When I am on the Systems overview page of this "sle_minion"
     And I follow "States" in the content area
     And I follow "Configuration Channels" in the content area
+    And I click on "Search" in element "search-row"
     Then I should see a "My State Channel" text
     And I should see a "statechannel" text
     And I should see a "statechannel2" text
@@ -69,6 +70,7 @@ Feature: State Configuration channels
     When I am on the Systems overview page of this "sle_minion"
     And I follow "States" in the content area
     And I follow "Configuration Channels" in the content area
+    And I click on "Search" in element "search-row"
     Then I should see a "Execute States" button
     When I click on "Execute States"
     Then I should see a "Applying the config channels has been scheduled" text

--- a/web/html/src/components/config-channels.tsx
+++ b/web/html/src/components/config-channels.tsx
@@ -104,8 +104,6 @@ class ConfigChannels extends React.Component<ConfigChannelsProps, ConfigChannels
     const channels = this.state.assigned;
     const request = this.props.saveRequest(channels).promise.then(
       (data, textStatus, jqXHR) => {
-        console.log("success: " + data);
-
         const newSearchResults = this.state.search.results.map(channel => {
           const changed = this.state.changed.get(channelKey(channel));
           if (changed !== undefined) {
@@ -128,8 +126,6 @@ class ConfigChannels extends React.Component<ConfigChannelsProps, ConfigChannels
         this.hideRanking();
       },
       (jqXHR, textStatus, errorThrown) => {
-        console.log("fail: " + textStatus);
-
         this.setState({
           messages: MessagesUtils.error(t("An error occurred on save.")),
         });
@@ -149,7 +145,6 @@ class ConfigChannels extends React.Component<ConfigChannelsProps, ConfigChannels
       return Promise.resolve();
     } else {
       return Network.get(this.props.matchUrl(this.state.filter)).promise.then(data => {
-        console.log(data);
         this.setState({
           search: {
             filter: this.state.filter,

--- a/web/html/src/components/config-channels.tsx
+++ b/web/html/src/components/config-channels.tsx
@@ -141,19 +141,19 @@ class ConfigChannels extends React.Component<ConfigChannelsProps, ConfigChannels
   }
 
   search() {
-    if (this.state.filter === this.state.search.filter) {
-      return Promise.resolve();
-    } else {
-      return Network.get(this.props.matchUrl(this.state.filter)).promise.then(data => {
-        this.setState({
-          search: {
-            filter: this.state.filter,
-            results: data,
-          },
-          messages: null,
+    return Promise.resolve().then( () => {
+      if (this.state.filter !== this.state.search.filter) {
+        Network.get(this.props.matchUrl(this.state.filter)).promise.then(data => {
+          this.setState({
+            search: {
+              filter: this.state.filter,
+              results: data,
+            },
+            messages: null,
+          });
         });
-      });
-    }
+      }
+    });
   }
 
   addChanged(original, key, selected) {

--- a/web/html/src/components/config-channels.tsx
+++ b/web/html/src/components/config-channels.tsx
@@ -204,7 +204,7 @@ class ConfigChannels extends React.Component<ConfigChannelsProps, ConfigChannels
         <tr
           id={currentChannel.label + "-row"}
           key={currentChannel.label}
-          className={changed !== undefined ? "warning" : ""}
+          className={changed !== undefined ? "changed" : ""}
         >
           <td>
             {channelIcon(currentChannel)}

--- a/web/html/src/components/config-channels.tsx
+++ b/web/html/src/components/config-channels.tsx
@@ -75,6 +75,10 @@ class ConfigChannels extends React.Component<ConfigChannelsProps, ConfigChannels
     Network.get(this.props.matchUrl()).promise.then(data => {
       this.setState({
         channels: data,
+        search: {
+          filter: this.state.filter,
+          results: data,
+        },
       });
     });
   }

--- a/web/html/src/components/config-channels.tsx
+++ b/web/html/src/components/config-channels.tsx
@@ -238,7 +238,7 @@ class ConfigChannels extends React.Component<ConfigChannelsProps, ConfigChannels
           elements
         ) : (
           <tr>
-            <td colSpan={2}>
+            <td colSpan={3}>
               <div>
                 {t("No states assigned. Use search to find and assign states.")}
               </div>

--- a/web/html/src/components/config-channels.tsx
+++ b/web/html/src/components/config-channels.tsx
@@ -315,7 +315,7 @@ class ConfigChannels extends React.Component<ConfigChannelsProps, ConfigChannels
             defaultType="btn-success"
             disabled={!assigned}
             action={this.applySaltState}
-            text={t("Apply")}
+            text={t("Execute States")}
           />,
         ];
 

--- a/web/html/src/components/config-channels.tsx
+++ b/web/html/src/components/config-channels.tsx
@@ -1,14 +1,13 @@
 import * as React from "react";
-import { AceEditor } from "../components/ace-editor";
-import { AsyncButton, LinkButton } from "../components/buttons";
+import { AsyncButton } from "../components/buttons";
 import { InnerPanel } from "components/panels/InnerPanel";
 import { TextField } from "../components/fields";
-import { PopUp } from "../components/popup";
 import { Messages, MessageType } from "../components/messages";
 import { Utils as MessagesUtils } from "../components/messages";
 import Network from "../utils/network";
 import { DEPRECATED_unsafeEquals } from "utils/legacy";
 import { RankingTable } from "../components/ranking-table";
+import { SaltStatePopup } from "../components/salt-state-popup";
 
 function channelKey(channel) {
   return channel.label;
@@ -25,66 +24,6 @@ function channelIcon(channel) {
   }
 
   return <i className={iconClass} title={iconTitle} />;
-}
-
-type SaltStatePopupProps = {
-  saltState?: {
-    id: string;
-    name: string;
-    content: React.ReactNode;
-  };
-  onClosePopUp: () => any;
-};
-
-class SaltStatePopup extends React.Component<SaltStatePopupProps> {
-  render() {
-    let popUpContent, icon, title, footer;
-
-    if (this.props.saltState) {
-      popUpContent = (
-        <AceEditor
-          className="form-control"
-          id="content-state"
-          minLines={20}
-          maxLines={40}
-          readOnly={true}
-          mode="yaml"
-          content={this.props.saltState.content}
-        ></AceEditor>
-      );
-
-      icon = this.props.saltState && channelIcon(this.props.saltState);
-      title = this.props.saltState && (
-        <span>
-          {icon}
-          {t("Configuration Channel: {0}", this.props.saltState.name)}
-        </span>
-      );
-
-      footer = (
-        <div className="btn-group">
-          <LinkButton
-            href={"/rhn/configuration/ChannelOverview.do?ccid=" + this.props.saltState.id}
-            className="btn-default"
-            icon="fa-edit"
-            text={t("Edit")}
-            title={t("Edit Configuration Channel")}
-          />
-        </div>
-      );
-    }
-
-    return (
-      <PopUp
-        title={title}
-        className="modal-lg"
-        id="saltStatePopUp"
-        content={popUpContent}
-        onClosePopUp={this.props.onClosePopUp}
-        footer={footer}
-      />
-    );
-  }
 }
 
 type ConfigChannelsProps = {

--- a/web/html/src/components/config-channels.tsx
+++ b/web/html/src/components/config-channels.tsx
@@ -8,15 +8,7 @@ import { Messages, MessageType } from "../components/messages";
 import { Utils as MessagesUtils } from "../components/messages";
 import Network from "../utils/network";
 import { DEPRECATED_unsafeEquals } from "utils/legacy";
-
-type Instance = JQuery & {};
-type Sortable = <T>(arg0: T, options?: any) => T extends string ? string[] : Instance;
-
-declare global {
-  interface JQuery {
-    sortable: Sortable;
-  }
-}
+import { RankingTable } from "../components/ranking-table";
 
 function channelKey(channel) {
   return channel.label;
@@ -522,106 +514,6 @@ class ConfigChannels extends React.Component<ConfigChannelsProps, ConfigChannels
           <SaltStatePopup saltState={this.state.showSaltState} onClosePopUp={this.onClosePopUp} />
         </InnerPanel>
       </span>
-    );
-  }
-}
-
-type RankingTableProps = {
-  items: any[];
-  onUpdate?: (newItems: any[]) => any;
-  emptyMsg: string;
-};
-
-type RankingTableState = {
-  items: any[];
-};
-
-class RankingTable extends React.Component<RankingTableProps, RankingTableState> {
-  defaultEmptyMsg = t("There are no entries to show.");
-  node: Element | null = null;
-
-  constructor(props) {
-    super(props);
-    this.state = {
-      items: this.props.items,
-    };
-  }
-
-  cloneItems() {
-    return this.state.items.map(i => Object.assign({}, i));
-  }
-
-  handleUpdate() {
-    if (!this.node) {
-      console.error("Failed to find node");
-      return;
-    }
-
-    const newItems = this.cloneItems();
-    const ids = jQuery(this.node).sortable("toArray", { attribute: "data-id" });
-    if (ids.length > 0) {
-      ids.forEach((id, ix) => {
-        const item = newItems.find(elm => elm.label === id);
-        item.position = ix + 1;
-      });
-    }
-
-    jQuery(this.node).sortable("cancel");
-    this.setState({ items: newItems });
-
-    if (this.props.onUpdate) {
-      this.props.onUpdate(newItems);
-    }
-  }
-
-  componentDidMount() {
-    if (!this.node) {
-      console.error("Failed to find node");
-      return;
-    }
-
-    jQuery(this.node).sortable({
-      update: this.handleUpdate.bind(this),
-      items: "a",
-    });
-
-    this.handleUpdate();
-  }
-
-  getElements() {
-    const sortedItems = this.state.items.sort((a, b) =>
-      DEPRECATED_unsafeEquals(a.position, undefined)
-        ? 1
-        : DEPRECATED_unsafeEquals(b.position, undefined)
-        ? -1
-        : a.position - b.position
-    );
-
-    return sortedItems.map(i => {
-      // TODO: Provide a callback as prop for optional mapping and generify this default implementation
-      const icon = channelIcon(i);
-      return (
-        // eslint-disable-next-line jsx-a11y/anchor-is-valid
-        <a href="#" className="list-group-item" key={i.label} data-id={i.label}>
-          <i className="fa fa-sort" />
-          {icon}
-          {i.name} ({i.label})
-        </a>
-      );
-    });
-  }
-
-  render() {
-    return (
-      <div>
-        {this.state.items.length > 0 ? (
-          <div ref={node => (this.node = node)} className="list-group">
-            {this.getElements()}
-          </div>
-        ) : (
-          <div className="alert alert-info">{this.props.emptyMsg || this.defaultEmptyMsg}</div>
-        )}
-      </div>
     );
   }
 }

--- a/web/html/src/components/messages.tsx
+++ b/web/html/src/components/messages.tsx
@@ -81,7 +81,7 @@ export class Messages extends React.Component<Props> {
 
         var msgs = items.map((item, index) => (
             <div key={"msg" + index} className={"alert alert-" + _classNames[item.severity]}>
-                {Array.isArray(item.text) ? item.text.map(txt => <div>{txt}</div>) : item.text}
+                {Array.isArray(item.text) ? item.text.map((txt, i) => <div key={i}>{txt}</div>) : item.text}
             </div>
         ));
 

--- a/web/html/src/components/ranking-table.tsx
+++ b/web/html/src/components/ranking-table.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { DEPRECATED_unsafeEquals } from "utils/legacy";
+import _cloneDeep from "lodash/cloneDeep";
 
 type Instance = JQuery & {};
 type Sortable = <T>(arg0: T, options?: any) => T extends string ? string[] : Instance;
@@ -45,7 +46,7 @@ class RankingTable extends React.Component<RankingTableProps, RankingTableState>
   }
 
   cloneItems() {
-    return this.state.items.map(i => Object.assign({}, i));
+    return this.state.items.map(i => _cloneDeep(i));
   }
 
   handleUpdate() {

--- a/web/html/src/components/ranking-table.tsx
+++ b/web/html/src/components/ranking-table.tsx
@@ -1,0 +1,126 @@
+import * as React from "react";
+import { DEPRECATED_unsafeEquals } from "utils/legacy";
+
+type Instance = JQuery & {};
+type Sortable = <T>(arg0: T, options?: any) => T extends string ? string[] : Instance;
+
+declare global {
+  interface JQuery {
+    sortable: Sortable;
+  }
+}
+
+function channelIcon(channel) {
+  let iconClass, iconTitle;
+  if (channel.type === "state") {
+    iconClass = "fa spacewalk-icon-salt-add";
+    iconTitle = t("State Configuration Channel");
+  } else {
+    iconClass = "fa spacewalk-icon-software-channels";
+    iconTitle = t("Normal Configuration Channel");
+  }
+
+  return <i className={iconClass} title={iconTitle} />;
+}
+
+type RankingTableProps = {
+  items: any[];
+  onUpdate?: (newItems: any[]) => any;
+  emptyMsg: string;
+};
+
+type RankingTableState = {
+  items: any[];
+};
+
+class RankingTable extends React.Component<RankingTableProps, RankingTableState> {
+  defaultEmptyMsg = t("There are no entries to show.");
+  node: Element | null = null;
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      items: this.props.items,
+    };
+  }
+
+  cloneItems() {
+    return this.state.items.map(i => Object.assign({}, i));
+  }
+
+  handleUpdate() {
+    if (!this.node) {
+      console.error("Failed to find node");
+      return;
+    }
+
+    const newItems = this.cloneItems();
+    const ids = jQuery(this.node).sortable("toArray", { attribute: "data-id" });
+    if (ids.length > 0) {
+      ids.forEach((id, ix) => {
+        const item = newItems.find(elm => elm.label === id);
+        item.position = ix + 1;
+      });
+    }
+
+    jQuery(this.node).sortable("cancel");
+    this.setState({ items: newItems });
+
+    if (this.props.onUpdate) {
+      this.props.onUpdate(newItems);
+    }
+  }
+
+  componentDidMount() {
+    if (!this.node) {
+      console.error("Failed to find node");
+      return;
+    }
+
+    jQuery(this.node).sortable({
+      update: this.handleUpdate.bind(this),
+      items: "a",
+    });
+
+    this.handleUpdate();
+  }
+
+  getElements() {
+    const sortedItems = this.state.items.sort((a, b) =>
+      DEPRECATED_unsafeEquals(a.position, undefined)
+        ? 1
+        : DEPRECATED_unsafeEquals(b.position, undefined)
+        ? -1
+        : a.position - b.position
+    );
+
+    return sortedItems.map(i => {
+      // TODO: Provide a callback as prop for optional mapping and generify this default implementation
+      const icon = channelIcon(i);
+      return (
+        // eslint-disable-next-line jsx-a11y/anchor-is-valid
+        <a href="#" className="list-group-item" key={i.label} data-id={i.label}>
+          <i className="fa fa-sort" />
+          {icon}
+          {i.name} ({i.label})
+        </a>
+      );
+    });
+  }
+
+  render() {
+    return (
+      <div>
+        {this.state.items.length > 0 ? (
+          <div ref={node => (this.node = node)} className="list-group">
+            {this.getElements()}
+          </div>
+        ) : (
+          <div className="alert alert-info">{this.props.emptyMsg || this.defaultEmptyMsg}</div>
+        )}
+      </div>
+    );
+  }
+}
+
+export { RankingTable };

--- a/web/html/src/components/salt-state-popup.tsx
+++ b/web/html/src/components/salt-state-popup.tsx
@@ -1,0 +1,79 @@
+import * as React from "react";
+import { AceEditor } from "./ace-editor";
+import { LinkButton } from "./buttons";
+import { PopUp } from "./popup";
+
+function channelIcon(channel) {
+  let iconClass, iconTitle;
+  if (channel.type === "state") {
+    iconClass = "fa spacewalk-icon-salt-add";
+    iconTitle = t("State Configuration Channel");
+  } else {
+    iconClass = "fa spacewalk-icon-software-channels";
+    iconTitle = t("Normal Configuration Channel");
+  }
+
+  return <i className={iconClass} title={iconTitle} />;
+}
+
+type SaltStatePopupProps = {
+  saltState?: {
+    id: string;
+    name: string;
+    content: React.ReactNode;
+  };
+  onClosePopUp: () => any;
+};
+
+class SaltStatePopup extends React.Component<SaltStatePopupProps> {
+  render() {
+    let popUpContent, icon, title, footer;
+
+    if (this.props.saltState) {
+      popUpContent = (
+        <AceEditor
+          className="form-control"
+          id="content-state"
+          minLines={20}
+          maxLines={40}
+          readOnly={true}
+          mode="yaml"
+          content={this.props.saltState.content}
+        ></AceEditor>
+      );
+
+      icon = this.props.saltState && channelIcon(this.props.saltState);
+      title = this.props.saltState && (
+        <span>
+          {icon}
+          {t("Configuration Channel: {0}", this.props.saltState.name)}
+        </span>
+      );
+
+      footer = (
+        <div className="btn-group">
+          <LinkButton
+            href={"/rhn/configuration/ChannelOverview.do?ccid=" + this.props.saltState.id}
+            className="btn-default"
+            icon="fa-edit"
+            text={t("Edit")}
+            title={t("Edit Configuration Channel")}
+          />
+        </div>
+      );
+    }
+
+    return (
+      <PopUp
+        title={title}
+        className="modal-lg"
+        id="saltStatePopUp"
+        content={popUpContent}
+        onClosePopUp={this.props.onClosePopUp}
+        footer={footer}
+      />
+    );
+  }
+}
+
+export { SaltStatePopup };

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Simplify state channels selection
 - Fix rendering of select items in modal dialogs (bsc#1183997)
 - Show the info about unsynced patches in the Content Lifecycle Management screens
 - virtual network edit action


### PR DESCRIPTION
## What does this PR change?

Follow up of https://github.com/uyuni-project/uyuni/pull/3482 from the original RFC https://github.com/uyuni-project/uyuni-rfc/blob/master/accepted/00076-state-channels-visibility.md

The following change is valid for:
- `Home > My Organization > Configuration Channels`
- `Systems > Details > States > Configuration Channels`
- `Systems > System Groups > Details > States > Configuration Channels`
- `Admin > Organizations > Details > States > Configuration Channels`

## GUI diff

Before:
![before-state-channels](https://user-images.githubusercontent.com/7080830/114266601-7131e800-99f7-11eb-80db-e0d70e6a86e3.gif)


After:
![after-state-channels](https://user-images.githubusercontent.com/7080830/114266596-6bd49d80-99f7-11eb-88fa-cbcb1a0edf29.gif)



- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)



- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
