### PR TITLE
Replace the waiting for package installation in retracted patches

### DIFF
--- a/testsuite/features/secondary/min_retracted_patches.feature
+++ b/testsuite/features/secondary/min_retracted_patches.feature
@@ -9,7 +9,8 @@ Feature: Retracted patches
 
   Scenario: Installed retracted package should show icon in the system packages list
     When I install package "rute-dummy=2.1-1.1" on this "sle_minion"
-    And I wait until package "rute-dummy-2.1-1.1.x86_64" is installed on "sle_minion" via spacecmd
+    And I refresh packages list via spacecmd on "sle_minion"
+    And I wait until refresh package list on "sle_minion" is finished
     And I am on the "Software" page of this "sle_minion"
     And I follow "Packages"
     And I follow "List / Remove"
@@ -28,7 +29,8 @@ Feature: Retracted patches
 
   Scenario: Retracted package should not be available for upgrade
     When I install old package "rute-dummy=2.0-1.2" on this "sle_minion"
-    And I wait until package "rute-dummy-2.0-1.2.x86_64" is installed on "sle_minion" via spacecmd
+    And I refresh packages list via spacecmd on "sle_minion"
+    And I wait until refresh package list on "sle_minion" is finished
     And I am on the "Software" page of this "sle_minion"
     And I follow "Packages"
     And I follow "Upgrade"
@@ -38,7 +40,8 @@ Feature: Retracted patches
 
   Scenario: Retracted patch should not affect any system
     When I install package "rute-dummy=2.0-1.2" on this "sle_minion"
-    And I wait until package "rute-dummy-2.0-1.2.x86_64" is installed on "sle_minion" via spacecmd
+    And I refresh packages list via spacecmd on "sle_minion"
+    And I wait until refresh package list on "sle_minion" is finished
     And I follow the left menu "Software > Channel List > All"
     And I follow "Test-Channel-x86_64"
     And I follow "Patches" in the content area


### PR DESCRIPTION
The new way is the one used in min_salt_install_package.feature.


## GUI diff

No difference.


- [x] **DONE**

## Documentation
- fix

- [x] **DONE**

## Test coverage
- Cucumber tests updated

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
