### PR TITLE
Install proxy after bootstrap and after refreshing metadata

### DIFF
--- a/testsuite/features/build_validation/init_clients/proxy.feature
+++ b/testsuite/features/build_validation/init_clients/proxy.feature
@@ -13,12 +13,6 @@ Feature: Setup SUSE Manager proxy
   Scenario: Clean up sumaform leftovers on a SUSE Manager proxy
     When I perform a full salt minion cleanup on "proxy"
 
-  Scenario: Install proxy software
-    # uncomment when product is out:
-    # When I install "SUSE-Manager-Proxy" product on the proxy
-    And I install proxy pattern on the proxy
-    And I let squid use avahi on the proxy
-
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
@@ -34,12 +28,15 @@ Feature: Setup SUSE Manager proxy
     And I wait until I see "Successfully bootstrapped host!" text
     And I wait until onboarding is completed for "proxy"
 
-  # bsc#1085436 - Apache returns 403 Forbidden after a zypper refresh on minion
-  Scenario: Check the new channel for proxy is working
-    When I refresh the metadata for "proxy"
-
   Scenario: Detect latest Salt changes on the proxy
     When I query latest Salt changes on "proxy"
+
+  Scenario: Install proxy software
+    When I refresh the metadata for "proxy"
+    # uncomment when product is out:
+    # When I install "SUSE-Manager-Proxy" product on the proxy
+    And I install proxy pattern on the proxy
+    And I let squid use avahi on the proxy
 
   Scenario: Copy the keys and configure the proxy
     When I copy server's keys to the proxy


### PR DESCRIPTION
## What does this PR change?

Follow-up of #3487

Installing proxy's software should happen after the bootstrap, so we pick the packages from the server.


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
