### PR TITLE
Ansible playbook details and schedule page

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -9052,6 +9052,12 @@ Alternatively, you will want to download &lt;strong&gt;Incremental Channel Conte
           <context context-type="sourcefile">/rhn/manager/systems/details/ansible</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="ansible.playbook" xml:space="preserve">
+        <source>Execute Ansible playbook</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">com.redhat.rhn.domain.action.ActionFormatter.getActionType</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="system.entitle.formula_error" xml:space="preserve">
         <source>There was a problem assigning the Prometheus Exporters formula.</source>
         <context-group name="ctx">

--- a/java/code/src/com/suse/manager/webui/templates/minion/ansible-path-content.jade
+++ b/java/code/src/com/suse/manager/webui/templates/minion/ansible-path-content.jade
@@ -4,6 +4,9 @@ include ./minion-header.jade
 
 script(type='text/javascript').
     window.csrfToken = "#{csrf_token}";
+    window.timezone = "#{h.renderTimezone()}";
+    window.localTime = "#{h.renderLocalTime()}";
+    window.actionChains = !{actionChains};
 
 script(src='/javascript/ace-editor/src-min-noconflict/ace.js?cb=#{webBuildtimestamp}')
 script(src='/javascript/ace-editor/src-min-noconflict/ext-modelist.js?cb=#{webBuildtimestamp}')

--- a/web/html/src/components/action-schedule.tsx
+++ b/web/html/src/components/action-schedule.tsx
@@ -25,7 +25,7 @@ type ActionScheduleProps = {
   localTime?: string;
   actionChains?: Array<ActionChain>;
   onDateTimeChanged: (date: Date) => void;
-  onActionChainChanged?: (actionChain: ActionChain | null | undefined) => void;
+  onActionChainChanged?: (actionChain: ActionChain) => void;
   systemIds?: Array<number>;
   actionType?: string;
 };

--- a/web/html/src/components/messages.tsx
+++ b/web/html/src/components/messages.tsx
@@ -80,9 +80,9 @@ export class Messages extends React.Component<Props> {
         const items: Array<MessageType> = Array.isArray(this.props.items) ? this.props.items : [this.props.items];
         if (items.length === 0) return null;
 
-        var msgs = items.map((item, index) => (
-            <div key={"msg" + index} className={"alert alert-" + _classNames[item.severity]}>
-                {Array.isArray(item.text) ? item.text.map(txt => <div>{txt}</div>) : item.text}
+        var msgs = items.map((item, i) => (
+            <div key={`msg${i}`} className={"alert alert-" + _classNames[item.severity]}>
+                {Array.isArray(item.text) ? item.text.map((txt, i) => <div key={`msg-text${i}`}>{txt}</div>) : item.text}
             </div>
         ));
 

--- a/web/html/src/components/messages.tsx
+++ b/web/html/src/components/messages.tsx
@@ -78,6 +78,7 @@ export class Messages extends React.Component<Props> {
 
     render() {
         const items: Array<MessageType> = Array.isArray(this.props.items) ? this.props.items : [this.props.items];
+        if (items.length === 0) return null;
 
         var msgs = items.map((item, index) => (
             <div key={"msg" + index} className={"alert alert-" + _classNames[item.severity]}>

--- a/web/html/src/manager/minion/ansible/accordion-path-content.tsx
+++ b/web/html/src/manager/minion/ansible/accordion-path-content.tsx
@@ -4,9 +4,11 @@ import Network from "utils/network";
 import { Messages, Utils } from "components/messages";
 import { Loading } from "components/utils/Loading";
 import { AceEditor } from "components/ace-editor";
+import { Button } from "components/buttons";
 
 type PropsType = {
   path: AnsiblePath;
+  onSelectPlaybook: (playbook: PlaybookDetails | null) => void
 };
 
 type StateType = {
@@ -31,7 +33,7 @@ function isPlaybook(path: AnsiblePath) {
   return path.type === "playbook";
 }
 
-interface PlaybookDetails {
+export interface PlaybookDetails {
   path: AnsiblePath,
   fullPath: string,
   customInventory?: string,
@@ -115,7 +117,13 @@ class AccordionPathContent extends React.Component<PropsType, StateType> {
         { i === 0 ? <br/> : null }
         <dl className="row">
           <dt className="col-xs-2">{t('Playbook File Name')}:</dt>
-          <dd className="col-xs-8">{p.name}</dd>
+          <dd className="col-xs-8">
+            <Button
+              icon="fa-file-text-o"
+              text={p.name}
+              handler={() => this.props.onSelectPlaybook(p)}
+              className="btn-link btn-sm" />
+          </dd>
         </dl>
         <dl className="row">
           <dt className="col-xs-2">{t('Full Path')}:</dt>

--- a/web/html/src/manager/minion/ansible/ansible-path-content.tsx
+++ b/web/html/src/manager/minion/ansible/ansible-path-content.tsx
@@ -3,8 +3,9 @@ import SpaRenderer from "core/spa/spa-renderer";
 import { Messages, Utils } from "components/messages";
 import Network from "utils/network";
 import { AnsiblePath } from "./ansible-path-type";
-import AccordionPathContent from "./accordion-path-content";
+import AccordionPathContent, { PlaybookDetails } from "./accordion-path-content";
 import { Loading } from "components/utils/Loading";
+import SchedulePlaybook from "./schedule-playbook";
 
 type PropsType = {
   minionServerId: number;
@@ -15,6 +16,7 @@ type StateType = {
   minionServerId: number;
   pathContentType: string;
   pathList: AnsiblePath[];
+  selectedPlaybook: PlaybookDetails | null;
   errors: string[];
   loading: boolean;
 };
@@ -27,6 +29,7 @@ class AnsiblePathContent extends React.Component<PropsType, StateType> {
       minionServerId: props.minionServerId,
       pathContentType: props.pathContentType,
       pathList: [],
+      selectedPlaybook: null,
       errors: [],
       loading: true
     };
@@ -43,6 +46,14 @@ class AnsiblePathContent extends React.Component<PropsType, StateType> {
   }
 
   render () {
+    if (this.state.selectedPlaybook) {
+      return (
+        <SchedulePlaybook
+          playbook={this.state.selectedPlaybook}
+          onBack={() => this.setState({selectedPlaybook: null})} />
+      );
+    }
+
     const errors = this.state.errors.length > 0 ? <Messages items={Utils.error(this.state.errors)} /> : null;
     return (
       <div>
@@ -52,7 +63,7 @@ class AnsiblePathContent extends React.Component<PropsType, StateType> {
               <Loading text={t("Loading..")} />
               :
               this.state.pathList?.length > 0 ?
-                this.state.pathList.map(p => <AccordionPathContent key={p.id} path={p} /> )
+                this.state.pathList.map(p => <AccordionPathContent key={p.id} path={p} onSelectPlaybook={(p) => this.setState({selectedPlaybook: p})} /> )
                 :
                 <div>
                   {t("Nothing configured. Please add paths in the ")}

--- a/web/html/src/manager/minion/ansible/schedule-playbook.tsx
+++ b/web/html/src/manager/minion/ansible/schedule-playbook.tsx
@@ -1,0 +1,178 @@
+import * as React from "react";
+import { useState, useEffect } from "react";
+import { Messages, MessageType, Utils as MsgUtils } from "components/messages";
+import Network, { JsonResult } from "utils/network";
+import { Combobox, ComboboxItem } from "components/combobox";
+import { ActionChain, ActionSchedule } from "components/action-schedule";
+import { AsyncButton, Button } from "components/buttons";
+import { AnsiblePath } from "./ansible-path-type";
+import { InnerPanel } from "components/panels/InnerPanel";
+import { AceEditor } from "components/ace-editor";
+import { PlaybookDetails } from "./accordion-path-content";
+import { Utils } from "utils/functions";
+import { ActionChainLink, ActionLink } from "components/links";
+
+interface SchedulePlaybookProps {
+  playbook: PlaybookDetails,
+  onBack: () => void
+}
+
+export default function SchedulePlaybook({ playbook, onBack }: SchedulePlaybookProps) {
+  const [loading, setLoading] = useState(true);
+  const [playbookContent, setPlaybookContent] = useState("");
+  const [messages, setMessages] = useState<MessageType[]>([]);
+  const [inventoryPath, setInventoryPath] = useState<ComboboxItem | null>(null);
+  const [inventories, setInventories] = useState<string[]>([]);
+  const [actionChain, setActionChain] = useState<ActionChain | null>(null);
+  const [datetime, setDatetime] = useState(new Date());
+
+  // TODO: Use UserLocalization hook instead
+  const timezone = window.timezone;
+  const localTime = window.localTime;
+
+  useEffect(() => {
+    const getInventoryPaths = async () => {
+      return Network.get(`/rhn/manager/api/systems/details/ansible/paths/inventory/${playbook.path.minionServerId}`).promise
+        .then((res: JsonResult<AnsiblePath[]>) => res.success ? res.data : Promise.reject(res))
+        .then(inv => inv.map(i => i.path))
+        .then(inv => {
+          if (playbook.customInventory) inv.push(playbook.customInventory);
+          setInventories(inv);
+        })
+        .catch(res =>
+          setMessages(res.messages?.flatMap(MsgUtils.error) || Network.responseErrorMessage(res))
+        );
+    }
+
+    const getPlaybookContents = async () => {
+      return Network.post("/rhn/manager/api/systems/details/ansible/paths/playbook-contents",
+        JSON.stringify({
+          pathId: playbook.path.id,
+          playbookRelPathStr: playbook.name
+        }),
+        "application/json"
+      ).promise
+        .then((res: JsonResult<string>) => res.success ? res.data : Promise.reject(res))
+        .then(setPlaybookContent)
+        .catch(res =>
+          setMessages(res.messages?.flatMap(MsgUtils.error) || Network.responseErrorMessage(res))
+        );
+    }
+
+    Promise.all([getInventoryPaths(), getPlaybookContents()]).finally(() => setLoading(false));
+  }, [playbook, localTime]);
+
+  useEffect(() => {
+    setDatetime(Utils.dateWithTimezone(localTime || ""));
+  }, [localTime]);
+
+  const schedule = async () => {
+    return Network.post("/rhn/manager/api/systems/details/ansible/schedule-playbook",
+      JSON.stringify({
+        playbookPath: playbook.fullPath,
+        inventoryPath: inventoryPath?.text,
+        controlNodeId: playbook.path.minionServerId,
+        actionChainLabel: actionChain?.text || null,
+        earliest: datetime
+      }),
+      "application/json"
+    ).promise
+      .then((res: JsonResult<number>) => res.success ? res.data : Promise.reject(res))
+      .then(actionId =>
+        setMessages(MsgUtils.info(<ScheduleMessage id={actionId} actionChain={actionChain?.text}/>)))
+      .catch(res =>
+        setMessages(res.messages?.flatMap(MsgUtils.error) || Network.responseErrorMessage(res))
+      );
+  };
+
+  if (loading)
+    return (<p>{t("Loading playbook contents...")}</p>); //TODO: Make pretty
+
+  const inventoryOpts: ComboboxItem[] = inventories.map((inv, i) => ({ id: i, text: inv }));
+
+  const buttons = (
+    <div className="btn-group pull-right">
+      <Button icon="fa-angle-left" className="btn-default" text={t("Back")} title={t("Back to playbook list")} handler={onBack} />
+      <AsyncButton defaultType="btn-success" action={schedule} title={t("Schedule playbook execution")} text={t("Schedule")} />
+    </div>
+  );
+
+  return (
+    <>
+      <Messages items={messages} />
+      <InnerPanel
+        title={t("Playbook '{0}'", playbook.name)}
+        icon="fa-file-text-o"
+        buttons={buttons}
+      >
+        <div className="panel panel-default">
+          <div className="panel-heading">
+            <div>
+              <h3>{t("Schedule Playbook Execution")}</h3>
+            </div>
+          </div>
+          <div className="panel-body">
+            <ActionSchedule
+              timezone={timezone}
+              localTime={localTime}
+              earliest={datetime}
+              actionChains={window.actionChains}
+              onDateTimeChanged={setDatetime}
+              onActionChainChanged={setActionChain}
+              systemIds={[playbook.path.minionServerId]}
+              actionType="states.apply"
+            />
+            <div className="form-horizontal">
+              <div className="form-group">
+                <div className="col-sm-3 control-label">
+                  <label>{t("Inventory Path")}:</label>
+                </div>
+                <div className="col-sm-6">
+                  <Combobox
+                    id="inventory-path-select"
+                    name="inventory-path-select"
+                    data={inventoryOpts}
+                    selectedId={inventoryPath?.id}
+                    onSelect={setInventoryPath}
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div>
+          <h3>{t("Playbook Content")}</h3>
+          <AceEditor
+            className="form-control"
+            id="playbook-content"
+            minLines={20}
+            maxLines={40}
+            readOnly={true}
+            mode="yaml"
+            content={playbookContent}
+          />
+        </div>
+      </InnerPanel>
+    </>
+  );
+}
+
+function ScheduleMessage({ id, actionChain }: { id: number, actionChain?: string }) {
+  if (actionChain) {
+    return (
+      <span>
+        {t("Action has been successfully added to action chain")}&nbsp;
+        <ActionChainLink id={id}>'{actionChain}'</ActionChainLink>
+      </span>
+    );
+  }
+  else {
+    return (
+      <span>
+        {t("Playbook execution has been")}&nbsp;
+        <ActionLink id={id}>{t("scheduled")}</ActionLink>
+      </span>
+    );
+  }
+}

--- a/web/html/src/manager/minion/ansible/schedule-playbook.tsx
+++ b/web/html/src/manager/minion/ansible/schedule-playbook.tsx
@@ -31,7 +31,7 @@ export default function SchedulePlaybook({ playbook, onBack }: SchedulePlaybookP
   const localTime = window.localTime;
 
   useEffect(() => {
-    const getInventoryPaths = async () => {
+    const getInventoryPaths = () => {
       return Network.get(`/rhn/manager/api/systems/details/ansible/paths/inventory/${playbook.path.minionServerId}`).promise
         .then((res: JsonResult<AnsiblePath[]>) => res.success ? res.data : Promise.reject(res))
         .then(inv => inv.map(i => i.path))
@@ -44,7 +44,7 @@ export default function SchedulePlaybook({ playbook, onBack }: SchedulePlaybookP
         );
     }
 
-    const getPlaybookContents = async () => {
+    const getPlaybookContents = () => {
       return Network.post("/rhn/manager/api/systems/details/ansible/paths/playbook-contents",
         JSON.stringify({
           pathId: playbook.path.id,
@@ -66,7 +66,7 @@ export default function SchedulePlaybook({ playbook, onBack }: SchedulePlaybookP
     setDatetime(Utils.dateWithTimezone(localTime || ""));
   }, [localTime]);
 
-  const schedule = async () => {
+  const schedule = () => {
     return Network.post("/rhn/manager/api/systems/details/ansible/schedule-playbook",
       JSON.stringify({
         playbookPath: playbook.fullPath,
@@ -120,7 +120,7 @@ export default function SchedulePlaybook({ playbook, onBack }: SchedulePlaybookP
               onDateTimeChanged={setDatetime}
               onActionChainChanged={setActionChain}
               systemIds={[playbook.path.minionServerId]}
-              actionType="states.apply"
+              actionType="ansible.playbook"
             />
             <div className="form-horizontal">
               <div className="form-group">

--- a/web/html/src/manager/minion/ansible/schedule-playbook.tsx
+++ b/web/html/src/manager/minion/ansible/schedule-playbook.tsx
@@ -11,6 +11,7 @@ import { AceEditor } from "components/ace-editor";
 import { PlaybookDetails } from "./accordion-path-content";
 import { Utils } from "utils/functions";
 import { ActionChainLink, ActionLink } from "components/links";
+import { Loading } from "components/utils/Loading";
 
 interface SchedulePlaybookProps {
   playbook: PlaybookDetails,
@@ -86,7 +87,8 @@ export default function SchedulePlaybook({ playbook, onBack }: SchedulePlaybookP
   };
 
   if (loading)
-    return (<p>{t("Loading playbook contents...")}</p>); //TODO: Make pretty
+    return <Loading text={t("Loading playbook contents..")} />;
+
 
   const inventoryOpts: ComboboxItem[] = inventories.map((inv, i) => ({ id: i, text: inv }));
 


### PR DESCRIPTION
Implement Ansible playbook details page to show a playbook's content and schedule execution.

## GUI diff
![playbook-details](https://user-images.githubusercontent.com/1103552/116690352-8cba5e00-a9b9-11eb-821b-8da7eb08c23c.png)

## Test coverage
- Unit tests will be added with a separate PR

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
