### PR TITLE
WIP: Add release option to the wait-for-build script

### DIFF
--- a/susemanager-utils/testing/automation/wait-for-builds.sh
+++ b/susemanager-utils/testing/automation/wait-for-builds.sh
@@ -1,14 +1,16 @@
 #!/bin/bash
 
 usage() {
-  echo "Usage: $0 -a api -c config_file -p project -u"
+  echo "Usage: $0 -a api -c config_file -p project -u -r"
   echo "project is mandatory. The rest are optionals."
   echo "u option is for unlocking the package after the build has finished"
+  echo "r option is for releasing the package after"
 }
 
 api=https://api.opensuse.org
 config_file=$HOME/.oscrc
 lock="yes"
+release="no"
 
 while getopts ":a:c:p:u" o;do
     case "${o}" in
@@ -23,6 +25,9 @@ while getopts ":a:c:p:u" o;do
             ;;
         u)
             lock="no"
+            ;;
+        r)
+            release="yes"
             ;;    
         :)
             echo "ERROR: Option -$OPTARG requires an argument"
@@ -51,3 +56,8 @@ for i in $(osc -A $api -c $config_file ls $project);do
       osc -A $api -c $config_file lock $project $i
     fi  
 done
+
+if [ "$release" == "yes" ];then
+    echo "Releasing"
+    osc -A $api -c $config_file release $project
+fi


### PR DESCRIPTION
## What does this PR change?

This is for the CI, no changes in the product.

Locking is giving us trouble, let's add the option to run release
instead.

## GUI diff

No difference.


- [X] **DONE**

## Documentation
- No documentation needed

- [X] **DONE**

## Test coverage
- No tests

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/14626

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
