### PR TITLE
Lower case fqdn comparation when calculating minion connection path

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/server/Server_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/server/Server_legacyUser.hbm.xml
@@ -252,7 +252,7 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         <![CDATA[ select s
                   from com.redhat.rhn.domain.server.Server as s
                   join s.fqdns as fqdn
-                  where fqdn.name = :name
+                  where LOWER(fqdn.name) = LOWER(:name)
         ]]>
     </query>
 

--- a/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/server/test/ServerFactoryTest.java
@@ -1419,6 +1419,48 @@ public class ServerFactoryTest extends BaseTestCaseWithUser {
     }
 
     /**
+     * Tests looking up of a proxy server, assuming the proxy's FQDN is
+     * in rhnServer and FQDN name have different cases.
+     * @throws Exception - if anything goes wrong.
+     */
+    public void testLookupProxyServerFQDNWithCaseName() throws Exception {
+        Server s = createTestServer(user,
+                false,
+                ServerConstants.getServerGroupTypeEnterpriseEntitled(),
+                TYPE_SERVER_PROXY);
+        String hostCaseName = "fooBeer.bar.com";
+        s.setHostname(hostCaseName);
+        s.addFqdn(hostCaseName);
+
+        HibernateFactory.getSession().flush();
+        HibernateFactory.getSession().clear();
+
+        // FQDN: precise lookup
+        assertEquals(s, ServerFactory.lookupProxyServer(hostCaseName).get());
+    }
+
+    /**
+     * Tests looking up of a proxy server, assuming the proxy's FQDN is
+     * in rhnServer and FQDN name with case different from the used in query.
+     * @throws Exception - if anything goes wrong.
+     */
+    public void testLookupProxyServerFQDNIgnoreCase() throws Exception {
+        Server s = createTestServer(user,
+                false,
+                ServerConstants.getServerGroupTypeEnterpriseEntitled(),
+                TYPE_SERVER_PROXY);
+        String hostCaseName = "fooBeer.bar.com";
+        s.setHostname(hostCaseName);
+        s.addFqdn(hostCaseName);
+
+        HibernateFactory.getSession().flush();
+        HibernateFactory.getSession().clear();
+
+        // FQDN: precise lookup
+        assertEquals(s, ServerFactory.lookupProxyServer(hostCaseName.toLowerCase()).get());
+    }
+
+    /**
      * Tests looking up of a proxy server, assuming the proxy's simple name is
      * in rhnServer.
      * @throws Exception - if anything goes wrong.

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Lower case fqdn comparation when calculating minion connection path (bsc#1184849)
+
 -------------------------------------------------------------------
 Mon Apr 19 14:51:51 CEST 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
Signed-off-by: Ricardo Mateus <rmateus@suse.com>

## What does this PR change?

POrt of: https://github.com/SUSE/spacewalk/pull/14635
relates to: https://github.com/SUSE/spacewalk/issues/14614

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
