### PR TITLE
Add support of DISABLE_LOCAL_REPOS=0 in the bootstrap script for salt minions (bsc#1185568)

### DIFF
--- a/spacewalk/certs-tools/rhn_bootstrap_strings.py
+++ b/spacewalk/certs-tools/rhn_bootstrap_strings.py
@@ -1052,6 +1052,14 @@ enable_legacy_startup_events: False
 enable_fqdns_grains: False
 start_event_grains: [machine_id, saltboot_initrd, susemanager]
 mine_enabled: False
+EOF
+    if [ "$DISABLE_LOCAL_REPOS" -eq 0 ]; then
+        echo "Do not disable local repos"
+        cat <<EOF >>"$SUSEMANAGER_MASTER_FILE"
+disable_local_repos: False
+EOF
+    fi
+    cat <<EOF >> "$SUSEMANAGER_MASTER_FILE"
 
 grains:
     susemanager:
@@ -1068,6 +1076,14 @@ EOF
         management_key: "$(echo $REACTIVATION_KEY)"
 EOF
     fi
+    cat <<EOF >> "$SUSEMANAGER_MASTER_FILE"
+
+system-environment:
+  modules:
+    pkg:
+      _:
+        SALT_RUNNING: 1
+EOF
 fi
 
 echo "* removing TLS certificate used for bootstrap"

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,7 @@
+- Add support of DISABLE_LOCAL_REPOS=0 for salt minions (bsc#1185568)
+- Add missing environment variable SALT_RUNNING for pkg module
+  to the minion configuration
+
 -------------------------------------------------------------------
 Wed May 05 16:33:57 CEST 2021 - jgonzalez@suse.com
 

--- a/susemanager-utils/susemanager-sls/salt/channels/disablelocalrepos.sls
+++ b/susemanager-utils/susemanager-sls/salt/channels/disablelocalrepos.sls
@@ -5,6 +5,7 @@
 {% endif %}
 {% do repos_disabled.update({'count': 0}) %}
 
+{% if salt['config.get']('disable_local_repos', True) %}
 {% set repos = salt['pkg.list_repos']() %}
 {% for alias, data in repos.items() %}
 {% if grains['os_family'] == 'Debian' %}
@@ -37,3 +38,4 @@ disable_repo_{{ alias }}:
 {% endif %}
 {% endif %}
 {% endfor %}
+{% endif %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,6 @@
+- Add support for 'disable_local_repos' salt minion config parameter
+  (bsc#1185568)
+
 -------------------------------------------------------------------
 Wed May 05 16:44:00 CEST 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Implements the possiblity to set DISABLE_LOCAL_REPOS=0 in the bootstrap script to prevent disabling local repos on the salt minions like it works for the traditional clients.

Adds missing SALT_RUNNING environment variable to salt minion config to prevent duplicated package list refreshes.

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Links

Fixes bsc#1185568
https://jira.suse.com/browse/PM-2615

## Changelogs
- Add support of DISABLE_LOCAL_REPOS=0 for salt minions (bsc#1185568)
- Add missing environment variable SALT_RUNNING for pkg module
  to the minion configuration

- Add support for 'disable_local_repos' salt minion config parameter
  (bsc#1185568)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "spacecmd_unittests"
