### PR TITLE
Remove warnings in suma bsc 1175369

### DIFF
--- a/proxy/installer/spacewalk-proxy-installer.spec
+++ b/proxy/installer/spacewalk-proxy-installer.spec
@@ -107,7 +107,7 @@ if [ -f /etc/sysconfig/apache2 ]; then
 fi
 sed -i -e"s/^range_offset_limit -1 KB/range_offset_limit none/" /etc/squid/squid.conf
 if ! grep pub\/repositories /etc/squid/squid.conf >/dev/null; then
-    sed -i 's;\(refresh_pattern /rhn/manager/download.*\);\1\nrefresh_pattern /pub/repositories/.*/repodata/.*$ 0 1% 1440 ignore-no-cache reload-into-ims refresh-ims;' /etc/squid/squid.conf
+    sed -i 's;\(refresh_pattern /rhn/manager/download.*\);\1\nrefresh_pattern /pub/repositories/.*/repodata/.*$ 0 1% 1440 reload-into-ims refresh-ims;' /etc/squid/squid.conf
 fi
 if [ -f %{apacheconfdir}/conf.d/cobbler-proxy.conf ]; then
     sed -i -e "s;download//cobbler_api;download/cobbler_api;g" %{apacheconfdir}/conf.d/cobbler-proxy.conf

--- a/proxy/installer/squid.conf
+++ b/proxy/installer/squid.conf
@@ -23,11 +23,11 @@ cache_replacement_policy heap LFUDA
 memory_replacement_policy heap GDSF
 
 # cache repodata only few minutes and then query parent whether it is fresh
-refresh_pattern /XMLRPC/GET-REQ/.*/repodata/.*$ 0 1% 1440 ignore-no-cache reload-into-ims refresh-ims
+refresh_pattern /XMLRPC/GET-REQ/.*/repodata/.*$ 0 1% 1440 reload-into-ims refresh-ims
 # salt minions get the repodata via a different URL
-refresh_pattern /rhn/manager/download/.*/repodata/.*$ 0 1% 1440 ignore-no-cache reload-into-ims refresh-ims
+refresh_pattern /rhn/manager/download/.*/repodata/.*$ 0 1% 1440 reload-into-ims refresh-ims
 # bootstrap repos needs to be handled as well
-refresh_pattern /pub/repositories/.*/repodata/.*$ 0 1% 1440 ignore-no-cache reload-into-ims refresh-ims
+refresh_pattern /pub/repositories/.*/repodata/.*$ 0 1% 1440 reload-into-ims refresh-ims
 # rpm will hardly ever change, force to cache it for very long time
 refresh_pattern  \.rpm$  10080 100% 525960 override-expire override-lastmod ignore-reload reload-into-ims
 refresh_pattern  \.deb$  10080 100% 525960 override-expire override-lastmod ignore-reload reload-into-ims

--- a/proxy/installer/squid.conf
+++ b/proxy/installer/squid.conf
@@ -29,9 +29,9 @@ refresh_pattern /rhn/manager/download/.*/repodata/.*$ 0 1% 1440 reload-into-ims 
 # bootstrap repos needs to be handled as well
 refresh_pattern /pub/repositories/.*/repodata/.*$ 0 1% 1440 reload-into-ims refresh-ims
 # rpm will hardly ever change, force to cache it for very long time
-refresh_pattern  \.rpm$  10080 100% 525960 override-expire override-lastmod ignore-reload reload-into-ims
-refresh_pattern  \.deb$  10080 100% 525960 override-expire override-lastmod ignore-reload reload-into-ims
-refresh_pattern 	.		0	100%	525960
+refresh_pattern  \.rpm$  10080 100% 525600 override-expire override-lastmod ignore-reload reload-into-ims
+refresh_pattern  \.deb$  10080 100% 525600 override-expire override-lastmod ignore-reload reload-into-ims
+refresh_pattern 	.		0	100%	525600
 
 # secure squid
 # allow request only from localhost and to http and https ports

--- a/proxy/proxy/spacewalk-proxy.changes
+++ b/proxy/proxy/spacewalk-proxy.changes
@@ -1,3 +1,5 @@
+- set max date to max one year (bsc#1175369)
+- remove 'ignore-no-cache' which is obsolete (bsc#1175369)
 - remove 127.0.0.1 acl which is already built in (bsc#1175369)
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

These removes ignore-no-cache option from squid, which is obsolete, to remove the warning

UPGRADE: refresh_pattern option 'ignore-no-cache' is obsolete. Remove it.

and sets the max date to a year, to remove the warning

refresh_pattern maximum age too high. Cropped back to 1 year.

## GUI diff

No difference.

Before: Running squid -k you should see the mentioned warnings

After: You should not see the mentioned warnings in the logs

- [X] **DONE**

## Documentation
- No documentation needed

- [X] **DONE**

## Test coverage
- No tests

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/14059

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
