### PR TITLE
Prevent stopping publishing messages on XPUB socket

### DIFF
--- a/proxy/proxy/salt-broker/salt-broker
+++ b/proxy/proxy/salt-broker/salt-broker
@@ -145,7 +145,11 @@ class PubChannelProxy(AbstractChannelProxy):
                                              self.opts['publish_port'])
 
             self.debug_log('setting up a XPUB sock on {0}'.format(pub_uri))
+
             frontend = context.socket(zmq.XPUB)
+            # Prevent stopping publishing messages on XPUB socket. (bsc#1182954)
+            frontend.setsockopt(zmq.XPUB_VERBOSE, 1)
+            frontend.setsockopt(zmq.XPUB_VERBOSER, 1)
             frontend.bind(pub_uri)
 
             # Forward all messages
@@ -332,7 +336,7 @@ if __name__ == "__main__":
     }
 
     try:
-        config = yaml.load(open(SALT_BROKER_CONF_FILE))
+        config = yaml.load(open(SALT_BROKER_CONF_FILE), Loader=yaml.SafeLoader)
         if not config:
             config = {}
         if not isinstance(config, dict):

--- a/proxy/proxy/spacewalk-proxy.changes
+++ b/proxy/proxy/spacewalk-proxy.changes
@@ -1,3 +1,8 @@
+- prevent stopping publishing messages on XPUB socket of salt-broker
+  (bsc#1182954)
+- using Loader=yaml.SafeLoader for yaml.load as using yaml.load
+  without Loader is deprecated as the default Loader is unsafe
+
 -------------------------------------------------------------------
 Wed May 05 16:35:36 CEST 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Prevents stopping publishing messages on XPUB socket in salt-broker XPUB<->XSUB proxy.
In some cases XPUB stops publishing messages after stopping one of the minions behind a proxy.
It could happen even if the minion is behind a chain of 2 (or probably more) proxies.

It also prevents messages in `journald` about deprecated way of calling `yaml.load`.
```
YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
```

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
- No tests: it's not possible to reproduce the issue in test environment.

## Links

Fixes `bsc#1182954`

## Changelogs

- prevent stopping publishing messages on XPUB socket of salt-broker
  (bsc#1182954)
- using Loader=yaml.SafeLoader for yaml.load as using yaml.load
  without Loader is deprecated as the default Loader is unsafe

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
