### PR TITLE
Allow Xen Dom0 to have virthost entitlement

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/entitlement/VirtualizationEntitlement.java
+++ b/java/code/src/com/redhat/rhn/domain/entitlement/VirtualizationEntitlement.java
@@ -19,6 +19,8 @@ import com.redhat.rhn.manager.entitlement.EntitlementManager;
 
 import com.suse.manager.reactor.utils.ValueMap;
 
+import org.apache.commons.lang3.StringUtils;
+
 
 /**
  * VirtualizationEntitlement
@@ -63,7 +65,22 @@ public class VirtualizationEntitlement extends Entitlement {
      * {@inheritDoc}
      */
     public boolean isAllowedOnServer(Server server, ValueMap grains) {
-        return super.isAllowedOnServer(server) &&
-                grains.getOptionalAsString("virtual").orElse("physical").equals("physical");
+        String type = grains.getOptionalAsString("virtual").orElse("physical");
+        String subtype = grains.getOptionalAsString("virtual_subtype").orElse("");
+        return super.isAllowedOnServer(server) && !isVirtualGuest(type, subtype);
+    }
+
+    /**
+     * Returns whether a system is a virtual guest or not according to its virtual and virtual_subtype grains.
+     *
+     * @param virtTypeLowerCase the virtual grain value
+     * @param virtSubtype the virtual_subtype grain value
+     *
+     * @return if the system is virtual
+     */
+    public static boolean isVirtualGuest(String virtTypeLowerCase, String virtSubtype) {
+        return StringUtils.isNotBlank(virtTypeLowerCase) &&
+                !"physical".equals(virtTypeLowerCase) &&
+                !("xen".equals(virtTypeLowerCase) && "Xen Dom0".equals(virtSubtype));
     }
 }

--- a/java/code/src/com/suse/manager/reactor/hardware/HardwareMapper.java
+++ b/java/code/src/com/suse/manager/reactor/hardware/HardwareMapper.java
@@ -15,6 +15,7 @@
 package com.suse.manager.reactor.hardware;
 
 import com.redhat.rhn.GlobalInstanceHolder;
+import com.redhat.rhn.domain.entitlement.VirtualizationEntitlement;
 import com.redhat.rhn.domain.org.OrgFactory;
 import com.redhat.rhn.domain.scc.SCCCachingFactory;
 import com.redhat.rhn.domain.server.CPU;
@@ -533,15 +534,6 @@ public class HardwareMapper {
         }
     }
 
-    private boolean isVirtualGuest(String virtTypeLowerCase, String virtSubtype) {
-        if (StringUtils.isNotBlank(virtTypeLowerCase) &&
-                !"physical".equals(virtTypeLowerCase) &&
-                !("xen".equals(virtTypeLowerCase) && "Xen Dom0".equals(virtSubtype))) {
-            return true;
-        }
-        return false;
-    }
-
     /**
      * Map PAYG information for the server to the database.
      */
@@ -586,7 +578,7 @@ public class HardwareMapper {
 
         VirtualInstanceType type = null;
 
-        if (isVirtualGuest(virtTypeLowerCase, virtSubtype)) {
+        if (VirtualizationEntitlement.isVirtualGuest(virtTypeLowerCase, virtSubtype)) {
             if (StringUtils.isNotBlank(virtUuid)) {
 
                 virtUuid = StringUtils.remove(virtUuid, '-');

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Allow virtualization host entitlement on Xen Dom0 (bsc#1185522)
 - Fix start/end timestamps for xccdf scan details (bsc#1186016)
 - Fix report links for SCAP Scans (bsc#1186017)
 - Fix the documentation for the parseReleaseFile method


### PR DESCRIPTION
## What does this PR change?

A Xen virtualization host has the `virtual` grain set to `xen` and an
additional `virtual_subtype` set to `Xen Dom0`. Handle this case when
checking if the virtualization host entitlement is allowed.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: would be too heavy to add

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/14807

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
