### PR TITLE
python3-certifi missing from bootstrap repo

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -374,6 +374,7 @@ RES8 = [
     "python3-psutil",
     "python3-pyyaml",
     "python3-requests",
+    "python3-certifi",
     "openpgm",
     "zeromq",
     "python3-urllib3",

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- Add python3-certifi to bootstrap repo for RES8
 - Enable bootstrap repository creation for openSUSE Leap 15.3 for Uyuni
 - Enable aarch64 for CentOS7/8, Oracle 7/8, Amazon Linux 2
   and Alibaba Linux 2


### PR DESCRIPTION
## What does this PR change?

This PR adds `python3-certifi` to the bootstrap repo for RES8.

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
- No tests: Well…


## Links

Fixes #3567

## Changelogs

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
