### PR TITLE
Ensure systemid file exists to indicate minion is managed by Uyuni

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/services/salt-minion.sls
+++ b/susemanager-utils/susemanager-sls/salt/services/salt-minion.sls
@@ -41,3 +41,10 @@ mgr_salt_minion:
     - enable: True
     - order: last
 {% endif %}
+
+{# ensure /etc/sysconfig/rhn/systemid is created to indicate minion is managed by SUSE Manager #}
+/etc/sysconfig/rhn/systemid:
+  file.managed:
+    - mode: 0640
+    - makedirs: True
+    - replace: False

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Always create systemid file to indicate minion is managed by Uyuni
 - Switch from GPLv2 to Apache 2.0.
 - Add support of salt bundle to pkgset notify beacon
 - Add automatic cookie file selection for pkgset beacon


### PR DESCRIPTION
## What does this PR change?

Ensure in highstate that `/etc/sysconfig/rhn/systemid` exists in order to indicate that salt client is managed by Uyuni/SUMA.
Proxies and traditional clients have this file present, only regular salt clients were missing it.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/14621

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
