### PR TITLE
Revert "QA: Remove workround on Ubuntu GPG Check"

### DIFF
--- a/testsuite/features/core/srv_channels_add.feature
+++ b/testsuite/features/core/srv_channels_add.feature
@@ -94,6 +94,11 @@ Feature: Adding channels
     And I select "AMD64 Debian" from "Architecture:"
     And I enter "Test-Channel-Deb-AMD64 for testing" as "Channel Summary"
     And I enter "No more description for base channel." as "Channel Description"
-    And I check "gpg_check"
+    # WORKAROUND
+    # GPG verification of Debian-like repos was added and the TestRepoDebUpdates repo
+    # is signed by a GPG key that is not in the keyring. This workaround temporarily
+    # disables GPG check, before this is properly handled at sumaform/terraform level.
+    And I uncheck "gpg_check"
+    # End of WORKAROUND
     And I click on "Create Channel"
     Then I should see a "Channel Test-Channel-Deb-AMD64 created." text

--- a/testsuite/features/core/srv_create_repository.feature
+++ b/testsuite/features/core/srv_create_repository.feature
@@ -82,7 +82,12 @@ Feature: Add a repository to a channel
     And I enter "Test-Repository-Deb" as "label"
     And I select "deb" from "contenttype"
     And I enter "http://localhost/pub/TestRepoDebUpdates/" as "url"
-    And I check "metadataSigned"
+    # WORKAROUND
+    # GPG verification of Debian-like repos was added and the TestRepoDebUpdates repo
+    # is signed by a GPG key that is not in the keyring. This workaround temporarily
+    # disables GPG check, before this is properly handled at sumaform/terraform level.
+    And I uncheck "metadataSigned"
+    # End of WORKAROUND
     And I click on "Create Repository"
     Then I should see a "Repository created successfully" text
 


### PR DESCRIPTION
Reverts uyuni-project/uyuni#3666

As @mcalmer explained, we can't remove this workaround:

This is a test repo signed by a GPG key created by OBS. This is a 3rd Party repo and we never have the GPG key trusted automatically.

Possible solutions: 
1. revert this
2. write a test to "trust" the GPG key. If you do that, you can also enable "metadataSigned" for the RPM test repos. 

