### PR TITLE
Sp to product migration

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
@@ -332,7 +332,7 @@ public class ActionFactory extends HibernateFactory {
     }
 
     /**
-     * Check if there is a pending service pack migration in the schedule. Return the
+     * Check if there is a pending product migration in the schedule. Return the
      * action ID if available or null otherwise.
      * @param serverId server
      * @return ID of a possibly scheduled migration or null.

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/SPMigrationAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/SPMigrationAction.java
@@ -68,7 +68,7 @@ import com.redhat.rhn.manager.errata.ErrataManager;
 import com.redhat.rhn.manager.rhnpackage.PackageManager;
 
 /**
- * Action class for scheduling distribution upgrades (Service Pack Migrations).
+ * Action class for scheduling distribution upgrades (Product Migrations).
  */
 public class SPMigrationAction extends RhnAction {
 
@@ -121,7 +121,7 @@ public class SPMigrationAction extends RhnAction {
         DynaActionForm form = (DynaActionForm) actionForm;
         String actionStep = TARGET;
 
-        // Called after redirect from event history after running a sp migration dry-run
+        // Called after redirect from event history after running a product migration dry-run
         if (ctx.hasParam("aid")) {
             DatePicker picker = getStrutsDelegate().prepopulateDatePicker(request, form,
                     "date", DatePicker.YEAR_RANGE_POSITIVE);

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -718,8 +718,8 @@
           <context context-type="sourcefile">Navigation Menu</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="Migrate" xml:space="preserve">
-        <source>Migrate</source>
+      <trans-unit id="Transfer" xml:space="preserve">
+        <source>Transfer</source>
         <context-group name="ctx">
           <context context-type="sourcefile">Navigation Menu</context>
         </context-group>
@@ -7509,13 +7509,13 @@ Follow this url to see the full list of inactive systems:
         </context-group>
       </trans-unit>
       <trans-unit id="system.migrate.user_no_perms" xml:space="preserve">
-        <source>This user lacks the required permissions to migrate this system.</source>
+        <source>This user lacks the required permissions to transfer this system.</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/details/SystemMigrate.do</context>
         </context-group>
       </trans-unit>
       <trans-unit id="system.migrate.org_not_trusted" xml:space="preserve">
-        <source>Systems can only be migrated between trusted organizations.</source>
+        <source>Systems can only be transferred between trusted organizations.</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/details/SystemMigrate.do</context>
         </context-group>
@@ -8439,10 +8439,10 @@ Follow this url to see the full list of inactive systems:
         <source>Server Delete</source>
       </trans-unit>
       <trans-unit id="ssm.migrate.systems.confirmmessage" xml:space="preserve">
-        <source>Systems Migrated</source>
+        <source>Systems Transferred</source>
       </trans-unit>
       <trans-unit id="ssm.migrate.systems.confirmbutton" xml:space="preserve">
-        <source>Migrate Systems</source>
+        <source>Transfer Systems</source>
       </trans-unit>
       <trans-unit id="ssm.migrate.systems.orgnone" xml:space="preserve">
         <source>This organization has no trusted organizations.  Systems can only be migrated between organizations with defined trusts.</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -8735,7 +8735,7 @@ Alternatively, you will want to download &lt;strong&gt;Incremental Channel Conte
         <source>You are not allowed to update entitlements in the Default Org.  These entitlements are determined by your @@PRODUCT_NAME@@ certificate file.</source>
       </trans-unit>
       <trans-unit id="distupgrade.upgrade" xml:space="preserve">
-        <source>Service Pack Migration</source>
+        <source>Product Migration</source>
       </trans-unit>
       <trans-unit id="spmigration.message.scheduled" xml:space="preserve">
         <source>This system is &lt;a href="/rhn/systems/details/history/Event.do?sid={0}&amp;aid={1}"&gt;scheduled&lt;/a&gt; to be migrated to &lt;strong&gt;{2}&lt;/strong&gt;.</source>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -24792,6 +24792,9 @@ given channel.</source>
       <trans-unit id="spmigration.jsp.target.title" xml:space="preserve">
         <source>Product Migration - Target</source>
       </trans-unit>
+      <trans-unit id="spmigration.jsp.target.description" xml:space="preserve">
+        <source>Only shows migrations that are officially supported by SUSE in an online way. For offline migrations the autoinstallation feature in upgrade mode should be used.</source>
+      </trans-unit>
       <trans-unit id="spmigration.jsp.target.submit" xml:space="preserve">
         <source>Select Channels</source>
       </trans-unit>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -4913,7 +4913,7 @@ organization. You may grant or remove the organization administrator role in the
         </context-group>
         </trans-unit>
         <trans-unit id="ssm.overview.misc.migrate">
-          <source>&lt;a href="/rhn/systems/ssm/MigrateSystems.do"&gt;Migrate&lt;/a&gt; systems to another organization</source>
+          <source>&lt;a href="/rhn/systems/ssm/MigrateSystems.do"&gt;Transfer&lt;/a&gt; systems to another organization</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/ssm/Index.do</context>
         </context-group>
@@ -4957,13 +4957,13 @@ organization. You may grant or remove the organization administrator role in the
         </trans-unit>
       <!-- SSM System Migration -->
       <trans-unit id="ssm.migrate.systems.header">
-          <source>Migrate Systems</source>
+          <source>Transfer Systems</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/ssm/MigrateSystems.do</context>
         </context-group>
         </trans-unit>
         <trans-unit id="ssm.migrate.systems.summary">
-          <source>Migrate the selected systems to the selected organization.  If the operation is successful, the systems will no longer be visible in this organization.</source>
+          <source>Transfer the selected systems to the selected organization. If the operation is successful, the systems will no longer be visible in this organization.</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/ssm/MigrateSystems.do</context>
         </context-group>
@@ -5098,7 +5098,7 @@ organization. You may grant or remove the organization administrator role in the
         </context-group>
         </trans-unit>
         <trans-unit id="ssm.misc.index.tabs.migrate">
-          <source>Migrate</source>
+          <source>Transfer</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/ssm/misc/Index.do</context>
         </context-group>
@@ -5158,19 +5158,19 @@ organization. You may grant or remove the organization administrator role in the
         </context-group>
         </trans-unit>
         <trans-unit id="ssm.misc.index.migrate.header">
-          <source>Migrate Systems</source>
+          <source>Transfer Systems</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/ssm/misc/Index.do</context>
         </context-group>
         </trans-unit>
         <trans-unit id="ssm.misc.index.migrate.summary">
-          <source>Migrate multiple systems from the current organization to another (trusted) organization in a single action.  The migrated systems will no longer be visible in the original organization.</source>
+          <source>Transfer multiple systems from the current organization to another (trusted) organization in a single action.  The transferred systems will no longer be visible in the original organization.</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/ssm/misc/Index.do</context>
         </context-group>
         </trans-unit>
         <trans-unit id="ssm.misc.index.migrate.migrate">
-          <source>Migrate Systems to another organization</source>
+          <source>Transfer Systems to another organization</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/ssm/misc/Index.do</context>
         </context-group>
@@ -7495,13 +7495,13 @@ organization management tools if you choose to remove this role from your login.
         </context-group>
       </trans-unit>
       <trans-unit id="orgtrustdetails.jsp.sysmigratedto" xml:space="preserve">
-        <source>Systems Migrated to Your Organization</source>
+        <source>Systems Transferred to Your Organization</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/multiorg/OrgTrustDetails</context>
         </context-group>
       </trans-unit>
       <trans-unit id="orgtrustdetails.jsp.sysmigratedfrom" xml:space="preserve">
-        <source>Systems Migrated from Your Organization</source>
+        <source>Systems Transferred from Your Organization</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/multiorg/OrgTrustDetails</context>
         </context-group>
@@ -20974,7 +20974,7 @@ The Tree Path, Base Channel, and Installer Generation should always match. This 
         </context-group>
       </trans-unit>
       <trans-unit id="sdc.details.migrate.header" xml:space="preserve">
-        <source>Migrate System Between Organizations</source>
+        <source>Transfer System Between Organizations</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/systems/details/SystemMigrate.do</context>
         </context-group>
@@ -20986,13 +20986,13 @@ The Tree Path, Base Channel, and Installer Generation should always match. This 
         </context-group>
       </trans-unit>
       <trans-unit id="sdc.details.migrate.migrate" xml:space="preserve">
-        <source>Migrate System</source>
+        <source>Transfer System</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/systems/details/SystemMigrate.do</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sdc.details.migrate.success" xml:space="preserve">
-        <source>System successfully migrated</source>
+        <source>System successfully transferred</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/systems/details/SystemMigrate.do</context>
         </context-group>

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -24790,7 +24790,7 @@ given channel.</source>
         </context-group>
       </trans-unit>
       <trans-unit id="spmigration.jsp.target.title" xml:space="preserve">
-        <source>Service Pack Migration - Target</source>
+        <source>Product Migration - Target</source>
       </trans-unit>
       <trans-unit id="spmigration.jsp.target.submit" xml:space="preserve">
         <source>Select Channels</source>
@@ -24805,7 +24805,7 @@ given channel.</source>
         <source>Target not available, the following channels are not synced: </source>
       </trans-unit>
       <trans-unit id="spmigration.jsp.setup.title" xml:space="preserve">
-        <source>Service Pack Migration - Channels</source>
+        <source>Product Migration - Channels</source>
       </trans-unit>
       <trans-unit id="spmigration.jsp.setup.installed-products" xml:space="preserve">
         <source>Installed Products:</source>
@@ -24829,13 +24829,13 @@ given channel.</source>
         <source>Schedule Migration</source>
       </trans-unit>
       <trans-unit id="spmigration.jsp.error.unsupported" xml:space="preserve">
-        <source>Service Pack Migrations are supported for &lt;strong&gt;SUSE&lt;/strong&gt; systems only.</source>
+        <source>Product Migrations are supported for &lt;strong&gt;SUSE&lt;/strong&gt; systems only.</source>
       </trans-unit>
       <trans-unit id="spmigration.jsp.error.update-zypp-plugin" xml:space="preserve">
-        <source>Service Pack Migrations are currently not supported for this system, please install the latest version of &lt;strong&gt;zypp-plugin-spacewalk&lt;/strong&gt;.</source>
+        <source>Product Migrations are currently not supported for this system, please install the latest version of &lt;strong&gt;zypp-plugin-spacewalk&lt;/strong&gt;.</source>
       </trans-unit>
       <trans-unit id="spmigration.jsp.error.scheduled" xml:space="preserve">
-        <source>A Service Pack Migration is already &lt;a href="/rhn/systems/details/history/Event.do?sid={0}&amp;aid={1}"&gt;scheduled&lt;/a&gt; for this system.</source>
+        <source>A Product Migration is already &lt;a href="/rhn/systems/details/history/Event.do?sid={0}&amp;aid={1}"&gt;scheduled&lt;/a&gt; for this system.</source>
       </trans-unit>
       <trans-unit id="spmigration.jsp.error.up-to-date" xml:space="preserve">
         <source>There is currently no migration available for this system. Either the latest Service Pack is already installed or possible target products are not available. Please use the &lt;a href="/rhn/manager/admin/setup/products"&gt;&lt;strong&gt;Setup Wizard&lt;/strong&gt;&lt;/a&gt; to identify and add missing products.</source>
@@ -24844,16 +24844,16 @@ given channel.</source>
         <source>Some software channels are missing for this migration, please make sure to sync all mandatory channels by adding the below target product(s) using the &lt;a href="/rhn/manager/admin/setup/products"&gt;&lt;strong&gt;Setup Wizard&lt;/strong&gt;&lt;/a&gt;.</source>
       </trans-unit>
       <trans-unit id="spmigration.jsp.error.updatestack-update-needed" xml:space="preserve">
-        <source>There are outstanding Package Management Stack updates available for this system. Please update all Software Update Stack related packages before you start a Service Pack migration.</source>
+        <source>There are outstanding Package Management Stack updates available for this system. Please update all Software Update Stack related packages before you start a Product migration.</source>
       </trans-unit>
       <trans-unit id="spmigration.jsp.error.update-salt-package-needed" xml:space="preserve">
-        <source>The installed &lt;strong&gt;Salt&lt;/strong&gt; package version on this system is out of date. Please update the package to the latest version before you start a Service Pack migration.</source>
+        <source>The installed &lt;strong&gt;Salt&lt;/strong&gt; package version on this system is out of date. Please update the package to the latest version before you start a Product migration.</source>
       </trans-unit>
       <trans-unit id="spmigration.jsp.error.missing-successor-extensions" xml:space="preserve">
         <source>There is no migration available for this system. For some of the installed extensions no successor could be found:</source>
       </trans-unit>
       <trans-unit id="spmigration.jsp.confirm.title" xml:space="preserve">
-        <source>Service Pack Migration - Confirm</source>
+        <source>Product Migration - Confirm</source>
       </trans-unit>
       <trans-unit id="spmigration.jsp.confirm.description" xml:space="preserve">
         <source>Please confirm below to schedule the migration of this system to the following products:</source>
@@ -24862,7 +24862,7 @@ given channel.</source>
         <source>Channel subscriptions after the migration:</source>
       </trans-unit>
       <trans-unit id="spmigration.jsp.confirm.note" xml:space="preserve">
-        <source>In order to detect any possible problems it is recommended to always do a &lt;strong&gt;Dry Run&lt;/strong&gt; before scheduling the actual Service Pack Migration.</source>
+        <source>In order to detect any possible problems it is recommended to always do a &lt;strong&gt;Dry Run&lt;/strong&gt; before scheduling the actual Product Migration.</source>
       </trans-unit>
       <trans-unit id="spmigration.jsp.confirm.back" xml:space="preserve">
         <source>Go Back</source>
@@ -25069,8 +25069,8 @@ given channel.</source>
       <trans-unit id="filedetails.jsp.note.macrosalt" xml:space="preserve">
         <source>&lt;strong&gt;Note:&lt;/strong&gt; Macro delimiters will be ignored when deploying to systems managed via Salt.</source>
       </trans-unit>
-      <trans-unit id="SP Migration" xml:space="preserve">
-        <source>SP Migration</source>
+      <trans-unit id="Product Migration" xml:space="preserve">
+        <source>Product Migration</source>
       </trans-unit>
       <trans-unit id="Mirror Credentials" xml:space="preserve">
         <source>Organization Credentials</source>

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/org/trusts/OrgTrustHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/org/trusts/OrgTrustHandler.java
@@ -171,9 +171,13 @@ public class OrgTrustHandler extends BaseHandler {
      *          the organization.")
      *          #prop_desc("int", "channels_consumed", "Number of channels consumed by
      *          the organization.")
-     *          #prop_desc("int", "systems_migrated_to", "Number of systems migrated to
+     *          #prop_desc("int", "systems_migrated_to", "(Deprecated by systems_transferred_to) Number
+     *          of systems transferred to the organization.")
+     *          #prop_desc("int", "systems_migrated_from", "(Deprecated by systems_transferred_from) Number
+     *          of systems transferred from the organization.")
+     *          #prop_desc("int", "systems_transferred_to", "Number of systems transferred to
      *          the organization.")
-     *          #prop_desc("int", "systems_migrated_from", "Number of systems migrated
+     *          #prop_desc("int", "systems_transferred_from", "Number of systems transferred
      *          from the organization.")
      *     #struct_end()
      */
@@ -211,6 +215,13 @@ public class OrgTrustHandler extends BaseHandler {
                 OrgManager.getMigratedSystems(loggedInUser,
                         trustOrg, loggedInUser.getOrg()));
         details.put("systems_migrated_from",
+                OrgManager.getMigratedSystems(loggedInUser,
+                        loggedInUser.getOrg(), trustOrg));
+
+        details.put("systems_transferred_to",
+                OrgManager.getMigratedSystems(loggedInUser,
+                        trustOrg, loggedInUser.getOrg()));
+        details.put("systems_transferred_from",
                 OrgManager.getMigratedSystems(loggedInUser,
                         loggedInUser.getOrg(), trustOrg));
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/org/trusts/test/OrgTrustHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/org/trusts/test/OrgTrustHandlerTest.java
@@ -195,8 +195,8 @@ public class OrgTrustHandlerTest extends BaseHandlerTestCase {
         assertTrue(result.containsKey("trusted_since"));
         assertTrue(result.containsKey("channels_provided"));
         assertTrue(result.containsKey("channels_consumed"));
-        assertTrue(result.containsKey("systems_migrated_to"));
-        assertTrue(result.containsKey("systems_migrated_from"));
+        assertTrue(result.containsKey("systems_transferred_to"));
+        assertTrue(result.containsKey("systems_transferred_from"));
     }
 
     private Org createOrg() throws Exception {

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -7011,11 +7011,11 @@ public class SystemHandler extends BaseHandler {
                                 t.getMissingChannelsMessage())
                                 .collect(Collectors.joining(System.getProperty("line.separator")));
                 log.error("No target products found for migration: " + targetsInfo);
-                throw new FaultException(-1, "servicePackMigrationNoTarget",
-                        "No target found for SP migration. " + targetsInfo);
+                throw new FaultException(-1, "productMigrationNoTarget",
+                        "No target found for Product migration. " + targetsInfo);
             }
             if (!targetProducts.getIsEveryChannelSynced()) {
-                throw new FaultException(-1, "servicePackMigrationNoTarget",
+                throw new FaultException(-1, "productMigrationNoTarget",
                         "Target not available, the following channels are not synced: " +
                         targetProducts.getMissingChannelsMessage());
             }
@@ -7053,8 +7053,8 @@ public class SystemHandler extends BaseHandler {
         }
 
         // We didn't find target products if we are still here
-        throw new FaultException(-1, "servicePackMigrationNoTarget",
-                "No target found for SP migration");
+        throw new FaultException(-1, "productMigrationNoTarget",
+                "No target found for Product migration");
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -6797,9 +6797,8 @@ public class SystemHandler extends BaseHandler {
         return returnList;
     }
 
-
     /**
-     * Schedule a Service Pack migration for a system. This call is the recommended and
+     * Schedule a Product migration for a system. This call is the recommended and
      * supported way of migrating a system to the next Service Pack.
      *
      * This call automatically select the nearest possible migration target.
@@ -6815,12 +6814,17 @@ public class SystemHandler extends BaseHandler {
      * @param dryRun set to true to perform a dry run
      * @param earliest earliest occurrence of the migration
      * @return action id, exception thrown otherwise
+     * @deprecated being replaced by scheduleProductMigration(User loggedInUser, Integer sid,
+     * String baseChannelLabel, List(String) optionalChildChannels, boolean dryRun, Date earliest)
      *
-     * @xmlrpc.doc Schedule a Service Pack migration for a system. This call is the
+     * @xmlrpc.doc Schedule a Product migration for a system. This call is the
      * recommended and supported way of migrating a system to the next Service Pack. It will
      * automatically find all mandatory product channels below a given target base channel
      * and subscribe the system accordingly. Any additional optional channels can be
      * subscribed by providing their labels.
+     *
+     * Note: This method is deprecated and will be removed in a future API version. Please use
+     * scheduleProductMigration instead.
      * @xmlrpc.param #param("string", "sessionKey")
      * @xmlrpc.param #param("int", "serverId")
      * @xmlrpc.param #param("string", "baseChannelLabel")
@@ -6829,91 +6833,268 @@ public class SystemHandler extends BaseHandler {
      * @xmlrpc.param #param("dateTime.iso8601", "earliest")
      * @xmlrpc.returntype #param_desc("int", "actionId", "The action id of the scheduled action")
      */
+    @Deprecated
     public Long scheduleSPMigration(User loggedInUser, Integer sid, String baseChannelLabel,
                                     List<String> optionalChildChannels, boolean dryRun, Date earliest) {
-        return scheduleSPMigration(loggedInUser, sid, baseChannelLabel, optionalChildChannels, dryRun, false, earliest);
-    }
-
-    /**
-     * Schedule a Service Pack migration for a system. This call is the recommended and
-     * supported way of migrating a system to the next Service Pack.
-     *
-     * This call automatically select the nearest possible migration target.
-     *
-     * It will automatically find all mandatory product channels below a given
-     * target base channel and subscribe the system accordingly. Any additional
-     * optional channels can be subscribed by providing their labels.
-     *
-     * @param loggedInUser the currently logged in user
-     * @param sid ID of the server
-     * @param baseChannelLabel label of the target base channel
-     * @param optionalChildChannels labels of optional child channels to subscribe
-     * @param dryRun set to true to perform a dry run
-     * @param allowVendorChange set to true to allow vendor change
-     * @param earliest earliest occurrence of the migration
-     * @return action id, exception thrown otherwise
-     *
-     * @xmlrpc.doc Schedule a Service Pack migration for a system. This call is the
-     * recommended and supported way of migrating a system to the next Service Pack. It will
-     * automatically find all mandatory product channels below a given target base channel
-     * and subscribe the system accordingly. Any additional optional channels can be
-     * subscribed by providing their labels.
-     * @xmlrpc.param #param("string", "sessionKey")
-     * @xmlrpc.param #param("int", "serverId")
-     * @xmlrpc.param #param("string", "baseChannelLabel")
-     * @xmlrpc.param #array_single("string", "optionalChildChannels")
-     * @xmlrpc.param #param("boolean", "dryRun")
-     * @xmlrpc.param #param("boolean", "allowVendorChange")
-     * @xmlrpc.param #param("dateTime.iso8601", "earliest")
-     * @xmlrpc.returntype #param_desc("int", "actionId", "The action id of the scheduled action")
-     */
-    public Long scheduleSPMigration(User loggedInUser, Integer sid, String baseChannelLabel,
-            List<String> optionalChildChannels, boolean dryRun, boolean allowVendorChange, Date earliest) {
-        return scheduleSPMigration(loggedInUser, sid, null, baseChannelLabel,
-                optionalChildChannels, dryRun, allowVendorChange, earliest);
-    }
-
-
-    /**
-     * Schedule a Service Pack migration for a system. This call is the recommended and
-     * supported way of migrating a system to the next Service Pack. It will automatically
-     * find all mandatory product channels below a given target base channel and subscribe
-     * the system accordingly. Any additional optional channels can be subscribed by
-     * providing their labels.
-     *
-     * @param loggedInUser the currently logged in user
-     * @param sid ID of the server
-     * @param targetIdent identifier for the selected migration
-     *                    target ({@link #listMigrationTargets})
-     * @param baseChannelLabel label of the target base channel
-     * @param optionalChildChannels labels of optional child channels to subscribe
-     * @param dryRun set to true to perform a dry run
-     * @param earliest earliest occurrence of the migration
-     * @return action id, exception thrown otherwise
-     *
-     * @xmlrpc.doc Schedule a Service Pack migration for a system. This call is the
-     * recommended and supported way of migrating a system to the next Service Pack. It will
-     * automatically find all mandatory product channels below a given target base channel
-     * and subscribe the system accordingly. Any additional optional channels can be
-     * subscribed by providing their labels.
-     * @xmlrpc.param #param("string", "sessionKey")
-     * @xmlrpc.param #param("int", "serverId")
-     * @xmlrpc.param #param("string", "targetIdent")
-     * @xmlrpc.param #param("string", "baseChannelLabel")
-     * @xmlrpc.param #array_single("string", "optionalChildChannels")
-     * @xmlrpc.param #param("boolean", "dryRun")
-     * @xmlrpc.param #param("dateTime.iso8601",  "earliest")
-     * @xmlrpc.returntype #param_desc("int", "actionId", "The action id of the scheduled action")
-     */
-    public Long scheduleSPMigration(User loggedInUser, Integer sid, String targetIdent,
-                                    String baseChannelLabel, List<String> optionalChildChannels, boolean dryRun,
-                                    Date earliest) {
-        return scheduleSPMigration(loggedInUser, sid, targetIdent, baseChannelLabel, optionalChildChannels, dryRun,
+        return scheduleProductMigration(loggedInUser, sid, baseChannelLabel, optionalChildChannels, dryRun,
                 false, earliest);
     }
 
     /**
-     * Schedule a Service Pack migration for a system. This call is the recommended and
+     * Schedule a Product migration for a system. This call is the recommended and
+     * supported way of migrating a system to the next Service Pack.
+     *
+     * This call automatically select the nearest possible migration target.
+     *
+     * It will automatically find all mandatory product channels below a given
+     * target base channel and subscribe the system accordingly. Any additional
+     * optional channels can be subscribed by providing their labels.
+     *
+     * @param loggedInUser the currently logged in user
+     * @param sid ID of the server
+     * @param baseChannelLabel label of the target base channel
+     * @param optionalChildChannels labels of optional child channels to subscribe
+     * @param dryRun set to true to perform a dry run
+     * @param allowVendorChange set to true to allow vendor change
+     * @param earliest earliest occurrence of the migration
+     * @return action id, exception thrown otherwise
+     * @deprecated being replaced by scheduleProductMigration(User loggedInUser, Integer sid,
+     * String baseChannelLabel, List(String) optionalChildChannels, boolean dryRun, boolean allowVendorChange,
+     * Date earliest)
+     *
+     * @xmlrpc.doc Schedule a Product migration for a system. This call is the
+     * recommended and supported way of migrating a system to the next Service Pack. It will
+     * automatically find all mandatory product channels below a given target base channel
+     * and subscribe the system accordingly. Any additional optional channels can be
+     * subscribed by providing their labels.
+     *
+     * Note: This method is deprecated and will be removed in a future API version. Please use
+     * scheduleProductMigration instead.
+     * @xmlrpc.param #param("string", "sessionKey")
+     * @xmlrpc.param #param("int", "serverId")
+     * @xmlrpc.param #param("string", "baseChannelLabel")
+     * @xmlrpc.param #array_single("string", "optionalChildChannels")
+     * @xmlrpc.param #param("boolean", "dryRun")
+     * @xmlrpc.param #param("boolean", "allowVendorChange")
+     * @xmlrpc.param #param("dateTime.iso8601", "earliest")
+     * @xmlrpc.returntype #param_desc("int", "actionId", "The action id of the scheduled action")
+     */
+    @Deprecated
+    public Long scheduleSPMigration(User loggedInUser, Integer sid, String baseChannelLabel,
+            List<String> optionalChildChannels, boolean dryRun, boolean allowVendorChange, Date earliest) {
+        return scheduleProductMigration(loggedInUser, sid, null, baseChannelLabel,
+                optionalChildChannels, dryRun, allowVendorChange, earliest);
+    }
+
+    /**
+     * Schedule a Product migration for a system. This call is the recommended and
+     * supported way of migrating a system to the next Service Pack. It will automatically
+     * find all mandatory product channels below a given target base channel and subscribe
+     * the system accordingly. Any additional optional channels can be subscribed by
+     * providing their labels.
+     *
+     * @param loggedInUser the currently logged in user
+     * @param sid ID of the server
+     * @param targetIdent identifier for the selected migration
+     *                    target ({@link #listMigrationTargets})
+     * @param baseChannelLabel label of the target base channel
+     * @param optionalChildChannels labels of optional child channels to subscribe
+     * @param dryRun set to true to perform a dry run
+     * @param earliest earliest occurrence of the migration
+     * @return action id, exception thrown otherwise
+     * @deprecated being replaced by scheduleProductMigration(User loggedInUser, Integer sid,
+     * String targetIdent, String baseChannelLabel, List(String) optionalChildChannels, boolean dryRun,
+     * Date earliest)
+     *
+     * @xmlrpc.doc Schedule a Prodcut migration for a system. This call is the
+     * recommended and supported way of migrating a system to the next Service Pack. It will
+     * automatically find all mandatory product channels below a given target base channel
+     * and subscribe the system accordingly. Any additional optional channels can be
+     * subscribed by providing their labels.
+     *
+     * Note: This method is deprecated and will be removed in a future API version. Please use
+     * scheduleProductMigration instead.
+     * @xmlrpc.param #param("string", "sessionKey")
+     * @xmlrpc.param #param("int", "serverId")
+     * @xmlrpc.param #param("string", "targetIdent")
+     * @xmlrpc.param #param("string", "baseChannelLabel")
+     * @xmlrpc.param #array_single("string", "optionalChildChannels")
+     * @xmlrpc.param #param("boolean", "dryRun")
+     * @xmlrpc.param #param("dateTime.iso8601",  "earliest")
+     * @xmlrpc.returntype #param_desc("int", "actionId", "The action id of the scheduled action")
+     */
+    @Deprecated
+    public Long scheduleSPMigration(User loggedInUser, Integer sid, String targetIdent,
+                                    String baseChannelLabel, List<String> optionalChildChannels, boolean dryRun,
+                                    Date earliest) {
+        return scheduleProductMigration(loggedInUser, sid, targetIdent, baseChannelLabel, optionalChildChannels,
+                dryRun, false, earliest);
+    }
+
+    /**
+     * Schedule a Product migration for a system. This call is the recommended and
+     * supported way of migrating a system to the next Service Pack. It will automatically
+     * find all mandatory product channels below a given target base channel and subscribe
+     * the system accordingly. Any additional optional channels can be subscribed by
+     * providing their labels.
+     *
+     * @param loggedInUser the currently logged in user
+     * @param sid ID of the server
+     * @param targetIdent identifier for the selected migration
+     *                    target ({@link #listMigrationTargets})
+     * @param baseChannelLabel label of the target base channel
+     * @param optionalChildChannels labels of optional child channels to subscribe
+     * @param dryRun set to true to perform a dry run
+     * @param allowVendorChange set to true to allow vendor change
+     * @param earliest earliest occurrence of the migration
+     * @return action id, exception thrown otherwise
+     * @deprecated being replaced by scheduleProductMigration(User loggedInUser, Integer sid,
+     * String targetIdent, String baseChannelLabel, List(String) optionalChildChannels, boolean dryRun,
+     * boolean allowVendorChange, Date earliest)
+     *
+     * @xmlrpc.doc Schedule a Product migration for a system. This call is the
+     * recommended and supported way of migrating a system to the next Service Pack. It will
+     * automatically find all mandatory product channels below a given target base channel
+     * and subscribe the system accordingly. Any additional optional channels can be
+     * subscribed by providing their labels.
+     *
+     * Note: This method is deprecated and will be removed in a future API version. Please use
+     * scheduleProductMigration instead.
+     * @xmlrpc.param #param("string", "sessionKey")
+     * @xmlrpc.param #param("int", "serverId")
+     * @xmlrpc.param #param("string", "targetIdent")
+     * @xmlrpc.param #param("string", "baseChannelLabel")
+     * @xmlrpc.param #array_single("string", "optionalChildChannels")
+     * @xmlrpc.param #param("boolean", "dryRun")
+     * @xmlrpc.param #param("boolean", "allowVendorChange")
+     * @xmlrpc.param #param("dateTime.iso8601",  "earliest")
+     * @xmlrpc.returntype #param_desc("int", "actionId", "The action id of the scheduled action")
+     */
+    @Deprecated
+    public Long scheduleSPMigration(User loggedInUser, Integer sid, String targetIdent,
+            String baseChannelLabel, List<String> optionalChildChannels, boolean dryRun,
+            boolean allowVendorChange, Date earliest) {
+        return scheduleProductMigration(loggedInUser, sid, targetIdent, baseChannelLabel, optionalChildChannels,
+                dryRun, allowVendorChange, earliest);
+    }
+
+    /**
+     * Schedule a Product migration for a system. This call is the recommended and
+     * supported way of migrating a system to the next Service Pack.
+     *
+     * This call automatically select the nearest possible migration target.
+     *
+     * It will automatically find all mandatory product channels below a given
+     * target base channel and subscribe the system accordingly. Any additional
+     * optional channels can be subscribed by providing their labels.
+     *
+     * @param loggedInUser the currently logged in user
+     * @param sid ID of the server
+     * @param baseChannelLabel label of the target base channel
+     * @param optionalChildChannels labels of optional child channels to subscribe
+     * @param dryRun set to true to perform a dry run
+     * @param earliest earliest occurrence of the migration
+     * @return action id, exception thrown otherwise
+     *
+     * @xmlrpc.doc Schedule a Product migration for a system. This call is the
+     * recommended and supported way of migrating a system to the next Service Pack. It will
+     * automatically find all mandatory product channels below a given target base channel
+     * and subscribe the system accordingly. Any additional optional channels can be
+     * subscribed by providing their labels.
+     * @xmlrpc.param #param("string", "sessionKey")
+     * @xmlrpc.param #param("int", "serverId")
+     * @xmlrpc.param #param("string", "baseChannelLabel")
+     * @xmlrpc.param #array_single("string", "optionalChildChannels")
+     * @xmlrpc.param #param("boolean", "dryRun")
+     * @xmlrpc.param #param("dateTime.iso8601", "earliest")
+     * @xmlrpc.returntype #param_desc("int", "actionId", "The action id of the scheduled action")
+     */
+    public Long scheduleProductMigration(User loggedInUser, Integer sid, String baseChannelLabel,
+                                         List<String> optionalChildChannels, boolean dryRun, Date earliest) {
+        return scheduleProductMigration(loggedInUser, sid, baseChannelLabel, optionalChildChannels, dryRun,
+                false, earliest);
+    }
+
+    /**
+     * Schedule a Product migration for a system. This call is the recommended and
+     * supported way of migrating a system to the next Service Pack.
+     *
+     * This call automatically select the nearest possible migration target.
+     *
+     * It will automatically find all mandatory product channels below a given
+     * target base channel and subscribe the system accordingly. Any additional
+     * optional channels can be subscribed by providing their labels.
+     *
+     * @param loggedInUser the currently logged in user
+     * @param sid ID of the server
+     * @param baseChannelLabel label of the target base channel
+     * @param optionalChildChannels labels of optional child channels to subscribe
+     * @param dryRun set to true to perform a dry run
+     * @param allowVendorChange set to true to allow vendor change
+     * @param earliest earliest occurrence of the migration
+     * @return action id, exception thrown otherwise
+     *
+     * @xmlrpc.doc Schedule a Product migration for a system. This call is the
+     * recommended and supported way of migrating a system to the next Service Pack. It will
+     * automatically find all mandatory product channels below a given target base channel
+     * and subscribe the system accordingly. Any additional optional channels can be
+     * subscribed by providing their labels.
+     * @xmlrpc.param #param("string", "sessionKey")
+     * @xmlrpc.param #param("int", "serverId")
+     * @xmlrpc.param #param("string", "baseChannelLabel")
+     * @xmlrpc.param #array_single("string", "optionalChildChannels")
+     * @xmlrpc.param #param("boolean", "dryRun")
+     * @xmlrpc.param #param("boolean", "allowVendorChange")
+     * @xmlrpc.param #param("dateTime.iso8601", "earliest")
+     * @xmlrpc.returntype #param_desc("int", "actionId", "The action id of the scheduled action")
+     */
+    public Long scheduleProductMigration(User loggedInUser, Integer sid, String baseChannelLabel,
+                                         List<String> optionalChildChannels, boolean dryRun, boolean allowVendorChange,
+                                         Date earliest) {
+        return scheduleProductMigration(loggedInUser, sid, null, baseChannelLabel,
+                optionalChildChannels, dryRun, allowVendorChange, earliest);
+    }
+
+    /**
+     * Schedule a Product migration for a system. This call is the recommended and
+     * supported way of migrating a system to the next Service Pack. It will automatically
+     * find all mandatory product channels below a given target base channel and subscribe
+     * the system accordingly. Any additional optional channels can be subscribed by
+     * providing their labels.
+     *
+     * @param loggedInUser the currently logged in user
+     * @param sid ID of the server
+     * @param targetIdent identifier for the selected migration
+     *                    target ({@link #listMigrationTargets})
+     * @param baseChannelLabel label of the target base channel
+     * @param optionalChildChannels labels of optional child channels to subscribe
+     * @param dryRun set to true to perform a dry run
+     * @param earliest earliest occurrence of the migration
+     * @return action id, exception thrown otherwise
+     *
+     * @xmlrpc.doc Schedule a Prodcut migration for a system. This call is the
+     * recommended and supported way of migrating a system to the next Service Pack. It will
+     * automatically find all mandatory product channels below a given target base channel
+     * and subscribe the system accordingly. Any additional optional channels can be
+     * subscribed by providing their labels.
+     * @xmlrpc.param #param("string", "sessionKey")
+     * @xmlrpc.param #param("int", "serverId")
+     * @xmlrpc.param #param("string", "targetIdent")
+     * @xmlrpc.param #param("string", "baseChannelLabel")
+     * @xmlrpc.param #array_single("string", "optionalChildChannels")
+     * @xmlrpc.param #param("boolean", "dryRun")
+     * @xmlrpc.param #param("dateTime.iso8601",  "earliest")
+     * @xmlrpc.returntype #param_desc("int", "actionId", "The action id of the scheduled action")
+     */
+    public Long scheduleProductMigration(User loggedInUser, Integer sid, String targetIdent,
+                                         String baseChannelLabel, List<String> optionalChildChannels, boolean dryRun,
+                                         Date earliest) {
+        return scheduleProductMigration(loggedInUser, sid, targetIdent, baseChannelLabel, optionalChildChannels,
+                dryRun, false, earliest);
+    }
+
+    /**
+     * Schedule a Product migration for a system. This call is the recommended and
      * supported way of migrating a system to the next Service Pack. It will automatically
      * find all mandatory product channels below a given target base channel and subscribe
      * the system accordingly. Any additional optional channels can be subscribed by
@@ -6930,7 +7111,7 @@ public class SystemHandler extends BaseHandler {
      * @param earliest earliest occurrence of the migration
      * @return action id, exception thrown otherwise
      *
-     * @xmlrpc.doc Schedule a Service Pack migration for a system. This call is the
+     * @xmlrpc.doc Schedule a Product migration for a system. This call is the
      * recommended and supported way of migrating a system to the next Service Pack. It will
      * automatically find all mandatory product channels below a given target base channel
      * and subscribe the system accordingly. Any additional optional channels can be
@@ -6945,9 +7126,9 @@ public class SystemHandler extends BaseHandler {
      * @xmlrpc.param #param("dateTime.iso8601",  "earliest")
      * @xmlrpc.returntype #param_desc("int", "actionId", "The action id of the scheduled action")
      */
-    public Long scheduleSPMigration(User loggedInUser, Integer sid, String targetIdent,
-            String baseChannelLabel, List<String> optionalChildChannels, boolean dryRun,
-            boolean allowVendorChange, Date earliest) {
+    public Long scheduleProductMigration(User loggedInUser, Integer sid, String targetIdent,
+                                         String baseChannelLabel, List<String> optionalChildChannels, boolean dryRun,
+                                         boolean allowVendorChange, Date earliest) {
         // Perform checks on the server
         Server server = null;
         try {

--- a/java/code/src/com/redhat/rhn/manager/audit/CVEAuditManager.java
+++ b/java/code/src/com/redhat/rhn/manager/audit/CVEAuditManager.java
@@ -471,7 +471,7 @@ public class CVEAuditManager {
 
     /**
      * Looks at installed products on the server and their previous and future
-     * SP migrations, adding channels to relevantChannels when they are found.
+     * product migrations, adding channels to relevantChannels when they are found.
      *
      * @param auditTarget the audit target object
      * @param maxRank starting rank for new channels found

--- a/java/code/src/com/redhat/rhn/manager/audit/test/CVEAuditManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/audit/test/CVEAuditManagerTest.java
@@ -333,7 +333,7 @@ public class CVEAuditManagerTest extends RhnBaseTestCase {
         createTestSUSEProductChannel(childChannel1, product, true);
         createTestSUSEProductChannel(childChannel2, product, true);
 
-        // Setup a next SP product for verifying SP migrations
+        // Setup a next SP product for verifying product migrations
         SUSEProduct productNextSP = createTestSUSEProduct(channelFamily);
         createTestSUSEUpgradePath(product, productNextSP);
         // Create channels

--- a/java/code/src/com/redhat/rhn/taskomatic/task/DailySummary.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/DailySummary.java
@@ -309,8 +309,8 @@ public class DailySummary extends RhnJavaJob {
             }
             else {
                 if (!nonErrataActions.containsKey(am.getType())) {
-                    if (am.getType().equals("Service Pack Migration")) {
-                        am.setType("Service Pack Migration (Total)");
+                    if (am.getType().equals("Product Migration")) {
+                        am.setType("Product Migration (Total)");
                     }
                     if (am.getType().equals("Apply states")) {
                         am.setType("Apply states (total)");

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -1431,7 +1431,7 @@ public class SaltUtils {
                 RH systems require some parsing on the grains to get the correct release
                 See RegisterMinionEventMessageAction#getOsRelease
 
-                However, release can change only after SP migration and SUMA supports this only on SUSE systems.
+                However, release can change only after product migration and SUMA supports this only on SUSE systems.
                 Also, the getOsRelease method requires remote command execution and was therefore avoided for now.
                 If we decide to support RedHat distro/SP upgrades in the future, this code has to be reviewed.
              */

--- a/java/code/webapp/WEB-INF/nav/system_detail.xml
+++ b/java/code/webapp/WEB-INF/nav/system_detail.xml
@@ -73,7 +73,7 @@
       <rhn-tab-url>/rhn/systems/details/SystemChannels.do</rhn-tab-url>
     </rhn-tab>
 
-    <rhn-tab name="SP Migration" acl="system_feature(ftr_package_updates)">
+    <rhn-tab name="Product Migration" acl="system_feature(ftr_package_updates)">
       <rhn-tab-url>/rhn/systems/details/SPMigration.do</rhn-tab-url>
     </rhn-tab>
 </rhn-tab>

--- a/java/code/webapp/WEB-INF/nav/system_detail.xml
+++ b/java/code/webapp/WEB-INF/nav/system_detail.xml
@@ -17,7 +17,7 @@
     <rhn-tab name="Hardware">
       <rhn-tab-url>/rhn/systems/details/SystemHardware.do</rhn-tab-url>
     </rhn-tab>
-    <rhn-tab name="Migrate" acl="user_role(org_admin)" url="/rhn/systems/details/SystemMigrate.do" />
+    <rhn-tab name="Transfer" acl="user_role(org_admin)" url="/rhn/systems/details/SystemMigrate.do" />
     <rhn-tab name="Notes">
       <rhn-tab-url>/rhn/systems/details/Notes.do</rhn-tab-url>
       <rhn-tab-url>/rhn/systems/details/EditNote.do</rhn-tab-url>

--- a/java/code/webapp/WEB-INF/pages/systems/spmigration/spmigration-target.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/spmigration/spmigration-target.jsp
@@ -17,6 +17,10 @@
         <bean:message key="spmigration.jsp.target.title" />
     </rhn:toolbar>
 
+    <div class="page-summary">
+        <p><bean:message key="spmigration.jsp.target.description" /></p>
+    </div>
+
     <c:choose>
         <c:when test="${not empty migrationScheduled}">
             <div class="alert alert-info">

--- a/java/code/webapp/WEB-INF/struts-config.xml
+++ b/java/code/webapp/WEB-INF/struts-config.xml
@@ -1082,7 +1082,7 @@
       <form-property name="allowVendorChange" type="java.lang.Boolean" />
     </form-bean>
 
-    <form-bean name="servicePackMigrationForm"
+    <form-bean name="productMigrationForm"
                type="com.redhat.rhn.frontend.struts.ScrubbingDynaActionForm">
       <form-property name="step" type="java.lang.String" />
       <form-property name="baseProduct" type="java.lang.Long" />
@@ -8084,10 +8084,10 @@
                  path="/WEB-INF/pages/systems/extra-packages-systems-list.jsp"/>
     </action>
 
-    <!-- Service Pack Migration -->
+    <!-- Product Migration -->
     <action path="/systems/details/SPMigration"
             scope="request"
-            name="servicePackMigrationForm"
+            name="productMigrationForm"
             type="com.redhat.rhn.frontend.action.systems.SPMigrationAction"
             className="com.redhat.rhn.frontend.struts.RhnActionMapping"
             parameter="dispatch">

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Rename system migration to system transfer
+- Rename SP to product migration
 - Change onboarding behavior to easier recycle systems (bsc#1183437)
 - The 'cookie' property for pkgset beacon was removed as no longer required
 - virtual console monitors VM state changes

--- a/schema/spacewalk/common/data/rhnActionType.sql
+++ b/schema/spacewalk/common/data/rhnActionType.sql
@@ -70,7 +70,7 @@ insert into rhnActionType values (49, 'proxy.deactivate', 'Deactivate Proxy', 'N
 insert into rhnActionType values (50, 'scap.xccdf_eval', 'OpenSCAP xccdf scanning', 'N', 'Y', 'N');
 insert into rhnActionType values (51, 'clientcert.update_client_cert', 'Update Client Certificate', 'N', 'Y', 'Y');
 insert into rhnActionType values (500, 'image.deploy', 'Deploy an image to a virtual host.', 'N', 'N', 'N');
-insert into rhnActionType values (501, 'distupgrade.upgrade', 'Service Pack Migration', 'N', 'N', 'Y');
+insert into rhnActionType values (501, 'distupgrade.upgrade', 'Product Migration', 'N', 'N', 'Y');
 insert into rhnActionType values (502, 'packages.setLocks', 'Lock packages', 'N', 'N', 'N');
 insert into rhnActionType values (503, 'states.apply', 'Apply states', 'N', 'N', 'Y');
 insert into rhnActionType values (504, 'image.build', 'Build an Image Profile', 'N', 'N', 'N');

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- Rename SP to product migration
 - Ansible integration: configure control node paths (playbooks and inventories)
 
 -------------------------------------------------------------------

--- a/schema/spacewalk/upgrade/susemanager-schema-4.2.9-to-susemanager-schema-4.2.10/400-rename-service-pack-migration.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.2.9-to-susemanager-schema-4.2.10/400-rename-service-pack-migration.sql
@@ -1,0 +1,12 @@
+--
+-- Copyright (c) 2021 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+
+UPDATE rhnActionType SET name='Product Migration' WHERE label='distupgrade.upgrade';

--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,6 @@
+- Rename system migration to system transfer
+- Rename SP to product migration
+
 -------------------------------------------------------------------
 Mon Apr 19 14:50:07 CEST 2021 - jgonzalez@suse.com
 

--- a/spacecmd/src/spacecmd/org.py
+++ b/spacecmd/src/spacecmd/org.py
@@ -320,8 +320,8 @@ def do_org_trustdetails(self, args):
 
         print(_('Trusted Organization:   %s') % trusted_org)
         print(_('Trusted Since:          %s') % details.get('trusted_since'))
-        print(_('Systems Migrated From:  %i') % details.get('systems_migrated_from'))
-        print(_('Systems Migrated To:    %i') % details.get('systems_migrated_to'))
+        print(_('Systems Transferred From:  %i') % details.get('systems_transferred_from'))
+        print(_('Systems Transferred To:    %i') % details.get('systems_transferred_to'))
         print('')
         print(_('Channels Consumed'))
         print('-----------------')

--- a/spacecmd/src/spacecmd/system.py
+++ b/spacecmd/src/spacecmd/system.py
@@ -4312,6 +4312,8 @@ def do_system_listmigrationtargets(self, args):
 
 
 def help_system_schedulespmigration(self):
+    print(_('This method is deprecated and will be removed in a future API version. Please use system_scheduleproductmigration instead.'))
+    logging.warning(_("This method is deprecated and will be removed in a future API version"))
     print(_('system_schedulespmigration: Schedule a Service Pack migration for systems.'))
     print(_('usage: system_schedulespmigration <SYSTEM> <BASE_CHANNEL_LABEL> <MIGRATION_TARGET> [options] \
 \n    For MIGRATION_TARGET parameter see system_listmigrationtargets. \
@@ -4325,6 +4327,27 @@ def help_system_schedulespmigration(self):
 
 
 def do_system_schedulespmigration(self, args):
+    print(_('This method is deprecated and will be removed in a future API version. Please use system_scheduleproductmigration instead.'))
+    logging.warning(_("This method is deprecated and will be removed in a future API version"))
+    self.do_system_scheduleproductmigration(self, args)
+
+####################
+
+
+def help_system_scheduleproductmigration(self):
+    print(_('system_scheduleproductmigration: Schedule a Product migration for systems.'))
+    print(_('usage: system_scheduleproductmigration <SYSTEM> <BASE_CHANNEL_LABEL> <MIGRATION_TARGET> [options] \
+\n    For MIGRATION_TARGET parameter see system_listmigrationtargets. \
+\n    The MIGRATION_TARGET parameter must be passed in the following format: [3143,3146,3147,3145,3144,3148,3062]. \
+\n    Options: \
+\n        -s START_TIME \
+\n        -d pass this flag, if you want to do a dry run \
+\n        -c CHILD_CHANNELS (comma-separated child channels labels (with no spaces))'))
+    print('')
+    print(self.HELP_SYSTEM_OPTS)
+
+
+def do_system_scheduleproductmigration(self, args):
     arg_parser = get_argument_parser()
     arg_parser.add_argument('-s', '--start-time')
     arg_parser.add_argument('-d', '--dry-run', action='store_true', default=False)
@@ -4333,7 +4356,7 @@ def do_system_schedulespmigration(self, args):
     (args, options) = parse_command_arguments(args, arg_parser)
 
     if len(args) < 3:
-        self.help_system_schedulespmigration()
+        self.help_system_scheduleproductmigration()
         return
 
     # POSITIONAL ARGS
@@ -4366,7 +4389,7 @@ def do_system_schedulespmigration(self, args):
             logging.warning(_N('Cannot find system ') + str(system) + _('. Skipping it.'))
             continue
 
-        print(_('Scheduling Service Pack migration for system ') + str(system))
+        print(_('Scheduling Product migration for system ') + str(system))
         try:
             result = self.client.system.scheduleSPMigration(self.session,
                     system_id, migration_target, base_channel_label,

--- a/spacecmd/tests/test_org.py
+++ b/spacecmd/tests/test_org.py
@@ -463,8 +463,8 @@ class TestSCOrg:
         shell.get_org_id = MagicMock(return_value=1)
         shell.client.org.trusts.getDetails = MagicMock(return_value={
             "trusted_since": "Mi 29. Mai 15:02:26 CEST 2019",
-            "systems_migrated_from": 3,
-            "systems_migrated_to": 8
+            "systems_transferred_from": 3,
+            "systems_transferred_to": 8
         })
         shell.client.org.trusts.listChannelsConsumed = MagicMock(return_value=[
             {"name": "base_channel"},
@@ -493,7 +493,7 @@ class TestSCOrg:
         exp = [
            'Trusted Organization:   myorg',
            'Trusted Since:          Mi 29. Mai 15:02:26 CEST 2019',
-           'Systems Migrated From:  3', 'Systems Migrated To:    8', '',
+           'Systems Transferred From:  3', 'Systems Transferred To:    8', '',
            'Channels Consumed', '-----------------',
            'base_channel\nspecial_channel', '',
            'Channels Provided', '-----------------',

--- a/testsuite/features/init_clients/sle_minion.feature
+++ b/testsuite/features/init_clients/sle_minion.feature
@@ -41,13 +41,13 @@ Feature: Bootstrap a Salt minion via the GUI
   Scenario: Migrate this minion to SLE 15 SP2
     Given I am on the Systems overview page of this "sle_spack_migrated_minion"
     When I follow "Software" in the content area
-    And I follow "SP Migration" in the content area
+    And I follow "Product Migration" in the content area
     And I wait until I see "Target Products:" text, refreshing the page
     And I click on "Select Channels"
     And I check "allowVendorChange"
     And I wait until I see "SUSE Linux Enterprise Server 15 SP2 x86_64" text
     And I click on "Schedule Migration"
-    And I should see a "Service Pack Migration - Confirm" text
+    And I should see a "Product Migration - Confirm" text
     And I click on "Confirm"
     Then I should see a "This system is scheduled to be migrated to" text
 
@@ -55,10 +55,10 @@ Feature: Bootstrap a Salt minion via the GUI
     Given I am on the Systems overview page of this "sle_spack_migrated_minion"
     When I follow "Events"
     And I follow "History"
-    And I wait at most 600 seconds until event "Service Pack Migration scheduled by admin" is completed
+    And I wait at most 600 seconds until event "Product Migration scheduled by admin" is completed
     And I follow "Details" in the content area
     Then I should see a "SUSE Linux Enterprise Server 15 SP2" text
-    And vendor change should be enabled for SP migration on "sle_spack_migrated_minion"
+    And vendor change should be enabled for product migration on "sle_spack_migrated_minion"
 
   Scenario: Install the latest Salt on this minion
     When I enable repositories before installing Salt on this "sle_spack_migrated_minion"

--- a/testsuite/features/init_clients/sle_ssh_minion.feature
+++ b/testsuite/features/init_clients/sle_ssh_minion.feature
@@ -4,7 +4,7 @@
 @ssh_minion
 Feature: Bootstrap a Salt host managed via salt-ssh
 
-  Scenario: Register this SSH minion for service pack migration
+  Scenario: Register this SSH minion for product migration
     Given I am authorized
     And I go to the bootstrapping page
     Then I should see a "Bootstrap Minions" text
@@ -37,13 +37,13 @@ Feature: Bootstrap a Salt host managed via salt-ssh
   Scenario: Migrate this SSH minion to SLE 15 SP2
     Given I am on the Systems overview page of this "ssh_spack_migrated_minion"
     When I follow "Software" in the content area
-    And I follow "SP Migration" in the content area
+    And I follow "Product Migration" in the content area
     And I wait until I see "Target Products:" text, refreshing the page
     And I click on "Select Channels"
     And I check "allowVendorChange"
     And I wait until I see "SUSE Linux Enterprise Server 15 SP2 x86_64" text
     And I click on "Schedule Migration"
-    And I should see a "Service Pack Migration - Confirm" text
+    And I should see a "Product Migration - Confirm" text
     And I click on "Confirm"
     Then I should see a "This system is scheduled to be migrated to" text
 
@@ -51,10 +51,10 @@ Feature: Bootstrap a Salt host managed via salt-ssh
     Given I am on the Systems overview page of this "ssh_spack_migrated_minion"
     When I follow "Events"
     And I follow "History"
-    And I wait at most 600 seconds until event "Service Pack Migration scheduled by admin" is completed
+    And I wait at most 600 seconds until event "Product Migration scheduled by admin" is completed
     And I follow "Details" in the content area
     Then I should see a "SUSE Linux Enterprise Server 15 SP2" text
-    And vendor change should be enabled for SP migration on "ssh_spack_migrated_minion"
+    And vendor change should be enabled for product migration on "ssh_spack_migrated_minion"
 
 @proxy
   Scenario: Check connection from SSH minion to proxy

--- a/testsuite/features/secondary/trad_product_migration.feature
+++ b/testsuite/features/secondary/trad_product_migration.feature
@@ -1,15 +1,15 @@
-# Copyright (c) 2017 SUSE LLC
+# Copyright (c) 2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
 # Since an advanced setup is needed for doing SP migration we test
 # only the alert warning message here for now.
 
 @scope_traditional_client
-@scope_sp_migration
-Feature: Service pack migration
+@scope_product_migration
+Feature: Product migration
 
-  Scenario: Check the warning message on tab "Software" => "SP Migration"
+  Scenario: Check the warning message on tab "Software" => "Product Migration"
     Given I am on the Systems overview page of this "sle_client"
     When I follow "Software" in the content area
-    And I follow "SP Migration" in the content area
-    Then I should see a "Service Pack Migration - Target" text
+    And I follow "Product Migration" in the content area
+    Then I should see a "Product Migration - Target" text


### PR DESCRIPTION
## What does this PR change?

Rename `SP` Migration to `Product` Migration
Rename `Migrate` Systems to `Transfer` Systems
Add new methods for `Product Migration` to spacecmd and XMLRPC API
and deprecate `SP Migration` methods

## GUI diff

### Changes:

**Product Migration:**
![migration-target](https://user-images.githubusercontent.com/31698054/116577745-0f3b1300-a911-11eb-9f6d-370108e4333b.png)
![migration-channels](https://user-images.githubusercontent.com/31698054/116577762-12ce9a00-a911-11eb-97e1-0fc91d80802c.png)
![migration-confirm](https://user-images.githubusercontent.com/31698054/116577775-14985d80-a911-11eb-86ed-39c72278dd26.png)
![history-event](https://user-images.githubusercontent.com/31698054/116577819-1eba5c00-a911-11eb-8014-3714f3abd07b.png)
![system-history](https://user-images.githubusercontent.com/31698054/116577882-2a0d8780-a911-11eb-86d3-f61f04faa2c7.png)
![action-summary](https://user-images.githubusercontent.com/31698054/116577850-2417a680-a911-11eb-9e8e-92f339837e83.png)
**Transfer Systems:**
![system-transfer](https://user-images.githubusercontent.com/31698054/116578009-46a9bf80-a911-11eb-9ac6-1bd5a39eb844.png)
![system-list](https://user-images.githubusercontent.com/31698054/116578087-588b6280-a911-11eb-903f-53db54a495fb.png)
![ssm-overview](https://user-images.githubusercontent.com/31698054/116578136-650fbb00-a911-11eb-86d0-d47cdb1b9ca2.png)
![ssm-transfer](https://user-images.githubusercontent.com/31698054/116578124-6214ca80-a911-11eb-9b2f-e0b8c0c3de8c.png)

- [x] **DONE**

## Documentation

- Documentation issue was created: https://github.com/SUSE/spacewalk/issues/14491

- [x] **DONE**

## Test coverage

- No tests: Just a rename shouldn't break any existing tests

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/14491

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
