### PR TITLE
Testsuite: Overview page doesn't show the activation key

### DIFF
--- a/testsuite/features/secondary/min_activationkey.feature
+++ b/testsuite/features/secondary/min_activationkey.feature
@@ -77,11 +77,6 @@ Feature: Bootstrap a Salt minion via the GUI with an activation key
     Given I am on the Systems overview page of this "sle_minion"
     Then I run spacecmd listevents for "sle_minion"
 
-  Scenario: Verify that minion bootstrapped with activation key
-    Given I am on the Systems overview page of this "sle_minion"
-    Then I should see a "Activation Key: 	1-MINION-TEST" text
-    And the "activation_key" on "sle_minion" grains does not exist
-
   Scenario: Verify that minion bootstrapped with base channel
     Given I am on the Systems page
     Then I should see a "Test-Channel-x86_64" text

--- a/testsuite/features/secondary/trad_migrate_to_minion.feature
+++ b/testsuite/features/secondary/trad_migrate_to_minion.feature
@@ -43,10 +43,6 @@ Feature: Migrate a traditional client into a Salt minion
     When I run "systemctl status nhsd" on "sle_migrated_minion" without error control
     Then the command should fail
 
-  Scenario: Check that minion has the new activation key
-    Given I am on the Systems overview page of this "sle_migrated_minion"
-    Then I should see a "Activation Key:	1-SUSE-KEY-x86_64" text
-
   Scenario: Check that channels are still the same after migration
     Given I am on the Systems overview page of this "sle_migrated_minion"
     Then I should see a "Test-Channel-x86_64" text
@@ -105,7 +101,3 @@ Feature: Migrate a traditional client into a Salt minion
     Given I am on the Systems overview page of this "sle_client"
     When I follow "Properties" in the content area
     Then I wait until I see "Base System Type:     Management" text, refreshing the page
-
-  Scenario: Cleanup: check that we still have the activation key
-    Given I am on the Systems overview page of this "sle_client"
-    Then I should see a "Activation Key:	1-SUSE-KEY-x86_64" text

--- a/testsuite/features/secondary/trad_migrate_to_sshminion.feature
+++ b/testsuite/features/secondary/trad_migrate_to_sshminion.feature
@@ -65,10 +65,6 @@ Feature: Migrate a traditional client into a Salt SSH minion
     When I run "systemctl status nhsd" on "sle_migrated_minion" without error control
     Then the command should fail
 
-  Scenario: Check that SSH minion has the new activation key
-    Given I am on the Systems overview page of this "sle_migrated_minion"
-    Then I should see a "Activation Key:       1-SUSE-KEY-x86_64" text
-
   Scenario: Check that channels are still the same after migration to Salt SSH
     Given I am on the Systems overview page of this "sle_migrated_minion"
     Then I should see a "Test-Channel-x86_64" text
@@ -135,7 +131,3 @@ Feature: Migrate a traditional client into a Salt SSH minion
     Given I am on the Systems overview page of this "sle_client"
     When I follow "Properties" in the content area
     Then I wait until I see "Base System Type:     Management" text, refreshing the page
-
-  Scenario: Cleanup: check that we still have the activation key after migration
-    Given I am on the Systems overview page of this "sle_client"
-    Then I should see a "Activation Key:	1-SUSE-KEY-x86_64" text


### PR DESCRIPTION
## What does this PR change?
Do not search for the activation key on the client overview page: it's not shown anymore.

It completes: https://github.com/uyuni-project/uyuni/pull/3638

## Links

Continuation of https://github.com/uyuni-project/uyuni/pull/3638
### Ports
None


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)
