### PR TITLE
ensure file owner/group and permissions when writing pillars (bsc#1179954)

### DIFF
--- a/java/code/src/com/redhat/rhn/common/util/FileUtils.java
+++ b/java/code/src/com/redhat/rhn/common/util/FileUtils.java
@@ -30,8 +30,16 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFileAttributeView;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.UserPrincipalLookupService;
+import java.util.Set;
+
 
 
 /**
@@ -73,6 +81,26 @@ public class FileUtils {
             log.error("Error trying to write file to disk: [" + path + "]", e);
             throw new RuntimeException(e);
         }
+    }
+
+    /**
+     * convenient method to set user/group and permissions of a file in one go.
+     *
+     * @param path path to file
+     * @param user username
+     * @param group groupname
+     * @param permissions set of permissions
+     * @throws IOException when any of the file operations fail
+     */
+    public static void setAttributes(Path path, String user, String group, Set<PosixFilePermission> permissions)
+            throws IOException {
+        FileSystem fileSystem = FileSystems.getDefault();
+        UserPrincipalLookupService service = fileSystem.getUserPrincipalLookupService();
+        PosixFileAttributeView view  = Files.getFileAttributeView(
+                path, PosixFileAttributeView.class, LinkOption.NOFOLLOW_LINKS);
+        view.setOwner(service.lookupPrincipalByName(user));
+        view.setGroup(service.lookupPrincipalByGroupName(group));
+        view.setPermissions(permissions);
     }
 
 

--- a/java/code/src/com/suse/manager/webui/services/SaltStateGeneratorService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltStateGeneratorService.java
@@ -22,6 +22,10 @@ import static com.suse.manager.webui.services.SaltConstants.SALT_SERVER_STATE_FI
 import static com.suse.manager.webui.services.SaltConstants.SUMA_PILLAR_IMAGES_DATA_PATH;
 import static com.suse.manager.webui.services.SaltConstants.SUMA_STATE_FILES_ROOT_PATH;
 import static com.suse.manager.webui.utils.SaltFileUtils.defaultExtension;
+import static java.nio.file.attribute.PosixFilePermission.GROUP_READ;
+import static java.nio.file.attribute.PosixFilePermission.GROUP_WRITE;
+import static java.nio.file.attribute.PosixFilePermission.OWNER_READ;
+import static java.nio.file.attribute.PosixFilePermission.OWNER_WRITE;
 
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.util.FileUtils;
@@ -54,6 +58,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
@@ -119,6 +124,8 @@ public enum SaltStateGeneratorService {
 
             SaltStateGenerator saltStateGenerator = new SaltStateGenerator(filePath.toFile());
             saltStateGenerator.generate(pillar);
+            FileUtils.setAttributes(filePath, "tomcat", "susemanager",
+                    Set.of(OWNER_READ, OWNER_WRITE, GROUP_READ, GROUP_WRITE));
         }
         catch (IOException e) {
             LOG.error(e.getMessage(), e);
@@ -518,6 +525,8 @@ public enum SaltStateGeneratorService {
             com.suse.manager.webui.utils.SaltStateGenerator saltStateGenerator =
                     new com.suse.manager.webui.utils.SaltStateGenerator(filePath.toFile());
             saltStateGenerator.generate(pillar);
+            FileUtils.setAttributes(filePath, "tomcat", "susemanager",
+                    Set.of(OWNER_READ, OWNER_WRITE, GROUP_READ, GROUP_WRITE));
         }
         catch (IOException e) {
             LOG.error("Failed to generate pillar data into " + filePath, e);

--- a/java/code/src/com/suse/manager/webui/services/pillar/MinionPillarFileManager.java
+++ b/java/code/src/com/suse/manager/webui/services/pillar/MinionPillarFileManager.java
@@ -15,7 +15,12 @@
 package com.suse.manager.webui.services.pillar;
 
 import static com.suse.manager.webui.services.SaltConstants.SUMA_PILLAR_DATA_PATH;
+import static java.nio.file.attribute.PosixFilePermission.GROUP_READ;
+import static java.nio.file.attribute.PosixFilePermission.GROUP_WRITE;
+import static java.nio.file.attribute.PosixFilePermission.OWNER_READ;
+import static java.nio.file.attribute.PosixFilePermission.OWNER_WRITE;
 
+import com.redhat.rhn.common.util.FileUtils;
 import com.redhat.rhn.domain.server.MinionServer;
 
 import com.suse.manager.webui.utils.SaltPillar;
@@ -23,10 +28,12 @@ import com.suse.manager.webui.utils.SaltStateGenerator;
 
 import org.apache.log4j.Logger;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Set;
 
 /**
  * Abstract manager class for generating or removing minion pillar files
@@ -62,7 +69,10 @@ public class MinionPillarFileManager {
     private void saveFileToDisk(SaltPillar pillar, String filename) {
         try {
             Files.createDirectories(this.pillarDataPath);
-            new SaltStateGenerator(this.pillarDataPath.resolve(filename).toFile()).generate(pillar);
+            File file = this.pillarDataPath.resolve(filename).toFile();
+            new SaltStateGenerator(file).generate(pillar);
+            FileUtils.setAttributes(file.toPath(), "tomcat", "susemanager",
+                    Set.of(OWNER_READ, OWNER_WRITE, GROUP_READ, GROUP_WRITE));
         }
         catch (IOException e) {
             LOG.error(e.getMessage(), e);

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- fix file ownership and permissions in /srv/susemanager/pillar_data/ (bsc#1179954)
 - Strip the modular metadata for newly created channels in CLM if modular filters present (bsc#1184118)
 - fix disapearing Autoinstallation Menu for minions (bsc#1184813)
 - catch not found repository and create a standard error page (bsc#1183992)

--- a/susemanager-utils/testing/docker/master/uyuni-master-pgsql/Dockerfile
+++ b/susemanager-utils/testing/docker/master/uyuni-master-pgsql/Dockerfile
@@ -5,6 +5,9 @@
 FROM registry.mgr.suse.de/uyuni-master-base:latest
 MAINTAINER Michael Calmer "Michael.Calmer@suse.com"
 
+RUN groupadd susemanager
+RUN gpasswd -a tomcat susemanager
+
 # Install the required packages
 ADD add_packages.sh /root/add_packages.sh
 RUN /root/add_packages.sh


### PR DESCRIPTION
## What does this PR change?

This pr makes sure that all pillar data written to `/srv/susemanager/pillar_data/`  is set with the correct owner/group/permissions to that files remain readable independent of it they were written by tomcat or taskomatic. In addition this also restricts read access to owner/group only since pillar data might contain sensitive data.


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/13456

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
