### PR TITLE
Move Prometheus exporters data to dedicated map

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/formula/FormulaFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/formula/FormulaFactory.java
@@ -910,9 +910,11 @@ public class FormulaFactory {
      */
     @SuppressWarnings("unchecked")
     public static Map<String, Object> disableMonitoring(Map<String, Object> formData) {
-        ((Map<String, Object>) formData.get("node_exporter")).put("enabled", false);
-        ((Map<String, Object>) formData.get("apache_exporter")).put("enabled", false);
-        ((Map<String, Object>) formData.get("postgres_exporter")).put("enabled", false);
+        Map<String, Object> exporters = (Map<String, Object>) formData.get("exporters");
+        for (Object exporter : exporters.values()) {
+            Map<String, Object> exporterMap = (Map<String, Object>) exporter;
+            exporterMap.put("enabled", false);
+        }
         return formData;
     }
 
@@ -940,11 +942,10 @@ public class FormulaFactory {
 
     @SuppressWarnings("unchecked")
     private static boolean hasMonitoringDataEnabled(Map<String, Object> formData) {
-        Map<String, Object> nodeExporter = (Map<String, Object>) formData.get("node_exporter");
-        Map<String, Object> apacheExporter = (Map<String, Object>) formData.get("apache_exporter");
-        Map<String, Object> postgresExporter = (Map<String, Object>) formData.get("postgres_exporter");
-        return (boolean) nodeExporter.get("enabled") || (boolean) apacheExporter.get("enabled") ||
-                (boolean) postgresExporter.get("enabled");
+        Map<String, Object> exporters = (Map<String, Object>) formData.get("exporters");
+        return exporters.values().stream()
+                .map(exporter -> (Map<String, Object>) exporter)
+                .anyMatch(exporter -> (boolean) exporter.get("enabled"));
     }
 
     /**


### PR DESCRIPTION
## What does this PR change?

This PR updates the methods which evaluate the body of Prometheus exporters formula data and reflects its new schema with dedicated map named `exporters`.

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: updated existing methods

- [x] **DONE**

## Links

Requires SUSE/salt-formulas#102

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
