### PR TITLE
Let spacecmd parse empty|null parameters

### DIFF
--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,5 @@
+- Parse empty argument when nothing in between the separator
+
 -------------------------------------------------------------------
 Wed May 05 16:31:43 CEST 2021 - jgonzalez@suse.com
 

--- a/spacecmd/src/spacecmd/utils.py
+++ b/spacecmd/src/spacecmd/utils.py
@@ -626,12 +626,13 @@ def parse_list_str(list_s, sep=","):
     simple parser for a list of items separated with "," (comma) or given
     separator chars.
 
-    >>> assert parse_list_str("") == []
+    >>> assert parse_list_str("") == [""]
     >>> assert parse_list_str("a,b") == ["a", "b"]
-    >>> assert parse_list_str("a,b,") == ["a", "b"]
-    >>> assert parse_list_str("a:b:", ":") == ["a", "b"]
+    >>> assert parse_list_str("a,b,") == ["a", "b", ""]
+    >>> assert parse_list_str("a,,b,c") == ["a", "", "b", "c"]
+    >>> assert parse_list_str("a:b:", ":") == ["a", "b", ""]
     """
-    return [p for p in list_s.split(sep) if p]
+    return [p for p in list_s.split(sep)]
 
 
 def parse_api_args(args, sep=','):

--- a/spacecmd/tests/test_utils.py
+++ b/spacecmd/tests/test_utils.py
@@ -501,10 +501,11 @@ class TestSCUtils:
         :return:
         """
 
-        assert spacecmd.utils.parse_list_str("") == []
+        assert spacecmd.utils.parse_list_str("") == [""]
         assert spacecmd.utils.parse_list_str("a,b") == ["a", "b"]
-        assert spacecmd.utils.parse_list_str("a,b,") == ["a", "b"]
-        assert spacecmd.utils.parse_list_str("a:b:", ":") == ["a", "b"]
+        assert spacecmd.utils.parse_list_str("a,b,") == ["a", "b", ""]
+        assert spacecmd.utils.parse_list_str("a,,b,c") == ["a", "", "b", "c"]
+        assert spacecmd.utils.parse_list_str("a:b:", ":") == ["a", "b", ""]
 
     def test_parse_api_args(self):
         """


### PR DESCRIPTION
https://github.com/uyuni-project/uyuni/issues/3525

## What does this PR change?

Let `spacecmd` parse empty arguments when there is nothing between the _item list separator_ . 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: 

- [x] **DONE**

## Test coverage
- No tests: adapted and added

- [x] **DONE**

## Links

Fixes # https://github.com/uyuni-project/uyuni/issues/3525
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
