### PR TITLE
Fix spacewalk-java building on openSUSE Leap 15.3

### DIFF
--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Fix package building on openSUSE Leap 15.3
+
 -------------------------------------------------------------------
 Mon May 24 12:37:31 CEST 2021 - jgonzalez@suse.com
 

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -634,10 +634,8 @@ rm -rf $RPM_BUILD_ROOT/classes/com/redhat/rhn/common/conf/test/conf
 rm -rf $RPM_BUILD_ROOT%{_datadir}/rhn/unittest.xml
 %endif
 
-# Prettifying symlinks, excluding openSUSE
-%if ! 0%{?is_opensuse}
+# Prettifying symlinks
 mv $RPM_BUILD_ROOT%{jardir}/jboss-loggingjboss-logging.jar $RPM_BUILD_ROOT%{jardir}/jboss-logging.jar
-%endif
 
 # Prettifying symlinks for RHEL
 %if 0%{?rhel}


### PR DESCRIPTION
## What does this PR change?

Fix spacewalk-java building on openSUSE Leap 15.3

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: Fix package building

- [x] **DONE**

## Test coverage

- No tests: Tested by OBS

- [x] **DONE**

## Links

None

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
