### PR TITLE
set file user/group/permissions for /srv/susemanager/salt/custom (bsc#1186325)

### DIFF
--- a/java/code/src/com/suse/manager/webui/services/SaltStateGeneratorService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltStateGeneratorService.java
@@ -22,8 +22,10 @@ import static com.suse.manager.webui.services.SaltConstants.SALT_SERVER_STATE_FI
 import static com.suse.manager.webui.services.SaltConstants.SUMA_PILLAR_IMAGES_DATA_PATH;
 import static com.suse.manager.webui.services.SaltConstants.SUMA_STATE_FILES_ROOT_PATH;
 import static com.suse.manager.webui.utils.SaltFileUtils.defaultExtension;
+import static java.nio.file.attribute.PosixFilePermission.GROUP_EXECUTE;
 import static java.nio.file.attribute.PosixFilePermission.GROUP_READ;
 import static java.nio.file.attribute.PosixFilePermission.GROUP_WRITE;
+import static java.nio.file.attribute.PosixFilePermission.OWNER_EXECUTE;
 import static java.nio.file.attribute.PosixFilePermission.OWNER_READ;
 import static java.nio.file.attribute.PosixFilePermission.OWNER_WRITE;
 
@@ -385,10 +387,14 @@ public enum SaltStateGeneratorService {
                 states.stream().map(confChannelSaltManager::getChannelStateName).collect(Collectors.toList());
         try {
             Files.createDirectories(baseDir);
+            FileUtils.setAttributes(baseDir, "tomcat", "susemanager",
+                    Set.of(OWNER_READ, OWNER_WRITE, OWNER_EXECUTE, GROUP_READ, GROUP_EXECUTE));
             Path filePath = baseDir.resolve(defaultExtension(fileName));
             com.suse.manager.webui.utils.SaltStateGenerator saltStateGenerator =
                     new com.suse.manager.webui.utils.SaltStateGenerator(filePath.toFile());
             saltStateGenerator.generate(new SaltConfigChannelState(stateNames));
+            FileUtils.setAttributes(filePath, "tomcat", "susemanager",
+                    Set.of(OWNER_READ, OWNER_WRITE, GROUP_READ, GROUP_WRITE));
         }
         catch (IOException e) {
             LOG.error(e.getMessage(), e);

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- fix permission problem with /srv/susemanager/salt/custom files (bsc#1186325)
+
 -------------------------------------------------------------------
 Mon May 24 12:37:31 CEST 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Explicitly sets user/group/permissions for files generated in  /srv/susemanager/salt/custom for the case its run as root from taskomatic.

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/14956

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
