### PR TITLE
Supportconfig: Fix the IS_SUSE variable reading

### DIFF
--- a/backend/satellite_tools/spacewalk-debug
+++ b/backend/satellite_tools/spacewalk-debug
@@ -28,7 +28,7 @@ IS_SUSE=0
 NO_REPORTS=0
 NO_COMPRESSION=0
 MAX_LOG_AGE=10
-if [ -f /etc/SuSE-release ]; then
+if `grep -iq '^ID_LIKE=.*suse' /etc/os-release`; then
     IS_SUSE=1
 fi
 if [ "$SPACEWALK_DEBUG_NO_REPORTS" == 1 ]; then


### PR DESCRIPTION
It seems it haven't worked for some time (I was missing files for inventory, for instance). This should make it work again.

In the end this rather obscure approach with grep was used.
Alternative (cleaner) approach with sourcing the os-release file was not
used as there is a danger of shadowing other env variables.


## Documentation
- No documentation needed: internal stuff

- [x] **DONE**

## Test coverage
- No tests: no tests here


- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
