### PR TITLE
Spacecmd fix dist help

### DIFF
--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,5 @@
+- enhance help for installation types when creating distributions (bsc#1186581)
+
 -------------------------------------------------------------------
 Mon May 24 12:35:44 CEST 2021 - jgonzalez@suse.com
 

--- a/spacecmd/src/spacecmd/distribution.py
+++ b/spacecmd/src/spacecmd/distribution.py
@@ -47,7 +47,7 @@ options:
   -n NAME
   -p path to tree
   -b base channel to associate with
-  -t install type [fedora|rhel_4/5/6|generic_rpm]'''))
+  -t install type [fedora18|rhel_6/7/8|sles12generic|sles15generic|suse|generic_rpm|...]'''))
 
 
 def do_distribution_create(self, args, update=False):
@@ -292,7 +292,7 @@ def help_distribution_update(self):
 options:
   -p path to tree
   -b base channel to associate with
-  -t install type [fedora|rhel_4/5/6|generic_rpm]'''))
+  -t install type [fedora18|rhel_6/7/8|sles12generic|sles15generic|suse|generic_rpm|...]'''))
 
 
 def complete_distribution_update(self, text, line, beg, end):


### PR DESCRIPTION
## What does this PR change?

The spacecmd help for distribution_create has only a very old and outdated list of installation types.
Drop old types and add new once for currently used distributions.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: just help update

- [x] **DONE**

## Test coverage
- No tests: **just help update**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/15034
Tracks 

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
