### PR TITLE
QA: Avoid using a console parameter inside a string parameter

### DIFF
--- a/testsuite/features/secondary/min_retracted_patches.feature
+++ b/testsuite/features/secondary/min_retracted_patches.feature
@@ -6,7 +6,7 @@ Feature: Retracted patches
 
   Scenario: Installed retracted package should show icon in the system packages list
     Given I am authorized as "admin" with password "admin"
-    When I install package "rute-dummy=2.1-1.1" on this "sle_minion"
+    When I install package "rute-dummy-2.1-1.1" on this "sle_minion"
     And I wait until package "rute-dummy-2.1-1.1.x86_64" is installed on "sle_minion" via spacecmd
     And I am on the "Software" page of this "sle_minion"
     And I follow "Packages"
@@ -27,7 +27,7 @@ Feature: Retracted patches
 
   Scenario: Retracted package should not be available for upgrade
     Given I am authorized as "admin" with password "admin"
-    When I install old package "rute-dummy=2.0-1.2" on this "sle_minion"
+    When I install old package "rute-dummy-2.0-1.2" on this "sle_minion"
     And I wait until package "rute-dummy-2.0-1.2.x86_64" is installed on "sle_minion" via spacecmd
     And I am on the "Software" page of this "sle_minion"
     And I follow "Packages"
@@ -38,7 +38,7 @@ Feature: Retracted patches
 
   Scenario: Retracted patch should not affect any system
     Given I am authorized as "admin" with password "admin"
-    When I install package "rute-dummy=2.0-1.2" on this "sle_minion"
+    When I install package "rute-dummy-2.0-1.2" on this "sle_minion"
     And I wait until package "rute-dummy-2.0-1.2.x86_64" is installed on "sle_minion" via spacecmd
     And I follow the left menu "Software > Channel List > All"
     And I follow "Test-Channel-x86_64"

--- a/testsuite/features/secondary/min_ubuntu_salt_install_package.feature
+++ b/testsuite/features/secondary/min_ubuntu_salt_install_package.feature
@@ -9,7 +9,7 @@ Feature: Install and upgrade package on the Ubuntu minion via Salt through the U
     When I enable repository "test_repo_deb_pool" on this "ubuntu_minion"
     And I run "apt update" on "ubuntu_minion" with logging
     And I remove package "andromeda-dummy" from this "ubuntu_minion"
-    And I install old package "virgo-dummy=1.0" on this "ubuntu_minion"
+    And I install old package "virgo-dummy-1.0" on this "ubuntu_minion"
     And I am on the Systems overview page of this "ubuntu_minion"
     And I follow "Software" in the content area
     And I click on "Update Package List"

--- a/testsuite/features/secondary/min_ubuntu_salt_install_with_staging.feature
+++ b/testsuite/features/secondary/min_ubuntu_salt_install_with_staging.feature
@@ -19,7 +19,7 @@ Feature: Install a package on the Ubuntu minion with staging enabled
     When I enable repository "test_repo_deb_pool" on this "ubuntu_minion"
     And I run "apt update" on "ubuntu_minion"
     And I remove package "orion-dummy" from this "ubuntu_minion"
-    And I install old package "virgo-dummy=1.0" on this "ubuntu_minion"
+    And I install old package "virgo-dummy-1.0" on this "ubuntu_minion"
 
   Scenario: Pre-requisite: refresh package list on Ubuntu minion
     When I refresh packages list via spacecmd on "ubuntu_minion"


### PR DESCRIPTION
## What does this PR change?

I don't consider good practice to include parameters inside a string parameter.

Example:
When we use `rute-dummy=2.1-1.1` we are using a parameter that defines the version we use, appended by the base name of the package, this could be not supported by other package managers (or it might do). I think that the best we can do for the installation step is to use the full package name that includes the version, so `rute-dummy-2.1-1.1`

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.0
- Manager-4.1

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
