### PR TITLE
Fix for pkgset beacon test

### DIFF
--- a/susemanager-utils/susemanager-sls/src/tests/test_beacon_pkgset.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_beacon_pkgset.py
@@ -22,12 +22,12 @@ def test_validate():
     '''
     Test validate() function
     '''
-    res, msg = pkgset.validate({'cookie': '/bogus/path'})
-    assert res is True
-    assert msg == 'Configuration validated'
-
-    for cfg in [{}, {'bogus': 'data'}]:
-        res, msg = pkgset.validate(cfg)
+    with patch.object(pkgset.os.path, "exists", MagicMock(return_value=True)):
+        res, msg = pkgset.validate({})
+        assert res is True
+        assert msg == 'Configuration validated'
+    with patch.object(pkgset.os.path, "exists", MagicMock(return_value=False)):
+        res, msg = pkgset.validate({})
         assert res is False
         assert msg == 'Cookie path has not been set.'
 


### PR DESCRIPTION
## What does this PR change?

Fix for test unit of `pkgset` beacon from PR https://github.com/uyuni-project/uyuni/pull/3645

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

- [ ] **DONE**

## Test coverage
- Unit tests were fixed

## Links

Fix for test unit related to this PR https://github.com/uyuni-project/uyuni/pull/3645

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "spacecmd_unittests"
