### PR TITLE
Clean up JS test utils

### DIFF
--- a/web/html/src/utils/test-utils/forms.ts
+++ b/web/html/src/utils/test-utils/forms.ts
@@ -1,10 +1,15 @@
 import { screen, queryHelpers } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import * as selectEvent from "react-select-event";
+
+// react-select testing utilities: https://github.com/romgain/react-select-event#api
+export * from "react-select-event";
 
 const queryAllByName = queryHelpers.queryAllByAttribute.bind(null, "name");
 
 // This isn't universal, but suffices for this context
 function isInput(input: HTMLElement): input is HTMLInputElement {
-  return input && Object.prototype.hasOwnProperty.call(input, 'value');
+  return input && Object.prototype.hasOwnProperty.call(input, "value");
 }
 
 /** Get all the values of fields of a field name within a form.
@@ -13,4 +18,46 @@ export const getFieldValuesByName = (formName: string, fieldName: string) => {
   const form = screen.getByTitle(formName);
   const fields = queryAllByName(form, fieldName);
   return fields.filter(isInput).map(field => field.value);
+};
+
+const asyncAnimationFrame = () => new Promise(resolve => window.requestAnimationFrame(() => resolve(undefined)));
+
+/**
+ * This is a usable alternative for @testing-library/user-event's `type()`.
+ * The library;s `type()` is non-deterministic without a delay and prohibitively
+ * slow even if you use Number.MIN_VALUE as the delay value.
+ * Instead we use the `paste()` method which inserts the full text in one go and
+ * pretend there is no difference.
+ */
+export const type = async <T extends HTMLElement>(
+  elementOrPromiseOfElement: T | Promise<T>,
+  text: string,
+  append = false
+) => {
+  const target = await elementOrPromiseOfElement;
+  if (!append) {
+    userEvent.clear(target);
+  }
+  userEvent.paste(target, text, undefined);
+
+  /**
+   * `window.requestAnimationFrame` mandatory to ensure we don't proceed until
+   * the UI has updated, expect non-deterministic results without this.
+   */
+  return asyncAnimationFrame();
+};
+
+type SelectParams = Parameters<typeof selectEvent.select>;
+type InputType = SelectParams[0];
+type WrappedInputType = InputType | null | Promise<InputType | null>;
+type OptionType = SelectParams[1];
+type ConfigType = SelectParams[2];
+/** Select a given option in a react-select dropdown, e.g. `select(screen.getByLabelText(/Foo/), "Bar")` */
+export const select = async (elementOrPromiseOfElement: WrappedInputType, option: OptionType, config?: ConfigType) => {
+  const target = await elementOrPromiseOfElement;
+  if (!target) {
+    throw new TypeError("Found no target to select via " + target);
+  }
+  await selectEvent.select(target, option, Object.assign({}, { container: document.body }, config));
+  return asyncAnimationFrame();
 };

--- a/web/html/src/utils/test-utils/forms.ts
+++ b/web/html/src/utils/test-utils/forms.ts
@@ -24,7 +24,7 @@ const asyncAnimationFrame = () => new Promise(resolve => window.requestAnimation
 
 /**
  * This is a usable alternative for @testing-library/user-event's `type()`.
- * The library;s `type()` is non-deterministic without a delay and prohibitively
+ * The library's `type()` is non-deterministic without a delay and prohibitively
  * slow even if you use Number.MIN_VALUE as the delay value.
  * Instead we use the `paste()` method which inserts the full text in one go and
  * pretend there is no difference.

--- a/web/html/src/utils/test-utils/index.ts
+++ b/web/html/src/utils/test-utils/index.ts
@@ -1,18 +1,14 @@
-import { rest } from "msw";
-import { setupServer } from "msw/node";
-
 // See https://testing-library.com/docs/ecosystem-user-event/#api
 import userEvent from "@testing-library/user-event";
-import * as selectEvent from "react-select-event";
 
 // Reexport everything so we can get all of our utilities from a single location
 // See https://testing-library.com/docs/react-testing-library/api/
 export * from "@testing-library/react";
 
-// react-select testing utilities: https://github.com/romgain/react-select-event#api
-export * from "react-select-event";
-
 export * from "./timer";
+export * from "./forms";
+export * from "./server";
+export * from "./mock";
 
 // @testing-library/user-event has messed up exports, just manually reexport everything
 export const {
@@ -26,54 +22,5 @@ export const {
   hover,
   unhover,
   paste,
+  // `type` is intentionally omitted here, see `./forms.ts`
 } = userEvent;
-
-/**
- * This is a usable alternative for @testing-library/user-event's `type()`.
- * The library;s `type()` is non-deterministic without a delay and prohibitively
- * slow even if you use Number.MIN_VALUE as the delay value.
- * Instead we use the `paste()` method which inserts the full text in one go and
- * pretend there is no difference.
- */
-export const type = async <T extends HTMLElement>(elementOrPromiseOfElement: T | Promise<T>, text: string, append = false) => {
-  const target = await elementOrPromiseOfElement;
-  if (!append) {
-    userEvent.clear(target);
-  }
-  userEvent.paste(target, text, undefined);
-
-  /**
-   * `window.requestAnimationFrame` mandatory to ensure we don't proceed until
-   * the UI has updated, expect non-deterministic results without this.
-   */
-  return new Promise(resolve => window.requestAnimationFrame(() => resolve(undefined)));
-};
-
-export * from "./forms";
-
-export const select = async (...[input, option, config]: Parameters<typeof selectEvent.select>) => {
-  return selectEvent.select(input, option, Object.assign({}, {container: document.body}, config));
-}
-
-const baseServer = setupServer();
-const serverAddons = {
-  /** Mock a GET request to `url` with a successful JSON response containing `response` */
-  mockGetJson(url, response) {
-    return server.use(
-      rest.get(url, (req, res, ctx) => {
-        return res(ctx.json(response));
-      })
-    );
-  }
-};
-
-type Server = typeof baseServer & typeof serverAddons;
-const server: Server = Object.assign(baseServer, serverAddons);
-
-beforeAll(() => server.listen());
-afterEach(() => server.resetHandlers());
-afterAll(() => server.close());
-
-export { server };
-
-export * from "./mock";

--- a/web/html/src/utils/test-utils/server.ts
+++ b/web/html/src/utils/test-utils/server.ts
@@ -1,0 +1,23 @@
+import { rest } from "msw";
+import { setupServer } from "msw/node";
+
+const baseServer = setupServer();
+const serverAddons = {
+  /** Mock a GET request to `url` with a successful JSON response containing `response` */
+  mockGetJson(url, response) {
+    return server.use(
+      rest.get(url, (req, res, ctx) => {
+        return res(ctx.json(response));
+      })
+    );
+  },
+};
+
+type Server = typeof baseServer & typeof serverAddons;
+const server: Server = Object.assign(baseServer, serverAddons);
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+export { server };


### PR DESCRIPTION
## What does this PR change?

Cleans up the test-utils directory to be a bit less everything-in-one-file.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
