### PR TITLE
Allow empty system profiles in cobbler

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemHardwareAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemHardwareAction.java
@@ -191,8 +191,12 @@ public class SystemHardwareAction extends RhnAction {
         Collections.sort(nicList);
 
         List nicList2 = new ArrayList();
+        List nicList3 = new ArrayList();
+        List nicList4 = new ArrayList();
         for (String nicName : nicList) {
             NetworkInterface n = server.getNetworkInterface(nicName);
+            boolean hasIPv4 = false;
+            boolean hasIPv6 = false;
             for (ServerNetAddress4 na4 : n.getIPv4Addresses()) {
                 Map nic = new HashMap();
                 nic.put("name", n.getName());
@@ -202,13 +206,8 @@ public class SystemHardwareAction extends RhnAction {
                 nic.put("hwaddr", n.getHwaddr());
                 nic.put("module", n.getModule());
                 nicList2.add(nic);
+                hasIPv4 = true;
             }
-        }
-        request.setAttribute("network_interfaces", nicList2);
-
-        List nicList3 = new ArrayList();
-        for (String nicName : nicList) {
-            NetworkInterface n = server.getNetworkInterface(nicName);
             for (ServerNetAddress6 na6 : n.getIPv6Addresses()) {
                 Map nic = new HashMap();
                 nic.put("name", n.getName());
@@ -218,9 +217,19 @@ public class SystemHardwareAction extends RhnAction {
                 nic.put("netmask", na6.getNetmask());
                 nic.put("scope", na6.getScope());
                 nicList3.add(nic);
+                hasIPv6 = true;
+            }
+            if (!(hasIPv4 || hasIPv6)) {
+                Map nic = new HashMap();
+                nic.put("name", n.getName());
+                nic.put("hwaddr", n.getHwaddr());
+                nic.put("module", n.getModule());
+                nicList4.add(nic);
             }
         }
+        request.setAttribute("network_interfaces", nicList2);
         request.setAttribute("ipv6_network_interfaces", nicList3);
+        request.setAttribute("noip_network_interfaces", nicList4);
 
         List miscDevices = new ArrayList();
         List videoDevices = new ArrayList();

--- a/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerCommand.java
+++ b/java/code/src/com/redhat/rhn/manager/kickstart/cobbler/CobblerCommand.java
@@ -228,7 +228,7 @@ public abstract class CobblerCommand {
         List macs = new LinkedList();
         for (NetworkInterface n : server.getNetworkInterfaces()) {
             // Skip localhost and non real interfaces
-            if (!n.isValid()) {
+            if (!n.isMacValid()) {
                 log.debug("Skipping.  not a real interface");
             }
             else {

--- a/java/code/webapp/WEB-INF/pages/systems/sdc/hardware.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/sdc/hardware.jsp
@@ -324,6 +324,43 @@
                 </div>
             </div>
         </c:if>
+        <c:if test="${not empty noip_network_interfaces}">
+            <div class="panel panel-default">
+                <div class="panel-body">
+                    <table class="table table-condensed">
+                        <thead>
+                            <tr>
+                                <th>Interface</th>
+                                <th>Hardware Address</th>
+                                <th>Driver Module</th>
+                            </tr>
+                        </thead>
+                        <c:forEach items="${noip_network_interfaces}" var="current" varStatus="loop">
+                            <c:choose>
+                                <c:when test="${loop.count % 2 == 0}">
+                                    <c:set var="style_class" value="list-row-even" />
+                                </c:when>
+                                <c:otherwise>
+                                    <c:set var="style_class" value="list-row-odd" />
+                                </c:otherwise>
+                            </c:choose>
+                            <tr class="${style_class}">
+                                <td>${current.name}</td>
+                                <c:choose>
+                                    <c:when test="${empty current.hwaddr}">
+                                        <td><span class="no-details">(unknown)</span></td>
+                                    </c:when>
+                                    <c:otherwise>
+                                        <td>${current.hwaddr}</td>
+                                    </c:otherwise>
+                                </c:choose>
+                                <td>${current.module}</td>
+                            </tr>
+                        </c:forEach>
+                    </table>
+                </div>
+            </div>
+        </c:if>
         <c:if test="${not empty storageDevices}">
             <div class="panel panel-default">
                 <div class="panel-heading">

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Show NICs without IPs in Hardware info
+- Allow interfaces with just valid mac address in cobbler record (bsc#1185416)
 - Allow virtualization host entitlement on Xen Dom0 (bsc#1185522)
 - Fix start/end timestamps for xccdf scan details (bsc#1186016)
 - Fix report links for SCAP Scans (bsc#1186017)


### PR DESCRIPTION
## What does this PR change?

Empty profiles created by `system.createSystemProfile` API call does not have complete information about what the hardware of bootstrapped will be. This includes network information such as IP address.
However MAC address, necessary for PXE booting can be provided.
This PR enabled cobbler integration to pass system mac address so autoinstallation pxe configuration can be created for the empty system profile.

Together with above mentioned change this PR also adds network interfaces without assigned IPv4 and IPv6 addresses in Hardware tab.

## GUI diff

Before:
![before_pr](https://user-images.githubusercontent.com/1260795/117965444-0d1a8080-b323-11eb-97f0-5097fb3f4b16.png)

After:
![after_pr](https://user-images.githubusercontent.com/1260795/117965498-1c013300-b323-11eb-8573-e592ca2ec9a6.png)

- [X] **DONE**

## Documentation
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).

- [ ] **DONE**

## Test coverage
- No tests: Unit tests will be added in next PR, regressions covered by existing tests

- [X] **DONE**

## Links

Fixes #https://github.com/SUSE/spacewalk/issues/14718

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
