### PR TITLE
[Port] QA: Check all child channels when we migrate from sp1 to sp2

### DIFF
--- a/testsuite/features/init_clients/sle_minion.feature
+++ b/testsuite/features/init_clients/sle_minion.feature
@@ -45,6 +45,7 @@ Feature: Bootstrap a Salt minion via the GUI
     And I follow "Product Migration" in the content area
     And I wait until I see "Target Products:" text, refreshing the page
     And I click on "Select Channels"
+    And I check all the child channels to be migrated
     And I check "allowVendorChange"
     And I wait until I see "SUSE Linux Enterprise Server 15 SP2 x86_64" text
     And I click on "Schedule Migration"

--- a/testsuite/features/init_clients/sle_ssh_minion.feature
+++ b/testsuite/features/init_clients/sle_ssh_minion.feature
@@ -40,6 +40,7 @@ Feature: Bootstrap a Salt host managed via salt-ssh
     And I follow "Product Migration" in the content area
     And I wait until I see "Target Products:" text, refreshing the page
     And I click on "Select Channels"
+    And I check all the child channels to be migrated
     And I check "allowVendorChange"
     And I wait until I see "SUSE Linux Enterprise Server 15 SP2 x86_64" text
     And I click on "Schedule Migration"

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -542,6 +542,13 @@ When(/^I check the child channel "([^"]*)"$/) do |channel|
   checkbox.set(true)
 end
 
+And(/^I check all the child channels to be migrated$/) do
+  child_channels_checkboxes = all(:xpath, "//input[@type='checkbox' and @name='child_channel']")
+  child_channels_checkboxes.each do |child_channel_checkbox|
+    child_channel_checkbox.set(true)
+  end
+end
+
 When(/^I check the custom channels for "([^"]*)"$/) do |client|
   node = get_target(client)
   _os_version, os_family = get_os_version(node)


### PR DESCRIPTION
## What does this PR change?

Adding child channels on the process for migration SLES15 SP1 to SP2

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Ports:
- Manager-4.1 https://github.com/SUSE/spacewalk/pull/14808

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
