### PR TITLE
Update libraries and resolve from Leap 15.3

### DIFF
--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -98,12 +98,12 @@
         <!-- <dependency org="suse" name="commons-lang" rev="2.6" /> -->
 
         <!-- Tomcat jars -->
-        <dependency org="suse" name="jasper" rev="9.0.35" />
-        <dependency org="suse" name="jasper-el" rev="9.0.35" />
-        <dependency org="suse" name="tomcat-el-3.0-api" rev="9.0.35" />
-        <dependency org="suse" name="tomcat-jsp-2.3-api" rev="9.0.35" />
-        <dependency org="suse" name="tomcat-juli" rev="9.0.35" />
-        <dependency org="suse" name="tomcat-servlet-4.0-api" rev="9.0.35" />
+        <dependency org="suse" name="jasper" rev="9.0.36" />
+        <dependency org="suse" name="jasper-el" rev="9.0.36" />
+        <dependency org="suse" name="tomcat-el-3.0-api" rev="9.0.36" />
+        <dependency org="suse" name="tomcat-jsp-2.3-api" rev="9.0.36" />
+        <dependency org="suse" name="tomcat-juli" rev="9.0.36" />
+        <dependency org="suse" name="tomcat-servlet-4.0-api" rev="9.0.36" />
 
         <!-- Compilation and testing -->
         <dependency org="checkstyle" name="checkstyle" rev="8.30" transitive="false">

--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -75,7 +75,7 @@
         <dependency org="suse" name="sitemesh" rev="2.1" />
         <dependency org="suse" name="slf4j-api" rev="1.7.30" />
         <dependency org="suse" name="slf4j-log4j12" rev="1.7.30" />
-        <dependency org="suse" name="snakeyaml" rev="1.10" />
+        <dependency org="suse" name="snakeyaml" rev="1.25" />
         <dependency org="suse" name="spark-core" rev="2.7.2" />
         <dependency org="suse" name="spark-template-jade" rev="2.3" />
         <dependency org="suse" name="spy" rev="0.8.3" />

--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -61,7 +61,7 @@
         <dependency org="suse" name="netty-transport-native-unix-common" rev="4.1.44.Final" />
         <dependency org="suse" name="oro" rev="2.0.8" />
         <dependency org="suse" name="pgjdbc-ng" rev="0.8.3" />
-        <dependency org="suse" name="postgresql-jdbc" rev="42.2.10" />
+        <dependency org="suse" name="postgresql-jdbc" rev="42.2.16" />
         <dependency org="suse" name="quartz" rev="2.3.0" />
         <dependency org="suse" name="redstone-xmlrpc" rev="1.1_20071120" />
         <dependency org="suse" name="redstone-xmlrpc-client" rev="1.1_20071120" />

--- a/java/buildconf/ivy/obs-maven-config.yaml
+++ b/java/buildconf/ivy/obs-maven-config.yaml
@@ -172,7 +172,7 @@ artifacts:
   - artifact: pgjdbc-ng
     repository: Uyuni_Other
   - artifact: postgresql-jdbc
-    repository: Uyuni_Other
+    repository: Leap
   - artifact: quartz
     repository: Uyuni_Other
   - artifact: redstone-xmlrpc

--- a/java/buildconf/ivy/obs-maven-config.yaml
+++ b/java/buildconf/ivy/obs-maven-config.yaml
@@ -4,10 +4,10 @@ repositories:
     repository: standard
   Uyuni_Other:
     project: systemsmanagement:Uyuni:Master:Other
-    repository: openSUSE_Leap_15.2
+    repository: openSUSE_Leap_15.3
   Uyuni:
     project: systemsmanagement:Uyuni:Master
-    repository: openSUSE_Leap_15.2
+    repository: openSUSE_Leap_15.3
 artifacts:
   - artifact: asm
     package: asm3

--- a/java/buildconf/ivy/obs-maven-config.yaml
+++ b/java/buildconf/ivy/obs-maven-config.yaml
@@ -212,7 +212,7 @@ artifacts:
     jar: log4j12
     repository: Leap
   - artifact: snakeyaml
-    repository: Uyuni_Other
+    repository: Leap
   - artifact: spark-core
     repository: Uyuni_Other
   - artifact: spark-template-jade

--- a/java/buildconf/ivy/obs-maven-config.yaml
+++ b/java/buildconf/ivy/obs-maven-config.yaml
@@ -1,6 +1,6 @@
 repositories:
   Leap:
-    project: openSUSE:Leap:15.2
+    project: openSUSE:Leap:15.3
     repository: standard
   Uyuni_Other:
     project: systemsmanagement:Uyuni:Master:Other

--- a/java/buildconf/ivy/obs-maven-config.yaml
+++ b/java/buildconf/ivy/obs-maven-config.yaml
@@ -131,13 +131,13 @@ artifacts:
   - artifact: javassist
     repository: Uyuni_Other
   - artifact: jboss-logging
-    repository: Uyuni_Other
+    repository: Leap
   - artifact: jcommon
     repository: Uyuni_Other
   - artifact: jdom
     repository: Leap
   - artifact: joda-time
-    repository: Uyuni_Other
+    repository: Leap
   - artifact: jose4j
     repository: Uyuni_Other
   - artifact: log4j

--- a/java/code/src/com/redhat/rhn/common/finder/test/JarFinderTest.java
+++ b/java/code/src/com/redhat/rhn/common/finder/test/JarFinderTest.java
@@ -28,12 +28,12 @@ public class JarFinderTest extends TestCase {
     // Sigh.
     // At least make it clear what we're looking for...
 
-    // Currently used jarfile: postgresql-jdbc-42.2.10.jar
+    // Currently used jarfile: postgresql-jdbc-42.2.16.jar
     // (previously redstone.xmlrpc could find either redstone-xmlrpc.jar or
     //  redstone-xmlrpc-client.jar, making test-results indeterminate)
     private static final String TESTJAR = "org.postgresql";
-    private static final int NUM_CLASSES_IN_TESTJAR = 343;
-    private static final int NUM_SUBDIRS_IN_TESTJAR = 343;
+    private static final int NUM_CLASSES_IN_TESTJAR = 375;
+    private static final int NUM_SUBDIRS_IN_TESTJAR = 375;
 
     public void testGetFinder() throws Exception {
         Finder f = FinderFactory.getFinder(TESTJAR);

--- a/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
@@ -2229,19 +2229,15 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         assertEquals("\n" +
                 "---\n" +
                 "retcode: 255.0\n" +
-                "stderr: 'F0528 17:04:20.778517   11913 join.go:63] error joining node dev-min-caasp-worker-2.lan: failed to apply state kubernetes.install-node-pattern:\n" +
-                "    failed to initialize client: dial unix /tmp/ssh-xthMe9M9b7/agent.12424: connect: no such file or directory\n" +
-                "\n" +
-                "    '\n" +
+                "stderr: |\n" +
+                "    F0528 17:04:20.778517   11913 join.go:63] error joining node dev-min-caasp-worker-2.lan: failed to apply state kubernetes.install-node-pattern: failed to initialize client: dial unix /tmp/ssh-xthMe9M9b7/agent.12424: connect: no such file or directory\n" +
                 "stdout: ''\n" +
                 "success: false\n" +
                 "\n" +
                 "---\n" +
                 "retcode: 255.0\n" +
-                "stderr: 'F0528 17:04:20.778517   11913 join.go:63] error joining node dev-min-caasp-worker-3.lan: failed to apply state kubernetes.install-node-pattern:\n" +
-                "    failed to initialize client: dial unix /tmp/ssh-xthMe9M9b7/agent.12424: connect: no such file or directory\n" +
-                "\n" +
-                "    '\n" +
+                "stderr: |\n" +
+                "    F0528 17:04:20.778517   11913 join.go:63] error joining node dev-min-caasp-worker-3.lan: failed to apply state kubernetes.install-node-pattern: failed to initialize client: dial unix /tmp/ssh-xthMe9M9b7/agent.12424: connect: no such file or directory\n" +
                 "stdout: ''\n" +
                 "success: false\n", serverAction.getResultMsg());
     }
@@ -2298,11 +2294,9 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 "    \\ → /usr/lib/systemd/system/crio.service.\\nE0518 17:50:24.071198   13844 ssh.go:195] Created symlink /etc/systemd/system/multi-user.target.wants/kubelet.service\\\n" +
                 "    \\ → /usr/lib/systemd/system/kubelet.service.\\nE0518 17:50:46.509489   13844 ssh.go:195] Created symlink /etc/systemd/system/timers.target.wants/skuba-update.timer\\\n" +
                 "    \\ → /usr/lib/systemd/system/skuba-update.timer.\\n\"\n" +
-                "stdout: '[join] applying states to new node\n" +
-                "\n" +
+                "stdout: |\n" +
+                "    [join] applying states to new node\n" +
                 "    [join] node successfully joined the cluster\n" +
-                "\n" +
-                "    '\n" +
                 "success: true\n" +
                 "\n" +
                 "---\n" +
@@ -2317,11 +2311,9 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 "    \\ → /usr/lib/systemd/system/crio.service.\\nE0518 17:50:24.071198   13844 ssh.go:195] Created symlink /etc/systemd/system/multi-user.target.wants/kubelet.service\\\n" +
                 "    \\ → /usr/lib/systemd/system/kubelet.service.\\nE0518 17:50:46.509489   13844 ssh.go:195] Created symlink /etc/systemd/system/timers.target.wants/skuba-update.timer\\\n" +
                 "    \\ → /usr/lib/systemd/system/skuba-update.timer.\\n\"\n" +
-                "stdout: '[join] applying states to new node\n" +
-                "\n" +
+                "stdout: |\n" +
+                "    [join] applying states to new node\n" +
                 "    [join] node successfully joined the cluster\n" +
-                "\n" +
-                "    '\n" +
                 "success: true\n", serverAction.getResultMsg());
     }
 
@@ -2368,10 +2360,8 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         assertEquals("\n" +
                 "---\n" +
                 "retcode: 255.0\n" +
-                "stderr: 'F0528 17:04:20.778517   11913 join.go:63] error removing node dev-min-caasp-worker-2.lan: failed to apply state kubernetes.install-node-pattern:\n" +
-                "    failed to initialize client: dial unix /tmp/ssh-xthMe9M9b7/agent.12424: connect: no such file or directory\n" +
-                "\n" +
-                "    '\n" +
+                "stderr: |\n" +
+                "    F0528 17:04:20.778517   11913 join.go:63] error removing node dev-min-caasp-worker-2.lan: failed to apply state kubernetes.install-node-pattern: failed to initialize client: dial unix /tmp/ssh-xthMe9M9b7/agent.12424: connect: no such file or directory\n" +
                 "stdout: ''\n" +
                 "success: false\n", serverAction.getResultMsg());
     }
@@ -2419,14 +2409,10 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 "---\n" +
                 "retcode: 0.0\n" +
                 "stderr: ''\n" +
-                "stdout: '[remove-node] removing worker node dev-min-caasp-worker-1.lan (drain timeout: 0s)\n" +
-                "\n" +
-                "    [remove-node] failed disarming kubelet: failed waiting for job caasp-kubelet-disarm-e009966a26df3d53840afc6318dc0d3c12f46858; node could be down, continuing\n" +
-                "    with node removal...\n" +
-                "\n" +
+                "stdout: |\n" +
+                "    [remove-node] removing worker node dev-min-caasp-worker-1.lan (drain timeout: 0s)\n" +
+                "    [remove-node] failed disarming kubelet: failed waiting for job caasp-kubelet-disarm-e009966a26df3d53840afc6318dc0d3c12f46858; node could be down, continuing with node removal...\n" +
                 "    [remove-node] node dev-min-caasp-worker-1.lan successfully removed from the cluster\n" +
-                "\n" +
-                "    '\n" +
                 "success: true\n", serverAction.getResultMsg());
     }
 
@@ -2473,14 +2459,11 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 "---\n" +
                 "retcode: 0.0\n" +
                 "stderr: ''\n" +
-                "stdout: 'Current Kubernetes cluster version: 1.16.2\n" +
-                "\n" +
+                "stdout: |\n" +
+                "    Current Kubernetes cluster version: 1.16.2\n" +
                 "    Latest Kubernetes version: 1.16.2\n" +
                 "\n" +
-                "\n" +
                 "    Congratulations! You are already at the latest version available\n" +
-                "\n" +
-                "    '\n" +
                 "success: true\n", serverAction.getResultMsg());
     }
 
@@ -2529,48 +2512,39 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 "stage0_upgrade_addons:\n" +
                 "    retcode: 0.0\n" +
                 "    stderr: ''\n" +
-                "    stdout: 'Current Kubernetes cluster version: 1.16.2\n" +
-                "\n" +
+                "    stdout: |\n" +
+                "        Current Kubernetes cluster version: 1.16.2\n" +
                 "        Latest Kubernetes version: 1.16.2\n" +
                 "\n" +
-                "\n" +
                 "        [apply] Congratulations! Addons for 1.16.2 are already at the latest version available\n" +
-                "\n" +
-                "        '\n" +
                 "    success: true\n" +
                 "stage1_upgrade_nodes:\n" +
                 "    dev-min-caasp-master.lan:\n" +
                 "        retcode: 1.0\n" +
                 "        stderr: ''\n" +
-                "        stdout: 'Unable to apply node upgrade: failed to initialize client: SSH_AUTH_SOCK is undefined. Make sure ssh-agent is running\n" +
-                "\n" +
-                "            '\n" +
+                "        stdout: |\n" +
+                "            Unable to apply node upgrade: failed to initialize client: SSH_AUTH_SOCK is undefined. Make sure ssh-agent is running\n" +
                 "        success: false\n" +
                 "    dev-min-caasp-worker-1.lan:\n" +
                 "        retcode: 1.0\n" +
                 "        stderr: ''\n" +
-                "        stdout: 'Unable to apply node upgrade: failed to initialize client: SSH_AUTH_SOCK is undefined. Make sure ssh-agent is running\n" +
-                "\n" +
-                "            '\n" +
+                "        stdout: |\n" +
+                "            Unable to apply node upgrade: failed to initialize client: SSH_AUTH_SOCK is undefined. Make sure ssh-agent is running\n" +
                 "        success: false\n" +
                 "    dev-min-caasp-worker-2.lan:\n" +
                 "        retcode: 1.0\n" +
                 "        stderr: ''\n" +
-                "        stdout: 'Unable to apply node upgrade: failed to initialize client: SSH_AUTH_SOCK is undefined. Make sure ssh-agent is running\n" +
-                "\n" +
-                "            '\n" +
+                "        stdout: |\n" +
+                "            Unable to apply node upgrade: failed to initialize client: SSH_AUTH_SOCK is undefined. Make sure ssh-agent is running\n" +
                 "        success: false\n" +
                 "stage2_upgrade_addons:\n" +
                 "    retcode: 0.0\n" +
                 "    stderr: ''\n" +
-                "    stdout: 'Current Kubernetes cluster version: 1.16.2\n" +
-                "\n" +
+                "    stdout: |\n" +
+                "        Current Kubernetes cluster version: 1.16.2\n" +
                 "        Latest Kubernetes version: 1.16.2\n" +
                 "\n" +
-                "\n" +
                 "        [apply] Congratulations! Addons for 1.16.2 are already at the latest version available\n" +
-                "\n" +
-                "        '\n" +
                 "    success: true\n" +
                 "success: false\n", serverAction.getResultMsg());
     }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Fix package building on openSUSE Leap 15.3
+
 -------------------------------------------------------------------
 Mon May 24 12:37:31 CEST 2021 - jgonzalez@suse.com
 

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -634,10 +634,8 @@ rm -rf $RPM_BUILD_ROOT/classes/com/redhat/rhn/common/conf/test/conf
 rm -rf $RPM_BUILD_ROOT%{_datadir}/rhn/unittest.xml
 %endif
 
-# Prettifying symlinks, excluding openSUSE
-%if ! 0%{?is_opensuse}
+# Prettifying symlinks
 mv $RPM_BUILD_ROOT%{jardir}/jboss-loggingjboss-logging.jar $RPM_BUILD_ROOT%{jardir}/jboss-logging.jar
-%endif
 
 # Prettifying symlinks for RHEL
 %if 0%{?rhel}


### PR DESCRIPTION
## What does this PR change?

We are trying to use as many libraries as possible from Leap repositories, only where we actually need a newer version than the one available from Leap or if the package is not available at all we would take it from Uyuni repos. With Leap 15.3 some libraries have been updated and this patch should update them for development environments and CI.

## GUI diff

No difference.

- [X] **DONE**

## Documentation

- No documentation needed, affects only development environments.

- [X] **DONE**

## Test coverage

- No tests needed, only affects development environments.

- [X] **DONE**

## Links

Fixes downstream issue: https://github.com/SUSE/spacewalk/issues/12357

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below).

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"     
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
