### PR TITLE
Testsuite: inspect the zypper rotated log as well

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -190,7 +190,11 @@ end
 
 When(/^vendor change should be enabled for "(?:[^"]*)" on "([^"]*)"$/) do |host|
   node = get_target(host)
-  _result, return_code = node.run("grep -- --allow-vendor-change /var/log/zypper.log")
+  pattern = '--allow-vendor-change'
+  log = '/var/log/zypper.log'
+  rotated_log = "#{log}-#{Time.now.strftime('%Y%m%d')}.xz"
+  _, return_code = node.run("grep -- #{pattern} #{log} || xzdec #{rotated_log} | grep -- #{pattern}")
+
   raise 'Vendor change option not found in logs' unless return_code.zero?
 end
 


### PR DESCRIPTION
## What does this PR change?

The zypper.log rotates at 00:00 if its size is >= 10 Mb.
At the time when we inspect this log, its size is >~ 10 Mb, thus
there are some chances that the log is rotated before we search for
the pattern inside it.

- testsuite/features/step_definitions/command_steps.rb:
Inspect both, zypper.log and the rotated one zypper.log-%Y%m%d.xz.

## Links

Fixes https://github.com/uyuni-project/uyuni/pull/3285
### Ports
- Manager-4.1: https://github.com/SUSE/spacewalk/pull/14642

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)
