### PR TITLE
QA: Fix OpenScap issue in CentOS minion

### DIFF
--- a/testsuite/features/secondary/min_centos_openscap_audit.feature
+++ b/testsuite/features/secondary/min_centos_openscap_audit.feature
@@ -12,6 +12,7 @@ Feature: OpenSCAP audit of CentOS Salt minion
   Scenario: Install the OpenSCAP packages on the CentOS minion
     Given I am on the Systems overview page of this "ceos_minion"
     When I enable repository "CentOS-Base" on this "ceos_minion"
+    And I enable SUSE Manager tools repositories on "ceos_minion"
     And I refresh the metadata for "ceos_minion"
     And I install OpenSCAP dependencies on "ceos_minion"
     And I fix CentOS 7 OpenSCAP files on "ceos_minion"
@@ -75,3 +76,4 @@ Feature: OpenSCAP audit of CentOS Salt minion
   Scenario: Cleanup: remove the OpenSCAP packages from the CentOS minion
     When I remove OpenSCAP dependencies from "ceos_minion"
     And I disable repository "CentOS-Base" on this "ceos_minion"
+    And I disable SUSE Manager tools repositories on "ceos_client"

--- a/testsuite/features/secondary/min_salt_openscap_audit.feature
+++ b/testsuite/features/secondary/min_salt_openscap_audit.feature
@@ -10,6 +10,7 @@ Feature: OpenSCAP audit of Salt minion
   Scenario: Install the OpenSCAP packages on the SLE minion
     Given I am on the Systems overview page of this "sle_minion"
     When I enable repository "os_pool_repo os_update_repo" on this "sle_minion"
+    And I enable SUSE Manager tools repositories on "sle_minion"
     And I refresh the metadata for "sle_minion"
     And I install OpenSCAP dependencies on "sle_minion"
     And I follow "Software" in the content area
@@ -88,3 +89,4 @@ Feature: OpenSCAP audit of Salt minion
   Scenario: Cleanup: remove the OpenSCAP packages from the SLE minion
     When I remove OpenSCAP dependencies from "sle_minion"
     And I disable repository "os_pool_repo os_update_repo" on this "sle_minion"
+    And I disable SUSE Manager tools repositories on "sle_minion"

--- a/testsuite/features/secondary/min_ubuntu_openscap_audit.feature
+++ b/testsuite/features/secondary/min_ubuntu_openscap_audit.feature
@@ -9,6 +9,16 @@ Feature: OpenSCAP audit of Ubuntu Salt minion
   I want to run an OpenSCAP scan on it
 
 @ubuntu_minion
+@uyuni
+  Scenario: Install the client tools packages for Uyuni on the Ubuntu minion
+    When I enable Uyuni tools repositories on "ubuntu_minion"
+
+@ubuntu_minion
+@susemanager
+  Scenario: Install the client tools packages for SUSE Manager on the Ubuntu minion
+    When I enable SUSE Manager tools repositories on "ubuntu_minion"
+
+@ubuntu_minion
   Scenario: Install the OpenSCAP packages on the Ubuntu minion
     Given I am on the Systems overview page of this "ubuntu_minion"
     When I enable universe repositories on "ubuntu_minion"
@@ -75,3 +85,13 @@ Feature: OpenSCAP audit of Ubuntu Salt minion
   Scenario: Cleanup: remove the OpenSCAP packages from the Ubuntu minion
     When I remove OpenSCAP dependencies from "ubuntu_minion"
     When I disable universe repositories on "ubuntu_minion"
+
+@ubuntu_minion
+@uyuni
+  Scenario: Cleanup: remove the client tools packages for Uyuni on the Ubuntu minion
+    When I disable Uyuni tools repositories on "ubuntu_minion"
+
+@ubuntu_minion
+@susemanager
+  Scenario: Cleanup: remove the client tools packages for SUSE Manager on the Ubuntu minion
+    When I disable SUSE Manager tools repositories on "ubuntu_minion"

--- a/testsuite/features/secondary/trad_centos_client.feature
+++ b/testsuite/features/secondary/trad_centos_client.feature
@@ -24,8 +24,8 @@ Feature: Be able to register a CentOS 7 traditional client and do some basic ope
 @centos_minion
   Scenario: Prepare the CentOS 7 traditional client
     Given I am authorized
-    When I enable SUSE Manager tools repositories on "ceos_client"
-    And I enable repository "CentOS-Base" on this "ceos_client"
+    When I enable repository "CentOS-Base" on this "ceos_client"
+    And I enable SUSE Manager tools repositories on "ceos_client"
     And I install the traditional stack utils on "ceos_client"
     And I install OpenSCAP dependencies on "ceos_client"
     And I fix CentOS 7 OpenSCAP files on "ceos_client"

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -863,23 +863,18 @@ When(/^I install package(?:s)? "([^"]*)" on this "([^"]*)"((?: without error con
   if host.include? 'ceos'
     cmd = "yum -y install #{package}"
     successcodes = [0]
+    not_found_msg = 'No package'
   elsif host.include? 'ubuntu'
     cmd = "apt-get --assume-yes install #{package}"
     successcodes = [0]
+    not_found_msg = 'Unable to locate package'
   else
     cmd = "zypper --non-interactive install -y #{package}"
     successcodes = [0, 100, 101, 102, 103, 106]
+    not_found_msg = 'not found in package names'
   end
-  node.run(cmd, error_control.empty?, DEFAULT_TIMEOUT, 'root', successcodes)
-end
-
-When(/^I install package tftpboot-installation on the server$/) do
-  output, _code = $server.run('find /var/spacewalk/packages -name tftpboot-installation-SLE-15-SP2-x86_64-*.noarch.rpm')
-  packages = output.split("\n")
-  pattern = '/tftpboot-installation-([^/]+)*.noarch.rpm'
-  # Reverse sort the package name to get the latest version first and install it
-  package = packages.min { |a, b| b.match(pattern)[0] <=> a.match(pattern)[0] }
-  $server.run("rpm -i #{package}")
+  output, _code = node.run(cmd, error_control.empty?, DEFAULT_TIMEOUT, 'root', successcodes)
+  raise "A package was not found. Output:\n #{output}" if output.include? not_found_msg
 end
 
 When(/^I install old package(?:s)? "([^"]*)" on this "([^"]*)"((?: without error control)?)$/) do |package, host, error_control|
@@ -887,14 +882,18 @@ When(/^I install old package(?:s)? "([^"]*)" on this "([^"]*)"((?: without error
   if host.include? 'ceos'
     cmd = "yum -y downgrade #{package}"
     successcodes = [0]
+    not_found_msg = 'No package'
   elsif host.include? 'ubuntu'
     cmd = "apt-get --assume-yes install #{package} --allow-downgrades"
     successcodes = [0]
+    not_found_msg = 'Unable to locate package'
   else
     cmd = "zypper --non-interactive install --oldpackage -y #{package}"
     successcodes = [0, 100, 101, 102, 103, 106]
+    not_found_msg = 'not found in package names'
   end
-  node.run(cmd, error_control.empty?, DEFAULT_TIMEOUT, 'root', successcodes)
+  output, _code = node.run(cmd, error_control.empty?, DEFAULT_TIMEOUT, 'root', successcodes)
+  raise "A package was not found. Output:\n #{output}" if output.include? not_found_msg
 end
 
 When(/^I remove package(?:s)? "([^"]*)" from this "([^"]*)"((?: without error control)?)$/) do |package, host, error_control|
@@ -910,6 +909,15 @@ When(/^I remove package(?:s)? "([^"]*)" from this "([^"]*)"((?: without error co
     successcodes = [0, 100, 101, 102, 103, 104, 106]
   end
   node.run(cmd, error_control.empty?, DEFAULT_TIMEOUT, 'root', successcodes)
+end
+
+When(/^I install package tftpboot-installation on the server$/) do
+  output, _code = $server.run('find /var/spacewalk/packages -name tftpboot-installation-SLE-15-SP2-x86_64-*.noarch.rpm')
+  packages = output.split("\n")
+  pattern = '/tftpboot-installation-([^/]+)*.noarch.rpm'
+  # Reverse sort the package name to get the latest version first and install it
+  package = packages.min { |a, b| b.match(pattern)[0] <=> a.match(pattern)[0] }
+  $server.run("rpm -i #{package}")
 end
 
 When(/^I wait until the package "(.*?)" has been cached on this "(.*?)"$/) do |pkg_name, host|

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -714,31 +714,47 @@ end
 # Repository steps
 
 # Enable tools repositories (both stable and development)
-When(/^I enable SUSE Manager tools repositories on "([^"]*)"$/) do |host|
+When(/^I enable (SUSE Manager|Uyuni) tools repositories on "([^"]*)"$/) do |base_product, host|
   node = get_target(host)
   _os_version, os_family = get_os_version(node)
-  if os_family =~ /^opensuse/ || os_family =~ /^sles/
+  case os_family
+  when /^(opensuse|sles)/
     repos, _code = node.run('zypper lr | grep "tools" | cut -d"|" -f2')
     node.run("zypper mr --enable #{repos.gsub(/\s/, ' ')}")
-  elsif os_family =~ /^centos/
+  when /^centos/
     repos, _code = node.run('yum repolist disabled 2>/dev/null | grep "tools" | cut -d" " -f1')
     repos.gsub(/\s/, ' ').split.each do |repo|
       node.run("sed -i 's/enabled=.*/enabled=1/g' /etc/yum.repos.d/#{repo}.repo")
     end
+  when /^ubuntu/
+    repos, _code = node.run("ls /etc/apt/sources.list.d | grep #{base_product == 'Uyuni' ? 'tools' : 'Tools'}")
+    repos.gsub(/\s/, ' ').split.each do |repo|
+      node.run("sed -i '/^#\\s*deb.*/ s/^#\\s*deb /deb /' /etc/apt/sources.list.d/#{repo}")
+    end
+  else
+    raise "This step has no implementation for #{os_family} system."
   end
 end
 
-When(/^I disable SUSE Manager tools repositories on "([^"]*)"$/) do |host|
+When(/^I disable (SUSE Manager|Uyuni) tools repositories on "([^"]*)"$/) do |base_product, host|
   node = get_target(host)
   _os_version, os_family = get_os_version(node)
-  if os_family =~ /^opensuse/ || os_family =~ /^sles/
+  case os_family
+  when /^(opensuse|sles)/
     repos, _code = node.run('zypper lr | grep "tools" | cut -d"|" -f2')
     node.run("zypper mr --disable #{repos.gsub(/\s/, ' ')}")
-  elsif os_family =~ /^centos/
+  when /^centos/
     repos, _code = node.run('yum repolist enabled 2>/dev/null | grep "tools" | cut -d" " -f1')
     repos.gsub(/\s/, ' ').split.each do |repo|
       node.run("sed -i 's/enabled=.*/enabled=0/g' /etc/yum.repos.d/#{repo}.repo")
     end
+  when /^ubuntu/
+    repos, _code = node.run("ls /etc/apt/sources.list.d | grep #{base_product == 'Uyuni' ? 'tools' : 'Tools'}")
+    repos.gsub(/\s/, ' ').split.each do |repo|
+      node.run("sed -i '/^deb.*/ s/^deb /# deb /' /etc/apt/sources.list.d/#{repo}")
+    end
+  else
+    raise "This step has no implementation for #{os_family} system."
   end
 end
 


### PR DESCRIPTION
## What does this PR change?

- We were not capturing the issues of not having available a package when trying to install it, therefore we were not using the right packages in some scenarios. This PR raises an exception based on the output message of the installation step.
- We were not including client tools before installing an OpenScap package which is included as part of the client tools. We are adding them to all our OpenScap features.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Ports:
- Manager-4.0
- Manager-4.1

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
