### PR TITLE
Testsuite: Add login scenario for Ansible cucumber tests

### DIFF
--- a/testsuite/features/secondary/min_ansible_control_node.feature
+++ b/testsuite/features/secondary/min_ansible_control_node.feature
@@ -4,6 +4,9 @@
 @scope_ansible
 Feature: Operate an Ansible control node in a normal minion
 
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
   Scenario: Pre-requisite: Deploy test playbooks and inventory file
     Given I am on the Systems overview page of this "sle_minion"
     When I deploy testing playbooks and inventory files to "sle_minion"

--- a/testsuite/features/secondary/minssh_ansible_control_node.feature
+++ b/testsuite/features/secondary/minssh_ansible_control_node.feature
@@ -6,6 +6,9 @@
 @ssh_minion
 Feature: Operate an Ansible control node in SSH minion
 
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
   Scenario: Pre-requisite: Deploy test playbooks and inventory file
     Given I am on the Systems overview page of this "ssh_minion"
     When I deploy testing playbooks and inventory files to "ssh_minion"


### PR DESCRIPTION
## What does this PR change?

This PR simply add a "login" scenario to the Ansible cucumber tests to keep consistency with other features.

This is not strictly needed when the testsuite is executed entirely but it's helpful when running features tests in an isolate way to avoid auth problems.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
