### PR TITLE
QA: Monitoring feature can't run in parallel (restart services)

### DIFF
--- a/testsuite/features/secondary/min_centos_monitoring.feature
+++ b/testsuite/features/secondary/min_centos_monitoring.feature
@@ -1,11 +1,14 @@
 # Copyright (c) 2021 SUSE LLC
 # Licensed under the terms of the MIT license.
+# This feature depends on:
+# - features/secondary/srv_monitoring.feature : As this feature disable/re-enable monitoring capabilities
+# - sumaform : As it is configuring monitoring to be enabled after deployment
 
 @centos_minion
 @scope_monitoring
 @scope_res
-Feature: Monitor SUMA environment with Prometheus on a CentOS minion
-  In order to monitore SUSE Manager server
+Feature: Monitor SUMA environment with Prometheus on a CentOS Salt minion
+  In order to monitor SUSE Manager server
   As an authorized user
   I want to enable Prometheus exporters
 
@@ -52,7 +55,7 @@ Feature: Monitor SUMA environment with Prometheus on a CentOS minion
     Then I should see a "Formula saved" text
 
   Scenario: Cleanup: apply highstate after test monitoring on the CentOS minion
-    And I follow "States" in the content area
+    When I follow "States" in the content area
     And I click on "Apply Highstate"
     Then I should see a "Applying the highstate has been scheduled." text
     And I wait until event "Apply highstate scheduled by admin" is completed

--- a/testsuite/features/secondary/min_monitoring.feature
+++ b/testsuite/features/secondary/min_monitoring.feature
@@ -1,10 +1,13 @@
 # Copyright (c) 2021 SUSE LLC
 # Licensed under the terms of the MIT license.
+# This feature depends on:
+# - features/secondary/srv_monitoring.feature : As this feature disable/re-enable monitoring capabilities
+# - sumaform : As it is configuring monitoring to be enabled after deployment
 
 @sle_minion
 @scope_monitoring
-Feature: Monitor SUMA environment with Prometheus on a normal minion
-  In order to monitore SUSE Manager server
+Feature: Monitor SUMA environment with Prometheus on a SLE Salt minion
+  In order to monitor SUSE Manager server
   As an authorized user
   I want to enable Prometheus exporters
 

--- a/testsuite/features/secondary/srv_monitoring.feature
+++ b/testsuite/features/secondary/srv_monitoring.feature
@@ -1,8 +1,13 @@
 # Copyright (c) 2019-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
+# This feature is a dependency for:
+# - features/secondary/min_monitoring.feature : If this feature fails could let monitoring feature disabled for SLE minion
+# - features/secondary/min_centos_monitoring.feature : If this feature fails could let monitoring feature disabled for CentOS minion
+# This feature depends on:
+# - sumaform : As it is configuring monitoring to be enabled after deployment
 
 @scope_monitoring
-Feature: Enable and disable monitoring of the server
+Feature: Disable and re-enable monitoring of the server
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section

--- a/testsuite/run_sets/secondary.yml
+++ b/testsuite/run_sets/secondary.yml
@@ -10,6 +10,15 @@
 
 - features/secondary/srv_users.feature
 - features/secondary/srv_menu.feature
+- features/secondary/srv_monitoring.feature
+- features/secondary/srv_virtual_host_manager.feature
+- features/secondary/srv_power_management.feature
+- features/secondary/srv_xmlrpc_power_management.feature
+- features/secondary/srv_power_management_redfish.feature
+- features/secondary/srv_delete_channel_from_ui.feature
+- features/secondary/srv_delete_channel_with_tool.feature
+- features/secondary/srv_test_maintenance_windows.feature
+- features/secondary/srv_user_configuration_salt_states.feature
 - features/secondary/buildhost_osimage_build_image.feature
 - features/secondary/allcli_reboot.feature
 - features/secondary/trad_config_channel.feature
@@ -29,30 +38,22 @@
 - features/secondary/trad_migrate_to_minion.feature
 - features/secondary/trad_migrate_to_sshminion.feature
 - features/secondary/trad_ssh_tunnel.feature
-- features/secondary/srv_virtual_host_manager.feature
 - features/secondary/trad_baremetal_discovery.feature
 - features/secondary/min_salt_minions_page.feature
 - features/secondary/min_salt_mgrcompat_state.feature
 - features/secondary/minkvm_guests.feature
 - features/secondary/minxen_guests.feature
 - features/secondary/min_empty_system_profiles.feature
-- features/secondary/srv_power_management.feature
-- features/secondary/srv_xmlrpc_power_management.feature
-- features/secondary/srv_power_management_redfish.feature
 - features/secondary/trad_need_reboot.feature
 - features/secondary/trad_action_chain.feature
 - features/secondary/min_action_chain.feature
 - features/secondary/minssh_action_chain.feature
 - features/secondary/allcli_action_chain.feature
-- features/secondary/srv_delete_channel_from_ui.feature
-- features/secondary/srv_delete_channel_with_tool.feature
 - features/secondary/buildhost_docker_build_image.feature
 - features/secondary/buildhost_docker_auth_registry.feature
 - features/secondary/min_docker_xmlrpc.feature
 - features/secondary/min_recurring_action.feature
 - features/secondary/min_change_software_channel.feature
-- features/secondary/srv_test_maintenance_windows.feature
-- features/secondary/srv_user_configuration_salt_states.feature
 - features/secondary/min_retracted_patches.feature
 
 ## Secondary features END ##

--- a/testsuite/run_sets/secondary_parallelizable.yml
+++ b/testsuite/run_sets/secondary_parallelizable.yml
@@ -32,7 +32,6 @@
 - features/secondary/srv_content_lifecycle.feature
 - features/secondary/srv_change_task_schedule.feature
 - features/secondary/srv_notifications.feature
-- features/secondary/srv_monitoring.feature
 - features/secondary/srv_push_package.feature
 
 - features/secondary/proxy_retail_pxeboot_and_mass_import.feature


### PR DESCRIPTION
## What does this PR change?

This PR moves the "monitoring" feature to the sequential list of tests, as it performs a restart of spacewalk-services.
It also documents its dependencies and reorders some other tests in the sequential list.

Related to https://github.com/SUSE/spacewalk/issues/11967

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.0 https://github.com/SUSE/spacewalk/pull/14911
- Manager-4.1 https://github.com/SUSE/spacewalk/pull/14912

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
