### PR TITLE
Correct the macro to check for opensuse ("is_opensuse")

### DIFF
--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -635,7 +635,7 @@ rm -rf $RPM_BUILD_ROOT%{_datadir}/rhn/unittest.xml
 %endif
 
 # Prettifying symlinks, excluding openSUSE
-%if ! 0%{?opensuse}
+%if ! 0%{?is_opensuse}
 mv $RPM_BUILD_ROOT%{jardir}/jboss-loggingjboss-logging.jar $RPM_BUILD_ROOT%{jardir}/jboss-logging.jar
 %endif
 


### PR DESCRIPTION
## What does this PR change?

This patch is fixing a macro in the spec file: `opensuse` -> `is_opensuse`.

## GUI diff

No difference.

- [X] **DONE**

## Documentation

- No documentation needed.

- [X] **DONE**

## Test coverage

- No tests needed.

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below).

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
