### PR TITLE
Manager 4.2 rc1 require pidof

### DIFF
--- a/spacewalk/admin/spacewalk-admin.changes
+++ b/spacewalk/admin/spacewalk-admin.changes
@@ -1,3 +1,5 @@
+- require sysvinit-tools to have pidof available (bsc#1186129)
+
 -------------------------------------------------------------------
 Wed May 05 16:32:08 CEST 2021 - jgonzalez@suse.com
 

--- a/spacewalk/admin/spacewalk-admin.spec
+++ b/spacewalk/admin/spacewalk-admin.spec
@@ -33,6 +33,7 @@ Release:        1%{?dist}
 Source0:        https://github.com/uyuni-project/uyuni/archive/%{name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 Requires:       lsof
+Requires:       sysvinit-tools
 Requires:       spacewalk-base
 Requires:       perl(MIME::Base64)
 Requires:       %{pythonX}


### PR DESCRIPTION
## What does this PR change?

We use pidof which is not anymore installed by default. So we need to explicit require it.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/14900

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
