### PR TITLE
Fix boot image url, change default to ftp (bsc#1185509)

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
@@ -1761,7 +1761,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
                 map = new Yaml().loadAs(fi, Map.class);
                 assertTrue(map.containsKey("boot_images"));
                 Map<String, Map<String, Map<String, Object>>> bootImages = (Map<String, Map<String, Map<String, Object>>>) map.get("boot_images");
-                assertEquals("tftp://tftp/boot/POS_Image_JeOS6-6.0.0/initrd-netboot-suse-SLES12.x86_64-2.1.1.gz", bootImages.get("POS_Image_JeOS6-6.0.0").get("initrd").get("url"));
+                assertEquals("ftp://ftp/boot/POS_Image_JeOS6.x86_64-6.0.0-build24/initrd-netboot-suse-SLES12.x86_64-2.1.1.gz", bootImages.get("POS_Image_JeOS6-6.0.0").get("initrd").get("url"));
                 Map<String, Map<String, Map<String, Object>>> images = (Map<String, Map<String, Map<String, Object>>>) map.get("images");
                 assertEquals("ftp://ftp/image/POS_Image_JeOS6.x86_64-6.0.0-build24/POS_Image_JeOS6.x86_64-6.0.0", images.get("POS_Image_JeOS6").get("6.0.0").get("url"));
                 assertEquals(1490026496, images.get("POS_Image_JeOS6").get("6.0.0").get("size"));

--- a/java/code/src/com/suse/manager/webui/services/SaltStateGeneratorService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltStateGeneratorService.java
@@ -174,14 +174,14 @@ public enum SaltStateGeneratorService {
         bootImagePillarInitrd.put("hash", bootImage.getInitrd().getHash());
         bootImagePillarInitrd.put("size", bootImage.getInitrd().getSize());
         bootImagePillarInitrd.put("version", bootImage.getInitrd().getVersion());
-        bootImagePillarInitrd.put("url", "tftp://tftp/boot/" + bootImageName + '/' +
+        bootImagePillarInitrd.put("url", "ftp://ftp/boot/" + bootLocalPath + '/' +
                 bootImage.getInitrd().getFilename());
 
         bootImagePillarKernel.put("filename", bootImage.getKernel().getFilename());
         bootImagePillarKernel.put("hash", bootImage.getKernel().getHash());
         bootImagePillarKernel.put("size", bootImage.getKernel().getSize());
         bootImagePillarKernel.put("version", bootImage.getKernel().getVersion());
-        bootImagePillarKernel.put("url", "tftp://tftp/boot/" + bootImageName + '/' +
+        bootImagePillarKernel.put("url", "ftp://ftp/boot/" + bootLocalPath + '/' +
                 bootImage.getKernel().getFilename());
 
         bootImagePillarSync.put("local_path", bootLocalPath);

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix boot image url, change default to ftp (bsc#1185509)
 - XMLRPC: Endpoint for aligning channel metadata based on another channel (bsc#1182810)
 - forward registration data to SUSE Customer Center
 - Rename system migration to system transfer


### PR DESCRIPTION
## What does this PR change?

Fix incorrect boot image url - without this url saltboot fails to set up local boot.
Change default protocol to ftp - the same is used for system images

## GUI diff

No difference.

## Documentation
- No documentation needed: bugfix

## Test coverage
- covered by openQA tests

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/14747 
https://bugzilla.suse.com/show_bug.cgi?id=1185509

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
