### PR TITLE
read product tree also from suma/ subdirectory in offline setups (bsc#1184283)

### DIFF
--- a/java/code/src/com/suse/scc/client/SCCFileClient.java
+++ b/java/code/src/com/suse/scc/client/SCCFileClient.java
@@ -89,8 +89,14 @@ public class SCCFileClient implements SCCClient {
 
     @Override
     public List<ProductTreeEntry> productTree() throws SCCClientException {
-        return getList("product_tree.json",
-                ProductTreeEntry.class);
+        try {
+            return getList("suma/product_tree.json",
+                    ProductTreeEntry.class);
+        }
+        catch (SCCClientException ex) {
+            return getList("product_tree.json",
+                    ProductTreeEntry.class);
+        }
     }
 
     @Override

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- fix problem reading product_tree.json from wrong location in offline setups (bsc#1184283)
 - Eliminate duplicate entries when displaying results from mgr-libmod
 - Fix boot image url, change default to ftp (bsc#1185509)
 - XMLRPC: Endpoint for aligning channel metadata based on another channel (bsc#1182810)


### PR DESCRIPTION
## What does this PR change?

Fixes a problem where we try to read the product tree file from the root directory of a offline setup while RMT puts it in a suma subdirectory. We keep the old location as a fallback since customers with working setups might have moved the file manually.

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed:

- [x] **DONE**

## Test coverage
- No tests: 

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/14467


- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
