### PR TITLE
More robust react-select cucumber tests

### DIFF
--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -152,8 +152,8 @@ When(/^I check "([^"]*)" if not checked$/) do |arg1|
 end
 
 When(/^I select "([^"]*)" from "([^"]*)"$/) do |option, field|
-  xpath_option = ".//*[contains(text(),'#{option}')]"
-  xpath_field = "//*[@name='#{field}']/.."
+  xpath_option = ".//*[contains(@class, 'class-#{field}__option') and contains(text(),'#{option}')]"
+  xpath_field = "//*[contains(@class, 'class-#{field}__control')]/../*[@name='#{field}']/.."
   if has_select?(field, with_options: [option], wait: 1)
     select(option, from: field)
   else
@@ -924,7 +924,7 @@ Then(/^option "([^"]*)" is selected as "([^"]*)"$/) do |option, field|
   next if has_select?(field, selected: option)
 
   # Custom React selector
-  next if has_xpath?("//*[@name='#{field}']/..//*[contains(text(),'#{option}')]")
+  next if has_xpath?("//*[contains(@class, 'class-#{field}__value-container')]/*[contains(text(),'#{option}')]")
 
   raise "#{option} is not selected as #{field}"
 end
@@ -937,7 +937,7 @@ When(/^I wait until option "([^"]*)" appears in list "([^"]*)"$/) do |option, fi
     break if has_select?(field, with_options: [option])
 
     # Custom React selector
-    break if has_xpath?("//*[@name='#{field}']/..//*[contains(text(),'#{option}')]")
+    break if has_xpath?("//*[contains(@class, 'class-#{field}__value-container')]/*[contains(text(),'#{option}')]")
   end
 end
 

--- a/web/html/src/components/combobox.tsx
+++ b/web/html/src/components/combobox.tsx
@@ -57,6 +57,14 @@ export class Combobox extends React.Component<ComboboxProps, ComboboxState> {
 
         return styles;
       },
+      menu: (styles: {}) => ({
+        ...styles,
+        zIndex: 3,
+      }),
+      menuPortal: (styles: {}) => ({
+        ...styles,
+        zIndex: 9999
+      }),
     };
 
     // The react-select is expecting the value to be a string, but let's keep the original id here so we can propagate
@@ -76,6 +84,8 @@ export class Combobox extends React.Component<ComboboxProps, ComboboxState> {
         value={options.find(option => option.id === this.props.selectedId)}
         options={options}
         styles={colourStyles}
+        menuPortalTarget={document.body}
+        classNamePrefix={`class-${this.props.name}`}
       />
     );
   }

--- a/web/html/src/components/input/Select.tsx
+++ b/web/html/src/components/input/Select.tsx
@@ -117,6 +117,7 @@ export function Select(props: Props) {
             isMulti={props.isMulti}
             aria-label={props.title}
             menuPortalTarget={document.body}
+            classNamePrefix={`class-${props.name}`}
           />
         );
       }}

--- a/web/html/src/manager/content-management/shared/components/panels/sources/channels/channels-selection.js
+++ b/web/html/src/manager/content-management/shared/components/panels/sources/channels/channels-selection.js
@@ -95,6 +95,20 @@ const ChannelsSelection = (props: PropsType) => {
             options={orderedBaseChannels}
             getOptionLabel={option => option.name}
             getOptionValue={option => option.id}
+            menuPortalTarget={document.body}
+            classNamePrefix={`class-selectedBaseChannel`}
+            styles={
+              {
+                menu: (styles: {}) => ({
+                  ...styles,
+                  zIndex: 3,
+                }),
+                menuPortal: (styles: {}) => ({
+                  ...styles,
+                  zIndex: 9999
+                }),
+              }
+            }
           />
           <span className='help-block'>
             {t("Choose the channel to be elected as the new base channel")}


### PR DESCRIPTION
## What does this PR change?

Follow the idea from https://ryanbigg.com/2020/09/react-select-capybara-selenium to make the react-select xpath expression more robust in the cucumber steps. Also applies the portalling fix to other uses of react-select.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
