### PR TITLE
QA: Enforce a check to have OpenSCAP available before start using it

### DIFF
--- a/testsuite/features/secondary/min_centos_openscap_audit.feature
+++ b/testsuite/features/secondary/min_centos_openscap_audit.feature
@@ -21,13 +21,13 @@ Feature: OpenSCAP audit of CentOS Salt minion
     And I fix CentOS 7 OpenSCAP files on "ceos_minion"
     And I follow "Software" in the content area
     And I click on "Update Package List"
-    And I follow "Events" in the content area
-    And I wait until I do not see "Package List Refresh scheduled by admin" text, refreshing the page
+    And I wait until event "Package List Refresh" is completed
 
   Scenario: Schedule an OpenSCAP audit job on the CentOS minion
     Given I am on the Systems overview page of this "ceos_minion"
     When I follow "Audit" in the content area
     And I follow "Schedule" in the content area
+    And I wait at most 30 seconds until I do not see "This system does not yet have OpenSCAP scan capability." text, refreshing the page
     And I enter "--profile standard" as "params"
     And I enter "/usr/share/xml/scap/ssg/content/ssg-rhel7-xccdf.xml" as "path"
     And I click on "Schedule"

--- a/testsuite/features/secondary/min_salt_openscap_audit.feature
+++ b/testsuite/features/secondary/min_salt_openscap_audit.feature
@@ -18,13 +18,13 @@ Feature: OpenSCAP audit of Salt minion
     And I install OpenSCAP dependencies on "sle_minion"
     And I follow "Software" in the content area
     And I click on "Update Package List"
-    And I follow "Events" in the content area
-    And I wait until I do not see "Package List Refresh scheduled by admin" text, refreshing the page
+    And I wait until event "Package List Refresh" is completed
 
   Scenario: Schedule an OpenSCAP audit job on the SLE minion
     Given I disable IPv6 forwarding on all interfaces of the SLE minion
     When I follow "Audit" in the content area
     And I follow "Schedule" in the content area
+    And I wait at most 30 seconds until I do not see "This system does not yet have OpenSCAP scan capability." text, refreshing the page
     And I enter "--profile Default" as "params"
     And I enter "/usr/share/openscap/scap-yast2sec-xccdf.xml" as "path"
     And I click on "Schedule"
@@ -45,6 +45,7 @@ Feature: OpenSCAP audit of Salt minion
     Given I enable IPv6 forwarding on all interfaces of the SLE minion
     When I follow "Audit" in the content area
     And I follow "Schedule" in the content area
+    And I wait at most 30 seconds until I do not see "This system does not yet have OpenSCAP scan capability." text, refreshing the page
     And I enter "--profile Default" as "params"
     And I enter "/usr/share/openscap/scap-yast2sec-xccdf.xml" as "path"
     And I click on "Schedule"

--- a/testsuite/features/secondary/min_ubuntu_openscap_audit.feature
+++ b/testsuite/features/secondary/min_ubuntu_openscap_audit.feature
@@ -22,13 +22,13 @@ Feature: OpenSCAP audit of Ubuntu Salt minion
     And I install OpenSCAP dependencies on "ubuntu_minion"
     And I follow "Software" in the content area
     And I click on "Update Package List"
-    And I follow "Events" in the content area
-    And I wait until I do not see "Package List Refresh scheduled by admin" text, refreshing the page
+    And I wait until event "Package List Refresh" is completed
 
   Scenario: Schedule an OpenSCAP audit job on the Ubuntu minion
     Given I am on the Systems overview page of this "ubuntu_minion"
     When I follow "Audit" in the content area
     And I follow "Schedule" in the content area
+    And I wait at most 30 seconds until I do not see "This system does not yet have OpenSCAP scan capability." text, refreshing the page
     And I enter "--profile standard" as "params"
     And I enter "/usr/share/xml/scap/ssg/content/ssg-ubuntu2004-xccdf.xml" as "path"
     And I click on "Schedule"

--- a/testsuite/features/secondary/trad_centos_client.feature
+++ b/testsuite/features/secondary/trad_centos_client.feature
@@ -64,6 +64,7 @@ Feature: Be able to register a CentOS 7 traditional client and do some basic ope
     Given I am on the Systems overview page of this "ceos_client"
     When I follow "Audit" in the content area
     And I follow "Schedule" in the content area
+    And I wait at most 30 seconds until I do not see "This system does not yet have OpenSCAP scan capability." text, refreshing the page
     And I enter "--profile standard" as "params"
     And I enter "/usr/share/xml/scap/ssg/content/ssg-rhel7-xccdf.xml" as "path"
     And I click on "Schedule"

--- a/testsuite/features/secondary/trad_openscap_audit.feature
+++ b/testsuite/features/secondary/trad_openscap_audit.feature
@@ -21,6 +21,7 @@ Feature: OpenSCAP audit of traditional client
     Given I am on the Systems overview page of this "sle_client"
     When I follow "Audit" in the content area
     And I follow "Schedule" in the content area
+    And I wait at most 30 seconds until I do not see "This system does not yet have OpenSCAP scan capability." text, refreshing the page
     And I enter "--profile Default" as "params"
     And I enter "/usr/share/openscap/scap-yast2sec-xccdf.xml" as "path"
     And I click on "Schedule"

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -65,6 +65,20 @@ When(/^I wait until I see "([^"]*)" text, refreshing the page$/) do |text|
   end
 end
 
+When(/^I wait at most (\d+) seconds until I do not see "([^"]*)" text, refreshing the page$/) do |seconds, text|
+  next if has_no_text?(text, wait: 3)
+  repeat_until_timeout(message: "Couldn't find text '#{text}'", timeout: seconds.to_i) do
+    break if has_no_text?(text, wait: 3)
+    begin
+      accept_prompt do
+        execute_script 'window.location.reload()'
+      end
+    rescue Capybara::ModalNotFound
+      # ignored
+    end
+  end
+end
+
 When(/^I wait at most (\d+) seconds until the event is completed, refreshing the page$/) do |timeout|
   last = Time.now
   next if has_content?("This action's status is: Completed.", wait: 3)


### PR DESCRIPTION
## What does this PR change?

It adds a step waiting for 30 seconds, refreshing the page, until the OpenSCAP feature is available.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Ports:
- Manager-4.0
- Manager-4.1

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
