### PR TITLE
QA: Fix flaky tests waiting for a pick-up of an event of a page without ajax

### DIFF
--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -52,9 +52,9 @@ end
 When(/^I wait until I see "([^"]*)" text, refreshing the page$/) do |text|
   text.gsub! '$PRODUCT', $product
   # TODO: get rid of this substitution, using another step
-  next if has_content?(text)
+  next if has_content?(text, wait: 3)
   repeat_until_timeout(message: "Couldn't find text '#{text}'") do
-    break if has_content?(text)
+    break if has_content?(text, wait: 3)
     begin
       accept_prompt do
         execute_script 'window.location.reload()'
@@ -67,10 +67,10 @@ end
 
 When(/^I wait at most (\d+) seconds until the event is completed, refreshing the page$/) do |timeout|
   last = Time.now
-  next if has_content?("This action's status is: Completed.")
+  next if has_content?("This action's status is: Completed.", wait: 3)
   repeat_until_timeout(timeout: timeout.to_i, message: 'Event not yet completed') do
-    break if has_content?("This action's status is: Completed.")
-    raise 'Event failed' if has_content?("This action's status is: Failed.")
+    break if has_content?("This action's status is: Completed.", wait: 3)
+    raise 'Event failed' if has_content?("This action's status is: Failed.", wait: 3)
     current = Time.now
     if current - last > 150
       STDOUT.puts "#{current} Still waiting for action to complete..."
@@ -92,9 +92,9 @@ When(/^I wait until I see the name of "([^"]*)", refreshing the page$/) do |host
 end
 
 When(/^I wait until I do not see "([^"]*)" text, refreshing the page$/) do |text|
-  next unless has_content?(text)
+  next unless has_content?(text, wait: 3)
   repeat_until_timeout(message: "Text '#{text}' is still visible") do
-    break unless has_content?(text)
+    break unless has_content?(text, wait: 3)
     begin
       accept_prompt do
         execute_script 'window.location.reload()'


### PR DESCRIPTION
## What does this PR change?

Reduce from 10 to 3 the seconds (enough to re-load the page) to wait for a text in a list that will not be updated unless we refresh the page

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.0
- Manager-4.1

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
