### PR TITLE
Fix doc search

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/help/DocSearchSetupAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/help/DocSearchSetupAction.java
@@ -89,11 +89,11 @@ public class DocSearchSetupAction extends BaseSearchAction {
         // get lang we are searching in
         RequestContext ctx = new RequestContext(request);
         User user = ctx.getCurrentUser();
-        String locale;
+        String locale = null;
         if (user != null) {
             locale = user.getPreferredDocsLocale();
         }
-        else {
+        if (locale == null) {
             locale = ConfigDefaults.get().getDefaultDocsLocale();
         }
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- fixing ISE when searching in docs for logged-in users (bsc#1186319)
+
 -------------------------------------------------------------------
 Mon May 24 12:37:31 CEST 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

When searching the docs as a logged-in user a Internal Server Error was the result.
The search works when searching without log-in.
The reason is, that the local is `null` when the user did not explicit select a language for the docs.
The code needs to fallback to the default locale.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: minor

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/14979

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
