### PR TITLE
Add group by clause to reduce the number of rows for groupAdvisoryTypes CTE to improve the performance

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/SystemGroup_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/SystemGroup_queries.xml
@@ -57,6 +57,7 @@ ORDER BY UPPER(NAME)
               INNER JOIN rhnServerFeaturesView sfv ON sgm.server_id = sfv.server_id
               LEFT JOIN rhnErrata e ON e.id = snpc.errata_id
           WHERE sfv.label = 'ftr_system_grouping'
+          GROUP BY sgm.server_group_id, e.advisory_type
     )
     SELECT rhnServerGroup.id,
         CASE (

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add group by clause to reduce the number of rows for groupAdvisoryTypes CTE to improve performance(bsc#1185015)
 - Drop stale libs for old not supported browsers
 - fix file ownership and permissions in /srv/susemanager/pillar_data/ (bsc#1179954)
 - Strip the modular metadata for newly created channels in CLM if modular filters present (bsc#1184118)


### PR DESCRIPTION


## What does this PR change?
Add group by clause to reduce the number of rows for groupAdvisoryTypes CTE to improve the performance.
## GUI diff

No difference.


- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage

- No tests: already covered

- [x ] **DONE**

## Links

Fixes # https://github.com/SUSE/spacewalk/issues/14629
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
