### PR TITLE
WIP: Build sources (tito) in parallel

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,7 @@
+yarn-path "./susemanager-frontend/susemanager-nodejs-sdk-devel/build/yarn/yarn-1.22.4.js"
+--install.cwd ./susemanager-frontend
+--clean.cwd ./susemanager-frontend
+--audit.cwd ./susemanager-frontend
+--autoclean.cwd ./susemanager-frontend
+--add.cwd ./susemanager-frontend/susemanager-nodejs-sdk-devel
+--remove.cwd ./susemanager-frontend/susemanager-nodejs-sdk-devel

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,7 +1,0 @@
-yarn-path "./susemanager-frontend/susemanager-nodejs-sdk-devel/build/yarn/yarn-1.22.4.js"
---install.cwd susemanager-frontend
---clean.cwd susemanager-frontend
---audit.cwd susemanager-frontend
---autoclean.cwd susemanager-frontend
---add.cwd susemanager-frontend/susemanager-nodejs-sdk-devel
---remove.cwd susemanager-frontend/susemanager-nodejs-sdk-devel

--- a/rel-eng/build-one-package-for-obs.sh
+++ b/rel-eng/build-one-package-for-obs.sh
@@ -1,0 +1,118 @@
+#! /bin/bash
+BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+set -e
+#
+# For all packages in git:/rel-eng/packages (or defined in $PACKAGES)
+# provide tarball, spec and changes in $WORKSPACE/SRPMS/<package>
+#
+# git_package_defs() has a hardcoded list of packages excluded by default.
+#
+WORKSPACE=${WORKSPACE:-/tmp/push-packages-to-obs}
+PKG_NAME=$1
+PKG_VER=$2
+PKG_DIR=$3
+
+# check cwd is in git
+GIT_DIR=$(git rev-parse --show-cdup)
+test -z "$GIT_DIR" || cd "$GIT_DIR"
+GIT_DIR=$(pwd)
+
+# check presence of tito
+test -x "/usr/bin/tito" || {
+  echo "Missing '/usr/bin/tito' needed for build." >&2
+  exit 2
+}
+TITO="/usr/bin/tito"
+
+# check for unrpm
+which unrpm &> /dev/null || {
+  echo "unrpm not found in the PATH, do 'zypper install build'" >&2
+  exit 2
+}
+
+# build the src rpms...
+SRPM_DIR="$WORKSPACE/SRPMS/$PKG_NAME"
+rm -rf "$SRPM_DIR"
+mkdir -p "$SRPM_DIR"
+
+SRPMBUILD_DIR="$WORKSPACE/SRPMBUILD/$PKG_NAME"
+rm -rf "$SRPMBUILD_DIR"
+mkdir -p "$SRPMBUILD_DIR"
+trap "test -d \"$SRPMBUILD_DIR\" && /bin/rm -rf -- \"$SRPMBUILD_DIR\" " 0 1 2 3 13 15
+
+# not nice but tito does not take it via CLI, via .rc
+# file prevents parallel execution for different OBS
+# projects.Thus we patched tito to take the builddir
+# from environment:
+export RPMBUILD_BASEDIR=$SRPMBUILD_DIR
+
+echo "Going to build new obs packages in $SRPM_DIR..."
+T_DIR="$SRPMBUILD_DIR/.build"
+T_LOG="$SRPMBUILD_DIR/.log"
+
+VERBOSE=$VERBOSE
+
+for tries in 1 2 3; do
+  echo "=== Building package [$PKG_NAME-$PKG_VER] from $PKG_DIR (Try $tries)"
+  rm -rf "$SRPMBUILD_DIR"
+  mkdir -p "$SRPMBUILD_DIR"
+
+  cd "$GIT_DIR/$PKG_DIR"
+  $TITO build ${VERBOSE:+--debug} ${TEST:+--test} --srpm >"$T_LOG" 2>&1 || {
+    cat "$T_LOG"
+    test $tries -eq 3 || continue
+    RESULT=-1
+    echo $PKG_NAME >> $WORKSPACE/failed
+    continue 2
+  }
+  ${VERBOSE:+cat "$T_LOG"}
+
+  eval $(awk '/^Wrote:.*src.rpm/{srpm=$2}/^Wrote:.*.changes/{changes=$2}END{ printf "SRPM=\"%s\"\n",srpm; printf "CHANGES=\"%s\"\n",changes; }' "$T_LOG")
+  if [ "$(head -n1 ${CHANGES}|grep '^- ')" != "" ]; then
+    echo "*** Untagged package, adding fake header..."
+    sed -i "1i Fri Jan 01 00:00:00 CEST 2038 - faketagger@suse.inet\n" ${CHANGES}
+    sed -i '1i -------------------------------------------------------------------' ${CHANGES}
+  fi
+  if [ -e "$SRPM" -a -e "$CHANGES" ]; then
+    mkdir "$T_DIR"
+    ( set -e; cd "$T_DIR"; unrpm "$SRPM"; ) >/dev/null 2>&1
+    test -z "$CHANGES" || mv "$CHANGES" "$T_DIR"
+  else
+    test $tries -eq 3 || continue
+    RESULT=-1
+    echo $PKG_NAME >> $WORKSPACE/failed
+    continue 2
+  fi
+
+  # Convert to obscpio
+  SPEC_VER=$(sed -n -e 's/^Version:\s*\(.*\)/\1/p' ${T_DIR}/${PKG_NAME}.spec)
+  SOURCE=$(sed -n -e 's/^\(Source\|Source0\):\s*.*[[:space:]\/]\(.*\)/\2/p' ${T_DIR}/${PKG_NAME}.spec|sed -e "s/%{name}/${PKG_NAME}/"|sed -e "s/%{version}/${SPEC_VER}/")
+  # If the package does not have sources, we don't need to repackage them
+  if [ "${SOURCE}" != "" ]; then
+    FOLDER=$(tar -tf ${T_DIR}/${SOURCE}|head -1|sed -e 's/\///')
+    (cd ${T_DIR}; tar -xf ${SOURCE}; rm ${SOURCE}; mv ${FOLDER} ${PKG_NAME}; find ${PKG_NAME} | cpio --create --format=newc --reproducible > ${FOLDER}.obscpio; rm -rf ${PKG_NAME})
+  fi
+  # Move to destination
+  mv "$T_DIR" "$SRPM_DIR/$PKG_NAME"
+  # If the package does not have sources, we don't need service or .obsinfo file
+  if [ "${SOURCE}" != "" ]; then
+    # Copy service
+    cp ${BASE_DIR}/_service "${SRPM_DIR}/${PKG_NAME}"
+    # Create .obsinfo file
+    cat > "${SRPM_DIR}/${PKG_NAME}/${PKG_NAME}.obsinfo" <<EOF
+name: ${PKG_NAME}
+version: $(echo ${FOLDER}|sed -e "s/${PKG_NAME}-//")
+mtime: $(date +%s)
+commit: $(git rev-parse --verify HEAD)
+EOF
+  fi
+  # Release is handled by the Buildservice
+  # Remove everything what prevents us from submitting
+  sed -i 's/^Release.*$/Release:    1/i' $SRPM_DIR/$PKG_NAME/*.spec
+  echo "$PKG_NAME" >> $WORKSPACE/succeeded
+  RESULT=0
+  break
+ done
+
+
+exit $RESULT

--- a/rel-eng/build-packages-for-obs.sh
+++ b/rel-eng/build-packages-for-obs.sh
@@ -1,5 +1,4 @@
 #! /bin/bash
-BASE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 set -e
 #
 # For all packages in git:/rel-eng/packages (or defined in $PACKAGES)
@@ -25,38 +24,6 @@ GIT_DIR=$(git rev-parse --show-cdup)
 test -z "$GIT_DIR" || cd "$GIT_DIR"
 GIT_DIR=$(pwd)
 
-# check presence of tito
-test -x "/usr/bin/tito" || {
-  echo "Missing '/usr/bin/tito' needed for build." >&2
-  exit 2
-}
-TITO="/usr/bin/tito"
-
-# check for unrpm
-which unrpm &> /dev/null || {
-  echo "unrpm not found in the PATH, do 'zypper install build'" >&2
-  exit 2
-}
-
-# create workspace
-test -d "$WORKSPACE" || mkdir -p "$WORKSPACE"
-
-# build the src rpms...
-SRPM_DIR="$WORKSPACE/SRPMS"
-rm -rf "$SRPM_DIR"
-mkdir -p "$SRPM_DIR"
-
-SRPMBUILD_DIR="$WORKSPACE/SRPMBUILD"
-rm -rf "$SRPMBUILD_DIR"
-mkdir -p "$SRPMBUILD_DIR"
-trap "test -d \"$SRPMBUILD_DIR\" && /bin/rm -rf -- \"$SRPMBUILD_DIR\" " 0 1 2 3 13 15
-
-# not nice but tito does not take it via CLI, via .rc
-# file prevents parallel execution for different OBS
-# projects.Thus we patched tito to take the builddir
-# from environment:
-export RPMBUILD_BASEDIR=$SRPMBUILD_DIR
-
 function git_package_defs() {
   # - "PKG_NAME PKG_VER PKG_DIR" from git:/rel-eng/packages/, using
   #   a hardcoded blacklist of packages we do not build.
@@ -75,79 +42,21 @@ function git_package_defs() {
   done
 }
 
-echo "Going to build new obs packages in $SRPM_DIR..."
-T_DIR="$SRPMBUILD_DIR/.build"
-T_LOG="$SRPMBUILD_DIR/.log"
-SUCCEED_CNT=0
-FAILED_CNT=0
-FAILED_PKG=
+# create workspace
+test -d "$WORKSPACE" || mkdir -p "$WORKSPACE"
 
-VERBOSE=$VERBOSE
+echo "# $(date)" > $WORKSPACE/succeeded
+echo "# $(date)" > $WORKSPACE/failed
+
 while read PKG_NAME PKG_VER PKG_DIR; do
- for tries in 1 2 3; do
-  echo "=== Building package [$PKG_NAME-$PKG_VER] from $PKG_DIR (Try $tries)"
-  rm -rf "$SRPMBUILD_DIR"
-  mkdir -p "$SRPMBUILD_DIR"
-
-  cd "$GIT_DIR/$PKG_DIR"
-  $TITO build ${VERBOSE:+--debug} ${TEST:+--test} --srpm >"$T_LOG" 2>&1 || {
-    cat "$T_LOG"
-    test $tries -eq 3 || continue
-    FAILED_CNT=$(($FAILED_CNT+1))
-    FAILED_PKG="$FAILED_PKG$(echo -ne "\n    $PKG_NAME-$PKG_VER")"
-    echo "*** FAILED Building package [$PKG_NAME-$PKG_VER]"
-    continue 2
-  }
-  ${VERBOSE:+cat "$T_LOG"}
-
-  eval $(awk '/^Wrote:.*src.rpm/{srpm=$2}/^Wrote:.*.changes/{changes=$2}END{ printf "SRPM=\"%s\"\n",srpm; printf "CHANGES=\"%s\"\n",changes; }' "$T_LOG")
-  if [ "$(head -n1 ${CHANGES}|grep '^- ')" != "" ]; then
-    echo "*** Untagged package, adding fake header..."
-    sed -i "1i Fri Jan 01 00:00:00 CEST 2038 - faketagger@suse.inet\n" ${CHANGES}
-    sed -i '1i -------------------------------------------------------------------' ${CHANGES}
-  fi
-  if [ -e "$SRPM" -a -e "$CHANGES" ]; then
-    mkdir "$T_DIR"
-    ( set -e; cd "$T_DIR"; unrpm "$SRPM"; ) >/dev/null 2>&1
-    test -z "$CHANGES" || mv "$CHANGES" "$T_DIR"
-  else
-    test $tries -eq 3 || continue
-    FAILED_CNT=$(($FAILED_CNT+1))
-    FAILED_PKG="$FAILED_PKG$(echo -ne "\n    $PKG_NAME-$PKG_VER")"
-    echo "*** FAILED Building package [$PKG_NAME-$PKG_VER] - src.rpm or changes file does not exist"
-    continue 2
-  fi
-
-  # Convert to obscpio
-  SPEC_VER=$(sed -n -e 's/^Version:\s*\(.*\)/\1/p' ${T_DIR}/${PKG_NAME}.spec)
-  SOURCE=$(sed -n -e 's/^\(Source\|Source0\):\s*.*[[:space:]\/]\(.*\)/\2/p' ${T_DIR}/${PKG_NAME}.spec|sed -e "s/%{name}/${PKG_NAME}/"|sed -e "s/%{version}/${SPEC_VER}/")
-  # If the package does not have sources, we don't need to repackage them
-  if [ "${SOURCE}" != "" ]; then
-    FOLDER=$(tar -tf ${T_DIR}/${SOURCE}|head -1|sed -e 's/\///')
-    (cd ${T_DIR}; tar -xf ${SOURCE}; rm ${SOURCE}; mv ${FOLDER} ${PKG_NAME}; find ${PKG_NAME} | cpio --create --format=newc --reproducible > ${FOLDER}.obscpio; rm -rf ${PKG_NAME})
-  fi
-  # Move to destination
-  mv "$T_DIR" "$SRPM_DIR/$PKG_NAME"
-  # If the package does not have sources, we don't need service or .obsinfo file
-  if [ "${SOURCE}" != "" ]; then
-    # Copy service
-    cp ${BASE_DIR}/_service "${SRPM_DIR}/${PKG_NAME}"
-    # Create .obsinfo file
-    cat > "${SRPM_DIR}/${PKG_NAME}/${PKG_NAME}.obsinfo" <<EOF
-name: ${PKG_NAME}
-version: $(echo ${FOLDER}|sed -e "s/${PKG_NAME}-//")
-mtime: $(date +%s)
-commit: $(git rev-parse --verify HEAD)
-EOF
-  fi
-  # Release is handled by the Buildservice
-  # Remove everything what prevents us from submitting
-  sed -i 's/^Release.*$/Release:    1/i' $SRPM_DIR/$PKG_NAME/*.spec
-
-  SUCCEED_CNT=$(($SUCCEED_CNT+1))
-  break
- done
+    ./rel-eng/build-one-package-for-obs.sh $PKG_NAME $PKG_VER $PKG_DIR &
 done < <(git_package_defs)
+
+wait
+
+SUCCEED_CNT=$(cat $WORKSPACE/succeeded | grep -v "#" | wc -l)
+FAILED_CNT=$(cat $WORKSPACE/failed | grep -v "#" | wc -l)
+FAILED_PKG=$(cat $WORKSPACE/failed)
 
 echo "======================================================================"
 echo "Built obs packages:  $SUCCEED_CNT"

--- a/susemanager-frontend/.yarnrc
+++ b/susemanager-frontend/.yarnrc
@@ -1,7 +1,0 @@
-yarn-path "./susemanager-nodejs-sdk-devel/build/yarn/yarn-1.22.4.js"
---install.cwd .
---clean.cwd .
---audit.cwd .
---autoclean.cwd .
---add.cwd ./susemanager-nodejs-sdk-devel
---remove.cwd ./susemanager-nodejs-sdk-devel

--- a/susemanager-frontend/.yarnrc
+++ b/susemanager-frontend/.yarnrc
@@ -1,0 +1,7 @@
+yarn-path "./susemanager-nodejs-sdk-devel/build/yarn/yarn-1.22.4.js"
+--install.cwd .
+--clean.cwd .
+--audit.cwd .
+--autoclean.cwd .
+--add.cwd ./susemanager-nodejs-sdk-devel
+--remove.cwd ./susemanager-nodejs-sdk-devel

--- a/web/.yarnrc
+++ b/web/.yarnrc
@@ -3,5 +3,3 @@ yarn-path "../susemanager-frontend/susemanager-nodejs-sdk-devel/build/yarn/yarn-
 --clean.cwd .
 --audit.cwd .
 --autoclean.cwd .
---add.cwd ./susemanager-nodejs-sdk-devel
---remove.cwd ./susemanager-nodejs-sdk-devel

--- a/web/.yarnrc
+++ b/web/.yarnrc
@@ -1,0 +1,7 @@
+yarn-path "../susemanager-frontend/susemanager-nodejs-sdk-devel/build/yarn/yarn-1.22.4.js"
+--install.cwd .
+--clean.cwd .
+--audit.cwd .
+--autoclean.cwd .
+--add.cwd ./susemanager-nodejs-sdk-devel
+--remove.cwd ./susemanager-nodejs-sdk-devel

--- a/web/setup.sh
+++ b/web/setup.sh
@@ -1,4 +1,6 @@
 set -euxo pipefail
+touch /tmp/uyuni-yarn-install.lock
 (cd web/html/src; yarn install --frozen-lockfile)
 (cd web/html/src; yarn build:novalidate)
+rm /tmp/uyuni-yarn-install.lock
 echo ""


### PR DESCRIPTION
## What does this PR change?

Building the sources of all the packages in the CI takes 20 minutes.
If we run this in parallel, it should take 5 minutes instead.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed

- [X] **DONE**

## Test coverage
- No tests

- [X] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/14762

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
