### PR TITLE
Testsuite - delete empty bootstrap profiles

### DIFF
--- a/testsuite/features/core/proxy_branch_network.feature
+++ b/testsuite/features/core/proxy_branch_network.feature
@@ -72,14 +72,6 @@ Feature: Setup SUSE Manager for Retail branch network
     And I enter the local IP address of "range end" in dynamic IP range end field
     And I enter the local IP address of "broadcast" in broadcast address field
     And I enter the local IP address of "proxy" in routers field
-    And I press "Add Item" in host reservations section
-    And I enter "client" in first reserved hostname field
-    And I enter the local IP address of "client" in first reserved IP field
-    And I enter the MAC address of "sle_client" in first reserved MAC field
-    And I press "Add Item" in host reservations section
-    And I enter "minion" in second reserved hostname field
-    And I enter the local IP address of "minion" in second reserved IP field
-    And I enter the MAC address of "sle_minion" in second reserved MAC field
     And I click on "Save Formula"
     Then I should see a "Formula saved" text
 
@@ -177,9 +169,6 @@ Feature: Setup SUSE Manager for Retail branch network
 
 @proxy
 @private_net
-  Scenario: Set up the terminals too
+@pxeboot_minion
+  Scenario: I restart the network on the PXE boot minion
     When I set up the private network on the terminals
-    Then terminal "sle_client" should have got a retail network IP address
-    And name resolution should work on terminal "sle_client"
-    And terminal "sle_minion" should have got a retail network IP address
-    And name resolution should work on terminal "sle_minion"

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -976,19 +976,8 @@ When(/^I copy server\'s keys to the proxy$/) do
   end
 end
 
-# rubocop:disable Metrics/BlockLength
 When(/^I set up the private network on the terminals$/) do
   proxy = net_prefix + ADDRESSES['proxy']
-  # /etc/sysconfig/network/ifcfg-eth1 and /etc/resolv.conf
-  nodes = [$client, $minion]
-  conf = "STARTMODE='auto'\\nBOOTPROTO='dhcp'"
-  file = "/etc/sysconfig/network/ifcfg-eth1"
-  script2 = "-e '/^#/d' -e 's/^search /search example.org /' -e '$anameserver #{proxy}' -e '/^nameserver /d'"
-  file2 = "/etc/resolv.conf"
-  nodes.each do |node|
-    next if node.nil?
-    node.run("echo -e \"#{conf}\" > #{file} && sed -i #{script2} #{file2} && ifup eth1")
-  end
   # /etc/sysconfig/network-scripts/ifcfg-eth1 and /etc/sysconfig/network
   nodes = [$ceos_minion]
   file = "/etc/sysconfig/network-scripts/ifcfg-eth1"
@@ -1015,7 +1004,6 @@ When(/^I set up the private network on the terminals$/) do
     step %(I restart the network on the PXE boot minion)
   end
 end
-# rubocop:enable Metrics/BlockLength
 
 Then(/^terminal "([^"]*)" should have got a retail network IP address$/) do |host|
   node = get_target(host)

--- a/testsuite/features/upload_files/massive-import-terminals.yml
+++ b/testsuite/features/upload_files/massive-import-terminals.yml
@@ -58,12 +58,6 @@ branches:
         IP: <NET_PREFIX><PXEBOOT>
         hwAddress: "<PXEBOOT_MAC>"
         hwtype: Intel-Genuine
-      client:
-        IP: <NET_PREFIX><CLIENT>
-        hwAddress: "<CLIENT_MAC>"
-      minion:
-        IP: <NET_PREFIX><MINION>
-        hwAddress: "<MINION_MAC>"
 
 hwtypes:
   Intel-Genuine:


### PR DESCRIPTION
## What does this PR change?

PR deletes (1) empty profiles and (2) dhcp test of regular systems in private network to prevent conflict with regular clients testing.

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
