### PR TITLE
Fix react-select selection due to commit 362b725b

### DIFF
--- a/testsuite/features/secondary/minkvm_guests.feature
+++ b/testsuite/features/secondary/minkvm_guests.feature
@@ -373,7 +373,7 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I click on "Stop" in "Stop Network" modal
     Then I wait until table row for "test-net2" contains button "Start"
     When I click on "Edit" in row "test-net2"
-    And I wait until option "bridge" appears in list "type"
+    And I wait until option "isolated" appears in list "type"
     And I enter "192.168.130.0" as "ipv4def_address"
     And I click on "remove_ipv4def_dhcpranges0"
     And I click on "Update"

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -158,10 +158,8 @@ When(/^I select "([^"]*)" from "([^"]*)"$/) do |option, field|
     select(option, from: field)
   else
     # Custom React selector
-    within(:xpath, xpath_field) do
-      find(:xpath, '.').click
-      find(:xpath, xpath_option, match: :first).click
-    end
+    find(:xpath, xpath_field).click
+    find(:xpath, xpath_option, match: :first).click
   end
 end
 


### PR DESCRIPTION
## What does this PR change?

Fix the step selecting in a reac-select component

## Test coverage
- No tests: already covered

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
