### PR TITLE
Exclude minions from the systems list for locally-managed/sandbox files during copy To operation.

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/config_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/config_queries.xml
@@ -1056,7 +1056,17 @@ ORDER BY  S.name
   </query>
 
 <mode name="systems_for_copy" class="com.redhat.rhn.frontend.dto.ConfigSystemDto">
-        <query name="find_systems"></query>
+        <query params="user_id">
+            SELECT  DISTINCT S.name, S.id
+            FROM  rhnServer S
+                INNER JOIN rhnUserServerPerms USP on USP.server_id = S.id
+                INNER JOIN rhnServerFeaturesView SFV on SFV.server_id = s.id
+            WHERE  USP.user_id = :user_id
+                AND  S.id = USP.server_id
+                AND SFV.label = 'ftr_config'
+                AND NOT EXISTS (SELECT 1 FROM suseMinionInfo WHERE server_id = S.id)
+            ORDER BY  S.name
+        </query>
         <elaborator params="cfnid,label">
 SELECT  S.id,
                 CC.id AS config_channel_id,

--- a/java/code/src/com/redhat/rhn/manager/configuration/test/ConfigurationManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/configuration/test/ConfigurationManagerTest.java
@@ -76,6 +76,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
+import java.util.stream.LongStream;
 
 public class ConfigurationManagerTest extends BaseTestCaseWithUser {
 
@@ -114,6 +115,7 @@ public class ConfigurationManagerTest extends BaseTestCaseWithUser {
 
         // Create a system
         Server srv1 = ServerFactoryTest.createTestServer(user, true);
+        Server minion = MinionServerFactoryTest.createTestMinionServer(user);
 
         // Create a local for that system
         ConfigChannel local = srv1.getLocalOverride();
@@ -159,6 +161,11 @@ public class ConfigurationManagerTest extends BaseTestCaseWithUser {
             listSystemsForFileCopy(user,
                     cfnids[0], ConfigChannelType.local(), null);
         assertNotNull(dr);
+
+        // make sure we don't get any minion back in the list because this is not supported
+        assertFalse(dr.stream().flatMapToLong(id -> LongStream.of(((ConfigSystemDto) id).getId()))
+                .anyMatch(id->id==minion.getId()));
+
         Map<String, Object> elabParams = new HashMap<String, Object>();
         elabParams.put("cfnid", cfnids[0]);
         elabParams.put("label", ConfigChannelType.local().getLabel());

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Exclude minions from the list of locally-managed/sandbox systems when copying config files (bsc#1184940)
 - Remove activation key display from system details page
 - change deprecated path /var/run into /run for systemd (bsc#1185059)
 - add virtual network edit action


### PR DESCRIPTION
## What does this PR change?

We don't support local-managed or sandbox files on the minion https://documentation.suse.com/external-tree/en-us/suma/4.1/suse-manager/client-configuration/configuration-management.html.
 But there was still the way that customers were able to assign locally-managed/sandbox file to the minion and later got stuck because there was a problem. This PR make sure that customers don't get into that situation, to begin with

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: documentation is already there that it is not suppored

- [x] **DONE**

## Test coverage
-Unit test : existing test updated
- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
