### PR TITLE
Fix salt proxy cleanup

### DIFF
--- a/testsuite/features/build_validation/init_clients/proxy.feature
+++ b/testsuite/features/build_validation/init_clients/proxy.feature
@@ -45,6 +45,7 @@ Feature: Setup SUSE Manager proxy
     When I copy server's keys to the proxy
     And I configure the proxy
     Then I should see "proxy" via spacecmd
+    And service "salt-broker" is active on "proxy"
 
   Scenario: Check proxy system details
     When I am on the Systems overview page of this "proxy"

--- a/testsuite/features/core/proxy_register_as_minion_with_gui.feature
+++ b/testsuite/features/core/proxy_register_as_minion_with_gui.feature
@@ -42,6 +42,7 @@ Feature: Setup SUSE Manager proxy
     When I copy server's keys to the proxy
     And I configure the proxy
     Then I should see "proxy" via spacecmd
+    And service "salt-broker" is active on "proxy"
 
   Scenario: Check proxy system details
     When I am on the Systems overview page of this "proxy"

--- a/testsuite/features/core/proxy_register_as_minion_with_script.feature
+++ b/testsuite/features/core/proxy_register_as_minion_with_script.feature
@@ -44,6 +44,7 @@ Feature: Setup SUSE Manager proxy
     When I copy server's keys to the proxy
     And I configure the proxy
     Then I should see "proxy" via spacecmd
+    And service "salt-broker" is active on "proxy"
 
   Scenario: Check proxy system details
     When I am on the Systems overview page of this "proxy"

--- a/testsuite/features/core/proxy_register_as_trad_with_script.feature
+++ b/testsuite/features/core/proxy_register_as_trad_with_script.feature
@@ -30,6 +30,7 @@ Feature: Setup SUSE Manager proxy
     When I copy server's keys to the proxy
     And I configure the proxy
     Then I should see "proxy" via spacecmd
+    And service "salt-broker" is active on "proxy"
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -674,10 +674,10 @@ When(/^I perform a full salt minion cleanup on "([^"]*)"$/) do |host|
   node = get_target(host)
   if host.include? 'ceos'
     node.run('yum -y remove --setopt=clean_requirements_on_remove=1 salt salt-minion', false)
-  elsif host.include? 'ubuntu'
+  elsif (host.include? 'ubuntu') || (host.include? 'debian')
     node.run('apt-get --assume-yes remove salt-common salt-minion && apt-get purge salt-common salt-minion && apt-get autoremove', false)
   else
-    node.run('zypper --non-interactive remove --clean-deps -y salt salt-minion', false)
+    node.run('zypper --non-interactive remove --clean-deps -y salt salt-minion spacewalk-proxy-salt', false)
   end
   node.run('rm -Rf /root/salt /var/cache/salt/minion /var/run/salt /var/log/salt /etc/salt /var/tmp/.root*', false)
   step %(I disable the repositories "tools_update_repo tools_pool_repo" on this "#{host}" without error control)


### PR DESCRIPTION
## What does this PR change?

This PR:
* cleans up the package `spacewalk-proxy-salt` holding the salt broker when we do a full salt cleanup
* handles the debian case
* tests that the `salt-broker` service is properly started


## Links

Ports:
* 4.0: SUSE/spacewalk#15027
* 4.1: SUSE/spacewalk#15026


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
