### PR TITLE
Fix filter template prefix generation

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/FilterTemplateManager.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/FilterTemplateManager.java
@@ -60,7 +60,7 @@ public class FilterTemplateManager {
         List<ContentFilter> createdFilters = new ArrayList<>(2);
 
         criteria.forEach((name, crit) -> createdFilters.add(
-                ContentProjectFactory.createFilter(prefix + "-" + name, ContentFilter.Rule.DENY,
+                ContentProjectFactory.createFilter(prefix + name, ContentFilter.Rule.DENY,
                         ContentFilter.EntityType.ERRATUM, crit, user)
         ));
 

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/FilterApiController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/FilterApiController.java
@@ -152,7 +152,7 @@ public class FilterApiController {
         PackageEvr kernelEvr = PackageEvrFactory.lookupPackageEvrById(createFilterRequest.getKernelEvrId());
 
         String prefix = createFilterRequest.getPrefix();
-        if (!StringUtils.endsWithAny(createFilterRequest.getPrefix(), "-", "_")) {
+        if (!StringUtils.endsWithAny(prefix, "-", "_")) {
             prefix += "-";
         }
 


### PR DESCRIPTION
Minor fix to prepend the specified prefix to the filter names.

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
