### PR TITLE
fix syntax error in push-to-obs

### DIFF
--- a/susemanager-utils/testing/automation/push-to-obs.sh
+++ b/susemanager-utils/testing/automation/push-to-obs.sh
@@ -34,7 +34,7 @@ while getopts ":d:c:p:n:vthe" opts; do
     v) VERBOSE="-v";;
     t) TEST="-t";;
     n) OBS_TEST_PROJECT="-n ${OPTARG}";;
-    e) $EXTRA_OPTS="-e";;
+    e) EXTRA_OPTS="-e";;
     h) help
        exit 0;;
     *) echo "Invalid syntax. Use ${SCRIPT} -h"

--- a/susemanager-utils/testing/docker/scripts/push-to-obs.sh
+++ b/susemanager-utils/testing/docker/scripts/push-to-obs.sh
@@ -32,7 +32,7 @@ while getopts ":d:c:p:n:vthe" opts; do
     v) export VERBOSE=1;;
     t) export TEST=1;;
     n) export OBS_TEST_PROJECT=${OPTARG};;
-    e) export OSC_EXPAND="TRUE"
+    e) export OSC_EXPAND="TRUE";;
     h) help
        exit 0;;
     *) echo "Invalid syntax. Use ${SCRIPT} -h"


### PR DESCRIPTION
## What does this PR change?

fix syntax error in push-to-obs

## GUI diff

No difference.

Before:

After:

- [X] **DONE**

## Documentation
- No documentation needed

- [X] **DONE**

## Test coverage
- No tests
- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
