### PR TITLE
Testsuite: Speed up a slow step

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -1150,7 +1150,7 @@ When(/^I check for failed events on history event page$/) do
   event_table_xpath = "//div[@class='table-responsive']/table/tbody"
   rows = find(:xpath, event_table_xpath)
   rows.all('tr').each do |tr|
-    if tr.has_css?('.fa.fa-times-circle-o.fa-1-5x.text-danger')
+    if tr.all(:css, '.fa.fa-times-circle-o.fa-1-5x.text-danger').any?
       failings << "#{tr.text}\n"
     end
   end


### PR DESCRIPTION
## What does this PR change?
Speed up a slow step.

We often the step `I check for failed events on history event page`.
This step should be quite fast (< 30 s); instead, it's taking
about 2-3 minutes on average.

This is because the `has_css?` inside the loop uses the default timeout,
i.e. `Capybara.default_max_wait_time` (10 s).

- testsuite/features/step_definitions/common_steps.rb:
Check if the elemnent is in the row with no waiting time.


## Links

Fixes https://github.com/SUSE/spacewalk/issues/15019
### Ports
- Manager-4.1: https://github.com/SUSE/spacewalk/pull/15020
- Manager-4.0: https://github.com/SUSE/spacewalk/pull/15021


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)
