### PR TITLE
QA: Installing the correct scap-security-guide package from client tools

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -839,11 +839,11 @@ When(/^I (install|remove) OpenSCAP dependencies (on|from) "([^"]*)"$/) do |actio
   node = get_target(host)
   _os_version, os_family = get_os_version(node)
   if os_family =~ /^opensuse/ || os_family =~ /^sles/
-    pkgs = 'openscap-utils openscap-content'
+    pkgs = 'openscap-utils openscap-content scap-security-guide'
   elsif os_family =~ /^centos/
-    pkgs = 'openscap-utils scap-security-guide'
+    pkgs = 'openscap-utils scap-security-guide-redhat'
   elsif os_family =~ /^ubuntu/
-    pkgs = 'libopenscap8 ssg-debderived'
+    pkgs = 'libopenscap8 ssg-debderived scap-security-guide-ubuntu'
   end
   pkgs += ' spacewalk-oscap' if host.include? 'client'
   step %(I #{action} packages "#{pkgs}" #{where} this "#{host}")


### PR DESCRIPTION
## What does this PR change?

We were relying on the scap-security-guide installed on the client, instead of using the package provided by our client tools.
This PR installs them from client tools, as we previously enabled the client tools repositories.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.0 https://github.com/SUSE/spacewalk/pull/14754
- Manager-4.1 https://github.com/SUSE/spacewalk/pull/14755

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
