### PR TITLE
Prevent exception when skipping indexer

### DIFF
--- a/search-server/spacewalk-search/spacewalk-search.changes
+++ b/search-server/spacewalk-search/spacewalk-search.changes
@@ -1,3 +1,6 @@
+- prevent writing error messages when just skipping the indexer run
+ (bsc#1185628)
+
 -------------------------------------------------------------------
 Thu Dec 03 13:50:06 CET 2020 - jgonzalez@suse.com
 

--- a/search-server/spacewalk-search/src/java/com/redhat/satellite/search/scheduler/tasks/GenericIndexTask.java
+++ b/search-server/spacewalk-search/src/java/com/redhat/satellite/search/scheduler/tasks/GenericIndexTask.java
@@ -91,6 +91,11 @@ public abstract class GenericIndexTask implements StatefulJob {
             throw new JobExecutionException(e);
         }
         catch (IndexingException e) {
+            log.debug(e);
+            if (e.getMessage().contains("LockObtainFailedException: Lock obtain timed out")) {
+                log.info("Indexer already running. Skipping");
+                return;
+            }
             throw new JobExecutionException(e);
         }
     }

--- a/search-server/spacewalk-search/src/java/com/redhat/satellite/search/scheduler/tasks/IndexErrataTask.java
+++ b/search-server/spacewalk-search/src/java/com/redhat/satellite/search/scheduler/tasks/IndexErrataTask.java
@@ -78,6 +78,11 @@ public class IndexErrataTask implements Job {
             throw new JobExecutionException(e);
         }
         catch (IndexingException e) {
+            log.debug(e);
+            if (e.getMessage().contains("LockObtainFailedException: Lock obtain timed out")) {
+                log.info("Indexer already running. Skipping");
+                return;
+            }
             throw new JobExecutionException(e);
         }
     }

--- a/search-server/spacewalk-search/src/java/com/redhat/satellite/search/scheduler/tasks/IndexPackagesTask.java
+++ b/search-server/spacewalk-search/src/java/com/redhat/satellite/search/scheduler/tasks/IndexPackagesTask.java
@@ -80,6 +80,11 @@ public class IndexPackagesTask implements Job {
             throw new JobExecutionException(e);
         }
         catch (IndexingException e) {
+            log.debug(e);
+            if (e.getMessage().contains("LockObtainFailedException: Lock obtain timed out")) {
+                log.info("Indexer already running. Skipping");
+                return;
+            }
             throw new JobExecutionException(e);
         }
     }


### PR DESCRIPTION
## What does this PR change?

The indexer job is executed every 5 Minutes. When a job takes longer, a second instance is started and try to get the Lock.
This fail and result in an error message in the journal.

This PR try to catch the exception and write a simple message into the log "Indexer already running. Skipping".
This should prevent missunderstanings as this is not an error.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **lost logging changes**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/14781
Tracks https://github.com/SUSE/spacewalk/pull/14864

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
