### PR TITLE
Testsuite: Minor tweak in a step definition

### DIFF
--- a/testsuite/features/init_clients/sle_minion.feature
+++ b/testsuite/features/init_clients/sle_minion.feature
@@ -58,7 +58,7 @@ Feature: Bootstrap a Salt minion via the GUI
     And I wait at most 600 seconds until event "Service Pack Migration scheduled by admin" is completed
     And I follow "Details" in the content area
     Then I should see a "SUSE Linux Enterprise Server 15 SP2" text
-    And vendor change should be enabled for "SP migration" on "sle_spack_migrated_minion"
+    And vendor change should be enabled for SP migration on "sle_spack_migrated_minion"
 
   Scenario: Install the latest Salt on this minion
     When I enable repositories before installing Salt on this "sle_spack_migrated_minion"

--- a/testsuite/features/init_clients/sle_ssh_minion.feature
+++ b/testsuite/features/init_clients/sle_ssh_minion.feature
@@ -54,7 +54,7 @@ Feature: Bootstrap a Salt host managed via salt-ssh
     And I wait at most 600 seconds until event "Service Pack Migration scheduled by admin" is completed
     And I follow "Details" in the content area
     Then I should see a "SUSE Linux Enterprise Server 15 SP2" text
-    And vendor change should be enabled for "SP migration" on "ssh_spack_migrated_minion"
+    And vendor change should be enabled for SP migration on "ssh_spack_migrated_minion"
 
 @proxy
   Scenario: Check connection from SSH minion to proxy

--- a/testsuite/features/secondary/min_salt_install_package.feature
+++ b/testsuite/features/secondary/min_salt_install_package.feature
@@ -37,7 +37,7 @@ Feature: Install a patch on the client via Salt through the UI
     And I click on "Confirm"
     Then I should see a "1 patch update has been scheduled for" text
     And I wait for "virgo-dummy-2.0-1.1" to be installed on "sle_minion"
-    And vendor change should be enabled for "package actions" on "sle_minion"
+    And vendor change should be enabled for package actions on "sle_minion"
 
   Scenario: Cleanup: remove virgo-dummy package from SLE minion
     When I disable repository "test_repo_rpm_pool" on this "sle_minion"

--- a/testsuite/features/secondary/trad_inst_package_and_patch.feature
+++ b/testsuite/features/secondary/trad_inst_package_and_patch.feature
@@ -48,7 +48,7 @@ Feature: Install a package to the traditional client
     Then I should see a "1 patch update has been scheduled for" text
     When I wait until event "Package Install/Upgrade scheduled by admin" is completed
     Then "andromeda-dummy-2.0-1.1" should be installed on "sle_client"
-    And vendor change should be enabled for "package actions" on "sle_client"
+    And vendor change should be enabled for package actions on "sle_client"
     And The metadata buildtime from package "andromeda-dummy" match the one in the rpm on "sle_client"
 
   Scenario: Cleanup: remove packages and restore non-update repo

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -188,7 +188,7 @@ When(/^I query latest Salt changes on ubuntu system "(.*?)"$/) do |host|
   end
 end
 
-When(/^vendor change should be enabled for "(?:[^"]*)" on "([^"]*)"$/) do |host|
+When(/^vendor change should be enabled for (?:[^"]*) on "([^"]*)"$/) do |host|
   node = get_target(host)
   pattern = '--allow-vendor-change'
   log = '/var/log/zypper.log'


### PR DESCRIPTION
## What does this PR change?
Align step definition with our code base to produce minimum sorprise.

- testsuite/features/step_definitions/command_steps.rb:
Don't wrap the shy group inside quotes to align with other
step definitions in our code base.

- testsuite/features/init_clients/sle_minion.feature
- testsuite/features/init_clients/sle_ssh_minion.feature
- testsuite/features/secondary/min_salt_install_package.feature
- testsuite/features/secondary/trad_inst_package_and_patch.feature:
All callers updated.


## Links

Continuation of: https://github.com/uyuni-project/uyuni/pull/3600
### Ports
No ports needed.

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

