### PR TITLE
Adapt tests for new Highstate page

### DIFF
--- a/java/code/src/com/suse/manager/webui/services/test/StateSourceServiceTest.java
+++ b/java/code/src/com/suse/manager/webui/services/test/StateSourceServiceTest.java
@@ -57,10 +57,9 @@ public class StateSourceServiceTest extends BaseTestCaseWithUser {
         List<StateSourceDto> result = StateSourceService.getSystemStateSources(server);
         assertEquals(3, result.size());
 
-        // Results must respect the order of assignment
-        assertStateSourceEquals(stateChannel, server, result.get(0));
-        assertStateSourceEquals(configChannel, server, result.get(1));
-        assertEquals("INTERNAL", result.get(2).getType());
+        assertStateSourceEquals(stateChannel, server, findResultById(stateChannel.getId(), result));
+        assertStateSourceEquals(configChannel, server, findResultById(configChannel.getId(), result));
+        assertTrue(result.stream().anyMatch(s -> "INTERNAL".equals(s.getType())));
     }
 
     public void testGroupAndOrgStates() {
@@ -89,11 +88,15 @@ public class StateSourceServiceTest extends BaseTestCaseWithUser {
         assertEquals(5, result.size());
 
         // Sources should be assigned in priority: System > Group > Org
-        assertStateSourceEquals(ch1, server, result.get(0));
-        assertStateSourceEquals(ch2, group1, result.get(1));
-        assertStateSourceEquals(ch3, group2, result.get(2));
-        assertStateSourceEquals(ch4, org, result.get(3));
-        assertEquals("INTERNAL", result.get(4).getType());
+        assertStateSourceEquals(ch1, server, findResultById(ch1.getId(), result));
+        assertStateSourceEquals(ch2, group1, findResultById(ch2.getId(), result));
+        assertStateSourceEquals(ch3, group2, findResultById(ch3.getId(), result));
+        assertStateSourceEquals(ch4, org, findResultById(ch4.getId(), result));
+        assertTrue(result.stream().anyMatch(s -> "INTERNAL".equals(s.getType())));
+    }
+
+    private StateSourceDto findResultById(Long id, List<StateSourceDto> results) {
+        return results.stream().filter(s -> id.equals(s.getId())).findFirst().orElseThrow();
     }
 
     private void assertStateSourceEquals(ConfigChannel expState, SaltConfigurable expSource, StateSourceDto actual) {

--- a/testsuite/features/secondary/min_salt_software_states.feature
+++ b/testsuite/features/secondary/min_salt_software_states.feature
@@ -114,6 +114,7 @@ Feature: Salt package states
     Given I am on the Systems overview page of this "sle_minion"
     Then I follow "States" in the content area
     And I follow "Highstate" in the content area
+    And I click on "Show full highstate output"
     And I wait for "6" seconds
     And I should see a "pkg_removed" or "running as PID" text in element "highstate"
 
@@ -122,6 +123,7 @@ Feature: Salt package states
     Then I follow "States" in the content area
     And I run "pkill salt-minion" on "sle_minion"
     And I follow "Highstate" in the content area
+    And I click on "Show full highstate output"
     And I wait until I see "No reply from minion" text
 
   Scenario: Cleanup: restart the salt service on SLES minion

--- a/testsuite/features/secondary/min_salt_user_states.feature
+++ b/testsuite/features/secondary/min_salt_user_states.feature
@@ -9,6 +9,7 @@ Feature: Coexistence with user-defined states
     When I follow "States" in the content area
     And I install a user-defined state for "sle_minion" on the server
     And I follow "Highstate" in the content area
+    And I click on "Show full highstate output"
     And I wait for "6" seconds
     Then I should see a "user_defined_state" or "running as PID" text in element "highstate"
 
@@ -26,5 +27,6 @@ Feature: Coexistence with user-defined states
     And I uninstall the user-defined state from the server
     And I uninstall the managed file from "sle_minion"
     And I follow "Highstate" in the content area
+    And I click on "Show full highstate output"
     And I wait for "6" seconds
     Then I should not see a "user_defined_state" text in element "highstate"


### PR DESCRIPTION
With the new Highstate summary page, the full highstate output is now hidden behind a "Show full highstate output" button. This PR reflects this change in cucumber.

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
