### PR TITLE
QA: Go back some features are they are dependency of others

### DIFF
--- a/testsuite/features/secondary/buildhost_docker_build_image.feature
+++ b/testsuite/features/secondary/buildhost_docker_build_image.feature
@@ -3,6 +3,9 @@
 #
 # Basic images do not contain zypper nor the name of the server,
 # so the inspect functionality is not tested here.
+#
+# This feature is a dependency for:
+# - features/secondary/srv_docker_cve_audit.feature : Due to the images listed in the CVE Audit images
 
 @buildhost
 @scope_building_container_images

--- a/testsuite/features/secondary/srv_docker_cve_audit.feature
+++ b/testsuite/features/secondary/srv_docker_cve_audit.feature
@@ -1,5 +1,8 @@
 # Copyright (c) 2017-2018 SUSE LLC
 # Licensed under the terms of the MIT license.
+#
+# This feature depends on:
+# - features/secondary/buildhost_docker_build_image.feature : Due to the images listed in the CVE Audit images
 
 @scope_cve_audit
 @no_auth_registry

--- a/testsuite/run_sets/secondary.yml
+++ b/testsuite/run_sets/secondary.yml
@@ -45,6 +45,8 @@
 - features/secondary/allcli_action_chain.feature
 - features/secondary/srv_delete_channel_from_ui.feature
 - features/secondary/srv_delete_channel_with_tool.feature
+- features/secondary/buildhost_docker_build_image.feature
+- features/secondary/buildhost_docker_auth_registry.feature
 - features/secondary/min_docker_xmlrpc.feature
 - features/secondary/min_recurring_action.feature
 - features/secondary/min_change_software_channel.feature

--- a/testsuite/run_sets/secondary_parallelizable.yml
+++ b/testsuite/run_sets/secondary_parallelizable.yml
@@ -79,7 +79,4 @@
 - features/secondary/trad_product_migration.feature
 - features/secondary/trad_check_registration.feature
 
-- features/secondary/buildhost_docker_build_image.feature
-- features/secondary/buildhost_docker_auth_registry.feature
-
 ## Parallelizable Secondary features END ##


### PR DESCRIPTION
## What does this PR change?

Rolling back some features as we found a dependency with CVE Audit tests, therefore they can't go to the parallel tests.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Ports:
- Manager-4.0 https://github.com/SUSE/spacewalk/pull/14830
- Manager-4.1 https://github.com/SUSE/spacewalk/pull/14829

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
