### PR TITLE
Fix get_os_version return nil instead of raise

### DIFF
--- a/testsuite/features/support/client_stack.rb
+++ b/testsuite/features/support/client_stack.rb
@@ -50,12 +50,13 @@ end
 # We get these data decoding the values in '/etc/os-release'
 # rubocop:disable Metrics/AbcSize
 def get_os_version(node)
-  os_family_raw, code = node.run('grep "^ID=" /etc/os-release')
-  raise "No os-release found in the node: #{node.hostname}" unless code.zero?
+  os_family_raw, code = node.run('grep "^ID=" /etc/os-release', false)
+  return nil,nil unless code.zero?
   os_family = os_family_raw.strip.split('=')[1]
   return nil, nil if os_family.nil?
   os_family.delete! '"'
-  os_version_raw = node.run('grep "^VERSION_ID=" /etc/os-release')
+  os_version_raw, code = node.run('grep "^VERSION_ID=" /etc/os-release', false)
+  return nil,nil unless code.zero?
   os_version = os_version_raw.strip.split('=')[1]
   return nil, nil if os_version.nil?
   os_version.delete! '"'

--- a/testsuite/features/support/client_stack.rb
+++ b/testsuite/features/support/client_stack.rb
@@ -51,12 +51,12 @@ end
 # rubocop:disable Metrics/AbcSize
 def get_os_version(node)
   os_family_raw, code = node.run('grep "^ID=" /etc/os-release', false)
-  return nil,nil unless code.zero?
+  return nil, nil unless code.zero?
   os_family = os_family_raw.strip.split('=')[1]
   return nil, nil if os_family.nil?
   os_family.delete! '"'
   os_version_raw, code = node.run('grep "^VERSION_ID=" /etc/os-release', false)
-  return nil,nil unless code.zero?
+  return nil, nil unless code.zero?
   os_version = os_version_raw.strip.split('=')[1]
   return nil, nil if os_version.nil?
   os_version.delete! '"'


### PR DESCRIPTION
## What does this PR change?

Fix get_os_version return nil instead of raise because when we call the method we expect nil, nil instead of a raise. Without this it doesn't work. Also the `false` is needed to use it as array instead of string

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
