### PR TITLE
Fix deleting stopped virtual network

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/virt/network-statechange.sls
+++ b/susemanager-utils/susemanager-sls/salt/virt/network-statechange.sls
@@ -5,15 +5,20 @@ mgr_network_{{ pillar['network_state'] }}:
     - m_name: {{ pillar['network_name'] }}
 
 {% else %}
+  {%- set net_info = salt.virt.network_info(pillar['network_name'])[pillar['network_name']] %}
+  {%- if net_info["active"] == 1 %}
 mgr_network_stop:
   mgrcompat.module_run:
     - name: virt.network_stop
     - m_name: {{ pillar['network_name'] }}
+  {%- endif %}
 
 mgr_network_delete:
   mgrcompat.module_run:
     - name: virt.network_undefine
     - m_name: {{ pillar['network_name'] }}
+  {%- if net_info["active"] == 1 %}
     - require:
         - mgrcompat: mgr_network_stop
+  {%- endif %}
 {% endif %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Fix deleting stopped virtual network (bsc#1186281)
 - Add support for 'disable_local_repos' salt minion config parameter
   (bsc#1185568)
 


### PR DESCRIPTION
## What does this PR change?

Don't fail when deleting a virtual network that is stopped.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: would require more cucumber tests that almost duplicate existing ones.

- [X] **DONE**

## Links

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1186281

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
