### PR TITLE
Testsuite: Fix trad_centos_client.feature

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -842,7 +842,7 @@ When(/^I (install|remove) OpenSCAP dependencies (on|from) "([^"]*)"$/) do |actio
   if os_family =~ /^opensuse/ || os_family =~ /^sles/
     pkgs = 'openscap-utils openscap-content'
   elsif os_family =~ /^centos/
-    pkgs = 'openscap-utils scap-security-guide'
+    pkgs = 'openscap-utils scap-security-guide-redhat'
   elsif os_family =~ /^ubuntu/
     pkgs = 'libopenscap8 ssg-debderived'
   end


### PR DESCRIPTION
## What does this PR change?
This test is failing because we are not installing the right OpenSCAP package.
Install the specific OpenSCAP package for Red Hat.

## What does this PR change?

## Links

### Ports
- Manager-4.1: https://github.com/SUSE/spacewalk/pull/14684
- Manager-4.0: https://github.com/SUSE/spacewalk/pull/14685

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)
