### PR TITLE
Do not render the section toolbar if nothing is expected

### DIFF
--- a/web/html/src/components/panels/InnerPanel.tsx
+++ b/web/html/src/components/panels/InnerPanel.tsx
@@ -5,26 +5,41 @@ import { SectionToolbar } from "components/section-toolbar/section-toolbar";
 type Props = {
   title: string;
   icon: string;
-  buttons: React.ReactNode;
-  buttonsLeft?: React.ReactNode;
+  buttons: React.ReactNode[];
+  buttonsLeft?: React.ReactNode[];
   children: React.ReactNode;
 };
 
 function InnerPanel(props: Props) {
+  let toolbar;
+
+  if (props.buttons?.length > 0 || props.buttonsLeft?.length !== 0) {
+    toolbar =
+      <SectionToolbar>
+        {
+          props.buttonsLeft?.length !== 0 ?
+            <div className="selector-button-wrapper">
+              <div className="btn-group">{props.buttonsLeft}</div>
+            </div>
+            : null
+        }
+        {
+          props.buttons?.length > 0 ?
+            <div className="action-button-wrapper">
+              <div className="btn-group">{props.buttons}</div>
+            </div>
+            : null
+        }
+      </SectionToolbar>;
+  }
+
   return (
     <div>
       <h2>
         <i className={`fa ${props.icon}`} />
         {props.title}
       </h2>
-      <SectionToolbar>
-        <div className="selector-button-wrapper">
-          <div className="btn-group">{props.buttonsLeft}</div>
-        </div>
-        <div className="action-button-wrapper">
-          <div className="btn-group">{props.buttons}</div>
-        </div>
-      </SectionToolbar>
+      { toolbar }
       <div className="row">
         <div className="panel panel-default">
           <div className="panel-body">{props.children}</div>

--- a/web/html/src/manager/maintenance/list/maintenance-windows-list.tsx
+++ b/web/html/src/manager/maintenance/list/maintenance-windows-list.tsx
@@ -18,7 +18,7 @@ type MaintenanceListProps = {
 const MaintenanceWindowsList = (props: MaintenanceListProps) => {
   const [type] = useState(props.type);
 
-  const createButton = [
+  const buttons = [
     <div className="btn-group pull-right">
       <Button
         className="btn-default"
@@ -36,7 +36,7 @@ const MaintenanceWindowsList = (props: MaintenanceListProps) => {
       <InnerPanel
         title={t("Maintenance") + " " + (type === "schedule" ? t("Schedules") : t("Calendars"))}
         icon="spacewalk-icon-schedule"
-        buttons={createButton}
+        buttons={buttons}
       >
         <div className="panel panel-default">
           <div className="panel-heading">

--- a/web/html/src/manager/minion/ansible/schedule-playbook.tsx
+++ b/web/html/src/manager/minion/ansible/schedule-playbook.tsx
@@ -92,12 +92,12 @@ export default function SchedulePlaybook({ playbook, onBack }: SchedulePlaybookP
 
   const inventoryOpts: ComboboxItem[] = inventories.map((inv, i) => ({ id: i, text: inv }));
 
-  const buttons = (
+  const buttons = [
     <div className="btn-group pull-right">
       <Button icon="fa-angle-left" className="btn-default" text={t("Back")} title={t("Back to playbook list")} handler={onBack} />
       <AsyncButton defaultType="btn-success" action={schedule} title={t("Schedule playbook execution")} text={t("Schedule")} />
-    </div>
-  );
+    </div>,
+  ];
 
   return (
     <>

--- a/web/html/src/manager/state/recurring-states-list.tsx
+++ b/web/html/src/manager/state/recurring-states-list.tsx
@@ -52,7 +52,7 @@ class RecurringStatesList extends React.Component<Props, State> {
   }
 
   render() {
-    const createButton = [
+    const buttons = [
       <div className="btn-group pull-right">
         <Button
           className="btn-default"
@@ -69,7 +69,7 @@ class RecurringStatesList extends React.Component<Props, State> {
         <InnerPanel
           title={t("Recurring States")}
           icon="spacewalk-icon-salt"
-          buttons={this.props.disableCreate ? null : createButton}
+          buttons={this.props.disableCreate ? [] : buttons}
         >
           <div className="panel panel-default">
             <div className="panel-heading">


### PR DESCRIPTION
## What does this PR change?

Hide the `Spacewalk Section Toolbar` if it has no children to render

## GUI diff

Before:
![image](https://user-images.githubusercontent.com/7080830/118798237-b7ebeb00-b89d-11eb-83f8-34fb65e16cdc.png)

After:
![Screenshot from 2021-05-19 12-29-02](https://user-images.githubusercontent.com/7080830/118798333-cfc36f00-b89d-11eb-8d7f-bdfc8927db48.png)


- [x] **DONE**

## Documentation
- No documentation needed: bugfix

- [x] **DONE**

## Test coverage
- No tests: UI bugfix

- [x] **DONE**

## Links

Fixes # https://github.com/SUSE/spacewalk/issues/13756
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
