### PR TITLE
SLE11 SP4 can't bootstrap without python-xml

### DIFF
--- a/testsuite/features/build_validation/init_clients/sle11sp4_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle11sp4_minion.feature
@@ -7,6 +7,9 @@ Feature: Bootstrap a SLES 11 SP4 Salt minion
   Scenario: Clean up sumaform leftovers on a SLES 11 SP4 Salt minion
     When I perform a full salt minion cleanup on "sle11sp4_minion"
 
+  Scenario: Install prerequisite packages on SLES 11 SP4 Salt minion
+    When I install package "python-xml" on this "sle11sp4_minion"
+
   Scenario: Bootstrap a SLES 11 SP4 minion
     Given I am authorized as "admin" with password "admin"
     When I go to the bootstrapping page

--- a/testsuite/features/build_validation/init_clients/sle11sp4_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle11sp4_ssh_minion.feature
@@ -7,6 +7,9 @@ Feature: Bootstrap a SLES 11 SP4 Salt SSH minion
   Scenario: Clean up sumaform leftovers on a SLES 11 SP4 Salt SSH minion
     When I perform a full salt minion cleanup on "sle11sp4_ssh_minion"
 
+  Scenario: Install prerequisite packages on SLES 11 SP4 Salt SSH minion
+    When I install package "python-xml" on this "sle11sp4_ssh_minion"
+
   Scenario: Bootstrap a SLES 11 SP4 system managed via salt-ssh
     Given I am authorized as "admin" with password "admin"
     When I go to the bootstrapping page


### PR DESCRIPTION
## What does this PR change?

BV test suite: add pre-requisite package on normal Salt and Salt SSH minions on SLE 11 SP4

Reference: https://documentation.suse.com/external-tree/en-us/suma/4.1/suse-manager/client-configuration/registration-bootstrap.html


## Links

Ports:
* 4.0: SUSE/spacewalk#14733
* 4.1: SUSE/spacewalk#14734


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
