### PR TITLE
bsc1185097 fix logrotate perms 

### DIFF
--- a/backend/common/rhnLog.py
+++ b/backend/common/rhnLog.py
@@ -191,10 +191,7 @@ class rhnLog:
                     apache_uid, apache_gid = getUidGid('wwwrun', 'www')
                 else:
                     apache_uid, apache_gid = getUidGid('apache', 'apache')
-                if os.getuid() == 0:
-                    os.chown(self.file, apache_uid, 0)
-                else:
-                    os.chown(self.file, apache_uid, apache_gid)
+                os.chown(self.file, apache_uid, apache_gid)
                 os.chmod(self.file, int('0660', 8))
         except:
             log_stderr("ERROR LOG FILE: Couldn't open log file %s" % self.file,

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- switch to www group for satellite logs (bsc#1185097)
 - Fix binary blob corruptions in tradidional config file deployment (bsc#1183864)
 - Fix for GPG checking on synchonizing mirrored dpkg repo (bsc#1184351)
 

--- a/backend/spacewalk-backend.spec
+++ b/backend/spacewalk-backend.spec
@@ -378,6 +378,9 @@ fi
 %else
 %service_add_post spacewalk-diskcheck.service spacewalk-diskcheck.timer
 %endif
+if test -f /var/log/rhn/rhn_server_satellite.log; then 
+    chown -f %{apache_user}:%{apache_group} /var/log/rhn/rhn_server_satellite.log
+fi
 
 %preun tools
 %if 0%{?rhel}


### PR DESCRIPTION
## What does this PR change?
This is a port of https://github.com/SUSE/spacewalk/pull/14827


Changes the rhnLog to use just the www instead of root group to match the logrotate 
#14651 
https://bugzilla.suse.com/show_bug.cgi?id=1185097
Port of # **remove rest of file if this is a port**
## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
