### PR TITLE
Fix ReactSelect options placement in modal dialogs (bsc#1183997)

### DIFF
--- a/web/html/src/components/input/Select.tsx
+++ b/web/html/src/components/input/Select.tsx
@@ -79,6 +79,10 @@ export function Select(props: Props) {
       ...styles,
       zIndex: 3,
     }),
+    menuPortal: (styles: {}) => ({
+      ...styles,
+      zIndex: 9999
+    }),
   };
 
   return (
@@ -112,6 +116,7 @@ export function Select(props: Props) {
             styles={bootstrapStyles}
             isMulti={props.isMulti}
             aria-label={props.title}
+            menuPortalTarget={document.body}
           />
         );
       }}

--- a/web/html/src/utils/test-utils/index.ts
+++ b/web/html/src/utils/test-utils/index.ts
@@ -3,6 +3,7 @@ import { setupServer } from "msw/node";
 
 // See https://testing-library.com/docs/ecosystem-user-event/#api
 import userEvent from "@testing-library/user-event";
+import * as selectEvent from "react-select-event";
 
 // Reexport everything so we can get all of our utilities from a single location
 // See https://testing-library.com/docs/react-testing-library/api/
@@ -47,6 +48,10 @@ export const type = async (elementOrPromiseOfElement, text) => {
 };
 
 export * from "./forms";
+
+export const select = async (...[input, option, config]: Parameters<typeof selectEvent.select>) => {
+  return selectEvent.select(input, option, Object.assign({}, {container: document.body}, config));
+}
 
 const baseServer = setupServer();
 const serverAddons = {

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Fix rendering of select items in modal dialogs (bsc#1183997)
 - Show the info about unsynced patches in the Content Lifecycle Management screens
 - virtual network edit action
 


### PR DESCRIPTION
## What does this PR change?

Fixes the positioning of the react select choices menu in modal dialogs.

## GUI diff

Before:

![image](https://user-images.githubusercontent.com/397931/115891520-76128500-a456-11eb-8caa-a8340d2e8fb7.png)

After:

![image](https://user-images.githubusercontent.com/397931/115891562-7f035680-a456-11eb-8b55-aabd40946d6d.png)

- [X] **DONE**

## Documentation
- No documentation needed: only fixes rendering

- [X] **DONE**

## Test coverage
- No tests: too hard to test

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
