### PR TITLE
Fix exporters checkbox selection

### DIFF
--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -1025,7 +1025,7 @@ end
 
 # Check a Prometheus exporter
 When(/^I check "([^"]*)" exporter$/) do |exporter_type|
-  step %(I check "#{exporter_type}_exporter#enabled")
+  step %(I check "exporters##{exporter_type}_exporter#enabled" if not checked)
 end
 
 # Navigate to a service endpoint


### PR DESCRIPTION
## What does this PR change?

Fix exporters checkbox selection, now the node exporter checkbox is by default enabled and with this fix it doesn't fail anymore the test.

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes No issue, directly fixed by head review
Tracks
4.1: https://github.com/SUSE/spacewalk/pull/14834
4.0: https://github.com/SUSE/spacewalk/pull/14835

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
