### PR TITLE
Easier recycling systems

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -153,11 +153,11 @@ public class RegisterMinionEventMessageAction implements MessageAction {
             grains-> {
                 boolean saltbootInitrd = grains.getSaltbootInitrd();
                 Optional<String> mkey = grains.getSuseManagerGrain().flatMap(sm -> sm.getManagementKey());
-                Optional<ActivationKey> activationKey =
+                Optional<ActivationKey> managementKey =
                         mkey.flatMap(mk -> ofNullable(ActivationKeyFactory.lookupByKey(mk)));
                 Optional<String> validReactivationKey =
-                        mkey.filter(mk -> isValidReactivationKey(activationKey, minionId));
-                updateKickStartSession(activationKey);
+                        mkey.filter(mk -> isValidReactivationKey(managementKey, minionId));
+                updateKickStartSession(managementKey);
                 Optional<String> machineIdOpt = grains.getMachineId();
                 Opt.consume(machineIdOpt,
                     ()-> LOG.error("Aborting: cannot find machine id for minion: " + minionId),

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Change onboarding behavior to easier recycle systems (bsc#1183437)
 - The 'cookie' property for pkgset beacon was removed as no longer required
 - virtual console monitors VM state changes
 - Ansible integration: configure paths, inspect inventories, discover and schedule playbooks


### PR DESCRIPTION
## What does this PR change?

Implement a different behavior when onboarding minions under certain conditions.
Introduced because of https://bugzilla.suse.com/1183437

Short: change the way we handle registration requests of minions when a similar system already exists in the DB.
Main changes: when a system with the minion_id already exists we aborted in the past. Now we try to cleanup the DB by deleting conflicting systems.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- https://github.com/uyuni-project/uyuni-docs/pull/933

- [x] **DONE**

## Test coverage
- Unit tests were added/updated

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/14261

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
