### PR TITLE
Remove 127.0.0.1 from ACL name localhost

### DIFF
--- a/proxy/installer/squid.conf
+++ b/proxy/installer/squid.conf
@@ -36,7 +36,6 @@ refresh_pattern 	.		0	100%	525960
 # secure squid
 # allow request only from localhost and to http and https ports
 acl all src 0.0.0.0/0.0.0.0
-acl localhost src 127.0.0.1/32
 acl SSL_ports port 443
 acl Safe_ports port 80          # http
 acl Safe_ports port 443         # https

--- a/proxy/proxy-docs/spacewalk-proxy-docs.changes
+++ b/proxy/proxy-docs/spacewalk-proxy-docs.changes
@@ -1,3 +1,5 @@
+- remove 127.0.0.1 acl which is already built in (bsc#1175369)
+
 -------------------------------------------------------------------
 Fri Sep 18 11:34:04 CEST 2020 - jgonzalez@suse.com
 

--- a/proxy/proxy-docs/squid.conf.sample
+++ b/proxy/proxy-docs/squid.conf.sample
@@ -16,7 +16,6 @@ memory_replacement_policy heap GDSF
 refresh_pattern 	.		0	100%	120000
 
 acl all src 0.0.0.0/0.0.0.0
-acl localhost src 127.0.0.1/255.255.255.255
 acl SSL_ports port 443
 acl Safe_ports port 80          # http
 acl Safe_ports port 443         # https

--- a/proxy/proxy/spacewalk-proxy.changes
+++ b/proxy/proxy/spacewalk-proxy.changes
@@ -1,3 +1,5 @@
+- remove 127.0.0.1 acl which is already built in (bsc#1175369)
+
 -------------------------------------------------------------------
 Thu Feb 25 12:07:16 CET 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

In proxy 3.2, 127.0.0.1 was added as a builtin acl. Having it
explicitely in squid.conf, is a duplication and makes this warning
appear:

2020/08/17 16:47:14| WARNING: (B) '127.0.0.1' is a subnetwork of (A)
'127.0.0.1'
2020/08/17 16:47:14| WARNING: because of this '127.0.0.1' is ignored to
keep splay tree searching predictable
2020/08/17 16:47:14| WARNING: You should probably remove '127.0.0.1'
from the ACL named 'localhost'

## GUI diff

Before:

If you run "systemctl status squid" you would see

```
Aug 17 16:46:48 sumaproxy squid[5606]: 2020/08/17 16:46:48| WARNING: (B) '127.0.0.1' is a subnetwork of (A) '127.0.0.1'
Aug 17 16:46:48 sumaproxy squid[5606]: 2020/08/17 16:46:48| WARNING: because of this '127.0.0.1' is ignored to keep splay tree searching predictable
Aug 17 16:46:48 sumaproxy squid[5606]: 2020/08/17 16:46:48| WARNING: You should probably remove '127.0.0.1' from the ACL named 'localhost'
```

After:

Running the same command, the warning has disappeared.

- [X] **DONE**

## Documentation
- No documentation needed: This is fixing an issue that does not really modify the product.

- [X] **DONE**

## Test coverage
- No tests: Run e2e tests for regressions

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/14059

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
