### PR TITLE
Utility script to help create pg_dump command for specific tables and their dependencies

### DIFF
--- a/utils/db-dump-specific-tables.py
+++ b/utils/db-dump-specific-tables.py
@@ -1,0 +1,66 @@
+#!/usr/bin/python3
+import psycopg2
+from psycopg2 import sql
+
+from argparse import ArgumentParser
+
+db_config = {
+    "dbname": "susemanager",
+    "user": "username",
+    "password": "password",
+    "host": "localhost",
+    "port": 5432,
+}
+
+
+def get_cursor(db_config):
+    """Returns a cursor to query the database."""
+    conn_string = "dbname='{dbname}' user='{user}' host='{host}' port='{port}' password='{password}'".format(
+        **db_config)
+    connection = psycopg2.connect(conn_string)
+    return connection.cursor()
+
+
+def get_dependencies(cursor, tablename, dependencies):
+    """Returns a list of tables that a table depends on """
+    if tablename in dependencies:
+        sql = f"""
+        SELECT cl2.relname AS ref_table
+        FROM   pg_constraint AS co
+               JOIN pg_class AS cl1
+             ON co.conrelid = cl1.oid
+               JOIN pg_class AS cl2
+             ON co.confrelid = cl2.oid
+        WHERE  co.contype = 'f'
+               AND cl1.relname = '{tablename}'
+        ORDER  BY cl2.relname; 
+        """
+        cursor.execute(sql)
+        rows = cursor.fetchall()
+        for row in rows:
+            if row[0] not in dependencies:
+                dependencies.append(row[0])
+                get_dependencies(cursor, row[0], dependencies)
+
+
+def main():
+    parser = ArgumentParser(description='Script to create pg_dump statement for all the supplied tables including '
+                                        'their dependecies')
+    requiredNamed = parser.add_argument_group('Required named arguments')
+    requiredNamed.add_argument('-t', '--table', action='append', help='The name of the table to include in pg_dump.'
+                                                                      ' It can be used multiple times.', required=True)
+    args = parser.parse_args()
+
+    cursor = get_cursor(db_config)
+    dependencies = args.table
+    for table in args.table:
+        get_dependencies(cursor, table, dependencies)
+    tables_to_dump = ' '.join(['-t ' + dep for dep in dependencies])
+    pg_dump_query = f"""
+                     su - postgres -c "pg_dump {tables_to_dump} --create `grep -oP 'db_name ?= ?\K.*' /etc/rhn/rhn.conf` | gzip > /tmp/backup/pg_dump.gz"
+                     """
+    print(pg_dump_query)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## What does this PR change?

Sometimes, to fix a performance-related problem, We ask the customer for a database dump. Most of the time it works but sometimes it's too big. In my case, I was recently working on an issue where the database dump was more than 100GB  and after restoring it twice, I came to know that even that was incomplete. 

In the end, I wasn't interested in all the data but only a few tables. So I had to provide a custom pg_dump command which included those tables that I was interested in but I also had to add tables(by manually checking) on which these tables were dependent. It took some time but it worked.

This script helps in reduce that manual part. You only need to mention the tables that you are actually interested in. It will add all the dependencies automatically in the pg_dump command, which you can simply provide to the user to get the database dump.


Instead of a complete database dump, this script helps to create pg_dump command for specified tables and their dependencies 

## Example

For rhnserverneededcache table, this script will create the following output
```
$ db-dump-specific-tables.py -t rhnserverneededcache

su - postgres -c "pg_dump -t rhnserverneededcache -t rhnchannel -t rhnchannelarch -t rhnarchtype -t rhnchannelproduct -t rhnchecksumtype -t rhnproductname -t web_customer -t rhnerrata -t rhnerrataseverity -t rhnpackage -t rhnchecksum -t rhnpackagearch -t rhnpackageevr -t rhnpackagegroup -t rhnpackagename -t rhnsourcerpm -t rhnserver -t rhnprovisionstate -t rhnserverarch -t susemaintenanceschedule -t susemaintenancecalendar -t suseservercontactmethod -t web_contact --create `grep -oP 'db_name ?= ?\K.*' /etc/rhn/rhn.conf` | gzip > /tmp/backup/pg_dump.gz"
```
- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
