### PR TITLE
Testsuite: Follow a UI change

### DIFF
--- a/testsuite/features/secondary/min_bootstrap_script.feature
+++ b/testsuite/features/secondary/min_bootstrap_script.feature
@@ -33,10 +33,6 @@ Feature: Register a Salt minion via Bootstrap-script
   Scenario: Detect latest Salt changes on the script-bootstrapped SLES minion
     When I query latest Salt changes on "sle_minion"
 
-  Scenario: Check the activation key
-    Given I am on the Systems overview page of this "sle_minion"
-    Then I should see a "1-SUSE-KEY-x86_64" text
-
   Scenario: Subscribe the script-bootstrapped SLES minion to a base channel
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Software" in the content area


### PR DESCRIPTION
## What does this PR change?

We don't show the activation key anymore in the minion overview page.
- testsuite/features/secondary/min_bootstrap_script.feature:
Delete this scenario.

## Links

https://github.com/SUSE/spacewalk/issues/14172
https://github.com/uyuni-project/uyuni/pull/3588
### Ports
None

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)
