### PR TITLE
Fix deprecation in systemd files

### DIFF
--- a/backend/cdn_tools/cdn-sync
+++ b/backend/cdn_tools/cdn-sync
@@ -125,7 +125,7 @@ if __name__ == '__main__':
 
         # acquire lock/check for other instances of cdn-sync
         #   i.e., lock against multiple instances of cdn-sync
-        LOCK = rhnLockfile.Lockfile('/var/run/cdn-sync.pid')
+        LOCK = rhnLockfile.Lockfile('/run/cdn-sync.pid')
 
         args = process_commandline()
 

--- a/backend/satellite_tools/mgr-update-pkg-extra-tags
+++ b/backend/satellite_tools/mgr-update-pkg-extra-tags
@@ -159,7 +159,7 @@ def main(args):
     global LOCK
     LOCK = None
     try:
-        LOCK = rhnLockfile.Lockfile('/var/run/mgr-refresh-pkg-extra-tags.pid')
+        LOCK = rhnLockfile.Lockfile('/run/mgr-refresh-pkg-extra-tags.pid')
     except rhnLockfile.LockfileLockedException:
         systemExit(1, 'ERROR: attempting to run more than one instance of '
                       'mgr-refresh-pkg-metadata Exiting.')

--- a/backend/satellite_tools/satellite-sync
+++ b/backend/satellite_tools/satellite-sync
@@ -65,7 +65,7 @@ except ImportError:
 #   i.e., lock against multiple instances of satellite-sync
 LOCK = None
 try:
-    LOCK = rhnLockfile.Lockfile('/var/run/satellite-sync.pid')
+    LOCK = rhnLockfile.Lockfile('/run/satellite-sync.pid')
 except rhnLockfile.LockfileLockedException:
     systemExit(1, "SYNC ERROR: attempting to run more than one instance of mgr-inter-sync. Exiting.")
 

--- a/backend/satellite_tools/spacewalk-remove-channel
+++ b/backend/satellite_tools/spacewalk-remove-channel
@@ -69,7 +69,7 @@ options_table = [
 ]
 
 LOCK = []
-LOCK_DIR = '/var/run'
+LOCK_DIR = '/run'
 
 
 def main():

--- a/backend/satellite_tools/spacewalk-repo-sync
+++ b/backend/satellite_tools/spacewalk-repo-sync
@@ -69,7 +69,7 @@ def main():
 
     global LOCK
     try:
-        LOCK = rhnLockfile.Lockfile('/var/run/spacewalk-repo-sync.pid')
+        LOCK = rhnLockfile.Lockfile('/run/spacewalk-repo-sync.pid')
     except rhnLockfile.LockfileLockedException:
         systemExit(1, "ERROR: attempting to run more than one instance of "
                       "spacewalk-repo-sync Exiting.")

--- a/backend/satellite_tools/update-packages
+++ b/backend/satellite_tools/update-packages
@@ -58,7 +58,7 @@ except ImportError:
 #   i.e., lock against multiple instances of updatePackages
 LOCK = None
 try:
-    LOCK = rhnLockfile.Lockfile('/var/run/update-packages.pid')
+    LOCK = rhnLockfile.Lockfile('/run/update-packages.pid')
 except rhnLockfile.LockfileLockedException:
     systemExit(1, "ERROR: attempting to run more than one instance of update-packages. Exiting.")
 

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,5 @@
+- change deprecated path /var/run into /run for systemd (bsc#1185059)
+
 -------------------------------------------------------------------
 Mon Apr 19 14:50:31 CEST 2021 - jgonzalez@suse.com
 

--- a/client/tools/mgr-osad/mgr-osad.changes
+++ b/client/tools/mgr-osad/mgr-osad.changes
@@ -1,3 +1,5 @@
+- change deprecated path /var/run into /run for systemd (bsc#1185178)
+
 -------------------------------------------------------------------
 Thu Feb 25 12:13:37 CET 2021 - jgonzalez@suse.com
 

--- a/client/tools/mgr-osad/osa-dispatcher-selinux/osa-dispatcher.fc
+++ b/client/tools/mgr-osad/osa-dispatcher-selinux/osa-dispatcher.fc
@@ -1,4 +1,4 @@
 /usr/sbin/osa-dispatcher(-\d.\d)?	gen_context(system_u:object_r:osa_dispatcher_exec_t,s0)
 /var/log/rhn/osa-dispatcher\.log	gen_context(system_u:object_r:osa_dispatcher_log_t,s0)
 /var/log/rhn/oracle/osa-dispatcher	gen_context(system_u:object_r:osa_dispatcher_log_t,s0)
-/var/run/osa-dispatcher\.pid	gen_context(system_u:object_r:osa_dispatcher_var_run_t,s0)
+/run/osa-dispatcher\.pid		gen_context(system_u:object_r:osa_dispatcher_var_run_t,s0)

--- a/client/tools/mgr-osad/osa-dispatcher.service
+++ b/client/tools/mgr-osad/osa-dispatcher.service
@@ -7,9 +7,9 @@ Requires=spacewalk-wait-for-jabberd.service
 [Service]
 Type=forking
 EnvironmentFile=-/etc/sysconfig/osa-dispatcher
-PIDFile=/var/run/osa-dispatcher.pid
-ExecStart=/usr/sbin/osa-dispatcher --pid-file /var/run/osa-dispatcher.pid
-ExecStartPre=/bin/rm -f /var/run/osa-dispatcher.pid
+PIDFile=/run/osa-dispatcher.pid
+ExecStart=/usr/sbin/osa-dispatcher --pid-file /run/osa-dispatcher.pid
+ExecStartPre=/bin/rm -f /run/osa-dispatcher.pid
 
 [Install]
 WantedBy=multi-user.target

--- a/client/tools/mgr-osad/osad.service
+++ b/client/tools/mgr-osad/osad.service
@@ -6,8 +6,8 @@ After=syslog.target network.target
 Type=forking
 KillMode=process
 EnvironmentFile=-/etc/sysconfig/osad
-PIDFile=/var/run/osad.pid
-ExecStart=/usr/sbin/osad --pid-file /var/run/osad.pid
+PIDFile=/run/osad.pid
+ExecStart=/usr/sbin/osad --pid-file /run/osad.pid
 
 [Install]
 WantedBy=multi-user.target

--- a/java/code/src/com/redhat/rhn/frontend/action/channel/manage/SyncRepositoriesAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/channel/manage/SyncRepositoriesAction.java
@@ -54,7 +54,7 @@ import javax.servlet.http.HttpServletResponse;
  */
 public class SyncRepositoriesAction extends RhnAction implements Listable {
 
-    private static final String REPOSYNC_LOCKFILE = "/var/run/spacewalk-repo-sync.pid";
+    private static final String REPOSYNC_LOCKFILE = "/run/spacewalk-repo-sync.pid";
 
   /**
    *

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- change deprecated path /var/run into /run for systemd (bsc#1185059)
 - add virtual network edit action
 - Lower case fqdn comparation when calculating minion connection path (bsc#1184849)
 

--- a/proxy/installer/jabberd/c2s.xml
+++ b/proxy/installer/jabberd/c2s.xml
@@ -6,7 +6,7 @@
   <!-- The process ID file. comment this out if you don't need to know
        to know the process ID from outside the process (eg for control
        scripts) -->
-  <pidfile>/var/run/jabberd/jabberd-c2s.pid</pidfile>
+  <pidfile>/run/jabberd/jabberd-c2s.pid</pidfile>
 
   <!-- Router connection configuration -->
   <router>

--- a/proxy/installer/jabberd/sm.xml
+++ b/proxy/installer/jabberd/sm.xml
@@ -9,7 +9,7 @@
   <!-- The process ID file. comment this out if you don't need to know
        to know the process ID from outside the process (eg for control
        scripts) -->
-  <pidfile>/var/run/jabberd/jabberd-sm.pid</pidfile>
+  <pidfile>/run/jabberd/jabberd-sm.pid</pidfile>
 
   <!-- Router connection configuration -->
   <router>

--- a/proxy/installer/spacewalk-proxy-installer.changes
+++ b/proxy/installer/spacewalk-proxy-installer.changes
@@ -1,3 +1,5 @@
+- change deprecated path /var/run into /run for systemd (bsc#1185059)
+
 -------------------------------------------------------------------
 Thu Feb 25 12:08:14 CET 2021 - jgonzalez@suse.com
 

--- a/spacewalk/admin/spacewalk-admin.changes
+++ b/spacewalk/admin/spacewalk-admin.changes
@@ -1,3 +1,5 @@
+- change deprecated path /var/run into /run for systemd (bsc#1185059)
+
 -------------------------------------------------------------------
 Tue Apr 20 16:27:53 CEST 2021 - jgonzalez@suse.com
 

--- a/spacewalk/admin/spacewalk-service.systemd
+++ b/spacewalk/admin/spacewalk-service.systemd
@@ -61,7 +61,7 @@ list() {
 
 start() {
     echo "Starting spacewalk services..."
-    DISABLE_FILE=/var/run/spacewalk-wait-for-tomcat-disable
+    DISABLE_FILE=/run/spacewalk-wait-for-tomcat-disable
     if [ "$WAIT_FOR_TOMCAT" == "1" ] ; then
         rm -f $DISABLE_FILE
     else

--- a/spacewalk/admin/spacewalk-wait-for-tomcat.service
+++ b/spacewalk/admin/spacewalk-wait-for-tomcat.service
@@ -2,7 +2,7 @@
 Description=Spacewalk wait for tomcat
 After=tomcat.service
 Before=httpd.service
-ConditionPathExists=!/var/run/spacewalk-wait-for-tomcat-disable
+ConditionPathExists=!/run/spacewalk-wait-for-tomcat-disable
 
 [Service]
 ExecStart=/usr/sbin/spacewalk-startup-helper wait-for-tomcat

--- a/spacewalk/admin/spacewalk-wait-for-tomcat.service.SUSE
+++ b/spacewalk/admin/spacewalk-wait-for-tomcat.service.SUSE
@@ -2,7 +2,7 @@
 Description=Spacewalk wait for tomcat
 After=tomcat.service
 Before=apache2.service
-ConditionPathExists=!/var/run/spacewalk-wait-for-tomcat-disable
+ConditionPathExists=!/run/spacewalk-wait-for-tomcat-disable
 
 [Service]
 ExecStart=/usr/sbin/spacewalk-startup-helper wait-for-tomcat

--- a/spacewalk/spacewalk-setup-postgresql/bin/spacewalk-setup-postgresql
+++ b/spacewalk/spacewalk-setup-postgresql/bin/spacewalk-setup-postgresql
@@ -94,7 +94,7 @@ PG_IDENT="$PG_DATA/pg_ident.conf"
 POSTGRESQL="$PG_DATA/postgresql.conf"
 POSTGRESQL_SW_APPEND=/usr/share/spacewalk/setup/postgresql.conf
 PORT=5432
-PG_PIDFILE="/var/run/postmaster.$PORT.pid"
+PG_PIDFILE="/run/postmaster.$PORT.pid"
 if isSUSE ; then
     PG_PIDFILE="$PG_DATA/postmaster.pid"
 fi

--- a/spacewalk/spacewalk-setup-postgresql/spacewalk-setup-postgresql.changes
+++ b/spacewalk/spacewalk-setup-postgresql/spacewalk-setup-postgresql.changes
@@ -1,3 +1,5 @@
+- change deprecated path /var/run into /run for systemd (bsc#1185059)
+
 -------------------------------------------------------------------
 Fri Sep 18 11:45:29 CEST 2020 - jgonzalez@suse.com
 

--- a/susemanager-utils/testing/docker/master/uyuni-master-cobbler/cobbler_web.conf
+++ b/susemanager-utils/testing/docker/master/uyuni-master-cobbler/cobbler_web.conf
@@ -8,7 +8,7 @@ RewriteCond %{REQUEST_URI} ^/cobbler_web
 RewriteRule (.*) https://%{HTTP_HOST}%{REQUEST_URI}
 
 # Use separate process group for wsgi
-WSGISocketPrefix /var/run/wsgi
+WSGISocketPrefix /run/wsgi
 WSGIScriptAlias /cobbler_web /usr/share/cobbler/web/cobbler.wsgi
 WSGIDaemonProcess cobbler_web display-name=%{GROUP}
 WSGIProcessGroup cobbler_web

--- a/susemanager/src/mgr-create-bootstrap-repo
+++ b/susemanager/src/mgr-create-bootstrap-repo
@@ -683,7 +683,7 @@ def main():
 
     global LOCK
     try:
-        LOCK = rhnLockfile.Lockfile('/var/run/mgr-create-bootstrap-repo.pid')
+        LOCK = rhnLockfile.Lockfile('/run/mgr-create-bootstrap-repo.pid')
     except rhnLockfile.LockfileLockedException:
         sys.stderr.write("ERROR: attempting to run more than one instance of "
                          "mgr-create-bootstrap-repo Exiting.\n")

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,5 @@
+- change deprecated path /var/run into /run for systemd (bsc#1185059)
+
 -------------------------------------------------------------------
 Mon Apr 19 14:52:48 CEST 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Path `/var/run` is deprecated and should be replaces with `/run/`

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/14660

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
