### PR TITLE
Pass the spec linter to some packages

### DIFF
--- a/backend/spacewalk-backend.spec
+++ b/backend/spacewalk-backend.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package spacewalk-backend
 #
-# Copyright (c) 2019 SUSE LINUX GmbH, Nuernberg, Germany.
+# Copyright (c) 2021 SUSE LLC
 # Copyright (c) 2008-2018 Red Hat, Inc.
 #
 # All modifications and additions to the file contributed by third parties
@@ -49,7 +49,7 @@ License:        GPL-2.0-only
 Group:          System/Management
 Version:        4.2.11
 Release:        1%{?dist}
-Url:            https://github.com/uyuni-project/uyuni
+URL:            https://github.com/uyuni-project/uyuni
 Source0:        https://github.com/uyuni-project/uyuni/archive/%{name}-%{version}-1.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 %if !0%{?suse_version} || 0%{?suse_version} >= 1120
@@ -71,18 +71,17 @@ Requires:       python3-debian
 %if 0%{?pylint_check}
 BuildRequires:  spacewalk-python3-pylint
 %endif
+BuildRequires:  %{m2crypto}
 BuildRequires:  /usr/bin/docbook2man
 BuildRequires:  /usr/bin/msgfmt
 BuildRequires:  docbook-utils
 BuildRequires:  fdupes
 BuildRequires:  python3
+BuildRequires:  python3-debian
 BuildRequires:  python3-rhn-client-tools
 BuildRequires:  python3-rhnlib >= 2.5.74
 BuildRequires:  python3-rpm
 BuildRequires:  python3-uyuni-common-libs
-BuildRequires:  python3-debian
-BuildRequires:  %{m2crypto}
-
 
 %description
 Generic program files needed by the Spacewalk server machines.
@@ -114,13 +113,12 @@ Summary:        Basic code that provides Spacewalk Server functionality
 Group:          System/Management
 Requires(pre):  %{name}-sql = %{version}-%{release}
 Requires:       %{name}-sql = %{version}-%{release}
-Requires:       (python3-pam or python3-python-pam)
-Requires:       (apache2-mod_wsgi-python3 or python3-mod_wsgi)
 Requires:       spacewalk-config
+Requires:       (apache2-mod_wsgi-python3 or python3-mod_wsgi)
+Requires:       (python3-pam or python3-python-pam)
 
 # cobbler-web is known to break our configuration
 Conflicts:      cobbler-web
-
 
 %description server
 This package contains the basic code that provides server/backend
@@ -226,29 +224,29 @@ Requires:       %{name}-xmlrpc = %{version}-%{release}
 Requires:       systemd
 BuildRequires:  systemd
 %if 0%{?rhel}
-BuildRequires:	systemd-rpm-macros
+BuildRequires:  systemd-rpm-macros
 %else
 %{?systemd_requires}
 %endif
 
-Requires:       (python3-dateutil or python3-python-dateutil)
 Requires:       python3-rhn-client-tools
 Requires:       python3-solv
 Requires:       python3-urlgrabber < 4
 Requires:       spacewalk-admin >= 0.1.1-0
 Requires:       spacewalk-certs-tools
 Requires:       susemanager-tools
+Requires:       (python3-dateutil or python3-python-dateutil)
 %if 0%{?suse_version}
 Requires(pre):  libzypp(plugin:system) >= 0
-Requires:       zypp-plugin-python
 Requires:       apache2-prefork
+Requires:       zypp-plugin-python
 %endif
 %if 0%{?fedora} || 0%{?rhel}
 Requires:       mod_ssl
 %endif
+Requires:       %{m2crypto}
 Requires:       %{name}-xml-export-libs
 Requires:       cobbler >= 3.0.0
-Requires:       %{m2crypto}
 Requires:       python3-requests
 Requires:       python3-rhnlib  >= 2.5.57
 
@@ -357,7 +355,6 @@ spacewalk-python3 $RPM_BUILD_ROOT%{python3rhnroot}/common \
 
 %endif
 
-
 %post server
 %if 0%{?suse_version}
 sysconf_addword /etc/sysconfig/apache2 APACHE_MODULES wsgi
@@ -397,7 +394,8 @@ fi
 
 %files
 %defattr(-,root,root)
-%doc LICENSE
+%{!?_licensedir:%global license %doc}
+%license LICENSE
 %dir %{python3rhnroot}
 %dir %{_prefix}/lib/susemanager
 %dir %{_prefix}/lib/susemanager/bin
@@ -425,7 +423,8 @@ fi
 
 %files sql
 %defattr(-,root,root)
-%doc LICENSE
+%{!?_licensedir:%global license %doc}
+%license LICENSE
 %dir %{rhnroot}/server
 # Need __init__ = share it with rhns-server
 %dir %{python3rhnroot}/server
@@ -444,13 +443,15 @@ fi
 
 %files sql-postgresql
 %defattr(-,root,root)
-%doc LICENSE
+%{!?_licensedir:%global license %doc}
+%license LICENSE
 %{python3rhnroot}/server/rhnSQL/driver_postgresql.py*
 %{python3rhnroot}/server/rhnSQL/__pycache__/driver_postgresql.*
 
 %files server -f %{name}-server.lang
 %defattr(-,root,root)
-%doc LICENSE
+%{!?_licensedir:%global license %doc}
+%license LICENSE
 %dir %{rhnroot}/server
 # modules
 %{python3rhnroot}/server/apacheAuth.py*
@@ -546,7 +547,8 @@ fi
 
 %files xmlrpc
 %defattr(-,root,root)
-%doc LICENSE
+%{!?_licensedir:%global license %doc}
+%license LICENSE
 %dir %{rhnroot}/server/handlers/xmlrpc
 %{rhnroot}/server/handlers/xmlrpc/*
 %dir %{python3rhnroot}/server/action
@@ -561,7 +563,8 @@ fi
 
 %files applet
 %defattr(-,root,root)
-%doc LICENSE
+%{!?_licensedir:%global license %doc}
+%license LICENSE
 %dir %{rhnroot}/server
 %dir %{rhnroot}/server/handlers/applet
 %{rhnroot}/server/handlers/applet/*
@@ -571,7 +574,8 @@ fi
 
 %files app
 %defattr(-,root,root)
-%doc LICENSE
+%{!?_licensedir:%global license %doc}
+%license LICENSE
 %dir %{rhnroot}/server
 %dir %{rhnroot}/server/handlers/app
 %{rhnroot}/server/handlers/app/*
@@ -581,7 +585,8 @@ fi
 
 %files iss
 %defattr(-,root,root)
-%doc LICENSE
+%{!?_licensedir:%global license %doc}
+%license LICENSE
 %dir %{rhnroot}/server
 %dir %{rhnroot}/server/handlers/sat
 %{rhnroot}/server/handlers/sat/*
@@ -589,7 +594,8 @@ fi
 
 %files iss-export
 %defattr(-,root,root)
-%doc LICENSE
+%{!?_licensedir:%global license %doc}
+%license LICENSE
 %dir %{python3rhnroot}/satellite_exporter
 %{python3rhnroot}/satellite_exporter/__init__.py*
 %{python3rhnroot}/satellite_exporter/satexport.py*
@@ -606,7 +612,8 @@ fi
 
 %files config-files-common
 %defattr(-,root,root)
-%doc LICENSE
+%{!?_licensedir:%global license %doc}
+%license LICENSE
 %{python3rhnroot}/server/configFilesHandler.py*
 %{python3rhnroot}/server/__pycache__/configFilesHandler.*
 %dir %{python3rhnroot}/server/config_common
@@ -614,7 +621,8 @@ fi
 
 %files config-files
 %defattr(-,root,root)
-%doc LICENSE
+%{!?_licensedir:%global license %doc}
+%license LICENSE
 %dir %{rhnroot}/server
 %dir %{rhnroot}/server/handlers/config
 %{rhnroot}/server/handlers/config/*
@@ -623,7 +631,8 @@ fi
 
 %files config-files-tool
 %defattr(-,root,root)
-%doc LICENSE
+%{!?_licensedir:%global license %doc}
+%license LICENSE
 %dir %{rhnroot}/server
 %dir %{rhnroot}/server/handlers/config_mgmt
 %{rhnroot}/server/handlers/config_mgmt/*
@@ -632,7 +641,8 @@ fi
 
 %files package-push-server
 %defattr(-,root,root)
-%doc LICENSE
+%{!?_licensedir:%global license %doc}
+%license LICENSE
 %dir %{rhnroot}/upload_server
 %{rhnroot}/upload_server/__init__.py*
 %dir %{rhnroot}/upload_server/handlers
@@ -644,7 +654,8 @@ fi
 
 %files tools
 %defattr(-,root,root)
-%doc LICENSE
+%{!?_licensedir:%global license %doc}
+%license LICENSE
 %doc README.ULN
 %attr(644,root,%{apache_group}) %{rhnconfigdefaults}/rhn_server_satellite.conf
 %config(noreplace) %{_sysconfdir}/logrotate.d/spacewalk-backend-tools
@@ -744,7 +755,8 @@ fi
 
 %files xml-export-libs
 %defattr(-,root,root)
-%doc LICENSE
+%{!?_licensedir:%global license %doc}
+%license LICENSE
 %dir %{python3rhnroot}/satellite_tools
 %{python3rhnroot}/satellite_tools/__init__.py*
 %{python3rhnroot}/satellite_tools/geniso.py*

--- a/client/rhel/dnf-plugin-spacewalk/dnf-plugin-spacewalk.spec
+++ b/client/rhel/dnf-plugin-spacewalk/dnf-plugin-spacewalk.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package dnf-plugin-spacewalk
 #
-# Copyright (c) 2019 SUSE LINUX GmbH, Nuernberg, Germany.
+# Copyright (c) 2021 SUSE LLC
 # Copyright (c) 2008-2018 Red Hat, Inc.
 #
 # All modifications and additions to the file contributed by third parties
@@ -36,7 +36,7 @@ Name:           dnf-plugin-spacewalk
 Version:        4.2.8
 Release:        1%{?dist}
 Source0:        https://github.com/spacewalkproject/spacewalk/archive/%{name}-%{version}.tar.gz
-Url:            https://github.com/uyuni-project/uyuni
+URL:            https://github.com/uyuni-project/uyuni
 BuildArch:      noarch
 
 Requires:       %{pythonX}-%{name} = %{version}-%{release}
@@ -45,11 +45,11 @@ Requires:       dnf-plugins-core
 Requires:       librepo >= 1.7.15
 %if 0%{?fedora}
 Obsoletes:      yum-rhn-plugin < 2.7
-Requires: dnf >= 4.0.9
+Requires:       dnf >= 4.0.9
 %endif
 %if 0%{?rhel} >= 8
 Provides:       yum-rhn-plugin = %{version}
-Requires: dnf >= 4.0.9
+Requires:       dnf >= 4.0.9
 %endif
 
 %description
@@ -75,8 +75,8 @@ Summary:        DNF plugin for Spacewalk
 Group:          System Environment/Base
 BuildRequires:  python3-devel
 Requires:       %{name} = %{version}-%{release}
-Requires:       python3-rhn-client-tools >= 2.8.4
 Requires:       python3-librepo
+Requires:       python3-rhn-client-tools >= 2.8.4
 
 %description -n python3-%{name}
 Python 3 specific files for %{name}.

--- a/client/rhel/spacewalk-client-tools/spacewalk-client-tools.spec
+++ b/client/rhel/spacewalk-client-tools/spacewalk-client-tools.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package spacewalk-client-tools
 #
-# Copyright (c) 2019 SUSE LINUX GmbH, Nuernberg, Germany.
+# Copyright (c) 2021 SUSE LLC
 # Copyright (c) 2008-2018 Red Hat, Inc.
 #
 # All modifications and additions to the file contributed by third parties
@@ -72,14 +72,14 @@ Name:           spacewalk-client-tools
 Summary:        Support programs and libraries for Spacewalk
 License:        GPL-2.0-only
 %if "%{_vendor}" == "debbuild"
-Group:      admin
-Packager:   Uyuni Project <uyuni-devel@opensuse.org>
+Group:          admin
+Packager:       Uyuni Project <uyuni-devel@opensuse.org>
 %else
 Group:          System Environment/Base
 %endif
 Source0:        spacewalk-client-tools-%{version}.tar.gz
 Source1:        %{name}-rpmlintrc
-Url:            https://github.com/uyuni-project/uyuni
+URL:            https://github.com/uyuni-project/uyuni
 Version:        4.2.10
 Release:        1%{?dist}
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -112,15 +112,15 @@ Requires:       yum
 %endif # {_vendor} != "debbuild"
 
 %if "%{_vendor}" == "debbuild"
-Requires: apt
+Requires:       apt
 %if 0%{?ubuntu} >= 1804
-Requires: gpg
+Requires:       gpg
 %else
-Requires: gnupg
+Requires:       gnupg
 %endif
-Requires: coreutils
+Requires:       coreutils
 %endif
-BuildRequires: rpm
+BuildRequires:  rpm
 
 Conflicts:      up2date < 5.0.0
 Conflicts:      yum-rhn-plugin < 1.6.4-1
@@ -139,7 +139,7 @@ BuildRequires:  fedora-logos
 %endif
 
 %if 0%{?mageia} >= 6
-BuildRequires: dnf
+BuildRequires:  dnf
 %endif
 
 %if 0%{?rhel}
@@ -153,8 +153,8 @@ BuildRequires:  yum
 
 # For the systemd presets
 %if 0%{?fedora} || 0%{?mageia} || 0%{?debian} >= 8 || 0%{?ubuntu} >= 1504 || 0%{?sle_version} >= 120000 || 0%{?rhel} >= 7
-BuildRequires: systemd
-Requires:      systemd
+BuildRequires:  systemd
+Requires:       systemd
 %endif
 
 %description
@@ -165,7 +165,7 @@ system to receive software updates from Spacewalk.
 %package -n python2-%{name}
 Summary:        Support programs and libraries for Spacewalk
 %if "%{_vendor}" == "debbuild"
-Group: python
+Group:          python
 %else
 Group:          System Environment/Base
 %endif
@@ -177,8 +177,8 @@ Requires:       %{name} = %{version}-%{release}
 Requires:       rhnlib >= 4.2.2
 
 %if "%{_vendor}" != "debbuild"
-Requires:       rpm-python
 Requires:       python2-uyuni-common-libs
+Requires:       rpm-python
 %ifnarch s390 s390x
 Requires:       python-dmidecode
 %endif
@@ -227,18 +227,18 @@ BuildRequires:  rpm-python
 %endif # if {_vendor} != "debbuild"
 
 %if "%{_vendor}" == "debbuild"
-Requires: python-rpm
-Requires: python-dmidecode
-Requires: python-ethtool >= 0.4
-BuildRequires: python-dev
-Requires: python2-hwdata
-BuildRequires: python-rpm
-BuildRequires: python-coverage
-Requires: gir1.2-gudev-1.0
-Requires: python-gi
-Requires: python-pyudev
-Requires: python-dbus
-Requires: python-newt
+Requires:       python-dmidecode
+Requires:       python-ethtool >= 0.4
+Requires:       python-rpm
+BuildRequires:  python-dev
+Requires:       python2-hwdata
+BuildRequires:  python-coverage
+BuildRequires:  python-rpm
+Requires:       gir1.2-gudev-1.0
+Requires:       python-dbus
+Requires:       python-gi
+Requires:       python-newt
+Requires:       python-pyudev
 Requires(preun): python-minimal
 Requires(post): python-minimal
 %endif
@@ -251,7 +251,7 @@ Python 2 specific files of %{name}.
 %package -n python3-%{name}
 Summary:        Support programs and libraries for Spacewalk
 %if "%{_vendor}" == "debbuild"
-Group: python
+Group:          python
 %else
 Group:          System Environment/Base
 %endif
@@ -287,12 +287,12 @@ Requires:       python3-rpm
 Requires:       python3-uyuni-common-libs
 
 %if "%{_vendor}" == "debbuild"
-BuildRequires: python3-dev
-Requires: python3-dbus
-Requires: python3-newt
-Requires: gir1.2-gudev-1.0
-Requires: python3-pyudev
-Requires: python3-gi
+BuildRequires:  python3-dev
+Requires:       gir1.2-gudev-1.0
+Requires:       python3-dbus
+Requires:       python3-gi
+Requires:       python3-newt
+Requires:       python3-pyudev
 Requires(preun): python3-minimal
 Requires(post): python3-minimal
 %endif
@@ -327,7 +327,7 @@ Requires:       yum-rhn-plugin >= 2.8.2
 %endif
 
 %if "%{_vendor}" == "debbuild"
-Requires: apt-transport-spacewalk
+Requires:       apt-transport-spacewalk
 %endif
 
 %description -n spacewalk-check
@@ -380,7 +380,7 @@ Requires:       %{pythonX}-spacewalk-client-setup
 Requires:       usermode >= 1.36
 %endif
 %if 0%{?mageia}
-Requires: usermode-consoleonly >= 1.36
+Requires:       usermode-consoleonly >= 1.36
 %endif
 Requires:       %{name} = %{version}-%{release}
 Requires:       %{rhnsd}
@@ -413,7 +413,6 @@ Requires:       python-newt
 Requires(preun): python-minimal
 Requires(post): python-minimal
 %endif
-
 
 %description -n python2-spacewalk-client-setup
 Python 2 specific files for spacewalk-client-setup.
@@ -450,10 +449,10 @@ Requires:       %{pythonX}-spacewalk-client-setup
 Requires:       spacewalk-client-setup = %{version}-%{release}
 
 %if "%{_vendor}" == "debbuild"
-Requires: libpam0g
-Requires: libpam-modules
-Requires: libpam-runtime
-Requires: libpam-gnome-keyring
+Requires:       libpam-gnome-keyring
+Requires:       libpam-modules
+Requires:       libpam-runtime
+Requires:       libpam0g
 %else
 Requires:       pam >= 0.72
 %endif
@@ -485,11 +484,11 @@ Requires:       liberation-sans-fonts
 %endif
 
 %if "%{_vendor}" == "debbuild"
-Requires: python-gnome2
-Requires: python-gtk2
-Requires: python-glade2
-Requires: usermode
-Requires: fonts-liberation
+Requires:       fonts-liberation
+Requires:       python-glade2
+Requires:       python-gnome2
+Requires:       python-gtk2
+Requires:       usermode
 Requires(preun): python-minimal
 Requires(post): python-minimal
 %endif
@@ -518,12 +517,12 @@ Requires:       liberation-sans-fonts
 %endif
 
 %if "%{_vendor}" == "debbuild"
-BuildRequires: libgtk2.0-dev
-Requires: libgtk-3-bin
-Requires: gir1.2-gtk-3.0
+BuildRequires:  libgtk2.0-dev
+Requires:       gir1.2-gtk-3.0
+Requires:       libgtk-3-bin
 
-Requires: python3-gi
-Requires: fonts-liberation
+Requires:       fonts-liberation
+Requires:       python3-gi
 Requires(preun): python3-minimal
 Requires(post): python3-minimal
 %endif
@@ -731,7 +730,8 @@ make -f Makefile.rhn-client-tools test
 # some info about mirrors
 %doc doc/mirrors.txt
 %doc doc/AUTHORS
-%doc doc/LICENSE
+%{!?_licensedir:%global license %doc}
+%license LICENSE
 %{_mandir}/man8/rhn-profile-sync.8*
 %{_mandir}/man5/up2date.5*
 
@@ -1103,6 +1103,5 @@ py3compile -p python3-rhn-setup-gnome -V -4.0
 py3clean -p python3-rhn-setup-gnome
 %endif
 %endif
-
 
 %changelog

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package spacewalk-java
 #
-# Copyright (c) 2019 SUSE LINUX GmbH, Nuernberg, Germany.
+# Copyright (c) 2021 SUSE LLC.
 # Copyright (c) 2008-2018 Red Hat, Inc.
 #
 # All modifications and additions to the file contributed by third parties
@@ -64,7 +64,7 @@ License:        GPL-2.0-only
 Group:          Applications/Internet
 Version:        4.2.18
 Release:        1%{?dist}
-Url:            https://github.com/uyuni-project/uyuni
+URL:            https://github.com/uyuni-project/uyuni
 Source0:        https://github.com/uyuni-project/uyuni/archive/%{name}-%{version}-1.tar.gz
 Source1:        %{name}-rpmlintrc
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/proxy/proxy/spacewalk-proxy.spec
+++ b/proxy/proxy/spacewalk-proxy.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package spacewalk-proxy
 #
-# Copyright (c) 2019 SUSE LINUX GmbH, Nuernberg, Germany.
+# Copyright (c) 2021 SUSE LLC
 # Copyright (c) 2008-2018 Red Hat, Inc.
 #
 # All modifications and additions to the file contributed by third parties
@@ -27,13 +27,13 @@ License:        GPL-2.0-only
 Group:          Applications/Internet
 Version:        4.2.4
 Release:        1%{?dist}
-Url:            https://github.com/uyuni-project/uyuni
+URL:            https://github.com/uyuni-project/uyuni
 Source0:        https://github.com/spacewalkproject/spacewalk/archive/%{name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildRequires:  python3
 BuildArch:      noarch
-Requires:       python3-uyuni-common-libs
 Requires:       httpd
+Requires:       python3-uyuni-common-libs
 %if 0%{?pylint_check}
 BuildRequires:  spacewalk-python3-pylint
 %endif
@@ -140,9 +140,9 @@ BuildRequires:  apache2
 %else
 Requires:       mod_ssl
 %endif
-Requires:       curl
-Requires:       apache2-mod_wsgi-python3
 Requires:       %{name}-broker >= %{version}
+Requires:       apache2-mod_wsgi-python3
+Requires:       curl
 Requires:       spacewalk-backend >= 1.7.24
 Requires(pre):  policycoreutils
 
@@ -158,9 +158,9 @@ Spacewalk Proxy components.
 %package package-manager
 Summary:        Custom Channel Package Manager for the Spacewalk Proxy Server
 Group:          Applications/Internet
+Requires:       mgr-push >= 4.0.0
 Requires:       python3
 Requires:       python3-rhnlib >= 4.2.2
-Requires:       mgr-push >= 4.0.0
 Requires:       spacewalk-backend >= 1.7.24
 # proxy isn't Python 3 yet
 Requires:       python3-mgr-push
@@ -186,7 +186,6 @@ Requires(pre):  %{name}-common
 BuildRequires:  systemd-rpm-macros
 %endif
 %{?systemd_requires}
-
 
 %description salt
 A ZeroMQ Proxy for Salt Minions

--- a/schema/spacewalk/susemanager-schema.spec
+++ b/schema/spacewalk/susemanager-schema.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package susemanager-schema
 #
-# Copyright (c) 2019 SUSE LINUX GmbH, Nuernberg, Germany.
+# Copyright (c) 2021 SUSE LLC
 # Copyright (c) 2008-2018 Red Hat, Inc.
 #
 # All modifications and additions to the file contributed by third parties
@@ -29,7 +29,7 @@ Release:        1%{?dist}
 Source0:        %{name}-%{version}.tar.gz
 Source1:        %{name}-rpmlintrc
 
-Url:            https://github.com/uyuni-project/uyuni
+URL:            https://github.com/uyuni-project/uyuni
 BuildArch:      noarch
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 

--- a/search-server/spacewalk-search/spacewalk-search.spec
+++ b/search-server/spacewalk-search/spacewalk-search.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package spacewalk-search
 #
-# Copyright (c) 2019 SUSE LINUX GmbH, Nuernberg, Germany.
+# Copyright (c) 2021 SUSE LLC
 # Copyright (c) 2008-2018 Red Hat, Inc.
 #
 # All modifications and additions to the file contributed by third parties
@@ -15,6 +15,7 @@
 
 # Please submit bugfixes or comments via https://bugs.opensuse.org/
 #
+
 
 %if 0%{?suse_version}
 %define java_version   11
@@ -35,7 +36,7 @@ Release:        1%{?dist}
 # git clone https://github.com/spacewalkproject/spacewalk.git
 # cd search-server
 # make test-srpm
-Url:            https://github.com/uyuni-project/uyuni
+URL:            https://github.com/uyuni-project/uyuni
 Source0:        %{name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
@@ -52,7 +53,6 @@ BuildRequires:  doc-indexes
 BuildRequires:  hadoop
 BuildRequires:  jakarta-commons-httpclient
 BuildRequires:  jakarta-oro
-BuildRequires:  (java-devel >= %{java_version} or java-11-openjdk-devel)
 BuildRequires:  javapackages-tools
 BuildRequires:  junit
 BuildRequires:  lucene == 2.4.1
@@ -64,6 +64,7 @@ BuildRequires:  redstone-xmlrpc
 BuildRequires:  simple-core
 BuildRequires:  slf4j
 BuildRequires:  systemd
+BuildRequires:  (java-devel >= %{java_version} or java-11-openjdk-devel)
 %if 0%{?rhel}
 BuildRequires:  systemd-rpm-macros
 %endif

--- a/spacecmd/spacecmd.spec
+++ b/spacecmd/spacecmd.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package spacecmd
 #
-# Copyright (c) 2019 SUSE LINUX GmbH, Nuernberg, Germany.
+# Copyright (c) 2021 SUSE LLC
 # Copyright (c) 2008-2018 Red Hat, Inc.
 # Copyright (c) 2011 Aron Parsons <aronparsons@gmail.com>
 #
@@ -47,14 +47,14 @@ Name:           spacecmd
 Version:        4.2.8
 Release:        1%{?dist}
 Summary:        Command-line interface to Spacewalk and Red Hat Satellite servers
+License:        GPL-3.0-or-later
 %if "%{_vendor}" == "debbuild"
 Packager:       Uyuni packagers <uyuni-devel@lists.opensuse.org>
 Group:          admin
 %else
 Group:          Applications/System
 %endif
-License:        GPL-3.0-or-later
-Url:            https://github.com/uyuni-project/uyuni
+URL:            https://github.com/uyuni-project/uyuni
 Source:         https://github.com/spacewalkproject/spacewalk/archive/%{name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 %if 0%{?fedora} || 0%{?rhel} || 0%{?suse_version} >= 1210 || "%{_vendor}" == "debbuild"
@@ -80,9 +80,9 @@ BuildRequires:  python3-dev
 %else
 BuildRequires:  python3-devel
 %endif
+Requires:       python3
 Requires:       python3-rpm
 Requires:       python3-simplejson
-Requires:       python3
 %else
 BuildRequires:  %{python2prefix}
 %if "%{_vendor}" == "debbuild"

--- a/spacewalk/certs-tools/spacewalk-certs-tools.spec
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package spacewalk-certs-tools
 #
-# Copyright (c) 2019 SUSE LINUX GmbH, Nuernberg, Germany.
+# Copyright (c) 2021 SUSE LLC
 # Copyright (c) 2008-2018 Red Hat, Inc.
 #
 # All modifications and additions to the file contributed by third parties
@@ -38,7 +38,6 @@
 %global default_py3 1
 %endif
 
-
 %define pythonX %{?default_py3: python3}%{!?default_py3: python2}
 
 Name:           spacewalk-certs-tools
@@ -47,15 +46,15 @@ License:        GPL-2.0-only
 Group:          Applications/Internet
 Version:        4.2.7
 Release:        1%{?dist}
-Url:            https://github.com/uyuni-project/uyuni
+URL:            https://github.com/uyuni-project/uyuni
 Source0:        https://github.com/spacewalkproject/spacewalk/archive/%{name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
 Requires(pre):  %{pythonX}-%{name} = %{version}-%{release}
+Requires:       %{rhn_client_tools}
 Requires:       openssl
 Requires:       rpm-build
 Requires:       spacewalk-base-minimal-config
-Requires:       %{rhn_client_tools}
 Requires:       sudo
 Requires:       tar
 BuildRequires:  docbook-utils
@@ -95,7 +94,6 @@ BuildRequires:  python2
 BuildRequires:  python
 %endif
 
-
 %description -n python2-%{name}
 Python 2 specific files for %{name}.
 
@@ -105,8 +103,8 @@ Summary:        Spacewalk SSL Key/Cert Tool
 Group:          Applications/Internet
 Requires:       %{name} = %{version}-%{release}
 Requires:       python3-rhn-client-tools
-Requires:       spacewalk-backend
 Requires:       python3-uyuni-common-libs
+Requires:       spacewalk-backend
 BuildRequires:  python3
 BuildRequires:  python3-rpm-macros
 
@@ -187,8 +185,8 @@ esac
 %attr(755,root,root) %{_sbindir}/mgr-package-rpm-certificate-osimage
 %doc %{_mandir}/man1/rhn-*.1*
 %doc %{_mandir}/man1/mgr-*.1*
-%doc LICENSE
 %doc ssl-howto-simple.txt ssl-howto.txt
+%license LICENSE
 %{pub_bootstrap_dir}/client_config_update.py*
 %if 0%{?suse_version}
 %dir %{rhnroot}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.spec
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package susemanager-sls
 #
-# Copyright (c) 2019 SUSE LINUX GmbH, Nuernberg, Germany.
+# Copyright (c) 2021 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -15,6 +15,7 @@
 # Please submit bugfixes or comments via https://bugs.opensuse.org/
 #
 
+
 %if 0%{?suse_version} > 1320 || 0%{?rhel}
 # SLE15 builds on Python 3
 %global build_py3   1
@@ -22,22 +23,22 @@
 
 Name:           susemanager-sls
 Version:        4.2.10
-Release:        1
+Release:        0
 Summary:        Static Salt state files for SUSE Manager
-License:        Apache-2.0 and LGPL-2.1-only
+License:        Apache-2.0 AND LGPL-2.1-only
 Group:          Applications/Internet
 Source:         %{name}-%{version}.tar.gz
 Requires(pre):  coreutils
 Requires:       susemanager-build-keys-web >= 12.0.1
 %if 0%{?build_py3}
-BuildRequires:  python3-pytest
 BuildRequires:  python3-mock
+BuildRequires:  python3-pytest
 BuildRequires:  python3-salt
 # Different package names for SUSE and RHEL:
 Requires:       (python3-PyYAML >= 5.1 or python3-pyyaml >= 5.1)
 %else
-BuildRequires:  python-pytest
 BuildRequires:  python-mock
+BuildRequires:  python-pytest
 BuildRequires:  python-salt
 Requires:       python-PyYAML >= 5.1
 %endif

--- a/susemanager/susemanager.spec
+++ b/susemanager/susemanager.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package susemanager
 #
-# Copyright (c) 2019 SUSE LINUX GmbH, Nuernberg, Germany.
+# Copyright (c) 2021 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -50,7 +50,7 @@ Release:        1%{?dist}
 Summary:        SUSE Manager specific scripts
 License:        GPL-2.0-only
 Group:          Applications/System
-Url:            https://github.com/uyuni-project/uyuni
+URL:            https://github.com/uyuni-project/uyuni
 Source0:        %{name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 #BuildArch:      noarch - not noarch because of ifarch usage!!!!

--- a/utils/spacewalk-utils.spec
+++ b/utils/spacewalk-utils.spec
@@ -1,8 +1,7 @@
 #
 # spec file for package spacewalk-utils
 #
-# Copyright (c) 2020 SUSE LLC
-# Copyright (c) 2019 SUSE LINUX GmbH, Nuernberg, Germany.
+# Copyright (c) 2021 SUSE LLC
 # Copyright (c) 2008-2018 Red Hat, Inc.
 #
 # All modifications and additions to the file contributed by third parties
@@ -17,6 +16,7 @@
 # Please submit bugfixes or comments via https://bugs.opensuse.org/
 #
 
+
 %if 0%{?fedora} || 0%{?rhel} >= 7
 %{!?pylint_check: %global pylint_check 1}
 %endif
@@ -27,18 +27,18 @@ Release:        1%{?dist}
 Summary:        Utilities that may be run against a SUSE Manager/Uyuni server
 License:        GPL-2.0-only AND GPL-3.0-or-later
 Group:          Productivity/Other
-Url:            https://github.com/uyuni-project/uyuni
+URL:            https://github.com/uyuni-project/uyuni
 Source0:        https://github.com/spacewalkproject/spacewalk/archive/%{name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
-BuildRequires:  fdupes
 BuildRequires:  docbook-utils
+BuildRequires:  fdupes
 BuildRequires:  python3
 %if 0%{?pylint_check}
-BuildRequires:  (python3-PyYAML or python3-pyyaml)
 BuildRequires:  python3-solv
 BuildRequires:  python3-uyuni-common-libs
 BuildRequires:  spacewalk-python3-pylint
+BuildRequires:  (python3-PyYAML or python3-pyyaml)
 %endif
 BuildRequires:  uyuni-base-common
 
@@ -87,13 +87,13 @@ Requires:       susemanager-schema
 # Required by cloneByDate.py, depsolver.py,spacewalk-clone-by-date
 Requires(pre):  uyuni-base-common
 
-
 %description
 Utilities that may be run against a SUSE Manager server (supported) or an Uyuni server
 
 %package extras
 Summary:        Extra utilities that may run against a SUSE Manager/Uyuni server
 # Required by spacewalk-watch-channel-sync.sh
+Group:          Productivity/Other
 Requires:       bash
 # Required by taskotop
 Requires:       python3-curses

--- a/web/spacewalk-web.spec
+++ b/web/spacewalk-web.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package spacewalk-web
 #
-# Copyright (c) 2019 SUSE LINUX GmbH, Nuernberg, Germany.
+# Copyright (c) 2021 SUSE LLC
 # Copyright (c) 2008-2018 Red Hat, Inc.
 #
 # All modifications and additions to the file contributed by third parties
@@ -39,15 +39,15 @@ License:        GPL-2.0-only
 Group:          Applications/Internet
 Version:        4.2.16
 Release:        1%{?dist}
-Url:            https://github.com/uyuni-project/uyuni
+URL:            https://github.com/uyuni-project/uyuni
 Source0:        https://github.com/uyuni-project/uyuni/archive/%{name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
 Requires(pre):  uyuni-base-common
+BuildRequires:  nodejs-packaging
+BuildRequires:  susemanager-nodejs-sdk-devel
 BuildRequires:  uyuni-base-common
 BuildRequires:  perl(ExtUtils::MakeMaker)
-BuildRequires:  susemanager-nodejs-sdk-devel
-BuildRequires:  nodejs-packaging
 
 %if 0%{?suse_version}
 BuildRequires:  apache2
@@ -63,7 +63,7 @@ but it does generate a number of sub-packages.
 
 %package -n susemanager-web-libs
 Summary:        Vendor bundles for spacewalk-web
-License:        0BSD and BSD-3-Clause and LGPL-3.0-or-later and MIT and MPL-2.0
+License:        0BSD AND BSD-3-Clause AND LGPL-3.0-or-later AND MIT AND MPL-2.0
 Group:          Applications/Internet
 
 BuildArch:      noarch
@@ -76,7 +76,7 @@ This package contains Vendor bundles needed for spacewalk-web
 
 %package -n susemanager-web-libs-debug
 Summary:        Vendor bundles for spacewalk-web debug files
-License:        0BSD and BSD-3-Clause and LGPL-3.0-or-later and MIT and MPL-2.0
+License:        0BSD AND BSD-3-Clause AND LGPL-3.0-or-later AND MIT AND MPL-2.0
 Group:          Applications/Internet
 
 BuildArch:      noarch
@@ -121,13 +121,13 @@ Provides:       spacewalk(spacewalk-base) = %{version}-%{release}
 %if 0%{?suse_version}
 Requires:       susemanager-frontend-libs
 %if 0%{?suse_version} >= 1500
-Requires:       python3-websockify
 Requires:       python3-PyJWT
 Requires:       python3-numpy
+Requires:       python3-websockify
 %else
-Requires:       python-websockify
 Requires:       python-PyJWT
 Requires:       python-numpy
+Requires:       python-websockify
 %endif
 %endif
 Requires:       httpd
@@ -252,7 +252,7 @@ cp html/src/dist/vendors/vendors.bundle.js.LICENSE %{buildroot}/%{www_path}/vend
 %{perl_vendorlib}/RHN/DB.pm
 %{perl_vendorlib}/RHN/DBI.pm
 %{perl_vendorlib}/PXT/Config.pm
-%doc LICENSE
+%license LICENSE
 
 %files -n spacewalk-base-minimal-config
 %defattr(644,root,root,755)
@@ -277,7 +277,7 @@ cp html/src/dist/vendors/vendors.bundle.js.LICENSE %{buildroot}/%{www_path}/vend
 %{www_path}/pub
 %{www_path}/javascript/manager/*.js
 %{www_path}/javascript/*.js
-%doc LICENSE
+%license LICENSE
 
 %files -n spacewalk-html-debug
 %defattr(644,root,root,755)


### PR DESCRIPTION
## What does this PR change?

Pass the spec linter to some packages, as requested by autobuild.

We are only changing packages that are to be submitted for SUSE Manager 4.2 GMC. The rest will come later.

For the packages used by client tools, I am defining `%license` if it doesn't exist, as we need to stay compatible with old OS.

This is WIP and merge candidate because:
- Needs to be merged before we submit GMC
- But we shouldn't merge before we check what packages we'll be submitting for GMC.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: SPEC change

- [x] **DONE**

## Test coverage
- No tests: The packages are able to build locally

- [x] **DONE**

## Links

Tracks: https://github.com/SUSE/spacewalk/issues/14840 and https://github.com/SUSE/spacewalk/issues/14841

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
