### PR TITLE
Fix stopping jabberd

### DIFF
--- a/spacewalk/admin/spacewalk-admin.changes
+++ b/spacewalk/admin/spacewalk-admin.changes
@@ -1,3 +1,4 @@
+- stop jabberd when osa-dispatcher is enabled (bsc#1185042)
 - change deprecated path /var/run into /run for systemd (bsc#1185059)
 
 -------------------------------------------------------------------

--- a/spacewalk/admin/spacewalk-service.systemd
+++ b/spacewalk/admin/spacewalk-service.systemd
@@ -91,7 +91,7 @@ start() {
 
 stop() {
     echo "Shutting down spacewalk services..."
-    if systemctl is-active osa-dispatcher > /dev/null 2>&1; then
+    if systemctl is-enabled osa-dispatcher > /dev/null 2>&1; then
         systemctl stop jabberd
     fi
     spacewalk_target_services | xargs systemctl stop


### PR DESCRIPTION
## What does this PR change?

`spacewalk-service stop` does not stop jabberd when osa-dispatcher failed to start.
Fix this by checking for `is-enabled`.

Port of https://github.com/SUSE/spacewalk/pull/14702

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/14702

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
