### PR TITLE
QA: Moving build host feature to secondary_parallelizable.yml

### DIFF
--- a/testsuite/features/secondary/buildhost_docker_auth_registry.feature
+++ b/testsuite/features/secondary/buildhost_docker_auth_registry.feature
@@ -60,7 +60,3 @@ Feature: Build image with authenticated registry
   Scenario: Cleanup: delete portus image
     Given I am authorized as "admin" with password "admin"
     When I delete the image "portus_profile" with version "latest" via XML-RPC calls
-
-@auth_registry
-  Scenario: Cleanup: kill stale portus image build jobs
-    When I kill remaining Salt jobs on "build_host"

--- a/testsuite/features/secondary/buildhost_docker_build_image.feature
+++ b/testsuite/features/secondary/buildhost_docker_build_image.feature
@@ -112,10 +112,6 @@ Feature: Build container images
     And I delete the image "suse_real_key" with version "GUI_DOCKERADMIN" via XML-RPC calls
 
 @no_auth_registry
-  Scenario: Cleanup: kill stale image build jobs
-    When I kill remaining Salt jobs on "build_host"
-
-@no_auth_registry
   Scenario: Cleanup: delete all profiles
     Given I am authorized as "admin" with password "admin"
     When I follow the left menu "Images > Profiles"

--- a/testsuite/run_sets/secondary.yml
+++ b/testsuite/run_sets/secondary.yml
@@ -45,8 +45,6 @@
 - features/secondary/allcli_action_chain.feature
 - features/secondary/srv_delete_channel_from_ui.feature
 - features/secondary/srv_delete_channel_with_tool.feature
-- features/secondary/buildhost_docker_build_image.feature
-- features/secondary/buildhost_docker_auth_registry.feature
 - features/secondary/min_docker_xmlrpc.feature
 - features/secondary/min_recurring_action.feature
 - features/secondary/min_change_software_channel.feature

--- a/testsuite/run_sets/secondary_parallelizable.yml
+++ b/testsuite/run_sets/secondary_parallelizable.yml
@@ -77,4 +77,7 @@
 - features/secondary/trad_sp_migration.feature
 - features/secondary/trad_check_registration.feature
 
+- features/secondary/buildhost_docker_build_image.feature
+- features/secondary/buildhost_docker_auth_registry.feature
+
 ## Parallelizable Secondary features END ##


### PR DESCRIPTION
## What does this PR change?

Moving build host Cucumber features to the parallel tests, removing the scenario that kills the salt events pending to don't cause any collision.

Related to https://github.com/SUSE/spacewalk/issues/13118

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.0
- Manager-4.1

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
