### PR TITLE
Oes2018 sp3 bootstrap data

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -1073,6 +1073,10 @@ DATA = {
         'PDID' : -9, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/5/bootstrap/'
     },
+    'OES2018-SP3-x86_64' : {
+        'PDID' : -21, 'PKGLIST' : PKGLIST12 + ONLYSLE12 + ENHANCE12SP1 + PKGLIST12_X86_ARM,
+        'DEST' : '/srv/www/htdocs/pub/repositories/sle/12/5/bootstrap/'
+    },
     'SLE-15-aarch64' : {
         'PDID' : [1589, 2053, 1709], 'BETAPDID' : [1925], 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15SP0SP1_SALT + PKGLIST15_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/sle/15/0/bootstrap/'

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- add bootstrap repo data for OES2018-SP3-x86_64 (bsc#1183845)
 - change deprecated path /var/run into /run for systemd (bsc#1185059)
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Add bootstrap repo data for OES 2018 SP3

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **On OES product to document this**

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/14673

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
