### PR TITLE
Deprecate `StatePersistedContext`

### DIFF
--- a/web/html/src/components/table/TableDataHandler.tsx
+++ b/web/html/src/components/table/TableDataHandler.tsx
@@ -6,7 +6,6 @@ import { SearchPanel } from "./SearchPanel";
 import { SearchField } from "./SearchField";
 import { PageControl, SimpleDataProvider, AsyncDataProvider } from "utils/data-providers";
 import { Utils } from "utils/functions";
-import { StatePersistedContext } from "../utils/StatePersistedContext";
 
 import { PagedData, Comparator } from "utils/data-providers";
 
@@ -103,8 +102,6 @@ export class TableDataHandler extends React.Component<Props, State> {
     deletable: false,
     columns: [],
   };
-
-  static contextType = StatePersistedContext;
 
   constructor(props: Props) {
     super(props);

--- a/web/html/src/components/utils/StatePersistedContext.ts
+++ b/web/html/src/components/utils/StatePersistedContext.ts
@@ -1,5 +1,0 @@
-import * as React from "react";
-
-const StatePersistedContext = React.createContext({ loadState: undefined, saveState: undefined });
-
-export { StatePersistedContext };

--- a/web/html/src/manager/audit/subscription-matching/subscription-matching.tsx
+++ b/web/html/src/manager/audit/subscription-matching/subscription-matching.tsx
@@ -11,7 +11,6 @@ import { TopPanel } from "components/panels/TopPanel";
 import { Utils as MessagesUtils } from "components/messages";
 import Network from "utils/network";
 import SpaRenderer from "core/spa/spa-renderer";
-import { StatePersistedContext } from "components/utils/StatePersistedContext";
 import { Cancelable } from "utils/functions";
 import { DEPRECATED_unsafeEquals } from "utils/legacy";
 
@@ -143,24 +142,6 @@ class SubscriptionMatchingTabContainer extends React.Component<SubscriptionMatch
 
     const messageLabelIcon = data.messages.length > 0 ? <WarningIcon iconOnRight={true} /> : null;
 
-    const subscriptionContextValues = [
-      "subscriptionTableState",
-      "unmatchedProductTableState",
-      "pinnedMatchesState",
-      "messageTableState",
-    ].reduce((res, stateName) => {
-      return Object.assign({}, res, {
-        [stateName]: {
-          loadState: () => this.state[stateName],
-          saveState: state => {
-            this.setState({
-              [stateName]: state
-            });
-          },
-        },
-      });
-    }, {});
-
     return (
       <TabContainer
         labels={[
@@ -177,28 +158,20 @@ class SubscriptionMatchingTabContainer extends React.Component<SubscriptionMatch
         ]}
         hashes={["#subscriptions", "#unmatched-products", "#pins", "#messages"]}
         tabs={[
-          <StatePersistedContext.Provider value={subscriptionContextValues["subscriptionTableState"]}>
-            <Subscriptions subscriptions={data.subscriptions} />
-          </StatePersistedContext.Provider>,
-          <StatePersistedContext.Provider value={subscriptionContextValues["unmatchedProductTableState"]}>
-            <UnmatchedProducts
-              products={data.products}
-              unmatchedProductIds={data.unmatchedProductIds}
-              systems={data.systems}
-            />
-          </StatePersistedContext.Provider>,
-          <StatePersistedContext.Provider value={subscriptionContextValues["pinnedMatchesState"]}>
-            <Pins
-              pinnedMatches={data.pinnedMatches}
-              products={data.products}
-              systems={data.systems}
-              subscriptions={data.subscriptions}
-              onPinChanged={this.props.onPinChanged}
-            />
-          </StatePersistedContext.Provider>,
-          <StatePersistedContext.Provider value={subscriptionContextValues["messageTableState"]}>
-            <Messages messages={data.messages} systems={data.systems} subscriptions={data.subscriptions} />
-          </StatePersistedContext.Provider>,
+          <Subscriptions subscriptions={data.subscriptions} />,
+          <UnmatchedProducts
+            products={data.products}
+            unmatchedProductIds={data.unmatchedProductIds}
+            systems={data.systems}
+          />,
+          <Pins
+            pinnedMatches={data.pinnedMatches}
+            products={data.products}
+            systems={data.systems}
+            subscriptions={data.subscriptions}
+            onPinChanged={this.props.onPinChanged}
+          />,
+          <Messages messages={data.messages} systems={data.systems} subscriptions={data.subscriptions} />,
         ]}
         initialActiveTabHash={this.state.activeTabHash}
         onTabHashChange={this.onTabHashChange}


### PR DESCRIPTION
## What does this PR change?

The saved context helper doesn't handle multiple components binding to it at the same time. Sadly that's the exact case it the only view where it's currently used. Removing the persisting in this view doesn't have any adverse effects since the data is already available. This was the only view that used this code so I removed it after removing it from this view.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/14106

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
