### PR TITLE
Revert "QA: Support Cucumber tags as environment variable (#3597)"

### DIFF
--- a/testsuite/Rakefile
+++ b/testsuite/Rakefile
@@ -14,11 +14,12 @@ namespace :cucumber do
       timestamp = Time.now.strftime('%Y%m%d%H%M%S')
       json_results = "-f json -o output_#{timestamp}-#{filename}.json"
       html_results = "-f html -o output_#{timestamp}-#{filename}.html"
-      profiles = ENV['PROFILE']
-      include_profiles = profiles.nil? ? '--profile default' : '--profile ' + profiles.gsub(',', ' --profile ')
-      tags = ENV['TAGS']
-      include_tags =  tags.nil? ? '' : '--tags ' + tags.gsub(',', ' or ')
-      cucumber_opts = %W[#{html_results} #{json_results} #{junit_results} -f rerun #{include_profiles} #{include_tags} --out failed.txt -f pretty -r features]
+      profiles = ENV['PROFILE'] || 'default'
+      include_profiles = ""
+      profiles.split(',').each do |profile|
+        include_profiles << "--profile #{profile} "
+      end
+      cucumber_opts = %W[#{html_results} #{json_results} #{junit_results} -f rerun #{include_profiles} --out failed.txt -f pretty -r features]
       features = YAML.safe_load(File.read(entry))
       t.cucumber_opts = cucumber_opts + features unless features.nil?
     end
@@ -32,11 +33,12 @@ namespace :parallel do
     task "#{run_set}" do
       timestamp = Time.now.strftime('%Y%m%d%H%M%S')
       features = YAML.safe_load(File.read(File.join(Dir.pwd, 'run_sets', "#{run_set}.yml"))).join(' ')
-      profiles = ENV['PROFILE']
-      include_profiles = profiles.nil? ? '--profile default' : '--profile ' + profiles.gsub(',', ' --profile ')
-      tags = ENV['TAGS']
-      include_tags =  tags.nil? ? '' : '--tags ' + tags.gsub(',', ' or ')
-      cucumber_opts = "#{include_profiles} #{include_tags} -f html -o output_#{timestamp}-#{run_set}-$TEST_ENV_NUMBER.html -f json -o output_#{timestamp}-#{run_set}-$TEST_ENV_NUMBER.json #{junit_results} -f rerun --out failed.txt -f CustomFormatter::PrettyFormatter -r features "
+      profiles = ENV['PROFILE'] || 'default'
+      include_profiles = ""
+      profiles.split(',').each do |profile|
+        include_profiles << "--profile #{profile} "
+      end
+      cucumber_opts = "#{include_profiles}  -f html -o output_#{timestamp}-#{run_set}-$TEST_ENV_NUMBER.html -f json -o output_#{timestamp}-#{run_set}-$TEST_ENV_NUMBER.json #{junit_results} -f rerun --out failed.txt -f CustomFormatter::PrettyFormatter -r features "
       sh "bundle exec parallel_cucumber -n 6 -o '#{cucumber_opts}' #{features}"
     end
   end


### PR DESCRIPTION
## What does this PR change?

This reverts commit 33a27ad2ee7b2a9ae9c5ef9ce918b5e8355c5b2d.
This commit is skipping all the secondary features in the CI.

## Links

https://github.com/uyuni-project/uyuni/pull/3597

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)
