### PR TITLE
CI: Publish rpms in jenkins node

### DIFF
--- a/susemanager-utils/testing/automation/obs-project.py
+++ b/susemanager-utils/testing/automation/obs-project.py
@@ -14,6 +14,7 @@ def add(args):
     pr_project = args.prproject
     pull_number = args.pullnumber
     maintainer=args.setmaintainer
+    disablepublish = args.disablepublish
     pr_project = pr_project + ":" + pull_number
     target_repo = args.repo
     config_file = args.configfile
@@ -68,6 +69,12 @@ def add(args):
         print("DEBUG: Adding user {} as maintainer".format(auth_user))
         new_person = ET.fromstring("<person userid=\"{}\" role=\"maintainer\"/>".format(auth_user))
         root.append(new_person)
+
+    if (disablepublish):
+        print("DEBUG: disabling publishing")
+        root.remove(root.find("publish"))
+        node = ET.fromstring("<publish><disable/></publish>")
+        root.append(node)
 
     root.find("description").text=str(datetime.datetime.now())
 
@@ -174,6 +181,7 @@ parser_add.add_argument('--project', help="Project from which to \"branch\" from
 parser_add.add_argument('--repo', help="Repo to build for, defaults to openSUSE.*|SLE.*", default="openSUSE.*|SLE.*")
 parser_add.add_argument('pullnumber', help="Pull Request number, for example 1")
 parser_add.add_argument('--setmaintainer', help="Set maintainer", default="")
+parser_add.add_argument('--disablepublish', help="Disable the publish", action="store_true", default=False)
 parser_add.set_defaults(func=add)
 
 parser_remove = subparser.add_parser("remove", help="remove project")

--- a/susemanager-utils/testing/automation/obs-project.py
+++ b/susemanager-utils/testing/automation/obs-project.py
@@ -14,7 +14,7 @@ def add(args):
     pr_project = args.prproject
     pull_number = args.pullnumber
     maintainer=args.setmaintainer
-    disablepublish = args.disablepublish
+    disable_publish = args.disablepublish
     pr_project = pr_project + ":" + pull_number
     target_repo = args.repo
     config_file = args.configfile
@@ -70,7 +70,7 @@ def add(args):
         new_person = ET.fromstring("<person userid=\"{}\" role=\"maintainer\"/>".format(auth_user))
         root.append(new_person)
 
-    if (disablepublish):
+    if (disable_publish):
         print("DEBUG: disabling publishing")
         root.remove(root.find("publish"))
         node = ET.fromstring("<publish><disable/></publish>")

--- a/susemanager-utils/testing/automation/publish-rpms.sh
+++ b/susemanager-utils/testing/automation/publish-rpms.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+usage()
+{
+    echo "Usage: $0 -p project -r repo -a arch -d dir"
+    echo "Where:"
+    echo "  -p project is the project in the build service"
+    echo "  -r repo is the repo in the build service"
+    echo "  -a arch is the arch in the build service"
+    echo "  -d dir is the directory where to create the repo"
+    echo "Example:"
+    echo "$0 -p systemsmanagement:Uyuni:Master:PR:123 -r openSUSE_Leap_15.2 -a x86_64 -d /home/jenkins/jenkins-build/workspace/"
+    echo "This will create a repo in /home/jenkins/jenkins-build/workspace/systemsmanagement:Uyuni:Master:PR:123/openSUSE_Leap_15.2/x86_64"
+}
+
+while getopts ":p:r:a:d:" opts;do
+    case "${opts}" in
+        p) echo "PPPP";obs_project=${OPTARG};;
+        r) echo "RRRR";obs_repo=${OPTARG};;
+        a) echo "AAA";obs_arch=${OPTARG};;
+        d) echo "DDDD";repo_dir=${OPTARG};;
+        \?) usage;exit -1;;
+    esac
+done
+shift $((OPTIND-1))
+
+if [ -z "${obs_project}" ] || \
+   [ -z "${obs_repo}" ] || \
+   [ -z "${obs_arch}" ] || \
+   [ -z "${repo_dir}" ];then
+    usage
+    echo "p ${obs_project} r ${obs_repo} a ${obs_arch} d ${repo_dir}"
+    exit -1
+fi
+
+repo_dir=$repo_dir/$obs_project/$obs_repo/$obs_arch
+
+osc getbinaries $obs_project $obs_repo $obs_arch -d $repo_dir
+cd $repo_dir && createrepo .


### PR DESCRIPTION
## What does this PR change?

Adding the availability for the CI to publish the RPMS in the jenkins node where they run.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed

- [X] **DONE**

## Test coverage
- No tests

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/14626

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
