### PR TITLE
Fix yum rhn plugin param change

### DIFF
--- a/client/rhel/dnf-plugin-spacewalk/actions/errata.py
+++ b/client/rhel/dnf-plugin-spacewalk/actions/errata.py
@@ -25,7 +25,7 @@ def __getErrataInfo(errata_id):
 def update(errataidlist, cache_only=None):
     packagelist = []
     if type(errataidlist) == dict:
-        errataidlist = params['errata_ids']
+        errataidlist = errataidlist['errata_ids']
 
     if type(errataidlist) not in [type([]), type(())]:
         errataidlist = [ errataidlist ]

--- a/client/rhel/dnf-plugin-spacewalk/dnf-plugin-spacewalk.changes
+++ b/client/rhel/dnf-plugin-spacewalk/dnf-plugin-spacewalk.changes
@@ -1,3 +1,5 @@
+- fix undefined parameter in errata action
+
 -------------------------------------------------------------------
 Mon Apr 19 14:46:52 CEST 2021 - jgonzalez@suse.com
 

--- a/client/rhel/yum-rhn-plugin/actions/errata.py
+++ b/client/rhel/yum-rhn-plugin/actions/errata.py
@@ -24,7 +24,7 @@ def __getErrataInfo(errata_id):
 def update(errataidlist, cache_only=None):
     packagelist = []
     if type(errataidlist) == dict:
-        errataidlist = params['errata_ids']
+        errataidlist = errataidlist['errata_ids']
 
     if type(errataidlist) not in [type([]), type(())]:
         errataidlist = [ errataidlist ]

--- a/client/rhel/yum-rhn-plugin/yum-rhn-plugin.changes
+++ b/client/rhel/yum-rhn-plugin/yum-rhn-plugin.changes
@@ -1,3 +1,5 @@
+- fix undefined parameter in errata action
+
 -------------------------------------------------------------------
 Mon Apr 19 14:53:19 CEST 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Fix undefined paramater usage in yum-rhn-plugin errata action.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
