### PR TITLE
Retracted patches filtered minions fix

### DIFF
--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -1107,19 +1107,19 @@ public class SaltServerActionService {
         List<Long> sids = minionSummaries.stream().map(s -> s.getServerId()).collect(toList());
         List<Long> pids = packages.stream().map(p -> p.getId()).collect(toList());
 
-        List<Tuple2<Long, Long>> pidsidpairs = ErrataFactory.retractedPackages(pids, sids);
-        Map<Long, List<Long>> pidsBySid = pidsidpairs.stream()
+        List<Tuple2<Long, Long>> retractedPidSidPairs = ErrataFactory.retractedPackages(pids, sids);
+        Map<Long, List<Long>> retractedPidsBySid = retractedPidSidPairs.stream()
                 .collect(groupingBy(t -> t.getB(), mapping(t -> t.getA(), toList())));
         action.getServerActions().forEach(sa -> {
-            List<Long> packageIds = pidsBySid.get(sa.getServerId());
+            List<Long> packageIds = retractedPidsBySid.get(sa.getServerId());
             if (packageIds != null) {
                 sa.fail("contains retracted packages: " +
                         packageIds.stream().map(i -> i.toString()).collect(joining(",")));
             }
         });
         List<MinionSummary> filteredMinions = minionSummaries.stream()
-                .filter(ms -> pidsBySid.get(ms.getServerId()) != null &&
-                        !pidsBySid.get(ms.getServerId()).isEmpty())
+                .filter(ms -> retractedPidsBySid.get(ms.getServerId()) != null &&
+                        !retractedPidsBySid.get(ms.getServerId()).isEmpty())
                 .collect(toList());
 
         List<List<String>> pkgs = action

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -1118,8 +1118,8 @@ public class SaltServerActionService {
             }
         });
         List<MinionSummary> filteredMinions = minionSummaries.stream()
-                .filter(ms -> retractedPidsBySid.get(ms.getServerId()) != null &&
-                        !retractedPidsBySid.get(ms.getServerId()).isEmpty())
+                .filter(ms -> retractedPidsBySid.get(ms.getServerId()) == null ||
+                        retractedPidsBySid.get(ms.getServerId()).isEmpty())
                 .collect(toList());
 
         List<List<String>> pkgs = action

--- a/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
+++ b/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
@@ -200,7 +200,9 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
         Action updateAction = ActionFactory.lookupById(action.getId());
 
         Map<LocalCall<?>, List<MinionSummary>> result = saltServerActionService.callsForAction(updateAction, minionSummaries);
-        RhnBaseTestCase.assertNotEmpty(result.values());
+        assertEquals(1, result.values().size());
+        MinionSummary minionSummary = result.values().iterator().next().iterator().next();
+        assertEquals(new MinionSummary(minion), minionSummary);
     }
 
     public void testPackageRemoveDebian() throws Exception {

--- a/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
+++ b/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
@@ -39,6 +39,9 @@ import com.redhat.rhn.domain.channel.AccessToken;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.channel.test.ChannelFactoryTest;
 import com.redhat.rhn.domain.config.ConfigRevision;
+import com.redhat.rhn.domain.errata.AdvisoryStatus;
+import com.redhat.rhn.domain.errata.Errata;
+import com.redhat.rhn.domain.errata.test.ErrataFactoryTest;
 import com.redhat.rhn.domain.rhnpackage.Package;
 import com.redhat.rhn.domain.rhnpackage.PackageFactory;
 import com.redhat.rhn.domain.rhnpackage.PackageType;
@@ -59,11 +62,9 @@ import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitler;
 import com.redhat.rhn.manager.system.entitling.SystemUnentitler;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
-import com.redhat.rhn.taskomatic.task.checkin.SystemSummary;
 import com.redhat.rhn.testing.ConfigTestUtils;
 import com.redhat.rhn.testing.ErrataTestUtils;
 import com.redhat.rhn.testing.JMockBaseTestCaseWithUser;
-import com.redhat.rhn.testing.RhnBaseTestCase;
 import com.redhat.rhn.testing.ServerTestUtils;
 import com.redhat.rhn.testing.TestUtils;
 
@@ -203,6 +204,55 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
         assertEquals(1, result.values().size());
         MinionSummary minionSummary = result.values().iterator().next().iterator().next();
         assertEquals(new MinionSummary(minion), minionSummary);
+    }
+
+    public void testRetractedPackageInstall() throws Exception {
+        MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
+        List<MinionServer> mins = new ArrayList<>();
+        mins.add(minion);
+
+        List<MinionSummary> minionSummaries = mins.stream().
+                map(MinionSummary::new).collect(Collectors.toList());
+
+        Channel channel = ChannelFactoryTest.createTestChannel(user);
+        SystemManager.subscribeServerToChannel(user, minion, channel);
+        Package p64 = ErrataTestUtils.createTestPackage(user, channel, "x86_64");
+        Errata retracted = ErrataFactoryTest.createTestErrata(null);
+        retracted.addChannel(channel);
+        retracted.setAdvisoryStatus(AdvisoryStatus.RETRACTED);
+        Package p32 = ErrataTestUtils.createLaterTestPackage(user, retracted, channel, p64);
+        p32.setPackageEvr(p64.getPackageEvr());
+        p32.setPackageArch(PackageFactory.lookupPackageArchByLabel("i686"));
+        TestUtils.saveAndFlush(p32);
+
+        List<Map<String, Long>> packageMaps = new ArrayList<>();
+        Map<String, Long> pkg32map = new HashMap<>();
+        pkg32map.put("name_id", p32.getPackageName().getId());
+        pkg32map.put("evr_id", p32.getPackageEvr().getId());
+        pkg32map.put("arch_id", p32.getPackageArch().getId());
+        packageMaps.add(pkg32map);
+        Map<String, Long> pkg64map = new HashMap<>();
+        pkg64map.put("name_id", p64.getPackageName().getId());
+        pkg64map.put("evr_id", p64.getPackageEvr().getId());
+        pkg64map.put("arch_id", p64.getPackageArch().getId());
+        packageMaps.add(pkg64map);
+
+        final ZonedDateTime now = ZonedDateTime.now(ZoneId.systemDefault());
+        Action action = ActionManager.createAction(user, ActionFactory.TYPE_PACKAGES_UPDATE,
+                "test action", Date.from(now.toInstant()));
+
+        ActionFactory.addServerToAction(minion, action);
+
+        ActionManager.addPackageActionDetails(Arrays.asList(action), packageMaps);
+        TestUtils.flushAndEvict(action);
+        Action updateAction = ActionFactory.lookupById(action.getId());
+
+        Map<LocalCall<?>, List<MinionSummary>> result = saltServerActionService.callsForAction(updateAction, minionSummaries);
+        assertEquals(1, result.values().size());
+        List<MinionSummary> summaries = result.values().iterator().next();
+        assertTrue(summaries.isEmpty());
+        ServerAction serverAction = HibernateFactory.reload(action.getServerActions().iterator().next());
+        assertEquals(STATUS_FAILED, serverAction.getStatus());
     }
 
     public void testPackageRemoveDebian() throws Exception {

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Bugfix: Retracted Patches: Filter minion correctly when executing package install (bsc#1184929)
+
 -------------------------------------------------------------------
 Fri Apr 16 15:59:32 CEST 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Previously, the list of filtered minions was computed incorrectly: the filtering condition was reversed, so instead of including minions with no retracted packages, the filter included only minions _with_ retracted packages.

Review commit-by-commit please.

## GUI diff

No diff.


- [x] **DONE**

## Documentation
- No documentation needed: fix

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/14605

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
