### PR TITLE
Uyuni fix mirrorlist url handling

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -1034,6 +1034,10 @@ public class ContentSyncManager {
             urls.add(new URI(uri.getScheme(), null, uri.getHost(), uri.getPort(), urlPath.toString(),
                     uri.getQuery(), null).toString());
         }
+        // In case url is a mirrorlist test the plain URL as well
+        if (Optional.ofNullable(uri.getQuery()).filter(q -> q.contains("=")).isPresent()) {
+            urls.add(url);
+        }
         return urls;
     }
 

--- a/java/code/src/com/redhat/rhn/manager/content/test/ContentSyncManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/content/test/ContentSyncManagerTest.java
@@ -14,9 +14,6 @@
  */
 package com.redhat.rhn.manager.content.test;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.reflect.TypeToken;
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.db.datasource.ModeFactory;
 import com.redhat.rhn.common.db.datasource.WriteMode;
@@ -59,10 +56,15 @@ import com.suse.scc.model.SCCRepositoryJson;
 import com.suse.scc.model.SCCSubscriptionJson;
 import com.suse.scc.model.UpgradePathJson;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+
 import org.apache.commons.io.FileUtils;
 
 import java.io.File;
 import java.io.InputStreamReader;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
@@ -1748,6 +1750,18 @@ public class ContentSyncManagerTest extends BaseTestCaseWithUser {
         assertContains(csm.buildRepoFileUrl(repourl, debrepo), repourl + "Release");
         assertContains(csm.buildRepoFileUrl(repourl, debrepo), repourl + "InRelease");
         assertEquals(5, csm.buildRepoFileUrl(repourl, debrepo).size());
+
+        repourl = "http://mirrorlist.centos.org/?release=8&arch=x86_64&repo=BaseOS&infra=stock";
+        rpmrepo.setDistroTarget("x86_64");
+
+        URI uri = new URI(repourl);
+        String url1 = new URI(uri.getScheme(), null, uri.getHost(), uri.getPort(), "/repodata/repomd.xml",
+                uri.getQuery(), null).toString();
+        String url2 = new URI(uri.getScheme(), null, uri.getHost(), uri.getPort(), "/",
+                uri.getQuery(), null).toString();
+        assertContains(csm.buildRepoFileUrl(repourl, rpmrepo), url1);
+        assertContains(csm.buildRepoFileUrl(repourl, rpmrepo), url2);
+        assertEquals(2, csm.buildRepoFileUrl(repourl, rpmrepo).size());
     }
 
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- fix check for for mirrorlist URLs when refreshing products (bsc#1184861)
+
 -------------------------------------------------------------------
 Fri Apr 16 13:23:01 CEST 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

The check for mirrolists like used for CentOS failed as we added the repomd.xml file path at the end.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/14586

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
