### PR TITLE
Testsuite: Do not install "python2" in testing containers (bsc#1167586) (bsc#1164192)

### DIFF
--- a/testsuite/features/profiles/Docker/add_packages.sh
+++ b/testsuite/features/profiles/Docker/add_packages.sh
@@ -16,4 +16,4 @@ zypper rr sles12sp4
 
 # do the real test
 zypper --non-interactive --gpg-auto-import-keys ref
-zypper --non-interactive in aaa_base aaa_base-extras net-tools timezone vim less sudo tar python python-xml python3 python3-xml
+zypper --non-interactive in aaa_base aaa_base-extras net-tools timezone vim less sudo tar python3 python3-xml

--- a/testsuite/features/profiles/internal_nue/Docker/add_packages.sh
+++ b/testsuite/features/profiles/internal_nue/Docker/add_packages.sh
@@ -16,4 +16,4 @@ zypper rr sles12sp4
 
 # do the real test
 zypper --non-interactive --gpg-auto-import-keys ref
-zypper --non-interactive in aaa_base aaa_base-extras net-tools timezone vim less sudo tar python python-xml python3 python3-xml
+zypper --non-interactive in aaa_base aaa_base-extras net-tools timezone vim less sudo tar python3 python3-xml

--- a/testsuite/features/profiles/internal_prv/Docker/add_packages.sh
+++ b/testsuite/features/profiles/internal_prv/Docker/add_packages.sh
@@ -16,4 +16,4 @@ zypper rr sles12sp4
 
 # do the real test
 zypper --non-interactive --gpg-auto-import-keys ref
-zypper --non-interactive in aaa_base aaa_base-extras net-tools timezone vim less sudo tar python python-xml python3 python3-xml
+zypper --non-interactive in aaa_base aaa_base-extras net-tools timezone vim less sudo tar python3 python3-xml


### PR DESCRIPTION
## What does this PR change?

After the fixes for (bsc#1167586) (bsc#1164192) in Salt [1], now the containers are not longer requiring Python 2 in order to inspect the image.

This PR fixes the testing containers to not install `python` and `python-xml` since these are not required anymore.

[1] https://github.com/openSUSE/salt/commit/271826b0baa6b2281bc2eac9118a0fcc4675f106

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- Documentation issue was created: https://github.com/uyuni-project/uyuni-docs/pull/970

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/11072

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
