### PR TITLE
Bugged search in formula catalog

### DIFF
--- a/web/html/src/manager/salt/formula-catalog/org-formula-catalog.tsx
+++ b/web/html/src/manager/salt/formula-catalog/org-formula-catalog.tsx
@@ -45,8 +45,8 @@ class FormulaCatalog extends React.Component<Props, State> {
     return rowData;
   };
 
-  searchData = (data, criteria) => {
-    return data.filter(row => row.toLowerCase().includes(criteria.toLowerCase()));
+  searchData = (row: string, criteria?: string) => {
+    return !criteria || row.toLowerCase().includes(criteria.toLowerCase());
   };
 
   render() {

--- a/web/html/src/manager/salt/formula-catalog/org-formula-catalog.tsx
+++ b/web/html/src/manager/salt/formula-catalog/org-formula-catalog.tsx
@@ -45,7 +45,7 @@ class FormulaCatalog extends React.Component<Props, State> {
     return rowData;
   };
 
-  searchData = (row: string, criteria?: string) => {
+  searchData = (row: string = "", criteria?: string) => {
     return !criteria || row.toLowerCase().includes(criteria.toLowerCase());
   };
 

--- a/web/html/src/manager/salt/formula-catalog/org-formula-catalog.tsx
+++ b/web/html/src/manager/salt/formula-catalog/org-formula-catalog.tsx
@@ -37,7 +37,7 @@ class FormulaCatalog extends React.Component<Props, State> {
     this.refreshServerData();
   }
 
-  sortByText = (aRaw, bRaw, columnKey, sortDirection) => {
+  sortByText = (aRaw = "", bRaw = "", columnKey, sortDirection) => {
     return aRaw.toLowerCase().localeCompare(bRaw.toLowerCase()) * sortDirection;
   };
 

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Fix bugged search in formula catalog
 - Convert Virtualization modal dialogs to react-modal
 
 -------------------------------------------------------------------

--- a/web/spacewalk-web.spec
+++ b/web/spacewalk-web.spec
@@ -63,7 +63,7 @@ but it does generate a number of sub-packages.
 
 %package -n susemanager-web-libs
 Summary:        Vendor bundles for spacewalk-web
-License:        0BSD and BSD-3-Clause and LGPL-3.0-or-later and MIT and MPL-2.0
+License:        0BSD AND BSD-3-Clause AND LGPL-3.0-or-later AND MIT AND MPL-2.0
 Group:          Applications/Internet
 
 BuildArch:      noarch

--- a/web/spacewalk-web.spec
+++ b/web/spacewalk-web.spec
@@ -63,7 +63,7 @@ but it does generate a number of sub-packages.
 
 %package -n susemanager-web-libs
 Summary:        Vendor bundles for spacewalk-web
-License:        0BSD AND BSD-3-Clause AND LGPL-3.0-or-later AND MIT AND MPL-2.0
+License:        0BSD and BSD-3-Clause and LGPL-3.0-or-later and MIT and MPL-2.0
 Group:          Applications/Internet
 
 BuildArch:      noarch


### PR DESCRIPTION
## What does this PR change?

The formula catalog page had an outdated filter function that expected different inputs than what's provided. This broke the search on that page, this PR fixes the issue.

## GUI diff

Before: Search throws an error.
After: Search no longer throws an error.

- [x] **DONE**

## Documentation
- No documentation needed: bugfix.

- [x] **DONE**

## Test coverage
- No tests: bugfix.

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/14954

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
