### PR TITLE
Fix the label and description for the almalinux8-ha channel

### DIFF
--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -2780,9 +2780,9 @@ base_channels = almalinux8-%(arch)s
 repo_url = https://repo.almalinux.org/almalinux/8/PowerTools/%(arch)s/os/
 
 [almalinux8-ha]
-label    = %(base_channel)s-extras
+label    = %(base_channel)s-ha
 archs    = x86_64
-name     = AlmaLinux 8 Extras (%(arch)s)
+name     = AlmaLinux 8 High Availability (%(arch)s)
 base_channels = almalinux8-%(arch)s
 repo_url = https://repo.almalinux.org/almalinux/8/HighAvailability/%(arch)s/os/
 


### PR DESCRIPTION
## What does this PR change?

Fix the label and description for the almalinux8-ha channel (they mentioned extra, probably because I did a copypaste and didn't adjust that)

Thanks @vzhestkov for spotting it.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Bugfix

- [x] **DONE**

## Test coverage
- No tests: AlmaLinux 8 not covered by the testsuite

- [x] **DONE**

## Links

None

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
