### PR TITLE
QA: Remove workround on Ubuntu GPG Check

### DIFF
--- a/testsuite/features/core/srv_channels_add.feature
+++ b/testsuite/features/core/srv_channels_add.feature
@@ -94,11 +94,6 @@ Feature: Adding channels
     And I select "AMD64 Debian" from "Architecture:"
     And I enter "Test-Channel-Deb-AMD64 for testing" as "Channel Summary"
     And I enter "No more description for base channel." as "Channel Description"
-    # WORKAROUND
-    # GPG verification of Debian-like repos was added and the TestRepoDebUpdates repo
-    # is signed by a GPG key that is not in the keyring. This workaround temporarily
-    # disables GPG check, before this is properly handled at sumaform/terraform level.
-    And I uncheck "gpg_check"
-    # End of WORKAROUND
+    And I check "gpg_check"
     And I click on "Create Channel"
     Then I should see a "Channel Test-Channel-Deb-AMD64 created." text

--- a/testsuite/features/core/srv_create_repository.feature
+++ b/testsuite/features/core/srv_create_repository.feature
@@ -82,12 +82,7 @@ Feature: Add a repository to a channel
     And I enter "Test-Repository-Deb" as "label"
     And I select "deb" from "contenttype"
     And I enter "http://localhost/pub/TestRepoDebUpdates/" as "url"
-    # WORKAROUND
-    # GPG verification of Debian-like repos was added and the TestRepoDebUpdates repo
-    # is signed by a GPG key that is not in the keyring. This workaround temporarily
-    # disables GPG check, before this is properly handled at sumaform/terraform level.
-    And I uncheck "metadataSigned"
-    # End of WORKAROUND
+    And I check "metadataSigned"
     And I click on "Create Repository"
     Then I should see a "Repository created successfully" text
 

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -223,7 +223,6 @@ When(/^I ([^ ]*) the "([^"]*)" formula$/) do |action, formula|
   # Complicated code because the checkbox is not a <input type=checkbox> but an <i>
   xpath_query = "//a[@id = '#{formula}']/i[@class = 'fa fa-lg fa-square-o']" if action == 'check'
   xpath_query = "//a[@id = '#{formula}']/i[@class = 'fa fa-lg fa-check-square-o']" if action == 'uncheck'
-  # WORKAROUND
   # DOM refreshes content of chooseFormulas element by accessing it. Then conditions are evaluated properly.
   find('#chooseFormulas')['innerHTML']
   if all(:xpath, xpath_query, wait: DEFAULT_TIMEOUT).any?
@@ -239,7 +238,6 @@ Then(/^the "([^"]*)" formula should be ([^ ]*)$/) do |formula, state|
   # Complicated code because the checkbox is not a <input type=checkbox> but an <i>
   xpath_query = "//a[@id = '#{formula}']/i[@class = 'fa fa-lg fa-square-o']" if state == 'checked'
   xpath_query = "//a[@id = '#{formula}']/i[@class = 'fa fa-lg fa-check-square-o']" if state == 'unchecked'
-  # WORKAROUND
   # DOM refreshes content of chooseFormulas element by accessing it. Then conditions are evaluated properly.
   find('#chooseFormulas')['innerHTML']
   raise "Checkbox is not #{state}" if all(:xpath, xpath_query).any?


### PR DESCRIPTION
## What does this PR change?

Related to https://github.com/SUSE/spacewalk/issues/13525

Removing the workaround to don't check GPG keys in Ubuntu, as far I can see we have the GPG keys in our server, so I guess we are fine.

```uyuni-master-srv:/srv/www/htdocs/pub # ls
AnotherRepo                                   centos6-gpg-pubkey-c105b9de.key          oes-gpg-pubkey-044ADAEE04881839.key   rhn-org-trusted-ssl-cert-1.0-1.noarch.rpm
RHN-ORG-TRUSTED-SSL-CERT                      centos7-gpg-pubkey-f4a80eb5.key          oes-gpg-pubkey-57DA9A6804A29DB0.key   sle-container-gpg-pubkey-d4ade9c3.key
RHN-ORG-TRUSTED-SSL-CERT.sha512               centos8-gpg-pubkey-05B555B38483C65D.key  ol67-gpg-pubkey-72F97B74EC551F03.key  sle10-gpg-pubkey-9c800aca.key
TestRepoDebUpdates                            debian-gpg-pubkey-112695A0E562B32A.key   ol8-gpg-pubkey-82562EA9AD986DA3.key   sle11-gpg-pubkey-307e3d54.key
TestRepoRpmUpdates                            debian-gpg-pubkey-648ACFD622F3D138.key   opensuse-gpg-pubkey-3dbdc284.key      sle12-gpg-pubkey-39db7c82.key
aliyunlinux2-gpg-pubkey-EFD752E7E232ED87.key  debian-gpg-pubkey-7638D0442B90D010.key   packagehub-gpg-pubkey-65176565.key    sle12-reserve-gpg-pubkey-50a3dd1c.key
almalinux8-gpg-pubkey-488FCF7C3ABB34F8.key    debian-gpg-pubkey-AA8E81B4331F7F50.key   ptf-gpg-pubkey-b37b98a9.key           ubuntu-gpg-pubkey-3B4FE6ACC0B21F32.key
amazonlinux2-gpg-pubkey-8312182E7F8CF5ED.key  debian-gpg-pubkey-DCC9EFBF77E11517.key   repositories                          ubuntu-gpg-pubkey-871920D1991BC93C.key
bootstrap                                     debian-gpg-pubkey-EF0F382A1A7B6500.key   res-gpg-pubkey-0182b964.key           uyuni-gpg-pubkey-0d20833e.key
uyuni-master-srv:/srv/www/htdocs/pub # cd TestRepoDebUpdates
uyuni-master-srv:/srv/www/htdocs/pub/TestRepoDebUpdates # ls
InRelease    Release      Sources.gz               andromeda-dummy_2.0.tar.xz  hoag-dummy_1.1.dsc      milkyway-dummy_2.0.tar.xz  perseus-dummy_1.1.dsc     virgo-dummy_2.0.tar.xz
Packages     Release.key  all                      blackhole-dummy_1.0.dsc     hoag-dummy_1.1.tar.xz   orion-dummy_1.1.dsc        perseus-dummy_1.1.tar.xz
Packages.gz  Sources      andromeda-dummy_2.0.dsc  blackhole-dummy_1.0.tar.xz  milkyway-dummy_2.0.dsc  orion-dummy_1.1.tar.xz     virgo-dummy_2.0.dsc
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Ports:
- Manager-4.0
- Manager-4.1

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
