### PR TITLE
Fix hostname rename check

### DIFF
--- a/utils/spacewalk-hostname-rename
+++ b/utils/spacewalk-hostname-rename
@@ -137,6 +137,7 @@ function initial_system_hostname_check {
 
     # set HOSTNAME to long hostname
     HOSTNAME=`hostname -f`
+    SHORT_HN=`hostname -s`
 
     # check for uppercase chars in hostname
     if [ "$HOSTNAME" != "$(echo $HOSTNAME | tr '[:upper:]' '[:lower:]')" ]
@@ -160,7 +161,8 @@ function initial_system_hostname_check {
         HN_ETC=`awk -F= '/HOSTNAME/ {print $2}' $HN_ETC_FILE`
     fi
 
-    if [ "$HOSTNAME" != "$HN_ETC" ]
+    # either short or long hostname would be ok
+    if [ "$SHORT_HN" != "$HN_ETC" -a "$HOSTNAME" != "$HN_ETC" ]
     then
         echo_err "Wrong hostname in $HN_ETC_FILE: \"$HN_ETC\""
         return 1

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,6 @@
+- adapt hostname rename check to allow also short hostname in various
+  hostname files on the filesystem (bsc#1176512)
+
 -------------------------------------------------------------------
 Wed May 05 16:39:14 CEST 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

spacewalk-hostname-rename test for configured hostnames before it starts.
It check various files like /etc/hostname, /etc/HOSTNAME and /etc/sysconfig/network and expect the FQDN there.
But often they should contain the short hostname only according to man pages. But they can deal also with FQDNs.
So just allow both.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **manual**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/12429
Tracks 

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
