### PR TITLE
handle and propagate salt ssh errors

### DIFF
--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -69,7 +69,7 @@
         <dependency org="suse" name="quartz" rev="2.3.0" />
         <dependency org="suse" name="redstone-xmlrpc" rev="1.1_20071120" />
         <dependency org="suse" name="redstone-xmlrpc-client" rev="1.1_20071120" />
-        <dependency org="suse" name="salt-netapi-client" rev="0.18.0" />
+        <dependency org="suse" name="salt-netapi-client" rev="0.19.0" />
         <dependency org="suse" name="simpleclient" rev="0.3.0" />
         <dependency org="suse" name="simpleclient_common" rev="0.3.0" />
         <dependency org="suse" name="simpleclient_httpserver" rev="0.3.0" />

--- a/java/code/src/com/redhat/rhn/taskomatic/task/sshpush/SSHPushWorkerSalt.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/sshpush/SSHPushWorkerSalt.java
@@ -160,6 +160,7 @@ public class SSHPushWorkerSalt implements QueueWorker {
                             Object::toString,
                             Object::toString,
                             Object::toString,
+                            Object::toString,
                             Object::toString
                     ));
                     saltSSHService.cleanPendingActionChainAsync(minion);
@@ -292,6 +293,10 @@ public class SSHPushWorkerSalt implements QueueWorker {
                             e ->  {
                                 log.error(e);
                                 return "Salt error: " + e.getMessage();
+                            },
+                            e -> {
+                                log.error(e);
+                                return "Salt SSH error: " + e.getRetcode() + " " + e.getMessage();
                             }
                     )).orElse("Unknown error");
 

--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -863,7 +863,8 @@ public class RegisterMinionEventMessageAction implements MessageAction {
                     err -> err.fold(err1 -> rpmErrQueryRHELProvidesRelease(minionId),
                             err2 -> rpmErrQueryRHELProvidesRelease(minionId),
                             err3 -> rpmErrQueryRHELProvidesRelease(minionId),
-                            err4 -> rpmErrQueryRHELProvidesRelease(minionId)),
+                            err4 -> rpmErrQueryRHELProvidesRelease(minionId),
+                            err5 -> rpmErrQueryRHELProvidesRelease(minionId)),
                     r -> of(r.split("\\r?\\n")[0]) // Take the first line if multiple results return
             ))
             .flatMap(pkgStr -> {
@@ -899,7 +900,8 @@ public class RegisterMinionEventMessageAction implements MessageAction {
                                         err1 -> rpmErrQueryRHELRelease(err1, minionId),
                                         err2 -> rpmErrQueryRHELRelease(err2, minionId),
                                         err3 -> rpmErrQueryRHELRelease(err3, minionId),
-                                        err4 -> rpmErrQueryRHELRelease(err4, minionId)),
+                                        err4 -> rpmErrQueryRHELRelease(err4, minionId),
+                                        err5 -> rpmErrQueryRHELRelease(err5, minionId)),
                                 r -> of(r)
                         ))
                         .map(result -> {

--- a/java/code/src/com/suse/manager/webui/controllers/StatesAPI.java
+++ b/java/code/src/com/suse/manager/webui/controllers/StatesAPI.java
@@ -730,6 +730,7 @@ public class StatesAPI {
                                                 Object::toString,
                                                 Object::toString,
                                                 e -> "Error during state.show_highstate",
+                                                Object::toString,
                                                 Object::toString
                                         ),
                                         YamlHelper.INSTANCE::dump

--- a/java/code/src/com/suse/manager/webui/services/iface/SaltApi.java
+++ b/java/code/src/com/suse/manager/webui/services/iface/SaltApi.java
@@ -20,6 +20,7 @@ import com.suse.manager.webui.services.impl.SaltSSHService;
 import com.suse.manager.webui.services.impl.SaltService;
 import com.suse.manager.webui.services.impl.runner.MgrK8sRunner;
 import com.suse.manager.webui.services.impl.runner.MgrUtilRunner;
+import com.suse.manager.webui.utils.ElementCallJson;
 import com.suse.manager.webui.utils.gson.BootstrapParameters;
 import com.suse.manager.webui.utils.salt.custom.ScheduleMetadata;
 import com.suse.salt.netapi.calls.LocalAsyncResult;
@@ -421,7 +422,19 @@ public interface SaltApi {
      * @param minionId of the target minion.
      * @return raw salt call result in json format.
      */
-    Optional<JsonElement> rawJsonCall(LocalCall<?> call, String minionId);
+    Optional<Result<JsonElement>> rawJsonCall(LocalCall<?> call, String minionId);
+
+    /**
+     * Execute generic salt call.
+     * @param call salt call to execute.
+     * @param minionId of the target minion.
+     * @return raw salt call result in json format.
+     * @deprecated this method should not be used for new code
+     */
+    @Deprecated
+    default Optional<JsonElement> rawJsonCallOld(LocalCall<?> call, String minionId) {
+        return callSync(new ElementCallJson(call), minionId);
+    }
 
     /**
      * @deprecated this function is too general and should be replaced by more specific functionality.

--- a/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
@@ -208,28 +208,32 @@ public class SaltService implements SystemQuery, SaltApi {
         }
     }
 
+    public <R> Optional<Result<R>> callSyncResult(LocalCall<R> call, String minionId) {
+        try {
+            Map<String, Result<R>> stringRMap = callSync(call, new MinionList(minionId));
+
+            return Opt.fold(Optional.ofNullable(stringRMap.get(minionId)), () -> {
+                        LOG.warn("Got no result for " + call.getPayload().get("fun") +
+                                " on minion " + minionId + " (minion did not respond in time)");
+                        return Optional.empty();
+                    }, Optional::of);
+        }
+        catch (SaltException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
     /**
      * {@inheritDoc}
      */
     @Override
     public <R> Optional<R> callSync(LocalCall<R> call, String minionId) {
-        try {
-            Map<String, Result<R>> stringRMap = callSync(call, new MinionList(minionId));
-
-            return Opt.fold(Optional.ofNullable(stringRMap.get(minionId)), () -> {
-                LOG.warn("Got no result for " + call.getPayload().get("fun") +
-                        " on minion " + minionId + " (minion did not respond in time)");
+        return callSyncResult(call, minionId).flatMap(r ->
+            r.fold(error -> {
+                LOG.warn(error.toString());
                 return Optional.<R>empty();
-            }, r ->
-                r.fold(error -> {
-                    LOG.warn(error.toString());
-                    return Optional.<R>empty();
-                }, Optional::of)
-            );
-        }
-        catch (SaltException e) {
-            throw new RuntimeException(e);
-        }
+            }, Optional::of)
+        );
     }
 
     /**
@@ -273,6 +277,12 @@ public class SaltService implements SystemQuery, SaltApi {
                         },
                         e -> {
                             LOG.error("Generic Salt error for runner call " +
+                                    runnerCallToString(call) +
+                                    ": " + e.getMessage());
+                            return Optional.empty();
+                        },
+                        e -> {
+                            LOG.error("SaltSSH error for runner call " +
                                     runnerCallToString(call) +
                                     ": " + e.getMessage());
                             return Optional.empty();
@@ -349,6 +359,12 @@ public class SaltService implements SystemQuery, SaltApi {
                     },
                     e -> {
                         LOG.error("Generic Salt error for wheel call " +
+                                wheelCallToString(call) +
+                                ": " + e.getMessage());
+                        return Optional.empty();
+                    },
+                    e -> {
+                        LOG.error("SaltSSH error for wheel call " +
                                 wheelCallToString(call) +
                                 ": " + e.getMessage());
                         return Optional.empty();
@@ -635,8 +651,8 @@ public class SaltService implements SystemQuery, SaltApi {
      * {@inheritDoc}
      */
     @Override
-    public Optional<JsonElement> rawJsonCall(LocalCall<?> call, String minionId) {
-        return callSync(new ElementCallJson(call), minionId);
+    public Optional<Result<JsonElement>> rawJsonCall(LocalCall<?> call, String minionId) {
+        return callSyncResult(new ElementCallJson(call), minionId);
     }
 
     /**
@@ -1131,6 +1147,13 @@ public class SaltService implements SystemQuery, SaltApi {
                                     e.getMessage());
                             return Optional.of(Collections.singletonMap(false,
                                     "Generic Salt error: " + e.getMessage()));
+                        },
+                        e -> {
+                            LOG.error("SaltSSH error for runner call " +
+                                    "[mgrutil.move_minion_uploaded_files]: " +
+                                    e.getMessage());
+                            return Optional.of(Collections.singletonMap(false,
+                                    "SaltSSH error: " + e.getMessage()));
                         }
                 )
         );
@@ -1234,6 +1257,12 @@ public class SaltService implements SystemQuery, SaltApi {
                     },
                     e -> {
                         LOG.error("Generic Salt error for runner call " +
+                                "[mgrk8s.get_all_containers]: " +
+                                e.getMessage());
+                        throw new NoSuchElementException();
+                    },
+                    e -> {
+                        LOG.error("SaltSSH error for runner call " +
                                 "[mgrk8s.get_all_containers]: " +
                                 e.getMessage());
                         throw new NoSuchElementException();

--- a/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
+++ b/java/code/src/com/suse/manager/webui/services/test/SaltServerActionServiceTest.java
@@ -87,6 +87,7 @@ import com.suse.manager.webui.utils.SaltSystemReboot;
 import com.suse.salt.netapi.calls.LocalAsyncResult;
 import com.suse.salt.netapi.calls.LocalCall;
 import com.suse.salt.netapi.datatypes.target.Target;
+import com.suse.salt.netapi.results.Result;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -132,8 +133,8 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
         };
         SaltService saltService = new SaltService() {
             @Override
-            public Optional<JsonElement> rawJsonCall(LocalCall<?> call, String minionId) {
-                return Optional.of(new JsonObject());
+            public Optional<Result<JsonElement>> rawJsonCall(LocalCall<?> call, String minionId) {
+                return Optional.of(Result.success(new JsonObject()));
             }
         };
         minion = MinionServerFactoryTest.createTestMinionServer(user);
@@ -640,7 +641,7 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
     private SaltServerActionService countSaltActionCalls(AtomicInteger counter) {
         SaltApi saltApi = new TestSaltApi() {
             @Override
-            public Optional<JsonElement> rawJsonCall(LocalCall<?> call, String minionId) {
+            public Optional<Result<JsonElement>> rawJsonCall(LocalCall<?> call, String minionId) {
                 counter.incrementAndGet();
                 throw new RuntimeException();
             }
@@ -678,9 +679,9 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
         AtomicInteger counter2 = new AtomicInteger();
         SaltApi saltApi = new TestSaltApi() {
             @Override
-            public Optional<JsonElement> rawJsonCall(LocalCall<?> call, String minionId) {
+            public Optional<Result<JsonElement>> rawJsonCall(LocalCall<?> call, String minionId) {
                 counter2.incrementAndGet();
-                return Optional.of(new JsonObject());
+                return Optional.of(Result.success(new JsonObject()));
             }
         };
         testService = createSaltServerActionService(new TestSystemQuery(), saltApi);
@@ -815,7 +816,7 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
 
         SaltApi saltApi = new TestSaltApi() {
             @Override
-            public Optional<JsonElement> rawJsonCall(LocalCall<?> call, String minionId) {
+            public Optional<Result<JsonElement>> rawJsonCall(LocalCall<?> call, String minionId) {
                 return Optional.empty();
             }
         };
@@ -841,7 +842,7 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
 
         SaltApi saltApi = new TestSaltApi() {
             @Override
-            public Optional<JsonElement> rawJsonCall(LocalCall<?> call, String minionId) {
+            public Optional<Result<JsonElement>> rawJsonCall(LocalCall<?> call, String minionId) {
                 throw new RuntimeException();
             }
         };
@@ -870,8 +871,8 @@ public class SaltServerActionServiceTest extends JMockBaseTestCaseWithUser {
         successWorker();
         SaltApi saltApi = new TestSaltApi() {
             @Override
-            public Optional<JsonElement> rawJsonCall(LocalCall<?> call, String minionId) {
-                return Optional.of(new JsonObject());
+            public Optional<Result<JsonElement>> rawJsonCall(LocalCall<?> call, String minionId) {
+                return Optional.of(Result.success(new JsonObject()));
             }
         };
         SaltServerActionService testService = createSaltServerActionService(new TestSystemQuery(), saltApi);

--- a/java/code/src/com/suse/manager/webui/services/test/TestSaltApi.java
+++ b/java/code/src/com/suse/manager/webui/services/test/TestSaltApi.java
@@ -266,7 +266,7 @@ public class TestSaltApi implements SaltApi {
     }
 
     @Override
-    public Optional<JsonElement> rawJsonCall(LocalCall<?> call, String minionId) {
+    public Optional<Result<JsonElement>> rawJsonCall(LocalCall<?> call, String minionId) {
         throw new UnsupportedOperationException();
     }
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Show salt ssh error message in failed action details
 - switch to best repo auth item for contentsources (bsc#1191442)
 - Add compressed flag to image pillars when kiwi image is compressed (bsc#1191702)
 

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -148,7 +148,7 @@ BuildRequires:  postgresql-jdbc
 BuildRequires:  prometheus-client-java
 BuildRequires:  quartz
 BuildRequires:  redstone-xmlrpc
-BuildRequires:  salt-netapi-client >= 0.18
+BuildRequires:  salt-netapi-client >= 0.19
 BuildRequires:  simple-core
 BuildRequires:  simple-xml
 BuildRequires:  sitemesh

--- a/java/tito.props
+++ b/java/tito.props
@@ -1,8 +1,8 @@
 [requires]
-salt-netapi-client=0.18
+salt-netapi-client=0.19
 
 [buildrequires]
-salt-netapi-client=0.18
+salt-netapi-client=0.19
 
 [dbschema]
 conf/rhn_java.conf=4.3.1


### PR DESCRIPTION
## What does this PR change?

This PR adjusts the code for the salt-netapi library PR https://github.com/SUSE/salt-netapi-client/pull/292. It introduces handling of ssh errors which previously caused `JsonParseError` and better error propagation in general to write more useful error messages in failed actions.

## GUI diff

Before:

![Screenshot from 2021-09-22 16-16-03](https://user-images.githubusercontent.com/688888/134360764-e4cd674a-10d2-4fbb-a4c9-02a816ff67ab.png)

After:

![Screenshot from 2021-09-22 15-56-33](https://user-images.githubusercontent.com/688888/134357523-9e7b4d53-c9ca-4504-8bcc-e411c874378e.png)

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

Fixes #https://github.com/SUSE/spacewalk/issues/12955


- [x] **DONE**


## Changelogs


If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
