### PR TITLE
Remove unused imports

### DIFF
--- a/susemanager-frontend/yarn.lock
+++ b/susemanager-frontend/yarn.lock
@@ -11027,15 +11027,10 @@ lodash.uniq@4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.17.21, lodash@^4.17.20:
+lodash@4.17.21, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
-
-lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19:
-  version "4.17.19"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
-  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
 loglevel@^1.6.8:
   version "1.7.0"

--- a/web/html/src/core/channels/api/mandatory-channels-api.ts
+++ b/web/html/src/core/channels/api/mandatory-channels-api.ts
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import useMandatoryChannelsApi, { UseMandatoryChannelsApiReturnType } from "./use-mandatory-channels-api";
 
 type Props = {

--- a/web/html/src/manager/state/recurring-states-list.tsx
+++ b/web/html/src/manager/state/recurring-states-list.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import ReactDOM from "react-dom";
 import { InnerPanel } from "components/panels/InnerPanel";
 import { Button } from "components/buttons";
 import { Toggler } from "components/toggler";

--- a/web/html/src/manager/systems/delete-system.tsx
+++ b/web/html/src/manager/systems/delete-system.tsx
@@ -1,13 +1,10 @@
 import * as React from "react";
-import ReactDOM from "react-dom";
 import { AsyncButton, Button } from "components/buttons";
 import Network from "utils/network";
 import { Messages } from "components/messages";
 import { Utils as MessagesUtils } from "components/messages";
-import { Utils } from "utils/functions";
 import { Dialog } from "components/dialog/LegacyDialog";
 import { showDialog } from "components/dialog/util";
-import { DeleteDialog } from "components/dialog/DeleteDialog";
 
 const msgMap = {
   minion_unreachable: t("Cleanup timed out. Please check if the machine is reachable."),

--- a/web/html/src/manager/systems/virtualhostmanager/virtualhostmanager-details.tsx
+++ b/web/html/src/manager/systems/virtualhostmanager/virtualhostmanager-details.tsx
@@ -9,7 +9,6 @@ import { Messages } from "components/messages";
 import { Utils as MessagesUtils } from "components/messages";
 import { Table } from "components/table/Table";
 import { Column } from "components/table/Column";
-import { SearchField } from "components/table/SearchField";
 
 type Props = {
   data: any;

--- a/web/html/src/manager/systems/virtualhostmanager/virtualhostmanager-edit.tsx
+++ b/web/html/src/manager/systems/virtualhostmanager/virtualhostmanager-edit.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import ReactDOM from "react-dom";
 import { SubmitButton, Button } from "components/buttons";
 import { Form } from "components/input/Form";
 import { FormGroup } from "components/input/FormGroup";
@@ -9,7 +8,6 @@ import { Text } from "components/input/Text";
 import { Select } from "components/input/Select";
 import Network from "utils/network";
 import { Messages } from "components/messages";
-import { Utils as MessagesUtils } from "components/messages";
 import { Utils } from "utils/functions";
 
 type Props = {

--- a/web/html/src/manager/systems/virtualhostmanager/virtualhostmanager-list.tsx
+++ b/web/html/src/manager/systems/virtualhostmanager/virtualhostmanager-list.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 import { Utils } from "utils/functions";
 import { Table } from "components/table/Table";
 import { Column } from "components/table/Column";
-import { SearchField } from "components/table/SearchField";
 import { Button } from "components/buttons";
 import { ModalButton } from "components/dialog/ModalButton";
 import { DeleteDialog } from "components/dialog/DeleteDialog";

--- a/web/html/src/manager/systems/virtualhostmanager/virtualhostmanager.tsx
+++ b/web/html/src/manager/systems/virtualhostmanager/virtualhostmanager.tsx
@@ -70,7 +70,6 @@ class VirtualHostManager extends React.Component<Props, State> {
   }
 
   updateView(action, id) {
-    let async;
     if ((action === "edit" || action === "details") && id)
       this.getVhmDetails(id, action).then(data => this.setState({ selected: data.data, action: action }));
     else if (!action) {

--- a/web/html/src/utils/test-utils/mock.tsx
+++ b/web/html/src/utils/test-utils/mock.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 // Mock the datetime picker to avoid it causing issues due to missing jQuery/Bootstrap parts
 jest.mock("components/datetimepicker", () => {
   return {
@@ -19,3 +17,5 @@ jest.mock("components/ace-editor", () => {
     },
   };
 });
+
+export {};

--- a/web/spacewalk-web.spec
+++ b/web/spacewalk-web.spec
@@ -63,7 +63,7 @@ but it does generate a number of sub-packages.
 
 %package -n susemanager-web-libs
 Summary:        Vendor bundles for spacewalk-web
-License:        0BSD and BSD-3-Clause and LGPL-3.0-or-later and MIT and MPL-2.0
+License:        0BSD AND BSD-3-Clause AND LGPL-3.0-or-later AND MIT AND MPL-2.0
 Group:          Applications/Internet
 
 BuildArch:      noarch

--- a/web/spacewalk-web.spec
+++ b/web/spacewalk-web.spec
@@ -63,7 +63,7 @@ but it does generate a number of sub-packages.
 
 %package -n susemanager-web-libs
 Summary:        Vendor bundles for spacewalk-web
-License:        0BSD AND BSD-3-Clause AND LGPL-3.0-or-later AND MIT AND MPL-2.0
+License:        0BSD and BSD-3-Clause and LGPL-3.0-or-later and MIT and MPL-2.0
 Group:          Applications/Internet
 
 BuildArch:      noarch


### PR DESCRIPTION
## What does this PR change?

Stumbled upon this while fixing another bug, cleaning up our lint output, removing a bunch of unused imports.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: only internal and user invisible changes

- [x] **DONE**

## Links

Part of https://github.com/SUSE/spacewalk/issues/13762

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
