### PR TITLE
add issue templates with basic labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE-Bug.md
+++ b/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE-Bug.md
@@ -1,3 +1,12 @@
+---
+name: Uyuni - Bugreport
+about: Use this issue template for createing bug reports.
+title: Uyuni Bugreport - Uyuni YYYY.MM
+labels: bug
+assignees:
+
+---
+
 # Additional Information
 
 _The following information is very important in order to help us to help you. Omission of the following details cause delays or could receive no attention at all._

--- a/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE-enhancement.md
+++ b/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE-enhancement.md
@@ -1,0 +1,17 @@
+---
+name: Uyuni - Enhancement request
+about: Use this issue template for creating enhancement requests
+title: Uyuni Enhancement Request - Uyuni YYYY.MM
+labels: enhancement
+assignees:
+
+---
+
+# Short description
+
+_Short description about the requested feature_
+
+# Details 
+_Include as many details as you can..._
+_In general: all that can help to understand what you suggest_
+

--- a/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE-question.md
+++ b/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE-question.md
@@ -1,0 +1,12 @@
+---
+name: Uyuni - Question
+about: Use this issue template when you have a question about Uyuni
+title: Uyuni Question - Uyuni YYYY.MM
+labels: question
+assignees:
+
+---
+
+# Question
+_What do you want to know about Uyuni?_
+


### PR DESCRIPTION
## What does this PR change?

Issue templates can assign lables. Use this to differentiate between Bugs, Feature Requests and Questions.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **templates**

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
