### PR TITLE
Testsuite: Make sure package is installed on/removed from client in retracted patches tests

### DIFF
--- a/testsuite/features/secondary/min_retracted_patches.feature
+++ b/testsuite/features/secondary/min_retracted_patches.feature
@@ -6,15 +6,14 @@ Feature: Retracted patches
 
   Scenario: Installed retracted package should show icon in the system packages list
     Given I am authorized as "admin" with password "admin"
-    When I install package "rute-dummy-2.1-1.1.x86_64" on this "sle_minion"
+    When I wait until package "rute-dummy-2.1-1.1.x86_64" is installed on "sle_minion" via spacecmd
     And I am on the "Software" page of this "sle_minion"
     And I follow "Packages"
     And I follow "List / Remove"
     And I enter "rute-dummy" as the filtered package name
     And I click on the filter button until page does contain "rute-dummy" text
     Then the table row for "rute-dummy-2.1-1.1" should contain "retracted" icon
-    When I remove package "rute-dummy" from this "sle_minion"
-    And I wait until refresh package list on "sle_minion" is finished
+    When I wait until package "rute-dummy" is removed from "sle_minion" via spacecmd
 
   Scenario: Retracted package should not be available for installation
     Given I am authorized as "admin" with password "admin"
@@ -26,25 +25,23 @@ Feature: Retracted patches
 
   Scenario: Retracted package should not be available for upgrade
     Given I am authorized as "admin" with password "admin"
-    When I install package "rute-dummy-2.0-1.2.x86_64" on this "sle_minion"
+    When I wait until package "rute-dummy-2.0-1.2.x86_64" is installed on "sle_minion" via spacecmd
     And I am on the "Software" page of this "sle_minion"
     And I follow "Packages"
     And I follow "Upgrade"
     Then I should not see a "rute-dummy-2.1-1.1" text
-    When I remove package "rute-dummy" from this "sle_minion"
-    And I wait until refresh package list on "sle_minion" is finished
+    When I wait until package "rute-dummy" is removed from "sle_minion" via spacecmd
 
   Scenario: Retracted patch should not affect any system
     Given I am authorized as "admin" with password "admin"
-    When I install package "rute-dummy-2.0-1.2.x86_64" on this "sle_minion"
+    When I wait until package "rute-dummy-2.0-1.2.x86_64" is installed on "sle_minion" via spacecmd
     And I follow the left menu "Software > Channel List > All"
     And I follow "Test-Channel-x86_64"
     And I follow "Patches" in the content area
     And I follow "rute-dummy-0817"
     And I follow "Affected Systems"
     Then I should see a "No systems." text
-    When I remove package "rute-dummy" from this "sle_minion"
-    And I wait until refresh package list on "sle_minion" is finished
+    When I wait until package "rute-dummy" is removed from "sle_minion" via spacecmd
    
   Scenario: Target systems for stable packages should not be empty
     Given I am authorized as "admin" with password "admin"


### PR DESCRIPTION
Previously, we were relying on the 'I wait until refresh package list on
"sle_minion" is finished' step, which didn't work very well in case
there was a lot of subsequent package installations/removals.

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
