### PR TITLE
Add openSUSE Tumbleweed/MicroOS

### DIFF
--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -1095,6 +1095,32 @@ gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/openSUSE_Leap_15-Uyuni-Client-Tools/openSUSE_Leap_15.0/
 
+[opensuse_tumbleweed]
+checksum = sha256
+archs    = x86_64, aarch64
+name     = openSUSE Leap Tumbleweed (%(arch)s)
+gpgkey_url = http://download.opensuse.org/tumbleweed/repo/oss/repodata/repomd.xml.key
+gpgkey_id = 3DBDC284
+gpgkey_fingerprint = 22C0 7BA5 3417 8CD0 2EFE  22AA B88B 2FD4 3DBD C284
+repo_url = http://download.opensuse.org/tumbleweed/repo/oss/
+dist_map_release = Tumbleweed
+
+[opensuse_tumbleweed-non-oss]
+label    = %(base_channel)s-non-oss
+name     = openSUSE Tumbleweed non oss (%(arch)s)
+archs    = x86_64, aarch64
+checksum = sha256
+base_channels = opensuse_tumbleweed-%(arch)s
+repo_url = http://download.opensuse.org/tumbleweed/repo/non-oss/
+
+[opensuse_tumbleweed-updates]
+label    = %(base_channel)s-updates
+name     = openSUSE Leap Tumbleweed Updates (%(arch)s)
+archs    = x86_64, aarch64
+checksum = sha256
+base_channels = opensuse_tumbleweed-%(arch)s
+repo_url = https://download.opensuse.org/update/tumbleweed/
+
 [sles12-sp3-uyuni-client]
 name     = Uyuni Client Tools for SLES12 SP3 %(arch)s
 archs    =  x86_64, s390x, aarch64, ppc64le

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,5 @@
+- Add openSUSE Tumbleweed/microOS
+
 -------------------------------------------------------------------
 Mon Apr 19 16:54:14 CEST 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Add openSUSE Tumbleweed/MicroOS

#### openSUSE Tumbleweed

I didn't test openSUSE Tumbleweed, but should hopefully "just" work, even without client tools, as salt-minion is available.

#### openSUSE MicroOS

What works:
- Onboarding from WebUI
- Listing packages
- Installing packages (requires rebooting)
- Removing packages (requires rebooting)
- Remote  commands (from the system details > Remote Command, but NOT from Salt > Remote Commands, where [stays in `Pending` forever and at the logs](https://github.com/SUSE/spacewalk/issues/14574) I can only see that the user admin sent the command)
- Rebooting

What does not work:
- [Applying highstates](https://github.com/SUSE/spacewalk/issues/14573). IT doesn't fail, but I see (I enabled a formula and changed the values for the time zone)
  ```
  ----------
          ID: mgr_do_nothing
    Function: test.nop
        Name: mgr_do_nothing
      Result: true
     Comment: Success!
     Started: 11:17:23.427925
    Duration: 0.78
         SLS: util.noop
     Changed: {}
  ```
- [Removing packages using action chains](https://github.com/SUSE/spacewalk/issues/14572), as for some reason salt insists on using zypper (despite it didn't use it for installing/removing WITHOUT action chains)
  ```
  {
    "file_|-mgrchannels_repo_|-/etc/zypp/repos.d/susemanager:channels.repo_|-managed": {
      "changes": {},
      "comment": "File /etc/zypp/repos.d/susemanager:channels.repo is in the correct state",
      "name": "/etc/zypp/repos.d/susemanager:channels.repo",
      "result": true,
      "__sls__": "channels",
      "__run_num__": 0.0,
      "start_time": "11:51:44.518283",
      "duration": 77.188,
      "__id__": "mgrchannels_repo"
    },
    "pkg_|-pkg_removed_|-pkg_removed_|-removed": {
      "name": "pkg_removed",
      "result": false,
      "changes": {},
      "comment": "An error was encountered while removing package(s): Zypper command failure: Running scope as unit: run-  r016c2353126e4939817c55e02db555ca.scope\nThis is a transactional-server, please use transactional-update to update or   modify the system.",
      "__sls__": "packages.pkgremove",
      "__run_num__": 1.0,
      "start_time": "11:51:46.612513",
      "duration": 70.613,
      "__id__": "pkg_removed"
    }
  }
  ```
- [Installing packages with action chains](https://github.com/SUSE/spacewalk/issues/14572), as for some reason salt insists on using zypper (despite it didn't use it for installing/removing WITHOUT action chains)
  ```
  {
    "file_|-mgrchannels_repo_|-/etc/zypp/repos.d/susemanager:channels.repo_|-managed": {
      "changes": {},
      "comment": "File /etc/zypp/repos.d/susemanager:channels.repo is in the correct state",
      "name": "/etc/zypp/repos.d/susemanager:channels.repo",
      "result": true,
      "__sls__": "channels",
      "__run_num__": 0.0,
      "start_time": "12:50:54.425330",
      "duration": 57.652,
      "__id__": "mgrchannels_repo"
    },
    "pkg_|-pkg_installed_|-pkg_installed_|-installed": {
      "name": "pkg_installed",
      "result": false,
      "changes": {},
      "comment": "An error was encountered while installing package(s): Zypper command failure: Running scope as unit: run-  r5df92aabc3294d978213cbbf406f591c.scope\nThis is a transactional-server, please use transactional-update to update or modify the system.",
      "__sls__": "packages.pkginstall",
      "__run_num__": 1.0,
      "start_time": "12:50:55.463477",
      "duration": 13903.721,
      "__id__": "pkg_installed"
    }
  ```

Annoying stuff:
- [salt-minion has a conflict with busybox-hostname](https://bugzilla.opensuse.org/show_bug.cgi?id=1184753)
- `/var/log/salt/minion` has the following [added to the log each second](https://github.com/SUSE/spacewalk/issues/14575):
  ```
  2021-04-14 12:44:10,063 [salt.beacons     :140 ][WARNING ][1150] Unable to process beacon pkgset
  ```

## GUI diff

No difference.
- [x] **DONE**

## Documentation
- Documentation PR: https://github.com/uyuni-project/uyuni-docs/pull/900

- [x] **DONE**

## Test coverage
- No tests: Manual. See above.

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/14551

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
