### PR TITLE
Fix unstable frontend build validation

### DIFF
--- a/web/html/src/build.js
+++ b/web/html/src/build.js
@@ -1,4 +1,5 @@
 const shell = require('shelljs');
+const path = require('path');
 const { fillSpecFile } = require("./build/fill-spec-file");
 
 const { code: codeBuild } = shell.exec("webpack --config build/webpack.config.js --mode production");
@@ -19,7 +20,10 @@ fillSpecFile()
   .then(() => {
     if(shouldValidateBuild) {
       // let's make a sanity check if the generated specfile with the right  licenses is commited on git
-      const {code: gitCheckCode, stdout} = shell.exec("(cd ../../;git ls-files -m)");
+      const webDir = path.resolve(__dirname, '../../');
+      const {code: gitCheckCode, stdout} = shell.exec("git ls-files -m", {
+        cwd: webDir,
+      });
       if (gitCheckCode !== 0) {
         shell.exit(gitCheckCode);
       }

--- a/web/spacewalk-web.spec
+++ b/web/spacewalk-web.spec
@@ -63,7 +63,7 @@ but it does generate a number of sub-packages.
 
 %package -n susemanager-web-libs
 Summary:        Vendor bundles for spacewalk-web
-License:        0BSD and BSD-3-Clause and LGPL-3.0-or-later and MIT and MPL-2.0
+License:        0BSD AND BSD-3-Clause AND LGPL-3.0-or-later AND MIT AND MPL-2.0
 Group:          Applications/Internet
 
 BuildArch:      noarch

--- a/web/spacewalk-web.spec
+++ b/web/spacewalk-web.spec
@@ -63,7 +63,7 @@ but it does generate a number of sub-packages.
 
 %package -n susemanager-web-libs
 Summary:        Vendor bundles for spacewalk-web
-License:        0BSD AND BSD-3-Clause AND LGPL-3.0-or-later AND MIT AND MPL-2.0
+License:        0BSD and BSD-3-Clause and LGPL-3.0-or-later and MIT and MPL-2.0
 Group:          Applications/Internet
 
 BuildArch:      noarch


### PR DESCRIPTION
## What does this PR change?

Currently, the frontend build validation [depends on the cwd](https://github.com/SUSE/spacewalk/issues/13915) and can pass while it shouldn't when executed in a subdirectory. This PR fixes the issue.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: only internal and user invisible changes

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/13915

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
