### PR TITLE
Testsuite: Fix cucumber Ansible tests

### DIFF
--- a/testsuite/features/secondary/min_ansible_control_node.feature
+++ b/testsuite/features/secondary/min_ansible_control_node.feature
@@ -5,7 +5,13 @@
 Feature: Operate an Ansible control node in a normal minion
 
   Scenario: Pre-requisite: Deploy test playbooks and inventory file
-    Given I deploy testing playbooks and inventory files to "sle_minion"
+    Given I am on the Systems overview page of this "sle_minion"
+    Then I deploy testing playbooks and inventory files to "sle_minion"
+
+  Scenario: Pre-requisite: Enable client tools repositories
+    Given I am on the Systems overview page of this "sle_minion"
+    Then I enable SUSE Manager tools repositories on "sle_minion"
+    And I refresh the metadata for "sle_minion"
 
   Scenario: Enable "Ansible control node" system type
     Given I am on the Systems overview page of this "sle_minion"
@@ -74,3 +80,8 @@ Feature: Operate an Ansible control node in a normal minion
     Then I should see a "System properties changed" text
     And I remove package "orion-dummy" from this "sle_minion" without error control
     And I remove "/tmp/file.txt" from "sle_minion"
+
+  Scenario: Cleanup: Disable client tools channel
+    Given I am on the Systems overview page of this "sle_minion"
+    Then I disable SUSE Manager tools repositories on "sle_minion"
+    And I refresh the metadata for "sle_minion"

--- a/testsuite/features/secondary/min_ansible_control_node.feature
+++ b/testsuite/features/secondary/min_ansible_control_node.feature
@@ -11,6 +11,7 @@ Feature: Operate an Ansible control node in a normal minion
   Scenario: Pre-requisite: Enable client tools repositories
     Given I am on the Systems overview page of this "sle_minion"
     Then I enable SUSE Manager tools repositories on "sle_minion"
+    And I enable repository "os_pool_repo os_update_repo" on this "sle_minion"
     And I refresh the metadata for "sle_minion"
 
   Scenario: Enable "Ansible control node" system type
@@ -84,4 +85,5 @@ Feature: Operate an Ansible control node in a normal minion
   Scenario: Cleanup: Disable client tools channel
     Given I am on the Systems overview page of this "sle_minion"
     Then I disable SUSE Manager tools repositories on "sle_minion"
+    And I disable repository "os_pool_repo os_update_repo" on this "sle_minion"
     And I refresh the metadata for "sle_minion"

--- a/testsuite/features/secondary/min_ansible_control_node.feature
+++ b/testsuite/features/secondary/min_ansible_control_node.feature
@@ -69,7 +69,7 @@ Feature: Operate an Ansible control node in a normal minion
     And I wait until I see "Playbook Content" text
     And I select "/srv/playbooks/orion_dummy/hosts" from "inventory-path-select"
     And I click on "Schedule"
-    Then I should see a "Playbook execution scheduled successfully" text
+    Then I should see a "Playbook execution has been scheduled" text
     And I wait until event "Execute playbook 'playbook_orion_dummy.yml' scheduled by admin" is completed
     And file "/tmp/file.txt" should exist on "sle_minion"
 

--- a/testsuite/features/secondary/min_ansible_control_node.feature
+++ b/testsuite/features/secondary/min_ansible_control_node.feature
@@ -6,11 +6,11 @@ Feature: Operate an Ansible control node in a normal minion
 
   Scenario: Pre-requisite: Deploy test playbooks and inventory file
     Given I am on the Systems overview page of this "sle_minion"
-    Then I deploy testing playbooks and inventory files to "sle_minion"
+    When I deploy testing playbooks and inventory files to "sle_minion"
 
   Scenario: Pre-requisite: Enable client tools repositories
     Given I am on the Systems overview page of this "sle_minion"
-    Then I enable SUSE Manager tools repositories on "sle_minion"
+    When I enable SUSE Manager tools repositories on "sle_minion"
     And I enable repository "os_pool_repo os_update_repo" on this "sle_minion"
     And I refresh the metadata for "sle_minion"
 
@@ -84,6 +84,6 @@ Feature: Operate an Ansible control node in a normal minion
 
   Scenario: Cleanup: Disable client tools channel
     Given I am on the Systems overview page of this "sle_minion"
-    Then I disable SUSE Manager tools repositories on "sle_minion"
+    When I disable SUSE Manager tools repositories on "sle_minion"
     And I disable repository "os_pool_repo os_update_repo" on this "sle_minion"
     And I refresh the metadata for "sle_minion"

--- a/testsuite/features/secondary/min_ansible_control_node.feature
+++ b/testsuite/features/secondary/min_ansible_control_node.feature
@@ -40,7 +40,7 @@ Feature: Operate an Ansible control node in a normal minion
     When I follow "Ansible" in the content area
     And I follow "Inventories" in the content area
     And I wait until I see "/srv/playbooks/orion_dummy/hosts" text
-    And I click on "/srv/playbooks/orion_dummy/hosts" text in Ansible paths
+    And I click on "/srv/playbooks/orion_dummy/hosts"
     Then I should see a "myself" text
 
   Scenario: Discover playbooks and display them
@@ -48,7 +48,7 @@ Feature: Operate an Ansible control node in a normal minion
     When I follow "Ansible" in the content area
     And I follow "Playbooks" in the content area
     And I wait until I see "/srv/playbooks" text
-    And I click on "/srv/playbooks" text in Ansible paths
+    And I click on "/srv/playbooks"
     Then I wait until I see "/srv/playbooks/orion_dummy/playbook_orion_dummy.yml" text
 
   Scenario: Run a playbook using custom inventory
@@ -56,7 +56,7 @@ Feature: Operate an Ansible control node in a normal minion
     When I follow "Ansible" in the content area
     And I follow "Playbooks" in the content area
     And I wait until I see "/srv/playbooks" text
-    And I click on "/srv/playbooks" text in Ansible paths
+    And I click on "/srv/playbooks"
     And I wait until I see "/srv/playbooks/orion_dummy/playbook_orion_dummy.yml" text
     And I click on "orion_dummy/playbook_orion_dummy.yml"
     And I wait until I see "Playbook Content" text

--- a/testsuite/features/secondary/minssh_ansible_control_node.feature
+++ b/testsuite/features/secondary/minssh_ansible_control_node.feature
@@ -8,11 +8,11 @@ Feature: Operate an Ansible control node in SSH minion
 
   Scenario: Pre-requisite: Deploy test playbooks and inventory file
     Given I am on the Systems overview page of this "ssh_minion"
-    Then I deploy testing playbooks and inventory files to "ssh_minion"
+    When I deploy testing playbooks and inventory files to "ssh_minion"
 
   Scenario: Pre-requisite: Enable client tools repositories
     Given I am on the Systems overview page of this "ssh_minion"
-    Then I enable SUSE Manager tools repositories on "ssh_minion"
+    When I enable SUSE Manager tools repositories on "ssh_minion"
     And I enable repository "os_pool_repo os_update_repo" on this "ssh_minion"
     And I refresh the metadata for "ssh_minion"
 
@@ -86,6 +86,6 @@ Feature: Operate an Ansible control node in SSH minion
 
   Scenario: Cleanup: Disable client tools channel
     Given I am on the Systems overview page of this "ssh_minion"
-    Then I disable SUSE Manager tools repositories on "ssh_minion"
+    When I disable SUSE Manager tools repositories on "ssh_minion"
     And I disable repository "os_pool_repo os_update_repo" on this "ssh_minion"
     And I refresh the metadata for "ssh_minion"

--- a/testsuite/features/secondary/minssh_ansible_control_node.feature
+++ b/testsuite/features/secondary/minssh_ansible_control_node.feature
@@ -42,7 +42,7 @@ Feature: Operate an Ansible control node in SSH minion
     When I follow "Ansible" in the content area
     And I follow "Inventories" in the content area
     And I wait until I see "/srv/playbooks/orion_dummy/hosts" text
-    And I click on "/srv/playbooks/orion_dummy/hosts" text in Ansible paths
+    And I click on "/srv/playbooks/orion_dummy/hosts"
     Then I should see a "myself" text
 
   Scenario: Discover playbooks and display them
@@ -50,7 +50,7 @@ Feature: Operate an Ansible control node in SSH minion
     When I follow "Ansible" in the content area
     And I follow "Playbooks" in the content area
     And I wait until I see "/srv/playbooks" text
-    And I click on "/srv/playbooks" text in Ansible paths
+    And I click on "/srv/playbooks"
     Then I wait until I see "/srv/playbooks/orion_dummy/playbook_orion_dummy.yml" text
 
   Scenario: Run a playbook using custom inventory
@@ -58,7 +58,7 @@ Feature: Operate an Ansible control node in SSH minion
     When I follow "Ansible" in the content area
     And I follow "Playbooks" in the content area
     And I wait until I see "/srv/playbooks" text
-    And I click on "/srv/playbooks" text in Ansible paths
+    And I click on "/srv/playbooks"
     And I wait until I see "/srv/playbooks/orion_dummy/playbook_orion_dummy.yml" text
     And I click on "orion_dummy/playbook_orion_dummy.yml"
     And I wait until I see "Playbook Content" text

--- a/testsuite/features/secondary/minssh_ansible_control_node.feature
+++ b/testsuite/features/secondary/minssh_ansible_control_node.feature
@@ -7,7 +7,13 @@
 Feature: Operate an Ansible control node in SSH minion
 
   Scenario: Pre-requisite: Deploy test playbooks and inventory file
-    Given I deploy testing playbooks and inventory files to "ssh_minion"
+    Given I am on the Systems overview page of this "ssh_minion"
+    Then I deploy testing playbooks and inventory files to "ssh_minion"
+
+  Scenario: Pre-requisite: Enable client tools repositories
+    Given I am on the Systems overview page of this "ssh_minion"
+    Then I enable SUSE Manager tools repositories on "ssh_minion"
+    And I refresh the metadata for "ssh_minion"
 
   Scenario: Enable "Ansible control node" system type
     Given I am on the Systems overview page of this "ssh_minion"
@@ -76,3 +82,8 @@ Feature: Operate an Ansible control node in SSH minion
     Then I should see a "System properties changed" text
     And I remove package "orion-dummy" from this "ssh_minion" without error control
     And I remove "/tmp/file.txt" from "ssh_minion"
+
+  Scenario: Cleanup: Disable client tools channel
+    Given I am on the Systems overview page of this "ssh_minion"
+    Then I disable SUSE Manager tools repositories on "ssh_minion"
+    And I refresh the metadata for "ssh_minion"

--- a/testsuite/features/secondary/minssh_ansible_control_node.feature
+++ b/testsuite/features/secondary/minssh_ansible_control_node.feature
@@ -13,6 +13,7 @@ Feature: Operate an Ansible control node in SSH minion
   Scenario: Pre-requisite: Enable client tools repositories
     Given I am on the Systems overview page of this "ssh_minion"
     Then I enable SUSE Manager tools repositories on "ssh_minion"
+    And I enable repository "os_pool_repo os_update_repo" on this "ssh_minion"
     And I refresh the metadata for "ssh_minion"
 
   Scenario: Enable "Ansible control node" system type
@@ -86,4 +87,5 @@ Feature: Operate an Ansible control node in SSH minion
   Scenario: Cleanup: Disable client tools channel
     Given I am on the Systems overview page of this "ssh_minion"
     Then I disable SUSE Manager tools repositories on "ssh_minion"
+    And I disable repository "os_pool_repo os_update_repo" on this "ssh_minion"
     And I refresh the metadata for "ssh_minion"

--- a/testsuite/features/secondary/minssh_ansible_control_node.feature
+++ b/testsuite/features/secondary/minssh_ansible_control_node.feature
@@ -71,7 +71,7 @@ Feature: Operate an Ansible control node in SSH minion
     And I wait until I see "Playbook Content" text
     And I select "/srv/playbooks/orion_dummy/hosts" from "inventory-path-select"
     And I click on "Schedule"
-    Then I should see a "Playbook execution scheduled successfully" text
+    Then I should see a "Playbook execution has been scheduled" text
     And I wait until event "Execute playbook 'playbook_orion_dummy.yml' scheduled by admin" is completed
     And file "/tmp/file.txt" should exist on "ssh_minion"
 

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -243,15 +243,6 @@ When(/^I click on "([^"]*)" in element "([^"]*)"$/) do |text, element_id|
 end
 
 #
-# Click on a text which appears inside of <div> with
-# the given "id"
-When(/^I click on "([^"]*)" text in Ansible paths$/) do |text|
-  within(:xpath, '//div[@id="ansible-path-content"]') do
-    find('h6', text: text).click
-  end
-end
-
-#
 # Click on a button and confirm in alert box
 When(/^I click on "([^"]*)" and confirm$/) do |text|
   begin


### PR DESCRIPTION
## What does this PR change?

This PR fixes the current failures in the Ansible cucumber scenarios after latest changes.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **testsuite**

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
