### PR TITLE
Do not install "python2-salt" on Docker build hosts with Salt 3002.2 (bsc#1185506)

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/services/docker.sls
+++ b/susemanager-utils/susemanager-sls/salt/services/docker.sls
@@ -15,7 +15,7 @@ mgr_install_docker:
 {%- endif %}
 {%- if grains['saltversioninfo'][0] >= 2018 %}
       - python3-salt
-    {%- if salt['pkg.info_available']('python-Jinja2', 'python2-Jinja2') and salt['pkg.info_available']('python', 'python2') and salt['pkg.info_available']('python2-salt') %}
+    {%- if grains['saltversioninfo'][0] < 3002 and salt['pkg.info_available']('python-Jinja2', 'python2-Jinja2') and salt['pkg.info_available']('python', 'python2') and salt['pkg.info_available']('python2-salt') %}
       - python2-salt
     {%- endif %}
 {%- endif %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Do not install python2-salt on Salt 3002.2 Docker build hosts (bsc#1185506)
 - Add support for 'disable_local_repos' salt minion config parameter
   (bsc#1185568)
 


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue when applying a "highstate" on a container build host that is using Salt 3002.2, where `python2-salt` shouldn't be marked to be installed (as it's not longer built):

The following error can be found at the zypper.log of the buildhost:

```
2021-04-30 15:00:42 <1> suma-40-min-build(31002) [zypp::solver] SATResolver.cc(problems):1687 Encountered problems! Here are the solutions:
2021-04-30 15:00:42 <1> suma-40-min-build(31002) [zypp::solver] SATResolver.cc(problems):1687 
2021-04-30 15:00:42 <1> suma-40-min-build(31002) [zypp::solver] SATResolver.cc(problems):1691 Problem 1:
2021-04-30 15:00:42 <1> suma-40-min-build(31002) [zypp::solver] SATResolver.cc(problems):1692 ====================================
2021-04-30 15:00:42 <1> suma-40-min-build(31002) [zypp::solver] SATResolver.cc(problems):1696 nothing provides salt = 3000-5.112.1 needed by python2-salt-3000-5.112.1.x86_64
2021-04-30 15:00:42 <1> suma-40-min-build(31002) [zypp::solver] SATResolver.cc(problems):1697 ------------------------------------
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/14806

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
