### PR TITLE
Testsuite: More robust client IP extraction

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -696,9 +696,7 @@ end
 Then(/^I add proxy record into hosts file on "([^"]*)" if avahi is used$/) do |host|
   node = get_target(host)
   if node.full_hostname.include? 'tf.local'
-    output, _code = $proxy.run("ip address show dev eth0")
-    ip = output.split("\n")[2].split[1].split('/')[0]
-    node.run("echo '#{ip} #{$proxy.full_hostname} #{$proxy.hostname}' >> /etc/hosts")
+    node.run("echo '#{$proxy.public_ip} #{$proxy.full_hostname} #{$proxy.hostname}' >> /etc/hosts")
   else
     puts 'Record not added - avahi domain is not detected'
   end

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -389,9 +389,7 @@ end
 
 When(/^I enter the IP address of "([^"]*)" in (.*) field$/) do |host, field|
   node = get_target(host)
-  output, _code = node.run("ip address show dev eth0")
-  ip = output.split("\n")[2].split[1].split('/')[0]
-  fill_in FIELD_IDS[field], with: ip
+  fill_in FIELD_IDS[field], with: node.public_ip
 end
 
 When(/^I enter the MAC address of "([^"]*)" in (.*) field$/) do |host, field|

--- a/testsuite/features/support/lavanda.rb
+++ b/testsuite/features/support/lavanda.rb
@@ -21,6 +21,10 @@ module LavandaBasic
     @in_ip = ip
   end
 
+  def init_public_ip(public_ip)
+    @in_public_ip = public_ip
+  end
+
   # getter functions, executed on testsuite
   def hostname
     raise 'empty hostname, something wrong' if @in_hostname.empty?
@@ -35,6 +39,11 @@ module LavandaBasic
   def ip
     raise 'empty ip, something wrong' if @in_ip.empty?
     @in_ip
+  end
+
+  def public_ip
+    raise 'empty public_ip, something wrong' if @in_public_ip.empty?
+    @in_public_ip
   end
 
   # run functions

--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -134,13 +134,6 @@ $nodes.each do |node|
   puts "Host '#{$named_nodes[node.hash]}' is alive with determined hostname #{hostname.strip} and FQDN #{fqdn.strip}" unless $build_validation
 end
 
-# Initialize IP address or domain name
-$nodes.each do |node|
-  next if node.nil?
-
-  node.init_ip(node.full_hostname)
-end
-
 # This function is used to get one of the nodes based on its type
 def get_target(host)
   node = $node_by_host[host]
@@ -288,3 +281,66 @@ $node_by_host = { 'localhost'                 => $localhost,
                   'sle12sp4_terminal'         => $sle12sp4_terminal,
                   'sle15sp3_buildhost'        => $sle15sp3_buildhost,
                   'sle15sp3_terminal'         => $sle15sp3_terminal }
+
+# This is the inverse of `node_by_host`.
+# For each node we choose as key the canonical host, i.e. we drop aliases.
+# For instance, we use 'ssh_minion` and ignore the alias 'ssh_spack_migrated_minion`.
+$host_by_node = {}
+$node_by_host.each do |host, node|
+  next if node.nil?
+
+  [host, node].each do |it|
+    raise ">>> Either host '#{host}' of node '#{node}' is empty.  Please check" if it == ''
+  end
+
+  ignored_hosts = %w[sle_ssh_tunnel_client sle_migrated_minion sle_spack_migrated_minion
+                     ssh_spack_migrated_minion sle_ssh_tunnel_minion
+                     ceos_ssh_minion ubuntu_ssh_minion]
+  next if ignored_hosts.include? host
+
+  $host_by_node[node] = host
+end
+
+# rubocop:disable Metrics/MethodLength
+def client_public_ip(host)
+  node = $node_by_host[host]
+  raise "Cannot resolve node for host '#{host}'" if node.nil?
+
+  # For each node that we support we must know which network interface uses (see the case below).
+  # Having the IP as an attribute is something useful for the clients.
+  # Let's not implement it for nodes where we are likely not need this feature (e.g. ctl).
+  not_implemented = [$localhost]
+  not_implemented.each do |it|
+    return 'NOT_IMPLEMENTED' if node == it
+  end
+
+  interface = case host
+              when /^sle/, /^ssh/, /^ceos/, /^debian/, 'server', 'proxy', 'build_host'
+                'eth0'
+              when /^ubuntu/
+                'ens3'
+              when 'kvm_server', 'xen_server'
+                'br0'
+              else
+                raise "Unknown net interface for #{host}"
+              end
+  output, code = node.run("ip address show dev #{interface} | grep 'inet '")
+  raise 'Cannot resolve public ip' unless code.zero?
+
+  output.split[1].split('/')[0]
+end
+# rubocop:enable Metrics/MethodLength
+
+# Initialize IP address or domain name
+$nodes.each do |node|
+  next if node.nil?
+  next if node.is_a?(String) && node.empty?
+
+  node.init_ip(node.full_hostname)
+
+  host = $host_by_node[node]
+  raise "Cannot resolve host for node: '#{node.hostname}'" if host.nil? || host == ''
+
+  ip = client_public_ip host
+  node.init_public_ip ip
+end


### PR DESCRIPTION
## What does this PR change?
We parse the output of `ip address show dev eth0`
assuming that the IP appears in the second line.

The following piece of output is from the server at the head branch in the CI:
```
2: eth0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc pfifo_fast state UP group default qlen 1000
    link/ether aa:b2:93:01:00:b2 brd ff:ff:ff:ff:ff:ff
    altname enp0s3
    altname ens3
    inet 10.162.210.178/24 brd 10.162.210.255 scope global eth0
```

The above lines with `altname` break our assumption: we'd extract `enp0s3` as the wrong IP.

![retail-wrong-public-ip-at-formula-Screenshot from 2021-05-19 10-44-59](https://user-images.githubusercontent.com/13642261/119847087-f8d1a880-bf0a-11eb-9388-d54906fca6d7.png)

- testsuite/features/step_definitions/common_steps.rb
- testsuite/features/step_definitions/salt_steps.rb
- testsuite/features/support/lavanda.rb
- testsuite/features/support/twopence_init.rb:
Grep for 'inet ' to select the right line.
Store the public IP as a new attribute of the clients.


## What does this PR change?

## Links
This comes from https://github.com/SUSE/spacewalk/issues/5838

### Ports
- Manager-4.1: https://github.com/SUSE/spacewalk/pull/15011
- Manager-4.0: https://github.com/SUSE/spacewalk/pull/15012

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)
