### PR TITLE
remove useless message about backup displayed

### DIFF
--- a/susemanager/bin/pg-migrate-10-to-12.sh
+++ b/susemanager/bin/pg-migrate-10-to-12.sh
@@ -45,13 +45,6 @@ else
     fi
 fi
 
-grep "^archive_command.*smdba-pgarchive" /var/lib/pgsql/data/postgresql.conf > /dev/null 2>&1
-if [ $? -eq 0 ]; then
-    BACKUP_CONFIGURED=1
-else
-    BACKUP_CONFIGURED=0
-fi
-
 echo "`date +"%H:%M:%S"`   Shut down spacewalk services..."
 spacewalk-service stop
 systemctl stop postgresql
@@ -130,10 +123,4 @@ echo "`date +"%H:%M:%S"`   Starting spacewalk services..."
 systemctl start postgresql
 spacewalk-service start
 
-if [ $BACKUP_CONFIGURED -eq 1 ]; then
-    echo
-    echo "It seems database backups via smdba had been configured for postgresql 10."
-    echo "Please re-configure backup for new database version!"
-    echo
-fi
 

--- a/susemanager/bin/pg-migrate-12-to-13.sh
+++ b/susemanager/bin/pg-migrate-12-to-13.sh
@@ -48,13 +48,6 @@ else
     fi
 fi
 
-grep "^archive_command.*smdba-pgarchive" /var/lib/pgsql/data/postgresql.conf > /dev/null 2>&1
-if [ $? -eq 0 ]; then
-    BACKUP_CONFIGURED=1
-else
-    BACKUP_CONFIGURED=0
-fi
-
 echo "`date +"%H:%M:%S"`   Shut down spacewalk services..."
 spacewalk-service stop
 systemctl stop postgresql
@@ -133,10 +126,4 @@ echo "`date +"%H:%M:%S"`   Starting spacewalk services..."
 systemctl start postgresql
 spacewalk-service start
 
-if [ $BACKUP_CONFIGURED -eq 1 ]; then
-    echo
-    echo "It seems database backups via smdba had been configured for postgresql $OLD_VERSION."
-    echo "Please re-configure backup for new database version!"
-    echo
-fi
 

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- remove useless message about backup configuration (bsc#1183080)
 - add additional default config values for forwarding registrations to SCC
 - Require gio-branding-SLE for SLE15 but not for openSUSE Leap 15
 - add bootstrap repo data for OES2018-SP3-x86_64 (bsc#1183845)


### PR DESCRIPTION
## What does this PR change?

removes useless message about backup displayed

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

fixes bsc#1183080 issue#14190

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
