### PR TITLE
QA: Assure that we don't have cookies in some scenarios

### DIFF
--- a/testsuite/features/secondary/srv_mainpage.feature
+++ b/testsuite/features/secondary/srv_mainpage.feature
@@ -4,6 +4,9 @@
 @scope_visualization
 Feature: Main landing page options and preferences
 
+  Background: Clear browser cookies
+    When I clear browser cookies
+
   Scenario: Access the Login page
     Given I am not authorized
     When I go to the home page

--- a/testsuite/features/secondary/srv_security.feature
+++ b/testsuite/features/secondary/srv_security.feature
@@ -7,6 +7,9 @@ Feature: Basic web security measures and recommendations
   As an authorized user
   I want to avoid session and other attacks
 
+  Background:
+    When I clear browser cookies
+
   Scenario: Caching should be enabled for static content
     Given I retrieve any static resource
     Then the response header "ETag" should not be present

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -1050,3 +1050,7 @@ end
 When(/^I enter the server hostname as the redfish server address$/) do
   step %(I enter "#{$server.full_hostname}:8443" as "powerAddress")
 end
+
+When(/^I clear browser cookies$/) do
+  page.driver.browser.manage.delete_all_cookies
+end


### PR DESCRIPTION
## What does this PR change?

This PR enforces the correct behavior of two features, which requires that we don't have old cookies stored in the browser.
These cookies, in case of no using a new web session, will cause a failed test, as they will keep the previous logged used authenticated.

Dependency of #3533 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Ports:
- Manager-4.0
- Manager-4.1

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
