### PR TITLE
QA: Support Cucumber tags as environment variable

### DIFF
--- a/testsuite/Rakefile
+++ b/testsuite/Rakefile
@@ -14,12 +14,11 @@ namespace :cucumber do
       timestamp = Time.now.strftime('%Y%m%d%H%M%S')
       json_results = "-f json -o output_#{timestamp}-#{filename}.json"
       html_results = "-f html -o output_#{timestamp}-#{filename}.html"
-      profiles = ENV['PROFILE'] || 'default'
-      include_profiles = ""
-      profiles.split(',').each do |profile|
-        include_profiles << "--profile #{profile} "
-      end
-      cucumber_opts = %W[#{html_results} #{json_results} #{junit_results} -f rerun #{include_profiles} --out failed.txt -f pretty -r features]
+      profiles = ENV['PROFILE']
+      include_profiles = profiles.nil? ? '--profile default' : '--profile ' + profiles.gsub(',', ' --profile ')
+      tags = ENV['TAGS']
+      include_tags =  tags.nil? ? '' : '--tags ' + tags.gsub(',', ' or ')
+      cucumber_opts = %W[#{html_results} #{json_results} #{junit_results} -f rerun #{include_profiles} #{include_tags} --out failed.txt -f pretty -r features]
       features = YAML.safe_load(File.read(entry))
       t.cucumber_opts = cucumber_opts + features unless features.nil?
     end
@@ -33,12 +32,11 @@ namespace :parallel do
     task "#{run_set}" do
       timestamp = Time.now.strftime('%Y%m%d%H%M%S')
       features = YAML.safe_load(File.read(File.join(Dir.pwd, 'run_sets', "#{run_set}.yml"))).join(' ')
-      profiles = ENV['PROFILE'] || 'default'
-      include_profiles = ""
-      profiles.split(',').each do |profile|
-        include_profiles << "--profile #{profile} "
-      end
-      cucumber_opts = "#{include_profiles}  -f html -o output_#{timestamp}-#{run_set}-$TEST_ENV_NUMBER.html -f json -o output_#{timestamp}-#{run_set}-$TEST_ENV_NUMBER.json #{junit_results} -f rerun --out failed.txt -f CustomFormatter::PrettyFormatter -r features "
+      profiles = ENV['PROFILE']
+      include_profiles = profiles.nil? ? '--profile default' : '--profile ' + profiles.gsub(',', ' --profile ')
+      tags = ENV['TAGS']
+      include_tags =  tags.nil? ? '' : '--tags ' + tags.gsub(',', ' or ')
+      cucumber_opts = "#{include_profiles} #{include_tags} -f html -o output_#{timestamp}-#{run_set}-$TEST_ENV_NUMBER.html -f json -o output_#{timestamp}-#{run_set}-$TEST_ENV_NUMBER.json #{junit_results} -f rerun --out failed.txt -f CustomFormatter::PrettyFormatter -r features "
       sh "bundle exec parallel_cucumber -n 6 -o '#{cucumber_opts}' #{features}"
     end
   end


### PR DESCRIPTION
## What does this PR change?

Add support to include the union of tags through an environment variable `TAGS`
This will allow selecting multiple functional areas from the Jenkins pipeline, as we can't do the union of Cucumber profiles as was expected the default behavior passing multiple profiles (it does the intersection).

**Dependency:** We need to change the pipelines code to use tags instead of profiles (https://github.com/SUSE/susemanager-ci/pull/248), but this PR can be merged safely without the change on the pipeline as it will not break the execution of tests.

Related to https://github.com/SUSE/spacewalk/issues/14618

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.0
- Manager-4.1

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
