### PR TITLE
QA: Adding more log when extracting OS Family

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -853,6 +853,8 @@ When(/^I (install|remove) OpenSCAP dependencies (on|from) "([^"]*)"$/) do |actio
     pkgs = 'openscap-utils scap-security-guide-redhat'
   elsif os_family =~ /^ubuntu/
     pkgs = 'libopenscap8 scap-security-guide-ubuntu'
+  else
+    raise "The node #{node.hostname} has not a supported OS Family"
   end
   pkgs += ' spacewalk-oscap' if host.include? 'client'
   step %(I #{action} packages "#{pkgs}" #{where} this "#{host}")

--- a/testsuite/features/support/client_stack.rb
+++ b/testsuite/features/support/client_stack.rb
@@ -61,13 +61,15 @@ def get_os_version(node)
     os_version.delete! '"'
     # on SLES, we need to replace the dot with '-SP'
     os_version.gsub!(/\./, '-SP') if os_family =~ /^sles/
-    [os_version, os_family]
   else
     # The only node that we handle which doesn't support 'os-release' file is Centos 6
     _os_family_raw, code = node.run('test -f /etc/centos-release', false)
     return nil, nil unless code.zero?
-    ['6', 'centos']
+    os_version = '6'
+    os_family = 'centos'
   end
+  puts "Node: #{node.hostname}, OS Version: #{os_version}, Family: #{os_family}"
+  [os_version, os_family]
 end
 
 def get_gpg_keys(node, target = $server)


### PR DESCRIPTION
## What does this PR change?

This PR aims to catch a flaky test related to OS Family by adding more logs into a method.
Also, it will raise an exception if the OS Family is not supported inside a step definition related to OpenScap packages

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were change

- [x] **DONE**

## Links

Ports:
- Manager-4.0
- Manager-4.1

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
