### PR TITLE
QA: Recovering from a failed scenario

### DIFF
--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -101,7 +101,7 @@ After do |scenario|
       puts "Error taking a screenshot: #{e.message}"
     ensure
       debug_server_on_realtime_failure
-      page.reset!
+      step %(I am authorized for the "Admin" section)
     end
   end
   page.instance_variable_set(:@touched, false)


### PR DESCRIPTION
## What does this PR change?

Due to the change of paradigm to follow (where we keep the browser session throughout the Cucumber feature), when a scenario fails we must try to recover the state we need in the next scenario.

This fix is ​​temporary, because actually, what I think we should do is skip the rest of the scenarios until we reach the cleanup scenarios (adding a new `@cleanup` tag to identify them).

At the moment we do this fix, we will discuss the correct solution when we have Head CI stable/greener.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.0
- Manager-4.1

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
