### PR TITLE
Uyuni master delete archived

### DIFF
--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,4 +1,4 @@
-- Adds schedule_deletearchived to delete bulk delete archived actions (bsc#1181223)
+- Adds schedule_deletearchived to bulk delete archived actions (bsc#1181223)
 - Add group_addconfigchannel and group_removeconfigchannel
 - Add group_listconfigchannels and configchannel_listgroups
 - Handle SIGPIPE without user-visible Exception (bsc#1181124)

--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,4 @@
+- Adds schedule_deletearchived to delete bulk delete archived actions (bsc#1181223)
 - Add group_addconfigchannel and group_removeconfigchannel
 - Add group_listconfigchannels and configchannel_listgroups
 - Handle SIGPIPE without user-visible Exception (bsc#1181124)

--- a/spacecmd/src/spacecmd/schedule.py
+++ b/spacecmd/src/spacecmd/schedule.py
@@ -465,6 +465,7 @@ def do_schedule_deletearchived(self, args):
     """
     This method removes all of the archived actions.
     """
+    args = args.split() or []
     if args:
         begin_date = parse_time_input(args[0])
         logging.debug('Begin Date: %s' % begin_date)

--- a/spacecmd/src/spacecmd/schedule.py
+++ b/spacecmd/src/spacecmd/schedule.py
@@ -457,42 +457,19 @@ def do_schedule_list(self, args):
 
 def help_schedule_deletearchived(self):
     print(_('schedule_deletearchived: Delete all archived actions'))
-    print(_('usage: schedule_deletearchived [BEGINDATE] [ENDDATE]'))
-    print('')
-    print(self.HELP_TIME_OPTS)
+    print(_('usage: schedule_deletearchived'))
 
 def do_schedule_deletearchived(self, args):
     """
     This method removes all of the archived actions.
     """
-    args = args.split() or []
-    if args:
-        begin_date = parse_time_input(args[0])
-        logging.debug('Begin Date: %s' % begin_date)
-    else:
-        begin_date = None
-
-    if len(args) > 1:
-        end_date = parse_time_input(args[1])
-        logging.debug('End Date:   %s' % end_date)
-    else:
-        end_date = None
-
     while True:
         # Needs to happen in a loop, since we can only fetch in batches. 10k is the default.
         actions = self.client.schedule.listArchivedActions(self.session)
         logging.debug("actions: {}".format(actions))
         if actions:
             # Collect IDs of actions that should be deleted
-            action_ids = []
-            for action in actions:
-                if begin_date:
-                    if action.get('earliest') < begin_date:
-                        continue
-                if end_date:
-                    if action.get('earliest') > end_date:
-                        continue
-                action_ids.append(action.get('id'))
+            action_ids = [action.get('id') for action in actions]
 
             # Pass list of actions that should be deleted
             if action_ids:

--- a/spacecmd/src/spacecmd/schedule.py
+++ b/spacecmd/src/spacecmd/schedule.py
@@ -495,6 +495,7 @@ def do_schedule_deletearchived(self, args):
 
             # Pass list of actions that should be deleted
             if action_ids:
-                self.client.schedule.deleteActions(self.session, action_ids)
+                # set needs to be cast to list, since set cannot be marshalled
+                self.client.schedule.deleteActions(self.session, list(set(action_ids)))
         else:
             break

--- a/spacecmd/tests/test_schedule.py
+++ b/spacecmd/tests/test_schedule.py
@@ -3,8 +3,6 @@
 Test suite for spacecmd.schedule module.
 """
 
-from datetime import datetime, timedelta
-
 from unittest.mock import MagicMock, patch
 from helpers import shell, assert_expect, assert_list_args_expect, assert_args_expect
 import spacecmd.schedule

--- a/spacecmd/tests/test_schedule.py
+++ b/spacecmd/tests/test_schedule.py
@@ -32,6 +32,8 @@ class TestSCSchedule:
         assert shell.client.schedule.listArchivedActions.called
         assert not shell.client.schedule.deleteActions.called
 
+    @patch('spacecmd.utils.input', create=True, new=MagicMock(return_value='y'))
+    @patch('spacecmd.utils.raw_input', create=True, new=MagicMock(return_value='y'))
     def test_schedule_deletearchived_with_archived(self, shell):
         """
         Test do_schedule_deletearchived with archived actions.
@@ -52,6 +54,52 @@ class TestSCSchedule:
         assert shell.client.schedule.deleteActions.call_count == 1
         assert shell.client.schedule.deleteActions.call_args[0][1] == [1, 2, 3]
 
+    @patch('spacecmd.utils.input', create=True, new=MagicMock(return_value='n'))
+    @patch('spacecmd.utils.raw_input', create=True, new=MagicMock(return_value='n'))
+    def test_schedule_deletearchived_with_archived_but_user_answer_is_no(self, shell):
+        """
+        Test do_schedule_deletearchived with archived actions and the user answers with
+        no "n".
+
+        :param shell:
+        :return:
+        """
+        archived_dummy_actions = [{'id': 1}, {'id': 2}, {'id': 3}]
+
+        shell.help_schedule_deletearchived = MagicMock()
+        shell.client.schedule.listArchivedActions = MagicMock()
+        shell.client.schedule.listArchivedActions.side_effect = [archived_dummy_actions] + [[]]
+        shell.client.schedule.deleteActions = MagicMock()
+        logger = MagicMock()
+
+        spacecmd.schedule.do_schedule_deletearchived(shell, "")
+
+        assert shell.client.schedule.deleteActions.call_count == 0
+
+    @patch('spacecmd.utils.input', create=True, new=MagicMock(return_value=''))
+    @patch('spacecmd.utils.raw_input', create=True, new=MagicMock(return_value=''))
+    def test_schedule_deletearchived_with_archived_but_no_user_answer(self, shell):
+        """
+        Test do_schedule_deletearchived with archived actions, but the user gives no answer.
+        This should default to no.
+
+        :param shell:
+        :return:
+        """
+        archived_dummy_actions = [{'id': 1}, {'id': 2}, {'id': 3}]
+
+        shell.help_schedule_deletearchived = MagicMock()
+        shell.client.schedule.listArchivedActions = MagicMock()
+        shell.client.schedule.listArchivedActions.side_effect = [archived_dummy_actions] + [[]]
+        shell.client.schedule.deleteActions = MagicMock()
+        logger = MagicMock()
+
+        spacecmd.schedule.do_schedule_deletearchived(shell, "")
+
+        assert shell.client.schedule.deleteActions.call_count == 0
+
+    @patch('spacecmd.utils.input', create=True, new=MagicMock(return_value='y'))
+    @patch('spacecmd.utils.raw_input', create=True, new=MagicMock(return_value='y'))
     def test_schedule_deletearchived_with_archived_batched(self, shell):
         """
         Test do_schedule_deletearchived with archived actions

--- a/spacecmd/tests/test_schedule.py
+++ b/spacecmd/tests/test_schedule.py
@@ -14,6 +14,64 @@ class TestSCSchedule:
     Test suite for "schedule" module.
     """
 
+    def test_schedule_deletearchived(self, shell):
+        """
+        Test do_schedule_deletearchived without arguments.
+
+        :param shell:
+        :return:
+        """
+
+        shell.help_schedule_deletearchived = MagicMock()
+        shell.client.schedule.listArchivedActions = MagicMock(return_value=[])
+        shell.client.schedule.deleteActions = MagicMock()
+        logger = MagicMock()
+
+        spacecmd.schedule.do_schedule_deletearchived(shell, "")
+
+        assert shell.client.schedule.listArchivedActions.called
+
+    def test_schedule_deletearchived_with_archived(self, shell):
+        """
+        Test do_schedule_deletearchived without arguments, but with archived actions.
+
+        :param shell:
+        :return:
+        """
+        archived_dummy_actions = [{'id': 1}, {'id': 2}, {'id': 3}]
+
+        shell.help_schedule_deletearchived = MagicMock()
+        shell.client.schedule.listArchivedActions = MagicMock()
+        shell.client.schedule.listArchivedActions.side_effect = [archived_dummy_actions] + [[]]
+        shell.client.schedule.deleteActions = MagicMock()
+        logger = MagicMock()
+
+        spacecmd.schedule.do_schedule_deletearchived(shell, "")
+
+        assert shell.client.schedule.listArchivedActions.called
+        assert shell.client.schedule.deleteActions.called
+
+    def test_schedule_deletearchived_with_archived_batched(self, shell):
+        """
+        Test do_schedule_deletearchived without arguments, but with archived actions
+        and in a batched way.
+
+        :param shell:
+        :return:
+        """
+        archived_dummy_actions = [{'id': 1}, {'id': 2}, {'id': 3}]
+
+        shell.help_schedule_deletearchived = MagicMock()
+        shell.client.schedule.listArchivedActions = MagicMock()
+        shell.client.schedule.listArchivedActions.side_effect = [archived_dummy_actions] + [archived_dummy_actions] + [[]]
+        shell.client.schedule.deleteActions = MagicMock()
+        logger = MagicMock()
+
+        spacecmd.schedule.do_schedule_deletearchived(shell, "")
+
+        assert shell.client.schedule.listArchivedActions.called
+        assert shell.client.schedule.deleteActions.call_count == 2
+
     def test_schedule_cancel_noargs(self, shell):
         """
         Test do_schedule_cancel without arguments.

--- a/spacecmd/tests/test_schedule.py
+++ b/spacecmd/tests/test_schedule.py
@@ -16,9 +16,9 @@ class TestSCSchedule:
     Test suite for "schedule" module.
     """
 
-    def test_schedule_deletearchived(self, shell):
+    def test_schedule_deletearchived_without_archived(self, shell):
         """
-        Test do_schedule_deletearchived without arguments.
+        Test do_schedule_deletearchived with no archived actions.
 
         :param shell:
         :return:
@@ -32,10 +32,11 @@ class TestSCSchedule:
         spacecmd.schedule.do_schedule_deletearchived(shell, "")
 
         assert shell.client.schedule.listArchivedActions.called
+        assert not shell.client.schedule.deleteActions.called
 
     def test_schedule_deletearchived_with_archived(self, shell):
         """
-        Test do_schedule_deletearchived without arguments, but with archived actions.
+        Test do_schedule_deletearchived with archived actions.
 
         :param shell:
         :return:
@@ -50,12 +51,12 @@ class TestSCSchedule:
 
         spacecmd.schedule.do_schedule_deletearchived(shell, "")
 
-        assert shell.client.schedule.listArchivedActions.called
-        assert shell.client.schedule.deleteActions.called
+        assert shell.client.schedule.deleteActions.call_count == 1
+        assert shell.client.schedule.deleteActions.call_args[0][1] == [1, 2, 3]
 
     def test_schedule_deletearchived_with_archived_batched(self, shell):
         """
-        Test do_schedule_deletearchived without arguments, but with archived actions
+        Test do_schedule_deletearchived with archived actions
         and in a batched way.
 
         :param shell:
@@ -74,64 +75,6 @@ class TestSCSchedule:
         assert shell.client.schedule.listArchivedActions.called
         assert shell.client.schedule.deleteActions.call_count == 2
         assert shell.client.schedule.deleteActions.call_args[0][1] == [1, 2, 3]
-
-    def test_schedule_deletearchived_with_begin_date(self, shell):
-        """
-        Test do_schedule_deletearchived with a begin date. Only one action
-        should be deleted and that's action 1.
-
-        :param shell:
-        :return:
-        """
-        timestamp = datetime.now()
-        timestamp_future = timestamp + timedelta(hours=1)
-        timestamp_past = timestamp - timedelta(hours=1)
-        archived_dummy_actions = [
-            {'id': 1, 'earliest': timestamp_future},
-            {'id': 2, 'earliest': timestamp_past},
-            {'id': 3, 'earliest': timestamp_past},
-        ]
-
-        shell.help_schedule_deletearchived = MagicMock()
-        shell.client.schedule.listArchivedActions = MagicMock()
-        shell.client.schedule.listArchivedActions.side_effect = [archived_dummy_actions] + [[]]
-        shell.client.schedule.deleteActions = MagicMock()
-        logger = MagicMock()
-
-        fun_args = [timestamp.strftime("%Y%m%d%H%M")]
-        spacecmd.schedule.do_schedule_deletearchived(shell, fun_args)
-
-        assert shell.client.schedule.deleteActions.call_count == 1
-        assert shell.client.schedule.deleteActions.call_args[0][1] == [1]
-
-    def test_schedule_deletearchived_with_end_date(self, shell):
-        """
-        Test do_schedule_deletearchived with a begin and end date. Only one action
-        should be deleted and that's action 1.
-
-        :param shell:
-        :return:
-        """
-        timestamp = datetime.now()
-        timestamp_future = timestamp + timedelta(hours=1)
-        timestamp_past = timestamp - timedelta(hours=1)
-        archived_dummy_actions = [
-            {'id': 1, 'earliest': timestamp},
-            {'id': 2, 'earliest': timestamp_future},
-            {'id': 3, 'earliest': timestamp_future},
-        ]
-
-        shell.help_schedule_deletearchived = MagicMock()
-        shell.client.schedule.listArchivedActions = MagicMock()
-        shell.client.schedule.listArchivedActions.side_effect = [archived_dummy_actions] + [[]]
-        shell.client.schedule.deleteActions = MagicMock()
-        logger = MagicMock()
-
-        fun_args = [timestamp_past.strftime("%Y%m%d%H%M"), timestamp_future.strftime("%Y%m%d%H%M")]
-        spacecmd.schedule.do_schedule_deletearchived(shell, fun_args)
-
-        assert shell.client.schedule.deleteActions.call_count == 1
-        assert shell.client.schedule.deleteActions.call_args[0][1] == [1]
 
     def test_schedule_cancel_noargs(self, shell):
         """


### PR DESCRIPTION
## What does this PR change?

This adds the possibility to delete archived actions from the database via spacecmd: `spacecmd -- schedule_deletearchived`

## GUI diff

Just cli.

## Documentation

- [ ] This still needs to be done.

- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage

- Unit tests were added

## Links

Fixes https://github.com/SUSE/spacewalk/issues/14196


## Changelogs

- [ ] Changelog needed

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
