### PR TITLE
QA: Fix navigation step to Clear SSM button

### DIFF
--- a/testsuite/features/secondary/buildhost_osimage_build_image.feature
+++ b/testsuite/features/secondary/buildhost_osimage_build_image.feature
@@ -71,6 +71,7 @@ Feature: Build OS images
     When I disable repositories after installing branch server
 
   Scenario: Cleanup: remove remaining systems from SSM after OS image tests
+    When I go to the home page
     And I follow "Clear"
 
   Scenario: Cleanup: remove OS image profile


### PR DESCRIPTION
## What does this PR change?

Fixing a navigation step to click on Clear SSM button.
On previous PRs we were starting the scenario from the homepage, that's not any more true, as now we keep the web browser session for the whole session, so we must assure to move to the proper page. In that case, we were finding an element with value "Clear" while we were in a page with a hyperlink that has a text "Clear" so... we had an ambiguity.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.0
- Manager-4.1

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
