### PR TITLE
QA: Get rid of extra login steps in core features

### DIFF
--- a/testsuite/documentation/cucumber-steps.md
+++ b/testsuite/documentation/cucumber-steps.md
@@ -130,7 +130,7 @@ To check for the initial log in, prefer ```Then I am logged in```.
 * Go to Salt => Keys
 
 ```cucumber
-  When I go to the minion onboarding page
+  When I follow the left menu "Salt > Keys"
 ```
 
 * Go to Systems => Overview
@@ -154,7 +154,7 @@ To check for the initial log in, prefer ```Then I am logged in```.
 * Go to Systems => Bootstrapping
 
 ```cucumber
-  When I go to the bootstrapping page
+  When I follow the left menu "Systems > Bootstrapping"
 ```
 
 * Go to Systems => Systems
@@ -184,7 +184,7 @@ To check for the initial log in, prefer ```Then I am logged in```.
 * Go to Users => Users list => Active
 
 ```cucumber
-  When I am on the Active Users page
+  When I follow the left menu "Users > User List > Active"
 ```
 
 * Go to details of a given client

--- a/testsuite/features/build_validation/init_clients/ceos6_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ceos6_minion.feature
@@ -12,7 +12,7 @@ Feature: Bootstrap a CentOS 6 Salt minion
 
   Scenario: Bootstrap a CentOS 6 Salt minion
     Given I am authorized as "admin" with password "admin"
-    When I go to the bootstrapping page
+    When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "ceos6_minion" as "hostname"
     And I enter "linux" as "password"

--- a/testsuite/features/build_validation/init_clients/ceos6_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ceos6_ssh_minion.feature
@@ -12,7 +12,7 @@ Feature: Bootstrap a CentOS 6 Salt SSH minion
 
   Scenario: Bootstrap a CentOS 6 Salt SSH minion
     Given I am authorized as "admin" with password "admin"
-    When I go to the bootstrapping page
+    When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I check "manageWithSSH"
     And I enter the hostname of "ceos6_ssh_minion" as "hostname"

--- a/testsuite/features/build_validation/init_clients/ceos7_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ceos7_minion.feature
@@ -12,7 +12,7 @@ Feature: Bootstrap a CentOS 7 Salt minion
 
   Scenario: Bootstrap a CentOS 7 Salt minion
     Given I am authorized as "admin" with password "admin"
-    When I go to the bootstrapping page
+    When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "ceos7_minion" as "hostname"
     And I enter "linux" as "password"

--- a/testsuite/features/build_validation/init_clients/ceos7_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ceos7_ssh_minion.feature
@@ -12,7 +12,7 @@ Feature: Bootstrap a CentOS 7 Salt SSH minion
 
   Scenario: Bootstrap a CentOS 7 Salt SSH minion
     Given I am authorized as "admin" with password "admin"
-    When I go to the bootstrapping page
+    When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I check "manageWithSSH"
     And I enter the hostname of "ceos7_ssh_minion" as "hostname"

--- a/testsuite/features/build_validation/init_clients/debian10_minion.feature
+++ b/testsuite/features/build_validation/init_clients/debian10_minion.feature
@@ -12,7 +12,7 @@ Feature: Bootstrap a Debian 10 Salt minion
 
   Scenario: Bootstrap a Debian 10 minion
     Given I am authorized as "admin" with password "admin"
-    When I go to the bootstrapping page
+    When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "debian10_minion" as "hostname"
     And I enter "root" as "user"

--- a/testsuite/features/build_validation/init_clients/debian10_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/debian10_ssh_minion.feature
@@ -12,7 +12,7 @@ Feature: Bootstrap a Debian 10 Salt SSH minion
 
   Scenario: Bootstrap a SSH-managed Debian 10 minion
     Given I am authorized as "admin" with password "admin"
-    When I go to the bootstrapping page
+    When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "debian10_ssh_minion" as "hostname"
     And I enter "root" as "user"

--- a/testsuite/features/build_validation/init_clients/debian9_minion.feature
+++ b/testsuite/features/build_validation/init_clients/debian9_minion.feature
@@ -12,7 +12,7 @@ Feature: Bootstrap a Debian 9 Salt minion
 
   Scenario: Bootstrap a Debian 9 minion
     Given I am authorized as "admin" with password "admin"
-    When I go to the bootstrapping page
+    When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "debian9_minion" as "hostname"
     And I enter "root" as "user"

--- a/testsuite/features/build_validation/init_clients/debian9_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/debian9_ssh_minion.feature
@@ -12,7 +12,7 @@ Feature: Bootstrap a Debian 9 Salt SSH minion
 
   Scenario: Bootstrap a SSH-managed Debian 9 minion
     Given I am authorized as "admin" with password "admin"
-    When I go to the bootstrapping page
+    When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "debian9_ssh_minion" as "hostname"
     And I enter "root" as "user"

--- a/testsuite/features/build_validation/init_clients/disabled/ceos8_minion.feature
+++ b/testsuite/features/build_validation/init_clients/disabled/ceos8_minion.feature
@@ -12,7 +12,7 @@ Feature: Bootstrap a CentOS 8 Salt minion
 
   Scenario: Bootstrap a CentOS 8 Salt minion
     Given I am authorized as "admin" with password "admin"
-    When I go to the bootstrapping page
+    When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "ceos8_minion" as "hostname"
     And I enter "linux" as "password"

--- a/testsuite/features/build_validation/init_clients/disabled/ceos8_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/disabled/ceos8_ssh_minion.feature
@@ -12,7 +12,7 @@ Feature: Bootstrap a CentOS 8 Salt SSH minion
 
   Scenario: Bootstrap a CentOS 8 Salt SSH minion
     Given I am authorized as "admin" with password "admin"
-    When I go to the bootstrapping page
+    When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I check "manageWithSSH"
     And I enter the hostname of "ceos8_ssh_minion" as "hostname"

--- a/testsuite/features/build_validation/init_clients/proxy.feature
+++ b/testsuite/features/build_validation/init_clients/proxy.feature
@@ -21,7 +21,7 @@ Feature: Setup SUSE Manager proxy
 
   Scenario: Bootstrap the proxy as a Salt minion
     Given I am authorized as "admin" with password "admin"
-    When I go to the bootstrapping page
+    When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "proxy" as "hostname"
     And I enter "22" as "port"

--- a/testsuite/features/build_validation/init_clients/sle11sp4_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle11sp4_minion.feature
@@ -9,7 +9,7 @@ Feature: Bootstrap a SLES 11 SP4 Salt minion
 
   Scenario: Bootstrap a SLES 11 SP4 minion
     Given I am authorized as "admin" with password "admin"
-    When I go to the bootstrapping page
+    When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "sle11sp4_minion" as "hostname"
     And I enter "22" as "port"
@@ -23,7 +23,7 @@ Feature: Bootstrap a SLES 11 SP4 Salt minion
 
   Scenario: Check the new bootstrapped SLES 11 SP4 minion in System Overview page
     Given I am authorized as "admin" with password "admin"
-    When I go to the minion onboarding page
+    When I follow the left menu "Salt > Keys"
     Then I should see a "accepted" text
     And the Salt master can reach "sle11sp4_minion"
 

--- a/testsuite/features/build_validation/init_clients/sle11sp4_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle11sp4_ssh_minion.feature
@@ -9,7 +9,7 @@ Feature: Bootstrap a SLES 11 SP4 Salt SSH minion
 
   Scenario: Bootstrap a SLES 11 SP4 system managed via salt-ssh
     Given I am authorized as "admin" with password "admin"
-    When I go to the bootstrapping page
+    When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I check "manageWithSSH"
     And I enter the hostname of "sle11sp4_ssh_minion" as "hostname"

--- a/testsuite/features/build_validation/init_clients/sle12sp4_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle12sp4_minion.feature
@@ -9,7 +9,7 @@ Feature: Bootstrap a SLES 12 SP4 Salt minion
 
   Scenario: Bootstrap a SLES 12 SP4 minion
     Given I am authorized as "admin" with password "admin"
-    When I go to the bootstrapping page
+    When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "sle12sp4_minion" as "hostname"
     And I enter "22" as "port"
@@ -23,7 +23,7 @@ Feature: Bootstrap a SLES 12 SP4 Salt minion
 
   Scenario: Check the new bootstrapped SLES 12 SP4 minion in System Overview page
     Given I am authorized as "admin" with password "admin"
-    When I go to the minion onboarding page
+    When I follow the left menu "Salt > Keys"
     Then I should see a "accepted" text
     And the Salt master can reach "sle12sp4_minion"
 

--- a/testsuite/features/build_validation/init_clients/sle12sp4_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle12sp4_ssh_minion.feature
@@ -9,7 +9,7 @@ Feature: Bootstrap a SLES 12 SP4 Salt SSH minion
 
   Scenario: Bootstrap a SLES 12 SP4 system managed via salt-ssh
     Given I am authorized as "admin" with password "admin"
-    When I go to the bootstrapping page
+    When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I check "manageWithSSH"
     And I enter the hostname of "sle12sp4_ssh_minion" as "hostname"

--- a/testsuite/features/build_validation/init_clients/sle15_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15_minion.feature
@@ -9,7 +9,7 @@ Feature: Bootstrap a SLES 15 Salt minion
 
   Scenario: Bootstrap a SLES 15 minion
     Given I am authorized as "admin" with password "admin"
-    When I go to the bootstrapping page
+    When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "sle15_minion" as "hostname"
     And I enter "22" as "port"
@@ -23,7 +23,7 @@ Feature: Bootstrap a SLES 15 Salt minion
 
   Scenario: Check the new bootstrapped SLES 15 minion in System Overview page
     Given I am authorized as "admin" with password "admin"
-    When I go to the minion onboarding page
+    When I follow the left menu "Salt > Keys"
     Then I should see a "accepted" text
     And the Salt master can reach "sle15_minion"
 

--- a/testsuite/features/build_validation/init_clients/sle15_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15_ssh_minion.feature
@@ -9,7 +9,7 @@ Feature: Bootstrap a SLES 15 Salt SSH minion
 
   Scenario: Bootstrap a SLES 15 system managed via salt-ssh
     Given I am authorized as "admin" with password "admin"
-    When I go to the bootstrapping page
+    When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I check "manageWithSSH"
     And I enter the hostname of "sle15_ssh_minion" as "hostname"

--- a/testsuite/features/build_validation/init_clients/sle15sp1_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp1_minion.feature
@@ -9,7 +9,7 @@ Feature: Bootstrap a SLES 15 SP1 Salt minion
 
   Scenario: Bootstrap a SLES 15 SP1 minion
     Given I am authorized as "admin" with password "admin"
-    When I go to the bootstrapping page
+    When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "sle15sp1_minion" as "hostname"
     And I enter "22" as "port"
@@ -23,7 +23,7 @@ Feature: Bootstrap a SLES 15 SP1 Salt minion
 
   Scenario: Check the new bootstrapped SLES 15 SP1 minion in System Overview page
     Given I am authorized as "admin" with password "admin"
-    When I go to the minion onboarding page
+    When I follow the left menu "Salt > Keys"
     Then I should see a "accepted" text
     And the Salt master can reach "sle15sp1_minion"
 

--- a/testsuite/features/build_validation/init_clients/sle15sp1_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp1_ssh_minion.feature
@@ -9,7 +9,7 @@ Feature: Bootstrap a SLES 15 SP1 Salt SSH minion
 
   Scenario: Bootstrap a SLES 15 SP1 system managed via salt-ssh
     Given I am authorized as "admin" with password "admin"
-    When I go to the bootstrapping page
+    When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I check "manageWithSSH"
     And I enter the hostname of "sle15sp1_ssh_minion" as "hostname"

--- a/testsuite/features/build_validation/init_clients/sle15sp2_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp2_minion.feature
@@ -9,7 +9,7 @@ Feature: Bootstrap a SLES 15 SP2 Salt minion
 
   Scenario: Bootstrap a SLES 15 SP2 minion
     Given I am authorized as "admin" with password "admin"
-    When I go to the bootstrapping page
+    When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "sle15sp2_minion" as "hostname"
     And I enter "22" as "port"
@@ -23,7 +23,7 @@ Feature: Bootstrap a SLES 15 SP2 Salt minion
 
   Scenario: Check the new bootstrapped SLES 15 SP2 minion in System Overview page
     Given I am authorized as "admin" with password "admin"
-    When I go to the minion onboarding page
+    When I follow the left menu "Salt > Keys"
     Then I should see a "accepted" text
     And the Salt master can reach "sle15sp2_minion"
 

--- a/testsuite/features/build_validation/init_clients/sle15sp2_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp2_ssh_minion.feature
@@ -9,7 +9,7 @@ Feature: Bootstrap a SLES 15 SP2 Salt SSH minion
 
   Scenario: Bootstrap a SLES 15 SP2 system managed via salt-ssh
     Given I am authorized as "admin" with password "admin"
-    When I go to the bootstrapping page
+    When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I check "manageWithSSH"
     And I enter the hostname of "sle15sp2_ssh_minion" as "hostname"

--- a/testsuite/features/build_validation/init_clients/sle15sp3_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp3_minion.feature
@@ -9,7 +9,7 @@ Feature: Bootstrap a SLES 15 SP3 Salt minion
 
   Scenario: Bootstrap a SLES 15 SP3 minion
     Given I am authorized as "admin" with password "admin"
-    When I go to the bootstrapping page
+    When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "sle15sp3_minion" as "hostname"
     And I enter "22" as "port"
@@ -23,7 +23,7 @@ Feature: Bootstrap a SLES 15 SP3 Salt minion
 
   Scenario: Check the new bootstrapped SLES 15 SP3 minion in System Overview page
     Given I am authorized as "admin" with password "admin"
-    When I go to the minion onboarding page
+    When I follow the left menu "Salt > Keys"
     Then I should see a "accepted" text
     And the Salt master can reach "sle15sp3_minion"
 

--- a/testsuite/features/build_validation/init_clients/sle15sp3_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle15sp3_ssh_minion.feature
@@ -9,7 +9,7 @@ Feature: Bootstrap a SLES 15 SP3 Salt SSH minion
 
   Scenario: Bootstrap a SLES 15 SP3 system managed via salt-ssh
     Given I am authorized as "admin" with password "admin"
-    When I go to the bootstrapping page
+    When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I check "manageWithSSH"
     And I enter the hostname of "sle15sp3_ssh_minion" as "hostname"

--- a/testsuite/features/build_validation/init_clients/ubuntu1604_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ubuntu1604_minion.feature
@@ -12,7 +12,7 @@ Feature: Bootstrap a Ubuntu 16.04 Salt minion
 
   Scenario: Bootstrap a Ubuntu 16.04 minion
     Given I am authorized as "admin" with password "admin"
-    When I go to the bootstrapping page
+    When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "ubuntu1604_minion" as "hostname"
     And I enter "root" as "user"

--- a/testsuite/features/build_validation/init_clients/ubuntu1604_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ubuntu1604_ssh_minion.feature
@@ -12,7 +12,7 @@ Feature: Bootstrap a Ubuntu 16.04 Salt SSH minion
 
   Scenario: Bootstrap a SSH-managed Ubuntu 16.04 minion
     Given I am authorized as "admin" with password "admin"
-    When I go to the bootstrapping page
+    When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "ubuntu1604_ssh_minion" as "hostname"
     And I enter "root" as "user"

--- a/testsuite/features/build_validation/init_clients/ubuntu1804_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ubuntu1804_minion.feature
@@ -12,7 +12,7 @@ Feature: Bootstrap a Ubuntu 18.04 Salt minion
 
   Scenario: Bootstrap a Ubuntu 18.04 minion
     Given I am authorized as "admin" with password "admin"
-    When I go to the bootstrapping page
+    When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "ubuntu1804_minion" as "hostname"
     And I enter "root" as "user"

--- a/testsuite/features/build_validation/init_clients/ubuntu1804_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ubuntu1804_ssh_minion.feature
@@ -12,7 +12,7 @@ Feature: Bootstrap a Ubuntu 18.04 Salt SSH minion
 
   Scenario: Bootstrap a SSH-managed Ubuntu 18.04 minion
     Given I am authorized as "admin" with password "admin"
-    When I go to the bootstrapping page
+    When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "ubuntu1804_ssh_minion" as "hostname"
     And I enter "root" as "user"

--- a/testsuite/features/build_validation/init_clients/ubuntu2004_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ubuntu2004_minion.feature
@@ -12,7 +12,7 @@ Feature: Bootstrap a Ubuntu 20.04 Salt minion
 
   Scenario: Bootstrap a Ubuntu 20.04 minion
     Given I am authorized as "admin" with password "admin"
-    When I go to the bootstrapping page
+    When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "ubuntu2004_minion" as "hostname"
     And I enter "root" as "user"

--- a/testsuite/features/build_validation/init_clients/ubuntu2004_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/ubuntu2004_ssh_minion.feature
@@ -12,7 +12,7 @@ Feature: Bootstrap a Ubuntu 20.04 Salt SSH minion
 
   Scenario: Bootstrap a SSH-managed Ubuntu 20.04 minion
     Given I am authorized as "admin" with password "admin"
-    When I go to the bootstrapping page
+    When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "ubuntu2004_ssh_minion" as "hostname"
     And I enter "root" as "user"

--- a/testsuite/features/build_validation/retail/sle11sp4_kiwi_image_buildhost.feature
+++ b/testsuite/features/build_validation/retail/sle11sp4_kiwi_image_buildhost.feature
@@ -9,7 +9,7 @@ Feature: Bootstrap a SLES 11 SP4 Salt build host via the GUI
 
   Scenario: Bootstrap a SLES 11 SP4 build host
      Given I am authorized as "admin" with password "admin"
-     When I go to the bootstrapping page
+     When I follow the left menu "Systems > Bootstrapping"
      Then I should see a "Bootstrap Minions" text
      When I enter the hostname of "sle11sp4_buildhost" as "hostname"
      And I enter "22" as "port"
@@ -21,7 +21,7 @@ Feature: Bootstrap a SLES 11 SP4 Salt build host via the GUI
 
   Scenario: Check the new bootstrapped SLES 11 SP4 build host in System Overview page
     Given I am authorized as "admin" with password "admin"
-    When I go to the minion onboarding page
+    When I follow the left menu "Salt > Keys"
     Then I should see a "accepted" text
     When I am on the System Overview page
     And I wait until I see the name of "sle11sp4_buildhost", refreshing the page

--- a/testsuite/features/build_validation/retail/sle12sp4_kiwi_image_buildhost.feature
+++ b/testsuite/features/build_validation/retail/sle12sp4_kiwi_image_buildhost.feature
@@ -9,7 +9,7 @@ Feature: Bootstrap a SLES 12 SP4 Salt build host via the GUI
 
   Scenario: Bootstrap a SLES build host
      Given I am authorized as "admin" with password "admin"
-     When I go to the bootstrapping page
+     When I follow the left menu "Systems > Bootstrapping"
      Then I should see a "Bootstrap Minions" text
      When I enter the hostname of "sle12sp4_buildhost" as "hostname"
      And I enter "22" as "port"
@@ -21,7 +21,7 @@ Feature: Bootstrap a SLES 12 SP4 Salt build host via the GUI
 
   Scenario: Check the new bootstrapped SLES 12 SP4 build host in System Overview page
     Given I am authorized as "admin" with password "admin"
-    When I go to the minion onboarding page
+    When I follow the left menu "Salt > Keys"
     Then I should see a "accepted" text
     When I am on the System Overview page
     And I wait until I see the name of "sle12sp4_buildhost", refreshing the page

--- a/testsuite/features/build_validation/retail/sle15sp2_kiwi_image_buildhost.feature
+++ b/testsuite/features/build_validation/retail/sle15sp2_kiwi_image_buildhost.feature
@@ -9,7 +9,7 @@ Feature: Bootstrap a SLES 15 SP2 Salt build host via the GUI
 
   Scenario: Bootstrap a SLES 15 SP2 build host
      Given I am authorized as "admin" with password "admin"
-     When I go to the bootstrapping page
+     When I follow the left menu "Systems > Bootstrapping"
      Then I should see a "Bootstrap Minions" text
      When I enter the hostname of "sle15sp2_buildhost" as "hostname"
      And I enter "22" as "port"
@@ -21,7 +21,7 @@ Feature: Bootstrap a SLES 15 SP2 Salt build host via the GUI
 
   Scenario: Check the new bootstrapped SLES 15 SP2 build host in System Overview page
     Given I am authorized as "admin" with password "admin"
-    When I go to the minion onboarding page
+    When I follow the left menu "Salt > Keys"
     Then I should see a "accepted" text
     When I am on the System Overview page
     And I wait until I see the name of "sle15sp2_buildhost", refreshing the page

--- a/testsuite/features/core/first_settings.feature
+++ b/testsuite/features/core/first_settings.feature
@@ -21,8 +21,10 @@ Feature: Very first settings
     And I click on "Create Organization"
     Then I am logged in
 
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
   Scenario: Create testing username
-    Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Users > User List > Active"
     And I follow "Create User"
     And I enter "testing" as "login"
@@ -37,7 +39,6 @@ Feature: Very first settings
     And I should see a "testing" link
 
   Scenario: Grant testing user administrative priviledges
-    Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Users > User List > Active"
     And I follow "testing"
     And I check "role_org_admin"
@@ -54,7 +55,6 @@ Feature: Very first settings
 
 @server_http_proxy
   Scenario: Setup HTTP proxy
-    Given I am authorized for the "Admin" section
     When I follow the left menu "Admin > Setup Wizard > HTTP Proxy"
     Then I should see a "HTTP Proxy Hostname" text
     And I should see a "HTTP Proxy Username" text

--- a/testsuite/features/core/proxy_branch_network.feature
+++ b/testsuite/features/core/proxy_branch_network.feature
@@ -29,6 +29,11 @@ Feature: Setup SUSE Manager for Retail branch network
 
 @proxy
 @private_net
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
+@proxy
+@private_net
   Scenario: Enable the branch network formulas on the branch server
     Given I am on the Systems overview page of this "proxy"
     When I follow "Formulas" in the content area

--- a/testsuite/features/core/proxy_register_as_minion_with_gui.feature
+++ b/testsuite/features/core/proxy_register_as_minion_with_gui.feature
@@ -19,9 +19,11 @@ Feature: Setup SUSE Manager proxy
     And I install proxy pattern on the proxy
     And I let squid use avahi on the proxy
 
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
   Scenario: Bootstrap the proxy as a Salt minion
-    Given I am authorized
-    When I go to the bootstrapping page
+    When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "proxy" as "hostname"
     And I enter "22" as "port"
@@ -31,7 +33,6 @@ Feature: Setup SUSE Manager proxy
     And I wait until I see "Successfully bootstrapped host!" text
 
   Scenario: Wait until the proxy appears
-    Given I am authorized
     When I wait until onboarding is completed for "proxy"
 
   Scenario: Detect latest Salt changes on the proxy

--- a/testsuite/features/core/proxy_register_as_minion_with_script.feature
+++ b/testsuite/features/core/proxy_register_as_minion_with_script.feature
@@ -26,14 +26,15 @@ Feature: Setup SUSE Manager proxy
     When I fetch "pub/bootstrap/bootstrap-proxy.sh" to "proxy"
     And I run "sh ./bootstrap-proxy.sh" on "proxy"
 
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
   Scenario: Accept the key for the proxy
-    Given I am authorized as "testing" with password "testing"
-    When I go to the minion onboarding page
+    When I follow the left menu "Salt > Keys"
     And I wait until I see "pending" text, refreshing the page
     And I accept "proxy" key
 
   Scenario: Wait until the proxy appears
-    Given I am authorized
     When I wait until onboarding is completed for "proxy"
 
   Scenario: Detect latest Salt changes on the proxy

--- a/testsuite/features/core/proxy_register_as_trad_with_script.feature
+++ b/testsuite/features/core/proxy_register_as_trad_with_script.feature
@@ -31,6 +31,9 @@ Feature: Setup SUSE Manager proxy
     And I configure the proxy
     Then I should see "proxy" via spacecmd
 
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
   Scenario: Check proxy system details
     When I am on the Systems overview page of this "proxy"
     Then I should see "proxy" hostname

--- a/testsuite/features/core/srv_channels_add.feature
+++ b/testsuite/features/core/srv_channels_add.feature
@@ -6,8 +6,10 @@ Feature: Adding channels
   As an authorized user
   I want to add channels
 
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
   Scenario: Add a base channel
-    Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Software > Manage > Channels"
     And I follow "Create Channel"
     And I enter "Test Base Channel" as "Channel Name"
@@ -20,7 +22,6 @@ Feature: Adding channels
     Then I should see a "Channel Test Base Channel created." text
 
   Scenario: Add a child channel
-    Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Software > Manage > Channels"
     And I follow "Create Channel"
     When I enter "Test Child Channel" as "Channel Name"
@@ -33,7 +34,6 @@ Feature: Adding channels
     Then I should see a "Channel Test Child Channel created." text
 
   Scenario: Add a base test channel for i586
-    Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Software > Manage > Channels"
     And I follow "Create Channel"
     And I enter "Test-Channel-i586" as "Channel Name"
@@ -46,7 +46,6 @@ Feature: Adding channels
     Then I should see a "Channel Test-Channel-i586 created." text
 
   Scenario: Add a child channel to the i586 test channel
-    Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Software > Manage > Channels"
     And I follow "Create Channel"
     And I enter "Test-Channel-i586 Child Channel" as "Channel Name"
@@ -59,7 +58,6 @@ Feature: Adding channels
     Then I should see a "Channel Test-Channel-i586 Child Channel created." text
 
   Scenario: Add a test base channel for x86_64
-    Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Software > Manage > Channels"
     And I follow "Create Channel"
     And I enter "Test-Channel-x86_64" as "Channel Name"
@@ -72,7 +70,6 @@ Feature: Adding channels
     Then I should see a "Channel Test-Channel-x86_64 created." text
 
   Scenario: Add a child channel to the x86_64 test channel
-    Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Software > Manage > Channels"
     And I follow "Create Channel"
     And I enter "Test-Channel-x86_64 Child Channel" as "Channel Name"
@@ -85,7 +82,6 @@ Feature: Adding channels
     Then I should see a "Channel Test-Channel-x86_64 Child Channel created." text
 
   Scenario: Add Ubuntu AMD64 base channel
-    Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Software > Manage > Channels"
     And I follow "Create Channel"
     And I enter "Test-Channel-Deb-AMD64" as "Channel Name"

--- a/testsuite/features/core/srv_create_activationkey.feature
+++ b/testsuite/features/core/srv_create_activationkey.feature
@@ -6,8 +6,10 @@ Feature: Create activation keys
   As the testing user
   I want to use activation keys
 
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
   Scenario: Create an activation key with a channel
-    Given I am on the Systems page
     When I follow the left menu "Systems > Activation Keys"
     And I follow "Create Key"
     And I enter "SUSE Test Key x86_64" as "description"
@@ -24,7 +26,6 @@ Feature: Create activation keys
 
 @ubuntu_minion
   Scenario: Create an activation key for Ubuntu
-    Given I am on the Systems page
     When I follow the left menu "Systems > Activation Keys"
     And I follow "Create Key"
     And I enter "Ubuntu Test Key" as "description"
@@ -39,7 +40,6 @@ Feature: Create activation keys
     And I should see a "Activated Systems" link
 
   Scenario: Create an activation key with a channel for salt-ssh
-    Given I am on the Systems page
     When I follow the left menu "Systems > Activation Keys"
     And I follow "Create Key"
     And I enter "SUSE SSH Test Key x86_64" as "description"
@@ -51,7 +51,6 @@ Feature: Create activation keys
     Then I should see a "Activation key SUSE SSH Test Key x86_64 has been created" text
 
   Scenario: Create an activation key with a channel for salt-ssh via tunnel
-    Given I am on the Systems page
     When I follow the left menu "Systems > Activation Keys"
     And I follow "Create Key"
     And I enter "SUSE SSH Tunnel Test Key x86_64" as "description"

--- a/testsuite/features/core/srv_create_repository.feature
+++ b/testsuite/features/core/srv_create_repository.feature
@@ -5,10 +5,12 @@ Feature: Add a repository to a channel
   In order to distribute software to the clients
   As an authorized user
   I want to add a repository
-  And I want to add this repository to the base channel
+  I want to add this repository to the base channel
+
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
 
   Scenario: Add a test repository for x86_64
-    Given I am authorized as "testing" with password "testing"
     When I follow the left menu "Software > Manage > Repositories"
     And I follow "Create Repository"
     And I enter "Test-Repository-x86_64" as "label"
@@ -18,7 +20,6 @@ Feature: Add a repository to a channel
     And I should see "metadataSigned" as checked
 
   Scenario: Disable metadata check for the x86_64 test repository
-    Given I am authorized as "testing" with password "testing"
     When I follow the left menu "Software > Manage > Repositories"
     And I follow "Test-Repository-x86_64"
     And I uncheck "metadataSigned"
@@ -27,7 +28,6 @@ Feature: Add a repository to a channel
     And I should see "metadataSigned" as unchecked
 
   Scenario: Add the repository to the x86_64 channel
-    Given I am authorized as "testing" with password "testing"
     When I follow the left menu "Software > Manage > Channels"
     And I follow "Test-Channel-x86_64"
     And I follow "Repositories" in the content area
@@ -36,7 +36,6 @@ Feature: Add a repository to a channel
     Then I should see a "Test-Channel-x86_64 repository information was successfully updated" text
 
   Scenario: Synchronize the repository in the x86_64 channel
-    Given I am authorized as "testing" with password "testing"
     When I enable source package syncing
     And I follow the left menu "Software > Manage > Channels"
     And I follow "Test-Channel-x86_64"
@@ -46,7 +45,6 @@ Feature: Add a repository to a channel
     Then I should see a "Repository sync scheduled for Test-Channel-x86_64." text
 
   Scenario: Add a test repository for i586
-    Given I am authorized as "testing" with password "testing"
     When I follow the left menu "Software > Manage > Repositories"
     And I follow "Create Repository"
     And I enter "Test-Repository-i586" as "label"
@@ -56,7 +54,6 @@ Feature: Add a repository to a channel
     Then I should see a "Repository created successfully" text
 
   Scenario: Add the repository to the i586 channel
-    Given I am authorized as "testing" with password "testing"
     When I follow the left menu "Software > Manage > Channels"
     And I follow "Test-Channel-i586"
     And I follow "Repositories" in the content area
@@ -65,7 +62,6 @@ Feature: Add a repository to a channel
     Then I should see a "Test-Channel-i586 repository information was successfully updated" text
 
   Scenario: Synchronize the repository in the i586 channel
-    Given I am authorized as "testing" with password "testing"
     When I disable source package syncing
     When I follow the left menu "Software > Manage > Channels"
     And I follow "Test-Channel-i586"
@@ -76,7 +72,6 @@ Feature: Add a repository to a channel
 
 @ubuntu_minion
   Scenario: Add a test repository for Ubuntu
-    Given I am authorized as "testing" with password "testing"
     When I follow the left menu "Software > Manage > Repositories"
     And I follow "Create Repository"
     And I enter "Test-Repository-Deb" as "label"
@@ -93,7 +88,6 @@ Feature: Add a repository to a channel
 
 @ubuntu_minion
   Scenario: Add the Ubuntu repository to the AMD64 channel
-    Given I am authorized as "testing" with password "testing"
     When I follow the left menu "Software > Manage > Channels"
     And I follow "Test-Channel-Deb-AMD64"
     And I follow "Repositories" in the content area
@@ -103,7 +97,6 @@ Feature: Add a repository to a channel
 
 @ubuntu_minion
   Scenario: Synchronize the Ubuntu repository in the AMD64 channel
-    Given I am authorized as "testing" with password "testing"
     When I follow the left menu "Software > Manage > Channels"
     And I follow "Test-Channel-Deb-AMD64"
     And I follow "Repositories" in the content area
@@ -112,7 +105,6 @@ Feature: Add a repository to a channel
     Then I should see a "Repository sync scheduled for Test-Channel-Deb-AMD64." text
 
   Scenario: Refresh the errata cache
-    Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Admin > Task Schedules"
     And I follow "errata-cache-default"
     And I follow "errata-cache-bunch"
@@ -121,7 +113,6 @@ Feature: Add a repository to a channel
     And I wait until the table contains "FINISHED" or "SKIPPED" followed by "FINISHED" in its first rows
 
   Scenario: Refresh the channel's repository data
-    Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Admin > Task Schedules"
     And I follow "channel-repodata-default"
     And I follow "channel-repodata-bunch"
@@ -130,7 +121,6 @@ Feature: Add a repository to a channel
     And I wait until the table contains "FINISHED" or "SKIPPED" followed by "FINISHED" in its first rows
 
   Scenario: Reposync handles wrong encoding on RPM attributes
-    Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Software > Channel List"
     And I follow "Test-Channel-x86_64"
     And I follow "Packages" in the content area
@@ -138,7 +128,6 @@ Feature: Add a repository to a channel
 
 @ubuntu_minion
   Scenario: Reposync handles wrong encoding on DEB attributes
-    Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Software > Channel List"
     And I follow "Test-Channel-Deb-AMD64"
     And I follow "Packages" in the content area

--- a/testsuite/features/core/srv_docker.feature
+++ b/testsuite/features/core/srv_docker.feature
@@ -3,9 +3,12 @@
 
 Feature: Prepare server for using Docker
 
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
   Scenario: Create a Docker user with image administrators rights
-    Given I am on the active Users page
-    When I follow "Create User"
+    When I follow the left menu "Users > User List > Active"
+    And I follow "Create User"
     And I enter "docker" as "login"
     And I enter "docker" as "desiredpassword"
     And I enter "docker" as "desiredpasswordConfirm"
@@ -22,7 +25,6 @@ Feature: Prepare server for using Docker
     And I click on "Update"
 
   Scenario: Create Docker activation key
-    Given I am on the Systems page
     When I follow the left menu "Systems > Activation Keys"
     And I follow "Create Key"
     When I enter "Docker testing" as "description"
@@ -37,7 +39,6 @@ Feature: Prepare server for using Docker
 
 @no_auth_registry
   Scenario: Create an image store without credentials
-    Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Images > Stores"
     And I follow "Create"
     And I enter "galaxy-registry" as "label"

--- a/testsuite/features/core/srv_osimage.feature
+++ b/testsuite/features/core/srv_osimage.feature
@@ -3,9 +3,12 @@
 
 Feature: Prepare server for using Kiwi
 
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
   Scenario: Create a Kiwi user with image administrators rights
-    Given I am on the active Users page
-    When I follow "Create User"
+    When I follow the left menu "Users > User List > Active"
+    And I follow "Create User"
     And I enter "kiwikiwi" as "login"
     And I enter "kiwikiwi" as "desiredpassword"
     And I enter "kiwikiwi" as "desiredpasswordConfirm"
@@ -22,7 +25,6 @@ Feature: Prepare server for using Kiwi
     And I click on "Update"
 
   Scenario: Create Kiwi activation key
-    Given I am on the Systems page
     When I follow the left menu "Systems > Activation Keys"
     And I follow "Create Key"
     And I enter "Kiwi testing" as "description"

--- a/testsuite/features/init_clients/buildhost_bootstrap.feature
+++ b/testsuite/features/init_clients/buildhost_bootstrap.feature
@@ -1,12 +1,14 @@
 # Copyright (c) 2016-2020 SUSE LLC
 # Licensed under the terms of the MIT license.
 
+@buildhost
 Feature: Bootstrap a Salt build host via the GUI
 
-@buildhost
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
   Scenario: Bootstrap a SLES build host
-     Given I am authorized
-     When I go to the bootstrapping page
+     When I follow the left menu "Systems > Bootstrapping"
      Then I should see a "Bootstrap Minions" text
      When I enter the hostname of "build_host" as "hostname"
      And I enter "22" as "port"
@@ -16,10 +18,8 @@ Feature: Bootstrap a Salt build host via the GUI
      And I click on "Bootstrap"
      And I wait until I see "Successfully bootstrapped host!" text
 
-@buildhost
   Scenario: Check the new bootstrapped build host in System Overview page
-    Given I am authorized
-    When I go to the minion onboarding page
+    When I follow the left menu "Salt > Keys"
     Then I should see a "accepted" text
     When I am on the System Overview page
     And I wait until I see the name of "build_host", refreshing the page
@@ -27,7 +27,6 @@ Feature: Bootstrap a Salt build host via the GUI
     Then the Salt master can reach "build_host"
 
 @proxy
-@buildhost
   Scenario: Check connection from build host to proxy
     Given I am on the Systems overview page of this "build_host"
     When I follow "Details" in the content area
@@ -35,18 +34,15 @@ Feature: Bootstrap a Salt build host via the GUI
     Then I should see "proxy" short hostname
 
 @proxy
-@buildhost
   Scenario: Check registration on build host of minion
     Given I am on the Systems overview page of this "proxy"
     When I follow "Details" in the content area
     And I follow "Proxy" in the content area
     Then I should see "build_host" hostname
 
-@buildhost
   Scenario: Detect latest Salt changes on the SLES build host
     When I query latest Salt changes on "build_host"
 
-@buildhost
   Scenario: Turn the SLES build host into a container build host
     Given I am on the Systems overview page of this "build_host"
     When I follow "Details" in the content area
@@ -58,7 +54,6 @@ Feature: Bootstrap a Salt build host via the GUI
     And I should see a "To apply the state, either use the states page or run state.highstate from the command line." text
     And I should see a "System properties changed" text
 
-@buildhost
   Scenario: Turn the SLES build host into a OS image build host
     Given I am on the Systems overview page of this "build_host"
     When I follow "Details" in the content area
@@ -70,7 +65,6 @@ Feature: Bootstrap a Salt build host via the GUI
     And I should see a "To apply the state, either use the states page or run state.highstate from the command line." text
     And I should see a "System properties changed" text
 
-@buildhost
   Scenario: Apply the highstate to the build host
     Given I am on the Systems overview page of this "build_host"
     When I wait until no Salt job is running on "build_host"
@@ -80,13 +74,11 @@ Feature: Bootstrap a Salt build host via the GUI
     And I wait until file "/var/lib/Kiwi/repo/rhn-org-trusted-ssl-cert-osimage-1.0-1.noarch.rpm" exists on "build_host"
     And I disable repositories after installing Docker
 
-@buildhost
   Scenario: Check that the build host is now a build host
     Given I am on the Systems overview page of this "build_host"
     Then I should see a "[Container Build Host]" text
     Then I should see a "[OS Image Build Host]" text
 
-@buildhost
   Scenario: Check events history for failures on SLES build host
     Given I am on the Systems overview page of this "build_host"
     Then I check for failed events on history event page

--- a/testsuite/features/init_clients/min_centos_salt.feature
+++ b/testsuite/features/init_clients/min_centos_salt.feature
@@ -4,12 +4,14 @@
 #  1) bootstrap a new CentOS minion via salt
 #  2) subscribe it to a base channel for testing
 
+@centos_minion
 Feature: Bootstrap a CentOS minion and do some basic operations on it
 
-@centos_minion
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
   Scenario: Bootstrap a CentOS minion
-    Given I am authorized
-    When I go to the bootstrapping page
+    When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "ceos_minion" as "hostname"
     And I enter "22" as "port"
@@ -24,7 +26,6 @@ Feature: Bootstrap a CentOS minion and do some basic operations on it
     And I wait until onboarding is completed for "ceos_minion"
 
 @proxy
-@centos_minion
   Scenario: Check connection from CentOS minion to proxy
     Given I am on the Systems overview page of this "ceos_minion"
     When I follow "Details" in the content area
@@ -32,14 +33,12 @@ Feature: Bootstrap a CentOS minion and do some basic operations on it
     Then I should see "proxy" short hostname
 
 @proxy
-@centos_minion
   Scenario: Check registration on proxy of CentOS minion
     Given I am on the Systems overview page of this "proxy"
     When I follow "Details" in the content area
     And I follow "Proxy" in the content area
     Then I should see "ceos_minion" hostname
 
-@centos_minion
   Scenario: Subscribe the CentOS minion to a base channel
     Given I am on the Systems overview page of this "ceos_minion"
     When I follow "Software" in the content area
@@ -53,11 +52,9 @@ Feature: Bootstrap a CentOS minion and do some basic operations on it
     Then I should see a "Changing the channels has been scheduled." text
     And I wait until event "Subscribe channels scheduled by admin" is completed
 
-@centos_minion
   Scenario: Detect latest Salt changes on the CentOS minion
     When I query latest Salt changes on "ceos_minion"
 
-@centos_minion
   Scenario: Check events history for failures on CentOS minion
     Given I am on the Systems overview page of this "ceos_minion"
     Then I check for failed events on history event page

--- a/testsuite/features/init_clients/min_ubuntu_salt.feature
+++ b/testsuite/features/init_clients/min_ubuntu_salt.feature
@@ -4,12 +4,14 @@
 #  1) bootstrap a new Ubuntu minion
 #  2) subscribe it to a base channel for testing
 
+@ubuntu_minion
 Feature: Bootstrap an Ubuntu minion and do some basic operations on it
 
-@ubuntu_minion
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
   Scenario: Bootstrap an Ubuntu minion
-    Given I am authorized
-    When I go to the bootstrapping page
+    When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "ubuntu_minion" as "hostname"
     And I enter "22" as "port"
@@ -25,7 +27,6 @@ Feature: Bootstrap an Ubuntu minion and do some basic operations on it
     And I query latest Salt changes on ubuntu system "ubuntu_minion"
 
 @proxy
-@ubuntu_minion
   Scenario: Check connection from the Ubuntu minion to proxy
     Given I am on the Systems overview page of this "ubuntu_minion"
     When I follow "Details" in the content area
@@ -33,14 +34,12 @@ Feature: Bootstrap an Ubuntu minion and do some basic operations on it
     Then I should see "proxy" short hostname
 
 @proxy
-@ubuntu_minion
   Scenario: Check registration on proxy of the Ubuntu minion
     Given I am on the Systems overview page of this "proxy"
     When I follow "Details" in the content area
     And I follow "Proxy" in the content area
     Then I should see "ubuntu_minion" hostname
 
-@ubuntu_minion
   Scenario: Subscribe the Ubuntu minion to a base channel
     Given I am on the Systems overview page of this "ubuntu_minion"
     When I follow "Software" in the content area
@@ -54,11 +53,9 @@ Feature: Bootstrap an Ubuntu minion and do some basic operations on it
     Then I should see a "Changing the channels has been scheduled." text
     And I wait until event "Subscribe channels scheduled by admin" is completed
 
-@ubuntu_minion
   Scenario: Detect latest Salt changes on the Ubuntu minion
     When I query latest Salt changes on ubuntu system "ubuntu_minion"
 
-@ubuntu_minion
   Scenario: Check events history for failures on Ubuntu minion
     Given I am on the Systems overview page of this "ubuntu_minion"
     Then I check for failed events on history event page

--- a/testsuite/features/init_clients/sle_client.feature
+++ b/testsuite/features/init_clients/sle_client.feature
@@ -5,8 +5,10 @@ Feature: Register a traditional client
   In order to register a traditional client to the SUSE Manager server
   I want to create, parametrize and run boostrap script from proxy
 
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
   Scenario: Register a traditional client
-    Given I am authorized
     When I bootstrap traditional client "sle_client" using bootstrap script with activation key "1-SUSE-KEY-x86_64" from the proxy
     And I wait until onboarding is completed for "sle_client"
     Then I should see "sle_client" via spacecmd

--- a/testsuite/features/init_clients/sle_minion.feature
+++ b/testsuite/features/init_clients/sle_minion.feature
@@ -3,9 +3,11 @@
 
 Feature: Bootstrap a Salt minion via the GUI
 
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
   Scenario: Bootstrap a SLES minion
-     Given I am authorized
-     When I go to the bootstrapping page
+     When I follow the left menu "Systems > Bootstrapping"
      Then I should see a "Bootstrap Minions" text
      When I enter the hostname of "sle_minion" as "hostname"
      And I enter "22" as "port"
@@ -16,8 +18,7 @@ Feature: Bootstrap a Salt minion via the GUI
      And I wait until I see "Successfully bootstrapped host!" text
 
   Scenario: Check the new bootstrapped minion in System Overview page
-    Given I am authorized
-    When I go to the minion onboarding page
+    When I follow the left menu "Salt > Keys"
     Then I should see a "accepted" text
     When I am on the System Overview page
     And I wait until I see the name of "sle_minion", refreshing the page

--- a/testsuite/features/init_clients/sle_ssh_minion.feature
+++ b/testsuite/features/init_clients/sle_ssh_minion.feature
@@ -4,9 +4,11 @@
 @ssh_minion
 Feature: Bootstrap a Salt host managed via salt-ssh
 
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
   Scenario: Register this SSH minion for service pack migration
-    Given I am authorized
-    And I go to the bootstrapping page
+    And I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     And I check "manageWithSSH"
     And I enter the hostname of "ssh_minion" as "hostname"
@@ -19,7 +21,6 @@ Feature: Bootstrap a Salt host managed via salt-ssh
     And I wait until onboarding is completed for "ssh_minion"
 
 @proxy
-@ssh_minion
   Scenario: Check connection from SSH minion to proxy
     Given I am on the Systems overview page of this "ssh_minion"
     When I follow "Details" in the content area
@@ -27,7 +28,6 @@ Feature: Bootstrap a Salt host managed via salt-ssh
     Then I should see "proxy" short hostname
 
 @proxy
-@ssh_minion
   Scenario: Check registration on proxy of SSH minion
     Given I am on the Systems overview page of this "proxy"
     When I follow "Details" in the content area

--- a/testsuite/features/secondary/allcli_reboot.feature
+++ b/testsuite/features/secondary/allcli_reboot.feature
@@ -10,6 +10,9 @@
 @scope_onboarding
 Feature: Reboot systems managed by SUSE Manager
 
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
 @ssh_minion
   Scenario: Reboot the SSH-managed SLES minion
     Given I am on the Systems overview page of this "ssh_minion"

--- a/testsuite/features/secondary/buildhost_osimage_build_image.feature
+++ b/testsuite/features/secondary/buildhost_osimage_build_image.feature
@@ -37,7 +37,10 @@ Feature: Build OS images
     And I select the hostname of "build_host" from "buildHostId"
     And I click on "submit-btn"
 
-  Scenario: Check the OS image built as Kiwi image administrator
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
+  Scenario: Check the OS image built
     Given I am on the Systems overview page of this "build_host"
     Then I should see a "[OS Image Build Host]" text
     When I wait until the image build "suse_os_image" is completed

--- a/testsuite/features/secondary/buildhost_osimage_build_image.feature
+++ b/testsuite/features/secondary/buildhost_osimage_build_image.feature
@@ -16,7 +16,7 @@
 Feature: Build OS images
 
   Scenario: Create an OS image profile with activation key
-    Given I am authorized as "admin" with password "admin"
+    Given I am authorized for the "Admin" section
     When I follow the left menu "Images > Profiles"
     And I follow "Create"
     And I enter "suse_os_image" as "label"
@@ -57,7 +57,6 @@ Feature: Build OS images
     Then the image should exist on "proxy"
 
   Scenario: Cleanup: remove the image from SUSE Manager server
-    Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Images > Image List"
     And I wait until I do not see "There are no entries to show." text
     And I check the first image
@@ -71,11 +70,9 @@ Feature: Build OS images
     When I disable repositories after installing branch server
 
   Scenario: Cleanup: remove remaining systems from SSM after OS image tests
-    When I am authorized as "admin" with password "admin"
     And I follow "Clear"
 
   Scenario: Cleanup: remove OS image profile
-    Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Images > Profiles"
     And I check "suse_os_image" in the list
     And I click on "Delete"

--- a/testsuite/features/secondary/min_action_chain.feature
+++ b/testsuite/features/secondary/min_action_chain.feature
@@ -5,8 +5,10 @@
 @scope_action_chains
 Feature: Action chains on Salt minions
 
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
   Scenario: Pre-requisite: downgrade repositories to lower version on Salt minion
-    Given I am authorized as "admin" with password "admin"
     When I enable repository "test_repo_rpm_pool" on this "sle_minion"
     And I remove package "andromeda-dummy" from this "sle_minion" without error control
     And I remove package "virgo-dummy" from this "sle_minion" without error control
@@ -27,7 +29,6 @@ Feature: Action chains on Salt minions
     And I click on the filter button until page does contain "andromeda-dummy-1.0" text
 
   Scenario: Pre-requisite: ensure the errata cache is computed before testing on Salt minion
-    Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Admin > Task Schedules"
     And I follow "errata-cache-default"
     And I follow "errata-cache-bunch"
@@ -73,7 +74,6 @@ Feature: Action chains on Salt minions
     Then I should see a "Action has been successfully added to the Action Chain" text
 
   Scenario: Create a configuration channel for testing action chain on Salt minion
-    Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Configuration > Channels"
     And I follow "Create Config Channel"
     And I enter "Action Chain Channel" as "cofName"
@@ -83,7 +83,6 @@ Feature: Action chains on Salt minions
     Then I should see a "Action Chain Channel" text
 
   Scenario: Add a configuration file to configuration channel for testing action chain on Salt minion
-    Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Configuration > Channels"
     And I follow "Action Chain Channel"
     And I follow "Create Configuration File or Directory"
@@ -94,7 +93,6 @@ Feature: Action chains on Salt minions
     And I should see a "Update Configuration File" button
 
   Scenario: Download the configuration file from configuration channel
-    Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Configuration > Channels"
     And I follow "Action Chain Channel"
     And I follow "List/Remove Files"
@@ -114,7 +112,6 @@ Feature: Action chains on Salt minions
     Then I should see a "Channel Subscriptions successfully changed for" text
 
   Scenario: Add a configuration file deployment to the action chain on Salt minion
-    Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Configuration > Channels"
     And I follow "Action Chain Channel"
     And I follow "Deploy Files" in the content area
@@ -164,7 +161,6 @@ Feature: Action chains on Salt minions
     And I should see a "7. Run a remote command on 1 system" text
 
   Scenario: Check that a different user cannot see the action chain for Salt minion
-    Given I am authorized as "testing" with password "testing"
     When I follow "Schedule"
     And I follow "Action Chains"
     Then I should not see a "new action chain" link
@@ -192,7 +188,6 @@ Feature: Action chains on Salt minions
     Then I should see a "Action has been successfully added to the Action Chain" text
 
   Scenario: Delete the action chain for Salt minion
-    Given I am authorized as "admin" with password "admin"
     When I follow "Schedule"
     And I follow "Action Chains"
     And I follow "new action chain"
@@ -249,7 +244,6 @@ Feature: Action chains on Salt minions
     And I wait until there are no more scheduled actions
 
   Scenario: Cleanup: remove Salt minion from configuration channel
-    Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Configuration > Channels"
     And I follow "Action Chain Channel"
     And I follow "Systems" in the content area
@@ -258,7 +252,6 @@ Feature: Action chains on Salt minions
     Then I should see a "Successfully unsubscribed 1 system(s)." text
 
   Scenario: Cleanup: remove configuration channel for Salt minion
-    Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Configuration > Channels"
     And I follow "Action Chain Channel"
     And I follow "Delete Channel"

--- a/testsuite/features/secondary/min_activationkey.feature
+++ b/testsuite/features/secondary/min_activationkey.feature
@@ -51,7 +51,7 @@ Feature: Bootstrap a Salt minion via the GUI with an activation key
 
   Scenario: Bootstrap a SLES minion with an activation key
     Given I am authorized
-    When I go to the bootstrapping page
+    When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "sle_minion" as "hostname"
     And I enter "22" as "port"
@@ -67,7 +67,7 @@ Feature: Bootstrap a Salt minion via the GUI with an activation key
 
   Scenario: Verify that minion bootstrapped with Salt key and packages
     Given I am authorized
-    When I go to the minion onboarding page
+    When I follow the left menu "Salt > Keys"
     Then I should see a "accepted" text
     And the Salt master can reach "sle_minion"
     When I wait for "orion-dummy" to be installed on "sle_minion"

--- a/testsuite/features/secondary/min_bootstrap_negative.feature
+++ b/testsuite/features/secondary/min_bootstrap_negative.feature
@@ -10,7 +10,7 @@ Feature: Negative tests for bootstrapping normal minions
 
   Scenario: Bootstrap should fail when minion already exists
      Given I am authorized
-     And I go to the bootstrapping page
+     And I follow the left menu "Systems > Bootstrapping"
      Then I should see a "Bootstrap Minions" text
      When I enter the hostname of "sle_minion" as "hostname"
      And I enter "22" as "port"
@@ -31,7 +31,7 @@ Feature: Negative tests for bootstrapping normal minions
 
   Scenario: Bootstrap a SLES minion with wrong hostname
      Given I am authorized
-     And I go to the bootstrapping page
+     And I follow the left menu "Systems > Bootstrapping"
      Then I should see a "Bootstrap Minions" text
      When I enter "not-existing-name" as "hostname"
      And I enter "22" as "port"
@@ -43,7 +43,7 @@ Feature: Negative tests for bootstrapping normal minions
 
   Scenario: Bootstrap a SLES minion with wrong SSH credentials
      Given I am authorized
-     And I go to the bootstrapping page
+     And I follow the left menu "Systems > Bootstrapping"
      Then I should see a "Bootstrap Minions" text
      When I enter the hostname of "sle_minion" as "hostname"
      And I enter "22" as "port"
@@ -55,7 +55,7 @@ Feature: Negative tests for bootstrapping normal minions
 
   Scenario: Bootstrap a SLES minion with wrong SSH port number
      Given I am authorized
-     And I go to the bootstrapping page
+     And I follow the left menu "Systems > Bootstrapping"
      Then I should see a "Bootstrap Minions" text
      When I enter the hostname of "sle_minion" as "hostname"
      And I enter "11" as "port"
@@ -68,7 +68,7 @@ Feature: Negative tests for bootstrapping normal minions
 
   Scenario: Cleanup: bootstrap a SLES minion after negative tests
      Given I am authorized
-     When I go to the bootstrapping page
+     When I follow the left menu "Systems > Bootstrapping"
      Then I should see a "Bootstrap Minions" text
      When I enter the hostname of "sle_minion" as "hostname"
      And I enter "22" as "port"

--- a/testsuite/features/secondary/min_bootstrap_negative.feature
+++ b/testsuite/features/secondary/min_bootstrap_negative.feature
@@ -8,8 +8,10 @@ Feature: Negative tests for bootstrapping normal minions
   As an authorized user
   I want to avoid registration with invalid input parameters
 
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
   Scenario: Bootstrap should fail when minion already exists
-     Given I am authorized
      And I follow the left menu "Systems > Bootstrapping"
      Then I should see a "Bootstrap Minions" text
      When I enter the hostname of "sle_minion" as "hostname"
@@ -30,7 +32,6 @@ Feature: Negative tests for bootstrapping normal minions
     Then "sle_minion" should not be registered
 
   Scenario: Bootstrap a SLES minion with wrong hostname
-     Given I am authorized
      And I follow the left menu "Systems > Bootstrapping"
      Then I should see a "Bootstrap Minions" text
      When I enter "not-existing-name" as "hostname"
@@ -42,7 +43,6 @@ Feature: Negative tests for bootstrapping normal minions
      Then I should not see a "GenericSaltError" text
 
   Scenario: Bootstrap a SLES minion with wrong SSH credentials
-     Given I am authorized
      And I follow the left menu "Systems > Bootstrapping"
      Then I should see a "Bootstrap Minions" text
      When I enter the hostname of "sle_minion" as "hostname"
@@ -54,7 +54,6 @@ Feature: Negative tests for bootstrapping normal minions
      Then I should not see a "GenericSaltError" text
 
   Scenario: Bootstrap a SLES minion with wrong SSH port number
-     Given I am authorized
      And I follow the left menu "Systems > Bootstrapping"
      Then I should see a "Bootstrap Minions" text
      When I enter the hostname of "sle_minion" as "hostname"
@@ -67,7 +66,6 @@ Feature: Negative tests for bootstrapping normal minions
      And I should see a "port 11: Connection refused" text or "port 11: Invalid argument" text
 
   Scenario: Cleanup: bootstrap a SLES minion after negative tests
-     Given I am authorized
      When I follow the left menu "Systems > Bootstrapping"
      Then I should see a "Bootstrap Minions" text
      When I enter the hostname of "sle_minion" as "hostname"

--- a/testsuite/features/secondary/min_bootstrap_ssh_key.feature
+++ b/testsuite/features/secondary/min_bootstrap_ssh_key.feature
@@ -18,7 +18,7 @@ Feature: Bootstrap a Salt minion via the GUI using SSH key
 
   Scenario: Bootstrap a SLES minion using SSH key with wrong passphrase
     Given I am authorized
-    When I go to the bootstrapping page
+    When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "sle_minion" as "hostname"
     And I enter "22" as "port"
@@ -31,7 +31,7 @@ Feature: Bootstrap a Salt minion via the GUI using SSH key
 
   Scenario: Bootstrap a SLES minion using SSH key
     Given I am authorized
-    When I go to the bootstrapping page
+    When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "sle_minion" as "hostname"
     And I enter "22" as "port"
@@ -45,7 +45,7 @@ Feature: Bootstrap a Salt minion via the GUI using SSH key
 
   Scenario: Check new minion bootstrapped with SSH key in System Overview page
     Given I am authorized
-    When I go to the minion onboarding page
+    When I follow the left menu "Salt > Keys"
     Then I should see a "accepted" text
     When I am on the Systems page
     And I wait until I see the name of "sle_minion", refreshing the page

--- a/testsuite/features/secondary/min_bootstrap_xmlrpc.feature
+++ b/testsuite/features/secondary/min_bootstrap_xmlrpc.feature
@@ -19,7 +19,7 @@ Feature: Register a Salt minion via XML-RPC API
 
   Scenario: Check new minion bootstrapped via XML-RPC in System Overview page
     Given I am authorized
-    When I go to the minion onboarding page
+    When I follow the left menu "Salt > Keys"
     Then I should see a "accepted" text
     When I am on the System Overview page
     And I wait until I see the name of "sle_minion", refreshing the page

--- a/testsuite/features/secondary/min_bootstrap_xmlrpc.feature
+++ b/testsuite/features/secondary/min_bootstrap_xmlrpc.feature
@@ -4,6 +4,9 @@
 @scope_onboarding
 Feature: Register a Salt minion via XML-RPC API
 
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
   Scenario: Delete SLES minion system profile before XML-RPC bootstrap test
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Delete System"
@@ -18,7 +21,6 @@ Feature: Register a Salt minion via XML-RPC API
     And I logout from XML-RPC system namespace
 
   Scenario: Check new minion bootstrapped via XML-RPC in System Overview page
-    Given I am authorized
     When I follow the left menu "Salt > Keys"
     Then I should see a "accepted" text
     When I am on the System Overview page

--- a/testsuite/features/secondary/min_centos_ssh.feature
+++ b/testsuite/features/secondary/min_centos_ssh.feature
@@ -8,7 +8,10 @@
 @scope_res
 Feature: Bootstrap a SSH-managed CentOS minion and do some basic operations on it
 
-@centos_minion
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
+  @centos_minion
   Scenario: Delete the CentOS minion before SSH minion tests
     When I am on the Systems overview page of this "ceos_minion"
     And I follow "Delete System"
@@ -19,7 +22,6 @@ Feature: Bootstrap a SSH-managed CentOS minion and do some basic operations on i
 
 @centos_minion
   Scenario: Bootstrap a SSH-managed CentOS minion
-    Given I am authorized
     When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I check "manageWithSSH"
@@ -69,7 +71,6 @@ Feature: Bootstrap a SSH-managed CentOS minion and do some basic operations on i
 
 @centos_minion
   Scenario: Run a remote command on the SSH-managed CentOS minion
-    Given I am authorized as "testing" with password "testing"
     When I follow the left menu "Salt > Remote Commands"
     Then I should see a "Remote Commands" text in the content area
     When I enter command "cat /etc/os-release"
@@ -98,7 +99,6 @@ Feature: Bootstrap a SSH-managed CentOS minion and do some basic operations on i
 
 @centos_minion
   Scenario: Cleanup: bootstrap a CentOS minion after SSH minion tests
-    Given I am authorized
     When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "ceos_minion" as "hostname"

--- a/testsuite/features/secondary/min_centos_ssh.feature
+++ b/testsuite/features/secondary/min_centos_ssh.feature
@@ -20,7 +20,7 @@ Feature: Bootstrap a SSH-managed CentOS minion and do some basic operations on i
 @centos_minion
   Scenario: Bootstrap a SSH-managed CentOS minion
     Given I am authorized
-    When I go to the bootstrapping page
+    When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I check "manageWithSSH"
     And I enter the hostname of "ceos_ssh_minion" as "hostname"
@@ -99,7 +99,7 @@ Feature: Bootstrap a SSH-managed CentOS minion and do some basic operations on i
 @centos_minion
   Scenario: Cleanup: bootstrap a CentOS minion after SSH minion tests
     Given I am authorized
-    When I go to the bootstrapping page
+    When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "ceos_minion" as "hostname"
     And I enter "22" as "port"

--- a/testsuite/features/secondary/min_salt_formulas.feature
+++ b/testsuite/features/secondary/min_salt_formulas.feature
@@ -7,13 +7,14 @@ Feature: Use salt formulas
   As an authorized user
   I want to be able to install and use salt formulas
 
-  Scenario: Install the locale formula package on the server
-     Given I am authorized
+   Scenario: Log in as admin user
+      Given I am authorized for the "Admin" section
+
+   Scenario: Install the locale formula package on the server
      When I manually install the "locale" formula on the server
      And I synchronize all Salt dynamic modules on "sle_minion"
 
   Scenario: The new formula appears on the server
-     Given I am authorized
      When I follow the left menu "Salt > Formula Catalog"
      Then I should see a "locale" text in the content area
 
@@ -161,9 +162,7 @@ Feature: Use salt formulas
      And the language on "sle_minion" should be "en_US.UTF-8"
 
   Scenario: Cleanup: uninstall formula package from the server
-     Given I am authorized
      And I manually uninstall the "locale" formula from the server
 
   Scenario: Cleanup: remove remaining systems from SSM after formula tests
-     When I am authorized as "admin" with password "admin"
      And I follow "Clear"

--- a/testsuite/features/secondary/min_salt_install_package.feature
+++ b/testsuite/features/secondary/min_salt_install_package.feature
@@ -14,6 +14,9 @@ Feature: Install a patch on the client via Salt through the UI
     And I wait until refresh package list on "sle_minion" is finished
     Then spacecmd should show packages "virgo-dummy-1.0" installed on "sle_minion"
 
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
   Scenario: Pre-requisite: ensure the errata cache is computed before patching Salt minion
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Software" in the content area

--- a/testsuite/features/secondary/min_salt_mgrcompat_state.feature
+++ b/testsuite/features/secondary/min_salt_mgrcompat_state.feature
@@ -5,6 +5,9 @@
 @scope_salt
 Feature: Verify that Salt mgrcompat state works when the new module.run syntax is enabled
 
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
   Scenario: Remove mgrcompat module from minion synced modules and schedule Hardware Refresh
     Given I remove "/var/cache/salt/minion/extmods/states/mgrcompat.py" from "sle_minion"
     And I remove "/var/cache/salt/minion/extmods/states/__pycache__/mgrcompat*" from "sle_minion"
@@ -35,7 +38,6 @@ Feature: Verify that Salt mgrcompat state works when the new module.run syntax i
 
   Scenario: Enable new module.run syntax on the minion and perform registration
     Given I store "use_superseded: [module.run]" into file "/etc/salt/minion.d/custom_modulerun.conf" on "sle_minion"
-    And I am authorized
     When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "sle_minion" as "hostname"
@@ -48,7 +50,6 @@ Feature: Verify that Salt mgrcompat state works when the new module.run syntax i
     And I wait until onboarding is completed for "sle_minion"
 
   Scenario: Check if onboarding for the minion with the new module.run syntax was successful
-    Given I am authorized as "admin" with password "admin"
     When I am on the System Overview page
     And I wait until I see the name of "sle_minion", refreshing the page
     And I wait until onboarding is completed for "sle_minion"
@@ -77,7 +78,6 @@ Feature: Verify that Salt mgrcompat state works when the new module.run syntax i
     Then "sle_minion" should not be registered
 
   Scenario: Cleanup: bootstrap again the minion after mgrcompat tests
-    Given I am authorized
     When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "sle_minion" as "hostname"

--- a/testsuite/features/secondary/min_salt_mgrcompat_state.feature
+++ b/testsuite/features/secondary/min_salt_mgrcompat_state.feature
@@ -36,7 +36,7 @@ Feature: Verify that Salt mgrcompat state works when the new module.run syntax i
   Scenario: Enable new module.run syntax on the minion and perform registration
     Given I store "use_superseded: [module.run]" into file "/etc/salt/minion.d/custom_modulerun.conf" on "sle_minion"
     And I am authorized
-    When I go to the bootstrapping page
+    When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "sle_minion" as "hostname"
     And I enter "22" as "port"
@@ -78,7 +78,7 @@ Feature: Verify that Salt mgrcompat state works when the new module.run syntax i
 
   Scenario: Cleanup: bootstrap again the minion after mgrcompat tests
     Given I am authorized
-    When I go to the bootstrapping page
+    When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "sle_minion" as "hostname"
     And I enter "22" as "port"

--- a/testsuite/features/secondary/min_salt_minions_page.feature
+++ b/testsuite/features/secondary/min_salt_minions_page.feature
@@ -7,6 +7,9 @@ Feature: Management of minion keys
   As an authorized user
   I want to verify all the minion key management features in the UI
 
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
   Scenario: Delete SLES minion system profile before exploring the onboarding page
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Delete System"
@@ -16,12 +19,10 @@ Feature: Management of minion keys
     Then "sle_minion" should not be registered
 
   Scenario: Completeness of the onboarding page
-    Given I am authorized as "testing" with password "testing"
     And I follow the left menu "Salt > Keys"
     Then I should see a "Keys" text in the content area
 
   Scenario: Minion is visible in the Pending section
-    Given I am authorized as "testing" with password "testing"
     And I restart salt-minion on "sle_minion"
     And I wait at most 10 seconds until Salt master sees "sle_minion" as "unaccepted"
     And I follow the left menu "Salt > Keys"
@@ -31,7 +32,6 @@ Feature: Management of minion keys
     And I should see a "pending" text
 
   Scenario: Reject and delete the pending key
-    Given I am authorized as "testing" with password "testing"
     And I follow the left menu "Salt > Keys"
     And I reject "sle_minion" from the Pending section
     And I wait at most 10 seconds until Salt master sees "sle_minion" as "rejected"
@@ -42,7 +42,6 @@ Feature: Management of minion keys
     And I refresh page until I do not see "sle_minion" hostname as text
 
   Scenario: Accepted minion shows up as a registered system
-    Given I am authorized as "testing" with password "testing"
     When I start salt-minion on "sle_minion"
     And I wait at most 10 seconds until Salt master sees "sle_minion" as "unaccepted"
     Then "sle_minion" should not be registered
@@ -54,7 +53,6 @@ Feature: Management of minion keys
     Then "sle_minion" should be registered
 
   Scenario: The minion communicates with the Salt master
-    Given I am authorized as "testing" with password "testing"
     Then the Salt master can reach "sle_minion"
     When I get OS information of "sle_minion" from the Master
     Then it should contain the OS of "sle_minion"
@@ -71,7 +69,6 @@ Feature: Management of minion keys
     Then "sle_minion" should not be registered
 
   Scenario: Cleanup: bootstrap again the minion
-    Given I am authorized
     When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "sle_minion" as "hostname"

--- a/testsuite/features/secondary/min_salt_minions_page.feature
+++ b/testsuite/features/secondary/min_salt_minions_page.feature
@@ -17,14 +17,14 @@ Feature: Management of minion keys
 
   Scenario: Completeness of the onboarding page
     Given I am authorized as "testing" with password "testing"
-    And I go to the minion onboarding page
+    And I follow the left menu "Salt > Keys"
     Then I should see a "Keys" text in the content area
 
   Scenario: Minion is visible in the Pending section
     Given I am authorized as "testing" with password "testing"
     And I restart salt-minion on "sle_minion"
     And I wait at most 10 seconds until Salt master sees "sle_minion" as "unaccepted"
-    And I go to the minion onboarding page
+    And I follow the left menu "Salt > Keys"
     And I refresh page until I see "sle_minion" hostname as text
     Then I should see a "Fingerprint" text
     And I see "sle_minion" fingerprint
@@ -32,7 +32,7 @@ Feature: Management of minion keys
 
   Scenario: Reject and delete the pending key
     Given I am authorized as "testing" with password "testing"
-    And I go to the minion onboarding page
+    And I follow the left menu "Salt > Keys"
     And I reject "sle_minion" from the Pending section
     And I wait at most 10 seconds until Salt master sees "sle_minion" as "rejected"
     Then I should see a "rejected" text
@@ -46,7 +46,7 @@ Feature: Management of minion keys
     When I start salt-minion on "sle_minion"
     And I wait at most 10 seconds until Salt master sees "sle_minion" as "unaccepted"
     Then "sle_minion" should not be registered
-    When I go to the minion onboarding page
+    When I follow the left menu "Salt > Keys"
     Then I should see a "pending" text
     When I accept "sle_minion" key
     And I wait at most 10 seconds until Salt master sees "sle_minion" as "accepted"
@@ -72,7 +72,7 @@ Feature: Management of minion keys
 
   Scenario: Cleanup: bootstrap again the minion
     Given I am authorized
-    When I go to the bootstrapping page
+    When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "sle_minion" as "hostname"
     And I enter "22" as "port"

--- a/testsuite/features/secondary/min_ssh_tunnel.feature
+++ b/testsuite/features/secondary/min_ssh_tunnel.feature
@@ -4,6 +4,9 @@
 @scope_salt_ssh
 Feature: Register a salt system to be managed via SSH tunnel
 
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
   Scenario: Delete the salt minion for SSH tunnel bootstrap
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Delete System"
@@ -13,7 +16,6 @@ Feature: Register a salt system to be managed via SSH tunnel
     Then "sle_minion" should not be registered
 
   Scenario: Register this minion for push via SSH tunnel
-    Given I am authorized
     When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     And I enter the hostname of "sle_ssh_tunnel_minion" as "hostname"
@@ -58,7 +60,6 @@ Feature: Register a salt system to be managed via SSH tunnel
     Then I wait until event "Package Removal scheduled by admin" is completed
 
   Scenario: Run a remote command on this SSH tunnel minion
-    Given I am authorized as "testing" with password "testing"
     When I follow the left menu "Salt > Remote Commands"
     Then I should see a "Remote Commands" text in the content area
     When I enter command "echo 'My remote command output'"

--- a/testsuite/features/secondary/min_ssh_tunnel.feature
+++ b/testsuite/features/secondary/min_ssh_tunnel.feature
@@ -14,7 +14,7 @@ Feature: Register a salt system to be managed via SSH tunnel
 
   Scenario: Register this minion for push via SSH tunnel
     Given I am authorized
-    When I go to the bootstrapping page
+    When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     And I enter the hostname of "sle_ssh_tunnel_minion" as "hostname"
     And I enter "22" as "port"

--- a/testsuite/features/secondary/min_ubuntu_ssh.feature
+++ b/testsuite/features/secondary/min_ubuntu_ssh.feature
@@ -7,9 +7,12 @@
 
 @scope_ubuntu
 @scope_salt_ssh
+@ubuntu_minion
 Feature: Bootstrap a SSH-managed Ubuntu minion and do some basic operations on it
 
-@ubuntu_minion
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
   Scenario: Delete the Ubuntu minion
     When I am on the Systems overview page of this "ubuntu_minion"
     And I follow "Delete System"
@@ -18,9 +21,7 @@ Feature: Bootstrap a SSH-managed Ubuntu minion and do some basic operations on i
     And I wait until I see "has been deleted" text
     Then "ubuntu_minion" should not be registered
 
-@ubuntu_minion
   Scenario: Bootstrap a SSH-managed Ubuntu minion
-    Given I am authorized
     When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I check "manageWithSSH"
@@ -34,7 +35,6 @@ Feature: Bootstrap a SSH-managed Ubuntu minion and do some basic operations on i
     And I wait until onboarding is completed for "ubuntu_ssh_minion"
 
 @proxy
-@ubuntu_minion
   Scenario: Check connection from SSH-managed Ubuntu minion to proxy
     Given I am on the Systems overview page of this "ubuntu_ssh_minion"
     When I follow "Details" in the content area
@@ -42,14 +42,12 @@ Feature: Bootstrap a SSH-managed Ubuntu minion and do some basic operations on i
     Then I should see "proxy" short hostname
 
 @proxy
-@ubuntu_minion
   Scenario: Check registration on proxy of SSH-managed Ubuntu minion
     Given I am on the Systems overview page of this "proxy"
     When I follow "Details" in the content area
     And I follow "Proxy" in the content area
     Then I should see "ubuntu_ssh_minion" hostname
 
-@ubuntu_minion
   Scenario: Subscribe the SSH-managed Ubuntu minion to a base channel
     Given I am on the Systems overview page of this "ubuntu_ssh_minion"
     When I follow "Software" in the content area
@@ -63,14 +61,11 @@ Feature: Bootstrap a SSH-managed Ubuntu minion and do some basic operations on i
     Then I should see a "Changing the channels has been scheduled." text
     And I wait until event "Subscribe channels scheduled by admin" is completed
 
-@ubuntu_minion
   Scenario: Check events history for failures on SSH-managed Ubuntu minion
     Given I am on the Systems overview page of this "ubuntu_ssh_minion"
     Then I check for failed events on history event page
 
-@ubuntu_minion
   Scenario: Run a remote command on the SSH-managed Ubuntu minion
-    Given I am authorized
     When I follow the left menu "Salt > Remote Commands"
     Then I should see a "Remote Commands" text in the content area
     When I enter command "cat /etc/os-release"
@@ -82,12 +77,10 @@ Feature: Bootstrap a SSH-managed Ubuntu minion and do some basic operations on i
     And I expand the results for "ubuntu_ssh_minion"
     Then I should see a "ID=ubuntu" text
 
-@ubuntu_minion
   Scenario: Check events history for failures on SSH-managed Ubuntu minion
     Given I am on the Systems overview page of this "ubuntu_ssh_minion"
     Then I check for failed events on history event page
 
-@ubuntu_minion
   Scenario: Cleanup: delete the SSH-managed Ubuntu minion
     When I am on the Systems overview page of this "ubuntu_ssh_minion"
     And I follow "Delete System"
@@ -96,9 +89,7 @@ Feature: Bootstrap a SSH-managed Ubuntu minion and do some basic operations on i
     And I wait until I see "has been deleted" text
     Then "ubuntu_ssh_minion" should not be registered
 
-@ubuntu_minion
   Scenario: Cleanup: bootstrap a Ubuntu minion
-    Given I am authorized
     When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "ubuntu_minion" as "hostname"
@@ -112,7 +103,6 @@ Feature: Bootstrap a SSH-managed Ubuntu minion and do some basic operations on i
     And I wait until I see the name of "ubuntu_minion", refreshing the page
     And I wait until onboarding is completed for "ubuntu_minion"
 
-@ubuntu_minion
   Scenario: Cleanup: re-subscribe the Ubuntu minion to a base channel
     Given I am on the Systems overview page of this "ubuntu_minion"
     When I follow "Software" in the content area

--- a/testsuite/features/secondary/min_ubuntu_ssh.feature
+++ b/testsuite/features/secondary/min_ubuntu_ssh.feature
@@ -21,7 +21,7 @@ Feature: Bootstrap a SSH-managed Ubuntu minion and do some basic operations on i
 @ubuntu_minion
   Scenario: Bootstrap a SSH-managed Ubuntu minion
     Given I am authorized
-    When I go to the bootstrapping page
+    When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I check "manageWithSSH"
     And I enter the hostname of "ubuntu_ssh_minion" as "hostname"
@@ -99,7 +99,7 @@ Feature: Bootstrap a SSH-managed Ubuntu minion and do some basic operations on i
 @ubuntu_minion
   Scenario: Cleanup: bootstrap a Ubuntu minion
     Given I am authorized
-    When I go to the bootstrapping page
+    When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "ubuntu_minion" as "hostname"
     And I enter "22" as "port"

--- a/testsuite/features/secondary/minkvm_guests.feature
+++ b/testsuite/features/secondary/minkvm_guests.feature
@@ -7,7 +7,7 @@ Feature: Be able to manage KVM virtual machines via the GUI
 @virthost_kvm
   Scenario: Bootstrap KVM virtual host
     Given I am authorized as "admin" with password "admin"
-    When I go to the bootstrapping page
+    When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "kvm_server" as "hostname"
     And I enter "22" as "port"

--- a/testsuite/features/secondary/minkvm_guests.feature
+++ b/testsuite/features/secondary/minkvm_guests.feature
@@ -2,11 +2,13 @@
 # Licensed under the terms of the MIT license.
 
 @scope_virtualization
+@virthost_kvm
 Feature: Be able to manage KVM virtual machines via the GUI
 
-@virthost_kvm
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
   Scenario: Bootstrap KVM virtual host
-    Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "kvm_server" as "hostname"
@@ -19,7 +21,6 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "kvm_server"
 
-@virthost_kvm
   Scenario: Setting the virtualization entitlement for KVM
     Given I am on the Systems overview page of this "kvm_server"
     When I follow "Details" in the content area
@@ -29,7 +30,6 @@ Feature: Be able to manage KVM virtual machines via the GUI
     Then I should see a "Since you added a Virtualization system type to the system" text
     And I restart salt-minion on "kvm_server"
 
-@virthost_kvm
   Scenario: Enable the virtualization host formula for KVM
     Given I am on the Systems overview page of this "kvm_server"
     When I follow "Formulas" in the content area
@@ -39,7 +39,6 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I click on "Save"
     Then the "virtualization-host" formula should be checked
 
-@virthost_kvm
   Scenario: Parametrize the KVM virtualization host
     Given I am on the Systems overview page of this "kvm_server"
     When I follow "Formulas" in the content area
@@ -51,7 +50,6 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I click on "Save Formula"
     Then I should see a "Formula saved" text
 
-@virthost_kvm
   Scenario: Apply the KVM virtualization host formula via the highstate
     Given I am on the Systems overview page of this "kvm_server"
     When I follow "States" in the content area
@@ -59,7 +57,6 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I wait until event "Apply highstate scheduled by admin" is completed
     Then service "libvirtd" is enabled on "kvm_server"
 
-@virthost_kvm
   Scenario: Prepare a KVM test virtual machine and list it
     Given I am on the "Virtualization" page of this "kvm_server"
     When I delete default virtual network on "kvm_server"
@@ -70,13 +67,11 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I create "test-vm" virtual machine on "kvm_server"
     And I wait until I see "test-vm" text
 
-@virthost_kvm
   Scenario: Start a KVM virtual machine
     Given I am on the "Virtualization" page of this "kvm_server"
     When I click on "Start" in row "test-vm"
     Then I should see "test-vm" virtual machine running on "kvm_server"
 
-@virthost_kvm
   Scenario: Show the VNC graphical console for KVM
     Given I am on the "Virtualization" page of this "kvm_server"
     When I click on "Graphical Console" in row "test-vm"
@@ -84,7 +79,6 @@ Feature: Be able to manage KVM virtual machines via the GUI
     Then I wait until I see the VNC graphical console
     When I close the last opened window
 
-@virthost_kvm
   Scenario: Suspend a KVM virtual machine
     Given I am on the "Virtualization" page of this "kvm_server"
     When I wait until table row for "test-vm" contains button "Suspend"
@@ -92,14 +86,12 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I click on "Suspend" in "Suspend Guest" modal
     Then I should see "test-vm" virtual machine paused on "kvm_server"
 
-@virthost_kvm
   Scenario: Resume a KVM virtual machine
     Given I am on the "Virtualization" page of this "kvm_server"
     When I wait until table row for "test-vm" contains button "Resume"
     And I click on "Resume" in row "test-vm"
     Then I should see "test-vm" virtual machine running on "kvm_server"
 
-@virthost_kvm
   Scenario: Shutdown a KVM virtual machine
     Given I am on the "Virtualization" page of this "kvm_server"
     When I wait until table row for "test-vm" contains button "Stop"
@@ -108,7 +100,6 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I click on "Stop" in "Stop Guest" modal
     Then I should see "test-vm" virtual machine shut off on "kvm_server"
 
-@virthost_kvm
   Scenario: Edit a KVM virtual machine
     Given I am on the "Virtualization" page of this "kvm_server"
     When I click on "Edit" in row "test-vm"
@@ -132,7 +123,6 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And "test-vm" virtual machine on "kvm_server" should have a NIC with 02:34:56:78:9a:bc MAC address
     And "test-vm" virtual machine on "kvm_server" should have a "test-vm_disk.qcow2" SCSI disk from pool "tmp"
 
-@virthost_kvm
   Scenario: Add a network interface to a KVM virtual machine
     Given I am on the "Virtualization" page of this "kvm_server"
     When I click on "Edit" in row "test-vm"
@@ -143,7 +133,6 @@ Feature: Be able to manage KVM virtual machines via the GUI
     Then I should see a "Hosted Virtual Systems" text
     And "test-vm" virtual machine on "kvm_server" should have 2 NIC using "test-net1" network
 
-@virthost_kvm
   Scenario: Delete a network interface from a KVM virtual machine
     Given I am on the "Virtualization" page of this "kvm_server"
     When I click on "Edit" in row "test-vm"
@@ -153,7 +142,6 @@ Feature: Be able to manage KVM virtual machines via the GUI
     Then I should see a "Hosted Virtual Systems" text
     And "test-vm" virtual machine on "kvm_server" should have 1 NIC using "test-net1" network
 
-@virthost_kvm
   Scenario: Add a disk and a cdrom to a KVM virtual machine
     Given I am on the "Virtualization" page of this "kvm_server"
     When I click on "Edit" in row "test-vm"
@@ -167,7 +155,6 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And "test-vm" virtual machine on "kvm_server" should have a "test-vm_disk-1" virtio disk from pool "test-pool0"
     And "test-vm" virtual machine on "kvm_server" should have a ide cdrom
 
-@virthost_kvm
   Scenario: Attach an image to a cdrom on a KVM virtual machine
     Given I am on the "Virtualization" page of this "kvm_server"
     When I click on "Edit" in row "test-vm"
@@ -178,7 +165,6 @@ Feature: Be able to manage KVM virtual machines via the GUI
     Then I should see a "Hosted Virtual Systems" text
     And "test-vm" virtual machine on "kvm_server" should have "/tmp/test-image.iso" attached to a cdrom
 
-@virthost_kvm
   Scenario: Delete a disk from a KVM virtual machine
     Given I am on the "Virtualization" page of this "kvm_server"
     When I click on "Edit" in row "test-vm"
@@ -188,14 +174,12 @@ Feature: Be able to manage KVM virtual machines via the GUI
     Then I should see a "Hosted Virtual Systems" text
     And "test-vm" virtual machine on "kvm_server" should have no cdrom
 
-@virthost_kvm
   Scenario: Delete a KVM virtual machine
     Given I am on the "Virtualization" page of this "kvm_server"
     When I click on "Delete" in row "test-vm"
     And I click on "Delete" in "Delete Guest" modal
     Then I should not see a "test-vm" virtual machine on "kvm_server"
 
-@virthost_kvm
   Scenario: Create a KVM virtual machine
     Given I am on the "Virtualization" page of this "kvm_server"
     And I create empty "/var/lib/libvirt/images/test-pool0/disk1.qcow2" qcow2 disk file on "kvm_server"
@@ -218,7 +202,6 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And "test-vm2" virtual machine on "kvm_server" should have a "test-vm2_system" virtio disk from pool "test-pool0"
     And "test-vm2" virtual machine on "kvm_server" should have a "disk1.qcow2" virtio disk from pool "test-pool0"
 
-@virthost_kvm
   Scenario: Show the Spice graphical console for KVM
     Given I am on the "Virtualization" page of this "kvm_server"
     When I click on "Graphical Console" in row "test-vm2"
@@ -226,7 +209,6 @@ Feature: Be able to manage KVM virtual machines via the GUI
     Then I wait until I see the spice graphical console
     When I close the last opened window
 
-@virthost_kvm
   Scenario: Show the virtual storage pools and volumes for KVM
     Given I am on the "Virtualization" page of this "kvm_server"
     When I refresh the "test-pool0" storage pool of this "kvm_server"
@@ -234,35 +216,30 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I open the sub-list of the product "test-pool0"
     Then I wait until I see "test-vm2_system" text
 
-@virthost_kvm
   Scenario: delete a running KVM virtual machine
     Given I am on the "Virtualization" page of this "kvm_server"
     When I click on "Delete" in row "test-vm2"
     And I click on "Delete" in "Delete Guest" modal
     Then I should not see a "test-vm2" virtual machine on "kvm_server"
 
-@virthost_kvm
   Scenario: Refresh a virtual storage pool for KVM
     Given I am on the "Virtualization" page of this "kvm_server"
     When I follow "Storage"
     And I click on "Refresh" in tree item "test-pool0"
     And I wait at most 600 seconds until the tree item "test-pool0" has no sub-list
 
-@virthost_kvm
   Scenario: Stop a virtual storage pool for KVM
     Given I am on the "Virtualization" page of this "kvm_server"
     When I follow "Storage"
     And I click on "Stop" in tree item "test-pool0"
     And I wait at most 600 seconds until the tree item "test-pool0" contains "inactive" text
 
-@virthost_kvm
   Scenario: Start a virtual storage pool for KVM
     Given I am on the "Virtualization" page of this "kvm_server"
     When I follow "Storage"
     And I click on "Start" in tree item "test-pool0"
     And I wait at most 600 seconds until the tree item "test-pool0" contains "running" text
 
-@virthost_kvm
   Scenario: Delete a virtual storage pool for KVM
     Given I am on the "Virtualization" page of this "kvm_server"
     When I follow "Storage"
@@ -272,7 +249,6 @@ Feature: Be able to manage KVM virtual machines via the GUI
     Then I wait until I do not see "test-pool0" text
     And file "/var/lib/libvirt/images/test-pool0" should not exist on "kvm_server"
 
-@virthost_kvm
   Scenario: Create a virtual storage pool for KVM
     Given I am on the "Virtualization" page of this "kvm_server"
     When I follow "Storage"
@@ -288,7 +264,6 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I wait at most 600 seconds until the tree item "test-pool1" contains "running" text
     And file "/var/lib/libvirt/images/test-pool1" should have 755 permissions on "kvm_server"
 
-@virthost_kvm
   Scenario: Edit a virtual storage pool for KVM
     Given I am on the "Virtualization" page of this "kvm_server"
     When I follow "Storage"
@@ -301,7 +276,6 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I wait at most 600 seconds until the tree item "test-pool1" contains "test-pool1 is started automatically" button
     And file "/var/lib/libvirt/images/test-pool1" should have 711 permissions on "kvm_server"
 
-@virthost_kvm
   Scenario: Delete a virtual volume
     Given I am on the "Virtualization" page of this "kvm_server"
     When I follow "Storage"
@@ -310,14 +284,12 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I click on "Delete" in "Delete Virtual Storage Volume" modal
     Then I wait until I do not see "test-net0.xml" text
 
-@virthost_kvm
   Scenario: List virtual networks
     Given I am on the "Virtualization" page of this "kvm_server"
     When I follow "Networks"
     Then I wait until I see "test-net0" text
     And I should see a "test-net1" text
 
-@virthost_kvm
   Scenario: Stop virtual network
     Given I am on the "Virtualization" page of this "kvm_server"
     When I follow "Networks"
@@ -327,7 +299,6 @@ Feature: Be able to manage KVM virtual machines via the GUI
     Then I wait until table row for "test-net1" contains button "Start"
     And table row for "test-net1" should contain "stopped"
 
-@virthost_kvm
   Scenario: Start virtual network
     Given I am on the "Virtualization" page of this "kvm_server"
     When I follow "Networks"
@@ -335,7 +306,6 @@ Feature: Be able to manage KVM virtual machines via the GUI
     Then I wait until table row for "test-net1" contains button "Stop"
     And table row for "test-net1" should contain "running"
 
-@virthost_kvm
   Scenario: Delete virtual network
     Given I am on the "Virtualization" page of this "kvm_server"
     When I follow "Networks"
@@ -344,7 +314,6 @@ Feature: Be able to manage KVM virtual machines via the GUI
     Then I wait until I do not see "test-net1" text
     And I should not see a "test-net1" virtual network on "kvm_server"
 
-@virthost_kvm
   Scenario: Create a virtual network
     Given I am on the "Virtualization" page of this "kvm_server"
     When I follow "Networks"
@@ -368,10 +337,8 @@ Feature: Be able to manage KVM virtual machines via the GUI
 # Start provisioning scenarios
 
 @long_test
-@virthost_kvm
 @scc_credentials
   Scenario: Create auto installation distribution
-    Given I am authorized
     And I install package tftpboot-installation on the server
     And I wait for "tftpboot-installation-SLE-15-SP2-x86_64" to be installed on "server"
     When I follow the left menu "Systems > Autoinstallation > Distributions"
@@ -386,10 +353,8 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I should see a "SLE-15-SP2-TFTP" link
 
 @long_test
-@virthost_kvm
 @scc_credentials
   Scenario: Create auto installation profile
-    Given I am authorized as "admin" with password "admin"
     And I follow the left menu "Systems > Autoinstallation > Profiles"
     And I follow "Upload Kickstart/Autoyast File"
     When I enter "15-sp2-kvm" as "kickstartLabel"
@@ -408,7 +373,6 @@ Feature: Be able to manage KVM virtual machines via the GUI
     Then I should see a "SLE-15-SP2-TFTP" text
 
 @long_test
-@virthost_kvm
 @scc_credentials
   Scenario: Create an auto installing KVM virtual machine
     Given I am on the "Virtualization" page of this "kvm_server"
@@ -435,10 +399,8 @@ Feature: Be able to manage KVM virtual machines via the GUI
     When I close the last opened window
 
 @long_test
-@virthost_kvm
 @scc_credentials
   Scenario: Cleanup: remove the auto installation profile
-    Given I am authorized as "admin" with password "admin"
     And I follow the left menu "Systems > Autoinstallation > Profiles"
     When I follow "15-sp2-kvm"
     And I follow "Delete Autoinstallation"
@@ -446,10 +408,8 @@ Feature: Be able to manage KVM virtual machines via the GUI
     Then I should not see a "15-sp2-kvm" text
 
 @long_test
-@virthost_kvm
 @scc_credentials
   Scenario: Cleanup: remove the auto installation distribution
-    Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Systems > Autoinstallation > Distributions"
     And I follow "SLE-15-SP2-TFTP"
     And I follow "Delete Distribution"
@@ -460,7 +420,6 @@ Feature: Be able to manage KVM virtual machines via the GUI
 
 # End of provisioning scenarios
 
-@virthost_kvm
   Scenario: Cleanup: Unregister the KVM virtualization host
     Given I am on the Systems overview page of this "kvm_server"
     When I follow "Delete System"
@@ -468,7 +427,6 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I click on "Delete Profile"
     Then I wait until I see "has been deleted" text
 
-@virthost_kvm
   Scenario: Cleanup: Cleanup KVM virtualization host
     When I run "zypper -n mr -e --all" on "kvm_server" without error control
     And I run "zypper -n rr SUSE-Manager-Bootstrap" on "kvm_server" without error control

--- a/testsuite/features/secondary/minssh_action_chain.feature
+++ b/testsuite/features/secondary/minssh_action_chain.feature
@@ -6,8 +6,10 @@
 @scope_salt_ssh
 Feature: Salt SSH action chain
 
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
   Scenario: Pre-requisite: downgrade repositories to lower version on SSH minion
-    Given I am authorized as "admin" with password "admin"
     When I enable repository "test_repo_rpm_pool" on this "ssh_minion"
     And I remove package "andromeda-dummy" from this "ssh_minion" without error control
     And I remove package "virgo-dummy" from this "ssh_minion" without error control
@@ -28,7 +30,6 @@ Feature: Salt SSH action chain
     And I click on the filter button until page does contain "andromeda-dummy-1.0" text
 
   Scenario: Pre-requisite: ensure the errata cache is computed before testing on SSH minion
-    Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Admin > Task Schedules"
     And I follow "errata-cache-default"
     And I follow "errata-cache-bunch"
@@ -74,7 +75,6 @@ Feature: Salt SSH action chain
     Then I should see a "Action has been successfully added to the Action Chain" text
 
   Scenario: Create a configuration channel for testing action chain on SSH minion
-    Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Configuration > Channels"
     And I follow "Create Config Channel"
     And I enter "Action Chain Channel" as "cofName"
@@ -84,7 +84,6 @@ Feature: Salt SSH action chain
     Then I should see a "Action Chain Channel" text
 
   Scenario: Add a configuration file to configuration channel for testing action chain on SSH minion
-    Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Configuration > Channels"
     And I follow "Action Chain Channel"
     And I follow "Create Configuration File or Directory"
@@ -105,7 +104,6 @@ Feature: Salt SSH action chain
     Then I should see a "Channel Subscriptions successfully changed for" text
 
   Scenario: Add a configuration file deployment to the action chain on SSH minion
-    Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Configuration > Channels"
     And I follow "Action Chain Channel"
     And I follow "Deploy Files" in the content area
@@ -158,6 +156,9 @@ Feature: Salt SSH action chain
     When I follow the left menu "Schedule > Action Chains"
     Then I should not see a "new action chain" link
 
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
   Scenario: Execute the action chain from the web UI on SSH minion
     Given I am on the Systems overview page of this "ssh_minion"
     When I follow the left menu "Schedule > Action Chains"
@@ -182,7 +183,6 @@ Feature: Salt SSH action chain
     Then I should see a "Action has been successfully added to the Action Chain" text
 
   Scenario: Delete the action chain for SSH minion
-    Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Schedule > Action Chains"
     And I follow "new action chain"
     And I follow "delete action chain" in the content area
@@ -240,7 +240,6 @@ Feature: Salt SSH action chain
     And I wait until there are no more scheduled actions
 
   Scenario: Cleanup: remove SSH minion from configuration channel
-    Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Configuration > Channels"
     And I follow "Action Chain Channel"
     And I follow "Systems" in the content area
@@ -249,7 +248,6 @@ Feature: Salt SSH action chain
     Then I should see a "Successfully unsubscribed 1 system(s)." text
 
   Scenario: Cleanup: remove configuration channel for SSH minion
-    Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Configuration > Channels"
     And I follow "Action Chain Channel"
     And I follow "Delete Channel"

--- a/testsuite/features/secondary/minssh_bootstrap_xmlrpc.feature
+++ b/testsuite/features/secondary/minssh_bootstrap_xmlrpc.feature
@@ -3,9 +3,12 @@
 
 @scope_salt_ssh
 @scope_onboarding
+@ssh_minion
 Feature: Register a salt-ssh system via XML-RPC
 
-@ssh_minion
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
   Scenario: Setup XML-RPC bootstrap: delete SSH minion system profile
     Given I am on the Systems overview page of this "ssh_minion"
     When I follow "Delete System"
@@ -14,43 +17,35 @@ Feature: Register a salt-ssh system via XML-RPC
     And I wait until I see "has been deleted" text
     Then "ssh_minion" should not be registered
 
-@ssh_minion
   Scenario: Bootstrap a SLES SSH minion via XML-RPC
     Given I am logged in via XML-RPC system as user "admin" and password "admin"
     When I call system.bootstrap() on host "ssh_minion" and salt-ssh "enabled"
     And I logout from XML-RPC system namespace
 
-@ssh_minion
   Scenario: Check new XML-RPC bootstrapped salt-ssh system in System Overview page
-     Given I am authorized
      And I am on the System Overview page
      And I wait until I see the name of "ssh_minion", refreshing the page
      And I wait until onboarding is completed for "ssh_minion"
 
-@ssh_minion
   Scenario: Check contact method of this Salt SSH system
     Given I am on the Systems overview page of this "ssh_minion"
     Then I should see a "Push via SSH" text
 
 @proxy
-@ssh_minion
   Scenario: Check registration on proxy of SSH minion bootstrapped via XML-RPC
     Given I am on the Systems overview page of this "proxy"
     When I follow "Details" in the content area
     And I follow "Proxy" in the content area
     Then I should see "ssh_minion" hostname
 
-@ssh_minion
   Scenario: Check spacecmd system ID of SSH minion bootstrapped via XML-RPC
     Given I am on the Systems overview page of this "ssh_minion"
     Then I run spacecmd listevents for "ssh_minion"
 
-@ssh_minion
   Scenario: Check events history for failures on SSH minion after XML-RPC bootstrap
     Given I am on the Systems overview page of this "ssh_minion"
     Then I check for failed events on history event page
 
-@ssh_minion
   Scenario: Cleanup: subscribe SSH minion to base channel
     Given I am on the Systems overview page of this "ssh_minion"
     When I follow "Software" in the content area

--- a/testsuite/features/secondary/minxen_guests.feature
+++ b/testsuite/features/secondary/minxen_guests.feature
@@ -7,7 +7,7 @@ Feature: Be able to manage XEN virtual machines via the GUI
 @virthost_xen
   Scenario: Bootstrap Xen virtual host
     Given I am authorized as "admin" with password "admin"
-    When I go to the bootstrapping page
+    When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "xen_server" as "hostname"
     And I enter "22" as "port"

--- a/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
+++ b/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
@@ -30,6 +30,9 @@ Feature: PXE boot a Retail terminal
     And I manually install the "pxe" formula on the server
     And I synchronize all Salt dynamic modules on "proxy"
 
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
   Scenario: Enable the PXE formulas on the branch server
     Given I am on the Systems overview page of this "proxy"
     When I follow "Formulas" in the content area
@@ -191,7 +194,6 @@ Feature: PXE boot a Retail terminal
     Then I should see a "Formula saved" text
 
   Scenario: PXE boot the PXE boot minion
-    Given I am authorized as "admin" with password "admin"
     When I reboot the PXE boot minion
     And I wait at most 180 seconds until Salt master sees "pxeboot_minion" as "unaccepted"
     And I accept "pxeboot_minion" key in the Salt master
@@ -336,7 +338,6 @@ Feature: PXE boot a Retail terminal
     And I disable repositories after installing branch server
 
   Scenario: Bootstrap the PXE boot minion
-    Given I am authorized
     When I stop and disable avahi on the PXE boot minion
     And I create bootstrap script and set the activation key "1-SUSE-KEY-x86_64" in the bootstrap script on the proxy
     And I bootstrap pxeboot minion via bootstrap script on the proxy

--- a/testsuite/features/secondary/srv_docker_advanced_content_management.feature
+++ b/testsuite/features/secondary/srv_docker_advanced_content_management.feature
@@ -26,6 +26,7 @@ Feature: Advanced content management
 
 @no_auth_registry
   Scenario: Create a user without rights nor roles
+    Given I am authorized for the "Users" section
     When I follow the left menu "Users > User List > Active"
     And I follow "Create User"
     And I enter "norole" as "login"
@@ -60,6 +61,7 @@ Feature: Advanced content management
 
 @no_auth_registry
   Scenario: Cleanup: delete no role user
+    Given I am authorized for the "Users" section
     When I follow the left menu "Users > User List > Active"
     And I follow "norole"
     And I follow "Delete User"

--- a/testsuite/features/secondary/srv_docker_advanced_content_management.feature
+++ b/testsuite/features/secondary/srv_docker_advanced_content_management.feature
@@ -26,8 +26,8 @@ Feature: Advanced content management
 
 @no_auth_registry
   Scenario: Create a user without rights nor roles
-    Given I am on the active Users page
-    When I follow "Create User"
+    When I follow the left menu "Users > User List > Active"
+    And I follow "Create User"
     And I enter "norole" as "login"
     And I enter "norole" as "desiredpassword"
     And I enter "norole" as "desiredpasswordConfirm"
@@ -60,8 +60,8 @@ Feature: Advanced content management
 
 @no_auth_registry
   Scenario: Cleanup: delete no role user
-    Given I am on the active Users page
-    When I follow "norole"
+    When I follow the left menu "Users > User List > Active"
+    And I follow "norole"
     And I follow "Delete User"
     Then I should see a "Confirm User Deletion" text
     And I should see a "This will delete this user permanently." text

--- a/testsuite/features/secondary/srv_user_configuration_salt_states.feature
+++ b/testsuite/features/secondary/srv_user_configuration_salt_states.feature
@@ -43,7 +43,7 @@ Feature: Create organizations, users, groups, and activation keys using Salt sta
     And I follow "Managers"
 
   Scenario: User Roles were assigned
-    Given I am on the active Users page
+    When I follow the left menu "Users > User List > Active"
     And I follow "user2"
     Then I should see a "User Details" text
     And I should see "role_activation_key_admin" as checked
@@ -72,7 +72,7 @@ Feature: Create organizations, users, groups, and activation keys using Salt sta
     And I should not see a "my_org2" text
 
   Scenario: Cleanup: user was successfully removed
-    Given I am on the active Users page
+    When I follow the left menu "Users > User List > Active"
     Then I should not see a "user2" text
 
   Scenario: Cleanup: activation key was successfully removed

--- a/testsuite/features/secondary/srv_user_configuration_salt_states.feature
+++ b/testsuite/features/secondary/srv_user_configuration_salt_states.feature
@@ -24,7 +24,8 @@ Feature: Create organizations, users, groups, and activation keys using Salt sta
     Then I should see a "my_org" text in the content area
 
   Scenario: Group was correctly created
-    Given I am on the groups page
+    Given I am authorized for the "Admin" section
+    And I am on the groups page
     When I follow "minions_group"
     Then I should see a "minions_group" text
     And I should see a "System Group Status" text
@@ -43,6 +44,7 @@ Feature: Create organizations, users, groups, and activation keys using Salt sta
     And I follow "Managers"
 
   Scenario: User Roles were assigned
+    Given I am authorized for the "Users" section
     When I follow the left menu "Users > User List > Active"
     And I follow "user2"
     Then I should see a "User Details" text

--- a/testsuite/features/secondary/srv_users.feature
+++ b/testsuite/features/secondary/srv_users.feature
@@ -8,6 +8,9 @@
 @scope_visualization
 Feature: Manage users
 
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
   Scenario: Display active users page
     When I follow the left menu "Users > User List > Active"
     Then I should see a "Active Users" text

--- a/testsuite/features/secondary/srv_users.feature
+++ b/testsuite/features/secondary/srv_users.feature
@@ -9,7 +9,7 @@
 Feature: Manage users
 
   Scenario: Display active users page
-    Given I am on the active Users page
+    When I follow the left menu "Users > User List > Active"
     Then I should see a "Active Users" text
     And I should see a "Create User" link
     And I should see a "User List" link in the left menu
@@ -20,8 +20,8 @@ Feature: Manage users
     And I should see a "Download CSV" link
 
   Scenario: Create a new user
-    Given I am on the active Users page
-    When I follow "Create User"
+    When I follow the left menu "Users > User List > Active"
+    And I follow "Create User"
     And I enter "user1" as "login"
     And I enter "user1" as "desiredpassword"
     And I enter "user1" as "desiredpasswordConfirm"
@@ -39,7 +39,7 @@ Feature: Manage users
     Then I should see a "user1" link
 
   Scenario: Access user details
-    Given I am on the active Users page
+    When I follow the left menu "Users > User List > Active"
     And I follow "user1"
     Then I should see a "User Details" text
     And I should see a "Delete User" link
@@ -61,7 +61,7 @@ Feature: Manage users
     And I should see a "Last Sign In:" text
 
   Scenario: Add roles
-    Given I am on the active Users page
+    When I follow the left menu "Users > User List > Active"
     And I follow "user1"
     When the "role_satellite_admin" checkbox should be disabled
     And I check "role_org_admin"
@@ -85,7 +85,7 @@ Feature: Manage users
     And I should see a "Above roles are granted via the Organization Administrator role." text
 
   Scenario: Verify user list
-    Given I am on the active Users page
+    When I follow the left menu "Users > User List > Active"
     Then table row for "user1" should contain "Organization Administrator"
     And table row for "user1" should contain "Channel Administrator"
     And table row for "user1" should contain "Configuration Administrator"
@@ -93,7 +93,7 @@ Feature: Manage users
     And table row for "user1" should contain "Activation Key Administrator"
 
   Scenario: Fail to deactivate organization administrator
-    Given I am on the active Users page
+    When I follow the left menu "Users > User List > Active"
     And I follow "user1"
     When I follow "Deactivate User"
     Then I should see a "This action will deactivate this user. This user will no longer be able to log in or perform actions unless it is reactivated." text
@@ -103,7 +103,7 @@ Feature: Manage users
     Then I should see a "No deactivated users." text
 
   Scenario: Remove role
-    Given I am on the active Users page
+    When I follow the left menu "Users > User List > Active"
     And I follow "user1"
     When I uncheck "role_org_admin"
     And I click on "Update"
@@ -114,7 +114,7 @@ Feature: Manage users
     And I should see "role_config_admin" as checked
 
   Scenario: Deactivate ordinary user
-    Given I am on the active Users page
+    When I follow the left menu "Users > User List > Active"
     And I follow "user1"
     Then I should see "role_org_admin" as unchecked
     When I follow "Deactivate User"
@@ -129,8 +129,8 @@ Feature: Manage users
     Then I should see a "user1" link
 
   Scenario: Reactivate user
-    Given I am on the active Users page
-    When I follow "Deactivated"
+    When I follow the left menu "Users > User List > Active"
+    And I follow "Deactivated"
     And I follow "user1"
     Then I should see a "Reactivate User" link
     When I follow "Reactivate User"
@@ -142,7 +142,7 @@ Feature: Manage users
     Then I should not see a "user1" link
 
   Scenario: Delete user
-    Given I am on the active Users page
+    When I follow the left menu "Users > User List > Active"
     And I follow "user1"
     When I follow "Delete User"
     Then I should see a "Confirm User Deletion" text

--- a/testsuite/features/secondary/trad_centos_client.feature
+++ b/testsuite/features/secondary/trad_centos_client.feature
@@ -114,7 +114,7 @@ Feature: Be able to register a CentOS 7 traditional client and do some basic ope
 @centos_minion
   Scenario: Cleanup: bootstrap a CentOS minion after traditional client tests
     Given I am authorized
-    When I go to the bootstrapping page
+    When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "ceos_minion" as "hostname"
     And I enter "22" as "port"

--- a/testsuite/features/secondary/trad_centos_client.feature
+++ b/testsuite/features/secondary/trad_centos_client.feature
@@ -10,9 +10,12 @@
 
 @scope_traditional_client
 @scope_res
+@centos_minion
 Feature: Be able to register a CentOS 7 traditional client and do some basic operations on it
 
-@centos_minion
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
   Scenario: Delete the CentOS minion before traditional client tests
     When I am on the Systems overview page of this "ceos_minion"
     And I follow "Delete System"
@@ -21,9 +24,7 @@ Feature: Be able to register a CentOS 7 traditional client and do some basic ope
     And I wait until I see "has been deleted" text
     Then "ceos_minion" should not be registered
 
-@centos_minion
   Scenario: Prepare the CentOS 7 traditional client
-    Given I am authorized
     When I enable SUSE Manager tools repositories on "ceos_client"
     And I enable repository "CentOS-Base" on this "ceos_client"
     And I install the traditional stack utils on "ceos_client"
@@ -33,7 +34,6 @@ Feature: Be able to register a CentOS 7 traditional client and do some basic ope
     And I run "rhn-actions-control --enable-all" on "ceos_client"
 
 @proxy
-@centos_minion
   Scenario: Check connection from CentOS 7 traditional to proxy
     Given I am on the Systems overview page of this "ceos_client"
     When I follow "Details" in the content area
@@ -41,14 +41,12 @@ Feature: Be able to register a CentOS 7 traditional client and do some basic ope
     Then I should see "proxy" short hostname
 
 @proxy
-@centos_minion
   Scenario: Check registration on proxy of traditional CentOS 7
     Given I am on the Systems overview page of this "proxy"
     When I follow "Details" in the content area
     And I follow "Proxy" in the content area
     Then I should see "ceos_client" hostname
 
-@centos_minion
   Scenario: Re-subscribe the CentOS traditional client to a base channel
     Given I am on the Systems overview page of this "ceos_client"
     When I follow "Software" in the content area
@@ -62,7 +60,6 @@ Feature: Be able to register a CentOS 7 traditional client and do some basic ope
     Then I should see a "Changing the channels has been scheduled." text
     And I wait until event "Subscribe channels scheduled by admin" is completed
 
-@centos_minion
   Scenario: Schedule an OpenSCAP audit job for the CentOS traditional client
     Given I am on the Systems overview page of this "ceos_client"
     When I follow "Audit" in the content area
@@ -74,7 +71,6 @@ Feature: Be able to register a CentOS 7 traditional client and do some basic ope
     Then I should see a "XCCDF scan has been scheduled" text
     And I wait at most 500 seconds until event "OpenSCAP xccdf scanning" is completed
 
-@centos_minion
   Scenario: Check the results of the OpenSCAP scan on the CentOS traditional client
     Given I am on the Systems overview page of this "ceos_client"
     When I follow "Audit" in the content area
@@ -86,16 +82,13 @@ Feature: Be able to register a CentOS 7 traditional client and do some basic ope
     And I click on the filter button
     Then I should see a "ensure_redhat_gpgkey_installed" link
 
-@centos_minion
   Scenario: Schedule some actions on the CentOS 7 traditional client
-    Given I am authorized as "admin" with password "admin"
     When I authenticate to XML-RPC
     And I refresh the packages on "ceos_client" through XML-RPC
     And I run a script on "ceos_client" through XML-RPC
     And I reboot "ceos_client" through XML-RPC
     And I unauthenticate from XML-RPC
 
-@centos_minion
   Scenario: Cleanup: delete the CentOS 7 traditional client
     Given I am on the Systems overview page of this "ceos_client"
     When I follow "Delete System"
@@ -104,16 +97,13 @@ Feature: Be able to register a CentOS 7 traditional client and do some basic ope
     And I wait until I see "has been deleted." text
     Then "ceos_client" should not be registered
 
-@centos_minion
   Scenario: Cleanup: delete the installed rpms on CentOS 7 traditional client
     When I remove the traditional stack utils from "ceos_client"
     And I remove OpenSCAP dependencies from "ceos_client"
     And I disable SUSE Manager tools repositories on "ceos_client"
     And I disable repository "CentOS-Base" on this "ceos_client"
 
-@centos_minion
   Scenario: Cleanup: bootstrap a CentOS minion after traditional client tests
-    Given I am authorized
     When I follow the left menu "Systems > Bootstrapping"
     Then I should see a "Bootstrap Minions" text
     When I enter the hostname of "ceos_minion" as "hostname"
@@ -127,7 +117,6 @@ Feature: Be able to register a CentOS 7 traditional client and do some basic ope
     And I wait until I see the name of "ceos_minion", refreshing the page
     And I wait until onboarding is completed for "ceos_minion"
 
-@centos_minion
   Scenario: Cleanup: re-subscribe the new CentOS minion to a base channel
     Given I am on the Systems overview page of this "ceos_minion"
     When I follow "Software" in the content area

--- a/testsuite/features/secondary/trad_migrate_to_minion.feature
+++ b/testsuite/features/secondary/trad_migrate_to_minion.feature
@@ -9,7 +9,7 @@ Feature: Migrate a traditional client into a Salt minion
 
   Scenario: Migrate a SLES client into a Salt minion
     Given I am authorized
-    When I go to the bootstrapping page
+    When I follow the left menu "Systems > Bootstrapping"
     And I enter the hostname of "sle_client" as "hostname"
     And I enter "22" as "port"
     And I enter "root" as "user"

--- a/testsuite/features/secondary/trad_migrate_to_sshminion.feature
+++ b/testsuite/features/secondary/trad_migrate_to_sshminion.feature
@@ -7,6 +7,9 @@ Feature: Migrate a traditional client into a Salt SSH minion
   As an authorized user
   I want to migrate these clients to Salt SSH minions and have everything as before
 
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
   Scenario: Install a package before migration to Salt SSH minion
     Given I am on the Systems overview page of this "sle_client"
     When I follow "Software" in the content area
@@ -20,7 +23,6 @@ Feature: Migrate a traditional client into a Salt SSH minion
     Then "orion-dummy-1.1-1.1" should be installed on "sle_client"
 
   Scenario: Change contact method of activation key to ssh-push
-    Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Systems > Activation Keys"
     And I follow "SUSE Test Key x86_64" in the content area
     And I select "Push via SSH" from "contactMethodId"
@@ -28,7 +30,6 @@ Feature: Migrate a traditional client into a Salt SSH minion
     Then I should see a "Activation key SUSE Test Key x86_64 has been modified" text
 
   Scenario: Migrate a SLES client into a Salt SSH minion
-    Given I am authorized
     When I follow the left menu "Systems > Bootstrapping"
     And I enter the hostname of "sle_client" as "hostname"
     And I enter "22" as "port"
@@ -124,7 +125,6 @@ Feature: Migrate a traditional client into a Salt SSH minion
     Then I should see "sle_client" via spacecmd
 
   Scenario: Cleanup: change contact method of activation key back to default
-    Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Systems > Activation Keys"
     And I follow "SUSE Test Key x86_64" in the content area
     And I select "Default" from "contactMethodId"

--- a/testsuite/features/secondary/trad_migrate_to_sshminion.feature
+++ b/testsuite/features/secondary/trad_migrate_to_sshminion.feature
@@ -29,7 +29,7 @@ Feature: Migrate a traditional client into a Salt SSH minion
 
   Scenario: Migrate a SLES client into a Salt SSH minion
     Given I am authorized
-    When I go to the bootstrapping page
+    When I follow the left menu "Systems > Bootstrapping"
     And I enter the hostname of "sle_client" as "hostname"
     And I enter "22" as "port"
     And I enter "root" as "user"

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -175,7 +175,6 @@ end
 # systemspage and clobber
 Given(/^I am on the Systems page$/) do
   steps %(
-    When I am authorized as "admin" with password "admin"
     And I follow the left menu "Systems > Overview"
     And I wait until I see "System Overview" text
   )

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -377,6 +377,8 @@ Given(/^I am authorized for the "([^"]*)" section$/) do |section|
   case section
   when 'Admin'
     step %(I am authorized as "admin" with password "admin")
+  when 'Users'
+    step %(I am authorized as "admin" with password "admin")
   end
 end
 

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -453,13 +453,6 @@ Given(/^I am on the groups page$/) do
   )
 end
 
-Given(/^I am on the active Users page$/) do
-  steps %(
-    Given I am authorized as "admin" with password "admin"
-    When I follow the left menu "Users > User List > Active"
-  )
-end
-
 Then(/^table row for "([^"]*)" should contain "([^"]*)"$/) do |arg1, arg2|
   step %(I wait until table row for "#{arg1}" contains "#{arg2}")
 end

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -589,14 +589,6 @@ When(/^I accept "([^"]*)" key$/) do |host|
   raise "xpath: #{xpath_query} not found" unless find(:xpath, xpath_query).click
 end
 
-When(/^I go to the minion onboarding page$/) do
-  step %(I follow the left menu "Salt > Keys")
-end
-
-When(/^I go to the bootstrapping page$/) do
-  step %(I follow the left menu "Systems > Bootstrapping")
-end
-
 When(/^I refresh page until I see "(.*?)" hostname as text$/) do |minion|
   within('#spacewalk-content') do
     step %(I wait until I see the name of "#{minion}", refreshing the page)


### PR DESCRIPTION
## What does this PR change?

As currently, we hold the session between scenarios, we can get rid of some extra steps made to accomplish pre-conditions, like the authentication process.
This PR reduces those extra steps in the core features.

Note: Indirectly, it will change a pair of steps in other secondary features, as I considered that we were doing extra jumps in our step definitions wasting time on an abstraction that I doubt will help too much on maintance.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.1
- Manager-4.0

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
