### PR TITLE
cleanup code from legacy things

### DIFF
--- a/backend/rhn-conf/rhn_server.conf
+++ b/backend/rhn-conf/rhn_server.conf
@@ -5,13 +5,12 @@
 ### unexposed ###
 log_file        = /var/log/rhn/rhn_server.log
 buffer_size     = 16384
-ca_chain        = /usr/share/rhn/RHNS-CA-CERT
+ca_chain        =
 
 # Name of parent for ISS.
 # # If left blank rhn_parent is taken by default.
 # # This option can be overriden on satellite-sync command line.
 iss_parent      =
-iss_ca_chain    = /usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT
 
 # Enable package uploads for same nvrea but different vendors.
 enable_nvrea = 1

--- a/backend/rhn-conf/rhn_server_satellite.conf
+++ b/backend/rhn-conf/rhn_server_satellite.conf
@@ -13,8 +13,7 @@ mount_point = /var/spacewalk
 rhn_metadata_handler = /SAT-DUMP
 rhn_iss_metadata_handler = /SAT-DUMP-INTERNAL
 rhn_xmlrpc_handler = /SAT
-ca_chain = /usr/share/rhn/RHNS-CA-CERT
-rhn_parent = satellite.rhn.redhat.com
+server.satellite.rhn_parent =
 
 sync_cache_dir = /var/cache/rhn/
 http_proxy =

--- a/backend/rhn-conf/rhn_server_satellite.conf
+++ b/backend/rhn-conf/rhn_server_satellite.conf
@@ -13,7 +13,7 @@ mount_point = /var/spacewalk
 rhn_metadata_handler = /SAT-DUMP
 rhn_iss_metadata_handler = /SAT-DUMP-INTERNAL
 rhn_xmlrpc_handler = /SAT
-server.satellite.rhn_parent =
+rhn_parent =
 
 sync_cache_dir = /var/cache/rhn/
 http_proxy =

--- a/backend/satellite_tools/satsync.py
+++ b/backend/satellite_tools/satsync.py
@@ -2301,23 +2301,21 @@ def processCommandline():
         log(-1, _("ERROR: Check if your database is running."), stream=sys.stderr)
         sys.exit(20)
 
-    CFG.set("ISS_Parent", getDbIssParent())
+    CFG.set("ISS_PARENT", getDbIssParent())
     CFG.set("TRACEBACK_MAIL", OPTIONS.traceback_mail or CFG.TRACEBACK_MAIL)
     CFG.set("RHN_PARENT", idn_ascii_to_puny(OPTIONS.iss_parent or OPTIONS.server or
                                             CFG.ISS_PARENT or CFG.RHN_PARENT))
+    CFG.set("CA_CHAIN", OPTIONS.ca_cert or getDbCaChain(CFG.RHN_PARENT) or CFG.CA_CHAIN)
     if OPTIONS.server and not OPTIONS.iss_parent:
         # server option on comman line should override ISS parent from config
         CFG.set("ISS_PARENT", None)
     else:
         CFG.set("ISS_PARENT", idn_ascii_to_puny(OPTIONS.iss_parent or CFG.ISS_PARENT))
-        CFG.set("ISS_CA_CHAIN", OPTIONS.ca_cert or getDbCaChain(CFG.RHN_PARENT)
-                or CFG.CA_CHAIN)
 
     if not OPTIONS.ignore_proxy:
         CFG.set("HTTP_PROXY", idn_ascii_to_puny(OPTIONS.http_proxy or CFG.HTTP_PROXY))
         CFG.set("HTTP_PROXY_USERNAME", OPTIONS.http_proxy_username or CFG.HTTP_PROXY_USERNAME)
         CFG.set("HTTP_PROXY_PASSWORD", OPTIONS.http_proxy_password or CFG.HTTP_PROXY_PASSWORD)
-        CFG.set("CA_CHAIN", OPTIONS.ca_cert or CFG.CA_CHAIN)
 
     CFG.set("SYNC_TO_TEMP", OPTIONS.sync_to_temp or CFG.SYNC_TO_TEMP)
 

--- a/backend/satellite_tools/xmlWireSource.py
+++ b/backend/satellite_tools/xmlWireSource.py
@@ -122,12 +122,9 @@ class BaseWireSource:
             return None
 
         # Check certificate
-        if CFG.ISS_PARENT:
-            caChain = CFG.ISS_CA_CHAIN
-        else:
-            caChain = CFG.CA_CHAIN
+        caChain = CFG.CA_CHAIN
         if caChain:
-            # require RHNS-CA-CERT file to be able to authenticate the SSL
+            # require SSL CA file to be able to authenticate the SSL
             # connections.
             if not os.access(caChain, os.R_OK):
                 message = "ERROR: can not find SUSE Manager CA file: %s" % caChain

--- a/client/rhel/spacewalk-client-tools/data/Makefile
+++ b/client/rhel/spacewalk-client-tools/data/Makefile
@@ -5,7 +5,7 @@ PREFIX		?= /
 
 GLADES		= gui.glade progress.glade rh_register.glade
 PUPLET_SS       = puplet-screenshot.png
-KEYS		= RHNS-CA-CERT
+KEYS		=
 
 # Distro
 RHEL		= $(shell rpm --eval 0%{?rhel})

--- a/client/rhel/spacewalk-client-tools/spacewalk-client-tools.spec
+++ b/client/rhel/spacewalk-client-tools/spacewalk-client-tools.spec
@@ -751,9 +751,6 @@ make -f Makefile.rhn-client-tools test
 
 %ghost %attr(600,root,root) %{_localstatedir}/spool/up2date/loginAuth.pkl
 
-#public keys and certificates
-%{_datadir}/rhn/RHNS-CA-CERT
-
 %if 0%{?fedora} || 0%{?mageia} || 0%{?debian} >= 8 || 0%{?ubuntu} >= 1504 || 0%{?sle_version} >= 120000 || 0%{?rhel} >= 7
 %{_presetdir}/50-spacewalk-client.preset
 %endif

--- a/client/rhel/spacewalk-client-tools/src/bin/rhn_check.py
+++ b/client/rhel/spacewalk-client-tools/src/bin/rhn_check.py
@@ -129,8 +129,7 @@ class CheckCli(rhncli.RhnCli):
             print("""
             This could signal that you are *NOT* talking to a server
             whose certificate was signed by a Certificate Authority
-            listed in the %s file or that the
-            RHNS-CA-CERT file is invalid.""" % self.rhns_ca_cert)
+            listed in the %s file.""" % self.rhns_ca_cert)
             sys.exit(-1)
         except socket.error:
             print("Could not retrieve action from %s.\n"\
@@ -163,8 +162,7 @@ class CheckCli(rhncli.RhnCli):
             print("""
             This could signal that you are *NOT* talking to a server
             whose certificate was signed by a Certificate Authority
-            listed in the %s file or that the
-            RHNS-CA-CERT file is invalid.""" % self.rhns_ca_cert)
+            listed in the %s file.""" % self.rhns_ca_cert)
             sys.exit(-1)
         except socket.error:
             print("Could not retrieve action from %s.\n"\
@@ -250,8 +248,7 @@ class CheckCli(rhncli.RhnCli):
             print("""
             This could signal that you are *NOT* talking to a server
             whose certificate was signed by a Certificate Authority
-            listed in the %s file or that the
-            RHNS-CA-CERT file is invalid.""" % self.rhns_ca_cert)
+            listed in the %s file.""" % self.rhns_ca_cert)
             sys.exit(-1)
         except socket.error:
             print("Could not submit to %s.\n"\

--- a/client/rhel/spacewalk-client-tools/src/up2date_client/rpcServer.py
+++ b/client/rhel/spacewalk-client-tools/src/up2date_client/rpcServer.py
@@ -131,7 +131,7 @@ def getServer(refreshCallback=None, serverOverride=None, timeout=None, caChain=N
     if not isinstance(ca, list):
         ca = [ca]
 
-    rhns_ca_certs = ca or ["/usr/share/rhn/RHNS-CA-CERT"]
+    rhns_ca_certs = ca or ["/usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT"]
     if cfg["enableProxy"]:
         proxyHost = config.getProxySetting()
     else:
@@ -173,7 +173,7 @@ def getServer(refreshCallback=None, serverOverride=None, timeout=None, caChain=N
     if lang:
         s.setlang(lang)
 
-    # require RHNS-CA-CERT file to be able to authenticate the SSL connections
+    # require SSL CA file to be able to authenticate the SSL connections
     need_ca = [ True for i in s.serverList.serverList
                      if urlparse.urlparse(i)[0] == 'https']
     if need_ca:

--- a/client/tools/mgr-cfg/config_client/rhncfg-client.conf
+++ b/client/tools/mgr-cfg/config_client/rhncfg-client.conf
@@ -37,7 +37,7 @@ server_url = https://%(server_name)s%(server_handler)s
 # httpProxy = some.proxy.example.com:3030
 # proxyUser = proxy_user_name
 # proxyPassword = proxy_password
-# sslCACert = /usr/share/rhn/RHNS-CA-CERT
+# sslCACert = /usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT
 
 # control of remote-script-logging
 # Should we store output of a RemoteCommand locally? 1 = yes, 0 = no

--- a/client/tools/mgr-cfg/config_client/rhncfgcli.conf
+++ b/client/tools/mgr-cfg/config_client/rhncfgcli.conf
@@ -38,5 +38,5 @@ server_url = https://%(server_name)s%(server_handler)s
 # httpProxy = some.proxy.example.com:3030
 # proxyUser = proxy_user_name
 # proxyPassword = proxy_password
-# sslCACert = /usr/share/rhn/RHNS-CA-CERT
+# sslCACert = /usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT
 

--- a/client/tools/mgr-cfg/config_common/repository.py
+++ b/client/tools/mgr-cfg/config_common/repository.py
@@ -264,7 +264,7 @@ class RPC_Repository(Repository):
         if isinstance(ca, basestring):
             ca = [ca]
 
-        ca_certs = ca or ["/usr/share/rhn/RHNS-CA-CERT"]
+        ca_certs = ca or ["/usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT"]
 
         # not sure if we need this or not...
         lang = None

--- a/client/tools/mgr-cfg/config_management/rhncfg-manager.conf
+++ b/client/tools/mgr-cfg/config_management/rhncfg-manager.conf
@@ -39,5 +39,5 @@ server_url = https://%(server_name)s%(server_handler)s
 # httpProxy = some.proxy.example.com:3030
 # proxyUser = proxy_user_name
 # proxyPassword = proxy_password
-# sslCACert = /usr/share/rhn/RHNS-CA-CERT
+# sslCACert = /usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT
 

--- a/client/tools/mgr-cfg/config_management/rhncfg.conf
+++ b/client/tools/mgr-cfg/config_management/rhncfg.conf
@@ -39,4 +39,4 @@ server_url = https://%(server_name)s%(server_handler)s
 # httpProxy = some.proxy.example.com:3030
 # proxyUser = proxy_user_name
 # proxyPassword = proxy_password
-# sslCACert = /usr/share/rhn/RHNS-CA-CERT
+# sslCACert = /usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT

--- a/client/tools/mgr-custom-info/rhn-custom-info.py
+++ b/client/tools/mgr-custom-info/rhn-custom-info.py
@@ -54,7 +54,7 @@ def create_server_obj(server_url):
     if isinstance(ca, basestring):
         ca = [ca]
 
-    ca_certs = ca or ["/usr/share/rhn/RHNS-CA-CERT"]
+    ca_certs = ca or ["/usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT"]
 
     lang = None
     for env in 'LANGUAGE', 'LC_ALL', 'LC_MESSAGES', 'LANG':

--- a/client/tools/mgr-osad/rhn-conf/rhn_osa-dispatcher.conf
+++ b/client/tools/mgr-osad/rhn-conf/rhn_osa-dispatcher.conf
@@ -1,7 +1,7 @@
 # Default log file
 log_file        = /var/log/rhn/osa-dispatcher.log
 # SSL cert
-osa_ssl_cert  = /usr/share/rhn/RHNS-OSA-CERT
+osa_ssl_cert  = /srv/www/htdocs/pub/RHN-ORG-TRUSTED-SSL-CERT
 # Jabber server to connect to
 jabber_server   = jabberserver.example.org:5234
 

--- a/proxy/installer/configure-proxy.sh
+++ b/proxy/installer/configure-proxy.sh
@@ -273,10 +273,7 @@ config_error() {
 
 # Return 0 if rhnParent is Hosted. Otherwise return 1.
 is_hosted() {
-    HOSTEDWHITELIST=$(awk -F '=[[:space:]]*' '/^[[:space:]]*hostedWhitelist[[:space:]]*=/ {print $2}' $UP2DATE_FILE)
-    [ "$1" = "xmlrpc.rhn.redhat.com" -o \
-        "$HOSTEDWHITELIST" = "True" ]
-    return $?
+    return 1
 }
 
 check_ca_conf() {
@@ -347,14 +344,6 @@ DIR=/usr/share/rhn/proxy-template
 HOSTNAME=$(hostname -f)
 
 default_or_input "SUSE Manager Parent" RHN_PARENT $PROPOSED_PARENT
-
-if [ "$RHN_PARENT" == "rhn.redhat.com" ]; then
-   RHN_PARENT="xmlrpc.rhn.redhat.com"
-   cat <<WARNING
-*** Warning: plain rhn.redhat.com should not be used as RHN Parent.
-*** Using xmlrpc.rhn.redhat.com instead.
-WARNING
-fi
 
 sed -i -e "s/^serverURL=.*/serverURL=https:\/\/$RHN_PARENT\/XMLRPC/" /etc/sysconfig/rhn/up2date
 
@@ -448,7 +437,7 @@ if [ $SQUID_VER_MAJOR -ge 3 ] ; then
     fi
 fi
 sed "$SQUID_REWRITE" < $DIR/squid.conf  > $SQUID_DIR/squid.conf
-sed -e "s|\${session.ca_chain:/usr/share/rhn/RHNS-CA-CERT}|$CA_CHAIN|g" \
+sed -e "s|\${session.ca_chain:/usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT}|$CA_CHAIN|g" \
     -e "s/\${session.http_proxy}/$HTTP_PROXY/g" \
     -e "s/\${session.http_proxy_username}/$HTTP_USERNAME/g" \
     -e "s/\${session.http_proxy_password}/$HTTP_PASSWORD/g" \

--- a/proxy/installer/rhn.conf
+++ b/proxy/installer/rhn.conf
@@ -2,7 +2,7 @@
 # -------------------------------------------------------------------------
 
 # SSL CA certificate location
-proxy.ca_chain = ${session.ca_chain:/usr/share/rhn/RHNS-CA-CERT}
+proxy.ca_chain = ${session.ca_chain:/usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT}
 
 # Corporate HTTP proxy, format: corp_gateway.example.com:8080
 proxy.http_proxy = ${session.http_proxy}

--- a/proxy/proxy/pm/rhn-conf/rhn_proxy_package_manager.conf
+++ b/proxy/proxy/pm/rhn-conf/rhn_proxy_package_manager.conf
@@ -6,8 +6,8 @@ headers_per_call    = 25
 
 ## exposed
 debug		    = 5
-rhn_parent          = xmlrpc.rhn.redhat.com
+rhn_parent          =
 http_proxy          = 
 http_proxy_username = 
 http_proxy_password = 
-ca_chain            = /usr/share/rhn/RHNS-CA-CERT
+ca_chain            = /usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT

--- a/proxy/proxy/rhn-conf/rhn_proxy.conf
+++ b/proxy/proxy/rhn-conf/rhn_proxy.conf
@@ -9,9 +9,9 @@ squid = 127.0.0.1:8080
 ## exposed:
 traceback_mail = user0@example.com, user1@example.com
 
-rhn_parent = xmlrpc.rhn.redhat.com
+rhn_parent =
 
-ca_chain = /usr/share/rhn/RHNS-CA-CERT
+ca_chain = /usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT
 
 http_proxy =
 http_proxy_username =

--- a/spacewalk/admin/Makefile.admin
+++ b/spacewalk/admin/Makefile.admin
@@ -41,7 +41,7 @@ SBIN_SCRIPTS = rhn-sat-restart-silent spacewalk-service spacewalk-startup-helper
 
 CONF_FILES = service-list
 
-GPGKEY_FILES = RHN-GPG-KEY
+GPGKEY_FILES =
 
 SYSTEMD_FILES = spacewalk.target spacewalk-wait-for-tomcat.service spacewalk-wait-for-salt.service \
 		spacewalk-wait-for-jabberd.service spacewalk-wait-for-taskomatic.service salt-secrets-config.service \

--- a/spacewalk/admin/spacewalk-admin.spec
+++ b/spacewalk/admin/spacewalk-admin.spec
@@ -108,7 +108,6 @@ fi
 %{_bindir}/salt-secrets-config.py
 %{_sbindir}/rhn-sat-restart-silent
 %{_sbindir}/mgr-monitoring-ctl
-%{rhnroot}/RHN-GPG-KEY
 %{_mandir}/man8/rhn-satellite.8*
 %{_mandir}/man8/rhn-config-schema.pl.8*
 %{_mandir}/man8/spacewalk-service.8*

--- a/spacewalk/config/usr/share/man/man5/rhn.conf.5
+++ b/spacewalk/config/usr/share/man/man5/rhn.conf.5
@@ -92,15 +92,6 @@ This parameter determines the HTTP proxy password.
 none
 
 .TP
-.B "server.satellite.ca_chain"
-This parameter specify the SSL certificate used for communicationg with
-.B server.satellite.rhn_parent.
-The default SSL CA certificate points to RHN Hosted.
-.IP
-.B Default:
-/usr/share/rhn/RHNS-CA-CERT
-
-.TP
 .B "debug"
 .P
 .RS

--- a/spacewalk/config/var/lib/rhn/rhn-satellite-prep/etc/rhn/rhn.conf
+++ b/spacewalk/config/var/lib/rhn/rhn-satellite-prep/etc/rhn/rhn.conf
@@ -69,11 +69,6 @@ enable_snapshots = 1
 #cobbler host name
 cobbler.host = @@cobblerDOThost@@
 
-# SUSE Manager Settings
-server.susemanager.mirrcred_email = @@serverDOTsusemanagerDOTmirrcred_email@@
-server.susemanager.mirrcred_user = @@serverDOTsusemanagerDOTmirrcred_user@@
-server.susemanager.mirrcred_pass = @@serverDOTsusemanagerDOTmirrcred_pass@@
-
 # Maximum Java Heap Size (in MB)
 # taskomatic.java.maxmemory=4096
 

--- a/spacewalk/config/var/lib/rhn/rhn-satellite-prep/etc/rhn/rhn.conf
+++ b/spacewalk/config/var/lib/rhn/rhn-satellite-prep/etc/rhn/rhn.conf
@@ -2,7 +2,6 @@ traceback_mail = @@traceback_mail@@
 mount_point = @@mount_point@@
 kickstart_mount_point = @@kickstart_mount_point@@
 repomd_cache_mount_point = /var/cache 
-server.satellite.rhn_parent = satellite.rhn.redhat.com
 
 # Use proxy FQDN, or FQDN:port
 server.satellite.http_proxy = @@serverDOTsatelliteDOThttp_proxy@@
@@ -13,7 +12,6 @@ server.satellite.http_proxy_password = @@serverDOTsatelliteDOThttp_proxy_passwor
 # is a '.', so host is within the same domain.
 # A leading '.' in the pattern is ignored.
 server.satellite.no_proxy =
-server.satellite.ca_chain = @@serverDOTsatelliteDOTca_chain@@
 
 # Completely disable ISS.
 # If set to 1, then no slave will be able to sync from this server

--- a/spacewalk/setup/bin/spacewalk-setup
+++ b/spacewalk/setup/bin/spacewalk-setup
@@ -964,7 +964,6 @@ sub populate_initial_configs {
      hibernate_driver_proto => $answers->{'hibernate.connection.driver_proto'},
      traceback_mail => $answers->{'admin-email'},
      jabberDOThostname => $answers->{hostname},
-     serverDOTsatelliteDOTca_chain => '/usr/share/rhn/RHNS-CA-CERT',
      serverDOTnls_lang => 'english.' . $charset,
      server_secret_key => generate_secret(),
      cobblerDOThost => $answers->{hostname},
@@ -976,11 +975,7 @@ sub populate_initial_configs {
 
   my %rhnopt = ();
   if ($answers->{disconnected} || $opts->{disconnected}) {
-    $rhnopt{'server.satellite.rhn_parent'} = '';
     $rhnopt{'disconnected'} = "1";
-  }
-  else {
-    $rhnopt{'server.satellite.rhn_parent'} = $answers->{'rhn-parent'} || 'satellite.rhn.redhat.com';
   }
   for my $key (qw/product_name web.version enable_nvrea web.subscribe_proxy_channel force_package_upload
           web.l10n_resourcebundles web.default_mail_from/) {

--- a/spacewalk/setup/bin/spacewalk-setup
+++ b/spacewalk/setup/bin/spacewalk-setup
@@ -968,9 +968,6 @@ sub populate_initial_configs {
      serverDOTnls_lang => 'english.' . $charset,
      server_secret_key => generate_secret(),
      cobblerDOThost => $answers->{hostname},
-     serverDOTsusemanagerDOTmirrcred_email => '',
-     serverDOTsusemanagerDOTmirrcred_user => '',
-     serverDOTsusemanagerDOTmirrcred_pass => '',
      );
 
     for ($config_opts{'db_password'}) {

--- a/spacewalk/setup/bin/spacewalk-setup
+++ b/spacewalk/setup/bin/spacewalk-setup
@@ -132,7 +132,6 @@ print Spacewalk::Setup::loc("* Setting up users and groups.\n");
 setup_users_and_groups();
 
 setup_services();
-setup_gpg(\%opts);
 
 setup_admin_email(\%opts, \%answers, \%rhnOptions);
 
@@ -1108,53 +1107,6 @@ sub random_bits {
   }
 
   return $rand_data;
-}
-
-sub setup_gpg {
-  my $opts = shift;
-
-  if ($opts->{"skip-gpg-key-import"}) {
-    print Spacewalk::Setup::loc("** GPG: Skipping gpg key import\n");
-    return 0;
-  }
-
-  print Spacewalk::Setup::loc("** GPG: Initializing GPG and importing key.\n");
-
-  unless (-d '/root/.gnupg') {
-    print Spacewalk::Setup::loc("** GPG: Creating /root/.gnupg directory\n");
-    Spacewalk::Setup::system_or_exit(['mkdir', '-m', '700', '/root/.gnupg'], 12, 'Could not create /root/.gnupg');
-  }
-
-  Spacewalk::Setup::system_or_exit(['/usr/bin/gpg', '--list-keys'], 12, 'Could not run gpg.');
-
-  my $key_path = '/usr/share/rhn/RHN-GPG-KEY';
-  if ( ! (-e $key_path) ) {
-    if ( -e '/etc/fedora-release' ) {
-
-      # this is a fedora system
-      $key_path = '/etc/pki/rpm-gpg/RPM-GPG-KEY-fedora';
-
-    } elsif ( -e '/etc/redhat-release' ) {
-
-      # need to read the file to see if it's a Red Hat or CentOS system.
-      # we only want to import the key if it's a Red Hat system because
-      # the file doesn't exist on a CentOS system.
-      open(RELEASE, '/etc/redhat-release') or die "Could not open '/etc/redhat-release': $OS_ERROR\n";
-      my @release = <RELEASE>;
-      close(RELEASE);
-
-      my $rel_str = join('', @release);
-
-      # this is a RHEL system... RHEL 5 path.
-      if ( $rel_str =~ m/^Red Hat/ ) {
-        $key_path = '/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release';
-      }
-    }
-  }
-
-  Spacewalk::Setup::system_or_exit(['/usr/bin/gpg', '--import', $key_path], 12, 'Could not import public GPG key.');
-
-  return 1;
 }
 
 # Satellite services are handled by chkconfig now.

--- a/spacewalk/setup/lib/Spacewalk/Setup.pm
+++ b/spacewalk/setup/lib/Spacewalk/Setup.pm
@@ -127,7 +127,6 @@ sub parse_options {
             "skip-db-install",
             "skip-db-diskspace-check",
             "skip-db-population",
-            "skip-gpg-key-import",
             "skip-ssl-cert-generation",
 	    "skip-ssl-ca-generation",
             "skip-ssl-vhost-setup",
@@ -156,7 +155,7 @@ sub parse_options {
 
   my $usage = loc("usage: %s %s\n",
                   $0,
-                  "[ --help ] [ --answer-file=<filename> ] [ --non-interactive ] [ --skip-system-version-test ] [ --skip-selinux-test ] [ --skip-fqdn-test ] [ --skip-db-install ] [ --skip-db-diskspace-check ] [ --skip-db-population ] [ --skip-gpg-key-import ] [ --skip-ssl-cert-generation ] [--skip-ssl-ca-generation] [--skip-ssl-vhost-setup] [ --skip-services-check ] [ --skip-services-restart ] [ --clear-db ] [ --re-register ] [ --upgrade ] [ --run-updater=<yes|no>] [--run-cobbler] [ --enable-tftp=<yes|no>] [ --external-oracle | --external-postgresql [ --external-postgresql-over-ssl ] ] [--scc] [--disconnected]" );
+                  "[ --help ] [ --answer-file=<filename> ] [ --non-interactive ] [ --skip-system-version-test ] [ --skip-selinux-test ] [ --skip-fqdn-test ] [ --skip-db-install ] [ --skip-db-diskspace-check ] [ --skip-db-population ] [ --skip-ssl-cert-generation ] [--skip-ssl-ca-generation] [--skip-ssl-vhost-setup] [ --skip-services-check ] [ --skip-services-restart ] [ --clear-db ] [ --re-register ] [ --upgrade ] [ --run-updater=<yes|no>] [--run-cobbler] [ --enable-tftp=<yes|no>] [ --external-oracle | --external-postgresql [ --external-postgresql-over-ssl ] ] [--scc] [--disconnected]" );
 
   # Terminate if any errors were encountered parsing the command line args:
   my %opts;
@@ -1946,10 +1945,6 @@ the embedded database.
 =item B<--skip-db-population>
 
 Do not populate the database schema.
-
-=item B<--skip-gpg-key-import>
-
-Do not import Red Hat's GPG key.
 
 =item B<--skip-ssl-cert-generation>
 

--- a/spacewalk/setup/spacewalk-setup.spec
+++ b/spacewalk/setup/spacewalk-setup.spec
@@ -106,7 +106,6 @@ Requires:       (python3-PyYAML or python3-pyyaml)
 %else
 Requires:       (python-PyYAML or PyYAML)
 %endif
-Requires:       /usr/bin/gpg
 Requires:       curl
 Requires:       perl-Mail-RFC822-Address
 Requires:       perl-Net-LibIDN

--- a/web/conf/rhn_web.conf
+++ b/web/conf/rhn_web.conf
@@ -81,11 +81,9 @@ web.maximum_config_file_size = 131072
 web.default_mail_from = Spacewalk <dev-null@localhost>
 
 # server configs needed for satellite installer
-server.satellite.rhn_parent =
 server.satellite.http_proxy =
 server.satellite.http_proxy_username =
 server.satellite.http_proxy_password =
-server.satellite.ca_chain =
 
 # Configure the set of XML message files for the system
 # These packages indicate where the XML Resource bundles should


### PR DESCRIPTION
## What does this PR change?

- remove mirror credential settings from rhn.conf - moved to DB since a long time
- remove `satellite.rhn.redhat.com` as default for rhn_parent. We do not set a default anymore
- remove iss_ca_chain. We use now just ca_cert as fallback
- set ca_chain to empty value or to /usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT on managed clients
- remove expired RHNS-CA-CERT certificate
- do not install RedHat's gpg key

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
