### PR TITLE
Don't install two SCAP Security guides on Ubuntu

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -843,7 +843,7 @@ When(/^I (install|remove) OpenSCAP dependencies (on|from) "([^"]*)"$/) do |actio
   elsif os_family =~ /^centos/
     pkgs = 'openscap-utils scap-security-guide-redhat'
   elsif os_family =~ /^ubuntu/
-    pkgs = 'libopenscap8 ssg-debderived scap-security-guide-ubuntu'
+    pkgs = 'libopenscap8 scap-security-guide-ubuntu'
   end
   pkgs += ' spacewalk-oscap' if host.include? 'client'
   step %(I #{action} packages "#{pkgs}" #{where} this "#{host}")


### PR DESCRIPTION
## What does this PR change?

Follow-up of #3673 Installing the correct scap-security-guide package from client tools.

We should not install two conflicting SSGs.


## Links

Ports:
* 4.0:
* 4.1:


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
