### PR TITLE
QA: Use the correct tags expressions for Cucumber 2.0.0

### DIFF
--- a/testsuite/Rakefile
+++ b/testsuite/Rakefile
@@ -15,10 +15,15 @@ namespace :cucumber do
       json_results = "-f json -o output_#{timestamp}-#{filename}.json"
       html_results = "-f html -o output_#{timestamp}-#{filename}.html"
       profiles = ENV['PROFILE']
+      # Our profiles include a --tags keyword in all of them, if we have multiple profiles in the list
+      # it will act as an intersection of tags, not as an union of them.
       include_profiles = profiles.nil? ? '--profile default' : '--profile ' + profiles.gsub(',', ' --profile ')
       tags = ENV['TAGS']
-      include_tags =  tags.nil? ? '' : '--tags ' + tags.gsub(',', ' or ')
-      cucumber_opts = %W[#{html_results} #{json_results} #{junit_results} -f rerun #{include_profiles} #{include_tags} --out failed.txt -f pretty -r features]
+      # We provide the list of tags including the '@', so if necessary we can provide a negative tag '~@' on this list.
+      # We generate the tags list as an union of tags, not as an intersection of them (that would be using multiple times `--tags`)
+      # WARNING: When we upgrade Cucumber 2.0.0 to a higher version, we need to use the new Tags expression implementation
+      include_tags =  tags.nil? ? [] : ['--tags', tags]
+      cucumber_opts = %W[#{html_results} #{json_results} #{junit_results} -f rerun #{include_profiles} --out failed.txt -f pretty -r features] + include_tags
       features = YAML.safe_load(File.read(entry))
       t.cucumber_opts = cucumber_opts + features unless features.nil?
     end
@@ -35,7 +40,7 @@ namespace :parallel do
       profiles = ENV['PROFILE']
       include_profiles = profiles.nil? ? '--profile default' : '--profile ' + profiles.gsub(',', ' --profile ')
       tags = ENV['TAGS']
-      include_tags =  tags.nil? ? '' : '--tags ' + tags.gsub(',', ' or ')
+      include_tags =  tags.nil? ? '' : "--tags #{tags}"
       cucumber_opts = "#{include_profiles} #{include_tags} -f html -o output_#{timestamp}-#{run_set}-$TEST_ENV_NUMBER.html -f json -o output_#{timestamp}-#{run_set}-$TEST_ENV_NUMBER.json #{junit_results} -f rerun --out failed.txt -f CustomFormatter::PrettyFormatter -r features "
       sh "bundle exec parallel_cucumber -n 6 -o '#{cucumber_opts}' #{features}"
     end


### PR DESCRIPTION
## What does this PR change?

As @calancha pointed out here https://github.com/uyuni-project/uyuni/pull/3615 we are using a tags expression that only works on a Cucumber version higher than 2.0.0, and we still need to use the previous style in the command line.

The Rake task expects a list of tags, separated by a comma, including any prepend necessary for the behavior the user wants to have, for instance: `TAGS=@scope_salt,@scope_traditional_client` which will run all the tests having one of those tags at least, another example could be `TAGS=~@scope_traditional_client` which will run all the tests not having this tag.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.0
- Manager-4.1

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
