### PR TITLE
QA: Prevent a flaky tests on KVM/XEN scenarios

### DIFF
--- a/testsuite/documentation/cucumber-steps.md
+++ b/testsuite/documentation/cucumber-steps.md
@@ -234,7 +234,7 @@ For a test with a regular expression, there is ```I should see a text like "..."
   When I wait until I see "Successfully bootstrapped host!" text
   When I wait until I do not see "Loading..." text
   When I wait at most 360 seconds until I see "Product Description" text
-  When I wait until the tree item "test-pool0" contains "inactive" text
+  When I wait at most 600 seconds until the tree item "test-pool0" contains "inactive" text
   When I wait until table row for "test-net1" contains "running"
 ```
 
@@ -254,7 +254,7 @@ For a test with a regular expression, there is ```I should see a text like "..."
 * Wait until a tree item has no sub list
 
 ```cucumber
-  When I wait until the tree item "test-pool0" has no sub-list
+  When I wait at most 600 seconds until the tree item "test-pool0" has no sub-list
 ```
 
 <a name="b4" />
@@ -363,7 +363,7 @@ The check box can be identified by name, id or label text.
 ```cucumber
   When I wait until table row for "test-vm" contains button "Resume"
   When I wait at most 300 seconds until table row for "test-vm" contains button "Resume"
-  When I wait until the tree item "test-pool1" contains "test-pool1 is started automatically" button
+  When I wait at most 600 seconds until the tree item "test-pool1" contains "test-pool1 is started automatically" button
 ```
 
 

--- a/testsuite/features/secondary/minkvm_guests.feature
+++ b/testsuite/features/secondary/minkvm_guests.feature
@@ -246,21 +246,21 @@ Feature: Be able to manage KVM virtual machines via the GUI
     Given I am on the "Virtualization" page of this "kvm_server"
     When I follow "Storage"
     And I click on "Refresh" in tree item "test-pool0"
-    And I wait until the tree item "test-pool0" has no sub-list
+    And I wait at most 600 seconds until the tree item "test-pool0" has no sub-list
 
 @virthost_kvm
   Scenario: Stop a virtual storage pool for KVM
     Given I am on the "Virtualization" page of this "kvm_server"
     When I follow "Storage"
     And I click on "Stop" in tree item "test-pool0"
-    And I wait until the tree item "test-pool0" contains "inactive" text
+    And I wait at most 600 seconds until the tree item "test-pool0" contains "inactive" text
 
 @virthost_kvm
   Scenario: Start a virtual storage pool for KVM
     Given I am on the "Virtualization" page of this "kvm_server"
     When I follow "Storage"
     And I click on "Start" in tree item "test-pool0"
-    And I wait until the tree item "test-pool0" contains "running" text
+    And I wait at most 600 seconds until the tree item "test-pool0" contains "running" text
 
 @virthost_kvm
   Scenario: Delete a virtual storage pool for KVM
@@ -285,7 +285,7 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I enter "0755" as "target_mode"
     And I click on "Create"
     Then I should see a "Virtual Storage Pools and Volumes" text
-    And I wait until the tree item "test-pool1" contains "running" text
+    And I wait at most 600 seconds until the tree item "test-pool1" contains "running" text
     And file "/var/lib/libvirt/images/test-pool1" should have 755 permissions on "kvm_server"
 
 @virthost_kvm
@@ -298,7 +298,7 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I check "autostart"
     And I click on "Update"
     Then I should see a "Virtual Storage Pools and Volumes" text
-    And I wait until the tree item "test-pool1" contains "test-pool1 is started automatically" button
+    And I wait at most 600 seconds until the tree item "test-pool1" contains "test-pool1 is started automatically" button
     And file "/var/lib/libvirt/images/test-pool1" should have 711 permissions on "kvm_server"
 
 @virthost_kvm

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -454,8 +454,8 @@ When(/^I (deselect|select) "([^\"]*)" as a (SUSE Manager|Uyuni) product$/) do |s
   end
 end
 
-When(/^I wait until the tree item "([^"]+)" has no sub-list$/) do |item|
-  repeat_until_timeout(message: "could still find a sub list for tree item #{item}") do
+When(/^I wait at most (\d+) seconds until the tree item "([^"]+)" has no sub-list$/) do |timeout, item|
+  repeat_until_timeout(timeout: timeout.to_i, message: "could still find a sub list for tree item #{item}") do
     xpath = "//span[contains(text(), '#{item}')]/ancestor::div[contains(@class, 'product-details-wrapper')]/div/i[contains(@class, 'fa-angle-')]"
     begin
       find(:xpath, xpath)
@@ -466,16 +466,16 @@ When(/^I wait until the tree item "([^"]+)" has no sub-list$/) do |item|
   end
 end
 
-When(/^I wait until the tree item "([^"]+)" contains "([^"]+)" text$/) do |item, text|
+When(/^I wait at most (\d+) seconds until the tree item "([^"]+)" contains "([^"]+)" text$/) do |timeout, item, text|
   within(:xpath, "//span[contains(text(), '#{item}')]/ancestor::div[contains(@class, 'product-details-wrapper')]") do
-    raise "could not find text #{text} for tree item #{item}" unless has_text?(text, wait: DEFAULT_TIMEOUT)
+    raise "could not find text #{text} for tree item #{item}" unless has_text?(text, wait: timeout.to_i)
   end
 end
 
-When(/^I wait until the tree item "([^"]+)" contains "([^"]+)" button$/) do |item, button|
+When(/^I wait at most (\d+) seconds until the tree item "([^"]+)" contains "([^"]+)" button$/) do |timeout, item, button|
   xpath_query = "//span[contains(text(), '#{item}')]/"\
       "ancestor::div[contains(@class, 'product-details-wrapper')]/descendant::*[@title='#{button}']"
-  raise "xpath: #{xpath_query} not found" unless find(:xpath, xpath_query, wait: DEFAULT_TIMEOUT)
+  raise "xpath: #{xpath_query} not found" unless find(:xpath, xpath_query, wait: timeout.to_i)
 end
 
 When(/^I open the sub-list of the product "(.*?)"$/) do |product|


### PR DESCRIPTION
## What does this PR change?

Change the default timeout of 250 seconds, to a bigger value of 600 seconds in some steps where most of the job executions these scenarios failed due to the timeout.

![image](https://user-images.githubusercontent.com/2827771/114557591-1f44c880-9c6a-11eb-8ca7-92f1743f9c74.png)


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.0
- Manager-4.1

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
