### PR TITLE
Fix testsuite Apply button rename

### DIFF
--- a/testsuite/features/secondary/min_config_state_channel.feature
+++ b/testsuite/features/secondary/min_config_state_channel.feature
@@ -45,8 +45,8 @@ Feature: Configuration state channels
     When I am on the Systems overview page of this "sle_minion"
     And I follow "States" in the content area
     And I follow "Configuration Channels" in the content area
-    Then I should see a "Apply" button
-    When I click on "Apply"
+    Then I should see a "Execute States" button
+    When I click on "Execute States"
     Then I should see a "Applying the config channels has been scheduled" text
     When I wait until event "Apply states [custom] scheduled by admin" is completed
     And I wait until file "/root/foobar" exists on "sle_minion"


### PR DESCRIPTION
## What does this PR change?

Testsuite fix after changes

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
