### PR TITLE
Add multiverse, restricted and backports to Ubuntu 16.04 and 18.04

### DIFF
--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -1639,6 +1639,96 @@ checksum = sha256
 base_channels = ubuntu-16.04-pool-amd64
 repo_url = http://archive.ubuntu.com/ubuntu/dists/xenial-security/universe/binary-amd64/
 
+[ubuntu-1604-amd64-main-backports]
+label     = ubuntu-1604-amd64-main-backports
+name      = Ubuntu 16.04 LTS AMD64 Main Backports
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-16.04-pool-amd64
+repo_url = http://archive.ubuntu.com/ubuntu/dists/xenial-backports/main/binary-amd64/
+
+[ubuntu-1604-amd64-multiverse-backports]
+label     = ubuntu-1604-amd64-multiverse-backports
+name      = Ubuntu 16.04 LTS AMD64 Multiverse Backports
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-16.04-pool-amd64
+repo_url = http://archive.ubuntu.com/ubuntu/dists/xenial-backports/multiverse/binary-amd64/
+
+[ubuntu-1604-amd64-restricted-backports]
+label     = ubuntu-1604-amd64-restricted-backports
+name      = Ubuntu 16.04 LTS AMD64 Restricted Backports
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-16.04-pool-amd64
+repo_url = http://archive.ubuntu.com/ubuntu/dists/xenial-backports/restricted/binary-amd64/
+
+[ubuntu-1604-amd64-universe-backports]
+label     = ubuntu-1604-amd64-universe-backports
+name      = Ubuntu 16.04 LTS AMD64 Universe Backports
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-16.04-pool-amd64
+repo_url = http://archive.ubuntu.com/ubuntu/dists/xenial-backports/universe/binary-amd64/
+
+[ubuntu-1604-amd64-multiverse]
+label    = ubuntu-1604-amd64-multiverse
+name     = Ubuntu 16.04 LTS AMD64 Multiverse
+archs    = amd64-deb
+repo_type = deb
+checksum = sha256
+base_channels = ubuntu-16.04-pool-amd64
+repo_url = http://archive.ubuntu.com/ubuntu/dists/xenial/multiverse/binary-amd64/
+
+[ubuntu-1604-amd64-restricted]
+label     = ubuntu-1604-amd64-restricted
+name      = Ubuntu 16.04 LTS AMD64 Restricted
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-16.04-pool-amd64
+repo_url  = http://archive.ubuntu.com/ubuntu/dists/xenial/restricted/binary-amd64/
+
+[ubuntu-1604-amd64-multiverse-security]
+label     = ubuntu-1604-amd64-multiverse-security
+name      = Ubuntu 16.04 LTS AMD64 Multiverse Security
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-16.04-pool-amd64
+repo_url  = http://security.ubuntu.com/ubuntu/dists/xenial-security/multiverse/binary-amd64/
+
+[ubuntu-1604-amd64-restricted-security]
+label     = ubuntu-1604-amd64-restricted-security
+name      = Ubuntu 16.04 LTS AMD64 Restricted Security
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-16.04-pool-amd64
+repo_url  = http://security.ubuntu.com/ubuntu/dists/xenial-security/restricted/binary-amd64/
+
+[ubuntu-1604-amd64-multiverse-updates]
+label     = ubuntu-1604-amd64-multiverse-updates
+name      = Ubuntu 16.04 LTS AMD64 Multiverse Updates
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-16.04-pool-amd64
+repo_url  = http://archive.ubuntu.com/ubuntu/dists/xenial-updates/multiverse/binary-amd64/
+
+[ubuntu-1604-amd64-restricted-updates]
+label     = ubuntu-1604-amd64-restricted-updates
+name      = Ubuntu 16.04 LTS AMD64 Restricted Updates
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-16.04-pool-amd64
+repo_url  = http://archive.ubuntu.com/ubuntu/dists/xenial-updates/restricted/binary-amd64/
+
 [ubuntu-1604-pool-amd64-uyuni]
 label    = ubuntu-16.04-pool-amd64-uyuni
 checksum = sha256
@@ -1703,6 +1793,96 @@ repo_type = deb
 checksum = sha256
 base_channels = ubuntu-16.04-pool-amd64-uyuni
 repo_url = http://archive.ubuntu.com/ubuntu/dists/xenial-security/universe/binary-amd64/
+
+[ubuntu-1604-amd64-main-backports-uyuni]
+label     = ubuntu-1604-amd64-main-backports-uyuni
+name      = Ubuntu 16.04 LTS AMD64 Main Backports for Uyuni
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-16.04-pool-amd64-uyuni
+repo_url = http://archive.ubuntu.com/ubuntu/dists/xenial-backports/main/binary-amd64/
+
+[ubuntu-1604-amd64-multiverse-backports-uyuni]
+label     = ubuntu-1604-amd64-multiverse-backports-uyuni
+name      = Ubuntu 16.04 LTS AMD64 Multiverse Backports for Uyuni
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-16.04-pool-amd64-uyuni
+repo_url = http://archive.ubuntu.com/ubuntu/dists/xenial-backports/multiverse/binary-amd64/
+
+[ubuntu-1604-amd64-restricted-backports-uyuni]
+label     = ubuntu-1604-amd64-restricted-backports-uyuni
+name      = Ubuntu 16.04 LTS AMD64 Restricted Backports for Uyuni
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-16.04-pool-amd64-uyuni
+repo_url = http://archive.ubuntu.com/ubuntu/dists/xenial-backports/restricted/binary-amd64/
+
+[ubuntu-1604-amd64-universe-backports-uyuni]
+label     = ubuntu-1604-amd64-universe-backports-uyuni
+name      = Ubuntu 16.04 LTS AMD64 Universe Backports for Uyuni
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-16.04-pool-amd64-uyuni
+repo_url = http://archive.ubuntu.com/ubuntu/dists/xenial-backports/universe/binary-amd64/
+
+[ubuntu-1604-amd64-multiverse-uyuni]
+label    = ubuntu-1604-amd64-multiverse-uyuni
+name     = Ubuntu 16.04 LTS AMD64 Multiverse for Uyuni
+archs    = amd64-deb
+repo_type = deb
+checksum = sha256
+base_channels = ubuntu-16.04-pool-amd64-uyuni
+repo_url = http://archive.ubuntu.com/ubuntu/dists/xenial/multiverse/binary-amd64/
+
+[ubuntu-1604-amd64-restricted-uyuni]
+label     = ubuntu-1604-amd64-restricted-uyuni
+name      = Ubuntu 16.04 LTS AMD64 Restricted for Uyuni
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-16.04-pool-amd64-uyuni
+repo_url  = http://archive.ubuntu.com/ubuntu/dists/xenial/restricted/binary-amd64/
+
+[ubuntu-1604-amd64-multiverse-security-uyuni]
+label     = ubuntu-1604-amd64-multiverse-security-uyuni
+name      = Ubuntu 16.04 LTS AMD64 Multiverse Security for Uyuni
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-16.04-pool-amd64-uyuni
+repo_url  = http://security.ubuntu.com/ubuntu/dists/xenial-security/multiverse/binary-amd64/
+
+[ubuntu-1604-amd64-restricted-security-uyuni]
+label     = ubuntu-1604-amd64-restricted-security-uyuni
+name      = Ubuntu 16.04 LTS AMD64 Restricted Security for Uyuni
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-16.04-pool-amd64-uyuni
+repo_url  = http://security.ubuntu.com/ubuntu/dists/xenial-security/restricted/binary-amd64/
+
+[ubuntu-1604-amd64-multiverse-updates-uyuni]
+label     = ubuntu-1604-amd64-multiverse-updates-uyuni
+name      = Ubuntu 16.04 LTS AMD64 Multiverse Updates for Uyuni
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-16.04-pool-amd64-uyuni
+repo_url  = http://archive.ubuntu.com/ubuntu/dists/xenial-updates/multiverse/binary-amd64/
+
+[ubuntu-1604-amd64-restricted-updates-uyuni]
+label     = ubuntu-1604-amd64-restricted-updates-uyuni
+name      = Ubuntu 16.04 LTS AMD64 Restricted Updates for Uyuni
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-16.04-pool-amd64-uyuni
+repo_url  = http://archive.ubuntu.com/ubuntu/dists/xenial-updates/restricted/binary-amd64/
 
 [ubuntu-1604-amd64-uyuni-client]
 label    = ubuntu-1604-amd64-uyuni-client
@@ -1787,6 +1967,95 @@ checksum = sha256
 base_channels = ubuntu-18.04-pool-amd64
 repo_url = http://archive.ubuntu.com/ubuntu/dists/bionic-security/universe/binary-amd64/
 
+[ubuntu-1804-amd64-main-backports]
+label     = ubuntu-1804-amd64-main-backports
+name      = Ubuntu 18.04 LTS AMD64 Main Backports
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-18.04-pool-amd64
+repo_url = http://archive.ubuntu.com/ubuntu/dists/xenial-backports/main/binary-amd64/
+
+[ubuntu-1804-amd64-multiverse-backports]
+label     = ubuntu-1804-amd64-multiverse-backports
+name      = Ubuntu 18.04 LTS AMD64 Multiverse Backports
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-18.04-pool-amd64
+repo_url = http://archive.ubuntu.com/ubuntu/dists/xenial-backports/multiverse/binary-amd64/
+
+[ubuntu-1804-amd64-restricted-backports]
+label     = ubuntu-1804-amd64-restricted-backports
+name      = Ubuntu 18.04 LTS AMD64 Restricted Backports
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-18.04-pool-amd64
+repo_url = http://archive.ubuntu.com/ubuntu/dists/xenial-backports/restricted/binary-amd64/
+
+[ubuntu-1804-amd64-universe-backports]
+label     = ubuntu-1804-amd64-universe-backports
+name      = Ubuntu 18.04 LTS AMD64 Universe Backports
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-18.04-pool-amd64
+repo_url = http://archive.ubuntu.com/ubuntu/dists/xenial-backports/universe/binary-amd64/
+
+[ubuntu-1804-amd64-multiverse]
+label    = ubuntu-1804-amd64-multiverse
+name     = Ubuntu 18.04 LTS AMD64 Multiverse
+archs    = amd64-deb
+repo_type = deb
+checksum = sha256
+base_channels = ubuntu-18.04-pool-amd64
+repo_url = http://archive.ubuntu.com/ubuntu/dists/xenial/multiverse/binary-amd64/
+
+[ubuntu-1804-amd64-restricted]
+label     = ubuntu-1804-amd64-restricted
+name      = Ubuntu 18.04 LTS AMD64 Restricted
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-18.04-pool-amd64
+repo_url  = http://archive.ubuntu.com/ubuntu/dists/xenial/restricted/binary-amd64/
+
+[ubuntu-1804-amd64-multiverse-security]
+label     = ubuntu-1804-amd64-multiverse-security
+name      = Ubuntu 18.04 LTS AMD64 Multiverse Security
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-18.04-pool-amd64
+repo_url  = http://security.ubuntu.com/ubuntu/dists/xenial-security/multiverse/binary-amd64/
+
+[ubuntu-1804-amd64-restricted-security]
+label     = ubuntu-1804-amd64-restricted-security
+name      = Ubuntu 18.04 LTS AMD64 Restricted Security
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-18.04-pool-amd64
+repo_url  = http://security.ubuntu.com/ubuntu/dists/xenial-security/restricted/binary-amd64/
+
+[ubuntu-1804-amd64-multiverse-updates]
+label     = ubuntu-1804-amd64-multiverse-updates
+name      = Ubuntu 18.04 LTS AMD64 Multiverse Updates
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-18.04-pool-amd64
+repo_url  = http://archive.ubuntu.com/ubuntu/dists/xenial-updates/multiverse/binary-amd64/
+
+[ubuntu-1804-amd64-restricted-updates]
+label     = ubuntu-1804-amd64-restricted-updates
+name      = Ubuntu 18.04 LTS AMD64 Restricted Updates
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-18.04-pool-amd64
+repo_url  = http://archive.ubuntu.com/ubuntu/dists/xenial-updates/restricted/binary-amd64/
 
 [ubuntu-1804-pool-amd64-uyuni]
 label    = ubuntu-18.04-pool-amd64-uyuni
@@ -1852,6 +2121,96 @@ repo_type = deb
 checksum = sha256
 base_channels = ubuntu-18.04-pool-amd64-uyuni
 repo_url = http://archive.ubuntu.com/ubuntu/dists/bionic-security/universe/binary-amd64/
+
+[ubuntu-1804-amd64-main-backports-uyuni]
+label     = ubuntu-1804-amd64-main-backports-uyuni
+name      = Ubuntu 18.04 LTS AMD64 Main Backports for Uyuni
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-18.04-pool-amd64-uyuni
+repo_url = http://archive.ubuntu.com/ubuntu/dists/xenial-backports/main/binary-amd64/
+
+[ubuntu-1804-amd64-multiverse-backports-uyuni]
+label     = ubuntu-1804-amd64-multiverse-backports-uyuni
+name      = Ubuntu 18.04 LTS AMD64 Multiverse Backports for Uyuni
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-18.04-pool-amd64-uyuni
+repo_url = http://archive.ubuntu.com/ubuntu/dists/xenial-backports/multiverse/binary-amd64/
+
+[ubuntu-1804-amd64-restricted-backports-uyuni]
+label     = ubuntu-1804-amd64-restricted-backports-uyuni
+name      = Ubuntu 18.04 LTS AMD64 Restricted Backports for Uyuni
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-18.04-pool-amd64-uyuni
+repo_url = http://archive.ubuntu.com/ubuntu/dists/xenial-backports/restricted/binary-amd64/
+
+[ubuntu-1804-amd64-universe-backports-uyuni]
+label     = ubuntu-1804-amd64-universe-backports-uyuni
+name      = Ubuntu 18.04 LTS AMD64 Universe Backports for Uyuni
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-18.04-pool-amd64-uyuni
+repo_url = http://archive.ubuntu.com/ubuntu/dists/xenial-backports/universe/binary-amd64/
+
+[ubuntu-1804-amd64-multiverse-uyuni]
+label    = ubuntu-1804-amd64-multiverse-uyuni
+name     = Ubuntu 18.04 LTS AMD64 Multiverse for Uyuni
+archs    = amd64-deb
+repo_type = deb
+checksum = sha256
+base_channels = ubuntu-18.04-pool-amd64-uyuni
+repo_url = http://archive.ubuntu.com/ubuntu/dists/xenial/multiverse/binary-amd64/
+
+[ubuntu-1804-amd64-restricted-uyuni]
+label     = ubuntu-1804-amd64-restricted-uyuni
+name      = Ubuntu 18.04 LTS AMD64 Restricted for Uyuni
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-18.04-pool-amd64-uyuni
+repo_url  = http://archive.ubuntu.com/ubuntu/dists/xenial/restricted/binary-amd64/
+
+[ubuntu-1804-amd64-multiverse-security-uyuni]
+label     = ubuntu-1804-amd64-multiverse-security-uyuni
+name      = Ubuntu 18.04 LTS AMD64 Multiverse Security for Uyuni
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-18.04-pool-amd64-uyuni
+repo_url  = http://security.ubuntu.com/ubuntu/dists/xenial-security/multiverse/binary-amd64/
+
+[ubuntu-1804-amd64-restricted-security-uyuni]
+label     = ubuntu-1804-amd64-restricted-security-uyuni
+name      = Ubuntu 18.04 LTS AMD64 Restricted Security for Uyuni
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-18.04-pool-amd64-uyuni
+repo_url  = http://security.ubuntu.com/ubuntu/dists/xenial-security/restricted/binary-amd64/
+
+[ubuntu-1804-amd64-multiverse-updates-uyuni]
+label     = ubuntu-1804-amd64-multiverse-updates-uyuni
+name      = Ubuntu 18.04 LTS AMD64 Multiverse Updates for Uyuni
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-18.04-pool-amd64-uyuni
+repo_url  = http://archive.ubuntu.com/ubuntu/dists/xenial-updates/multiverse/binary-amd64/
+
+[ubuntu-1804-amd64-restricted-updates-uyuni]
+label     = ubuntu-1804-amd64-restricted-updates-uyuni
+name      = Ubuntu 18.04 LTS AMD64 Restricted Updates for Uyuni
+archs     = amd64-deb
+repo_type = deb
+checksum  = sha256
+base_channels = ubuntu-18.04-pool-amd64-uyuni
+repo_url  = http://archive.ubuntu.com/ubuntu/dists/xenial-updates/restricted/binary-amd64/
 
 [ubuntu-1804-amd64-uyuni-client]
 label    = ubuntu-1804-amd64-uyuni-client

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -2,7 +2,7 @@
 - Add Amazon Linux 2 repositories
 - Add Alibaba Cloud Linux 2 repositories
 - Add current UEK repos to Oracle Linux
-- Add multiverse, restricted and backports to Ubuntu 20.04
+- Add multiverse, restricted and backports to Ubuntu 16.04, 18.04 and 20.04
 - Add the Universe Security repositories for Ubuntu
 - Complete the fix arch handling in spacewalk-common-channels
 


### PR DESCRIPTION
## What does this PR change?

Add multiverse, restricted and backports to Ubuntu 16.04 and 18.04

For both SUSE Manager and Uyuni

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: We don't have such channels as part of the doc

- [x] **DONE**

## Test coverage
- I checked manually that the URLs exist.

- [x] **DONE**

## Links

None

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
