### PR TITLE
Accept package list refresh scheduled by (none)

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1445,7 +1445,7 @@ Then(/^I wait until refresh package list on "(.*?)" is finished$/) do |client|
   node = get_system_name(client)
   $server.run("spacecmd -u admin -p admin clear_caches")
   # Gather all the ids of package refreshes existing at SUMA
-  refreshes, = $server.run("spacecmd -u admin -p admin schedule_list | grep 'Package List Refresh scheduled by admin' | cut -f1 -d' '", false)
+  refreshes, = $server.run("spacecmd -u admin -p admin schedule_list | grep 'Package List Refresh scheduled by' | cut -f1 -d' '", false)
   node_refreshes = ""
   refreshes.split(' ').each do |refresh_id|
     next unless refresh_id.match('/[0-9]{1,4}/')


### PR DESCRIPTION
## What does this PR change?

When the user adds/removes a package on a client, Salt automatically triggers a package list refresh.

But in that case, the action is triggered by `(none)`. Our wait step was waiting for an action triggered by `admin`.

This PR makes the test not care about who triggered the action.


## Links

Ports:
* 4.0: SUSE/spacewalk#14770
* 4.1: SUSE/spacewalk#14771

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
