### PR TITLE
Various build validation fixes

### DIFF
--- a/testsuite/features/build_validation/smoke_tests/smoke_tests.template
+++ b/testsuite/features/build_validation/smoke_tests/smoke_tests.template
@@ -22,7 +22,7 @@ Feature: Smoke tests for <client>
     Given I am on the Systems overview page of this "<client>"
     Then I can see all system information for "<client>"
 
-@skip_for_ubuntu
+@skip_for_debianlike
   Scenario: Install a patch on the <client>
     When I follow "Software" in the content area
     And I follow "Patches" in the content area
@@ -103,8 +103,7 @@ Feature: Smoke tests for <client>
     And I wait until event "Hardware List Refresh scheduled by admin" is completed
 
   Scenario: Subscribe a <client> to the configuration channel
-    When I follow "Details" in the content area
-    And I follow "Configuration" in the content area
+    When I follow "Configuration" in the content area
     And I follow "Manage Configuration Channels" in the content area
     And I follow first "Subscribe to Channels" in the content area
     And I check "Mixed Channel" in the list

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -139,10 +139,10 @@ PACKAGE_BY_CLIENT = { 'sle_client' => 'bison',
                       'ubuntu1804_ssh_minion' => 'bison',
                       'ubuntu2004_minion' => 'bison',
                       'ubuntu2004_ssh_minion' => 'bison',
-                      'debian9_minion' => 'bison',
-                      'debian9_ssh_minion' => 'bison',
-                      'debian10_minion' => 'bison',
-                      'debian10_ssh_minion' => 'bison' }.freeze
+                      'debian9_minion' => 'joe',
+                      'debian9_ssh_minion' => 'joe',
+                      'debian10_minion' => 'joe',
+                      'debian10_ssh_minion' => 'joe' }.freeze
 
 BASE_CHANNEL_BY_CLIENT = { 'proxy' => 'SLE-Product-SUSE-Manager-Proxy-4.2-Pool',
                            'sle_client' => 'SLES12-SP4-Pool',

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -284,8 +284,9 @@ Before('@sle15sp3_client') do
   skip_this_scenario unless $sle15sp3_client
 end
 
-Before('@skip_for_ubuntu') do |scenario|
-  skip_this_scenario if scenario.feature.location.file.include? 'ubuntu'
+Before('@skip_for_debianlike') do |scenario|
+  filename = scenario.feature.location.file
+  skip_this_scenario if (filename.include? 'ubuntu') || (filename.include? 'debian')
 end
 
 Before('@skip_for_minion') do |scenario|


### PR DESCRIPTION
## What does this PR change?

This PR fixes various problems:
* we can't test patching on Debian, the notion does not exist
* there is no "bison" nor "autoconf" package to test on Debian - use "joe" instead"
* there is no need to go to "Details" to choose "Configuration" on the top menu


## Links

Ports:
* 4.0:
* 4.1:


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
