### PR TITLE
virtual console: update JWT token before it expires

### DIFF
--- a/web/html/src/manager/virtualization/nets/network-properties.js
+++ b/web/html/src/manager/virtualization/nets/network-properties.js
@@ -434,7 +434,7 @@ export function NetworkProperties(props: Props) {
                         value => Object.values(value).every(item =>
                           typeof item === "string" && (item === "" || item.match(/^[0-9]+$/))),
                         ({nat_port_start, nat_port_end}) => (nat_port_start === "" && nat_port_end === "") ||
-                          parseInt(nat_port_start) <= parseInt(nat_port_end),
+                          parseInt(nat_port_start, 10) <= parseInt(nat_port_end, 10),
                       ]}
                       invalidHint={t('Both values has to be positive integers')}
                     />

--- a/web/html/src/manager/virtualization/nets/virtualization-network-devs-api.js
+++ b/web/html/src/manager/virtualization/nets/virtualization-network-devs-api.js
@@ -22,10 +22,10 @@ export function VirtualizationNetworkDevsApi(props: Props) {
         }
       }, (xhr) => {
         const errMessages = xhr.status === 0
-          ? [Messages.Utils.error(
+          ? Messages.Utils.error(
             t('Could not get network devices from the server. Please try again.'),
-          )]
-          : [Messages.Utils.error(Network.errorMessageByStatus(xhr.status))];
+          )
+          : Messages.Utils.error(Network.errorMessageByStatus(xhr.status));
         setMessages(errMessages);
       });
     return () => {subscribded = false};

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Refresh JWT virtual console token before it expires
 - Drop stale libs for old not supported browsers
 - Fix date-time picker radio controls (bsc#1185968)
 


### PR DESCRIPTION
## What does this PR change?

Update the JWT token before it expires in the virtual machine graphical console. This avoids authentication errors when refreshing it after it expired.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
