### PR TITLE
Add the missing elaborators to list the correct information on the proxy page

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
@@ -2507,6 +2507,9 @@ SELECT SP.server_id ID, S.name
   </query>
   <elaborator name="system_overview"/>
   <elaborator name="entitlements"/>
+  <elaborator name="system_config_files_with_diffs" />
+  <elaborator name="is_virtual_guest" />
+  <elaborator name="is_virtual_host" />
 </mode>
 
 <write-mode name="add_to_client_capabilities">

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Fix the problem with wrong icons for virtual systems (bsc#1185507)
+
 -------------------------------------------------------------------
 Wed May 05 16:35:15 CEST 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Add the missing elaborators to list the correct information on the proxy page. Currently, we are showing default values for some columns.


## GUI diff

Before:
![Screenshot from 2021-05-10 10-42-47](https://user-images.githubusercontent.com/12951268/117631696-ca1ea880-b17c-11eb-9053-7d5637c56bb4.png)


After:
![Screenshot from 2021-05-10 10-44-00](https://user-images.githubusercontent.com/12951268/117631719-cee35c80-b17c-11eb-9993-7e971f5579d8.png)

- [ ] **DONE**

## Documentation
- No documentation needed: Display the correct icons



- [ ] **DONE**

## Test coverage
- No tests: already covered


- [ ] **DONE**

## Links

Fixes # https://github.com/SUSE/spacewalk/issues/14774
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
