### PR TITLE
Deprecate `objectDefaultValueHandler`

### DIFF
--- a/web/html/src/core/utils/objects.ts
+++ b/web/html/src/core/utils/objects.ts
@@ -1,8 +1,0 @@
-// TODO: This is obsolete, see https://github.com/SUSE/spacewalk/issues/13648
-export function objectDefaultValueHandler(defaultValue: any) {
-  return {
-    get: function(target: any, name: string) {
-      return target.hasOwnProperty(name) ? target[name] : defaultValue;
-    },
-  };
-}

--- a/web/html/src/manager/content-management/shared/business/states.enum.ts
+++ b/web/html/src/manager/content-management/shared/business/states.enum.ts
@@ -1,9 +1,10 @@
-import { objectDefaultValueHandler } from "core/utils/objects";
 import _find from "lodash/find";
 
 type stateType = {
   key: string;
   description: string;
+  deletion: boolean;
+  edited: boolean;
   sign: string;
 };
 
@@ -11,20 +12,15 @@ type statesEnumType = {
   [key: string]: stateType;
 };
 
-const defaultState: any = {};
+const statesEnum: statesEnumType = {
+  ATTACHED: { key: "ATTACHED", description: "added", deletion: false, edited: true, sign: "+" },
+  DETACHED: { key: "DETACHED", description: "deleted", deletion: true, edited: true, sign: "-" },
+  EDITED: { key: "EDITED", description: "edited", deletion: false, edited: true, sign: " " },
+  BUILT: { key: "BUILT", description: "built", deletion: false, edited: false, sign: " " },
+};
 
-const statesEnum: statesEnumType = new Proxy(
-  {
-    ATTACHED: { key: "ATTACHED", description: "added", deletion: false, edited: true, sign: "+" },
-    DETACHED: { key: "DETACHED", description: "deleted", deletion: true, edited: true, sign: "-" },
-    EDITED: { key: "EDITED", description: "edited", deletion: false, edited: true, sign: " " },
-    BUILT: { key: "BUILT", description: "built", deletion: false, edited: false, sign: " " },
-  },
-  objectDefaultValueHandler(defaultState)
-);
-
-function findByKey(key: string) {
-  return _find(statesEnum, entry => entry.key === key) || defaultState;
+function findByKey(key: string): stateType | Partial<stateType> {
+  return _find(statesEnum, entry => entry.key === key) || {};
 }
 
 function isDeletion(key: string) {
@@ -40,9 +36,4 @@ export default {
   findByKey,
   isDeletion,
   isEdited,
-} as {
-  enum: statesEnumType;
-  findByKey: (arg0: string) => stateType;
-  isDeletion: (arg0: string) => boolean;
-  isEdited: (arg0: string) => boolean;
 };

--- a/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment-view.tsx
+++ b/web/html/src/manager/content-management/shared/components/panels/environment-lifecycle/environment-view.tsx
@@ -3,7 +3,6 @@ import _isEmpty from "lodash/isEmpty";
 
 import { ProjectEnvironmentType, ProjectHistoryEntry } from "../../../type";
 import { getVersionMessageByNumber } from "../properties/properties.utils";
-import { objectDefaultValueHandler } from "core/utils/objects";
 import BuildVersion from "../build/build-version";
 
 type Props = {
@@ -19,16 +18,13 @@ type EnvironmentStatusEnumType = {
   };
 };
 
-const environmentStatusEnum: EnvironmentStatusEnumType = new Proxy(
-  {
-    new: { key: "new", text: t("New"), isBuilding: false },
-    building: { key: "building", text: t("Cloning channels"), isBuilding: true },
-    generating_repodata: { key: "generating_repodata", text: t("Generating repositories data"), isBuilding: true },
-    built: { key: "built", text: t("Built"), isBuilding: false },
-    failed: { key: "failed", text: t("Failed"), isBuilding: false },
-  },
-  objectDefaultValueHandler({ text: "", isBuilding: false })
-);
+const environmentStatusEnum: EnvironmentStatusEnumType = {
+  new: { key: "new", text: t("New"), isBuilding: false },
+  building: { key: "building", text: t("Cloning channels"), isBuilding: true },
+  generating_repodata: { key: "generating_repodata", text: t("Generating repositories data"), isBuilding: true },
+  built: { key: "built", text: t("Built"), isBuilding: false },
+  failed: { key: "failed", text: t("Failed"), isBuilding: false },
+};
 
 const EnvironmentView = React.memo((props: Props) => {
   return (

--- a/web/spacewalk-web.spec
+++ b/web/spacewalk-web.spec
@@ -63,7 +63,7 @@ but it does generate a number of sub-packages.
 
 %package -n susemanager-web-libs
 Summary:        Vendor bundles for spacewalk-web
-License:        0BSD AND BSD-3-Clause AND LGPL-3.0-or-later AND MIT and MPL-2.0
+License:        0BSD and BSD-3-Clause and LGPL-3.0-or-later and MIT and MPL-2.0
 Group:          Applications/Internet
 
 BuildArch:      noarch

--- a/web/spacewalk-web.spec
+++ b/web/spacewalk-web.spec
@@ -63,7 +63,7 @@ but it does generate a number of sub-packages.
 
 %package -n susemanager-web-libs
 Summary:        Vendor bundles for spacewalk-web
-License:        0BSD and BSD-3-Clause and LGPL-3.0-or-later and MIT and MPL-2.0
+License:        0BSD AND BSD-3-Clause AND LGPL-3.0-or-later AND MIT AND MPL-2.0
 Group:          Applications/Internet
 
 BuildArch:      noarch

--- a/web/spacewalk-web.spec
+++ b/web/spacewalk-web.spec
@@ -63,7 +63,7 @@ but it does generate a number of sub-packages.
 
 %package -n susemanager-web-libs
 Summary:        Vendor bundles for spacewalk-web
-License:        0BSD and BSD-3-Clause and LGPL-3.0-or-later and MIT and MPL-2.0
+License:        0BSD AND BSD-3-Clause AND LGPL-3.0-or-later AND MIT and MPL-2.0
 Group:          Applications/Internet
 
 BuildArch:      noarch

--- a/web/spacewalk-web.spec
+++ b/web/spacewalk-web.spec
@@ -63,7 +63,7 @@ but it does generate a number of sub-packages.
 
 %package -n susemanager-web-libs
 Summary:        Vendor bundles for spacewalk-web
-License:        0BSD AND BSD-3-Clause AND LGPL-3.0-or-later AND MIT AND MPL-2.0
+License:        0BSD and BSD-3-Clause and LGPL-3.0-or-later and MIT and MPL-2.0
 Group:          Applications/Internet
 
 BuildArch:      noarch


### PR DESCRIPTION
## What does this PR change?

[`objectDefaultValueHandler`](https://github.com/uyuni-project/uyuni/blob/master/web/html/src/core/utils/objects.ts) is currently imported in only two views and is practically not used in either of them. This is evidenced by the fact that the util is actually bugged but the branch is never hit because all the values are defined in all the inputs. This PR removes the bugged utilty, removing unnecessary complexity.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: only internal and user invisible changes

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/13648

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
