### PR TITLE
QA: Fix some navigation issues

### DIFF
--- a/testsuite/features/secondary/minkvm_guests.feature
+++ b/testsuite/features/secondary/minkvm_guests.feature
@@ -199,7 +199,8 @@ Feature: Be able to manage KVM virtual machines via the GUI
     Then I wait until I see "test-vm2_system" text
 
   Scenario: delete a running KVM virtual machine
-    When I click on "Delete" in row "test-vm2"
+    When I follow "Virtualization" in the content area
+    And I click on "Delete" in row "test-vm2"
     And I click on "Delete" in "Delete Guest" modal
     Then I should not see a "test-vm2" virtual machine on "kvm_server"
 

--- a/testsuite/features/secondary/minssh_salt_install_package.feature
+++ b/testsuite/features/secondary/minssh_salt_install_package.feature
@@ -18,6 +18,7 @@ Feature: Install a package on the SSH minion via Salt through the UI
     And I wait until the table contains "FINISHED" or "SKIPPED" followed by "FINISHED" in its first rows
 
   Scenario: Install a package on the SSH minion
+    When I am on the Systems overview page of this "ssh_minion"
     And I follow "Software" in the content area
     And I follow "Install"
     And I check row with "hoag-dummy-1.1-1.1" and arch of "ssh_minion"

--- a/testsuite/features/secondary/srv_scc_user_credentials.feature
+++ b/testsuite/features/secondary/srv_scc_user_credentials.feature
@@ -37,5 +37,5 @@ Feature: SCC user credentials in the Setup Wizard
     When I follow the left menu "Admin > Setup Wizard > Organization Credentials"
     And I wait for the trash icon to appear for "SCC user"
     And I ask to delete the credentials for "SCC user"
-    And I click on "Delete"
+    And I click on "Delete" in "Are you sure you want to delete these credentials?" modal
     Then I should not see a "SCC user" text


### PR DESCRIPTION
## What does this PR change?

- Use a different step to click in a modal, when deleting a SSC User
- Missing navigation to the sshminion page, before install a package
- Missing navigation to the virtualization section, before deleting the VM

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Ports:
- Manager-4.0
- Manager-4.1

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
