### PR TITLE
Testsuite: Fix union syntaxis for tags

### DIFF
--- a/testsuite/Rakefile
+++ b/testsuite/Rakefile
@@ -17,8 +17,8 @@ namespace :cucumber do
       profiles = ENV['PROFILE']
       include_profiles = profiles.nil? ? '--profile default' : '--profile ' + profiles.gsub(',', ' --profile ')
       tags = ENV['TAGS']
-      include_tags =  tags.nil? ? '' : '--tags ' + tags.gsub(',', ' or ')
-      cucumber_opts = %W[#{html_results} #{json_results} #{junit_results} -f rerun #{include_profiles} #{include_tags} --out failed.txt -f pretty -r features]
+      include_tags = tags.nil? ? [] : ['--tags'] + [tags.split(',').map {|x| '@' + x}.join(',')]
+      cucumber_opts = %W[#{html_results} #{json_results} #{junit_results} -f rerun #{include_profiles} --out failed.txt -f pretty -r features] + include_tags
       features = YAML.safe_load(File.read(entry))
       t.cucumber_opts = cucumber_opts + features unless features.nil?
     end
@@ -35,7 +35,7 @@ namespace :parallel do
       profiles = ENV['PROFILE']
       include_profiles = profiles.nil? ? '--profile default' : '--profile ' + profiles.gsub(',', ' --profile ')
       tags = ENV['TAGS']
-      include_tags =  tags.nil? ? '' : '--tags ' + tags.gsub(',', ' or ')
+      include_tags = tags.nil? ? '' : '--tags ' + tags.split(',').map {|x| '@' + x}.join(',')
       cucumber_opts = "#{include_profiles} #{include_tags} -f html -o output_#{timestamp}-#{run_set}-$TEST_ENV_NUMBER.html -f json -o output_#{timestamp}-#{run_set}-$TEST_ENV_NUMBER.json #{junit_results} -f rerun --out failed.txt -f CustomFormatter::PrettyFormatter -r features "
       sh "bundle exec parallel_cucumber -n 6 -o '#{cucumber_opts}' #{features}"
     end


### PR DESCRIPTION
## What does this PR change?
It fixes the union of the tags.

The Cucumber syntaxis for tag union (i.e. OR) is:
```
--tags @foo,@bar,@baz
```

While the syntaxis for tag intersection (i.e. AND) is:
```
--tags @foo --tags @bar --tags @baz.
```

- testsuite/Rakefile:
Prefix tags with '@'.
Use the right syntaxis for their union.


## Links

Fixes https://github.com/uyuni-project/uyuni/pull/3614
### Ports
- Manager-4.1: https://github.com/SUSE/spacewalk/pull/14665
- Manager-4.0: https://github.com/SUSE/spacewalk/pull/14666

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

