### PR TITLE
WIP: Build sources (tito) in parallel

### DIFF
--- a/rel-eng/build-one-package-for-obs.sh
+++ b/rel-eng/build-one-package-for-obs.sh
@@ -1,0 +1,121 @@
+#! /bin/bash
+BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+set -e
+#
+# For all packages in git:/rel-eng/packages (or defined in $PACKAGES)
+# provide tarball, spec and changes in $WORKSPACE/SRPMS/<package>
+#
+# git_package_defs() has a hardcoded list of packages excluded by default.
+#
+WORKSPACE=${WORKSPACE:-/tmp/push-packages-to-obs}
+PKG_NAME=$1
+PKG_VER=$2
+PKG_DIR=$3
+
+# check cwd is in git
+GIT_DIR=$(git rev-parse --show-cdup)
+test -z "$GIT_DIR" || cd "$GIT_DIR"
+GIT_DIR=$(pwd)
+
+# check presence of tito
+test -x "/usr/bin/tito" || {
+  echo "Missing '/usr/bin/tito' needed for build." >&2
+  exit 2
+}
+TITO="/usr/bin/tito"
+
+# check for unrpm
+which unrpm &> /dev/null || {
+  echo "unrpm not found in the PATH, do 'zypper install build'" >&2
+  exit 2
+}
+
+# create workspace
+test -d "$WORKSPACE" || mkdir -p "$WORKSPACE"
+
+# build the src rpms...
+SRPM_DIR="$WORKSPACE/SRPMS/$PKG_NAME"
+rm -rf "$SRPM_DIR"
+mkdir -p "$SRPM_DIR"
+
+SRPMBUILD_DIR="$WORKSPACE/SRPMBUILD/$PKG_NAME"
+rm -rf "$SRPMBUILD_DIR"
+mkdir -p "$SRPMBUILD_DIR"
+trap "test -d \"$SRPMBUILD_DIR\" && /bin/rm -rf -- \"$SRPMBUILD_DIR\" " 0 1 2 3 13 15
+
+# not nice but tito does not take it via CLI, via .rc
+# file prevents parallel execution for different OBS
+# projects.Thus we patched tito to take the builddir
+# from environment:
+export RPMBUILD_BASEDIR=$SRPMBUILD_DIR
+
+echo "Going to build new obs packages in $SRPM_DIR..."
+T_DIR="$SRPMBUILD_DIR/.build"
+T_LOG="$SRPMBUILD_DIR/.log"
+
+VERBOSE=$VERBOSE
+
+for tries in 1 2 3; do
+  echo "=== Building package [$PKG_NAME-$PKG_VER] from $PKG_DIR (Try $tries)"
+  rm -rf "$SRPMBUILD_DIR"
+  mkdir -p "$SRPMBUILD_DIR"
+
+  cd "$GIT_DIR/$PKG_DIR"
+  $TITO build ${VERBOSE:+--debug} ${TEST:+--test} --srpm >"$T_LOG" 2>&1 || {
+    cat "$T_LOG"
+    test $tries -eq 3 || continue
+    RESULT=-1
+    echo $PKG_NAME >> $WORKSPACE/failed
+    continue 2
+  }
+  ${VERBOSE:+cat "$T_LOG"}
+
+  eval $(awk '/^Wrote:.*src.rpm/{srpm=$2}/^Wrote:.*.changes/{changes=$2}END{ printf "SRPM=\"%s\"\n",srpm; printf "CHANGES=\"%s\"\n",changes; }' "$T_LOG")
+  if [ "$(head -n1 ${CHANGES}|grep '^- ')" != "" ]; then
+    echo "*** Untagged package, adding fake header..."
+    sed -i "1i Fri Jan 01 00:00:00 CEST 2038 - faketagger@suse.inet\n" ${CHANGES}
+    sed -i '1i -------------------------------------------------------------------' ${CHANGES}
+  fi
+  if [ -e "$SRPM" -a -e "$CHANGES" ]; then
+    mkdir "$T_DIR"
+    ( set -e; cd "$T_DIR"; unrpm "$SRPM"; ) >/dev/null 2>&1
+    test -z "$CHANGES" || mv "$CHANGES" "$T_DIR"
+  else
+    test $tries -eq 3 || continue
+    RESULT=-1
+    echo $PKG_NAME >> $WORKSPACE/failed
+    continue 2
+  fi
+
+  # Convert to obscpio
+  SPEC_VER=$(sed -n -e 's/^Version:\s*\(.*\)/\1/p' ${T_DIR}/${PKG_NAME}.spec)
+  SOURCE=$(sed -n -e 's/^\(Source\|Source0\):\s*.*[[:space:]\/]\(.*\)/\2/p' ${T_DIR}/${PKG_NAME}.spec|sed -e "s/%{name}/${PKG_NAME}/"|sed -e "s/%{version}/${SPEC_VER}/")
+  # If the package does not have sources, we don't need to repackage them
+  if [ "${SOURCE}" != "" ]; then
+    FOLDER=$(tar -tf ${T_DIR}/${SOURCE}|head -1|sed -e 's/\///')
+    (cd ${T_DIR}; tar -xf ${SOURCE}; rm ${SOURCE}; mv ${FOLDER} ${PKG_NAME}; find ${PKG_NAME} | cpio --create --format=newc --reproducible > ${FOLDER}.obscpio; rm -rf ${PKG_NAME})
+  fi
+  # Move to destination
+  mv "$T_DIR" "$SRPM_DIR/$PKG_NAME"
+  # If the package does not have sources, we don't need service or .obsinfo file
+  if [ "${SOURCE}" != "" ]; then
+    # Copy service
+    cp ${BASE_DIR}/_service "${SRPM_DIR}/${PKG_NAME}"
+    # Create .obsinfo file
+    cat > "${SRPM_DIR}/${PKG_NAME}/${PKG_NAME}.obsinfo" <<EOF
+name: ${PKG_NAME}
+version: $(echo ${FOLDER}|sed -e "s/${PKG_NAME}-//")
+mtime: $(date +%s)
+commit: $(git rev-parse --verify HEAD)
+EOF
+  fi
+  # Release is handled by the Buildservice
+  # Remove everything what prevents us from submitting
+  sed -i 's/^Release.*$/Release:    1/i' $SRPM_DIR/$PKG_NAME/*.spec
+  echo "$PKG_NAME" >> $WORKSPACE/succeeded
+  RESULT=0
+  break
+ done
+
+
+exit $RESULT

--- a/rel-eng/build-one-package-for-obs.sh
+++ b/rel-eng/build-one-package-for-obs.sh
@@ -30,9 +30,6 @@ which unrpm &> /dev/null || {
   exit 2
 }
 
-# create workspace
-test -d "$WORKSPACE" || mkdir -p "$WORKSPACE"
-
 # build the src rpms...
 SRPM_DIR="$WORKSPACE/SRPMS/$PKG_NAME"
 rm -rf "$SRPM_DIR"

--- a/rel-eng/build-packages-for-obs.sh
+++ b/rel-eng/build-packages-for-obs.sh
@@ -8,8 +8,6 @@ set -e
 #
 WORKSPACE=${WORKSPACE:-/tmp/push-packages-to-obs}
 PACKAGE="$@"
-echo > $WORKSPACE/succeeded
-echo > $WORKSPACE/failed
 
 grep -v -- "\(--help\|-h\|-?\)\>" <<<"$@" || {
   cat <<EOF
@@ -44,6 +42,11 @@ function git_package_defs() {
   done
 }
 
+# create workspace
+test -d "$WORKSPACE" || mkdir -p "$WORKSPACE"
+
+echo > $WORKSPACE/succeeded
+echo > $WORKSPACE/failed
 
 while read PKG_NAME PKG_VER PKG_DIR; do
     ./rel-eng/build-one-package-for-obs.sh $PKG_NAME $PKG_VER $PKG_DIR &

--- a/rel-eng/build-packages-for-obs.sh
+++ b/rel-eng/build-packages-for-obs.sh
@@ -45,8 +45,8 @@ function git_package_defs() {
 # create workspace
 test -d "$WORKSPACE" || mkdir -p "$WORKSPACE"
 
-echo > $WORKSPACE/succeeded
-echo > $WORKSPACE/failed
+echo "# $(date)" > $WORKSPACE/succeeded
+echo "# $(date)" > $WORKSPACE/failed
 
 while read PKG_NAME PKG_VER PKG_DIR; do
     ./rel-eng/build-one-package-for-obs.sh $PKG_NAME $PKG_VER $PKG_DIR &
@@ -54,8 +54,8 @@ done < <(git_package_defs)
 
 wait
 
-SUCCEED_CNT=$(cat $WORKSPACE/succeeded | wc -l)
-FAILED_CNT=$(cat $WORKSPACE/failed | wc -l)
+SUCCEED_CNT=$(cat $WORKSPACE/succeeded | grep -v "#" | wc -l)
+FAILED_CNT=$(cat $WORKSPACE/failed | grep -v "#" | wc -l)
 FAILED_PKG=$(cat $WORKSPACE/failed)
 
 echo "======================================================================"

--- a/rel-eng/push-packages-to-obs.sh
+++ b/rel-eng/push-packages-to-obs.sh
@@ -15,9 +15,6 @@ PACKAGE="$@"
 OSCRC=${OSCRC:+-c $OSCRC}
 OSCAPI=${OSCAPI:-https://api.suse.de}
 
-# FIXME HACK. This sets no concurrency for yarn but it will set this into ~/.yarnrc, overwriting any value you may have...
-
-yarn config set child-concurrency 1
 
 
 OSC="osc ${OSCRC} -A ${OSCAPI}"

--- a/rel-eng/push-packages-to-obs.sh
+++ b/rel-eng/push-packages-to-obs.sh
@@ -15,6 +15,11 @@ PACKAGE="$@"
 OSCRC=${OSCRC:+-c $OSCRC}
 OSCAPI=${OSCAPI:-https://api.suse.de}
 
+# FIXME HACK. This sets no concurrency for yarn but it will set this into ~/.yarnrc, overwriting any value you may have...
+
+yarn config set child-concurrency 1
+
+
 OSC="osc ${OSCRC} -A ${OSCAPI}"
 if [ "$OSC_EXPAND" == "TRUE" ];then
     OSC_CHECKOUT="$OSC checkout -e"

--- a/susemanager-frontend/susemanager-nodejs-sdk-devel/setup.sh
+++ b/susemanager-frontend/susemanager-nodejs-sdk-devel/setup.sh
@@ -2,10 +2,15 @@ set -euxo pipefail
 # FIXME HACK. This sets no concurrency for yarn but it will set this into ~/.yarnrc, overwriting any value you may have...
 export CHILD_CONCURRENCY=1
 yarn config set child-concurrency 1
+while [ -f /tmp/uyuni-yarn-install.lock ];do
+    sleep 30s
+done
+touch /tmp/uyuni-yarn-install.lock
 (cd susemanager-frontend/susemanager-nodejs-sdk-devel; rm -rf node_modules)
 yarn install --frozen-lockfile
 yarn autoclean --force
 (cd susemanager-frontend/susemanager-nodejs-sdk-devel; yarn run remove-packages-before-obs-zip)
 (cd susemanager-frontend/susemanager-nodejs-sdk-devel; yarn zip)
 (cd susemanager-frontend/susemanager-nodejs-sdk-devel; yarn run restore-packages-after-obs-zip)
+rm /tmp/uyuni-yarn-install.lock
 echo "susemanager-nodejs-modules.tar.gz"

--- a/susemanager-frontend/susemanager-nodejs-sdk-devel/setup.sh
+++ b/susemanager-frontend/susemanager-nodejs-sdk-devel/setup.sh
@@ -1,4 +1,7 @@
 set -euxo pipefail
+# FIXME HACK. This sets no concurrency for yarn but it will set this into ~/.yarnrc, overwriting any value you may have...
+export CHILD_CONCURRENCY=1
+yarn config set child-concurrency 1
 (cd susemanager-frontend/susemanager-nodejs-sdk-devel; rm -rf node_modules)
 yarn install --frozen-lockfile
 yarn autoclean --force

--- a/web/setup.sh
+++ b/web/setup.sh
@@ -2,6 +2,11 @@ set -euxo pipefail
 # FIXME HACK. This sets no concurrency for yarn but it will set this into ~/.yarnrc, overwriting any value you may have...
 export CHILD_CONCURRENCY=1
 yarn config set child-concurrency 1
+while [ -f /tmp/uyuni-yarn-install.lock ];do
+    sleep 30s
+done
+touch /tmp/uyuni-yarn-install.lock
 (cd web/html/src; yarn install --frozen-lockfile)
 (cd web/html/src; yarn build:novalidate)
+rm /tmp/uyuni-yarn-install.lock
 echo ""

--- a/web/setup.sh
+++ b/web/setup.sh
@@ -1,4 +1,7 @@
 set -euxo pipefail
+# FIXME HACK. This sets no concurrency for yarn but it will set this into ~/.yarnrc, overwriting any value you may have...
+export CHILD_CONCURRENCY=1
+yarn config set child-concurrency 1
 (cd web/html/src; yarn install --frozen-lockfile)
 (cd web/html/src; yarn build:novalidate)
 echo ""


### PR DESCRIPTION
## What does this PR change?

Building the sources of all the packages in the CI takes 20 minutes.
If we run this in parallel, it should take 5 minutes instead.


## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed:

- [X] **DONE**

## Test coverage
- No tests

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
