### PR TITLE
Porting susemanager package to python3

### DIFF
--- a/susemanager/Makefile.defs
+++ b/susemanager/Makefile.defs
@@ -29,44 +29,57 @@ INSTALL_DIR	= $(INSTALL) -m 755 -d
 
 # This is for the subdir part
 PYFILES		= $(addsuffix .py,$(FILES))
-PYCFILES	= $(addsuffix .pyc,$(FILES))
-PYOFILES	= $(addsuffix .pyo,$(FILES))
 
 SPACEWALK_PYFILES		= $(addsuffix .py,$(SPACEWALK_FILES))
-SPACEWALK_PYCFILES	= $(addsuffix .pyc,$(SPACEWALK_FILES))
+
+ifeq ($(PYTHON_BIN), python3)
+SPACEWALK_PYCFILES = __pycache__/* mgr_sync/__pycache__/*
+else
+SPACEWALK_PYCFILES = $(addsuffix .pyc,$(SPACEWALK_FILES)) $(addsuffix .pyo,$(SPACEWALK_FILES))
+endif
+$(info DEBUG ORIG: $(SPACEWALK_PYCFILES))
+
 SPACEWALK_DEST	?= $(SPACEWALK_ROOT)/$(SUBDIR)
 
 # what do we need to install and where
-INSTALL_FILES	+= $(PYFILES) $(PYCFILES)
+INSTALL_FILES	+= $(PYFILES)
 INSTALL_DEST	?= $(ROOT)/$(SUBDIR)
 
-SPACEWALK_INSTALL_FILES	+= $(SPACEWALK_PYFILES) $(SPACEWALK_PYCFILES)
+SPACEWALK_INSTALL_FILES	+= $(SPACEWALK_PYFILES)
 
 DIRS		+= $(addprefix $(PREFIX), \
 			$(sort $(EXTRA_DIRS)) $(INSTALL_DEST) $(SPACEWALK_ROOT) $(SPACEWALK_DEST))
 
-all :: $(INSTALL_FILES)
+all :: compileall $(INSTALL_FILES)
 
 install :: all $(DIRS) $(INSTALL_FILES) $(SPACEWALK_INSTALL_FILES)
 	$(INSTALL_DIR) $(PREFIX)$(SPACEWALK_DEST)/mgr_sync
+ifeq ($(PYTHON_BIN), python3)
+	$(INSTALL_DIR) $(PREFIX)$(SPACEWALK_DEST)/__pycache__
+	$(INSTALL_DIR) $(PREFIX)$(SPACEWALK_DEST)/mgr_sync/__pycache__
+endif
 	@$(foreach f,$(INSTALL_FILES), \
 		$(INSTALL_DATA) $(f) $(PREFIX)$(INSTALL_DEST)/$(f) ; )
 	@$(foreach f,$(SPACEWALK_INSTALL_FILES), \
+		$(INSTALL_DATA) $(f) $(PREFIX)$(SPACEWALK_DEST)/$(f) ; )
+	@$(foreach f,$(wildcard $(SPACEWALK_PYCFILES)), \
 		$(INSTALL_DATA) $(f) $(PREFIX)$(SPACEWALK_DEST)/$(f) ; )
 
 $(DIRS):
 	$(INSTALL_DIR) $@
 
 clean ::
-	@rm -fv *~ *.pyc *.pyo .??*~
+	@find . -name '*.pyc' -exec rm {} \;
+	@find . -name '*.pyo' -exec rm {} \;
+	@find . -name '__pycache__' -type d | xargs rm -rf
+	@rm -fv *~ .??*~
 	@rm -fv .\#*
 	@rm -fv core
 
 # default compile rules
-%.pyc : %.py
-	python2 -c "import compileall; compileall.compile_dir('$(CURDIR)')"
-%.pyo : %.py
-	python2 -OO -c "import compileall; compileall.compile_dir('$(CURDIR)')"
+compileall ::
+	$(PYTHON_BIN) -c "import compileall; compileall.compile_dir('$(CURDIR)')"
+	$(PYTHON_BIN) -OO -c "import compileall; compileall.compile_dir('$(CURDIR)')"
 
 # useful macro
 descend-subdirs = @$(foreach d,$(SUBDIRS), $(MAKE) -C $(d) $@ || exit 1; )

--- a/susemanager/src/Makefile
+++ b/susemanager/src/Makefile
@@ -26,10 +26,14 @@ SCRIPTS  = mgr-clean-old-patchnames \
 
 SUMA_DATA_FILES = mgr_bootstrap_data
 
-PYSUMA_DATA_FILES       = $(addsuffix .py,$(SUMA_DATA_FILES))
-PYCSUMA_DATA_FILES      = $(addsuffix .pyc,$(SUMA_DATA_FILES))
+PYSUMA_DATA_FILES  = $(addsuffix .py,$(SUMA_DATA_FILES))
+ifeq ($(PYTHON_BIN), python3)
+PYCSUMA_DATA_FILES = $(addsuffix *,$(addprefix __pycache__/,$(SUMA_DATA_FILES)))
+else
+PYCSUMA_DATA_FILES = $(addsuffix .pyc,$(SUMA_DATA_FILES)) $(addsuffix .pyo,$(SUMA_DATA_FILES))
+endif
 
-SUMA_INSTALL_DATA_FILES += $(PYSUMA_DATA_FILES) $(PYCSUMA_DATA_FILES)
+SUMA_INSTALL_DATA_FILES += $(PYSUMA_DATA_FILES)
 
 
 # check if we can build man pages
@@ -51,7 +55,11 @@ all :: $(SCRIPTS)
 install :: $(SCRIPTS) $(PREFIX)/$(SBINDIR) $(SUMA_INSTALL_DATA_FILES)
 	$(INSTALL_BIN) $(SCRIPTS) $(PREFIX)/$(SBINDIR)
 	$(INSTALL_DIR) $(PREFIX)/usr/share/susemanager
-	$(INSTALL_DIR) $(PREFIX)/$(SPACEWALK_DEST)/mgr_sync
+ifeq ($(PYTHON_BIN), python3)
+	$(INSTALL_DIR) $(PREFIX)/usr/share/susemanager/__pycache__
+endif
+	@$(foreach f,$(wildcard $(PYCSUMA_DATA_FILES)), \
+		$(INSTALL_DATA) $(f) $(PREFIX)/usr/share/susemanager/$(f) ; )
 	$(INSTALL_DATA) $(SUMA_INSTALL_DATA_FILES) $(PREFIX)/usr/share/susemanager
 
 ifneq ($(DOCBOOK),)

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,6 @@
+- porting the package to python3 with proper placement
+  compiled python files
+
 -------------------------------------------------------------------
 Mon May 24 12:40:08 CEST 2021 - jgonzalez@suse.com
 

--- a/susemanager/susemanager.spec
+++ b/susemanager/susemanager.spec
@@ -345,8 +345,10 @@ fi
 %{pythonsmroot}/susemanager/package_helper.py*
 %{pythonsmroot}/susemanager/mgr_sync
 %{_datadir}/susemanager/mgr_bootstrap_data.py*
-%if 0%{?rhel}
-%{pythonsmroot}/susemanager/__pycache__/*.pyc
+%if 0%{?rhel} || 0%{?build_py3}
+%{pythonsmroot}/susemanager/__pycache__/
+%{pythonsmroot}/susemanager/mgr_sync/__pycache__/
+%{_datadir}/susemanager/__pycache__/
 %endif
 %{_mandir}/man8/mgr-sync.8*
 %{wwwdocroot}/pub/repositories/empty/repodata/*.xml*


### PR DESCRIPTION
## What does this PR change?

Fixes issue https://github.com/SUSE/spacewalk/issues/13305

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
- No tests: build time changes

## Links

Fixes https://github.com/SUSE/spacewalk/issues/13305

## Changelogs

- porting the package to python3 with proper placement
  compiled python files

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
