### PR TITLE
Fix migration on SSH minion

### DIFF
--- a/testsuite/features/init_clients/sle_minion.feature
+++ b/testsuite/features/init_clients/sle_minion.feature
@@ -56,7 +56,8 @@ Feature: Bootstrap a Salt minion via the GUI
     Given I am on the Systems overview page of this "sle_spack_migrated_minion"
     When I follow "Events"
     And I follow "History"
-    And I wait at most 600 seconds until event "Product Migration scheduled by admin" is completed
+    And I wait at most 600 seconds until event "Product Migration" is completed
+    And I wait until event "Package List Refresh" is completed
     And I follow "Details" in the content area
     Then I should see a "SUSE Linux Enterprise Server 15 SP2" text
     And vendor change should be enabled for product migration on "sle_spack_migrated_minion"

--- a/testsuite/features/init_clients/sle_ssh_minion.feature
+++ b/testsuite/features/init_clients/sle_ssh_minion.feature
@@ -51,7 +51,8 @@ Feature: Bootstrap a Salt host managed via salt-ssh
     Given I am on the Systems overview page of this "ssh_spack_migrated_minion"
     When I follow "Events"
     And I follow "History"
-    And I wait at most 600 seconds until event "Product Migration scheduled by admin" is completed
+    And I wait at most 600 seconds until event "Product Migration" is completed
+    And I wait until event "Package List Refresh" is completed
     And I follow "Details" in the content area
     Then I should see a "SUSE Linux Enterprise Server 15 SP2" text
     And vendor change should be enabled for product migration on "ssh_spack_migrated_minion"

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1445,7 +1445,7 @@ Then(/^I wait until refresh package list on "(.*?)" is finished$/) do |client|
   node = get_system_name(client)
   $server.run("spacecmd -u admin -p admin clear_caches")
   # Gather all the ids of package refreshes existing at SUMA
-  refreshes, = $server.run("spacecmd -u admin -p admin schedule_list | grep 'Package List Refresh scheduled by' | cut -f1 -d' '", false)
+  refreshes, = $server.run("spacecmd -u admin -p admin schedule_list | grep 'Package List Refresh' | cut -f1 -d' '", false)
   node_refreshes = ""
   refreshes.split(' ').each do |refresh_id|
     next unless refresh_id.match('/[0-9]{1,4}/')


### PR DESCRIPTION
## What does this PR change?

Follow-up of #3704 (thanks Tino for the analysis of the problem).

Wait for the package list refresh right after the SP migration.

The SP migration fully completes once a package list refresh finish; only
after that, the client overview page will show the migrated products.


## Links

Ports:
* 4.0:
* 4.1:


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
