### PR TITLE
Fix scap audit issues

### DIFF
--- a/java/code/src/com/redhat/rhn/common/util/DateFormatTransformer.java
+++ b/java/code/src/com/redhat/rhn/common/util/DateFormatTransformer.java
@@ -45,11 +45,12 @@ public class DateFormatTransformer implements Transform<Date> {
     }
 
     /**
-     * Parses a datetime from XML format (e.g. 2017-02-22T10:23).
-     * @return a transformer for parsing YYYY-MM-dd'T'HH:mm
+     * Parses a datetime from XML format (e.g. 2017-02-22T10:23:55).
+     * See https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/text/SimpleDateFormat.html
+     * @return a transformer for parsing yyyy-MM-dd'T'HH:mm:ss
      */
     public static DateFormatTransformer createXmlDateTransformer() {
-        DateFormat dateFormat = new SimpleDateFormat("YYYY-MM-dd'T'HH:mm");
+        DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
         return new DateFormatTransformer(dateFormat);
     }
 }

--- a/java/code/webapp/WEB-INF/pages/systems/details/audit/xccdfdetails.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/details/audit/xccdfdetails.jsp
@@ -115,7 +115,8 @@
               <c:param name="name" value="${file.filename}" />
           </c:url>
           <a href="${fileUrl}"
-             target="${file.HTML ? '_blank' : '_self'}"><c:out value="${file.filename}"/></a> &nbsp;
+             target="${file.HTML ? '_blank' : '_self'}"
+             data-senna-off="true"><c:out value="${file.filename}"/></a> &nbsp;
         </c:forEach>
       </td>
     </tr>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Fix start/end timestamps for xccdf scan details (bsc#1186016)
+- Fix report links for SCAP Scans (bsc#1186017)
 - Fix the documentation for the parseReleaseFile method
 - Add group by clause to reduce the number of rows for groupAdvisoryTypes CTE to improve performance(bsc#1185015)
 - Drop stale libs for old not supported browsers


### PR DESCRIPTION
## What does this PR change?

Fixes the report links in `System` -> `Audit` -> `List Scans`
As well as the start/end timestamps displayed in `xccdf scan` details

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: **Bugfix**

- [x] **DONE**

## Test coverage

- No tests: **Bugfix**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/14895
Tracks https://github.com/SUSE/spacewalk/issues/14896

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
