### PR TITLE
Disable server and proxy stable channels for leap 15.3

### DIFF
--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -1590,15 +1590,15 @@ gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Server-POOL-x86_64-Media1/
 
-[uyuni-server-stable-leap-153]
-name     = Uyuni Server Stable for %(base_channel_name)s
-archs    = x86_64, aarch64
-base_channels = opensuse_leap15_3-%(arch)s
-checksum = sha256
-gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Server-POOL-x86_64-Media1/repodata/repomd.xml.key
-gpgkey_id = %(_uyuni_gpgkey_id)s
-gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Server-POOL-x86_64-Media1/
+# [uyuni-server-stable-leap-153]
+# name     = Uyuni Server Stable for %(base_channel_name)s
+# archs    = x86_64, aarch64
+# base_channels = opensuse_leap15_3-%(arch)s
+# checksum = sha256
+# gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Server-POOL-x86_64-Media1/repodata/repomd.xml.key
+# gpgkey_id = %(_uyuni_gpgkey_id)s
+# gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+# repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Server-POOL-x86_64-Media1/
 
 [uyuni-server-devel-leap]
 name     = Uyuni Server Devel for %(base_channel_name)s (Development)
@@ -1630,15 +1630,15 @@ gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Proxy-POOL-x86_64-Media1/
 
-[uyuni-proxy-stable-leap-153]
-name     = Uyuni Proxy Stable for %(base_channel_name)s
-archs    = x86_64, aarch64
-base_channels = opensuse_leap15_3-%(arch)s
-checksum = sha256
-gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Proxy-POOL-x86_64-Media1/repodata/repomd.xml.key
-gpgkey_id = %(_uyuni_gpgkey_id)s
-gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Proxy-POOL-x86_64-Media1/
+# [uyuni-proxy-stable-leap-153]
+# name     = Uyuni Proxy Stable for %(base_channel_name)s
+# archs    = x86_64, aarch64
+# base_channels = opensuse_leap15_3-%(arch)s
+# checksum = sha256
+# gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Proxy-POOL-x86_64-Media1/repodata/repomd.xml.key
+# gpgkey_id = %(_uyuni_gpgkey_id)s
+# gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
+# repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable/images/repo/Uyuni-Proxy-POOL-x86_64-Media1/
 
 [uyuni-proxy-devel-leap]
 name     = Uyuni Proxy Devel for %(base_channel_name)s (Development)


### PR DESCRIPTION
## What does this PR change?

leap 15.3 is not yet ready ;) .
We will enable them later.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed

- [X] **DONE**

## Test coverage
- No tests

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/14528

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
