### PR TITLE
QA: Moving srv_menu to sequential test set

### DIFF
--- a/testsuite/features/secondary/srv_menu.feature
+++ b/testsuite/features/secondary/srv_menu.feature
@@ -1,5 +1,9 @@
 # Copyright (c) 2017-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
+# This feature depends on:
+# This features expect empty content in all the UI pages, so depends in almost all our features
+# TODO: Ideally we should refactor this Cucumber feature to only verify UI static content,
+#       only then we can move this feature to our parallel tests
 
 @scope_visualization
 Feature: Web UI - Main landing page menu, texts and links

--- a/testsuite/run_sets/secondary.yml
+++ b/testsuite/run_sets/secondary.yml
@@ -9,6 +9,7 @@
 # IDEMPOTENT
 
 - features/secondary/srv_users.feature
+- features/secondary/srv_menu.feature
 - features/secondary/buildhost_osimage_build_image.feature
 - features/secondary/allcli_reboot.feature
 - features/secondary/trad_config_channel.feature

--- a/testsuite/run_sets/secondary_parallelizable.yml
+++ b/testsuite/run_sets/secondary_parallelizable.yml
@@ -8,7 +8,6 @@
 
 # IDEMPOTENT
 
-- features/secondary/srv_menu.feature
 - features/secondary/srv_check_sync_source_packages.feature
 - features/secondary/srv_change_password.feature
 - features/secondary/srv_clone_channel_npn.feature


### PR DESCRIPTION
## What does this PR change?

The srv_menu Cucumber feature can't go to our parallel tests set, as the feature checks UI Menu and their content, expecting that everything is empty. If we run this in parallel, it will randomly fail.

We could improve this feature to only check static UI content, but for now, we will just move it to the sequential set of tests, as we might need a discussion for the other approach.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were moved

- [x] **DONE**

## Links

Ports:
- Manager-4.0
- Manager-4.1

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
