### PR TITLE
Make spec license canonical

### DIFF
--- a/web/html/src/build/fill-spec-file.js
+++ b/web/html/src/build/fill-spec-file.js
@@ -10,7 +10,7 @@ function fillSpecFile() {
         }
         return item;
     });
-    const mappedProcessedLicenses = Array.from(new Set(processedLicenses)).sort().join(" and ");
+    const mappedProcessedLicenses = Array.from(new Set(processedLicenses)).sort().join(" AND ");
 
     const specFileLocation = "../../spacewalk-web.spec";
 


### PR DESCRIPTION
## What does this PR change?

The frontend build step currently checks licenses and joins them using `and`, whereas OBS tools use `AND`. This means that pulling master will result in a broken frontend project build. This PR fixes the issue.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: only internal and user invisible changes

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/15002

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
