### PR TITLE
Wait until products page is loaded

### DIFF
--- a/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
+++ b/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
@@ -11,7 +11,8 @@ Feature: Synchronize products in the products page of the Setup Wizard
 
   Scenario: Add Ubuntu 18.04
     When I follow the left menu "Admin > Setup Wizard > Products"
-    When I enter "Ubuntu 18.04" as the filtered product description
+    And I wait until I do not see "Loading" text
+    And I enter "Ubuntu 18.04" as the filtered product description
     And I select "Ubuntu 18.04" as a product
     Then I should see the "Ubuntu 18.04" selected
     When I click the Add Product button
@@ -19,7 +20,8 @@ Feature: Synchronize products in the products page of the Setup Wizard
 
   Scenario: Add Ubuntu 20.04
     When I follow the left menu "Admin > Setup Wizard > Products"
-    When I enter "Ubuntu 20.04" as the filtered product description
+    And I wait until I do not see "Loading" text
+    And I enter "Ubuntu 20.04" as the filtered product description
     And I select "Ubuntu 20.04" as a product
     Then I should see the "Ubuntu 20.04" selected
     When I click the Add Product button
@@ -27,7 +29,8 @@ Feature: Synchronize products in the products page of the Setup Wizard
 
   Scenario: SUSE Linux Enterprise Server 11 SP3
     When I follow the left menu "Admin > Setup Wizard > Products"
-    When I enter "SUSE Linux Enterprise Server 11 SP3 i586" as the filtered product description
+    And I wait until I do not see "Loading" text
+    And I enter "SUSE Linux Enterprise Server 11 SP3 i586" as the filtered product description
     And I select "SUSE Linux Enterprise Server 11 SP3 i586" as a product
     Then I should see the "SUSE Linux Enterprise Server 11 SP3 i586" selected
     When I click the Add Product button
@@ -36,10 +39,11 @@ Feature: Synchronize products in the products page of the Setup Wizard
 
   Scenario: SUSE Linux Enterprise Server 11 SP4
     When I follow the left menu "Admin > Setup Wizard > Products"
-    When I enter "SUSE Linux Enterprise Server 11 SP4" as the filtered product description
+    And I wait until I do not see "Loading" text
+    And I enter "SUSE Linux Enterprise Server 11 SP4" as the filtered product description
     And I select "SUSE Linux Enterprise Server 11 SP4 x86_64" as a product
     Then I should see the "SUSE Linux Enterprise Server 11 SP4 x86_64" selected
-    And I open the sub-list of the product "SUSE Linux Enterprise Server 11 SP4 x86_64"
+    When I open the sub-list of the product "SUSE Linux Enterprise Server 11 SP4 x86_64"
     And I select "SUSE Linux Enterprise Software Development Kit 11 SP4" as a product
     Then I should see the "SUSE Linux Enterprise Software Development Kit 11 SP4" selected
     When I click the Add Product button
@@ -48,7 +52,8 @@ Feature: Synchronize products in the products page of the Setup Wizard
 
   Scenario: SUSE Linux Enterprise Server 12 SP4
     When I follow the left menu "Admin > Setup Wizard > Products"
-    When I enter "SUSE Linux Enterprise Server 12 SP4" as the filtered product description
+    And I wait until I do not see "Loading" text
+    And I enter "SUSE Linux Enterprise Server 12 SP4" as the filtered product description
     And I select "SUSE Linux Enterprise Server 12 SP4 x86_64" as a product
     Then I should see the "SUSE Linux Enterprise Server 12 SP4 x86_64" selected
     When I open the sub-list of the product "SUSE Linux Enterprise Server 12 SP4 x86_64"
@@ -59,19 +64,21 @@ Feature: Synchronize products in the products page of the Setup Wizard
 
   Scenario: SUSE Linux Enterprise Server 15
     When I follow the left menu "Admin > Setup Wizard > Products"
-    When I enter "SUSE Linux Enterprise Server 15" as the filtered product description
+    And I wait until I do not see "Loading" text
+    And I enter "SUSE Linux Enterprise Server 15" as the filtered product description
     And I select "SUSE Linux Enterprise Server 15 x86_64" as a product
     Then I should see the "SUSE Linux Enterprise Server 15 x86_64" selected
     When I open the sub-list of the product "SUSE Linux Enterprise Server 15 x86_64"
     Then I should see the "SUSE Linux Enterprise Server 15 x86_64" selected
-    And I select "SUSE Linux Enterprise Server LTSS 15 x86_64" as a product
+    When I select "SUSE Linux Enterprise Server LTSS 15 x86_64" as a product
     Then I should see the "SUSE Linux Enterprise Server LTSS 15 x86_64" selected
     When I click the Add Product button
     And I wait until I see "SUSE Linux Enterprise Server 15 x86_64" product has been added
 
   Scenario: SUSE Linux Enterprise Server 15 SP1
     When I follow the left menu "Admin > Setup Wizard > Products"
-    When I enter "SUSE Linux Enterprise Server 15 SP1" as the filtered product description
+    And I wait until I do not see "Loading" text
+    And I enter "SUSE Linux Enterprise Server 15 SP1" as the filtered product description
     And I select "SUSE Linux Enterprise Server 15 SP1 x86_64" as a product
     Then I should see the "SUSE Linux Enterprise Server 15 SP1 x86_64" selected
     When I click the Add Product button
@@ -79,7 +86,8 @@ Feature: Synchronize products in the products page of the Setup Wizard
 
   Scenario: SUSE Linux Enterprise Server 15 SP2
     When I follow the left menu "Admin > Setup Wizard > Products"
-    When I enter "SUSE Linux Enterprise Server 15 SP2" as the filtered product description
+    And I wait until I do not see "Loading" text
+    And I enter "SUSE Linux Enterprise Server 15 SP2" as the filtered product description
     And I select "SUSE Linux Enterprise Server 15 SP2 x86_64" as a product
     Then I should see the "SUSE Linux Enterprise Server 15 SP2 x86_64" selected
     When I open the sub-list of the product "SUSE Linux Enterprise Server 15 SP2 x86_64"
@@ -94,7 +102,8 @@ Feature: Synchronize products in the products page of the Setup Wizard
 
   Scenario: SUSE Linux Enterprise Server 15 SP3
     When I follow the left menu "Admin > Setup Wizard > Products"
-    When I enter "SUSE Linux Enterprise Server 15 SP3 x86_64 (BETA)" as the filtered product description
+    And I wait until I do not see "Loading" text
+    And I enter "SUSE Linux Enterprise Server 15 SP3 x86_64 (BETA)" as the filtered product description
     And I select "SUSE Linux Enterprise Server 15 SP3 x86_64 (BETA)" as a product
     Then I should see the "SUSE Linux Enterprise Server 15 SP3 x86_64 (BETA)" selected
     When I open the sub-list of the product "SUSE Linux Enterprise Server 15 SP3 x86_64 (BETA)"
@@ -110,7 +119,8 @@ Feature: Synchronize products in the products page of the Setup Wizard
 
   Scenario: SUSE Linux Enterprise Server with Expanded Support 7
     When I follow the left menu "Admin > Setup Wizard > Products"
-    When I enter "SUSE Linux Enterprise Server with Expanded Support 7" as the filtered product description
+    And I wait until I do not see "Loading" text
+    And I enter "SUSE Linux Enterprise Server with Expanded Support 7" as the filtered product description
     And I select "SUSE Linux Enterprise Server with Expanded Support 7" as a product
     Then I should see the "SUSE Linux Enterprise Server with Expanded Support 7" selected
     When I click the Add Product button
@@ -118,7 +128,8 @@ Feature: Synchronize products in the products page of the Setup Wizard
 
   Scenario: SUSE Linux Enterprise Server with Expanded Support 8
     When I follow the left menu "Admin > Setup Wizard > Products"
-    When I enter "RHEL or SLES ES or CentOS 8 Base" as the filtered product description
+    And I wait until I do not see "Loading" text
+    And I enter "RHEL or SLES ES or CentOS 8 Base" as the filtered product description
     And I select "RHEL or SLES ES or CentOS 8 Base" as a product
     Then I should see the "RHEL or SLES ES or CentOS 8 Base" selected
     When I open the sub-list of the product "RHEL or SLES ES or CentOS 8 Base"
@@ -129,7 +140,8 @@ Feature: Synchronize products in the products page of the Setup Wizard
 
   Scenario: SUSE Manager Proxy 4.2 x86_64
     When I follow the left menu "Admin > Setup Wizard > Products"
-    When I enter "SUSE Manager Proxy 4.2 x86_64" as the filtered product description
+    And I wait until I do not see "Loading" text
+    And I enter "SUSE Manager Proxy 4.2 x86_64" as the filtered product description
     And I select "SUSE Manager Proxy 4.2 x86_64" as a product
     Then I should see the "SUSE Manager Proxy 4.2 x86_64" selected
     When I click the Add Product button
@@ -138,7 +150,8 @@ Feature: Synchronize products in the products page of the Setup Wizard
 
   Scenario: SUSE Manager Retail Branch Server 4.2 x86_64
     When I follow the left menu "Admin > Setup Wizard > Products"
-    When I enter "SUSE Manager Retail Branch Server 4.2 x86_64" as the filtered product description
+    And I wait until I do not see "Loading" text
+    And I enter "SUSE Manager Retail Branch Server 4.2 x86_64" as the filtered product description
     And I select "SUSE Manager Retail Branch Server 4.2 x86_64" as a product
     Then I should see the "SUSE Manager Retail Branch Server 4.2 x86_64" selected
     When I click the Add Product button

--- a/testsuite/features/reposync/srv_sync_products.feature
+++ b/testsuite/features/reposync/srv_sync_products.feature
@@ -15,6 +15,7 @@ Feature: Synchronize products in the products page of the Setup Wizard
 @scc_credentials
   Scenario: Use the products and architecture filters
     When I follow the left menu "Admin > Setup Wizard > Products"
+    And I wait until I do not see "Loading" text
     And I enter "RHEL7" as the filtered product description
     Then I should see a "RHEL7 Base" text
     When I select "x86_64" in the dropdown list of the architecture filter
@@ -23,7 +24,8 @@ Feature: Synchronize products in the products page of the Setup Wizard
 @scc_credentials
   Scenario: View the channels list in the products page
     When I follow the left menu "Admin > Setup Wizard > Products"
-    When I enter "SUSE Linux Enterprise Server for SAP Applications 15 x86_64" as the filtered product description
+    And I wait until I do not see "Loading" text
+    And I enter "SUSE Linux Enterprise Server for SAP Applications 15 x86_64" as the filtered product description
     And I click the channel list of product "SUSE Linux Enterprise Server for SAP Applications 15 x86_64"
     Then I should see a "Product Channels" text
     And I should see a "Mandatory Channels" text
@@ -33,8 +35,9 @@ Feature: Synchronize products in the products page of the Setup Wizard
 @scc_credentials
   Scenario: Add a product and one of its modules
     When I follow the left menu "Admin > Setup Wizard > Products"
-    When I enter "SUSE Linux Enterprise Server 12 SP5" as the filtered product description
-    Then I wait until I see "SUSE Linux Enterprise Server 12 SP5 x86_64" text
+    And I wait until I do not see "Loading" text
+    And I enter "SUSE Linux Enterprise Server 12 SP5" as the filtered product description
+    And I wait until I see "SUSE Linux Enterprise Server 12 SP5 x86_64" text
     And I select "SUSE Linux Enterprise Server 12 SP5 x86_64" as a product
     Then I should see the "SUSE Linux Enterprise Server 12 SP5 x86_64" selected
     When I open the sub-list of the product "SUSE Linux Enterprise Server 12 SP5 x86_64"
@@ -49,8 +52,9 @@ Feature: Synchronize products in the products page of the Setup Wizard
 @scc_credentials
   Scenario: Add the initial product for the service pack migration
     When I follow the left menu "Admin > Setup Wizard > Products"
-    When I enter "SUSE Linux Enterprise Server 15 SP1" as the filtered product description
-    Then I wait until I see "SUSE Linux Enterprise Server 15 SP1 x86_64" text
+    And I wait until I do not see "Loading" text
+    And I enter "SUSE Linux Enterprise Server 15 SP1" as the filtered product description
+    And I wait until I see "SUSE Linux Enterprise Server 15 SP1 x86_64" text
     And I open the sub-list of the product "SUSE Linux Enterprise Server 15 SP1 x86_64"
     Then I should see a "Basesystem Module 15 SP1 x86_64" text
     When I select "SUSE Linux Enterprise Server 15 SP1 x86_64" as a product
@@ -61,8 +65,9 @@ Feature: Synchronize products in the products page of the Setup Wizard
 @scc_credentials
   Scenario: Add a product with recommended enabled
     When I follow the left menu "Admin > Setup Wizard > Products"
-    When I enter "SUSE Linux Enterprise Server 15 SP2" as the filtered product description
-    Then I wait until I see "SUSE Linux Enterprise Server 15 SP2 x86_64" text
+    And I wait until I do not see "Loading" text
+    And I enter "SUSE Linux Enterprise Server 15 SP2" as the filtered product description
+    And I wait until I see "SUSE Linux Enterprise Server 15 SP2 x86_64" text
     And I open the sub-list of the product "SUSE Linux Enterprise Server 15 SP2 x86_64"
     Then I should see a "Basesystem Module 15 SP2 x86_64" text
     And I should see that the "Basesystem Module 15 SP2 x86_64" product is "recommended"
@@ -71,8 +76,8 @@ Feature: Synchronize products in the products page of the Setup Wizard
     And I open the sub-list of the product "Basesystem Module 15 SP2 x86_64"
     And I deselect "SUSE Manager Client Tools Beta for SLE 15 x86_64 (BETA)" as a SUSE Manager product
     Then I should see the "SUSE Linux Enterprise Server 15 SP2 x86_64" selected
-    Then I should see the "Basesystem Module 15 SP2 x86_64" selected
-    And I click the Add Product button
+    And I should see the "Basesystem Module 15 SP2 x86_64" selected
+    When I click the Add Product button
     And I wait until I see "SUSE Linux Enterprise Server 15 SP2 x86_64" product has been added
     Then the SLE15 SP2 product should be added
 


### PR DESCRIPTION
## What does this PR change?

We get sometimes failures, especially in the build validation test suite, when products page had not the time to finish loading.

![image](https://user-images.githubusercontent.com/1932575/118636358-e81b8700-b7d4-11eb-9665-14acbec29e92.png)

This PR waits until the "Loading" text has gone. It also cleans up the `When`/`Then`/`And` sequence in the affected files.

Note: it might be we need to add `, refreshing the page` clause in a second PR. That was impossible for me to test.


## Links

Ports:
* 4.0: SUSE/spacewalk#14915
* 4.1: SUSE/spacewalk#14913


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
