### PR TITLE
Remove the smdba tests from the finishing set for Pull Requests e2e

### DIFF
--- a/testsuite/run_sets/finishing_pr.yml
+++ b/testsuite/run_sets/finishing_pr.yml
@@ -1,0 +1,16 @@
+# This file describes the order of features in a normal testsuite run.
+#
+# If you create new features, please see conventions about naming of the
+# feature files in testsuite/docs/Guidelines.md in "Rules for features" chapter,
+# as well as guidelines about idempotency in "Idempotency" chapter.
+
+
+## Post run features BEGIN ##
+
+# IMMUTABLE ORDER
+
+# these features are needed for gathering log/debug info
+- features/finishing/srv_debug.feature
+- features/finishing/allcli_debug.feature
+
+## Post run features END ##


### PR DESCRIPTION
## What does this PR change?

This takes 9 minutes and this test is not required for Pull Requests.

fixes https://github.com/SUSE/spacewalk/issues/14707


## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed

- [X] **DONE**

## Test coverage
- No tests

- [X] **DONE**

## Links

Fixes #https://github.com/SUSE/spacewalk/issues/14707

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
