### PR TITLE
fix syntax to push-to-obs script

### DIFF
--- a/susemanager-utils/testing/docker/scripts/push-to-obs.sh
+++ b/susemanager-utils/testing/docker/scripts/push-to-obs.sh
@@ -21,7 +21,7 @@ help() {
   echo ""
 }
 
-while getopts ":d:c:p:vth" opts; do
+while getopts ":d:c:p:n:vth" opts; do
   case "${opts}" in
     d) DESTINATIONS=${OPTARG};;
     p) PACKAGES="$(echo ${OPTARG}|tr ',' ' ')";;


### PR DESCRIPTION
## What does this PR change?

fix syntax to push-to-obs script


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed




## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
