### PR TITLE
BV: Revert default package name to bison

### DIFF
--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -139,10 +139,10 @@ PACKAGE_BY_CLIENT = { 'sle_client' => 'bison',
                       'ubuntu1804_ssh_minion' => 'bison',
                       'ubuntu2004_minion' => 'bison',
                       'ubuntu2004_ssh_minion' => 'bison',
-                      'debian9_minion' => 'joe',
-                      'debian9_ssh_minion' => 'joe',
-                      'debian10_minion' => 'joe',
-                      'debian10_ssh_minion' => 'joe' }.freeze
+                      'debian9_minion' => 'bison',
+                      'debian9_ssh_minion' => 'bison',
+                      'debian10_minion' => 'bison',
+                      'debian10_ssh_minion' => 'bison' }.freeze
 
 BASE_CHANNEL_BY_CLIENT = { 'proxy' => 'SLE-Product-SUSE-Manager-Proxy-4.2-Pool',
                            'sle_client' => 'SLES12-SP4-Pool',


### PR DESCRIPTION
## What does this PR change?

Partial revert of previous PR.

Sorry, I did not realize I already installed "bison" in a previous run.


## Links

Ports:
* 4.0: SUSE/spacewalk#15054
* 4.1: SUSE/spacewalk#15053


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
