### PR TITLE
Virtual console improvements

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/LibvirtEngineDomainLifecycleMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/LibvirtEngineDomainLifecycleMessageAction.java
@@ -68,6 +68,8 @@ public class LibvirtEngineDomainLifecycleMessageAction implements MessageAction 
                 final String guid = VirtualInstanceManager.fixUuidIfSwappedUuidExists(
                         message.getDomainUUID().replaceAll("-", ""));
 
+                VirtNotifications.spreadGuestEvent(minion.getId(), guid, event, message.getDetail());
+
                 List<VirtualInstance> vms = VirtualInstanceFactory.getInstance().lookupVirtualInstanceByUuid(guid);
                 if (vms.isEmpty()) {
                     // We got a machine created from outside SUMA,

--- a/java/code/src/com/suse/manager/webui/controllers/virtualization/AbstractVirtualizationController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/virtualization/AbstractVirtualizationController.java
@@ -66,7 +66,7 @@ public abstract class AbstractVirtualizationController {
             .serializeNulls()
             .create();
 
-    private final String jadeTemplatesPath;
+    protected final String jadeTemplatesPath;
     protected final VirtManager virtManager;
 
     /**

--- a/java/code/src/com/suse/manager/webui/controllers/virtualization/VirtualGuestsController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/virtualization/VirtualGuestsController.java
@@ -330,6 +330,10 @@ public class VirtualGuestsController extends AbstractVirtualizationController {
         String guestUuid = request.params("guestuuid");
         VirtualInstance guest = getVirtualInstanceFromUuid(guestUuid);
         Server host = guest.getHostSystem();
+        // The host may be null if the virtual machine has no assigned host yet
+        if (host == null) {
+            Spark.halt(HttpStatus.SC_BAD_REQUEST);
+        }
 
         try {
             ensureAccessToVirtualInstance(user, guest);

--- a/java/code/src/com/suse/manager/webui/templates/virtualization/guests/console.jade
+++ b/java/code/src/com/suse/manager/webui/templates/virtualization/guests/console.jade
@@ -14,6 +14,7 @@ script(type='text/javascript').
                   hostId: "#{serverId}",
                   guestUuid: "#{guestUuid}",
                   guestName: "#{guestName}",
+                  guestState: "#{guestState}",
                   graphicsType: "#{graphicsType}",
                   token: "#{token}",
               }

--- a/java/code/src/com/suse/manager/webui/templates/virtualization/guests/console.jade
+++ b/java/code/src/com/suse/manager/webui/templates/virtualization/guests/console.jade
@@ -1,5 +1,10 @@
 #virtualguests-console(style="height: 100%")
 
+input(type="hidden", name="csrf_token" value="#{csrf_token}")
+
+script(type='text/javascript').
+    window.csrfToken = "#{csrf_token}";
+
 script(type='text/javascript').
     spaImportReactPage('virtualization/guests/console/guests-console')
         .then(function(module) {

--- a/java/code/src/com/suse/manager/webui/templates/virtualization/guests/console.jade
+++ b/java/code/src/com/suse/manager/webui/templates/virtualization/guests/console.jade
@@ -11,7 +11,7 @@ script(type='text/javascript').
              module.renderer(
               'virtualguests-console',
               {
-                  hostId: "#{server.id}",
+                  hostId: "#{serverId}",
                   guestUuid: "#{guestUuid}",
                   guestName: "#{guestName}",
                   graphicsType: "#{graphicsType}",

--- a/java/code/src/com/suse/manager/webui/utils/test/TokenBuilderTest.java
+++ b/java/code/src/com/suse/manager/webui/utils/test/TokenBuilderTest.java
@@ -47,4 +47,17 @@ public class TokenBuilderTest extends BaseTestCaseWithUser {
         NumericDate expDate = tokenBuilder.getClaims().getExpirationTime();
         assertNotNull(expDate);
     }
+
+    public void testVerifyToken() throws Exception {
+        TokenBuilder tokenBuilder = new TokenBuilder();
+        tokenBuilder.useServerSecret();
+        String token = tokenBuilder.getToken();
+        assertTrue(TokenBuilder.verifyToken(token));
+    }
+
+    public void testWrongOriginToken() {
+        String wrongOriginToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikpva" +
+                "G4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
+        assertFalse(TokenBuilder.verifyToken(wrongOriginToken));
+    }
 }

--- a/java/code/src/com/suse/manager/webui/websocket/json/VirtNotificationMessage.java
+++ b/java/code/src/com/suse/manager/webui/websocket/json/VirtNotificationMessage.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.webui.websocket.json;
+
+import java.util.Optional;
+
+/**
+ * Describes the payload on message sent to VirtNotifications
+ */
+public class VirtNotificationMessage {
+    private Optional<Long> sid = Optional.empty();
+    private Optional<String> guestUuid = Optional.empty();
+
+    /**
+     * @return value of sid
+     */
+    public Optional<Long> getSid() {
+        return sid;
+    }
+
+    /**
+     * @param sidIn value of sid
+     */
+    public void setSid(Optional<Long> sidIn) {
+        sid = sidIn;
+    }
+
+    /**
+     * @return value of guestUuid
+     */
+    public Optional<String> getGuestUuid() {
+        return guestUuid;
+    }
+
+    /**
+     * @param guestUuidIn value of guestUuid
+     */
+    public void setGuestUuid(Optional<String> guestUuidIn) {
+        guestUuid = guestUuidIn;
+    }
+}

--- a/java/code/webapp/WEB-INF/decorators.xml
+++ b/java/code/webapp/WEB-INF/decorators.xml
@@ -10,7 +10,8 @@
         <pattern>/manager/login</pattern>
     </excludes>
     <decorator name="layout_bare" page="layout_bare.jsp">
-        <pattern>/manager/systems/details/virtualization/guests/*/console/*</pattern>
+        <pattern>/manager/systems/details/virtualization/*/guests/console/*</pattern>
+        <pattern>/manager/systems/details/virtualization/guests/console/*</pattern>
     </decorator>
     <decorator name="layout_error" page="layout_error.jsp" >
         <pattern>/manager/download/*</pattern>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- virtual console monitors VM state changes
 - Ansible integration: configure paths, inspect inventories, discover and schedule playbooks
 - support Amazon Linux mirror list URLs and set signed Metadata flag correct
 - Bugfix: Remove the unneeded check that was stopping updating a virtual instance type (bsc#1180673)

--- a/web/html/src/manager/virtualization/guests/console/MessagePopUp.tsx
+++ b/web/html/src/manager/virtualization/guests/console/MessagePopUp.tsx
@@ -1,0 +1,72 @@
+import * as React from "react";
+import { PopUp } from 'components/popup';
+import { Loading } from 'components/utils/Loading';
+import { Form } from 'components/input/Form';
+import { Password } from 'components/input/Password';
+import { Button } from 'components/buttons';
+import { hideDialog } from 'components/dialog/util';
+
+type Props = {
+  id: string,
+  onSubmit?: () => void,
+  popupState: "wait" | "askPassword" | "errors",
+  model: any,
+  setModel: (model: any) => void,
+  error: React.ReactNode,
+};
+
+export function MessagePopUp(props: Props) {
+  const buttonValues = {
+    askPassword: {
+      text: t('Submit'),
+    },
+    errors: {
+      text: t('Retry'),
+    },
+  }[props.popupState];
+
+  const popupContent = () => {
+    if (props.popupState === 'wait') {
+      return <Loading text={t('Connecting...')} withBorders={false} />;
+    }
+    if (props.popupState === 'askPassword') {
+      return (
+        <Form model={props.model} className="form-horizontal" onChange={props.setModel}>
+          <Password
+            name="password"
+            label={t('Password')}
+            labelClass="col-md-3"
+            divClass="col-md-6"
+          />
+        </Form>
+      );
+    }
+    return props.error;
+  };
+
+  return (
+    <PopUp
+      id={props.id}
+      hideHeader
+      content={popupContent()}
+      footer={
+        buttonValues && [
+          <Button
+            key="submit"
+            className="btn-primary"
+            text={buttonValues.text}
+            title={buttonValues.text}
+            handler={() => props.onSubmit?.()}
+          />,
+          <Button
+            key="cancel"
+            className="btn-default"
+            text={t('Cancel')}
+            title={t('Cancel')}
+            handler={() => hideDialog('popup')}
+          />,
+        ]
+      }
+    />
+  );
+};

--- a/web/html/src/manager/virtualization/guests/console/guests-console-types.js
+++ b/web/html/src/manager/virtualization/guests/console/guests-console-types.js
@@ -11,4 +11,6 @@ export interface ConsoleClientType {
   toggleScale(expanded: boolean): void;
 
   canResize: boolean;
+
+  removeErrorHandler(): void;
 }

--- a/web/html/src/manager/virtualization/guests/console/guests-console.css
+++ b/web/html/src/manager/virtualization/guests/console/guests-console.css
@@ -18,6 +18,14 @@
   margin: auto;
 }
 
+.canvas div {
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  align-items: center;
+  color: #dcddde;
+}
+
 /* Client-specific classes */
 
 .display_area_vnc {

--- a/web/html/src/manager/virtualization/guests/console/guests-console.js
+++ b/web/html/src/manager/virtualization/guests/console/guests-console.js
@@ -32,7 +32,6 @@ type State = {
 
 class GuestsConsole extends React.Component<Props, State> {
   client: ConsoleClientType;
-  inhibitPopup: boolean;
   popupSubmit: Function;
 
   constructor(props: Props) {
@@ -64,7 +63,7 @@ class GuestsConsole extends React.Component<Props, State> {
     this.connect();
 
     window.onbeforeunload = () => {
-      this.inhibitPopup = true;
+      this.client.removeErrorHandler();
     };
   }
 
@@ -98,12 +97,8 @@ class GuestsConsole extends React.Component<Props, State> {
         connected: false,
       };
     });
-    if (!this.inhibitPopup) {
-      this.popupSubmit = this.connect;
-      this.setState({ popupState: 'errors' }, this.showPopup);
-    } else {
-      hideDialog('popup');
-    }
+    this.popupSubmit = this.connect;
+    this.setState({ popupState: 'errors' }, this.showPopup);
   }
 
   toggleScale = () => {

--- a/web/html/src/manager/virtualization/guests/console/guests-console.js
+++ b/web/html/src/manager/virtualization/guests/console/guests-console.js
@@ -2,16 +2,13 @@
 
 import { hot } from 'react-hot-loader/root';
 import * as React from 'react';
-import { Loading } from 'components/utils/Loading';
-import { PopUp } from 'components/popup';
 import { Button } from 'components/buttons';
-import { Form } from 'components/input/Form';
-import { Password } from 'components/input/Password';
 import { showDialog } from 'components/dialog/util';
 import { hideDialog } from 'components/dialog/util';
 import { VncClient } from './vnc-client';
 import type { ConsoleClientType } from './guests-console-types';
 import { SpiceClient } from './spice-client';
+import { MessagePopUp } from './MessagePopUp';
 import styles from './guests-console.css';
 
 type Props = {
@@ -128,33 +125,7 @@ class GuestsConsole extends React.Component<Props, State> {
   }
 
   render() {
-    const buttonValues = {
-      askPassword: {
-        text: t('Submit'),
-      },
-      errors: {
-        text: t('Retry'),
-      },
-    }[this.state.popupState];
     const canResize = this.client != null && this.client.canResize;
-    const popupContent = () => {
-      if (this.state.popupState === 'wait') {
-        return <Loading text={t('Connecting...')} withBorders={false} />;
-      }
-      if (this.state.popupState === 'askPassword') {
-        return (
-          <Form model={this.state} className="form-horizontal" onChange={this.onPasswordChange}>
-            <Password
-              name="password"
-              label={t('Password')}
-              labelClass="col-md-3"
-              divClass="col-md-6"
-            />
-          </Form>
-        );
-      }
-      return this.state.error;
-    };
     const areaClassName = `display_area_${this.props.graphicsType}`;
     return (
       <>
@@ -176,32 +147,13 @@ class GuestsConsole extends React.Component<Props, State> {
             </li>
           </ul>
         </header>
-        <PopUp
+        <MessagePopUp
           id="popup"
-          hideHeader
-          content={popupContent()}
-          footer={
-            buttonValues !== undefined && [
-              <Button
-                key="submit"
-                className="btn-primary"
-                text={buttonValues.text}
-                title={buttonValues.text}
-                handler={() => {
-                  if (this.popupSubmit != null) {
-                    this.popupSubmit();
-                  }
-                }}
-              />,
-              <Button
-                key="cancel"
-                className="btn-default"
-                text={t('Cancel')}
-                title={t('Cancel')}
-                handler={() => hideDialog('popup')}
-              />,
-            ]
-          }
+          onSubmit={this.popupSubmit}
+          popupState={this.state.popupState}
+          model={this.state}
+          setModel={this.onPasswordChange}
+          error={this.state.error}
         />
         <div
           id="display-area"

--- a/web/html/src/manager/virtualization/guests/console/guests-console.renderer.js
+++ b/web/html/src/manager/virtualization/guests/console/guests-console.renderer.js
@@ -6,6 +6,7 @@ export const renderer = (id, {
   hostId,
   guestUuid,
   guestName,
+  guestState,
   graphicsType,
   token,
 }) => {
@@ -14,6 +15,7 @@ export const renderer = (id, {
       hostId={hostId}
       guestUuid={guestUuid}
       guestName={guestName}
+      guestState={guestState}
       graphicsType={graphicsType}
       token={token}
     />,

--- a/web/html/src/manager/virtualization/guests/console/spice-client.js
+++ b/web/html/src/manager/virtualization/guests/console/spice-client.js
@@ -11,6 +11,7 @@ class SpiceClient implements ConsoleClientType {
   connected: Function;
   disconnected: Function;
   askPassword: Function;
+  ignoreErrors: boolean;
 
   constructor(canvasId: string, socketUrl: string, connected: Function, disconnected: Function, askPassword: Function) {
     this.canvasId = canvasId;
@@ -18,10 +19,18 @@ class SpiceClient implements ConsoleClientType {
     this.connected = connected;
     this.disconnected = disconnected;
     this.askPassword = askPassword;
+    this.ignoreErrors = false;
+  }
+
+  removeErrorHandler = () => {
+    this.ignoreErrors = true;
   }
 
   onError = (e: ?Error) => {
     this.disconnect();
+    if (this.ignoreErrors) {
+      return;
+    }
     if (this.disconnected != null && e != null) {
       this.disconnected(e.message);
     }

--- a/web/html/src/manager/virtualization/guests/console/vnc-client.js
+++ b/web/html/src/manager/virtualization/guests/console/vnc-client.js
@@ -13,6 +13,13 @@ class VncClient implements ConsoleClientType {
   disconnected: Function;
   askPassword: Function;
 
+  disconnectHandler = (e) => {
+    const error = e.detail.clean ? undefined : t('Something went wrong, connection is closed');
+    if (this.disconnected != null) {
+      this.disconnected(error);
+    }
+  }
+
   constructor(canvasId: string, socketUrl: string, connected: Function, disconnected: Function, askPassword: Function) {
     this.canvasId = canvasId;
     this.socketUrl = socketUrl;
@@ -25,12 +32,7 @@ class VncClient implements ConsoleClientType {
     if (this.canvasId != null && this.socketUrl != null) {
       const rfb = new RFB(document.getElementById(this.canvasId), this.socketUrl);
       rfb.addEventListener('connect', this.onConnect);
-      rfb.addEventListener('disconnect', (e) => {
-        const error = e.detail.clean ? undefined : t('Something went wrong, connection is closed');
-        if (this.disconnected != null) {
-          this.disconnected(error);
-        }
-      });
+      rfb.addEventListener('disconnect', this.disconnectHandler);
       rfb.addEventListener('credentialsrequired',
         () => {
           if (this.askPassword != null) {
@@ -41,6 +43,10 @@ class VncClient implements ConsoleClientType {
       rfb.resizeSession = false;
       this.rfb = rfb;
     }
+  }
+
+  removeErrorHandler = () => {
+    this.rfb.removeEventListener('disconnect', this.disconnectHandler);
   }
 
   onConnect = () => {

--- a/web/html/src/manager/virtualization/guests/list/guests-list.js
+++ b/web/html/src/manager/virtualization/guests/list/guests-list.js
@@ -175,7 +175,7 @@ export function GuestsList(props: Props) {
                         title={t('Graphical Console')}
                         className="btn-default btn-sm"
                         icon="fa-desktop"
-                        href={`/rhn/manager/systems/details/virtualization/guests/${props.serverId}/console/${row.uuid}`}
+                        href={`/rhn/manager/systems/details/virtualization/guests/console/${row.uuid}`}
                         target="_blank"
                       />
                     )}

--- a/web/html/src/manager/virtualization/guests/list/guests-list.js
+++ b/web/html/src/manager/virtualization/guests/list/guests-list.js
@@ -79,12 +79,14 @@ export function GuestsList(props: Props) {
         (createModalButton, onAction) => {
             const columns = [
               <Column
+                key="name"
                 columnKey="name"
                 comparator={Utils.sortByText}
                 header={t('Guest')}
                 cell={row => row.name}
               />,
               <Column
+                key="server"
                 columnKey="serverName"
                 comparator={Utils.sortByText}
                 header={t('System')}
@@ -100,6 +102,7 @@ export function GuestsList(props: Props) {
                 }}
               />,
               <Column
+                key="status"
                 columnKey="statusType"
                 comparator={ListUtils.sortByUpdate}
                 header={t('Updates')}
@@ -111,24 +114,28 @@ export function GuestsList(props: Props) {
                 }}
               />,
               <Column
+                key="state"
                 columnKey="stateLabel"
                 header={t('State')}
                 comparator={ListUtils.sortByState}
                 cell={row => row.stateName}
               />,
               <Column
+                key="memory"
                 columnKey="memory"
                 comparator={Utils.sortByNumber}
                 header={t('Current Memory')}
                 cell={row => `${row.memory} MiB`}
               />,
               <Column
+                key="vcpus"
                 columnKey="vcpus"
                 comparator={Utils.sortByNumber}
                 header={t('vCPUs')}
                 cell={row => row.vcpus}
               />,
               <Column
+                key="channel"
                 columnKey="channelLabels"
                 comparator={Utils.sortByText}
                 header={t('Base Software Channel')}

--- a/web/html/src/manager/virtualization/guests/list/guests-list.js
+++ b/web/html/src/manager/virtualization/guests/list/guests-list.js
@@ -170,7 +170,7 @@ export function GuestsList(props: Props) {
                     {state === 'running' && row.name !== 'Domain-0' && createModalButton('suspend', modalsData, row)}
                     {state !== 'stopped' && row.name !== 'Domain-0' && createModalButton('shutdown', modalsData, row)}
                     {(state === 'paused' || state === 'running') && createModalButton('restart', modalsData, row)}
-                    {props.saltEntitled && state === 'running' && (
+                    {props.saltEntitled && (
                       <LinkButton
                         title={t('Graphical Console')}
                         className="btn-default btn-sm"

--- a/web/html/src/manager/virtualization/nets/list/nets-list.js
+++ b/web/html/src/manager/virtualization/nets/list/nets-list.js
@@ -48,18 +48,21 @@ export function NetsList(props: Props) {
           (createModalButton, onAction) => {
             const columns = [
               <Column
+                key="name"
                 columnKey="name"
                 comparator={Utils.sortByText}
                 header={t('Name')}
                 cell={row => row.name}
               />,
               <Column
+                key="state"
                 columnKey="state"
                 header={t('State')}
                 comparator={ListUtils.sortByState}
                 cell={row => row.active ? 'running' : 'stopped'}
               />,
               <Column
+                key="autostart"
                 columnKey="autostart"
                 header={t('Autostart')}
                 cell={
@@ -68,6 +71,7 @@ export function NetsList(props: Props) {
                 }
               />,
               <Column
+                key="persistent"
                 columnKey="persistent"
                 header={t('Persistent')}
                 cell={
@@ -76,6 +80,7 @@ export function NetsList(props: Props) {
                 }
               />,
               <Column
+                key="bridge"
                 columnKey="bridge"
                 comparator={Utils.sortByText}
                 header={t('Bridge')}

--- a/web/html/src/manager/virtualization/useVirtNotification.js
+++ b/web/html/src/manager/virtualization/useVirtNotification.js
@@ -39,7 +39,7 @@ export function useVirtNotification(
 
       ws.onopen = () => {
         // Tell the websocket that we want to hear from all action results on this virtual host.
-        ws.send(serverId);
+        ws.send(`{sid: ${serverId}}`);
       };
 
       ws.onclose = () => {

--- a/web/html/src/manager/virtualization/virtualization-list-refresh-api.js
+++ b/web/html/src/manager/virtualization/virtualization-list-refresh-api.js
@@ -14,9 +14,9 @@ export function VirtualizationListRefreshApi(props: Props) {
   const [data, setData] = React.useState(undefined);
   const [error, setError] = React.useState(undefined);
 
-  React.useEffect(() => refreshServerData(), [props.lastRefresh]);
+  React.useEffect(() => refreshServerData(), [props.lastRefresh, refreshServerData]);
 
-  const refreshServerData = () => {
+  const refreshServerData = React.useCallback(() => {
     Network.get(`/rhn/manager/api/systems/details/virtualization/${props.type}/${props.serverId}/data`,
                 'application/json').promise
       .then((data) => {
@@ -26,7 +26,7 @@ export function VirtualizationListRefreshApi(props: Props) {
       .catch(jqXHR => {
         setError(Network.responseErrorMessage(jqXHR));
       });
-  }
+  }, [props.serverId, props.type]);
 
   return props.children({
     data,

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- virtual console monitors VM state changes
 - Ansible integration: configure paths, inspect inventories, discover and schedule playbooks
 - Improved filtering, deleting etc in CLM filter list
 - Simplify state channels selection


### PR DESCRIPTION
## What does this PR change?

This PR improves the way the virtual console works:

  * The console can be opened even if the VM is stopped. In such a case the console will automatically connect once the VM starts.
  * The console URL doesn't depend on the virtual host server ID. This means the URL can be used to show the console of the VM wherever it is located. This is useful when the VM is migrated to another host.
  * The console doesn't show any error message when the VM is properly shut down

## GUI diff

See above.

- [X] **DONE**

## Documentation
- No documentation needed: It just makes the console more convenient to use: no need to document it.

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
