### PR TITLE
Move autoinstall files upload from sumaform to spacewalk project

### DIFF
--- a/testsuite/features/secondary/srv_distro_cobbler.feature
+++ b/testsuite/features/secondary/srv_distro_cobbler.feature
@@ -6,6 +6,7 @@ Feature: Cobbler and distribution autoinstallation
 
   Background:
     Given I am authorized
+    When I copy autoinstall mocked files on server
 
   Scenario: Ask cobbler to create a distribution via XML-RPC
     Given cobblerd is running
@@ -25,7 +26,7 @@ Feature: Cobbler and distribution autoinstallation
     When I follow the left menu "Systems > Autoinstallation > Distributions"
     And I follow "Create Distribution"
     And I enter "SLE-15-FAKE" as "label"
-    And I enter "/install/SLES15-SP2-x86_64/DVD1/" as "basepath"
+    And I enter "/var/autoinstall/SLES15-SP2-x86_64/DVD1/" as "basepath"
     And I select "SLE-Product-SLES15-SP2-Pool for x86_64" from "channelid"
     And I select "SUSE Linux Enterprise 15" from "installtype"
     And I click on "Create Autoinstallable Distribution"
@@ -38,7 +39,7 @@ Feature: Cobbler and distribution autoinstallation
     When I follow the left menu "Systems > Autoinstallation > Distributions"
     And I follow "Create Distribution"
     When I enter "fedora_kickstart_distro" as "label"
-    And I enter "/install/Fedora_12_i386/" as "basepath"
+    And I enter "/var/autoinstall/Fedora_12_i386/" as "basepath"
     And I select "Fedora" from "installtype"
     And I click on "Create Autoinstallable Distribution"
     Then I should see a "Autoinstallable Distributions" text

--- a/testsuite/features/secondary/srv_distro_cobbler.feature
+++ b/testsuite/features/secondary/srv_distro_cobbler.feature
@@ -26,7 +26,7 @@ Feature: Cobbler and distribution autoinstallation
     When I follow the left menu "Systems > Autoinstallation > Distributions"
     And I follow "Create Distribution"
     And I enter "SLE-15-FAKE" as "label"
-    And I enter "/tmp/autoinstall/SLES15-SP2-x86_64/DVD1/" as "basepath"
+    And I enter "/var/autoinstall/SLES15-SP2-x86_64/DVD1/" as "basepath"
     And I select "SLE-Product-SLES15-SP2-Pool for x86_64" from "channelid"
     And I select "SUSE Linux Enterprise 15" from "installtype"
     And I click on "Create Autoinstallable Distribution"
@@ -39,7 +39,7 @@ Feature: Cobbler and distribution autoinstallation
     When I follow the left menu "Systems > Autoinstallation > Distributions"
     And I follow "Create Distribution"
     When I enter "fedora_kickstart_distro" as "label"
-    And I enter "/tmp/autoinstall/Fedora_12_i386/" as "basepath"
+    And I enter "/var/autoinstall/Fedora_12_i386/" as "basepath"
     And I select "Fedora" from "installtype"
     And I click on "Create Autoinstallable Distribution"
     Then I should see a "Autoinstallable Distributions" text

--- a/testsuite/features/secondary/srv_distro_cobbler.feature
+++ b/testsuite/features/secondary/srv_distro_cobbler.feature
@@ -26,7 +26,7 @@ Feature: Cobbler and distribution autoinstallation
     When I follow the left menu "Systems > Autoinstallation > Distributions"
     And I follow "Create Distribution"
     And I enter "SLE-15-FAKE" as "label"
-    And I enter "/var/autoinstall/SLES15-SP2-x86_64/DVD1/" as "basepath"
+    And I enter "/tmp/autoinstall/SLES15-SP2-x86_64/DVD1/" as "basepath"
     And I select "SLE-Product-SLES15-SP2-Pool for x86_64" from "channelid"
     And I select "SUSE Linux Enterprise 15" from "installtype"
     And I click on "Create Autoinstallable Distribution"
@@ -39,7 +39,7 @@ Feature: Cobbler and distribution autoinstallation
     When I follow the left menu "Systems > Autoinstallation > Distributions"
     And I follow "Create Distribution"
     When I enter "fedora_kickstart_distro" as "label"
-    And I enter "/var/autoinstall/Fedora_12_i386/" as "basepath"
+    And I enter "/tmp/autoinstall/Fedora_12_i386/" as "basepath"
     And I select "Fedora" from "installtype"
     And I click on "Create Autoinstallable Distribution"
     Then I should see a "Autoinstallable Distributions" text

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1588,5 +1588,4 @@ When(/^I copy autoinstall mocked files on server$/) do
   return_codes << file_inject($server, base_dir + 'sles15sp2/initrd', source_dir + 'SLES15-SP2-x86_64/DVD1/boot/x86_64/loader/initrd')
   return_codes << file_inject($server, base_dir + 'sles15sp2/linux', source_dir + 'SLES15-SP2-x86_64/DVD1/boot/x86_64/loader/linux')
   raise 'File injection failed' unless return_codes.all?(&:zero?)
-  $server.run("chmod 644 $(find #{source_dir} -type f)")
 end

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -535,25 +535,25 @@ When(/^the server stops mocking an IPMI host$/) do
 end
 
 When(/^the server starts mocking a Redfish host$/) do
-  $server.run('mkdir -p /var/Redfish-Mockup-Server/')
+  $server.run('mkdir -p /root/Redfish-Mockup-Server/')
   ['redfishMockupServer.py', 'rfSsdpServer.py'].each do |file|
     source = File.dirname(__FILE__) + '/../upload_files/Redfish-Mockup-Server/' + file
-    dest = '/var/Redfish-Mockup-Server/' + file
+    dest = '/root/Redfish-Mockup-Server/' + file
     return_code = file_inject($server, source, dest)
     raise 'File injection failed' unless return_code.zero?
   end
   $server.run('curl --output DSP2043_2019.1.zip https://www.dmtf.org/sites/default/files/standards/documents/DSP2043_2019.1.zip')
   $server.run('unzip DSP2043_2019.1.zip')
-  cmd = "/usr/bin/python3 /var/Redfish-Mockup-Server/redfishMockupServer.py " \
+  cmd = "/usr/bin/python3 /root/Redfish-Mockup-Server/redfishMockupServer.py " \
         "-H #{$server.full_hostname} -p 8443 " \
-        "-S -D /var/DSP2043_2019.1/public-catfish/ " \
+        "-S -D /root/DSP2043_2019.1/public-catfish/ " \
         "--ssl --cert /etc/pki/tls/certs/spacewalk.crt --key /etc/pki/tls/private/spacewalk.key " \
         "< /dev/null > /dev/null 2>&1 &"
   $server.run(cmd)
 end
 
 When(/^the server stops mocking a Redfish host$/) do
-  $server.run('pkill -e -f /var/Redfish-Mockup-Server/redfishMockupServer.py')
+  $server.run('pkill -e -f /root/Redfish-Mockup-Server/redfishMockupServer.py')
 end
 
 When(/^I install a user-defined state for "([^"]*)" on the server$/) do |host|
@@ -980,10 +980,10 @@ end
 
 When(/^I copy server\'s keys to the proxy$/) do
   ['RHN-ORG-PRIVATE-SSL-KEY', 'RHN-ORG-TRUSTED-SSL-CERT', 'rhn-ca-openssl.cnf'].each do |file|
-    return_code = file_extract($server, '/var/ssl-build/' + file, '/tmp/' + file)
+    return_code = file_extract($server, '/root/ssl-build/' + file, '/tmp/' + file)
     raise 'File extraction failed' unless return_code.zero?
-    $proxy.run('mkdir -p /var/ssl-build')
-    return_code = file_inject($proxy, '/tmp/' + file, '/var/ssl-build/' + file)
+    $proxy.run('mkdir -p /root/ssl-build')
+    return_code = file_inject($proxy, '/tmp/' + file, '/root/ssl-build/' + file)
     raise 'File injection failed' unless return_code.zero?
   end
 end

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1577,10 +1577,10 @@ When(/^I apply "([^"]*)" local salt state on "([^"]*)"$/) do |state, host|
 end
 
 When(/^I copy autoinstall mocked files on server$/) do
-  target_dirs = "/tmp/autoinstall/Fedora_12_i386/images/pxeboot /tmp/autoinstall/SLES15-SP2-x86_64/DVD1/boot/x86_64/loader /tmp/autoinstall/mock"
+  target_dirs = "/var/autoinstall/Fedora_12_i386/images/pxeboot /var/autoinstall/SLES15-SP2-x86_64/DVD1/boot/x86_64/loader /var/autoinstall/mock"
   $server.run("mkdir -p #{target_dirs}")
   base_dir = File.dirname(__FILE__) + "/../upload_files/autoinstall/cobbler/"
-  source_dir = "/tmp/autoinstall/"
+  source_dir = "/var/autoinstall/"
   return_codes = []
   return_codes << file_inject($server, base_dir + 'fedora12/vmlinuz', source_dir + 'Fedora_12_i386/images/pxeboot/vmlinuz')
   return_codes << file_inject($server, base_dir + 'fedora12/initrd.img', source_dir + 'Fedora_12_i386/images/pxeboot/initrd.img')

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1577,10 +1577,10 @@ When(/^I apply "([^"]*)" local salt state on "([^"]*)"$/) do |state, host|
 end
 
 When(/^I copy autoinstall mocked files on server$/) do
-  target_dirs = "/var/autoinstall/Fedora_12_i386/images/pxeboot /var/autoinstall/SLES15-SP2-x86_64/DVD1/boot/x86_64/loader /var/autoinstall/mock"
+  target_dirs = "/tmp/autoinstall/Fedora_12_i386/images/pxeboot /tmp/autoinstall/SLES15-SP2-x86_64/DVD1/boot/x86_64/loader /tmp/autoinstall/mock"
   $server.run("mkdir -p #{target_dirs}")
   base_dir = File.dirname(__FILE__) + "/../upload_files/autoinstall/cobbler/"
-  source_dir = "/var/autoinstall/"
+  source_dir = "/tmp/autoinstall/"
   return_codes = []
   return_codes << file_inject($server, base_dir + 'fedora12/vmlinuz', source_dir + 'Fedora_12_i386/images/pxeboot/vmlinuz')
   return_codes << file_inject($server, base_dir + 'fedora12/initrd.img', source_dir + 'Fedora_12_i386/images/pxeboot/initrd.img')
@@ -1588,4 +1588,5 @@ When(/^I copy autoinstall mocked files on server$/) do
   return_codes << file_inject($server, base_dir + 'sles15sp2/initrd', source_dir + 'SLES15-SP2-x86_64/DVD1/boot/x86_64/loader/initrd')
   return_codes << file_inject($server, base_dir + 'sles15sp2/linux', source_dir + 'SLES15-SP2-x86_64/DVD1/boot/x86_64/loader/linux')
   raise 'File injection failed' unless return_codes.all?(&:zero?)
+  $server.run("chmod 644 $(find #{source_dir} -type f)")
 end

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1588,4 +1588,5 @@ When(/^I copy autoinstall mocked files on server$/) do
   return_codes << file_inject($server, base_dir + 'sles15sp2/initrd', source_dir + 'SLES15-SP2-x86_64/DVD1/boot/x86_64/loader/initrd')
   return_codes << file_inject($server, base_dir + 'sles15sp2/linux', source_dir + 'SLES15-SP2-x86_64/DVD1/boot/x86_64/loader/linux')
   raise 'File injection failed' unless return_codes.all?(&:zero?)
+  $server.run("chmod 644 $(find #{source_dir} -type f)")
 end

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1588,5 +1588,4 @@ When(/^I copy autoinstall mocked files on server$/) do
   return_codes << file_inject($server, base_dir + 'sles15sp2/initrd', source_dir + 'SLES15-SP2-x86_64/DVD1/boot/x86_64/loader/initrd')
   return_codes << file_inject($server, base_dir + 'sles15sp2/linux', source_dir + 'SLES15-SP2-x86_64/DVD1/boot/x86_64/loader/linux')
   raise 'File injection failed' unless return_codes.all?(&:zero?)
-  $server.run("chmod 755 -R #{source_dir}")
 end

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -100,7 +100,7 @@ end
 
 # spacewalk errors steps
 Then(/^the up2date logs on client should contain no Traceback error$/) do
-  cmd = 'if grep "Traceback" /tmp/log/up2date ; then exit 1; else exit 0; fi'
+  cmd = 'if grep "Traceback" /var/log/up2date ; then exit 1; else exit 0; fi'
   _out, code = $client.run(cmd)
   raise 'error found, check the client up2date logs' if code.nonzero?
 end
@@ -190,7 +190,7 @@ Then(/^create distro "([^"]*)" as user "([^"]*)" with password "([^"]*)"$/) do |
   ct = CobblerTest.new
   ct.login(user, pwd)
   raise 'distro ' + distro + ' already exists' if ct.distro_exists(distro)
-  ct.distro_create(distro, '/tmp/autoinstall/SLES15-SP2-x86_64/DVD1/boot/x86_64/loader/linux', '/tmp/autoinstall/SLES15-SP2-x86_64/DVD1/boot/x86_64/loader/initrd')
+  ct.distro_create(distro, '/var/autoinstall/SLES15-SP2-x86_64/DVD1/boot/x86_64/loader/linux', '/var/autoinstall/SLES15-SP2-x86_64/DVD1/boot/x86_64/loader/initrd')
 end
 
 When(/^I trigger cobbler system record$/) do
@@ -220,7 +220,7 @@ Then(/^create profile "([^"]*)" as user "([^"]*)" with password "([^"]*)"$/) do 
   ct = CobblerTest.new
   ct.login(arg2, arg3)
   raise 'profile ' + arg1 + ' already exists' if ct.profile_exists(arg1)
-  ct.profile_create('testprofile', 'testdistro', '/tmp/autoinstall/mock/empty.xml')
+  ct.profile_create('testprofile', 'testdistro', '/var/autoinstall/mock/empty.xml')
 end
 
 When(/^I remove kickstart profiles and distros$/) do
@@ -343,14 +343,14 @@ Given(/^I am on the manage software channels page$/) do
 end
 
 Given(/^metadata generation finished for "([^"]*)"$/) do |channel|
-  $server.run_until_ok("ls /tmp/cache/rhn/repodata/#{channel}/updateinfo.xml.gz")
+  $server.run_until_ok("ls /var/cache/rhn/repodata/#{channel}/updateinfo.xml.gz")
 end
 
 When(/^I push package "([^"]*)" into "([^"]*)" channel$/) do |arg1, arg2|
   srvurl = "http://#{ENV['SERVER']}/APP"
   command = "rhnpush --server=#{srvurl} -u admin -p admin --nosig -c #{arg2} #{arg1} "
   $server.run(command, true, 500, 'root')
-  $server.run('ls -lR /tmp/spacewalk/packages', true, 500, 'root')
+  $server.run('ls -lR /var/spacewalk/packages', true, 500, 'root')
 end
 
 Then(/^I should see package "([^"]*)" in channel "([^"]*)"$/) do |pkg, channel|
@@ -1259,8 +1259,8 @@ end
 
 When(/^I backup the SSH authorized_keys file of host "([^"]*)"$/) do |host|
   # authorized_keys paths on the client
-  auth_keys_path = '/tmp/.ssh/authorized_keys'
-  auth_keys_sav_path = '/tmp/.ssh/authorized_keys.sav'
+  auth_keys_path = '/var/.ssh/authorized_keys'
+  auth_keys_sav_path = '/var/.ssh/authorized_keys.sav'
   target = get_target(host)
   _, ret_code = target.run("cp #{auth_keys_path} #{auth_keys_sav_path}")
   raise 'error backing up authorized_keys on host' if ret_code.nonzero?
@@ -1274,14 +1274,14 @@ And(/^I add pre\-generated SSH public key to authorized_keys of host "([^"]*)"$/
     File.dirname(__FILE__) + '/../upload_files/ssh_keypair/' + key_filename,
     '/tmp/' + key_filename
   )
-  target.run("cat /tmp/#{key_filename} >> /tmp/.ssh/authorized_keys", true, 500, 'root')
+  target.run("cat /tmp/#{key_filename} >> /var/.ssh/authorized_keys", true, 500, 'root')
   raise 'Error copying ssh pubkey to host' if ret_code.nonzero?
 end
 
 When(/^I restore the SSH authorized_keys file of host "([^"]*)"$/) do |host|
   # authorized_keys paths on the client
-  auth_keys_path = '/tmp/.ssh/authorized_keys'
-  auth_keys_sav_path = '/tmp/.ssh/authorized_keys.sav'
+  auth_keys_path = '/var/.ssh/authorized_keys'
+  auth_keys_sav_path = '/var/.ssh/authorized_keys.sav'
   target = get_target(host)
   target.run("cp #{auth_keys_sav_path} #{auth_keys_path}")
   target.run("rm #{auth_keys_sav_path}")

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -100,7 +100,7 @@ end
 
 # spacewalk errors steps
 Then(/^the up2date logs on client should contain no Traceback error$/) do
-  cmd = 'if grep "Traceback" /var/log/up2date ; then exit 1; else exit 0; fi'
+  cmd = 'if grep "Traceback" /tmp/log/up2date ; then exit 1; else exit 0; fi'
   _out, code = $client.run(cmd)
   raise 'error found, check the client up2date logs' if code.nonzero?
 end
@@ -190,7 +190,7 @@ Then(/^create distro "([^"]*)" as user "([^"]*)" with password "([^"]*)"$/) do |
   ct = CobblerTest.new
   ct.login(user, pwd)
   raise 'distro ' + distro + ' already exists' if ct.distro_exists(distro)
-  ct.distro_create(distro, '/var/autoinstall/SLES15-SP2-x86_64/DVD1/boot/x86_64/loader/linux', '/var/autoinstall/SLES15-SP2-x86_64/DVD1/boot/x86_64/loader/initrd')
+  ct.distro_create(distro, '/tmp/autoinstall/SLES15-SP2-x86_64/DVD1/boot/x86_64/loader/linux', '/tmp/autoinstall/SLES15-SP2-x86_64/DVD1/boot/x86_64/loader/initrd')
 end
 
 When(/^I trigger cobbler system record$/) do
@@ -220,7 +220,7 @@ Then(/^create profile "([^"]*)" as user "([^"]*)" with password "([^"]*)"$/) do 
   ct = CobblerTest.new
   ct.login(arg2, arg3)
   raise 'profile ' + arg1 + ' already exists' if ct.profile_exists(arg1)
-  ct.profile_create('testprofile', 'testdistro', '/var/autoinstall/mock/empty.xml')
+  ct.profile_create('testprofile', 'testdistro', '/tmp/autoinstall/mock/empty.xml')
 end
 
 When(/^I remove kickstart profiles and distros$/) do
@@ -343,14 +343,14 @@ Given(/^I am on the manage software channels page$/) do
 end
 
 Given(/^metadata generation finished for "([^"]*)"$/) do |channel|
-  $server.run_until_ok("ls /var/cache/rhn/repodata/#{channel}/updateinfo.xml.gz")
+  $server.run_until_ok("ls /tmp/cache/rhn/repodata/#{channel}/updateinfo.xml.gz")
 end
 
 When(/^I push package "([^"]*)" into "([^"]*)" channel$/) do |arg1, arg2|
   srvurl = "http://#{ENV['SERVER']}/APP"
   command = "rhnpush --server=#{srvurl} -u admin -p admin --nosig -c #{arg2} #{arg1} "
   $server.run(command, true, 500, 'root')
-  $server.run('ls -lR /var/spacewalk/packages', true, 500, 'root')
+  $server.run('ls -lR /tmp/spacewalk/packages', true, 500, 'root')
 end
 
 Then(/^I should see package "([^"]*)" in channel "([^"]*)"$/) do |pkg, channel|
@@ -1259,8 +1259,8 @@ end
 
 When(/^I backup the SSH authorized_keys file of host "([^"]*)"$/) do |host|
   # authorized_keys paths on the client
-  auth_keys_path = '/var/.ssh/authorized_keys'
-  auth_keys_sav_path = '/var/.ssh/authorized_keys.sav'
+  auth_keys_path = '/tmp/.ssh/authorized_keys'
+  auth_keys_sav_path = '/tmp/.ssh/authorized_keys.sav'
   target = get_target(host)
   _, ret_code = target.run("cp #{auth_keys_path} #{auth_keys_sav_path}")
   raise 'error backing up authorized_keys on host' if ret_code.nonzero?
@@ -1274,14 +1274,14 @@ And(/^I add pre\-generated SSH public key to authorized_keys of host "([^"]*)"$/
     File.dirname(__FILE__) + '/../upload_files/ssh_keypair/' + key_filename,
     '/tmp/' + key_filename
   )
-  target.run("cat /tmp/#{key_filename} >> /var/.ssh/authorized_keys", true, 500, 'root')
+  target.run("cat /tmp/#{key_filename} >> /tmp/.ssh/authorized_keys", true, 500, 'root')
   raise 'Error copying ssh pubkey to host' if ret_code.nonzero?
 end
 
 When(/^I restore the SSH authorized_keys file of host "([^"]*)"$/) do |host|
   # authorized_keys paths on the client
-  auth_keys_path = '/var/.ssh/authorized_keys'
-  auth_keys_sav_path = '/var/.ssh/authorized_keys.sav'
+  auth_keys_path = '/tmp/.ssh/authorized_keys'
+  auth_keys_sav_path = '/tmp/.ssh/authorized_keys.sav'
   target = get_target(host)
   target.run("cp #{auth_keys_sav_path} #{auth_keys_path}")
   target.run("rm #{auth_keys_sav_path}")

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -190,7 +190,7 @@ Then(/^create distro "([^"]*)" as user "([^"]*)" with password "([^"]*)"$/) do |
   ct = CobblerTest.new
   ct.login(user, pwd)
   raise 'distro ' + distro + ' already exists' if ct.distro_exists(distro)
-  ct.distro_create(distro, '/tmp/autoinstall/SLES15-SP2-x86_64/DVD1/boot/x86_64/loader/linux', '/tmp/autoinstall/SLES15-SP2-x86_64/DVD1/boot/x86_64/loader/initrd')
+  ct.distro_create(distro, '/var/autoinstall/SLES15-SP2-x86_64/DVD1/boot/x86_64/loader/linux', '/var/autoinstall/SLES15-SP2-x86_64/DVD1/boot/x86_64/loader/initrd')
 end
 
 When(/^I trigger cobbler system record$/) do
@@ -220,7 +220,7 @@ Then(/^create profile "([^"]*)" as user "([^"]*)" with password "([^"]*)"$/) do 
   ct = CobblerTest.new
   ct.login(arg2, arg3)
   raise 'profile ' + arg1 + ' already exists' if ct.profile_exists(arg1)
-  ct.profile_create('testprofile', 'testdistro', '/tmp/autoinstall/mock/empty.xml')
+  ct.profile_create('testprofile', 'testdistro', '/var/autoinstall/mock/empty.xml')
 end
 
 When(/^I remove kickstart profiles and distros$/) do

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -190,7 +190,7 @@ Then(/^create distro "([^"]*)" as user "([^"]*)" with password "([^"]*)"$/) do |
   ct = CobblerTest.new
   ct.login(user, pwd)
   raise 'distro ' + distro + ' already exists' if ct.distro_exists(distro)
-  ct.distro_create(distro, '/install/SLES15-SP2-x86_64/DVD1/boot/x86_64/loader/linux', 'install/SLES15-SP2-x86_64/DVD1/boot/x86_64/loader/initrd')
+  ct.distro_create(distro, '/var/autoinstall/SLES15-SP2-x86_64/DVD1/boot/x86_64/loader/linux', '/var/autoinstall/SLES15-SP2-x86_64/DVD1/boot/x86_64/loader/initrd')
 end
 
 When(/^I trigger cobbler system record$/) do
@@ -220,7 +220,7 @@ Then(/^create profile "([^"]*)" as user "([^"]*)" with password "([^"]*)"$/) do 
   ct = CobblerTest.new
   ct.login(arg2, arg3)
   raise 'profile ' + arg1 + ' already exists' if ct.profile_exists(arg1)
-  ct.profile_create('testprofile', 'testdistro', '/install/empty.xml')
+  ct.profile_create('testprofile', 'testdistro', '/var/autoinstall/mock/empty.xml')
 end
 
 When(/^I remove kickstart profiles and distros$/) do
@@ -1259,8 +1259,8 @@ end
 
 When(/^I backup the SSH authorized_keys file of host "([^"]*)"$/) do |host|
   # authorized_keys paths on the client
-  auth_keys_path = '/root/.ssh/authorized_keys'
-  auth_keys_sav_path = '/root/.ssh/authorized_keys.sav'
+  auth_keys_path = '/var/.ssh/authorized_keys'
+  auth_keys_sav_path = '/var/.ssh/authorized_keys.sav'
   target = get_target(host)
   _, ret_code = target.run("cp #{auth_keys_path} #{auth_keys_sav_path}")
   raise 'error backing up authorized_keys on host' if ret_code.nonzero?
@@ -1274,14 +1274,14 @@ And(/^I add pre\-generated SSH public key to authorized_keys of host "([^"]*)"$/
     File.dirname(__FILE__) + '/../upload_files/ssh_keypair/' + key_filename,
     '/tmp/' + key_filename
   )
-  target.run("cat /tmp/#{key_filename} >> /root/.ssh/authorized_keys", true, 500, 'root')
+  target.run("cat /tmp/#{key_filename} >> /var/.ssh/authorized_keys", true, 500, 'root')
   raise 'Error copying ssh pubkey to host' if ret_code.nonzero?
 end
 
 When(/^I restore the SSH authorized_keys file of host "([^"]*)"$/) do |host|
   # authorized_keys paths on the client
-  auth_keys_path = '/root/.ssh/authorized_keys'
-  auth_keys_sav_path = '/root/.ssh/authorized_keys.sav'
+  auth_keys_path = '/var/.ssh/authorized_keys'
+  auth_keys_sav_path = '/var/.ssh/authorized_keys.sav'
   target = get_target(host)
   target.run("cp #{auth_keys_sav_path} #{auth_keys_path}")
   target.run("rm #{auth_keys_sav_path}")

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -1259,8 +1259,8 @@ end
 
 When(/^I backup the SSH authorized_keys file of host "([^"]*)"$/) do |host|
   # authorized_keys paths on the client
-  auth_keys_path = '/var/.ssh/authorized_keys'
-  auth_keys_sav_path = '/var/.ssh/authorized_keys.sav'
+  auth_keys_path = '/root/.ssh/authorized_keys'
+  auth_keys_sav_path = '/root/.ssh/authorized_keys.sav'
   target = get_target(host)
   _, ret_code = target.run("cp #{auth_keys_path} #{auth_keys_sav_path}")
   raise 'error backing up authorized_keys on host' if ret_code.nonzero?
@@ -1274,14 +1274,14 @@ And(/^I add pre\-generated SSH public key to authorized_keys of host "([^"]*)"$/
     File.dirname(__FILE__) + '/../upload_files/ssh_keypair/' + key_filename,
     '/tmp/' + key_filename
   )
-  target.run("cat /tmp/#{key_filename} >> /var/.ssh/authorized_keys", true, 500, 'root')
+  target.run("cat /tmp/#{key_filename} >> /root/.ssh/authorized_keys", true, 500, 'root')
   raise 'Error copying ssh pubkey to host' if ret_code.nonzero?
 end
 
 When(/^I restore the SSH authorized_keys file of host "([^"]*)"$/) do |host|
   # authorized_keys paths on the client
-  auth_keys_path = '/var/.ssh/authorized_keys'
-  auth_keys_sav_path = '/var/.ssh/authorized_keys.sav'
+  auth_keys_path = '/root/.ssh/authorized_keys'
+  auth_keys_sav_path = '/root/.ssh/authorized_keys.sav'
   target = get_target(host)
   target.run("cp #{auth_keys_sav_path} #{auth_keys_path}")
   target.run("rm #{auth_keys_sav_path}")

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -190,7 +190,7 @@ Then(/^create distro "([^"]*)" as user "([^"]*)" with password "([^"]*)"$/) do |
   ct = CobblerTest.new
   ct.login(user, pwd)
   raise 'distro ' + distro + ' already exists' if ct.distro_exists(distro)
-  ct.distro_create(distro, '/var/autoinstall/SLES15-SP2-x86_64/DVD1/boot/x86_64/loader/linux', '/var/autoinstall/SLES15-SP2-x86_64/DVD1/boot/x86_64/loader/initrd')
+  ct.distro_create(distro, '/tmp/autoinstall/SLES15-SP2-x86_64/DVD1/boot/x86_64/loader/linux', '/tmp/autoinstall/SLES15-SP2-x86_64/DVD1/boot/x86_64/loader/initrd')
 end
 
 When(/^I trigger cobbler system record$/) do
@@ -220,7 +220,7 @@ Then(/^create profile "([^"]*)" as user "([^"]*)" with password "([^"]*)"$/) do 
   ct = CobblerTest.new
   ct.login(arg2, arg3)
   raise 'profile ' + arg1 + ' already exists' if ct.profile_exists(arg1)
-  ct.profile_create('testprofile', 'testdistro', '/var/autoinstall/mock/empty.xml')
+  ct.profile_create('testprofile', 'testdistro', '/tmp/autoinstall/mock/empty.xml')
 end
 
 When(/^I remove kickstart profiles and distros$/) do

--- a/testsuite/features/upload_files/autoinstall/cobbler/fedora12/initrd.img
+++ b/testsuite/features/upload_files/autoinstall/cobbler/fedora12/initrd.img
@@ -1,0 +1,1 @@
+This is mocked contents for /pxeboot/initrd.img

--- a/testsuite/features/upload_files/autoinstall/cobbler/fedora12/vmlinuz
+++ b/testsuite/features/upload_files/autoinstall/cobbler/fedora12/vmlinuz
@@ -1,0 +1,1 @@
+This is mocked contents for /pxeboot/vmlinuz

--- a/testsuite/features/upload_files/autoinstall/cobbler/mock/empty.xml
+++ b/testsuite/features/upload_files/autoinstall/cobbler/mock/empty.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+<!DOCTYPE profile>
+<profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+  <report>
+    <errors>
+      <log config:type="boolean">false</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">10</timeout>
+    </errors>
+    <messages>
+      <log config:type="boolean">false</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">5</timeout>
+    </messages>
+    <warnings>
+      <log config:type="boolean">false</log>
+      <show config:type="boolean">true</show>
+      <timeout config:type="integer">10</timeout>
+    </warnings>
+  </report>
+  <networking>
+    <keep_install_network config:type="boolean">true</keep_install_network>
+  </networking>
+  <deploy_image>
+      <image_installation config:type="boolean">true</image_installation>
+  </deploy_image>
+  <software>
+    <install_recommended config:type="boolean">true</install_recommended>
+    <patterns config:type="list">
+      <pattern>base</pattern>
+    </patterns>
+  </software> 
+  <users config:type="list">
+    <user>
+      <encrypted config:type="boolean">false</encrypted>
+      <fullname>root</fullname>
+      <gid>0</gid>
+      <home>/root</home>
+      <password_settings>
+        <expire></expire>
+        <flag></flag>
+        <inact></inact>
+        <max></max>
+        <min></min>
+        <warn></warn>
+      </password_settings>
+      <shell>/bin/bash</shell>
+      <uid>0</uid>
+<!--      <user_password>$2a$05$7.BjUXGxN2uCmcmNZMr62.U9x/MZPAJ73ZMYmEUg5RuR3PDFytFyq</user_password> -->
+      <user_password>s1mCtpa%</user_password>
+      <username>root</username>
+    </user>
+  </users>
+  <scripts/>
+</profile>

--- a/testsuite/features/upload_files/autoinstall/cobbler/sles15sp2/initrd
+++ b/testsuite/features/upload_files/autoinstall/cobbler/sles15sp2/initrd
@@ -1,0 +1,1 @@
+This is mocked contents for /boot/x86_64/loader/linux

--- a/testsuite/features/upload_files/autoinstall/cobbler/sles15sp2/linux
+++ b/testsuite/features/upload_files/autoinstall/cobbler/sles15sp2/linux
@@ -1,0 +1,1 @@
+This is mocked contents for /boot/x86_64/loader/linux


### PR DESCRIPTION
## What does this PR change?

The PR remove the upload of install files needed for srv_distro_cobbler.feature from the sumaform deployment to the testsuite execution.

Dependency : https://github.com/uyuni-project/sumaform/pull/873
New version of : https://github.com/uyuni-project/uyuni/pull/3562

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Links

Issue : 
https://github.com/SUSE/spacewalk/issues/13755

- [x] **DONE**

## Test coverage
- Cucumber background test were added

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
