### PR TITLE
[Ansible] Add new SLS file to trigger Ansible playbook execution

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/ansible/runplaybook.sls
+++ b/susemanager-utils/susemanager-sls/salt/ansible/runplaybook.sls
@@ -1,0 +1,22 @@
+#
+# SLS to trigger a playbook execution on an Ansible control node
+#
+# This SLS requires pillar data to render properly.
+# 
+# Example (inventory is optional):
+#
+# pillar = {
+#   "playbook_path": "/root/ansible-examples/lamp_simple/site.yml",
+#   "rundir": "/root/ansible-examples/lamp_simple"
+#   "inventory": "/root/ansible-examples/lamp_simple/hosts"
+# }
+#
+
+run_ansible_playbook:
+  ansible.playbooks:
+    - name: {{ pillar["playbook_path"] }}
+    - rundir: {{ pillar["rundir"] }}
+{%- if "inventory" in pillar %}
+    - ansible_kwargs:
+        inventory: {{ pillar["inventory"] }}
+{% endif %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,5 @@
+- Add new SLS files files to operate Ansible control node
+
 -------------------------------------------------------------------
 Fri Apr 16 13:35:25 CEST 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

This PR simply introduces a new SLS file that triggers the execution of an Ansible playbook in a minion. This `ansible.runplaybook` state needs some pillar data to render properly:

- `playbook_path`: path to the playbook in the minion
- `rundir`: directory `ansible-playbook` is executed
- (optional) `inventory`: define an alternative inventory file (default `/etc/ansible/hosts`) 

An example running this playbook: https://github.com/ansible/ansible-examples/tree/master/lamp_simple

```console
# salt-call --local state.apply ansible.runplaybook pillar='{"playbook_path": "/root/playbooks/lamp_simple/site.yml", "rundir": "/root/playbooks/lamp_simple/"}'
local:
----------
          ID: run_ansible_playbook
    Function: ansible.playbooks
        Name: /root/playbooks/lamp_simple/site.yml
      Result: True
     Comment: Changes were made by playbook /root/playbooks/lamp_simple/site.yml
     Started: 12:11:00.192506
    Duration: 16707.01 ms
     Changes:   
              ----------
              apply common configuration to all nodes:
                  ----------
                  common : Configure ntp file:
                      ----------
                      uyuni-stable-ansible-test.tf.local:
                          |_
                            ----------
                            after:
                                
                                driftfile /var/lib/ntp/drift
                                
                                restrict 127.0.0.1 
                                restrict -6 ::1
                                
                                server 192.168.1.2
                                
                                includefile /etc/ntp/crypto/pw
                                
                                keys /etc/ntp/keys
                                
                            after_header:
                                /root/.ansible/tmp/ansible-local-14436vgjkf689/tmpie23tcfd/ntp.conf.j2
                            before:
                                # For more information about this file, see the man pages
                                # ntp.conf(5), ntp_acc(5), ntp_auth(5), ntp_clock(5), ntp_misc(5), ntp_mon(5).
                                
                                driftfile /var/lib/ntp/drift
                                
                                # Permit time synchronization with our time source, but do not
                                # permit the source to query or modify the service on this system.
                                restrict default nomodify notrap nopeer noquery
                                
                                # Permit all access over the loopback interface.  This could
                                # be tightened as well, but to do so would effect some of
                                # the administrative functions.
                                restrict 127.0.0.1 
                                restrict ::1
                                
                                # Hosts on local network are less restricted.
                                #restrict 192.168.1.0 mask 255.255.255.0 nomodify notrap
                                
                                # Use public servers from the pool.ntp.org project.
                                # Please consider joining the pool (http://www.pool.ntp.org/join.html).
                                server 0.centos.pool.ntp.org iburst
                                server 1.centos.pool.ntp.org iburst
                                server 2.centos.pool.ntp.org iburst
                                server 3.centos.pool.ntp.org iburst
                                
                                #broadcast 192.168.1.255 autokey	# broadcast server
                                #broadcastclient			# broadcast client
                                #broadcast 224.0.1.1 autokey		# multicast server
                                #multicastclient 224.0.1.1		# multicast client
                                #manycastserver 239.255.254.254		# manycast server
                                #manycastclient 239.255.254.254 autokey # manycast client
                                
                                # Enable public key cryptography.
                                #crypto
                                
                                includefile /etc/ntp/crypto/pw
                                
                                # Key file containing the keys and key identifiers used when operating
                                # with symmetric key cryptography. 
                                keys /etc/ntp/keys
                                
                                # Specify the key identifiers which are trusted.
                                #trustedkey 4 8 42
                                
                                # Specify the key identifier to use with the ntpdc utility.
                                #requestkey 8
                                
                                # Specify the key identifier to use with the ntpq utility.
                                #controlkey 8
                                
                                # Enable writing of statistics records.
                                #statistics clockstats cryptostats loopstats peerstats
                                
                                # Disable the monitoring facility to prevent amplification attacks using ntpdc
                                # monlist command when default restrict does not include the noquery flag. See
                                # CVE-2013-5211 for more details.
                                # Note: Monitoring will not be disabled with the limited restriction flag.
                                disable monitor
                            before_header:
                                /etc/ntp.conf
                  common : Install ntp:
                      ----------
                      uyuni-stable-ansible-test.tf.local:
                          ----------
                          installed:
                              - ntp
                  common : Start the ntp service:
                      ----------
                      uyuni-stable-ansible-test.tf.local:
                          ----------
                  common : restart ntp:
                      ----------
                      uyuni-stable-ansible-test.tf.local:
                          ----------

Summary for local
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
Total states run:     1
Total run time:  16.707 s
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **no tests yet - the whole ansible feature will be tested by cucumber**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/14515

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"