### PR TITLE
Fix for GPG checking on synchonizing mirrored dpkg repo (bsc#1184351)

### DIFF
--- a/backend/common/repo.py
+++ b/backend/common/repo.py
@@ -300,9 +300,11 @@ class DpkgRepo:
         release_file = None
         if os.access(self._get_parent_url(local_path, 2, "InRelease"), os.R_OK):
             release_file = self._get_parent_url(local_path, 2, "InRelease")
+            local_path = self._get_parent_url(local_path, 2)
             self._flat = False
         elif os.access(self._get_parent_url(local_path, 2, "Release"), os.R_OK):
             release_file = self._get_parent_url(local_path, 2, "Release")
+            local_path = self._get_parent_url(local_path, 2)
             self._flat = False
         else:
             self._flat = True

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,5 @@
+- Fix for GPG checking on synchonizing mirrored dpkg repo (bsc#1184351)
+
 -------------------------------------------------------------------
 Wed May 05 16:32:29 CEST 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Fixes GPG checking on synchronizing mirrored dpkg repo.
The following traceback appears on synchronizing mirrored dpkg repo if GPG check is enabled:
```
2021/04/02 04:14:00 +02:00 Unhandled error occurred: [Errno 2] No such file or directory: '/mirror/repo/RPMMD/ubuntu-2004-amd64-universe/Packages.gz'
2021/04/02 04:14:00 +02:00 Unexpected error: <class 'FileNotFoundError'>
2021/04/02 04:14:00 +02:00 Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/spacewalk/satellite_tools/reposync.py", line 572, in sync
    client_key_file=client_key_file)
  File "/usr/lib/python3.6/site-packages/spacewalk/satellite_tools/repo_plugins/deb_src.py", line 277, in __init__
    self.repo.verify()
  File "/usr/lib/python3.6/site-packages/spacewalk/satellite_tools/repo_plugins/deb_src.py", line 121, in verify
    if not repo.DpkgRepo(self.url, self._get_proxies(), self.gpg_verify).verify_packages_index():
  File "/usr/lib/python3.6/site-packages/spacewalk/common/repo.py", line 394, in verify_packages_index
    name, data = self.get_pkg_index_raw()
  File "/usr/lib/python3.6/site-packages/spacewalk/common/repo.py", line 114, in get_pkg_index_raw
    with open(packages_url.replace("file://", ""), "rb") as f:
FileNotFoundError: [Errno 2] No such file or directory: '/mirror/repo/RPMMD/ubuntu-2004-amd64-universe/Packages.gz'
```

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Links

Fixes https://github.com/SUSE/spacewalk/issues/14482

## Changelogs

- Fix for GPG checking on synchonizing mirrored dpkg repo (bsc#1184351)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "susemanager_unittests"
