### PR TITLE
Add script to update TEST:CR obs projects

### DIFF
--- a/susemanager-utils/testing/automation/update-obs-environment-cr-project.sh
+++ b/susemanager-utils/testing/automation/update-obs-environment-cr-project.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [ $# -ne 1 ];then
+    echo "usage: $0 N"
+    echo "where N is the environment"
+    echo "$0 will add new packages in systemsmanagement:Uyuni:Master to systemsmanagement:Uyuni:Master:TEST:N:CR"
+    exit -1
+fi    
+
+
+for i in $(diff <( osc ls systemsmanagement:Uyuni:Master:TEST:$1:CR ) <( osc ls systemsmanagement:Uyuni:Master ) | grep ">" | cut -d" " -f2);do
+    echo "Found new package $i in systemsmanagement:Uyuni:Master. Creating a link to systemsmanagement:Uyuni:Master:TEST:$1:CR"
+    osc linkpac systemsmanagement:Uyuni:Master $i systemsmanagement:Uyuni:Master:TEST:$1:CR
+done
+    


### PR DESCRIPTION
## What does this PR change?

There is TEST:CR projects for each environment that "links" to
systemsmanagement:Uyuni:Master.

The purpose of these projects is to be able to freeze them before
running the e2e tests in the PR, so there is no issues with having
wrong metadata that does not reflect the state of the repository, which
happens if packages are rebuild after having done a "zypper up" and
before a "zypper in".

When this happens, we have the rerun the pipeline which takes 2-3 hours,
which is a major pain.

This script, is expected to be called from a jenkins job that will
update the packages in the TEST:CR projects to make sure there are links
to all the packages.

## GUI diff

No difference. This is CI.


- [X] **DONE**

## Documentation
- No documentation needed

- [X] **DONE**

## Test coverage
- No tests

- [X] **DONE**

## Links

related to https://github.com/SUSE/spacewalk/issues/14654

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
