### PR TITLE
CI: add option for not expanding links

### DIFF
--- a/rel-eng/push-packages-to-obs.sh
+++ b/rel-eng/push-packages-to-obs.sh
@@ -17,7 +17,7 @@ OSCAPI=${OSCAPI:-https://api.suse.de}
 
 OSC="osc ${OSCRC} -A ${OSCAPI}"
 if [ "$OSC_EXPAND" == "TRUE" ];then
-    OSC_CHECKOUT="$OSC checkout"
+    OSC_CHECKOUT="$OSC checkout -e"
 else
     OSC_CHECKOUT="$OSC checkout -u"
 fi

--- a/rel-eng/push-packages-to-obs.sh
+++ b/rel-eng/push-packages-to-obs.sh
@@ -16,6 +16,11 @@ OSCRC=${OSCRC:+-c $OSCRC}
 OSCAPI=${OSCAPI:-https://api.suse.de}
 
 OSC="osc ${OSCRC} -A ${OSCAPI}"
+if [ "$OSC_EXPAND" == "TRUE" ];then
+    OSC_CHECKOUT="$OSC checkout"
+else
+    OSC_CHECKOUT="$OSC checkout -u"
+fi
 OBS_PROJ=${OBS_PROJ:-Devel:Galaxy:Manager:TEST}
 
 FAKE_COMITTOBS=${FAKE_COMITTOBS:+1}
@@ -249,7 +254,7 @@ while read PKG_NAME; do
     echo "Try: $tries"
     OBS_PKG_DIR="$OBS_PROJ/$PKG_NAME"
     rm -rf "$OBS_PKG_DIR"
-    $OSC co -u "$OBS_PROJ" "$PKG_NAME" 2>"$T_LOG" || {
+    $OSC_CHECKOUT "$OBS_PROJ" "$PKG_NAME" 2>"$T_LOG" || {
       if grep 'does not exist in project' "$T_LOG" || grep '404: Not Found' "$T_LOG"; then
         test -d "$OBS_PROJ" || ( mkdir "$OBS_PROJ"; cd "$OBS_PROJ"; $OSC init "$OBS_PROJ"; )
         ( set -e; cd "$OBS_PROJ"; $OSC mkpac "$PKG_NAME"; )

--- a/susemanager-utils/testing/automation/push-to-obs.sh
+++ b/susemanager-utils/testing/automation/push-to-obs.sh
@@ -22,10 +22,11 @@ help() {
   echo "  -n  If used, update PROJECT instead of the projects specified with -d,"
   echo "      for example, if you want to package only the changes from a PR on"
   echo "      a separate project"
+  echo "  -e  If used, when checking out projects from obs, links will be expanded. Useful for comparing packages that are links" 
   echo ""
 }
 
-while getopts ":d:c:p:n:vth" opts; do
+while getopts ":d:c:p:n:vthe" opts; do
   case "${opts}" in
     d) DESTINATIONS=${OPTARG};;
     p) PACKAGES=${OPTARG};;
@@ -33,6 +34,7 @@ while getopts ":d:c:p:n:vth" opts; do
     v) VERBOSE="-v";;
     t) TEST="-t";;
     n) OBS_TEST_PROJECT="-n ${OPTARG}";;
+    e) $EXTRA_OPTS="-e";;
     h) help
        exit 0;;
     *) echo "Invalid syntax. Use ${SCRIPT} -h"
@@ -57,7 +59,7 @@ if [ ! -f ${CREDENTIALS} ]; then
 fi
 
 INITIAL_CMD="/manager/susemanager-utils/testing/automation/initial-objects.sh"
-CMD="/manager/susemanager-utils/testing/docker/scripts/push-to-obs.sh -d '${DESTINATIONS}' -c /tmp/.oscrc -p '${PACKAGES}' ${VERBOSE} ${TEST} ${OBS_TEST_PROJECT}"
+CMD="/manager/susemanager-utils/testing/docker/scripts/push-to-obs.sh -d '${DESTINATIONS}' -c /tmp/.oscrc -p '${PACKAGES}' ${VERBOSE} ${TEST} ${OBS_TEST_PROJECT} ${EXTRA_OPTS}"
 CHOWN_CMD="/manager/susemanager-utils/testing/automation/chown-objects.sh $(id -u) $(id -g)"
 
 docker pull $REGISTRY/$PUSH2OBS_CONTAINER

--- a/susemanager-utils/testing/docker/scripts/push-to-obs.sh
+++ b/susemanager-utils/testing/docker/scripts/push-to-obs.sh
@@ -18,10 +18,13 @@ help() {
   echo "  -v  Verbose mode"
   echo "  -t  For tito, use current branch HEAD instead of latest package tag"
   echo "  -n  If used, update PROJECT instead of the projects specified with -d"
+  echo "  -e  If used, when checking out projects from obs, links will be expanded. Useful for comparing packages that are links" 
   echo ""
 }
 
-while getopts ":d:c:p:n:vth" opts; do
+OSC_EXPAND="FALSE"
+
+while getopts ":d:c:p:n:vthe" opts; do
   case "${opts}" in
     d) DESTINATIONS=${OPTARG};;
     p) PACKAGES="$(echo ${OPTARG}|tr ',' ' ')";;
@@ -29,6 +32,7 @@ while getopts ":d:c:p:n:vth" opts; do
     v) export VERBOSE=1;;
     t) export TEST=1;;
     n) export OBS_TEST_PROJECT=${OPTARG};;
+    e) export OSC_EXPAND="TRUE"
     h) help
        exit 0;;
     *) echo "Invalid syntax. Use ${SCRIPT} -h"


### PR DESCRIPTION

## What does this PR change?

when comparing if packages need to be updated, by default we were not
expanding links, and as result, all packages were found to need updates.

Let's add an option so we can expand links and we only update packages
that need to. This is needed for testing Pull Requests because
systemsmanagement:Uyuni:Master:TEST:X:CR are links to
systemsmanagement:Uyuni:Master, and without this option, all packages
are found that need to be updated and so the task takes longer.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed

- [X] **DONE**

## Test coverage
- No tests

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/14706

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
