### PR TITLE
QA: Add Universe repository for Ubuntu in Openscap test

### DIFF
--- a/testsuite/features/secondary/min_ubuntu_openscap_audit.feature
+++ b/testsuite/features/secondary/min_ubuntu_openscap_audit.feature
@@ -12,11 +12,10 @@ Feature: OpenSCAP audit of Ubuntu Salt minion
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
-@ubuntu_minion
-  Scenario: Install the client tools packages on the Ubuntu minion
-    When I enable client tools repositories on "ubuntu_minion"
+  Scenario: Enable all the necessary repositories for OpenSCAP on Ubuntu minion
+    When I enable Ubuntu "universe" repository on "ubuntu_minion"
+    And I enable client tools repositories on "ubuntu_minion"
 
-@ubuntu_minion
   Scenario: Install the OpenSCAP packages on the Ubuntu minion
     Given I am on the Systems overview page of this "ubuntu_minion"
     When I refresh the metadata for "ubuntu_minion"
@@ -76,6 +75,6 @@ Feature: OpenSCAP audit of Ubuntu Salt minion
   Scenario: Cleanup: remove the OpenSCAP packages from the Ubuntu minion
     When I remove OpenSCAP dependencies from "ubuntu_minion"
 
-@ubuntu_minion
-  Scenario: Cleanup: remove the client tools packages on the Ubuntu minion
+  Scenario: Cleanup: remove all the necessary repositories for OpenSCAP on Ubuntu minion
     When I disable client tools repositories on "ubuntu_minion"
+    And I disable Ubuntu "universe" repository on "ubuntu_minion"

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -781,6 +781,14 @@ When(/^I migrate the non-SUMA repositories on "([^"]*)"$/) do |host|
   # node.run('salt-call state.apply channels.disablelocalrepos') does not work
 end
 
+When(/^I (enable|disable) Ubuntu "([^"]*)" repository on "([^"]*)"$/) do |action, repo, host|
+  node = get_target(host)
+  _os_version, os_family = get_os_version(node)
+  raise "#{node.hostname} is not a Ubuntu host." unless os_family =~ /^ubuntu/
+
+  node.run("sudo add-apt-repository -y -u #{action == 'disable' ? '--remove' : ''} #{repo}")
+end
+
 When(/^I (enable|disable) (the repositories|repository) "([^"]*)" on this "([^"]*)"((?: without error control)?)$/) do |action, _optional, repos, host, error_control|
   node = get_target(host)
   _os_version, os_family = get_os_version(node)


### PR DESCRIPTION
## What does this PR change?

This PR enables the Universe repository in the OpenScap test for Ubuntu.
As for Uyuni, the libopenscap8 is only available there.
In SUMA we have it available from the client tools, but in any case, we will not make a difference here and we will enable this repository for both cases.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.0
- Manager-4.1

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
