### PR TITLE
Testuite: Wait for package list refresh rigth after the SP migration

### DIFF
--- a/testsuite/features/init_clients/sle_minion.feature
+++ b/testsuite/features/init_clients/sle_minion.feature
@@ -54,9 +54,10 @@ Feature: Bootstrap a Salt minion via the GUI
 
   Scenario: Check the migration is successful for this minion
     Given I am on the Systems overview page of this "sle_spack_migrated_minion"
-    When I follow "Events"
+    When I wait at most 600 seconds until event "Product Migration scheduled by admin" is completed
+    And I follow "Events"
     And I follow "History"
-    And I wait at most 600 seconds until event "Product Migration scheduled by admin" is completed
+    And I wait until at least 2 events "Package List Refresh scheduled by (none)" are completed, refreshing the page
     And I follow "Details" in the content area
     Then I should see a "SUSE Linux Enterprise Server 15 SP2" text
     And vendor change should be enabled for product migration on "sle_spack_migrated_minion"

--- a/testsuite/features/init_clients/sle_ssh_minion.feature
+++ b/testsuite/features/init_clients/sle_ssh_minion.feature
@@ -49,9 +49,10 @@ Feature: Bootstrap a Salt host managed via salt-ssh
 
   Scenario: Check the migration is successful for this SSH minion
     Given I am on the Systems overview page of this "ssh_spack_migrated_minion"
-    When I follow "Events"
+    When I wait at most 600 seconds until event "Product Migration scheduled by admin" is completed
+    And I follow "Events"
     And I follow "History"
-    And I wait at most 600 seconds until event "Product Migration scheduled by admin" is completed
+    And I wait until at least 2 events "Package List Refresh scheduled by (none)" are completed, refreshing the page
     And I follow "Details" in the content area
     Then I should see a "SUSE Linux Enterprise Server 15 SP2" text
     And vendor change should be enabled for product migration on "ssh_spack_migrated_minion"

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -73,6 +73,23 @@ When(/^I wait at most (\d+) seconds until event "([^"]*)" is completed$/) do |fi
   )
 end
 
+When(/^I wait until at least (\d+) events "([^"]*)" are completed, refreshing the page$/) do |amount, event|
+  repeat_until_timeout(message: "Couldn't find the event #{event}") do
+    xpath = "//tr/td[3]/a[contains(text(),'#{event}')]"
+    matches = all(:xpath, xpath, wait: 1)
+
+    break if matches.length >= amount.to_i
+
+    begin
+      accept_prompt do
+        execute_script 'window.location.reload()'
+      end
+    rescue Capybara::ModalNotFound
+      # ignored
+    end
+  end
+end
+
 When(/^I wait until I see the event "([^"]*)" completed during last minute, refreshing the page$/) do |event|
   repeat_until_timeout(message: "Couldn't find the event #{event}") do
     now = Time.now


### PR DESCRIPTION
## What does this PR change?
Wait for the package list refresh right after the SP migration.

The SP migration fully completes once a package list refresh finish; only
after that, the client overview page will show the migrated products.

## Links
### Ports
- Manager-4.1: 

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

