### PR TITLE
BV: Enable patches for SLES15 SP3

### DIFF
--- a/testsuite/features/build_validation/smoke_tests/smoke_tests.template
+++ b/testsuite/features/build_validation/smoke_tests/smoke_tests.template
@@ -22,8 +22,6 @@ Feature: Smoke tests for <client>
     Given I am on the Systems overview page of this "<client>"
     Then I can see all system information for "<client>"
 
-# TODO: Remove the @skip_for_sle15sp3 when 15sp3 gets released and has patches
-@skip_for_sle15sp3
 @skip_for_ubuntu
   Scenario: Install a patch on the <client>
     When I follow "Software" in the content area
@@ -90,6 +88,7 @@ Feature: Smoke tests for <client>
     And I wait until file "/tmp/remote-command-on-<client>" exists on "<client>"
 
   Scenario: Check that Software package refresh works on a <client>
+    Given I am on the Systems overview page of this "<client>"
     When I follow "Software" in the content area
     And I click on "Update Package List"
     And I force picking pending events on "<client>" if necessary

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -284,11 +284,6 @@ Before('@sle15sp3_client') do
   skip_this_scenario unless $sle15sp3_client
 end
 
-# TODO: Remove this when 15sp3 gets released and has patches
-Before('@skip_for_sle15sp3') do |scenario|
-  skip_this_scenario if scenario.feature.location.file.include? '15sp3'
-end
-
 Before('@skip_for_ubuntu') do |scenario|
   skip_this_scenario if scenario.feature.location.file.include? 'ubuntu'
 end


### PR DESCRIPTION
## What does this PR change?

- Enabling installation of patches for SLES15 SP3
- Fixing a missing navigation step for salt minions

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Port:
- Manager-4.0
- Manager-4.1
 
- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
