### PR TITLE
[Ansible] Fix test due a change on master top definitions

### DIFF
--- a/susemanager-utils/susemanager-sls/src/tests/test_mgr_master_tops.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_mgr_master_tops.py
@@ -23,7 +23,8 @@ TEST_MANAGER_STATIC_TOP = {
         "formulas",
         "services.salt-minion",
         "services.docker",
-        "services.kiwi-image-server"
+        "services.kiwi-image-server",
+        "ansible"
     ]
 }
 


### PR DESCRIPTION
## What does this PR change?

This PR fixes test failure introduced in `ansible-integration` branch that is preventing the `susemanager-sls` package to build.
 
## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
