### PR TITLE
lock project instead of packages

### DIFF
--- a/susemanager-utils/testing/automation/wait-for-builds.sh
+++ b/susemanager-utils/testing/automation/wait-for-builds.sh
@@ -45,9 +45,7 @@ fi
 echo "Waiting for $project to build"
 osc -A $api -c $config_file results $project -w --xml
 
-for i in $(osc -A $api -c $config_file ls $project);do
-    if [ $lock == "yes" ];then
-      echo "Locking $project/$i so there are not further rebuilds"
-      osc -A $api -c $config_file lock $project $i
-    fi  
-done
+if [ $lock == "yes" ];then
+  echo "Locking $project so there are not further rebuilds"
+  osc -A $api -c $config_file lock $project
+fi  


### PR DESCRIPTION
## What does this PR change?

locking package by package is creating corrupted metadata
this is CI, no product related.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed
- [X] **DONE**

## Test coverage
- No tests

- [X] **DONE**

## Links

Fixes #https://github.com/SUSE/spacewalk/issues/14626

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
