### PR TITLE
QA: Enforce the cleanup of salt-minion dependencies before bootstrap

### DIFF
--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -683,13 +683,13 @@ end
 When(/^I perform a full salt minion cleanup on "([^"]*)"$/) do |host|
   node = get_target(host)
   if host.include? 'ceos'
-    node.run('yum -y remove salt salt-minion', false)
+    node.run('yum -y remove --setopt=clean_requirements_on_remove=1 salt salt-minion', false)
   elsif host.include? 'ubuntu'
-    node.run('apt-get --assume-yes remove salt-common salt-minion', false)
+    node.run('apt-get --assume-yes remove salt-common salt-minion && apt-get purge salt-common salt-minion && apt-get autoremove', false)
   else
-    node.run('zypper --non-interactive remove -y salt salt-minion', false)
+    node.run('zypper --non-interactive remove --clean-deps -y salt salt-minion', false)
   end
-  node.run('rm -Rf /var/cache/salt/minion /var/run/salt /var/log/salt /etc/salt /var/tmp/.root*', false)
+  node.run('rm -Rf /root/salt /var/cache/salt/minion /var/run/salt /var/log/salt /etc/salt /var/tmp/.root*', false)
   step %(I disable the repositories "tools_update_repo tools_pool_repo" on this "#{host}" without error control)
 end
 


### PR DESCRIPTION
## What does this PR change?

It performs some extra clean-up when we prepare the VM before bootstrap a salt minion

Related to https://github.com/SUSE/spacewalk/issues/13336

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.0
- Manager-4.1

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
