### PR TITLE
Fix db schema version check

### DIFF
--- a/spacewalk/admin/spacewalk-admin.changes
+++ b/spacewalk/admin/spacewalk-admin.changes
@@ -1,3 +1,5 @@
+- check db schema version against the current schema only (bsc#1185027)
+
 -------------------------------------------------------------------
 Fri Apr 16 13:18:00 CEST 2021 - jgonzalez@suse.com
 

--- a/spacewalk/admin/spacewalk-startup-helper
+++ b/spacewalk/admin/spacewalk-startup-helper
@@ -16,13 +16,13 @@ perform_db_schema_upgrade() {
 
 check_schema_version() {
     MIN_JAVA_SCHEMA=$( egrep -m1 "^java.min_schema_version[[:space:]]*=" /usr/share/rhn/config-defaults/rhn_java.conf | sed 's/^java.min_schema_version[[:space:]]*=[[:space:]]*\(.*\)/\1/' || echo "" )
-    CMP=$(echo "select evr_t_compare(X.evr, evr_t('0', '$MIN_JAVA_SCHEMA', '0', 'rpm')) from (select PE.evr from rhnVersionInfo vi join rhnPackageEVR pe on vi.evr_id = pe.id) X;" | spacewalk-sql --select-mode - | sed -n 3p | xargs)
+    CMP=$(echo "select evr_t_compare(X.evr, evr_t('0', '$MIN_JAVA_SCHEMA', '0', 'rpm')) from (select PE.evr from rhnVersionInfo vi join rhnPackageEVR pe on vi.evr_id = pe.id where vi.label = 'schema') X;" | spacewalk-sql --select-mode - | sed -n 3p | xargs)
     if [ $CMP -lt 0 ]; then
         echo "Incompatible database schema version detected! Minimal schema version required by Java: $MIN_JAVA_SCHEMA"
         exit 1
     fi
     MIN_BACK_SCHEMA=$( egrep -m1 "^min_schema_version[[:space:]]*=" /usr/share/rhn/config-defaults/rhn_server_xmlrpc.conf | sed 's/^min_schema_version[[:space:]]*=[[:space:]]*\(.*\)/\1/' || echo "" )
-    CMP=$(echo "select evr_t_compare(X.evr, evr_t('0', '$MIN_BACK_SCHEMA', '0', 'rpm')) from (select PE.evr from rhnVersionInfo vi join rhnPackageEVR pe on vi.evr_id = pe.id) X;" | spacewalk-sql --select-mode - | sed -n 3p | xargs)
+    CMP=$(echo "select evr_t_compare(X.evr, evr_t('0', '$MIN_BACK_SCHEMA', '0', 'rpm')) from (select PE.evr from rhnVersionInfo vi join rhnPackageEVR pe on vi.evr_id = pe.id where vi.label = 'schema') X;" | spacewalk-sql --select-mode - | sed -n 3p | xargs)
     if [ $CMP -lt 0 ]; then
         echo "Incompatible database schema version detected! Minimal schema version required by Backend: $MIN_BACK_SCHEMA"
         exit 1


### PR DESCRIPTION
## What does this PR change?

The DB schema version check was done against all entries in rhnVersionInfo table.
But we only need to check against the "current" schema as the older ones will just fail.
This caused the startup of the server to fail when multiple schema migrations were done in the past.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/14624

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
