### PR TITLE
Fix insecure JXM configuration

### DIFF
--- a/java/code/src/com/suse/manager/webui/services/impl/test/monitoring/disable.json
+++ b/java/code/src/com/suse/manager/webui/services/impl/test/monitoring/disable.json
@@ -26,6 +26,22 @@
             "duration": 286.435,
             "__id__": "postgres_exporter_service"
         },
+        "cmd_|-remove_tomcat_jmx_host_|-sed -ri 's/JAVA_OPTS=\"(.*)-Dcom\\.sun\\.management\\.jmxremote\\.host=localhost(.*)\"/JAVA_OPTS=\"\\1 \\2\"/' /etc/sysconfig/tomcat_|-run": {
+            "name": "sed -ri 's/JAVA_OPTS=\"(.*)-Dcom\\.sun\\.management\\.jmxremote\\.host=localhost(.*)\"/JAVA_OPTS=\"\\1 \\2\"/' /etc/sysconfig/tomcat",
+            "changes": {
+                "pid": 6335,
+                "retcode": 0,
+                "stdout": "",
+                "stderr": ""
+            },
+            "result": true,
+            "comment": "Command \"sed -ri 's/JAVA_OPTS=\"(.*)-Dcom\\.sun\\.management\\.jmxremote\\.host=localhost(.*)\"/JAVA_OPTS=\"\\1 \\2\"/' /etc/sysconfig/tomcat\" run",
+            "__sls__": "srvmonitoring.disable",
+            "__run_num__": 2,
+            "start_time": "16:06:06.461899",
+            "duration": 13.875,
+            "__id__": "remove_tomcat_jmx_host"
+        },
         "cmd_|-remove_tomcat_jmx_port_|-sed -ri 's/JAVA_OPTS=\"(.*)-Dcom\\.sun\\.management\\.jmxremote\\.port=[0-9]*(.*)\"/JAVA_OPTS=\"\\1 \\2\"/' /etc/sysconfig/tomcat_|-run": {
             "name": "sed -ri 's/JAVA_OPTS=\"(.*)-Dcom\\.sun\\.management\\.jmxremote\\.port=[0-9]*(.*)\"/JAVA_OPTS=\"\\1 \\2\"/' /etc/sysconfig/tomcat",
             "changes": {
@@ -90,8 +106,8 @@
             "duration": 13.157,
             "__id__": "remove_tomcat_jmx_hostname"
         },
-        "cmd_|-jmx_tomcat_config_|-grep -q -v -- '-Dcom.sun.management.jmxremote.port=3333' /etc/sysconfig/tomcat && grep -q -v -- '-Dcom.sun.management.jmxremote.ssl=false' /etc/sysconfig/tomcat && grep -q -v -- '-Dcom.sun.management.jmxremote.authenticate=false' /etc/sysconfig/tomcat && grep -q -v -- '-Djava.rmi.server.hostname=' /etc/sysconfig/tomcat_|-run": {
-            "name": "grep -q -v -- '-Dcom.sun.management.jmxremote.port=3333' /etc/sysconfig/tomcat && grep -q -v -- '-Dcom.sun.management.jmxremote.ssl=false' /etc/sysconfig/tomcat && grep -q -v -- '-Dcom.sun.management.jmxremote.authenticate=false' /etc/sysconfig/tomcat && grep -q -v -- '-Djava.rmi.server.hostname=' /etc/sysconfig/tomcat",
+        "cmd_|-jmx_tomcat_config_|-grep -q -v -- '-Dcom.sun.management.jmxremote.host=localhost' /etc/sysconfig/tomcat && grep -q -v -- '-Dcom.sun.management.jmxremote.port=3333' /etc/sysconfig/tomcat && grep -q -v -- '-Dcom.sun.management.jmxremote.ssl=false' /etc/sysconfig/tomcat && grep -q -v -- '-Dcom.sun.management.jmxremote.authenticate=false' /etc/sysconfig/tomcat && grep -q -v -- '-Djava.rmi.server.hostname=' /etc/sysconfig/tomcat_|-run": {
+            "name": "grep -q -v -- '-Dcom.sun.management.jmxremote.host=localhost' /etc/sysconfig/tomcat && grep -q -v -- '-Dcom.sun.management.jmxremote.port=3333' /etc/sysconfig/tomcat && grep -q -v -- '-Dcom.sun.management.jmxremote.ssl=false' /etc/sysconfig/tomcat && grep -q -v -- '-Dcom.sun.management.jmxremote.authenticate=false' /etc/sysconfig/tomcat && grep -q -v -- '-Djava.rmi.server.hostname=' /etc/sysconfig/tomcat",
             "changes": {
                 "pid": 6342,
                 "retcode": 0,
@@ -99,7 +115,7 @@
                 "stderr": ""
             },
             "result": true,
-            "comment": "Command \"grep -q -v -- '-Dcom.sun.management.jmxremote.port=3333' /etc/sysconfig/tomcat && grep -q -v -- '-Dcom.sun.management.jmxremote.ssl=false' /etc/sysconfig/tomcat && grep -q -v -- '-Dcom.sun.management.jmxremote.authenticate=false' /etc/sysconfig/tomcat && grep -q -v -- '-Djava.rmi.server.hostname=' /etc/sysconfig/tomcat\" run",
+            "comment": "Command \"grep -q -v -- '-Dcom.sun.management.jmxremote.host=localhost' /etc/sysconfig/tomcat && grep -q -v -- '-Dcom.sun.management.jmxremote.port=3333' /etc/sysconfig/tomcat && grep -q -v -- '-Dcom.sun.management.jmxremote.ssl=false' /etc/sysconfig/tomcat && grep -q -v -- '-Dcom.sun.management.jmxremote.authenticate=false' /etc/sysconfig/tomcat && grep -q -v -- '-Djava.rmi.server.hostname=' /etc/sysconfig/tomcat\" run",
             "__sls__": "srvmonitoring.disable",
             "__run_num__": 6,
             "start_time": "16:06:06.519393",
@@ -118,6 +134,22 @@
             "start_time": "16:06:06.530091",
             "duration": 615.425,
             "__id__": "jmx_exporter_tomcat_service"
+        },
+        "cmd_|-remove_taskomatic_jmx_host_|-sed -ri 's/JAVA_OPTS=\"(.*)-Dcom\\.sun\\.management\\.jmxremote\\.host=localhost(.*)\"/JAVA_OPTS=\"\\1 \\2\"/' /etc/rhn/taskomatic.conf_|-run": {
+            "name": "sed -ri 's/JAVA_OPTS=\"(.*)-Dcom\\.sun\\.management\\.jmxremote\\.host=localhost(.*)\"/JAVA_OPTS=\"\\1 \\2\"/' /etc/rhn/taskomatic.conf",
+            "changes": {
+                "pid": 6372,
+                "retcode": 0,
+                "stdout": "",
+                "stderr": ""
+            },
+            "result": true,
+            "comment": "Command \"sed -ri 's/JAVA_OPTS=\"(.*)-Dcom\\.sun\\.management\\.jmxremote\\.host=localhost(.*)\"/JAVA_OPTS=\"\\1 \\2\"/' /etc/rhn/taskomatic.conf\" run",
+            "__sls__": "srvmonitoring.disable",
+            "__run_num__": 8,
+            "start_time": "16:06:07.145892",
+            "duration": 14.262,
+            "__id__": "remove_taskomatic_jmx_host"
         },
         "cmd_|-remove_taskomatic_jmx_port_|-sed -ri 's/JAVA_OPTS=\"(.*)-Dcom\\.sun\\.management\\.jmxremote\\.port=[0-9]*(.*)\"/JAVA_OPTS=\"\\1 \\2\"/' /etc/rhn/taskomatic.conf_|-run": {
             "name": "sed -ri 's/JAVA_OPTS=\"(.*)-Dcom\\.sun\\.management\\.jmxremote\\.port=[0-9]*(.*)\"/JAVA_OPTS=\"\\1 \\2\"/' /etc/rhn/taskomatic.conf",
@@ -183,8 +215,8 @@
             "duration": 13.131,
             "__id__": "remove_taskomatic_jmx_hostname"
         },
-        "cmd_|-jmx_taskomatic_config_|-grep -q -v -- '-Dcom.sun.management.jmxremote.port=3333' /etc/rhn/taskomatic.conf && grep -q -v -- '-Dcom.sun.management.jmxremote.ssl=false' /etc/rhn/taskomatic.conf && grep -q -v -- '-Dcom.sun.management.jmxremote.authenticate=false' /etc/rhn/taskomatic.conf && grep -q -v -- '-Djava.rmi.server.hostname=' /etc/rhn/taskomatic.conf_|-run": {
-            "name": "grep -q -v -- '-Dcom.sun.management.jmxremote.port=3333' /etc/rhn/taskomatic.conf && grep -q -v -- '-Dcom.sun.management.jmxremote.ssl=false' /etc/rhn/taskomatic.conf && grep -q -v -- '-Dcom.sun.management.jmxremote.authenticate=false' /etc/rhn/taskomatic.conf && grep -q -v -- '-Djava.rmi.server.hostname=' /etc/rhn/taskomatic.conf",
+        "cmd_|-jmx_taskomatic_config_|-grep -q -v -- '-Dcom.sun.management.jmxremote.host=localhost' /etc/rhn/taskomatic.conf && grep -q -v -- '-Dcom.sun.management.jmxremote.port=3333' /etc/rhn/taskomatic.conf && grep -q -v -- '-Dcom.sun.management.jmxremote.ssl=false' /etc/rhn/taskomatic.conf && grep -q -v -- '-Dcom.sun.management.jmxremote.authenticate=false' /etc/rhn/taskomatic.conf && grep -q -v -- '-Djava.rmi.server.hostname=' /etc/rhn/taskomatic.conf_|-run": {
+            "name": "grep -q -v -- '-Dcom.sun.management.jmxremote.host=localhost' /etc/rhn/taskomatic.conf && grep -q -v -- '-Dcom.sun.management.jmxremote.port=3333' /etc/rhn/taskomatic.conf && grep -q -v -- '-Dcom.sun.management.jmxremote.ssl=false' /etc/rhn/taskomatic.conf && grep -q -v -- '-Dcom.sun.management.jmxremote.authenticate=false' /etc/rhn/taskomatic.conf && grep -q -v -- '-Djava.rmi.server.hostname=' /etc/rhn/taskomatic.conf",
             "changes": {
                 "pid": 6379,
                 "retcode": 0,
@@ -192,7 +224,7 @@
                 "stderr": ""
             },
             "result": true,
-            "comment": "Command \"grep -q -v -- '-Dcom.sun.management.jmxremote.port=3333' /etc/rhn/taskomatic.conf && grep -q -v -- '-Dcom.sun.management.jmxremote.ssl=false' /etc/rhn/taskomatic.conf && grep -q -v -- '-Dcom.sun.management.jmxremote.authenticate=false' /etc/rhn/taskomatic.conf && grep -q -v -- '-Djava.rmi.server.hostname=' /etc/rhn/taskomatic.conf\" run",
+            "comment": "Command \"grep -q -v -- '-Dcom.sun.management.jmxremote.host=localhost' /etc/rhn/taskomatic.conf && grep -q -v -- '-Dcom.sun.management.jmxremote.port=3333' /etc/rhn/taskomatic.conf && grep -q -v -- '-Dcom.sun.management.jmxremote.ssl=false' /etc/rhn/taskomatic.conf && grep -q -v -- '-Dcom.sun.management.jmxremote.authenticate=false' /etc/rhn/taskomatic.conf && grep -q -v -- '-Djava.rmi.server.hostname=' /etc/rhn/taskomatic.conf\" run",
             "__sls__": "srvmonitoring.disable",
             "__run_num__": 12,
             "start_time": "16:06:07.202697",

--- a/java/code/src/com/suse/manager/webui/services/impl/test/monitoring/enable.json
+++ b/java/code/src/com/suse/manager/webui/services/impl/test/monitoring/enable.json
@@ -100,6 +100,18 @@
             "duration": 12.73,
             "__id__": "jmx_exporter"
         },
+        "cmd_|-remove_tomcat_jmx_host_|-sed -ri 's/JAVA_OPTS=\"(.*)-Dcom\\.sun\\.management\\.jmxremote\\.host=localhost(.*)\"/JAVA_OPTS=\"\\1 \\2\"/' /etc/sysconfig/tomcat_|-run": {
+            "name": "sed -ri 's/JAVA_OPTS=\"(.*)-Dcom\\.sun\\.management\\.jmxremote\\.host=localhost(.*)\"/JAVA_OPTS=\"\\1 \\2\"/' /etc/sysconfig/tomcat",
+            "changes": {},
+            "result": true,
+            "comment": "onlyif condition is false",
+            "skip_watch": true,
+            "__sls__": "srvmonitoring.enable",
+            "__run_num__": 7,
+            "start_time": "16:14:48.941835",
+            "duration": 7.032,
+            "__id__": "remove_tomcat_jmx_host"
+        },
         "cmd_|-remove_tomcat_jmx_port_|-sed -ri 's/JAVA_OPTS=\"(.*)-Dcom\\.sun\\.management\\.jmxremote\\.port=[0-9]*(.*)\"/JAVA_OPTS=\"\\1 \\2\"/' /etc/sysconfig/tomcat_|-run": {
             "name": "sed -ri 's/JAVA_OPTS=\"(.*)-Dcom\\.sun\\.management\\.jmxremote\\.port=[0-9]*(.*)\"/JAVA_OPTS=\"\\1 \\2\"/' /etc/sysconfig/tomcat",
             "changes": {},
@@ -148,8 +160,8 @@
             "duration": 6.529,
             "__id__": "remove_tomcat_jmx_hostname"
         },
-        "cmd_|-jmx_tomcat_config_|-sed -i 's/JAVA_OPTS=\"\\(.*\\)\"/JAVA_OPTS=\"\\1 -Dcom.sun.management.jmxremote.port=3333 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname=test-srv.tf.local\"/' /etc/sysconfig/tomcat_|-run": {
-            "name": "sed -i 's/JAVA_OPTS=\"\\(.*\\)\"/JAVA_OPTS=\"\\1 -Dcom.sun.management.jmxremote.port=3333 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname=test-srv.tf.local\"/' /etc/sysconfig/tomcat",
+        "cmd_|-jmx_tomcat_config_|-sed -i 's/JAVA_OPTS=\"\\(.*\\)\"/JAVA_OPTS=\"\\1 -Dcom.sun.management.jmxremote.host=localhost -Dcom.sun.management.jmxremote.port=3333 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname=test-srv.tf.local\"/' /etc/sysconfig/tomcat_|-run": {
+            "name": "sed -i 's/JAVA_OPTS=\"\\(.*\\)\"/JAVA_OPTS=\"\\1 -Dcom.sun.management.jmxremote.host=localhost -Dcom.sun.management.jmxremote.port=3333 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname=test-srv.tf.local\"/' /etc/sysconfig/tomcat",
             "changes": {
                 "pid": 6918,
                 "retcode": 0,
@@ -157,7 +169,7 @@
                 "stderr": ""
             },
             "result": true,
-            "comment": "Command \"sed -i 's/JAVA_OPTS=\"\\(.*\\)\"/JAVA_OPTS=\"\\1 -Dcom.sun.management.jmxremote.port=3333 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname=test-srv.tf.local\"/' /etc/sysconfig/tomcat\" run",
+            "comment": "Command \"sed -i 's/JAVA_OPTS=\"\\(.*\\)\"/JAVA_OPTS=\"\\1 -Dcom.sun.management.jmxremote.host=localhost -Dcom.sun.management.jmxremote.port=3333 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname=test-srv.tf.local\"/' /etc/sysconfig/tomcat\" run",
             "__sls__": "srvmonitoring.enable",
             "__run_num__": 11,
             "start_time": "16:14:48.971125",
@@ -188,6 +200,18 @@
             "start_time": "16:14:49.327986",
             "duration": 2.472,
             "__id__": "jmx_exporter_taskomatic_systemd_config"
+        },
+        "cmd_|-remove_taskomatic_jmx_host_|-sed -ri 's/JAVA_OPTS=\"(.*)-Dcom\\.sun\\.management\\.jmxremote\\.host=localhost(.*)\"/JAVA_OPTS=\"\\1 \\2\"/' /etc/rhn/taskomatic.conf_|-run": {
+            "name": "sed -ri 's/JAVA_OPTS=\"(.*)-Dcom\\.sun\\.management\\.jmxremote\\.host=localhost(.*)\"/JAVA_OPTS=\"\\1 \\2\"/' /etc/rhn/taskomatic.conf",
+            "changes": {},
+            "result": true,
+            "comment": "onlyif condition is false",
+            "skip_watch": true,
+            "__sls__": "srvmonitoring.enable",
+            "__run_num__": 14,
+            "start_time": "16:14:49.330573",
+            "duration": 6.169,
+            "__id__": "remove_taskomatic_jmx_host"
         },
         "cmd_|-remove_taskomatic_jmx_port_|-sed -ri 's/JAVA_OPTS=\"(.*)-Dcom\\.sun\\.management\\.jmxremote\\.port=[0-9]*(.*)\"/JAVA_OPTS=\"\\1 \\2\"/' /etc/rhn/taskomatic.conf_|-run": {
             "name": "sed -ri 's/JAVA_OPTS=\"(.*)-Dcom\\.sun\\.management\\.jmxremote\\.port=[0-9]*(.*)\"/JAVA_OPTS=\"\\1 \\2\"/' /etc/rhn/taskomatic.conf",
@@ -237,8 +261,8 @@
             "duration": 6.445,
             "__id__": "remove_taskomatic_jmx_hostname"
         },
-        "cmd_|-jmx_taskomatic_config_|-sed -i 's/JAVA_OPTS=\"\\(.*\\)\"/JAVA_OPTS=\"\\1 -Dcom.sun.management.jmxremote.port=3334 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname=test-srv.tf.local\"/' /etc/rhn/taskomatic.conf_|-run": {
-            "name": "sed -i 's/JAVA_OPTS=\"\\(.*\\)\"/JAVA_OPTS=\"\\1 -Dcom.sun.management.jmxremote.port=3334 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname=test-srv.tf.local\"/' /etc/rhn/taskomatic.conf",
+        "cmd_|-jmx_taskomatic_config_|-sed -i 's/JAVA_OPTS=\"\\(.*\\)\"/JAVA_OPTS=\"\\1 -Dcom.sun.management.jmxremote.host=localhost -Dcom.sun.management.jmxremote.port=3334 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname=test-srv.tf.local\"/' /etc/rhn/taskomatic.conf_|-run": {
+            "name": "sed -i 's/JAVA_OPTS=\"\\(.*\\)\"/JAVA_OPTS=\"\\1 -Dcom.sun.management.jmxremote.host=localhost -Dcom.sun.management.jmxremote.port=3334 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname=test-srv.tf.local\"/' /etc/rhn/taskomatic.conf",
             "changes": {
                 "pid": 6967,
                 "retcode": 0,
@@ -246,7 +270,7 @@
                 "stderr": ""
             },
             "result": true,
-            "comment": "Command \"sed -i 's/JAVA_OPTS=\"\\(.*\\)\"/JAVA_OPTS=\"\\1 -Dcom.sun.management.jmxremote.port=3334 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname=test-srv.tf.local\"/' /etc/rhn/taskomatic.conf\" run",
+            "comment": "Command \"sed -i 's/JAVA_OPTS=\"\\(.*\\)\"/JAVA_OPTS=\"\\1 -Dcom.sun.management.jmxremote.host=localhost -Dcom.sun.management.jmxremote.port=3334 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname=test-srv.tf.local\"/' /etc/rhn/taskomatic.conf\" run",
             "__sls__": "srvmonitoring.enable",
             "__run_num__": 18,
             "start_time": "16:14:49.357508",

--- a/susemanager-utils/susemanager-sls/salt/srvmonitoring/disable.sls
+++ b/susemanager-utils/susemanager-sls/salt/srvmonitoring/disable.sls
@@ -13,7 +13,7 @@ postgres_exporter_service:
 
 jmx_tomcat_config:
   cmd.run:
-    - name: grep -q -v -- '-Dcom.sun.management.jmxremote.port=3333' /etc/sysconfig/tomcat && grep -q -v -- '-Dcom.sun.management.jmxremote.ssl=false' /etc/sysconfig/tomcat && grep -q -v -- '-Dcom.sun.management.jmxremote.authenticate=false' /etc/sysconfig/tomcat && grep -q -v -- '-Djava.rmi.server.hostname=' /etc/sysconfig/tomcat
+    - name: grep -q -v -- '-Dcom.sun.management.jmxremote.host=' /etc/sysconfig/tomcat && grep -q -v -- '-Dcom.sun.management.jmxremote.port=3333' /etc/sysconfig/tomcat && grep -q -v -- '-Dcom.sun.management.jmxremote.ssl=false' /etc/sysconfig/tomcat && grep -q -v -- '-Dcom.sun.management.jmxremote.authenticate=false' /etc/sysconfig/tomcat && grep -q -v -- '-Djava.rmi.server.hostname=' /etc/sysconfig/tomcat
     - require:
       - cmd: remove_tomcat_jmx_*
 
@@ -29,7 +29,7 @@ jmx_exporter_tomcat_service:
 
 jmx_taskomatic_config:
   cmd.run:
-    - name: grep -q -v -- '-Dcom.sun.management.jmxremote.port=3333' /etc/rhn/taskomatic.conf && grep -q -v -- '-Dcom.sun.management.jmxremote.ssl=false' /etc/rhn/taskomatic.conf && grep -q -v -- '-Dcom.sun.management.jmxremote.authenticate=false' /etc/rhn/taskomatic.conf && grep -q -v -- '-Djava.rmi.server.hostname=' /etc/rhn/taskomatic.conf
+    - name: grep -q -v -- '-Dcom.sun.management.jmxremote.host=' /etc/rhn/taskomatic.conf && grep -q -v -- '-Dcom.sun.management.jmxremote.port=3334' /etc/rhn/taskomatic.conf && grep -q -v -- '-Dcom.sun.management.jmxremote.ssl=false' /etc/rhn/taskomatic.conf && grep -q -v -- '-Dcom.sun.management.jmxremote.authenticate=false' /etc/rhn/taskomatic.conf && grep -q -v -- '-Djava.rmi.server.hostname=' /etc/rhn/taskomatic.conf
     - require:
       - cmd: remove_taskomatic_jmx_*
 

--- a/susemanager-utils/susemanager-sls/salt/srvmonitoring/enable.sls
+++ b/susemanager-utils/susemanager-sls/salt/srvmonitoring/enable.sls
@@ -51,7 +51,7 @@ jmx_exporter:
 
 jmx_tomcat_config:
   cmd.run:
-    - name: sed -i 's/JAVA_OPTS="\(.*\)"/JAVA_OPTS="\1 -Dcom.sun.management.jmxremote.port=3333 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname={{ grains['fqdns'][0] }}"/' /etc/sysconfig/tomcat
+    - name: sed -i 's/JAVA_OPTS="\(.*\)"/JAVA_OPTS="\1 -Dcom.sun.management.jmxremote.host=localhost -Dcom.sun.management.jmxremote.port=3333 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname=localhost"/' /etc/sysconfig/tomcat
     - require:
       - cmd: remove_tomcat_jmx_*
 
@@ -79,7 +79,7 @@ jmx_exporter_taskomatic_systemd_config:
 
 jmx_taskomatic_config:
   cmd.run:
-    - name: sed -i 's/JAVA_OPTS="\(.*\)"/JAVA_OPTS="\1 -Dcom.sun.management.jmxremote.port=3334 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname={{ grains['fqdns'][0] }}"/' /etc/rhn/taskomatic.conf
+    - name: sed -i 's/JAVA_OPTS="\(.*\)"/JAVA_OPTS="\1 -Dcom.sun.management.jmxremote.host=localhost -Dcom.sun.management.jmxremote.port=3334 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname=localhost"/' /etc/rhn/taskomatic.conf
     - require:
       - cmd: remove_taskomatic_jmx_*
 
@@ -118,4 +118,3 @@ mgr_enable_prometheus_self_monitoring:
 mgr_is_prometheus_self_monitoring_enabled:
   cmd.run:
     - name: grep -qF 'prometheus_monitoring_enabled = 1' /etc/rhn/rhn.conf
-

--- a/susemanager-utils/susemanager-sls/salt/srvmonitoring/removejmxprops.sls
+++ b/susemanager-utils/susemanager-sls/salt/srvmonitoring/removejmxprops.sls
@@ -1,3 +1,8 @@
+remove_{{remove_jmx_props.service}}_jmx_host:
+  cmd.run:
+    - name: sed -ri 's/JAVA_OPTS="(.*)-Dcom\.sun\.management\.jmxremote\.host=\S*(.*)"/JAVA_OPTS="\1 \2"/' {{remove_jmx_props.file}}
+    - onlyif: grep -F -- '-Dcom.sun.management.jmxremote.host=' {{remove_jmx_props.file}}
+
 remove_{{remove_jmx_props.service}}_jmx_port:
   cmd.run:
     - name: sed -ri 's/JAVA_OPTS="(.*)-Dcom\.sun\.management\.jmxremote\.port=[0-9]*(.*)"/JAVA_OPTS="\1 \2"/' {{remove_jmx_props.file}}

--- a/susemanager-utils/susemanager-sls/salt/srvmonitoring/status.sls
+++ b/susemanager-utils/susemanager-sls/salt/srvmonitoring/status.sls
@@ -22,13 +22,13 @@ jmx_tomcat_java_config:
   mgrcompat.module_run:
     - name: file.search
     - path: /etc/sysconfig/tomcat
-    - pattern: "-Dcom\\.sun\\.management\\.jmxremote\\.port=3333 -Dcom\\.sun\\.management\\.jmxremote\\.ssl=false -Dcom\\.sun\\.management\\.jmxremote\\.authenticate=false -Djava\\.rmi\\.server\\.hostname="
+    - pattern: "-Dcom\\.sun\\.management\\.jmxremote\\.host=\\S* -Dcom\\.sun\\.management\\.jmxremote\\.port=3333 -Dcom\\.sun\\.management\\.jmxremote\\.ssl=false -Dcom\\.sun\\.management\\.jmxremote\\.authenticate=false -Djava\\.rmi\\.server\\.hostname="
 
 jmx_taskomatic_java_config:
   mgrcompat.module_run:
     - name: file.search
     - path: /etc/rhn/taskomatic.conf
-    - pattern: "-Dcom\\.sun\\.management\\.jmxremote\\.port=3334 -Dcom\\.sun\\.management\\.jmxremote\\.ssl=false -Dcom\\.sun\\.management\\.jmxremote\\.authenticate=false -Djava\\.rmi\\.server\\.hostname="
+    - pattern: "-Dcom\\.sun\\.management\\.jmxremote\\.host=\\S* -Dcom\\.sun\\.management\\.jmxremote\\.port=3334 -Dcom\\.sun\\.management\\.jmxremote\\.ssl=false -Dcom\\.sun\\.management\\.jmxremote\\.authenticate=false -Djava\\.rmi\\.server\\.hostname="
 
 mgr_is_prometheus_self_monitoring_enabled:
   cmd.run:

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Fix insecure JMX configuration (bsc#1184617)
 - Add support for notify beacon for Debian/Ubuntu systems
 - Automatically start needed networks and storage pools when creating/starting a VM
 - Avoid conflicts with running ioloop on mgr_events engine (bsc#1172711)

--- a/susemanager-utils/susemanager-sls/susemanager-sls.spec
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.spec
@@ -141,6 +141,29 @@ base:
 EOF
     fi
 fi
+# Restrict Java RMI to localhost (bsc#1184617)
+restrict_to_localhost()
+{
+  JMXREMOTE_HOST='-Dcom.sun.management.jmxremote.host='
+  JMXREMOTE_PORT='-Dcom.sun.management.jmxremote.port='
+  RMI_SERVER_HOSTNAME='-Djava.rmi.server.hostname='
+  systemctl is-enabled ${1} > /dev/null 2>&1
+  jmx_exporter_enabled=$?
+  grep -q -- $JMXREMOTE_HOST ${2}
+  jmxremote_host_configured=$?
+  if [ $jmx_exporter_enabled -eq 0 ] && [ $jmxremote_host_configured -eq 1 ]; then
+    sed -ri "s/JAVA_OPTS=\"(.*)${JMXREMOTE_PORT}(.*)\"/JAVA_OPTS=\"\1${JMXREMOTE_HOST}localhost\ ${JMXREMOTE_PORT}\2\"/" ${2}
+    sed -ri "s/JAVA_OPTS=\"(.*)${RMI_SERVER_HOSTNAME}\S*(.*)\"/JAVA_OPTS=\"\1${RMI_SERVER_HOSTNAME}localhost\2\"/" ${2}
+  fi
+}
+tomcat_config=/etc/sysconfig/tomcat
+taskomatic_config=/etc/rhn/taskomatic.conf
+if [ $1 -gt 1 ] && [ -e $tomcat_config ]; then
+  restrict_to_localhost prometheus-jmx_exporter@tomcat.service $tomcat_config
+fi
+if [ $1 -gt 1 ] && [ -e $taskomatic_config ]; then
+  restrict_to_localhost prometheus-jmx_exporter@taskomatic.service $taskomatic_config
+fi
 
 %files
 %defattr(-,root,root)


### PR DESCRIPTION
## What does this PR change?

The change restricts access to Java Remote Method Invocation to
`localhost` to prevent unauthorized remote code execution.

## GUI diff

No change.

## Documentation
- [ ] Release notes: JMX configuration hardening should be mentioned.

## Test coverage
- No tests: Tests updated

- [x] **DONE**

## Links

Fixes # https://bugzilla.suse.com/show_bug.cgi?id=1184617

- [x] **DONE**

## Changelogs

- [x] susemanager-sls.changes

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
