### PR TITLE
Testsuite: only execute Ansible feature tests on SUSE Manager

### DIFF
--- a/testsuite/features/secondary/min_ansible_control_node.feature
+++ b/testsuite/features/secondary/min_ansible_control_node.feature
@@ -1,6 +1,7 @@
 # Copyright (c) 2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
+@susemanager
 @scope_ansible
 Feature: Operate an Ansible control node in a normal minion
 

--- a/testsuite/features/secondary/minssh_ansible_control_node.feature
+++ b/testsuite/features/secondary/minssh_ansible_control_node.feature
@@ -1,6 +1,7 @@
 # Copyright (c) 2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
+@susemanager
 @scope_ansible
 @scope_salt_ssh
 @ssh_minion


### PR DESCRIPTION
## What does this PR change?

This PR disables the Ansible feature tests for Uyuni since they're going to fail until SUMA 4.1.8 is released.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
