### PR TITLE
Correct expected text for product sync

### DIFF
--- a/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
+++ b/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
@@ -56,7 +56,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     When I enter "SUSE Linux Enterprise Server 12 SP4" as the filtered product description
     And I select "SUSE Linux Enterprise Server 12 SP4 x86_64" as a product
     Then I should see the "SUSE Linux Enterprise Server 12 SP4 x86_64" selected
-    When I open the sub-list of the product "SUSE Linux Enterprise Server 12 SP4"
+    When I open the sub-list of the product "SUSE Linux Enterprise Server 12 SP4 x86_64"
     And I select "SUSE Linux Enterprise Server LTSS 12 SP4 x86_64" as a product
     Then I should see the "SUSE Linux Enterprise Server LTSS 12 SP4 x86_64" selected
     When I click the Add Product button

--- a/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
+++ b/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
@@ -110,6 +110,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I select "Development Tools Module 15 SP3 x86_64" as a product
     Then I should see the "Development Tools Module 15 SP3 x86_64" selected
     When I click the Add Product button
+    And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
     And I wait until I see "SUSE Linux Enterprise Server 15 SP3 x86_64 (BETA)" product has been added
 
   Scenario: SUSE Linux Enterprise Server with Expanded Support 6
@@ -145,6 +146,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I select "SUSE Manager Proxy 4.2 x86_64" as a product
     Then I should see the "SUSE Manager Proxy 4.2 x86_64" selected
     When I click the Add Product button
+    And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
     And I wait until I see "SUSE Manager Proxy 4.2 x86_64" product has been added
 
   Scenario: SUSE Manager Retail Branch Server 4.2 x86_64
@@ -153,4 +155,5 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I select "SUSE Manager Retail Branch Server 4.2 x86_64" as a product
     Then I should see the "SUSE Manager Retail Branch Server 4.2 x86_64" selected
     When I click the Add Product button
+    And I wait until I see "Selected channels/products were scheduled successfully for syncing." text
     And I wait until I see "SUSE Manager Retail Branch Server 4.2 x86_64" product has been added


### PR DESCRIPTION
## What does this PR change?

Correct expected text for product sync, adding the text that appears in the UI. This should only be for 4.2 for master.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes No issue, directly from BV testsuite review
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
