### PR TITLE
Fail early - ensure minimal performance

### DIFF
--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -37,8 +37,8 @@ if File.exist?(custom_repos_path)
   # HACK
   # Build Validations will require longer timeouts due to the low performance of our VMs
   # if we ever improve this fact, we can reduce these timeouts.
-  Capybara.default_max_wait_time = 30
-  DEFAULT_TIMEOUT = 1800
+  Capybara.default_max_wait_time = 20
+  DEFAULT_TIMEOUT = 500
 end
 
 def enable_assertions


### PR DESCRIPTION
## What does this PR change?

This PR changes the default timeout for build validations from half an hour (!) to 8 minutes.

Rationale:
 * fail early
 * ensure minimal performance
 
**Fail early**: the less we wait for failures, the less we lose our time. Today I lost one hour and a half for 3 failed bootstraps...

**Ensure minimal performance**: with a default timeout of half an hour, any action that takes, say, 25 minutes, will be considered as acceptable. Our customers will certainly not be of that opinion.

If SUSE Manager can't cope with parallel bootstraps in a reasonable delay, then it is a product bug, that should be addressed as such. We should not hide that problem in the test suite.

The comment says:
```
  # Build Validations will require longer timeouts due to the low performance of our VMs
  # if we ever improve this fact, we can reduce these timeouts.
```
If that is really the cause for longer timeouts, then accepting VMs that are twice as slow is generous enough, I think.


## Links

Ports:
* 4.0:
* 4.1:


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
