### PR TITLE
License change for susemanager-sls

### DIFF
--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Switch from GPLv2 to Apache 2.0.
 - Add support of salt bundle to pkgset notify beacon
 - Add automatic cookie file selection for pkgset beacon
 - Ansible integration: new SLS files files to operate Ansible control node

--- a/susemanager-utils/susemanager-sls/susemanager-sls.spec
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.spec
@@ -24,7 +24,7 @@ Name:           susemanager-sls
 Version:        4.2.8
 Release:        1
 Summary:        Static Salt state files for SUSE Manager
-License:        GPL-2.0-only
+License:        Apache-2.0 and LGPL-2.1-only
 Group:          Applications/Internet
 Source:         %{name}-%{version}.tar.gz
 Requires(pre):  coreutils


### PR DESCRIPTION
## What does this PR change?

Switching from GPLv2 to Apache 2.0. One file still remains LGPLv2.1 though.

## GUI diff

No difference.

## Documentation
- No documentation needed: I don't think we have that in the documentation.

## Test coverage
- No tests: Just a license change.

## Links

Fixes https://github.com/SUSE/spacewalk/issues/11589


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
