### PR TITLE
Remove Activation key from system details page

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemOverviewAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemOverviewAction.java
@@ -147,7 +147,6 @@ public class SystemOverviewAction extends RhnAction {
         request.setAttribute("minionId", s.getMinionId());
         request.setAttribute("hasLocation",
                 !(s.getLocation() == null || s.getLocation().isEmpty()));
-        request.setAttribute("activationKey", SystemManager.getActivationKeys(s));
         request.setAttribute("kernelLiveVersion",
                 s.asMinionServer().map(MinionServer::getKernelLiveVersion).orElse(null));
 

--- a/java/code/webapp/WEB-INF/pages/systems/sdc/overview.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/sdc/overview.jsp
@@ -159,14 +159,6 @@
           </tr>
           <rhn:require acl="system_has_management_entitlement() or system_has_salt_entitlement()">
           <tr>
-            <td><bean:message key="sdc.details.overview.activationkey"/></td>
-            <td>
-              <c:forEach items="${activationKey}" var="key">
-                <c:out value="${key.token}" /></br>
-              </c:forEach>
-            </td>
-          </tr>
-          <tr>
             <td><bean:message key="sdc.details.overview.installedproducts"/></td>
             <td>
               <c:choose>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Remove activation key display from system details page
 - change deprecated path /var/run into /run for systemd (bsc#1185059)
 - add virtual network edit action
 - Lower case fqdn comparation when calculating minion connection path (bsc#1184849)


### PR DESCRIPTION
## What does this PR change?

Stop displaying the activation key on the system details page

## GUI diff

Before:
![activation-before](https://user-images.githubusercontent.com/31698054/115525944-d99e8600-a28f-11eb-9830-6c44d41e426a.png)

After:
![activation-after](https://user-images.githubusercontent.com/31698054/115525967-de633a00-a28f-11eb-9f49-3433eae3294e.png)

- [x] **DONE**

## Documentation

- No documentation needed

- [x] **DONE**

## Test coverage

- No tests: Only visual change

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/14172

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
