### PR TITLE
Add option to push to an obs test project

### DIFF
--- a/rel-eng/push-packages-to-obs.sh
+++ b/rel-eng/push-packages-to-obs.sh
@@ -32,7 +32,9 @@ grep -v -- "\(--help\|-h\|-?\)\>" <<<"$@" || {
 Usage: push-packages-to-obs.sh [PACKAGE]..
 Submitt changed packages from \$WORKSPACE/SRPMS/<package> ($WORKSPACE)
 to OBS ($OBS_PROJ). Without argument all packages in SRPMS are processed.
-If $OBS_TEST_PROJECT is specified, packages will be submitted to it, instead.
+If OBS_TEST_PROJECT environment variable has been set, packages will be
+submitted to it, instead. This is useful for, for example, building a project
+that contains packages that have been changed in a Pull Request.
 EOF
   exit 0
 }

--- a/susemanager-utils/testing/automation/push-to-obs.sh
+++ b/susemanager-utils/testing/automation/push-to-obs.sh
@@ -10,7 +10,7 @@ help() {
   echo ""
   echo "Syntax: "
   echo ""
-  echo "${SCRIPT} -d <API1|PROJECT1>[,<API2|PROJECT2>...] -c OSC_CFG_FILE [-p PACKAGE1,PACKAGE2,...,PACKAGEN] [-v] [-t]"
+  echo "${SCRIPT} -d <API1|PROJECT1>[,<API2|PROJECT2>...] -c OSC_CFG_FILE [-p PACKAGE1,PACKAGE2,...,PACKAGEN] [-v] [-t] [-n PROJECT]"
   echo ""
   echo "Where: "
   echo "  -d  Comma separated list of destionations in the format API/PROJECT,"
@@ -19,6 +19,7 @@ help() {
   echo "  -p  Comma separated list of packages. If absent, all packages are submitted"
   echo "  -v  Verbose mode"
   echo "  -t  For tito, use current branch HEAD instead of latest package tag"
+  echo "  -n  If used, update PROJECT instead of the projects specified with -d"
   echo ""
 }
 
@@ -29,6 +30,7 @@ while getopts ":d:c:p:vth" opts; do
     c) CREDENTIALS=${OPTARG};;
     v) VERBOSE="-v";;
     t) TEST="-t";;
+    n) OBS_TEST_PROJECT="-n ${OPTARG};;
     h) help
        exit 0;;
     *) echo "Invalid syntax. Use ${SCRIPT} -h"
@@ -53,7 +55,7 @@ if [ ! -f ${CREDENTIALS} ]; then
 fi
 
 INITIAL_CMD="/manager/susemanager-utils/testing/automation/initial-objects.sh"
-CMD="/manager/susemanager-utils/testing/docker/scripts/push-to-obs.sh -d '${DESTINATIONS}' -c /tmp/.oscrc -p '${PACKAGES}' ${VERBOSE} ${TEST}"
+CMD="/manager/susemanager-utils/testing/docker/scripts/push-to-obs.sh -d '${DESTINATIONS}' -c /tmp/.oscrc -p '${PACKAGES}' ${VERBOSE} ${TEST} ${OBS_TEST_PROJECT}"
 CHOWN_CMD="/manager/susemanager-utils/testing/automation/chown-objects.sh $(id -u) $(id -g)"
 
 docker pull $REGISTRY/$PUSH2OBS_CONTAINER

--- a/susemanager-utils/testing/automation/push-to-obs.sh
+++ b/susemanager-utils/testing/automation/push-to-obs.sh
@@ -19,7 +19,9 @@ help() {
   echo "  -p  Comma separated list of packages. If absent, all packages are submitted"
   echo "  -v  Verbose mode"
   echo "  -t  For tito, use current branch HEAD instead of latest package tag"
-  echo "  -n  If used, update PROJECT instead of the projects specified with -d"
+  echo "  -n  If used, update PROJECT instead of the projects specified with -d,"
+  echo "      for example, if you want to package only the changes from a PR on"
+  echo "      a separate project"
   echo ""
 }
 

--- a/susemanager-utils/testing/docker/scripts/push-to-obs.sh
+++ b/susemanager-utils/testing/docker/scripts/push-to-obs.sh
@@ -8,7 +8,7 @@ help() {
   echo ""
   echo "Syntax: "
   echo ""
-  echo "${SCRIPT} -d <API1|PROJECT1>[,<API2|PROJECT2>...] -c OSC_CFG_FILE [-p PACKAGE1,PACKAGE2,...,PACKAGEN] [-v] [-t]"
+  echo "${SCRIPT} -d <API1|PROJECT1>[,<API2|PROJECT2>...] -c OSC_CFG_FILE [-p PACKAGE1,PACKAGE2,...,PACKAGEN] [-v] [-t] [-n PROJECT]"
   echo ""
   echo "Where: "
   echo "  -d  Comma separated list of destionations in the format API/PROJECT,"
@@ -17,6 +17,7 @@ help() {
   echo "  -c  Path to the OSC credentials (usually ~/.osrc)"
   echo "  -v  Verbose mode"
   echo "  -t  For tito, use current branch HEAD instead of latest package tag"
+  echo "  -n  If used, update PROJECT instead of the projects specified with -d"
   echo ""
 }
 
@@ -27,6 +28,7 @@ while getopts ":d:c:p:vth" opts; do
     c) export OSCRC=${OPTARG};;
     v) export VERBOSE=1;;
     t) export TEST=1;;
+    n) export OBS_TEST_PROJECT=${OPTARG};;
     h) help
        exit 0;;
     *) echo "Invalid syntax. Use ${SCRIPT} -h"


### PR DESCRIPTION
## What does this PR change?

With this option, we can push new packages to a separate project instead
of updating the current one.

This is useful for pushing new packages into obs project for testing
pull requests, so that we only build new packages, instead of building
all the packages.

### Long explanation

The current behavious is that packages will be updated in the specified projects, by using the -d option.

For example, we have systemsmanagement:Uyuni:Master, where we have ALL the packages. Note I am highlighting ALL.
Then, we take the sources from github/uyuni-project/uyuni/ , and build the SRPMs locally.
Once you have the SRPMs, we checkout systemsmanagement:Uyuni:Master and compare each package with the SRPMs.
Then, for each package that there are differences, we are updating the package and pushing it to systemsmanagement:Uyuni:Master.
This way, we are only submitting and rebuilding packages that contain updates.

This is ok for the master branch.

However, when we try to test a Pull Request, we are creating a new blank project for the Pull Request. For example, if the Pull Request is github/uyuni-project/uyuni/pulls/1234, we are creating systemsmanagement:Uyuni:Master:PR:1234 . This is a blank project, so no packages, in contrast with systemsmanagement:Uyuni:Master, which contains ALL packages.

Then, if we run the same script, we are basically adding ALL packages to systemsmanagement:Uyuni:Master:PR:1234 and building ALL of them, which can take 40-50 minutes (depending on obs load).

What we aim for, is submitting and building only the packages that are updated by the code updated in github/uyuni-project/uyuni/pulls/1234, so it would take 5 minutes in the best case that there is only one package.

Thus, what we need, is to checkout systemsmanagement:Uyuni:Master, build the SRPMS, compare them with the checkout , and then, instead of pushing them to systemsmanagement:Uyuni:Master, we need to push them to systemsmanagement:Uyuni:Master:PR:1234 .


## GUI diff

No difference.


- [X] **DONE**

## Documentation
- No documentation needed

- [X] **DONE**

## Test coverage
- No tests
- [X] **DONE**

## Links

Fixes # https://github.com/SUSE/spacewalk/issues/14612

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
