### PR TITLE
Return the correct return code for spacewalk-pylint.sh

### DIFF
--- a/susemanager-utils/testing/automation/spacewalk-pylint.sh
+++ b/susemanager-utils/testing/automation/spacewalk-pylint.sh
@@ -159,7 +159,7 @@ PYLINT_CMD="mkdir -p /manager/reports; cd /manager/; pylint --disable=E0203,E061
 CHOWN_CMD="/manager/susemanager-utils/testing/automation/chown-objects.sh $(id -u) $(id -g)"
 
 docker pull $REGISTRY/$PYLINT_CONTAINER
-docker run --rm=true -e $DOCKER_RUN_EXPORT -v "$GITROOT:/manager" $REGISTRY/$PGSQL_CONTAINER /bin/sh -c "${INITIAL_CMD}; $PYLINT_CMD `echo $SPACEWALK_FILES` > reports/pylint.log || :; RET=\${?}; ${CHOWN_CMD} && exit \${RET}"
+docker run --rm=true -e $DOCKER_RUN_EXPORT -v "$GITROOT:/manager" $REGISTRY/$PGSQL_CONTAINER /bin/sh -c "${INITIAL_CMD}; $PYLINT_CMD `echo $SPACEWALK_FILES` > reports/pylint.log; RET=\${?}; ${CHOWN_CMD} && exit \${RET}"
 
 if [ $? -ne 0 ]; then
    EXIT=1


### PR DESCRIPTION
## What does this PR change?

Return the correct return code for spacewalk-pylint.sh. `|| :` caused that `0` was always returned.

Now tests will fail until https://github.com/uyuni-project/uyuni/pull/3449 is merged.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Bugix for the tests

- [x] **DONE**

## Test coverage
- Bugfix for the tests.

- [x] **DONE**

## Links

Related:  https://github.com/uyuni-project/uyuni/pull/3449

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
