### PR TITLE
Fix generation of unique repository name

### DIFF
--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -230,7 +230,7 @@ def generate_repository_name(repo_url)
   repo_name = repo_url.strip
   repo_name.delete_prefix! 'http://download.suse.de/ibs/SUSE:/Maintenance:/'
   repo_name.delete_prefix! 'http://minima-mirror-qam.mgr.prv.suse.net/ibs/SUSE:/Maintenance:/'
-  repo_name.sub!('/', '_')
+  repo_name.gsub!('/', '_')
   repo_name[0...64] # HACK: Due to the 64 characters size limit of a repository label
 end
 


### PR DESCRIPTION
## What does this PR change?

This PR fixes the function that generates a unique repository name:

It transforms *all* `/` to `_`, not only the *first one* (`gsub!` instead of `sub!`).


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
