### PR TITLE
Ubuntu bootstrap repo fixes

### DIFF
--- a/susemanager/src/mgr-create-bootstrap-repo
+++ b/susemanager/src/mgr-create-bootstrap-repo
@@ -2,6 +2,7 @@
 
 import sys
 import os
+import glob
 import shutil
 import subprocess
 import time
@@ -489,6 +490,18 @@ def create_repo(label, options, mgr_bootstrap_data, additional=[]):
     log("The bootstrap repo should contain the following packages: {0}".format(packagelist), 2)
 
     debs_dir = os.path.join(destdirtmp, 'debs')
+    if repotype == 'deb' and not options.dryrun:
+        # reprepro is picky with packages having the same name, but different checksums.
+        # To avoid aborting, we copy the old packages to debs and add or overwrite them
+        # with new found packages and run reprepro again (bsc#1184330)
+        if not os.path.exists(debs_dir):
+            os.makedirs(debs_dir)
+        for file_path in glob.glob(os.path.join(destdirtmp, 'pool/**/*.deb'), recursive=True):
+            shutil.copy2(file_path, debs_dir)
+        cleanup_dir(os.path.join(destdirtmp, 'pool'))
+        cleanup_dir(os.path.join(destdirtmp, 'db'))
+        cleanup_dir(os.path.join(destdirtmp, 'dists'))
+
     for pkgaltstr in packagelist:
         alt = pkgaltstr.split("|")
         altpretty =  ', '.join("'%s'" %(e) for e in alt)

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,6 @@
+- fix creating deb bootstrap repos with packages having new checksums
+  (bsc#1184330)
+
 -------------------------------------------------------------------
 Wed May 05 16:42:14 CEST 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

reprepro is picky with packages having the same name, but different checksums.
To avoid aborting, we copy the old packages to debs, add or overwrite them
with new found packages and run reprepro again (bsc#1184330)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **manual**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/14499
Tracks https://github.com/SUSE/spacewalk/pull/14777

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
