### PR TITLE
Resolve input control conflicts

### DIFF
--- a/web/html/src/components/table/SearchField.tsx
+++ b/web/html/src/components/table/SearchField.tsx
@@ -13,6 +13,7 @@ type SearchFieldProps = {
   onSearch?: (criteria: string) => void;
 
   /** filtering function */
+  // This is manually used in TableDataHandler as an argument to SimpleDataProvider
   filter?: (datum: any, criteria?: string) => boolean;
 
   /** input field name */

--- a/web/html/src/components/table/SearchPanel.tsx
+++ b/web/html/src/components/table/SearchPanel.tsx
@@ -44,7 +44,7 @@ export function SearchPanel(props: SearchPanelProps) {
                * The child might be either a component that accepts these props or a regular DOM node such as
                * span etc. For the latter case, it isn't valid to pass these props through.
                */
-              child.type === "function" ? { criteria: props.criteria, onSearch: props.onSearch } : undefined
+              typeof child.type === "string" ? undefined : { criteria: props.criteria, onSearch: props.onSearch }
             )
           : child;
       })}

--- a/web/html/src/manager/admin/setup/products/products.tsx
+++ b/web/html/src/manager/admin/setup/products/products.tsx
@@ -546,7 +546,6 @@ class Products extends React.Component<ProductsProps> {
           searchField={
             <SearchField
               filter={searchCriteriaInExtension}
-              criteria={""}
               placeholder={t("Filter by product Description")}
               name="product-description-filter"
             />

--- a/web/html/src/manager/admin/task-engine-status/taskotop.tsx
+++ b/web/html/src/manager/admin/task-engine-status/taskotop.tsx
@@ -191,7 +191,7 @@ class TaskoTop extends React.Component<Props> {
               cssClassFunction={row => (row["status"] === "skipped" ? "text-muted" : null)}
               initialSortColumnKey="status"
               initialItemsPerPage={window.userPrefPageSize}
-              searchField={<SearchField filter={this.searchData} criteria={""} placeholder={t("Filter by name")} />}
+              searchField={<SearchField filter={this.searchData} placeholder={t("Filter by name")} />}
             >
               <Column columnKey="id" comparator={Utils.sortById} header={t("Task Id")} cell={row => row["id"]} />
               <Column

--- a/web/html/src/manager/audit/cveaudit/cveaudit.tsx
+++ b/web/html/src/manager/audit/cveaudit/cveaudit.tsx
@@ -250,7 +250,7 @@ class CVEAudit extends React.Component<Props, State> {
             selectable={this.state.resultType === TARGET_SERVER && this.state.results.length > 0}
             onSelect={this.handleSelectItems}
             selectedItems={this.state.selectedItems}
-            searchField={<SearchField filter={this.searchData} criteria={""} placeholder={t("Filter by name")} />}
+            searchField={<SearchField filter={this.searchData} placeholder={t("Filter by name")} />}
           >
             <Column
               columnKey="patchStatus"

--- a/web/html/src/manager/audit/subscription-matching/subscription-matching-subscriptions.tsx
+++ b/web/html/src/manager/audit/subscription-matching/subscription-matching-subscriptions.tsx
@@ -57,7 +57,7 @@ class Subscriptions extends React.Component<SubscriptionsProps> {
             initialSortColumnKey="partNumber"
             initialItemsPerPage={window.userPrefPageSize}
             searchField={
-              <SearchField filter={this.searchData} criteria={""} placeholder={t("Filter by description")} />
+              <SearchField filter={this.searchData} placeholder={t("Filter by description")} />
             }
           >
             <Column

--- a/web/html/src/manager/audit/subscription-matching/subscription-matching-unmatched-products.tsx
+++ b/web/html/src/manager/audit/subscription-matching/subscription-matching-unmatched-products.tsx
@@ -140,7 +140,7 @@ class UnmatchedSystemPopUp extends React.Component<UnmatchedSystemPopUpProps> {
         identifier={row => row.id}
         initialSortColumnKey="systemName"
         initialItemsPerPage={window.userPrefPageSize}
-        searchField={<SearchField filter={this.searchData} criteria={""} placeholder={t("Filter by name")} />}
+        searchField={<SearchField filter={this.searchData} placeholder={t("Filter by name")} />}
       >
         <Column
           columnKey="systemName"

--- a/web/html/src/manager/images/image-profiles.tsx
+++ b/web/html/src/manager/images/image-profiles.tsx
@@ -167,7 +167,7 @@ class ImageProfiles extends React.Component<Props, State> {
             identifier={profile => profile.profileId}
             initialSortColumnKey="profileId"
             initialItemsPerPage={window.userPrefPageSize}
-            searchField={<SearchField filter={this.searchData} criteria={""} />}
+            searchField={<SearchField filter={this.searchData} />}
             selectable
             selectedItems={this.state.selectedItems}
             onSelect={this.handleSelectItems}

--- a/web/html/src/manager/images/image-stores.tsx
+++ b/web/html/src/manager/images/image-stores.tsx
@@ -170,7 +170,7 @@ class ImageStores extends React.Component<Props, State> {
             identifier={imagestore => imagestore.id}
             initialSortColumnKey="id"
             initialItemsPerPage={window.userPrefPageSize}
-            searchField={<SearchField filter={this.searchData} criteria={""} />}
+            searchField={<SearchField filter={this.searchData} />}
             selectable
             selectedItems={this.state.selectedItems}
             onSelect={this.handleSelectItems}

--- a/web/html/src/manager/images/image-view-packages.tsx
+++ b/web/html/src/manager/images/image-view-packages.tsx
@@ -43,7 +43,7 @@ class ImageViewPackages extends React.Component<Props> {
         identifier={p => p.name + p.arch}
         initialSortColumnKey="name"
         initialItemsPerPage={window.userPrefPageSize}
-        searchField={<SearchField filter={this.searchData} criteria={""} />}
+        searchField={<SearchField filter={this.searchData} />}
       >
         <Column columnKey="name" comparator={Utils.sortByText} header={t("Package Name")} cell={row => row.name} />
         <Column columnKey="arch" comparator={Utils.sortByText} header={t("Architecture")} cell={row => row.arch} />

--- a/web/html/src/manager/images/image-view-patches.tsx
+++ b/web/html/src/manager/images/image-view-patches.tsx
@@ -75,7 +75,7 @@ class ImageViewPatches extends React.Component<ImageViewPatchesProps> {
         identifier={p => p.id}
         initialSortColumnKey="name"
         initialItemsPerPage={window.userPrefPageSize}
-        searchField={<SearchField filter={this.searchData} criteria={""} />}
+        searchField={<SearchField filter={this.searchData} />}
       >
         <Column
           columnKey="type"

--- a/web/html/src/manager/images/image-view.tsx
+++ b/web/html/src/manager/images/image-view.tsx
@@ -620,7 +620,7 @@ class ImageViewList extends React.Component<ImageViewListProps, ImageViewListSta
           initialSortColumnKey="modified"
           initialSortDirection={-1}
           initialItemsPerPage={window.userPrefPageSize}
-          searchField={<SearchField filter={this.searchData} criteria={""} />}
+          searchField={<SearchField filter={this.searchData} />}
           selectable
           selectedItems={this.state.selectedItems}
           onSelect={this.handleSelectItems}

--- a/web/html/src/manager/maintenance/details/schedule-details.tsx
+++ b/web/html/src/manager/maintenance/details/schedule-details.tsx
@@ -187,7 +187,7 @@ const SystemPicker = (props: SystemPickerProps) => {
         <Table
           data="/rhn/manager/api/maintenance/schedule/systems"
           identifier={system => system.id}
-          searchField={<SearchField placeholder={t("Search systems")} criteria="" />}
+          searchField={<SearchField placeholder={t("Search systems")} />}
           selectable
           selectedItems={selectedSystems}
           onSelect={onSelect}

--- a/web/html/src/manager/notifications/notification-messages.tsx
+++ b/web/html/src/manager/notifications/notification-messages.tsx
@@ -474,7 +474,7 @@ class NotificationMessages extends React.Component<Props, State> {
             selectable
             selectedItems={this.state.selectedItems}
             onSelect={this.handleSelectItems}
-            searchField={<SearchField filter={this.searchData} criteria={""} placeholder={t("Filter by summary")} />}
+            searchField={<SearchField filter={this.searchData} placeholder={t("Filter by summary")} />}
             additionalFilters={[typeFilter]}
           >
             <Column

--- a/web/html/src/manager/salt/keys/key-management.tsx
+++ b/web/html/src/manager/salt/keys/key-management.tsx
@@ -150,7 +150,7 @@ class KeyManagement extends React.Component<Props, State> {
             initialSortColumnKey="id"
             initialItemsPerPage={window.userPrefPageSize}
             loading={this.state.loading}
-            searchField={<SearchField filter={this.searchData} criteria={""} />}
+            searchField={<SearchField filter={this.searchData} />}
           >
             <Column
               columnKey="id"

--- a/web/html/src/manager/virtualization/ListTab.js
+++ b/web/html/src/manager/virtualization/ListTab.js
@@ -233,7 +233,6 @@ export function ListTab(props: Props) {
                         searchField={(
                           <SearchField
                             filter={searchData}
-                            criteria=""
                             placeholder={t('Filter by name')}
                           />
                         )}

--- a/web/html/src/manager/virtualization/pools/list/pools-list.js
+++ b/web/html/src/manager/virtualization/pools/list/pools-list.js
@@ -371,7 +371,6 @@ export function PoolsList(props: Props) {
                     additionalFilters={[]}
                     searchField={
                         <SearchField filter={searchData}
-                            criteria={''}
                             placeholder={t('Filter by pool or volume name')}
                             name='pool-name-filter'
                         />


### PR DESCRIPTION
## What does this PR change?

https://github.com/uyuni-project/uyuni/commit/af11d65a3377e2ce2ad7e8720285ca9694120d49#diff-8cc13d70de76cf2c345bea40bd41c6ec0b8a51040de802915b25967886025748R47 broke search field usage in cases where the type checking for children didn't match components correctly.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
