### PR TITLE
virt_utils state: remove libvirt import

### DIFF
--- a/susemanager-utils/susemanager-sls/src/states/virt_utils.py
+++ b/susemanager-utils/susemanager-sls/src/states/virt_utils.py
@@ -2,7 +2,6 @@
 virt utility functions
 """
 
-import libvirt
 import re
 
 __virtualname__ = "virt_utils"
@@ -61,9 +60,9 @@ def _all_running(name, kind, names, is_running):
             ", ".join(stopped), kind, "s have" if len(stopped) > 1 else " has"
         )
 
-    except libvirt.libvirtError as err:
+    except Exception as err:
         ret["result"] = False
-        ret["comment"] = err.get_error_message()
+        ret["comment"] = str(err)
 
     return ret
 
@@ -102,9 +101,9 @@ def pool_running(name, pools=None):
                 __salt__["virt.pool_refresh"](pool_name)
             ret["changes"][pool_name] = "refreshed"
 
-        except libvirt.libvirtError as err:
+        except Exception as err:
             ret["result"] = False
-            ret["comment"] = err.get_error_message()
+            ret["comment"] = str(err)
 
     return ret
 
@@ -149,8 +148,8 @@ def vm_resources_running(name):
         ret["comment"] = "{}, {}".format(net_ret["comment"], pool_ret["comment"])
         ret["changes"] = {"networks": net_ret["changes"], "pools": pool_ret["changes"]}
 
-    except libvirt.libvirtError as err:
+    except Exception as err:
         ret["result"] = False
-        ret["comment"] = err.get_error_message()
+        ret["comment"] = str(err)
 
     return ret


### PR DESCRIPTION
## What does this PR change?

Fix `susemanager-sls` build failure by removing the libvirt import.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: package build fix

- [X] **DONE**

## Test coverage
- No tests: package build fix

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
