### PR TITLE
Hostname rename for mgr sync

### DIFF
--- a/utils/spacewalk-hostname-rename
+++ b/utils/spacewalk-hostname-rename
@@ -27,6 +27,7 @@ HTTP_PUB_DIR=/srv/www/htdocs/pub/
 BOOTSTRAP_SH=/srv/www/htdocs/pub/bootstrap/bootstrap.sh
 BOOTSTRAP_CCO=/srv/www/htdocs/pub/bootstrap/client-config-overrides.txt
 SAT_LOCAL_RULES_CONF=/var/lib/rhn/rhn-satellite-prep/satellite-local-rules.conf
+MGR_SYNC_CONF=/root/.mgr-sync
 BACKUP_EXT=.rnmbck
 CA_CERT_TRUST_DIR=/etc/pki/ca-trust/source/anchors
 if [ -d /etc/pki/trust/anchors/ ]; then
@@ -572,6 +573,14 @@ else
        >> /dev/null 2>&1
 fi
 print_status $?
+
+# change /root/.mgr-sync
+if [ -e $MGR_SYNC_CONF ]; then
+    backup_file $MGR_SYNC_CONF
+    sed -i "s/$OLD_HOSTNAME/$HOSTNAME/g" $MGR_SYNC_CONF
+    sed -i "s/^\(mgrsync.session.token \?=\).*$/\1/g" $MGR_SYNC_CONF
+fi
+print_status 0  # just simulate end
 
 echo -n "Starting spacewalk services ... " | tee -a $LOG
 if [ "$DB_SERVICE" != "" ]

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,4 @@
+- spacewalk-hostname-rename: change hostname in /root/.mgr-sync (bsc#1183994)
 - adapt hostname rename check to allow also short hostname in various
   hostname files on the filesystem (bsc#1176512)
 


### PR DESCRIPTION
## What does this PR change?

When renaming the Uyuni Server, replace the hostname also in /root/.mgr-sync config file.
Delete also old tokens to require a new authentication.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **not tested**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/14414
Tracks https://github.com/SUSE/spacewalk/pull/14865

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
