### PR TITLE
Fix provisioning menu

### DIFF
--- a/java/code/webapp/WEB-INF/nav/system_detail.xml
+++ b/java/code/webapp/WEB-INF/nav/system_detail.xml
@@ -160,15 +160,6 @@
     </rhn-tab>
   </rhn-tab>
 
-<!--
-  FIX: Temporary decouple "ftr_power_management" from "ftr_kickstart" for Salt minions.
-  This should be removed as soon as "ftr_kickstart" is implemented for minions.
--->
-  <rhn-tab name="Provisioning" acl="system_feature(ftr_power_management); system_has_salt_entitlement(); not system_feature(ftr_kickstart)" url="/rhn/systems/details/kickstart/PowerManagement.do">
-    <rhn-tab name="Power Management" url="/rhn/systems/details/kickstart/PowerManagement.do" acl="system_feature(ftr_power_management)" node-id="power_management" />
-  </rhn-tab>
-<!-- ENDFIX -->
-
   <rhn-tab name="Groups" acl="system_feature(ftr_system_grouping); user_role(org_admin) or user_role(system_group_admin);system_has_management_entitlement() or system_has_salt_entitlement() or system_is_bootstrap_minion_server()" url="/rhn/systems/details/groups/ListRemove.do">
 
     <rhn-tab name="List / Leave" url="/rhn/systems/details/groups/ListRemove.do"/>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- fix disapearing Autoinstallation Menu for minions (bsc#1184813)
+
 -------------------------------------------------------------------
 Mon May 10 17:43:42 CEST 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

When clicking in the Systems Details page of a Minion on Provisioning Tab, 2 sub menus are visible:
Autoinstallation and Power Management .
When you now click on "Power Management" the Autoinstallation become invisible.

This PR fix this problem.
In the past "Autoinstallation" was not supported for Minions. This has changed a while ago, but this menu workaround was not removed.

## GUI diff

After:

![image](https://user-images.githubusercontent.com/1038917/117449961-e33b1580-af40-11eb-9170-d1a52f1728fa.png)

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: **minimal change**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/14623
Tracks https://github.com/SUSE/spacewalk/pull/14866

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
