### PR TITLE
[WIP] Ansible introspect inventories and playbooks

### DIFF
--- a/java/code/src/com/redhat/rhn/common/hibernate/AnnotationRegistry.java
+++ b/java/code/src/com/redhat/rhn/common/hibernate/AnnotationRegistry.java
@@ -63,6 +63,9 @@ import com.redhat.rhn.domain.scc.SCCRepositoryBasicAuth;
 import com.redhat.rhn.domain.scc.SCCRepositoryNoAuth;
 import com.redhat.rhn.domain.scc.SCCRepositoryTokenAuth;
 import com.redhat.rhn.domain.scc.SCCSubscription;
+import com.redhat.rhn.domain.server.ansible.AnsiblePath;
+import com.redhat.rhn.domain.server.ansible.InventoryPath;
+import com.redhat.rhn.domain.server.ansible.PlaybookPath;
 import com.redhat.rhn.domain.server.virtualhostmanager.VirtualHostManagerNodeInfo;
 import com.suse.manager.model.clusters.Cluster;
 
@@ -141,6 +144,9 @@ public class AnnotationRegistry {
         ANNOTATION_CLASSES.add(Cluster.class);
         ANNOTATION_CLASSES.add(MaintenanceSchedule.class);
         ANNOTATION_CLASSES.add(MaintenanceCalendar.class);
+        ANNOTATION_CLASSES.add(AnsiblePath.class);
+        ANNOTATION_CLASSES.add(InventoryPath.class);
+        ANNOTATION_CLASSES.add(PlaybookPath.class);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/common/hibernate/PathConverter.java
+++ b/java/code/src/com/redhat/rhn/common/hibernate/PathConverter.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.common.hibernate;
+
+import java.nio.file.Path;
+
+import javax.persistence.AttributeConverter;
+
+/**
+ * JPA converter between Path and String
+ */
+public class PathConverter implements AttributeConverter<Path, String> {
+
+    @Override
+    public String convertToDatabaseColumn(Path path) {
+        return path.toString();
+    }
+
+    @Override
+    public Path convertToEntityAttribute(String s) {
+        return Path.of(s);
+    }
+}

--- a/java/code/src/com/redhat/rhn/common/security/acl/Access.java
+++ b/java/code/src/com/redhat/rhn/common/security/acl/Access.java
@@ -250,6 +250,27 @@ public class Access extends BaseHandler {
     }
 
     /**
+     * Check if any system has an Ansible Control Node entitlement.
+     * @param ctx Context map to pass in.
+     * @param params Parameters to use to fetch from context.
+     * @return True if system has salt entitlement, false otherwise.
+     */
+    public boolean aclSystemHasAnsibleControlNodeEntitlement(Object ctx, String[] params) {
+        @SuppressWarnings("unchecked")
+        Map<String, Object> map = (Map<String, Object>) ctx;
+        Long sid = getAsLong(map.get("sid"));
+        boolean ret = false;
+        if (sid != null) {
+            User user = (User) map.get("user");
+            Server server = SystemManager.lookupByIdAndUser(sid, user);
+            if (server != null) {
+                ret = server.hasEntitlement(EntitlementManager.ANSIBLE_CONTROL_NODE);
+            }
+        }
+        return ret;
+    }
+
+    /**
      * Check if any system has a Foreign entitlement.
      * @param ctx Context map to pass in.
      * @param params Parameters to use to fetch from context.

--- a/java/code/src/com/redhat/rhn/domain/server/MinionServerFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/server/MinionServerFactory.java
@@ -30,6 +30,7 @@ import org.hibernate.criterion.Projections;
 import org.hibernate.criterion.Restrictions;
 
 import java.math.BigDecimal;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -300,6 +301,22 @@ public class MinionServerFactory extends HibernateFactory {
         return HibernateFactory.getSession()
                 .createQuery("SELECT p FROM AnsiblePath p WHERE id = :id")
                 .setParameter("id", id)
+                .uniqueResultOptional();
+    }
+
+    /**
+     * Lookup {@link AnsiblePath} by path and minion id
+     *
+     * @param path the path
+     * @param minionServerId the minion id
+     * @return optional of {@link AnsiblePath}
+     */
+    public static Optional<AnsiblePath> lookupAnsiblePathByPathAndMinion(Path path, long minionServerId) {
+        return HibernateFactory.getSession().createQuery("SELECT p FROM AnsiblePath p " +
+                "WHERE p.path = :path " +
+                "AND p.minionServer.id = :minionServerId")
+                .setParameter("path", path)
+                .setParameter("minionServerId", minionServerId)
                 .uniqueResultOptional();
     }
 

--- a/java/code/src/com/redhat/rhn/domain/server/MinionServerFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/server/MinionServerFactory.java
@@ -19,9 +19,10 @@ import static java.util.stream.Collectors.toList;
 
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.action.server.ServerAction;
+import com.redhat.rhn.domain.server.ansible.AnsiblePath;
 import com.redhat.rhn.domain.user.User;
-
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
+
 import org.apache.log4j.Logger;
 import org.hibernate.Criteria;
 import org.hibernate.Session;
@@ -33,6 +34,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
+
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Join;
@@ -286,5 +288,52 @@ public class MinionServerFactory extends HibernateFactory {
         List<Object[]> results = findByIds(serverIds, "Server.findSimpleMinionsByServerIds", "serverIds");
         return results.stream().map(row -> new MinionIds(((BigDecimal) row[0]).longValue(), row[1].toString()))
                 .collect(toList());
+    }
+
+    /**
+     * Lookup an {@link AnsiblePath} by id
+     *
+     * @param id the id
+     * @return the {@link AnsiblePath}
+     */
+    public static Optional<AnsiblePath> lookupAnsiblePathById(long id) {
+        return HibernateFactory.getSession()
+                .createQuery("SELECT p FROM AnsiblePath p WHERE id = :id")
+                .setParameter("id", id)
+                .uniqueResultOptional();
+    }
+
+    /**
+     * List {@link AnsiblePath}s associated with a {@link MinionServer} with given id
+     *
+     * @param minionId the id of {@link MinionServer}
+     * @return the list of {@link AnsiblePath}s
+     */
+    public static List<AnsiblePath> listAnsiblePaths(long minionId) {
+        return HibernateFactory.getSession()
+                .createQuery("SELECT p FROM AnsiblePath p " +
+                        "WHERE p.minionServer.id = :mid ")
+                .setParameter("mid", minionId)
+                .list();
+    }
+
+    /**
+     * Save an {@link AnsiblePath}
+     *
+     * @param path the {@link AnsiblePath}
+     * @return the updated {@link AnsiblePath}
+     */
+    public static AnsiblePath saveAnsiblePath(AnsiblePath path) {
+        HibernateFactory.getSession().saveOrUpdate(path);
+        return path;
+    }
+
+    /**
+     * Remove an {@link AnsiblePath}
+     *
+     * @param path the {@link AnsiblePath}
+     */
+    public static void removeAnsiblePath(AnsiblePath path) {
+        HibernateFactory.getSession().delete(path);
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/server/MinionServerFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/server/MinionServerFactory.java
@@ -20,6 +20,8 @@ import static java.util.stream.Collectors.toList;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.action.server.ServerAction;
 import com.redhat.rhn.domain.server.ansible.AnsiblePath;
+import com.redhat.rhn.domain.server.ansible.InventoryPath;
+import com.redhat.rhn.domain.server.ansible.PlaybookPath;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
 
@@ -331,6 +333,34 @@ public class MinionServerFactory extends HibernateFactory {
                 .createQuery("SELECT p FROM AnsiblePath p " +
                         "WHERE p.minionServer.id = :sid ")
                 .setParameter("sid", minionServerId)
+                .list();
+    }
+
+    /**
+     * List {@link PlaybookPath}s associated with a {@link MinionServer} with given id
+     *
+     * @param minionId the id of {@link MinionServer}
+     * @return the list of {@link PlaybookPath}s
+     */
+    public static List<PlaybookPath> listAnsiblePlaybookPaths(long minionId) {
+        return HibernateFactory.getSession()
+                .createQuery("SELECT p FROM PlaybookPath p " +
+                        "WHERE p.minionServer.id = :mid ")
+                .setParameter("mid", minionId)
+                .list();
+    }
+
+    /**
+     * List {@link InventoryPath}s associated with a {@link MinionServer} with given id
+     *
+     * @param minionId the id of {@link MinionServer}
+     * @return the list of {@link PlaybookPath}s
+     */
+    public static List<InventoryPath> listAnsibleInventoryPaths(long minionId) {
+        return HibernateFactory.getSession()
+                .createQuery("SELECT p FROM InventoryPath p " +
+                        "WHERE p.minionServer.id = :mid ")
+                .setParameter("mid", minionId)
                 .list();
     }
 

--- a/java/code/src/com/redhat/rhn/domain/server/MinionServerFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/server/MinionServerFactory.java
@@ -323,14 +323,14 @@ public class MinionServerFactory extends HibernateFactory {
     /**
      * List {@link AnsiblePath}s associated with a {@link MinionServer} with given id
      *
-     * @param minionId the id of {@link MinionServer}
+     * @param minionServerId the id of {@link MinionServer}
      * @return the list of {@link AnsiblePath}s
      */
-    public static List<AnsiblePath> listAnsiblePaths(long minionId) {
+    public static List<AnsiblePath> listAnsiblePaths(long minionServerId) {
         return HibernateFactory.getSession()
                 .createQuery("SELECT p FROM AnsiblePath p " +
-                        "WHERE p.minionServer.id = :mid ")
-                .setParameter("mid", minionId)
+                        "WHERE p.minionServer.id = :sid ")
+                .setParameter("sid", minionServerId)
                 .list();
     }
 

--- a/java/code/src/com/redhat/rhn/domain/server/ansible/AnsiblePath.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ansible/AnsiblePath.java
@@ -16,6 +16,7 @@
 package com.redhat.rhn.domain.server.ansible;
 
 import com.redhat.rhn.common.hibernate.PathConverter;
+import com.redhat.rhn.domain.BaseDomainHelper;
 import com.redhat.rhn.domain.server.MinionServer;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -46,7 +47,7 @@ import javax.persistence.Transient;
 @Table(name = "suseAnsiblePAth")
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @DiscriminatorColumn(name = "type")
-public abstract class AnsiblePath {
+public abstract class AnsiblePath extends BaseDomainHelper {
 
     private Long id;
     private MinionServer minionServer;

--- a/java/code/src/com/redhat/rhn/domain/server/ansible/AnsiblePath.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ansible/AnsiblePath.java
@@ -1,0 +1,205 @@
+/**
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.domain.server.ansible;
+
+import com.redhat.rhn.common.hibernate.PathConverter;
+import com.redhat.rhn.domain.server.MinionServer;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+import java.nio.file.Path;
+
+import javax.persistence.Column;
+import javax.persistence.Convert;
+import javax.persistence.DiscriminatorColumn;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.SequenceGenerator;
+import javax.persistence.Table;
+import javax.persistence.Transient;
+
+/**
+ * Represents path to an Ansible entity (inventory, playbook).
+ */
+@Entity
+@Table(name = "suseAnsiblePAth")
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "type")
+public abstract class AnsiblePath {
+
+    private Long id;
+    private MinionServer minionServer;
+    private Path path;
+
+    public enum Type {
+        INVENTORY("inventory"),
+        PLAYBOOK("playbook");
+
+        private final String dbLabel;
+
+        Type(String dbLabelIn) {
+            this.dbLabel = dbLabelIn;
+        }
+
+        /**
+         * Gets the dbLabel.
+         *
+         * @return dbLabel
+         */
+        public String getLabel() {
+            return dbLabel;
+        }
+
+        /**
+         * Convert from label
+         * @param lbl the lable
+         * @return the Type
+         */
+        public static Type fromLabel(String lbl) {
+            for (Type value : values()) {
+                if (value.dbLabel.equals(lbl)) {
+                    return value;
+                }
+            }
+            throw new IllegalArgumentException("Unsupported label: " + lbl);
+        }
+    }
+
+    /**
+     * Standard constructor
+     */
+    public AnsiblePath() { }
+
+    /**
+     * Standard constructor
+     * @param minionServerIn the minion server
+     */
+    public AnsiblePath(MinionServer minionServerIn) {
+        this.minionServer = minionServerIn;
+    }
+
+    /**
+     * Gets the type of the Path.
+     * @return the Path type
+     */
+    @Transient
+    public abstract Type getEntityType();
+
+    /**
+     * Gets the id.
+     *
+     * @return id
+     */
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "ansible_path_seq")
+    @SequenceGenerator(name = "ansible_path_seq", sequenceName = "suse_ansible_path_seq", allocationSize = 1)
+    public Long getId() {
+        return id;
+    }
+
+    /**
+     * Sets the id.
+     *
+     * @param idIn the id
+     */
+    public void setId(Long idIn) {
+        id = idIn;
+    }
+
+    /**
+     * Gets the minionServer.
+     *
+     * @return minionServer
+     */
+    @ManyToOne
+    @JoinColumn(name = "server_id")
+    public MinionServer getMinionServer() {
+        return minionServer;
+    }
+
+    /**
+     * Sets the minionServer.
+     *
+     * @param minionServerIn the minionServer
+     */
+    public void setMinionServer(MinionServer minionServerIn) {
+        minionServer = minionServerIn;
+    }
+
+    /**
+     * Gets the path.
+     *
+     * @return path
+     */
+    @Column
+    @Convert(converter = PathConverter.class)
+    public Path getPath() {
+        return path;
+    }
+
+    /**
+     * Sets the path.
+     *
+     * @param pathIn the path
+     */
+    public void setPath(Path pathIn) {
+        path = pathIn;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .append("id", id)
+                .append("type", getEntityType())
+                .append("minionServer", minionServer)
+                .append("path", path)
+                .toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        AnsiblePath that = (AnsiblePath) o;
+
+        return new EqualsBuilder()
+                .append(getEntityType(), that.getEntityType())
+                .append(minionServer, that.minionServer)
+                .append(path, that.path).isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 37)
+                .append(minionServer)
+                .append(path)
+                .toHashCode();
+    }
+}

--- a/java/code/src/com/redhat/rhn/domain/server/ansible/AnsiblePath.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ansible/AnsiblePath.java
@@ -44,7 +44,7 @@ import javax.persistence.Transient;
  * Represents path to an Ansible entity (inventory, playbook).
  */
 @Entity
-@Table(name = "suseAnsiblePAth")
+@Table(name = "suseAnsiblePath")
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @DiscriminatorColumn(name = "type")
 public abstract class AnsiblePath extends BaseDomainHelper {

--- a/java/code/src/com/redhat/rhn/domain/server/ansible/InventoryPath.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ansible/InventoryPath.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.domain.server.ansible;
+
+import com.redhat.rhn.domain.server.MinionServer;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.Transient;
+
+/**
+ * Ansible Inventory Path
+ */
+@Entity
+@DiscriminatorValue("inventory")
+public class InventoryPath extends AnsiblePath {
+
+    /**
+     * Standard constructor
+     */
+    public InventoryPath() { }
+
+    /**
+     * Standard constructor
+     * @param minionServer the minion server
+     */
+    public InventoryPath(MinionServer minionServer) {
+        super(minionServer);
+    }
+
+    @Override
+    @Transient
+    public Type getEntityType() {
+        return Type.INVENTORY;
+    }
+}

--- a/java/code/src/com/redhat/rhn/domain/server/ansible/PlaybookPath.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ansible/PlaybookPath.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.domain.server.ansible;
+
+import com.redhat.rhn.domain.server.MinionServer;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.Transient;
+
+/**
+ * Ansible Playbook path
+ */
+@Entity
+@DiscriminatorValue("playbook")
+public class PlaybookPath extends AnsiblePath {
+
+    /**
+     * Standard constructor
+     */
+    public PlaybookPath() { }
+
+    /**
+     * Standard constructor
+     * @param minionServer the minion server
+     */
+    public PlaybookPath(MinionServer minionServer) {
+        super(minionServer);
+    }
+
+    @Override
+    @Transient
+    public Type getEntityType() {
+        return Type.PLAYBOOK;
+    }
+}

--- a/java/code/src/com/redhat/rhn/domain/server/test/MinionServerFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/MinionServerFactoryTest.java
@@ -117,6 +117,7 @@ public class MinionServerFactoryTest extends BaseTestCaseWithUser {
         HibernateFactory.getSession().evict(playbookPath);
 
         assertEquals(inventoryPath, MinionServerFactory.lookupAnsiblePathById(inventoryPath.getId()).get());
+        assertEquals(inventoryPath, MinionServerFactory.lookupAnsiblePathByPathAndMinion(Path.of("/tmp/test1"), minionServer1.getId()).get());
         assertEquals(playbookPath, MinionServerFactory.lookupAnsiblePathById(playbookPath.getId()).get());
         assertEquals(1, MinionServerFactory.listAnsiblePaths(minionServer1.getId()).size());
         assertEquals(inventoryPath, MinionServerFactory.listAnsiblePaths(minionServer1.getId()).iterator().next());

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -9017,13 +9017,19 @@ Alternatively, you will want to download &lt;strong&gt;Incremental Channel Conte
         </context-group>
       </trans-unit>
       <trans-unit id="ansible.invalid_path" xml:space="preserve">
-        <source>Invalid path.</source>
+        <source>Invalid path</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/manager/systems/details/ansible</context>
         </context-group>
       </trans-unit>
       <trans-unit id="ansible.duplicate_path" xml:space="preserve">
-        <source>Path already exists.</source>
+        <source>Path already exists</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/manager/systems/details/ansible</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ansible.invalid_path_type" xml:space="preserve">
+        <source>Invalid path type</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/manager/systems/details/ansible</context>
         </context-group>

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -9017,7 +9017,7 @@ Alternatively, you will want to download &lt;strong&gt;Incremental Channel Conte
         </context-group>
       </trans-unit>
       <trans-unit id="ansible.invalid_path" xml:space="preserve">
-        <source>Invalid path</source>
+        <source>Invalid path (must be a valid absolute path)</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/manager/systems/details/ansible</context>
         </context-group>

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -9016,6 +9016,18 @@ Alternatively, you will want to download &lt;strong&gt;Incremental Channel Conte
           <context context-type="sourcefile">/rhn/systems/details/Overview.do</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="ansible.invalid_path" xml:space="preserve">
+        <source>Invalid path.</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/manager/systems/details/ansible</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="ansible.duplicate_path" xml:space="preserve">
+        <source>Path already exists.</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/manager/systems/details/ansible</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="system.entitle.formula_error" xml:space="preserve">
         <source>There was a problem assigning the Prometheus Exporters formula.</source>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/strings/nav/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/nav/StringResource_en_US.xml
@@ -541,6 +541,12 @@
           <context context-type="sourcefile">Navigation Menu (system details)</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="Ansible" xml:space="preserve">
+        <source>Ansible</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">Navigation Menu (system details)</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="Misc" xml:space="preserve">
         <source>Misc</source>
         <context-group name="ctx">

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/MinionNotRespondingFaultException.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/MinionNotRespondingFaultException.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.frontend.xmlrpc;
+
+import com.redhat.rhn.FaultException;
+import com.redhat.rhn.domain.server.MinionServer;
+
+/**
+ * XMLRPC Fault thrown when minion does not respond
+ */
+public class MinionNotRespondingFaultException extends FaultException {
+
+    private static final int CODE = 1071;
+    private static final String LABEL = "minionNotResponding";
+
+    /**
+     * Constructor
+     */
+    public MinionNotRespondingFaultException() {
+        super(CODE, LABEL, "Minion not responding");
+    }
+
+    /**
+     * Constructor
+     * @param minion the affected minion
+     */
+    public MinionNotRespondingFaultException(MinionServer minion) {
+        super(CODE, LABEL,
+                String.format("Minion id '%d', minionId '%s' not responding", minion.getId(), minion.getMinionId()));
+    }
+}

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/ansible/AnsibleHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/ansible/AnsibleHandler.java
@@ -14,18 +14,27 @@
  */
 package com.redhat.rhn.frontend.xmlrpc.ansible;
 
+import com.redhat.rhn.common.hibernate.LookupException;
+import com.redhat.rhn.common.validator.ValidatorException;
 import com.redhat.rhn.domain.org.Org;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.ServerFactory;
+import com.redhat.rhn.domain.server.ansible.AnsiblePath;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.xmlrpc.BaseHandler;
+import com.redhat.rhn.frontend.xmlrpc.EntityNotExistsFaultException;
 import com.redhat.rhn.frontend.xmlrpc.InvalidParameterException;
 import com.redhat.rhn.frontend.xmlrpc.NoSuchSystemException;
 import com.redhat.rhn.frontend.xmlrpc.TaskomaticApiException;
+import com.redhat.rhn.frontend.xmlrpc.ValidationException;
 import com.redhat.rhn.manager.action.ActionChainManager;
+import com.redhat.rhn.manager.system.SystemManager;
+
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.Date;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Ansible XMLRPC handler
@@ -69,7 +78,145 @@ public class AnsibleHandler extends BaseHandler {
         }
     }
 
+    /**
+     * List ansible paths for server (control node)
+     *
+     * @param loggedInUser the logged in user
+     * @param controlNodeId the id of the server
+     * @return List ansible paths
+     *
+     *
+     * @xmlrpc.doc List ansible paths for server (control node)
+     * @xmlrpc.param #session_key()
+     * @xmlrpc.param #param_desc("int", "controlNodeId", "id of ansible control node server")
+     * @xmlrpc.returntype
+     * #array_begin()
+     * $AnsiblePathSerializer
+     * #array_end()
+     */
+    public List<AnsiblePath> listAnsiblePaths(User loggedInUser, Integer controlNodeId) {
+        try {
+            return SystemManager.listAnsiblePaths(controlNodeId, loggedInUser);
+        }
+        catch (LookupException e) {
+            throw new NoSuchSystemException(e);
+        }
+    }
+
+    /**
+     * Lookup ansible path by path id
+     *
+     * @param loggedInUser the logged in user
+     * @param pathId the path id
+     * @return matching path
+     *
+     * @xmlrpc.doc Lookup ansible path by path id
+     * @xmlrpc.param #session_key()
+     * @xmlrpc.param #param_desc("int", "pathId", "path id")
+     * @xmlrpc.returntype
+     * $AnsiblePathSerializer
+     */
+    public AnsiblePath lookupAnsiblePathById(User loggedInUser, Integer pathId) {
+        try {
+            return SystemManager.lookupAnsiblePathById(pathId, loggedInUser)
+                    .orElseThrow(() -> new EntityNotExistsFaultException(pathId));
+        }
+        catch (LookupException e) {
+            throw new EntityNotExistsFaultException(pathId);
+        }
+    }
+
+    /**
+     * Create ansible path
+     *
+     * @param loggedInUser the logged in user
+     * @param props the props with the path properties
+     * @return created path
+     *
+     * @xmlrpc.doc Create ansible path
+     * @xmlrpc.param #session_key()
+     * @xmlrpc.param #param_desc("int", "pathId", "path id")
+     * @xmlrpc.param
+     *  #struct_begin("props")
+     *      #prop_desc("string", "type", "The ansible path type: 'inventory' or 'playbook'")
+     *      #prop_desc("int", "server_id", "ID of control node server")
+     *      #prop_desc("string", "path", "The local path to inventory/playbook")
+     *  #struct_end()
+     * @xmlrpc.returntype
+     * $AnsiblePathSerializer
+     */
+    public AnsiblePath createAnsiblePath(User loggedInUser, Map<String, Object> props) {
+        String typeLabel = getFieldValue(props, "type");
+        Integer controlNodeId = getFieldValue(props, "server_id");
+        String path = getFieldValue(props, "path");
+
+        try {
+            return SystemManager.createAnsiblePath(typeLabel, controlNodeId, path, loggedInUser);
+        }
+        catch (LookupException e) {
+            throw new EntityNotExistsFaultException(controlNodeId);
+        }
+        catch (ValidatorException e) {
+            throw new ValidationException(e);
+        }
+    }
+
+    /**
+     * Update ansible path
+     *
+     * @param loggedInUser the logged in user
+     * @param props the props with the path properties
+     * @return updated path
+     *
+     * @xmlrpc.doc Create ansible path
+     * @xmlrpc.param #session_key()
+     * @xmlrpc.param #param_desc("int", "pathId", "path id")
+     * @xmlrpc.param
+     *  #struct_begin("props")
+     *      #prop_desc("string", "path", "The local path to inventory/playbook")
+     *  #struct_end()
+     * @xmlrpc.returntype
+     * $AnsiblePathSerializer
+     */
+    public AnsiblePath updateAnsiblePath(User loggedInUser, Integer pathId, Map<String, Object> props) {
+        try {
+            String newPath = getFieldValue(props,"path");
+            return SystemManager.updateAnsiblePath(pathId, newPath, loggedInUser);
+        }
+        catch (LookupException e) {
+            throw new EntityNotExistsFaultException(pathId);
+        }
+        catch (ValidatorException e) {
+            throw new ValidationException(e);
+        }
+    }
+
+    /**
+     * Update ansible path
+     *
+     * @param loggedInUser the logged in user
+     * @param pathId the path id
+     * @return 1 on success
+     * @throws EntityNotExistsFaultException when path not found or not accessible
+     *
+     * @xmlrpc.doc Create ansible path
+     * @xmlrpc.param #session_key()
+     * @xmlrpc.param #param_desc("int", "pathId", "path id")
+     * @xmlrpc.returntype #return_int_success()
+     *
+     */
+    public int removeAnsiblePath(User loggedInUser, Integer pathId) {
+        try {
+            SystemManager.removeAnsiblePath(pathId, loggedInUser);
+            return 1;
+        }
+        catch (LookupException e) {
+            throw new EntityNotExistsFaultException(pathId);
+        }
+    }
+
     private Server validateAnsibleControlNode(long systemId, Org org) {
+        // todo fkobzik: ask cbb about perms checking
         Server controlNode = ServerFactory.lookupByIdAndOrg(systemId, org);
         if (controlNode == null) {
             throw new NoSuchSystemException();
@@ -78,5 +225,18 @@ public class AnsibleHandler extends BaseHandler {
             throw new NoSuchSystemException(controlNode.getHostname() + " is not an Ansible control node");
         }
         return controlNode;
+    }
+
+    private static <T> T getFieldValue(Map<String, Object> props, String field) {
+        Object val = props.get(field);
+        if (val == null) {
+            throw new InvalidParameterException(String.format("Missing field '%s'", field));
+        }
+        try {
+            return (T) val;
+        }
+        catch (ClassCastException e) {
+            throw new InvalidParameterException(String.format("Invalid type of field '%s'", field));
+        }
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/ansible/AnsibleHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/ansible/AnsibleHandler.java
@@ -229,13 +229,13 @@ public class AnsibleHandler extends BaseHandler {
     private static <T> T getFieldValue(Map<String, Object> props, String field) {
         Object val = props.get(field);
         if (val == null) {
-            throw new InvalidParameterException(String.format("Missing field '%s'", field));
+            throw new ValidationException(String.format("Missing field '%s'", field));
         }
         try {
             return (T) val;
         }
         catch (ClassCastException e) {
-            throw new InvalidParameterException(String.format("Invalid type of field '%s'", field));
+            throw new ValidationException(String.format("Invalid type of field '%s'", field));
         }
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/ansible/AnsibleHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/ansible/AnsibleHandler.java
@@ -165,6 +165,7 @@ public class AnsibleHandler extends BaseHandler {
      * Update ansible path
      *
      * @param loggedInUser the logged in user
+     * @param pathId the path id
      * @param props the props with the path properties
      * @return updated path
      *
@@ -180,7 +181,7 @@ public class AnsibleHandler extends BaseHandler {
      */
     public AnsiblePath updateAnsiblePath(User loggedInUser, Integer pathId, Map<String, Object> props) {
         try {
-            String newPath = getFieldValue(props,"path");
+            String newPath = getFieldValue(props, "path");
             return SystemManager.updateAnsiblePath(pathId, newPath, loggedInUser);
         }
         catch (LookupException e) {

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/ansible/AnsibleHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/ansible/AnsibleHandler.java
@@ -240,6 +240,24 @@ public class AnsibleHandler extends BaseHandler {
                 .orElseThrow(() -> new MinionNotRespondingFaultException());
     }
 
+    /**
+     * Introspect inventory under given inventory path with given pathId
+     *
+     * @param loggedInUser the logged in user
+     * @param pathId the path id
+     * @return the inventory contents under given path
+     *
+     * @xmlrpc.doc Introspect inventory under given inventory path with given pathId
+     * @xmlrpc.param #session_key()
+     * @xmlrpc.param #param_desc("int", "pathId", "path id")
+     * @xmlrpc.returntype todo update
+     */
+    // todo: more fitting structure?
+    public Map<String, Map<String, Object>> introspectInventory(User loggedInUser, Integer pathId) {
+        return SystemManager.introspectInventory(pathId, loggedInUser)
+                .orElseThrow(() -> new MinionNotRespondingFaultException());
+    }
+
     private Server validateAnsibleControlNode(long systemId, Org org) {
         Server controlNode = ServerFactory.lookupByIdAndOrg(systemId, org);
         if (controlNode == null) {

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/ansible/AnsibleHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/ansible/AnsibleHandler.java
@@ -24,10 +24,12 @@ import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.xmlrpc.BaseHandler;
 import com.redhat.rhn.frontend.xmlrpc.EntityNotExistsFaultException;
 import com.redhat.rhn.frontend.xmlrpc.InvalidParameterException;
+import com.redhat.rhn.frontend.xmlrpc.MinionNotRespondingFaultException;
 import com.redhat.rhn.frontend.xmlrpc.NoSuchSystemException;
 import com.redhat.rhn.frontend.xmlrpc.TaskomaticApiException;
 import com.redhat.rhn.frontend.xmlrpc.ValidationException;
 import com.redhat.rhn.manager.action.ActionChainManager;
+import com.redhat.rhn.manager.system.AnsiblePlaybookResponse;
 import com.redhat.rhn.manager.system.SystemManager;
 
 import org.apache.commons.lang3.StringUtils;
@@ -214,6 +216,28 @@ public class AnsibleHandler extends BaseHandler {
         catch (LookupException e) {
             throw new EntityNotExistsFaultException(pathId);
         }
+    }
+
+    /**
+     * Discover playbooks under given playbook path with given pathId
+     *
+     * @param loggedInUser the logged in user
+     * @param pathId the path id
+     * @return the playbooks under given path
+     *
+     * @xmlrpc.doc Discover playbooks under given playbook path with given pathId
+     * @xmlrpc.param #session_key()
+     * @xmlrpc.param #param_desc("int", "pathId", "path id")
+     * @xmlrpc.returntype
+     * #struct_begin("playbooks")
+     *     #struct_begin("playbook")
+     *         $AnsiblePathSerializer
+     *     #struct_end()
+     * #struct_end()
+     */
+    public Map<String, Map<String, AnsiblePlaybookResponse>> discoverPlaybooks(User loggedInUser, Integer pathId) {
+        return SystemManager.discoverPlaybooks(pathId, loggedInUser)
+                .orElseThrow(() -> new MinionNotRespondingFaultException());
     }
 
     private Server validateAnsibleControlNode(long systemId, Org org) {

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/ansible/AnsibleHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/ansible/AnsibleHandler.java
@@ -216,7 +216,6 @@ public class AnsibleHandler extends BaseHandler {
     }
 
     private Server validateAnsibleControlNode(long systemId, Org org) {
-        // todo fkobzik: ask cbb about perms checking
         Server controlNode = ServerFactory.lookupByIdAndOrg(systemId, org);
         if (controlNode == null) {
             throw new NoSuchSystemException();

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/AnsiblePathSerializer.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/AnsiblePathSerializer.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.frontend.xmlrpc.serializer;
+
+import com.redhat.rhn.domain.server.ansible.AnsiblePath;
+import com.redhat.rhn.frontend.xmlrpc.serializer.util.SerializerHelper;
+
+import java.io.IOException;
+import java.io.Writer;
+
+import redstone.xmlrpc.XmlRpcException;
+import redstone.xmlrpc.XmlRpcSerializer;
+
+/**
+ * XMLRPC Serializer for AnsiblePath
+ *
+ * @xmlrpc.doc
+ *   #struct_begin("ansible path")
+ *     #prop("int", "path id")
+ *     #prop("string", "type label")
+ *     #prop("int", "id of the ansible control node system")
+ *     #prop("string", "local path to inventory or playbook")
+ *   #struct_end()
+ */
+public class AnsiblePathSerializer extends RhnXmlRpcCustomSerializer {
+
+    @Override
+    public Class getSupportedClass() {
+        return AnsiblePath.class;
+    }
+
+    @Override
+    protected void doSerialize(Object obj, Writer output, XmlRpcSerializer serializer) throws XmlRpcException, IOException {
+        AnsiblePath path = (AnsiblePath) obj;
+        SerializerHelper helper = new SerializerHelper(serializer);
+
+        helper.add("id", path.getId());
+        helper.add("type", path.getEntityType().getLabel());
+        helper.add("server_id", path.getMinionServer().getId());
+        helper.add("path", path.getPath().toString());
+
+        helper.writeTo(output);
+    }
+}

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/AnsiblePathSerializer.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/AnsiblePathSerializer.java
@@ -43,7 +43,8 @@ public class AnsiblePathSerializer extends RhnXmlRpcCustomSerializer {
     }
 
     @Override
-    protected void doSerialize(Object obj, Writer output, XmlRpcSerializer serializer) throws XmlRpcException, IOException {
+    protected void doSerialize(Object obj, Writer output, XmlRpcSerializer serializer)
+            throws XmlRpcException, IOException {
         AnsiblePath path = (AnsiblePath) obj;
         SerializerHelper helper = new SerializerHelper(serializer);
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/AnsiblePlaybookSerializer.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/AnsiblePlaybookSerializer.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.frontend.xmlrpc.serializer;
+
+import com.redhat.rhn.frontend.xmlrpc.serializer.util.SerializerHelper;
+import com.redhat.rhn.manager.system.AnsiblePlaybookResponse;
+
+import java.io.IOException;
+import java.io.Writer;
+
+import redstone.xmlrpc.XmlRpcException;
+import redstone.xmlrpc.XmlRpcSerializer;
+
+/**
+ * XMLRPC Serializer for {@link AnsiblePlaybookResponse}
+ *
+ * @xmlrpc.doc
+ *   #struct_begin("ansible playbook")
+ *     #prop("string", "fullpath")
+ *     #prop("string", "custom_inventory")
+ *   #struct_end()
+ */
+public class AnsiblePlaybookSerializer extends RhnXmlRpcCustomSerializer {
+
+    @Override
+    public Class getSupportedClass() {
+        return AnsiblePlaybookResponse.class;
+    }
+
+    @Override
+    protected void doSerialize(Object obj, Writer output, XmlRpcSerializer serializer)
+            throws XmlRpcException, IOException {
+        AnsiblePlaybookResponse playbook = (AnsiblePlaybookResponse) obj;
+        SerializerHelper helper = new SerializerHelper(serializer);
+
+        helper.add("fullpath", playbook.getFullPath());
+        helper.add("custom_inventory", playbook.getCustomInventory());
+
+        helper.writeTo(output);
+    }
+}

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/SerializerRegistry.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/SerializerRegistry.java
@@ -152,6 +152,7 @@ public class SerializerRegistry {
         SERIALIZER_CLASSES.add(MaintenanceCalendarSerializer.class);
         SERIALIZER_CLASSES.add(RescheduleResultSerializer.class);
         SERIALIZER_CLASSES.add(AnsiblePathSerializer.class);
+        SERIALIZER_CLASSES.add(AnsiblePlaybookSerializer.class);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/SerializerRegistry.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/SerializerRegistry.java
@@ -151,6 +151,7 @@ public class SerializerRegistry {
         SERIALIZER_CLASSES.add(MaintenanceScheduleSerializer.class);
         SERIALIZER_CLASSES.add(MaintenanceCalendarSerializer.class);
         SERIALIZER_CLASSES.add(RescheduleResultSerializer.class);
+        SERIALIZER_CLASSES.add(AnsiblePathSerializer.class);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/system/AnsiblePlaybookResponse.java
+++ b/java/code/src/com/redhat/rhn/manager/system/AnsiblePlaybookResponse.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.manager.system;
+
+import com.google.gson.annotations.SerializedName;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+// todo find be a better place!
+public class AnsiblePlaybookResponse {
+
+    @SerializedName("fullpath")
+    private String fullPath;
+
+    @SerializedName("custom_inventory")
+    private String customInventory;
+
+    /**
+     * Gets the fullPath.
+     *
+     * @return fullPath
+     */
+    public String getFullPath() {
+        return fullPath;
+    }
+
+    /**
+     * Gets the customInventory.
+     *
+     * @return customInventory
+     */
+    public String getCustomInventory() {
+        return customInventory;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .append("fullPath", fullPath)
+                .append("customInventory", customInventory)
+                .toString();
+    }
+}

--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -3649,7 +3649,7 @@ public class SystemManager extends BaseManager {
      * @throws LookupException if the user does not have permissions to the minion
      */
     public static List<AnsiblePath> listAnsiblePaths(long minionServerId, User user) {
-        ensureAvailableToUser(user, minionServerId);
+        lookupAnsibleControlNode(minionServerId, user);
         return MinionServerFactory.listAnsiblePaths(minionServerId);
     }
 

--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -3643,14 +3643,14 @@ public class SystemManager extends BaseManager {
     /**
      * List ansible paths by minion
      *
-     * @param minionId the minion id
+     * @param minionServerId the minion id
      * @param user the user performing the action
      * @return the list of AnsiblePaths of minion
      * @throws LookupException if the user does not have permissions to the minion
      */
-    public static List<AnsiblePath> listAnsiblePaths(long minionId, User user) {
-        ensureAvailableToUser(user, minionId);
-        return MinionServerFactory.listAnsiblePaths(minionId);
+    public static List<AnsiblePath> listAnsiblePaths(long minionServerId, User user) {
+        ensureAvailableToUser(user, minionServerId);
+        return MinionServerFactory.listAnsiblePaths(minionServerId);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -3729,8 +3729,14 @@ public class SystemManager extends BaseManager {
             result.addFieldError("path", "ansible.invalid_path");
         }
 
+        Path actualPath = Path.of(path);
+
+        if (!actualPath.isAbsolute()) {
+            result.addFieldError("path", "ansible.invalid_path");
+        }
+
         Optional<AnsiblePath> duplicatePath = MinionServerFactory
-                .lookupAnsiblePathByPathAndMinion(Path.of(path), minionServerId);
+                .lookupAnsiblePathByPathAndMinion(actualPath, minionServerId);
         duplicatePath.ifPresent(dup -> { // an ansible path with same minion and path exists
             pathId.ifPresentOrElse(p -> { // if we're updating, the IDs must be same
                         if (!p.equals(dup.getId())) {

--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -3611,7 +3611,7 @@ public class SystemManager extends BaseManager {
             packageState.setName(pkgName);
             pkgStates.add(packageState);
         }
-        else if (pkgState == PackageStates.PURGED) { // using PERGED flag for unmanged here for now.
+        else if (pkgState == PackageStates.PURGED) { // using PURGED flag for unmanaged here for now.
             pkgStates.removeIf(ps -> ps.getName().equals(pkgName));
         }
 

--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -3715,7 +3715,7 @@ public class SystemManager extends BaseManager {
                 AnsiblePath.Type.fromLabel(lbl);
             }
             catch (IllegalArgumentException e) {
-                result.addFieldError("type", "ansible.invalid_type");
+                result.addFieldError("type", "ansible.invalid_path_type");
             }
         });
 

--- a/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
@@ -32,6 +32,7 @@ import com.redhat.rhn.common.db.datasource.WriteMode;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.common.hibernate.LookupException;
 import com.redhat.rhn.common.validator.ValidatorError;
+import com.redhat.rhn.common.validator.ValidatorException;
 import com.redhat.rhn.common.validator.ValidatorResult;
 import com.redhat.rhn.common.validator.ValidatorWarning;
 import com.redhat.rhn.domain.action.Action;
@@ -1853,10 +1854,26 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
         MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
 
         try {
-            AnsiblePath path = SystemManager.createAnsiblePath("inventory", minion.getId(), "/tmp/test", user);
+            SystemManager.createAnsiblePath("inventory", minion.getId(), "/tmp/test", user);
             fail("An exception should have been thrown.");
         }
         catch (LookupException e) {
+            // expected
+        }
+    }
+
+    /**
+     * Tests creating an {@link AnsiblePath} with a relative path. This is forbidden.
+     *
+     * @throws Exception
+     */
+    public void testSaveAnsibleRelativePath() throws Exception {
+        MinionServer minion = createAnsibleControlNode(user);
+        try {
+            SystemManager.createAnsiblePath("inventory", minion.getId(), "relative/path", user);
+            fail("An exception should have been thrown.");
+        }
+        catch (ValidatorException e) {
             // expected
         }
     }

--- a/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
@@ -1774,7 +1774,7 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
         MinionServer minion = createAnsibleControlNode(user);
         AnsiblePath path = new InventoryPath(minion);
         path.setPath(Path.of("/tmp/test1"));
-        path = SystemManager.createAnsiblePath(AnsiblePath.Type.INVENTORY, minion.getId(), "/tmp/test", user);
+        path = SystemManager.createAnsiblePath("inventory", minion.getId(), "/tmp/test", user);
 
         HibernateFactory.getSession().flush();
         HibernateFactory.getSession().evict( path);
@@ -1794,7 +1794,7 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
         path.setPath(Path.of("/tmp/test1"));
 
         try {
-            SystemManager.createAnsiblePath(AnsiblePath.Type.INVENTORY, minion.getId(), "/tmp/test", chuck);
+            SystemManager.createAnsiblePath("inventory", minion.getId(), "/tmp/test", chuck);
             fail("An exception should have been thrown.");
         }
         catch (LookupException e) {
@@ -1802,7 +1802,7 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
         }
 
         // now save with allowed user
-        path = SystemManager.createAnsiblePath(AnsiblePath.Type.INVENTORY, minion.getId(), "/tmp/test", user);
+        path = SystemManager.createAnsiblePath("inventory", minion.getId(), "/tmp/test", user);
 
         try {
             SystemManager.lookupAnsiblePathById(path.getId(), chuck);
@@ -1841,7 +1841,7 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
      */
     public void testUpdateAnsiblePath() throws Exception {
         MinionServer minion = createAnsibleControlNode(user);
-        AnsiblePath path = SystemManager.createAnsiblePath(AnsiblePath.Type.INVENTORY, minion.getId(), "/tmp/test", user);
+        AnsiblePath path = SystemManager.createAnsiblePath("inventory", minion.getId(), "/tmp/test", user);
         path = SystemManager.updateAnsiblePath(path.getId(), "/tmp/test-updated", user);
         HibernateFactory.getSession().flush();
         HibernateFactory.getSession().evict(path);
@@ -1853,7 +1853,7 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
         MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
 
         try {
-            AnsiblePath path = SystemManager.createAnsiblePath(AnsiblePath.Type.INVENTORY, minion.getId(), "/tmp/test", user);
+            AnsiblePath path = SystemManager.createAnsiblePath("inventory", minion.getId(), "/tmp/test", user);
             fail("An exception should have been thrown.");
         }
         catch (LookupException e) {

--- a/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/test/SystemManagerTest.java
@@ -73,6 +73,8 @@ import com.redhat.rhn.domain.server.ServerGroupFactory;
 import com.redhat.rhn.domain.server.ServerNetAddress4;
 import com.redhat.rhn.domain.server.ServerNetworkFactory;
 import com.redhat.rhn.domain.server.VirtualInstance;
+import com.redhat.rhn.domain.server.ansible.AnsiblePath;
+import com.redhat.rhn.domain.server.ansible.InventoryPath;
 import com.redhat.rhn.domain.server.test.CPUTest;
 import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
 import com.redhat.rhn.domain.server.test.ServerFactoryTest;
@@ -1760,6 +1762,90 @@ public class SystemManagerTest extends JMockBaseTestCaseWithUser {
         createIfaceForServer(server2, "virbr0", "192.168.178.1", "11:22:33:44:55:78");
 
         assertTrue(SystemManager.listDuplicatesByIP(user, 24).isEmpty());
+    }
+
+    /**
+     * Test saving and looking up {@link AnsiblePath} by given user
+     *
+     * @throws Exception
+     */
+    public void testSaveAndLookupAnsiblePath() throws Exception {
+        MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
+        AnsiblePath path = new InventoryPath(minion);
+        path.setPath(Path.of("/tmp/test1"));
+        path = SystemManager.createAnsiblePath(AnsiblePath.Type.INVENTORY, minion.getId(), "/tmp/test", user);
+
+        HibernateFactory.getSession().flush();
+        HibernateFactory.getSession().evict( path);
+        assertEquals(path, SystemManager.lookupAnsiblePathById(path.getId(), user).get());
+    }
+
+    /**
+     * Test saving, listing and looking up {@link AnsiblePath} by an unauthorized user
+     *
+     * @throws Exception
+     */
+    public void testSaveAndLookupAnsiblePathNoPerms() throws Exception {
+        User chuck = UserTestUtils.findNewUser("testUser", "testOrg" + this.getClass().getSimpleName());
+
+        MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
+        AnsiblePath path = new InventoryPath(minion);
+        path.setPath(Path.of("/tmp/test1"));
+
+        try {
+            SystemManager.createAnsiblePath(AnsiblePath.Type.INVENTORY, minion.getId(), "/tmp/test", chuck);
+            fail("An exception should have been thrown.");
+        }
+        catch (LookupException e) {
+            // expected
+        }
+
+        // now save with allowed user
+        path = SystemManager.createAnsiblePath(AnsiblePath.Type.INVENTORY, minion.getId(), "/tmp/test", user);
+
+        try {
+            SystemManager.lookupAnsiblePathById(path.getId(), chuck);
+            fail("An exception should have been thrown.");
+        }
+        catch (LookupException e) {
+            // expected
+        }
+
+        try {
+            SystemManager.listAnsiblePaths(minion.getId(), chuck);
+            fail("An exception should have been thrown.");
+        }
+        catch (LookupException e) {
+            // expected
+        }
+    }
+
+    /**
+     * Test updating non existing ansible path
+     */
+    public void testUpdateNonExistingAnsiblePath() {
+        try {
+            SystemManager.updateAnsiblePath(-12345, "/tmp/test", user);
+            fail("An exception should have been thrown.");
+        }
+        catch (LookupException e) {
+            // expected
+        }
+    }
+
+    /**
+     * Test updating an existing ansible path
+     *
+     * @throws Exception
+     */
+    public void testUpdateAnsiblePath() throws Exception {
+        MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
+        AnsiblePath path = SystemManager.createAnsiblePath(AnsiblePath.Type.INVENTORY, minion.getId(), "/tmp/test", user);
+        path = SystemManager.updateAnsiblePath(path.getId(), "/tmp/test-updated", user);
+        HibernateFactory.getSession().flush();
+        HibernateFactory.getSession().evict(path);
+        AnsiblePath updated = SystemManager.lookupAnsiblePathById(path.getId(), user).get();
+        assertEquals(path, updated);
     }
 
     private static void createIfaceForServer(Server server, String ifaceName, String ip4address, String hwAddr) {

--- a/java/code/src/com/suse/manager/webui/Router.java
+++ b/java/code/src/com/suse/manager/webui/Router.java
@@ -25,13 +25,12 @@ import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.manager.formula.FormulaManager;
 import com.redhat.rhn.manager.system.ServerGroupManager;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
-
 import com.suse.manager.clusters.ClusterManager;
 import com.suse.manager.kubernetes.KubernetesManager;
 import com.suse.manager.utils.SaltKeyUtils;
 import com.suse.manager.webui.controllers.ActivationKeysController;
+import com.suse.manager.webui.controllers.AnsibleController;
 import com.suse.manager.webui.controllers.CVEAuditController;
-import com.suse.manager.webui.controllers.clusters.ClustersController;
 import com.suse.manager.webui.controllers.DownloadController;
 import com.suse.manager.webui.controllers.FormulaCatalogController;
 import com.suse.manager.webui.controllers.FormulaController;
@@ -39,8 +38,6 @@ import com.suse.manager.webui.controllers.FrontendLogController;
 import com.suse.manager.webui.controllers.ImageBuildController;
 import com.suse.manager.webui.controllers.ImageProfileController;
 import com.suse.manager.webui.controllers.ImageStoreController;
-import com.suse.manager.webui.controllers.maintenance.MaintenanceCalendarController;
-import com.suse.manager.webui.controllers.maintenance.MaintenanceController;
 import com.suse.manager.webui.controllers.MinionController;
 import com.suse.manager.webui.controllers.MinionsAPI;
 import com.suse.manager.webui.controllers.NotificationMessageController;
@@ -58,9 +55,12 @@ import com.suse.manager.webui.controllers.VisualizationController;
 import com.suse.manager.webui.controllers.admin.AdminApiController;
 import com.suse.manager.webui.controllers.admin.AdminViewsController;
 import com.suse.manager.webui.controllers.channels.ChannelsApiController;
+import com.suse.manager.webui.controllers.clusters.ClustersController;
 import com.suse.manager.webui.controllers.contentmanagement.ContentManagementApiController;
 import com.suse.manager.webui.controllers.contentmanagement.ContentManagementViewsController;
 import com.suse.manager.webui.controllers.login.LoginController;
+import com.suse.manager.webui.controllers.maintenance.MaintenanceCalendarController;
+import com.suse.manager.webui.controllers.maintenance.MaintenanceController;
 import com.suse.manager.webui.controllers.maintenance.MaintenanceScheduleController;
 import com.suse.manager.webui.controllers.utils.RegularMinionBootstrapper;
 import com.suse.manager.webui.controllers.utils.SSHMinionBootstrapper;
@@ -71,12 +71,9 @@ import com.suse.manager.webui.errors.NotFoundException;
 import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.manager.webui.services.iface.VirtManager;
-
-import org.apache.http.HttpStatus;
-
 import java.util.HashMap;
 import java.util.Map;
-
+import org.apache.http.HttpStatus;
 import spark.ModelAndView;
 import spark.servlet.SparkApplication;
 import spark.template.jade.JadeTemplateEngine;
@@ -202,6 +199,9 @@ public class Router implements SparkApplication {
         MaintenanceController.initRoutes();
         MaintenanceScheduleController.initRoutes(jade);
         MaintenanceCalendarController.initRoutes(jade);
+
+        // Ansible Control Node
+        AnsibleController.initRoutes(jade);
     }
 
     private void  initNotFoundRoutes(JadeTemplateEngine jade) {

--- a/java/code/src/com/suse/manager/webui/controllers/AnsibleController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/AnsibleController.java
@@ -70,6 +70,9 @@ public class AnsibleController {
         // todo no CSRF?
         post("/manager/api/systems/details/ansible/paths/save",
                 withUser(AnsibleController::saveAnsiblePath));
+
+        post("/manager/api/systems/details/ansible/paths/delete",
+                withUser(AnsibleController::deleteAnsiblePath));
     }
 
     /**
@@ -138,6 +141,30 @@ public class AnsibleController {
         Map<String, Object> data = new HashMap<>();
         data.put("success", ResultJson.success());
         data.put("newPathId", currentPath.getId());
+        return json(res, data);
+    }
+    /**
+     * Delete an Ansible path
+     *
+     * @param req the request object
+     * @param res the response object
+     * @param user the authorized user
+     * @return the string with JSON response
+     */
+    public static String deleteAnsiblePath(Request req, Response res, User user) {
+        AnsiblePathJson json = GSON.fromJson(req.body(), AnsiblePathJson.class);
+
+        try {
+            SystemManager.removeAnsiblePath(SystemManager.lookupAnsiblePathById(json.getId(), user).get(), user);
+        }
+        catch (ValidatorException e) {
+            return json(res, ResultJson.error(
+                    ValidationUtils.convertValidationErrors(e),
+                    ValidationUtils.convertFieldValidationErrors(e)));
+        }
+
+        Map<String, Object> data = new HashMap<>();
+        data.put("success", ResultJson.success());
         return json(res, data);
     }
 

--- a/java/code/src/com/suse/manager/webui/controllers/AnsibleController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/AnsibleController.java
@@ -15,19 +15,32 @@
 
 package com.suse.manager.webui.controllers;
 
+import static com.suse.manager.webui.utils.SparkApplicationHelper.json;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.withCsrfToken;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.withDocsLocale;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.withUser;
 import static spark.Spark.get;
+import static spark.Spark.post;
+
+import com.redhat.rhn.common.localization.LocalizationService;
+import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerFactory;
+import com.redhat.rhn.domain.server.ansible.AnsiblePath;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.manager.system.SystemManager;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.redhat.rhn.domain.server.Server;
-import com.redhat.rhn.domain.server.ServerFactory;
-import com.redhat.rhn.domain.user.User;
-import java.util.HashMap;
-import java.util.Map;
+import com.suse.manager.webui.utils.gson.AnsiblePathJson;
+import com.suse.manager.webui.utils.gson.ResultJson;
+
 import org.apache.log4j.Logger;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import spark.ModelAndView;
 import spark.Request;
 import spark.Response;
@@ -39,6 +52,7 @@ import spark.template.jade.JadeTemplateEngine;
 public class AnsibleController {
 
     private static final Gson GSON = new GsonBuilder().create();
+    private static final LocalizationService LOCAL = LocalizationService.getInstance();
 
     private static Logger log = Logger.getLogger(AnsibleController.class);
 
@@ -52,6 +66,12 @@ public class AnsibleController {
     public static void initRoutes(JadeTemplateEngine jade) {
         get("/manager/systems/details/ansible",
                 withCsrfToken(withDocsLocale(withUser(AnsibleController::view))), jade);
+
+        get("/manager/api/systems/details/ansible/paths/:minionId",
+                withUser(AnsibleController::listAnsiblePathsByMinion));
+        // todo no CSRF?
+        post("/manager/api/systems/details/ansible/paths/save",
+                withUser(AnsibleController::saveAnsiblePath));
     }
 
     /**
@@ -70,4 +90,48 @@ public class AnsibleController {
 
         return new ModelAndView(data, "templates/ansible/view.jade");
     }
+
+    /**
+     * List Ansible Paths by minion
+     *
+     * @param req the request object
+     * @param res the response object
+     * @param user the authorized user
+     * @return string with JSON representation of the paths
+     */
+    public static String listAnsiblePathsByMinion(Request req, Response res, User user) {
+        long minionId = Long.parseLong(req.params("minionId"));
+        List<AnsiblePathJson> paths = SystemManager.listAnsiblePaths(minionId, user).stream()
+                .map(AnsiblePathJson::new)
+                .collect(Collectors.toList());
+        return json(res, paths);
+    }
+
+    /**
+     * Save or update (depends of the json.getId() contents) an Ansible path
+     *
+     * @param req the request object
+     * @param res the response object
+     * @param user the authorized user
+     * @return the string with JSON response
+     */
+    // todo path validation: path format + existence (in case of update) + constraints. do it in SystemManager
+    // and reuse in xmlrpc
+    public static String saveAnsiblePath(Request req, Response res, User user) {
+        AnsiblePathJson json = GSON.fromJson(req.body(), AnsiblePathJson.class);
+
+        if (json.getId() == null) {
+            SystemManager.createAnsiblePath(AnsiblePath.Type.fromLabel(json.getType()),
+                    json.getMinionId(),
+                    json.getPath(),
+                    user);
+        }
+        else {
+            SystemManager.updateAnsiblePath(json.getId(),
+                    json.getPath(),
+                    user);
+        }
+        return json(res, ResultJson.success());
+    }
+
 }

--- a/java/code/src/com/suse/manager/webui/controllers/AnsibleController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/AnsibleController.java
@@ -65,7 +65,7 @@ public class AnsibleController {
         get("/manager/systems/details/ansible",
                 withCsrfToken(withDocsLocale(withUser(AnsibleController::view))), jade);
 
-        get("/manager/api/systems/details/ansible/paths/:minionId",
+        get("/manager/api/systems/details/ansible/paths/:minionServerId",
                 withUser(AnsibleController::listAnsiblePathsByMinion));
         // todo no CSRF?
         post("/manager/api/systems/details/ansible/paths/save",
@@ -97,8 +97,8 @@ public class AnsibleController {
      * @return string with JSON representation of the paths
      */
     public static String listAnsiblePathsByMinion(Request req, Response res, User user) {
-        long minionId = Long.parseLong(req.params("minionId"));
-        List<AnsiblePathJson> paths = SystemManager.listAnsiblePaths(minionId, user).stream()
+        long minionServerId = Long.parseLong(req.params("minionServerId"));
+        List<AnsiblePathJson> paths = SystemManager.listAnsiblePaths(minionServerId, user).stream()
                 .map(AnsiblePathJson::new)
                 .collect(Collectors.toList());
         return json(res, paths);
@@ -119,7 +119,7 @@ public class AnsibleController {
         try {
             if (json.getId() == null) {
                 currentPath = SystemManager.createAnsiblePath(AnsiblePath.Type.fromLabel(json.getType()),
-                        json.getMinionId(),
+                        json.getMinionServerId(),
                         json.getPath(),
                         user);
             }

--- a/java/code/src/com/suse/manager/webui/controllers/AnsibleController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/AnsibleController.java
@@ -121,7 +121,7 @@ public class AnsibleController {
         AnsiblePath currentPath;
         try {
             if (json.getId() == null) {
-                currentPath = SystemManager.createAnsiblePath(AnsiblePath.Type.fromLabel(json.getType()),
+                currentPath = SystemManager.createAnsiblePath(json.getType(),
                         json.getMinionServerId(),
                         json.getPath(),
                         user);

--- a/java/code/src/com/suse/manager/webui/controllers/AnsibleController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/AnsibleController.java
@@ -88,7 +88,7 @@ public class AnsibleController {
         Server server = ServerFactory.lookupById(Long.valueOf(serverId));
         data.put("server", server);
 
-        return new ModelAndView(data, "templates/ansible/view.jade");
+        return new ModelAndView(data, "templates/minion/ansible-control-node.jade");
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/controllers/AnsibleController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/AnsibleController.java
@@ -24,6 +24,8 @@ import static spark.Spark.post;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+
+import com.redhat.rhn.common.hibernate.LookupException;
 import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.common.validator.ValidatorException;
 import com.redhat.rhn.domain.server.Server;
@@ -42,6 +44,7 @@ import org.apache.log4j.Logger;
 import spark.ModelAndView;
 import spark.Request;
 import spark.Response;
+import spark.Spark;
 import spark.template.jade.JadeTemplateEngine;
 
 /**
@@ -155,12 +158,10 @@ public class AnsibleController {
         AnsiblePathJson json = GSON.fromJson(req.body(), AnsiblePathJson.class);
 
         try {
-            SystemManager.removeAnsiblePath(SystemManager.lookupAnsiblePathById(json.getId(), user).get(), user);
+            SystemManager.removeAnsiblePath(json.getId(), user);
         }
-        catch (ValidatorException e) {
-            return json(res, ResultJson.error(
-                    ValidationUtils.convertValidationErrors(e),
-                    ValidationUtils.convertFieldValidationErrors(e)));
+        catch (LookupException e) {
+            Spark.halt(404);
         }
 
         Map<String, Object> data = new HashMap<>();

--- a/java/code/src/com/suse/manager/webui/controllers/AnsibleController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/AnsibleController.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.suse.manager.webui.controllers;
+
+import static com.suse.manager.webui.utils.SparkApplicationHelper.withCsrfToken;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.withDocsLocale;
+import static com.suse.manager.webui.utils.SparkApplicationHelper.withUser;
+import static spark.Spark.get;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerFactory;
+import com.redhat.rhn.domain.user.User;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.log4j.Logger;
+import spark.ModelAndView;
+import spark.Request;
+import spark.Response;
+import spark.template.jade.JadeTemplateEngine;
+
+/**
+ * Spark controller class the CVE Audit page.
+ */
+public class AnsibleController {
+
+    private static final Gson GSON = new GsonBuilder().create();
+
+    private static Logger log = Logger.getLogger(AnsibleController.class);
+
+    private AnsibleController() { }
+
+    /**
+     * Invoked from Router. Initialize routes for Systems Views.
+     *
+     * @param jade the Jade engine to use to render the pages
+     */
+    public static void initRoutes(JadeTemplateEngine jade) {
+        get("/manager/systems/details/ansible",
+                withCsrfToken(withDocsLocale(withUser(AnsibleController::view))), jade);
+    }
+
+    /**
+     * Returns the ansible control node page
+     *
+     * @param req the request object
+     * @param res the response object
+     * @param user the authorized user
+     * @return the model and view
+     */
+    public static ModelAndView view(Request req, Response res, User user) {
+        String serverId = req.queryParams("sid");
+        Map<String, Object> data = new HashMap<>();
+        Server server = ServerFactory.lookupById(Long.valueOf(serverId));
+        data.put("server", server);
+
+        return new ModelAndView(data, "templates/ansible/view.jade");
+    }
+}

--- a/java/code/src/com/suse/manager/webui/templates/ansible/view.jade
+++ b/java/code/src/com/suse/manager/webui/templates/ansible/view.jade
@@ -1,0 +1,10 @@
+
+
+#ansible-control-node
+
+script(type='text/javascript').
+    window.csrfToken = "#{csrf_token}";
+
+script(type='text/javascript').
+    spaImportReactPage('minion/ansible')
+        .then(function (module) { module.renderer('ansible-control-node', {id: #{server.id}, name: "#{server.name}"}) });

--- a/java/code/src/com/suse/manager/webui/templates/minion/ansible-control-node.jade
+++ b/java/code/src/com/suse/manager/webui/templates/minion/ansible-control-node.jade
@@ -1,4 +1,4 @@
-
+include ./minion-header.jade
 
 #ansible-control-node
 

--- a/java/code/src/com/suse/manager/webui/templates/minion/ansible-control-node.jade
+++ b/java/code/src/com/suse/manager/webui/templates/minion/ansible-control-node.jade
@@ -7,4 +7,4 @@ script(type='text/javascript').
 
 script(type='text/javascript').
     spaImportReactPage('minion/ansible')
-        .then(function (module) { module.renderer('ansible-control-node', {id: #{server.id}, name: "#{server.name}"}) });
+        .then(function (module) { module.renderer('ansible-control-node', {id: #{server.id} }) });

--- a/java/code/src/com/suse/manager/webui/utils/gson/AnsiblePathJson.java
+++ b/java/code/src/com/suse/manager/webui/utils/gson/AnsiblePathJson.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.suse.manager.webui.utils.gson;
+
+import com.redhat.rhn.domain.server.ansible.AnsiblePath;
+
+/**
+ * DTO for AnsiblePath
+ */
+public class AnsiblePathJson {
+
+    private Long id;
+    private Long minionId;
+    private String type;
+    private String path;
+
+    /**
+     * Standard constructor
+     *
+     * @param entity the backend entity
+     */
+    public AnsiblePathJson(AnsiblePath entity) {
+        this.id = entity.getId();
+        this.minionId = entity.getMinionServer().getId();
+        this.type = entity.getEntityType().getLabel();
+        this.path = entity.getPath().toString();
+    }
+
+    /**
+     * Gets the id.
+     *
+     * @return id
+     */
+    public Long getId() {
+        return id;
+    }
+
+    /**
+     * Gets the minionId.
+     *
+     * @return minionId
+     */
+    public Long getMinionId() {
+        return minionId;
+    }
+
+    /**
+     * Gets the type.
+     *
+     * @return type
+     */
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * Gets the path.
+     *
+     * @return path
+     */
+    public String getPath() {
+        return path;
+    }
+}

--- a/java/code/src/com/suse/manager/webui/utils/gson/AnsiblePathJson.java
+++ b/java/code/src/com/suse/manager/webui/utils/gson/AnsiblePathJson.java
@@ -23,7 +23,7 @@ import com.redhat.rhn.domain.server.ansible.AnsiblePath;
 public class AnsiblePathJson {
 
     private Long id;
-    private Long minionId;
+    private Long minionServerId;
     private String type;
     private String path;
 
@@ -34,7 +34,7 @@ public class AnsiblePathJson {
      */
     public AnsiblePathJson(AnsiblePath entity) {
         this.id = entity.getId();
-        this.minionId = entity.getMinionServer().getId();
+        this.minionServerId = entity.getMinionServer().getId();
         this.type = entity.getEntityType().getLabel();
         this.path = entity.getPath().toString();
     }
@@ -49,12 +49,12 @@ public class AnsiblePathJson {
     }
 
     /**
-     * Gets the minionId.
+     * Gets the minion server id.
      *
-     * @return minionId
+     * @return minionServerId
      */
-    public Long getMinionId() {
-        return minionId;
+    public Long getMinionServerId() {
+        return minionServerId;
     }
 
     /**

--- a/java/code/webapp/WEB-INF/nav/system_detail.xml
+++ b/java/code/webapp/WEB-INF/nav/system_detail.xml
@@ -217,8 +217,7 @@
     <rhn-tab-url>/rhn/manager/systems/details/formulas</rhn-tab-url>
   </rhn-tab>
 
-  <!-- TODO <rhn-tab name="Ansible" acl="system_feature(ftr_ansible_control_node)">-->
-  <rhn-tab name="Ansible" acl="system_has_salt_entitlement()">
+  <rhn-tab name="Ansible" acl="system_has_ansible_control_node_entitlement()">
     <rhn-tab-url>/rhn/manager/systems/details/ansible</rhn-tab-url>
   </rhn-tab>
 

--- a/java/code/webapp/WEB-INF/nav/system_detail.xml
+++ b/java/code/webapp/WEB-INF/nav/system_detail.xml
@@ -220,9 +220,6 @@
   <!-- TODO <rhn-tab name="Ansible" acl="system_feature(ftr_ansible_control_node)">-->
   <rhn-tab name="Ansible" acl="system_has_salt_entitlement()">
     <rhn-tab-url>/rhn/manager/systems/details/ansible</rhn-tab-url>
-    <rhn-tab name="Ansible">
-      <rhn-tab-url>/rhn/manager/systems/details/ansible</rhn-tab-url>
-    </rhn-tab>
   </rhn-tab>
 
   <rhn-tab name="Events" acl="system_has_management_entitlement() or system_has_salt_entitlement()">

--- a/java/code/webapp/WEB-INF/nav/system_detail.xml
+++ b/java/code/webapp/WEB-INF/nav/system_detail.xml
@@ -217,6 +217,14 @@
     <rhn-tab-url>/rhn/manager/systems/details/formulas</rhn-tab-url>
   </rhn-tab>
 
+  <!-- TODO <rhn-tab name="Ansible" acl="system_feature(ftr_ansible_control_node)">-->
+  <rhn-tab name="Ansible" acl="system_has_salt_entitlement()">
+    <rhn-tab-url>/rhn/manager/systems/details/ansible</rhn-tab-url>
+    <rhn-tab name="Ansible">
+      <rhn-tab-url>/rhn/manager/systems/details/ansible</rhn-tab-url>
+    </rhn-tab>
+  </rhn-tab>
+
   <rhn-tab name="Events" acl="system_has_management_entitlement() or system_has_salt_entitlement()">
     <rhn-tab-url>/rhn/systems/details/history/Pending.do</rhn-tab-url>
     <rhn-tab-url>/rhn/systems/details/history/Event.do</rhn-tab-url>

--- a/schema/spacewalk/common/tables/suseAnsiblePath.sql
+++ b/schema/spacewalk/common/tables/suseAnsiblePath.sql
@@ -13,8 +13,13 @@ CREATE TABLE suseAnsiblePath(
 
     type VARCHAR(16) NOT NULL
         CONSTRAINT suse_ansible_path_type_ck
-        CHECK (type in ('inventory', 'playbook'))
+        CHECK (type in ('inventory', 'playbook')),
 
+    created     TIMESTAMPTZ
+        DEFAULT (current_timestamp) NOT NULL,
+
+    modified    TIMESTAMPTZ
+        DEFAULT (current_timestamp) NOT NULL
 );
 
 CREATE SEQUENCE suse_ansible_path_seq;
@@ -27,4 +32,19 @@ CREATE INDEX suse_ansible_path_server_id_idx
 
 CREATE INDEX suse_ansible_server_id_type_idx
     ON suseAnsiblePath(server_id, type);
+
+CREATE OR REPLACE function suse_ansible_path_mod_trig_fun() RETURNS TRIGGER AS
+$$
+BEGIN
+        new.modified := current_timestamp;
+        RETURN new;
+END;
+$$ language plpgsql;
+
+DROP TRIGGER IF EXISTS suse_ansible_path_mod_trig ON suseAnsiblePath;
+CREATE TRIGGER
+suse_ansible_path_mod_trig
+BEFORE INSERT OR UPDATE ON suseAnsiblePath
+FOR EACH ROW
+EXECUTE PROCEDURE suse_ansible_path_mod_trig_fun();
 

--- a/schema/spacewalk/common/tables/suseAnsiblePath.sql
+++ b/schema/spacewalk/common/tables/suseAnsiblePath.sql
@@ -1,0 +1,30 @@
+
+CREATE TABLE suseAnsiblePath(
+
+    id NUMERIC NOT NULL
+        CONSTRAINT suse_ansible_path_id_pk PRIMARY KEY,
+
+    server_id NUMERIC NOT NULL -- references minion
+        CONSTRAINT suse_ansible_path_sid_fk
+        REFERENCES suseMinionInfo (server_id)
+        ON DELETE CASCADE,
+
+    path VARCHAR(1024) NOT NULL,
+
+    type VARCHAR(16) NOT NULL
+        CONSTRAINT suse_ansible_path_type_ck
+        CHECK (type in ('inventory', 'playbook'))
+
+);
+
+CREATE SEQUENCE suse_ansible_path_seq;
+
+CREATE UNIQUE INDEX suse_ansible_path_uq
+    ON suseAnsiblePath(server_id, path, type);
+
+CREATE INDEX suse_ansible_path_server_id_idx
+    ON suseAnsiblePath(server_id);
+
+CREATE INDEX suse_ansible_server_id_type_idx
+    ON suseAnsiblePath(server_id, type);
+

--- a/schema/spacewalk/upgrade/susemanager-schema-4.2.9-to-susemanager-schema-4.2.10/360-ansible_path.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.2.9-to-susemanager-schema-4.2.10/360-ansible_path.sql
@@ -13,7 +13,13 @@ CREATE TABLE IF NOT EXISTS suseAnsiblePath(
 
     type VARCHAR(16) NOT NULL
         CONSTRAINT suse_ansible_path_type_ck
-        CHECK (type in ('inventory', 'playbook'))
+        CHECK (type in ('inventory', 'playbook')),
+
+    created     TIMESTAMPTZ
+        DEFAULT (current_timestamp) NOT NULL,
+
+    modified    TIMESTAMPTZ
+        DEFAULT (current_timestamp) NOT NULL
 
 );                                                                                                                                                       
 
@@ -27,3 +33,18 @@ CREATE INDEX IF NOT EXISTS suse_ansible_path_server_id_idx
 
 CREATE INDEX IF NOT EXISTS suse_ansible_server_id_type_idx
     ON suseAnsiblePath(server_id, type);
+
+CREATE OR REPLACE function suse_ansible_path_mod_trig_fun() RETURNS TRIGGER AS
+$$
+BEGIN
+        new.modified := current_timestamp;
+        RETURN new;
+END;
+$$ language plpgsql;
+
+DROP TRIGGER IF EXISTS suse_ansible_path_mod_trig ON suseAnsiblePath;
+CREATE TRIGGER
+suse_ansible_path_mod_trig
+BEFORE INSERT OR UPDATE ON suseAnsiblePath
+FOR EACH ROW
+EXECUTE PROCEDURE suse_ansible_path_mod_trig_fun();

--- a/schema/spacewalk/upgrade/susemanager-schema-4.2.9-to-susemanager-schema-4.2.10/360-ansible_path.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.2.9-to-susemanager-schema-4.2.10/360-ansible_path.sql
@@ -1,0 +1,29 @@
+
+CREATE TABLE IF NOT EXISTS suseAnsiblePath(
+
+    id NUMERIC NOT NULL
+        CONSTRAINT suse_ansible_path_id_pk PRIMARY KEY,
+
+    server_id NUMERIC NOT NULL -- references minion
+        CONSTRAINT suse_ansible_path_sid_fk
+        REFERENCES suseMinionInfo (server_id)
+        ON DELETE CASCADE,
+
+    path VARCHAR(1024) NOT NULL,
+
+    type VARCHAR(16) NOT NULL
+        CONSTRAINT suse_ansible_path_type_ck
+        CHECK (type in ('inventory', 'playbook'))
+
+);                                                                                                                                                       
+
+CREATE SEQUENCE IF NOT EXISTS suse_ansible_path_seq;
+
+CREATE UNIQUE INDEX IF NOT EXISTS suse_ansible_path_uq
+    ON suseAnsiblePath(server_id, path, type);
+
+CREATE INDEX IF NOT EXISTS suse_ansible_path_server_id_idx
+    ON suseAnsiblePath(server_id);
+
+CREATE INDEX IF NOT EXISTS suse_ansible_server_id_type_idx
+    ON suseAnsiblePath(server_id, type);

--- a/web/html/src/manager/minion/ansible/ansible-control-node.tsx
+++ b/web/html/src/manager/minion/ansible/ansible-control-node.tsx
@@ -174,17 +174,9 @@ class AnsibleControlNode extends React.Component<PropsType, StateType> {
                   />
                   :
                   <div className="d-block" key={p.id}>
-                    <pre>
-                      {p.path}
+                    <pre className="pointer" onClick={() => this.setState({ editPlaybookPath: p })}>
+                      {p.path}<i className="fa fa-edit pull-right" />
                     </pre>
-                    <div className="btn-group pull-right">
-                      <Button
-                        className="btn-default btn-sm"
-                        icon="fa-edit"
-                        title={t("Edit")}
-                        handler={() => this.setState({ editPlaybookPath: p })}
-                      />
-                    </div>
                   </div>
             )}
             <hr/>
@@ -215,17 +207,9 @@ class AnsibleControlNode extends React.Component<PropsType, StateType> {
                   />
                   :
                   <div className="d-block" key={p.id}>
-                    <pre>
-                      {p.path}
+                    <pre className="pointer" onClick={() => this.setState({ editInventoryPath: p })}>
+                      {p.path}<i className="fa fa-edit pull-right" />
                     </pre>
-                    <div className="btn-group pull-right">
-                      <Button
-                        className="btn-default btn-sm"
-                        icon="fa-edit"
-                        title={t("Edit")}
-                        handler={() => this.setState({ editInventoryPath: p })}
-                      />
-                    </div>
                   </div>
             )}
             <hr/>

--- a/web/html/src/manager/minion/ansible/ansible-control-node.tsx
+++ b/web/html/src/manager/minion/ansible/ansible-control-node.tsx
@@ -16,7 +16,7 @@ type AnsiblePath = {
 }
 
 type PropsType = {
-  id: number;
+  minionServerId: number;
 };
 
 type StateType = {
@@ -35,7 +35,7 @@ class AnsibleControlNode extends React.Component<PropsType, StateType> {
     super(props);
 
     this.state = {
-      minionServerId: props.system.id,
+      minionServerId: props.minionServerId,
       playbooksPaths: [],
       inventoriesPaths: [],
       newPlaybookPath: "",
@@ -45,7 +45,7 @@ class AnsibleControlNode extends React.Component<PropsType, StateType> {
       errors: [],
     };
 
-    Network.get("/rhn/manager/api/systems/details/ansible/paths/" + props.system.id)
+    Network.get("/rhn/manager/api/systems/details/ansible/paths/" + props.minionServerId)
     .promise.then(data => {
       this.setState({ playbooksPaths: data.filter(p => p.type === "playbook"), inventoriesPaths: data.filter(p => p.type === "inventory") });
     });
@@ -227,4 +227,4 @@ class AnsibleControlNode extends React.Component<PropsType, StateType> {
   }
 }
 
-export const renderer = (id: string, system: any) => SpaRenderer.renderNavigationReact(<AnsibleControlNode system={system} />, document.getElementById(id));
+export const renderer = (renderId: string, { id }) => SpaRenderer.renderNavigationReact(<AnsibleControlNode minionServerId={ id } />, document.getElementById(renderId));

--- a/web/html/src/manager/minion/ansible/ansible-control-node.tsx
+++ b/web/html/src/manager/minion/ansible/ansible-control-node.tsx
@@ -8,7 +8,7 @@ import Network from "utils/network";
 
 type AnsiblePath = {
   id: Number;
-  minionId: Number;
+  minionServerId: Number;
   type: String;
   path: String;
 }
@@ -59,14 +59,14 @@ class AnsibleControlNode extends React.Component<PropsType, StateType> {
     Network.post(
       "/rhn/manager/api/systems/details/ansible/paths/save",
       JSON.stringify({
-        minionId: this.state.systemId,
+        minionServerId: this.state.systemId,
         type: type,
         path: newPath
       }),
       "application/json"
     ).promise.then(data => {
       if (data.success) {
-        const newAnsiblePath = { id: data.newPathId, minionId: this.state.systemId, type: type, path: newPath};
+        const newAnsiblePath = { id: data.newPathId, minionServerId: this.state.systemId, type: type, path: newPath};
         if (type === "playbook") {
           this.setState({ playbooksPaths: this.state.playbooksPaths.concat(newAnsiblePath), newPlaybookPath: "" });
         }

--- a/web/html/src/manager/minion/ansible/ansible-control-node.tsx
+++ b/web/html/src/manager/minion/ansible/ansible-control-node.tsx
@@ -70,8 +70,6 @@ class AnsibleControlNode extends React.Component<PropsType, StateType> {
   }
   
   render () {
-    console.log(this.state.playbooksPaths);
-    console.log(this.state.inventoriesPaths);
     const messages = this.state.messages.length > 0 ? <Messages items={this.state.messages} /> : null;
     return (
       <div>

--- a/web/html/src/manager/minion/ansible/ansible-control-node.tsx
+++ b/web/html/src/manager/minion/ansible/ansible-control-node.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import SpaRenderer from "core/spa/spa-renderer";
-import { Messages } from "components/messages";
+import { Messages, Utils } from "components/messages";
 import { TextField } from "components/fields";
 import { Panel } from "components/panels/Panel";
 import { AsyncButton } from "components/buttons";
@@ -19,11 +19,11 @@ type PropsType = {
 
 type StateType = {
   systemId: Number;
-  messages: any[];
   playbooksPaths: AnsiblePath[];
   inventoriesPaths: AnsiblePath[];
   newPlaybookPath: string;
   newInventoryPath: string;
+  errors: string[];
 };
 
 class AnsibleControlNode extends React.Component<PropsType, StateType> {
@@ -32,11 +32,11 @@ class AnsibleControlNode extends React.Component<PropsType, StateType> {
 
     this.state = {
       systemId: props.system.id,
-      messages: [],
       playbooksPaths: [],
       inventoriesPaths: [],
       newPlaybookPath: "",
       newInventoryPath: "",
+      errors: [],
     };
 
     Network.get("/rhn/manager/api/systems/details/ansible/paths/"+props.system.id)
@@ -74,14 +74,17 @@ class AnsibleControlNode extends React.Component<PropsType, StateType> {
           this.setState({ inventoriesPaths: this.state.inventoriesPaths.concat(newAnsiblePath), newInventoryPath: "" });
         }
       }
+      else {
+        this.setState({ errors: data.errors.path });
+      }
     });
   }
   
   render () {
-    const messages = this.state.messages.length > 0 ? <Messages items={this.state.messages} /> : null;
+    const errors = this.state.errors.length > 0 ? <Messages items={Utils.error(this.state.errors)} /> : null;
     return (
       <div>
-        {messages}
+        {errors}
         <div className="col-md-6">
           <Panel
             headingLevel="h3"

--- a/web/html/src/manager/minion/ansible/ansible-control-node.tsx
+++ b/web/html/src/manager/minion/ansible/ansible-control-node.tsx
@@ -20,7 +20,7 @@ type PropsType = {
 };
 
 type StateType = {
-  systemId: number;
+  minionServerId: number;
   playbooksPaths: AnsiblePath[];
   inventoriesPaths: AnsiblePath[];
   newPlaybookPath: string;
@@ -35,7 +35,7 @@ class AnsibleControlNode extends React.Component<PropsType, StateType> {
     super(props);
 
     this.state = {
-      systemId: props.system.id,
+      minionServerId: props.system.id,
       playbooksPaths: [],
       inventoriesPaths: [],
       newPlaybookPath: "",
@@ -45,7 +45,7 @@ class AnsibleControlNode extends React.Component<PropsType, StateType> {
       errors: [],
     };
 
-    Network.get("/rhn/manager/api/systems/details/ansible/paths/"+props.system.id)
+    Network.get("/rhn/manager/api/systems/details/ansible/paths/" + props.system.id)
     .promise.then(data => {
       this.setState({ playbooksPaths: data.filter(p => p.type === "playbook"), inventoriesPaths: data.filter(p => p.type === "inventory") });
     });
@@ -127,14 +127,14 @@ class AnsibleControlNode extends React.Component<PropsType, StateType> {
     Network.post(
       "/rhn/manager/api/systems/details/ansible/paths/save",
       JSON.stringify({
-        minionServerId: this.state.systemId,
+        minionServerId: this.state.minionServerId,
         type: type,
         path: newPath
       }),
       "application/json"
     ).promise.then(data => {
       if (data.success) {
-        const newAnsiblePath = { id: data.newPathId, minionServerId: this.state.systemId, type: type, path: newPath};
+        const newAnsiblePath = { id: data.newPathId, minionServerId: this.state.minionServerId, type: type, path: newPath};
         if (type === "playbook") {
           this.setState({ playbooksPaths: this.state.playbooksPaths.concat(newAnsiblePath), newPlaybookPath: "" });
         }

--- a/web/html/src/manager/minion/ansible/ansible-control-node.tsx
+++ b/web/html/src/manager/minion/ansible/ansible-control-node.tsx
@@ -1,0 +1,48 @@
+import * as React from "react";
+import SpaRenderer from "core/spa/spa-renderer";
+import { Messages } from "components/messages";
+
+type Minion = {
+  id: Number;
+  name: String;
+}
+
+type PropsType = {
+  system: Minion;
+};
+
+type StateType = {
+  system: Minion;
+  messages: any[];
+  playbooksPaths: string[];
+  inventoriesPaths: string[];
+};
+
+class AnsibleControlNode extends React.Component<PropsType, StateType> {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      system: props.system,
+      messages: [],
+      playbooksPaths: ["/usr/share/playbooks", "/srv/playbooks"],
+      inventoriesPaths: ["/usr/share/inventories", "/srv/inventories"],
+    };
+  }
+  
+  render () {
+    const messages = this.state.messages.length > 0 ? <Messages items={this.state.messages} /> : null;
+    const buttons = [];
+    const buttonsLeft = [];
+    return (
+      <div>
+        {messages}
+        {this.state.system.name} - {this.state.system.id}
+        {this.state.playbooksPaths.map(p => <div>{p}</div>)}
+        {this.state.inventoriesPaths.map(p => <div>{p}</div>)}
+      </div>
+    );
+  }
+}
+
+export const renderer = (id: string, system: any) => SpaRenderer.renderNavigationReact(<AnsibleControlNode system={system} />, document.getElementById(id));

--- a/web/html/src/manager/minion/ansible/ansible-control-node.tsx
+++ b/web/html/src/manager/minion/ansible/ansible-control-node.tsx
@@ -1,6 +1,9 @@
 import * as React from "react";
 import SpaRenderer from "core/spa/spa-renderer";
 import { Messages } from "components/messages";
+import { TextField } from "components/fields";
+import { Panel } from "components/panels/Panel";
+import { AsyncButton } from "components/buttons";
 
 type Minion = {
   id: Number;
@@ -29,17 +32,61 @@ class AnsibleControlNode extends React.Component<PropsType, StateType> {
       inventoriesPaths: ["/usr/share/inventories", "/srv/inventories"],
     };
   }
+
+  addPath(type: string, newPath: string) {
+    if (type === "playbook") {
+      this.setState({ playbooksPaths: this.state.playbooksPaths.concat(newPath)});
+    }
+    else {
+      this.setState({ inventoriesPaths: this.state.inventoriesPaths.concat(newPath)});
+    }
+  }
   
   render () {
+    console.log(this.state.playbooksPaths);
+    console.log(this.state.inventoriesPaths);
     const messages = this.state.messages.length > 0 ? <Messages items={this.state.messages} /> : null;
-    const buttons = [];
-    const buttonsLeft = [];
     return (
       <div>
         {messages}
-        {this.state.system.name} - {this.state.system.id}
-        {this.state.playbooksPaths.map(p => <div>{p}</div>)}
-        {this.state.inventoriesPaths.map(p => <div>{p}</div>)}
+        <div className="col-md-6">
+          <Panel
+            headingLevel="h3"
+            title="Playbooks Paths"
+          >
+            {this.state.playbooksPaths.map(p =>
+              <pre>
+                {p}
+              </pre>
+            )}
+            <hr/>
+            <div className="form-group">
+              <TextField placeholder={t("New playbook path")} onPressEnter={(e) => this.addPath("playbook", e.target.value.toString())} />
+            </div>
+            <div className="pull-right btn-group">
+              <AsyncButton text={t("Save")} icon="fa-save" className="btn-success" />
+            </div>
+          </Panel>
+        </div>
+        <div className="col-md-6">
+          <Panel
+            headingLevel="h3"
+            title="Inventories Paths"
+          >
+            {this.state.inventoriesPaths.map(p =>
+              <pre>
+                {p}
+              </pre>
+            )}
+            <hr/>
+            <div className="form-group">
+              <TextField placeholder={t("New inventory path")} onPressEnter={(e) => this.addPath("inventory", e.target.value.toString())} />
+            </div>
+            <div className="pull-right btn-group">
+              <AsyncButton text={t("Save")} icon="fa-save" className="btn-success" />
+            </div>
+          </Panel>
+        </div>
       </div>
     );
   }

--- a/web/html/src/manager/minion/ansible/ansible-control-node.tsx
+++ b/web/html/src/manager/minion/ansible/ansible-control-node.tsx
@@ -4,6 +4,7 @@ import { Messages } from "components/messages";
 import { TextField } from "components/fields";
 import { Panel } from "components/panels/Panel";
 import { AsyncButton } from "components/buttons";
+import Network from "utils/network";
 
 type Minion = {
   id: Number;
@@ -19,6 +20,8 @@ type StateType = {
   messages: any[];
   playbooksPaths: string[];
   inventoriesPaths: string[];
+  newPlaybookPath: string;
+  newInventoryPath: string;
 };
 
 class AnsibleControlNode extends React.Component<PropsType, StateType> {
@@ -30,16 +33,40 @@ class AnsibleControlNode extends React.Component<PropsType, StateType> {
       messages: [],
       playbooksPaths: ["/usr/share/playbooks", "/srv/playbooks"],
       inventoriesPaths: ["/usr/share/inventories", "/srv/inventories"],
+      newPlaybookPath: "",
+      newInventoryPath: "",
     };
   }
 
-  addPath(type: string, newPath: string) {
+  newPath(type: string, newPath: string) {
     if (type === "playbook") {
-      this.setState({ playbooksPaths: this.state.playbooksPaths.concat(newPath)});
+      this.setState({ newPlaybookPath: newPath });
     }
     else {
-      this.setState({ inventoriesPaths: this.state.inventoriesPaths.concat(newPath)});
+      this.setState({ newInventoryPath: newPath });
     }
+  }
+
+  savePath(type: string) {
+    const newPath = type === "playbook" ? this.state.newPlaybookPath : this.state.newInventoryPath;
+    Network.post(
+      "/rhn/manager/api/systems/details/ansible/paths/save",
+      JSON.stringify({
+        minionId: this.state.system.id,
+        type: type,
+        path: newPath
+      }),
+      "application/json"
+    ).promise.then(data => {
+      if (data) {
+        if (type === "playbook") {
+          this.setState({ playbooksPaths: this.state.playbooksPaths.concat(this.state.newPlaybookPath) });
+        }
+        else {
+          this.setState({ inventoriesPaths: this.state.inventoriesPaths.concat(this.state.newInventoryPath) });
+        }
+      }
+    });
   }
   
   render () {
@@ -60,11 +87,17 @@ class AnsibleControlNode extends React.Component<PropsType, StateType> {
               </pre>
             )}
             <hr/>
+            <h4>{t("Add a Playbook path to discover")}</h4>
             <div className="form-group">
-              <TextField placeholder={t("New playbook path")} onPressEnter={(e) => this.addPath("playbook", e.target.value.toString())} />
+              <TextField placeholder={t("New playbook path")} onChange={(e) => this.newPath("playbook", e.target.value.toString())} />
             </div>
             <div className="pull-right btn-group">
-              <AsyncButton text={t("Save")} icon="fa-save" className="btn-success" />
+              <AsyncButton
+                action={() => this.savePath("playbook")}
+                defaultType="btn-success"
+                text={t("Save")}
+                icon="fa-save"
+              />
             </div>
           </Panel>
         </div>
@@ -79,11 +112,17 @@ class AnsibleControlNode extends React.Component<PropsType, StateType> {
               </pre>
             )}
             <hr/>
+            <h4>{t("Add an Inventory path to discover")}</h4>
             <div className="form-group">
-              <TextField placeholder={t("New inventory path")} onPressEnter={(e) => this.addPath("inventory", e.target.value.toString())} />
+              <TextField placeholder={t("New inventory path")} onChange={(e) => this.newPath("inventory", e.target.value.toString())} />
             </div>
             <div className="pull-right btn-group">
-              <AsyncButton text={t("Save")} icon="fa-save" className="btn-success" />
+              <AsyncButton
+                action={() => this.savePath("inventory")}
+                defaultType="btn-success"
+                text={t("Save")}
+                icon="fa-save"
+              />
             </div>
           </Panel>
         </div>

--- a/web/html/src/manager/minion/ansible/edit-ansible-path.tsx
+++ b/web/html/src/manager/minion/ansible/edit-ansible-path.tsx
@@ -1,0 +1,41 @@
+import * as React from "react";
+import { TextField } from "components/fields";
+import { AsyncButton, Button } from "components/buttons";
+
+const EditAnsiblePath = (props) => {
+  return (
+    <>
+      <div className="d-block">
+        <div className="col-md-10">
+          <TextField
+            value={props.ansiblePath.path}
+            onChange={(e) => props.editPath(e.target.value.toString())}
+          />
+        </div>
+        <div className="btn-group pull-right">
+          <AsyncButton
+            defaultType="btn-success btn-sm"
+            icon="fa-save"
+            title={t("Save")}
+            action={() => props.saveEditPath(props.editEntity)}
+          />
+          <Button
+            className="btn-default btn-sm"
+            icon="fa-close"
+            title={t("Cancel")}
+            handler={props.cancelHandler}
+          />
+          <AsyncButton
+            defaultType="btn-danger btn-sm"
+            icon="fa-trash"
+            title={t("Delete")}
+            action={() => props.deletePath(props.ansiblePath)}
+          />
+        </div>
+      </div>
+      <br/>
+    </>
+  )
+}
+
+export default EditAnsiblePath;

--- a/web/html/src/manager/minion/ansible/new-ansible-path.tsx
+++ b/web/html/src/manager/minion/ansible/new-ansible-path.tsx
@@ -1,0 +1,28 @@
+import * as React from "react";
+import { TextField } from "components/fields";
+import { AsyncButton } from "components/buttons";
+
+const NewAnsiblePath = (props) => {
+  return(
+    <>
+      <h4>{props.title}</h4>
+      <div className="form-group">
+        <TextField
+          placeholder={t("New path")}
+          value={props.newInventoryPath}
+          onChange={(e) => props.newPath(e.target.value.toString())}
+        />
+      </div>
+      <div className="pull-right btn-group">
+        <AsyncButton
+          action={props.savePath}
+          defaultType="btn-success"
+          text={t("Save")}
+          icon="fa-save"
+        />
+      </div>
+    </>
+  )
+}
+
+export default NewAnsiblePath;

--- a/web/html/src/manager/minion/index.js
+++ b/web/html/src/manager/minion/index.js
@@ -2,5 +2,6 @@ export default {
   'minion/config-channels/minion-config-channels': () => import('./config-channels/minion-config-channels'),
   'minion/formula/minion-formula': () => import('./formula/minion-formula.renderer'),
   'minion/formula/minion-formula-selection': () => import('./formula/minion-formula-selection.renderer'),
-  'minion/packages/package-states': () => import('./packages/package-states.renderer')
+  'minion/packages/package-states': () => import('./packages/package-states.renderer'),
+  "minion/ansible": () => import("./ansible/ansible-control-node")
 }


### PR DESCRIPTION
WIP WIP WIP
https://github.com/uyuni-project/uyuni/pull/3577 must be merged first

## TODO
- [ ] Agree on the output structure

## What does this PR change?

Implement backend and xmlrpc for ansible inventory introspection and playbook discovery

Example output:

playbooks
```python
client.ansible.discoverPlaybooks(key, PATH_ID)

> {'/root/ansible-examples/lamp_haproxy': {
      'aws/demo-aws-launch.yml': {   'fullpath': '/root/ansible-examples/lamp_haproxy/aws/demo-aws-launch.yml'},
      'aws/rolling_update.yml': {   'fullpath': '/root/ansible-examples/lamp_haproxy/aws/rolling_update.yml'},
      'aws/site.yml': {   'fullpath': '/root/ansible-examples/lamp_haproxy/aws/site.yml'},
      'provision.yml': {   'custom_inventory': '/root/ansible-examples/lamp_haproxy/hosts',
      'fullpath': '/root/ansible-examples/lamp_haproxy/provision.yml'},
      'rolling_update.yml': {   'custom_inventory': '/root/ansible-examples/lamp_haproxy/hosts',
      'fullpath': '/root/ansible-examples/lamp_haproxy/rolling_update.yml'},
      'site.yml': {   'custom_inventory': '/root/ansible-examples/lamp_haproxy/hosts',
      'fullpath': '/root/ansible-examples/lamp_haproxy/site.yml'}}}
```

inventory
```python
client.ansible.introspectInventory(key, PATH_ID)

> {   '_meta': {   'hostvars': {   'web2': {   'dbname': 'foodb',
                                             'dbuser': 'foouser',
                                             'httpd_port': 80.0,
                                             'mysql_port': 3306.0,
                                             'mysqlservice': 'mysqld',
                                             'ntpserver': '192.168.1.2',
                                             'repository': 'https://github.com/bennojoy/mywebapp.git',
                                             'upassword': 'abc'},
                                 'web3': {   'httpd_port': 80.0,
                                             'ntpserver': '192.168.1.2',
                                             'repository': 'https://github.com/bennojoy/mywebapp.git'}}},

    'all': {   'children': ['dbservers', 'ungrouped', 'webservers']},
    'dbservers': {   'hosts': ['web2']},
    'webservers': {   'hosts': ['web3']}}



```


## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

backend:
https://github.com/SUSE/spacewalk/issues/14518
https://github.com/SUSE/spacewalk/issues/14517

xmlrpc:
https://github.com/SUSE/spacewalk/issues/14526
https://github.com/SUSE/spacewalk/issues/14525


- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
