### PR TITLE
Master: ansible inventory parsing to show registered systems

### DIFF
--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Parse ansible inventory and show registered systems
 - fix problem reading product_tree.json from wrong location in offline setups (bsc#1184283)
 - Eliminate duplicate entries when displaying results from mgr-libmod
 - Fix boot image url, change default to ftp (bsc#1185509)

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Parse ansible inventory and show registered systems
 - virtual console monitors VM state changes
 - Ansible integration: configure paths, inspect inventories, discover and schedule playbooks
 - Improved filtering, deleting etc in CLM filter list


### PR DESCRIPTION
## What does this PR change?

Parse Inventory content to distinguish already registered and managed systems against Uyuni or unknown hostnames.

## GUI diff

No difference.

Before:
![inventoryContent](https://user-images.githubusercontent.com/7080830/116991348-b387d580-acd4-11eb-8ed8-e3ce3fe3b3b7.png)


After:
![Screenshot from 2021-05-04 12-30-19](https://user-images.githubusercontent.com/7080830/116991338-af5bb800-acd4-11eb-8def-eab7bb180683.png)


- [x] **DONE**

## Documentation
- No documentation needed: included in ansible documentations

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes # https://github.com/SUSE/spacewalk/issues/14753
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
