### PR TITLE
Add tagged template support to test-util `t()`

### DIFF
--- a/web/html/src/jest.config.js
+++ b/web/html/src/jest.config.js
@@ -17,5 +17,5 @@ module.exports = {
   },
   modulePaths: ["<rootDir>"],
   moduleDirectories: ["node_modules"],
-  setupFiles: ["./utils/test-utils/setup.ts"],
+  setupFiles: ["./utils/test-utils/setup/index.ts"],
 };

--- a/web/html/src/tsconfig.json
+++ b/web/html/src/tsconfig.json
@@ -28,7 +28,9 @@
       "dom",
       "dom.iterable",
       "es2019.array",
-      "es2019.object"
+      "es2019.object",
+      // For: String.replaceAll()
+      "ESNext.String"
     ],
     "strict": true,
     // Should eventually be false

--- a/web/html/src/utils/test-utils/setup/index.ts
+++ b/web/html/src/utils/test-utils/setup/index.ts
@@ -1,10 +1,11 @@
 import "manager/polyfills";
 import jQuery from "jquery";
+import t from "./t";
 
 // Allows us to mock and test the existing network layer easily
 global.jQuery = jQuery;
 
-global.t = string => string;
+global.t = t;
 
 global.Loggerhead = {
   error: string => {

--- a/web/html/src/utils/test-utils/setup/t.test.ts
+++ b/web/html/src/utils/test-utils/setup/t.test.ts
@@ -1,0 +1,15 @@
+import t from "./t";
+
+describe("test-utils t()", () => {
+  test("passthrough", () => {
+    expect(t("foo")).toEqual("foo");
+    expect(t("undefined")).toEqual("undefined");
+    expect(t("")).toEqual("");
+  });
+
+  test("tagged templates", () => {
+    expect(t("foo {0} tea {1}", "bar", "cup")).toEqual("foo bar tea cup");
+    expect(t("foo {0} tea {1}", undefined, 123)).toEqual("foo undefined tea 123");
+    expect(t("foo {0} tea {1}", "", "")).toEqual("foo  tea ");
+  });
+});

--- a/web/html/src/utils/test-utils/setup/t.ts
+++ b/web/html/src/utils/test-utils/setup/t.ts
@@ -1,0 +1,4 @@
+/** Mimic the translation function `t()`, this doesn't match the full functionality but should suffice for tests */
+export default function t(template: string, ...substitutions: any[]): string {
+  return template.replaceAll(/{(\d)}/g, (_, match: string) => substitutions[match]);
+}

--- a/web/html/src/utils/test-utils/setup/t.ts
+++ b/web/html/src/utils/test-utils/setup/t.ts
@@ -1,4 +1,4 @@
 /** Mimic the translation function `t()`, this doesn't match the full functionality but should suffice for tests */
-export default function t(template: string, ...substitutions: any[]): string {
+export default function t(template: string = "", ...substitutions: any[]): string {
   return template.replaceAll(/{(\d)}/g, (_, match: string) => substitutions[match]);
 }


### PR DESCRIPTION
## What does this PR change?

Previously our JS unit test setup only supported `t()` as a simple identity function, this PR adds support for tagged templates.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
