### PR TITLE
Fix image building UI

### DIFF
--- a/web/html/src/build/fill-spec-file.js
+++ b/web/html/src/build/fill-spec-file.js
@@ -10,7 +10,7 @@ function fillSpecFile() {
         }
         return item;
     });
-    const mappedProcessedLicenses = Array.from(new Set(processedLicenses)).sort().join(" and ");
+    const mappedProcessedLicenses = Array.from(new Set(processedLicenses)).sort().join(" AND ");
 
     const specFileLocation = "../../spacewalk-web.spec";
 

--- a/web/html/src/manager/images/image-build.tsx
+++ b/web/html/src/manager/images/image-build.tsx
@@ -10,7 +10,7 @@ import { FormGroup } from "components/input/FormGroup";
 import { Select } from "components/input/Select";
 import { Text } from "components/input/Text";
 import { ActionLink, ActionChainLink } from "components/links";
-import { ActionSchedule } from "components/action-schedule";
+import { ActionChain, ActionSchedule } from "components/action-schedule";
 import SpaRenderer from "core/spa/spa-renderer";
 import { DEPRECATED_unsafeEquals } from "utils/legacy";
 
@@ -181,26 +181,24 @@ class BuildImage extends React.Component<Props, State> {
     });
   }
 
-  onDateTimeChanged(date) {
-    /**
-     * TODO: This is a bug and is probably not what was intended
-     * Do not assign to state fields directly, use `setState()` instead
-     */
-    this.state.model.earliest = date;
-    this.state.model.actionChain = null;
+  onDateTimeChanged(date: Date) {
+     const model: State['model'] = Object.assign({}, this.state.model, {
+      earliest: date,
+      actionChain: null,
+     });
     this.setState({
       actionChain: null,
+      model,
     });
   }
 
-  onActionChainChanged(actionChain) {
-    /**
-     * TODO: This is a bug and is probably not what was intended
-     * Do not assign to state fields directly, use `setState()` instead
-     */
-    this.state.model.actionChain = actionChain.text;
+  onActionChainChanged(actionChain: ActionChain | null) {
+    const model: State['model'] = Object.assign({}, this.state.model, {
+      actionChain: actionChain?.text,
+    });
     this.setState({
-      actionChain: actionChain,
+      actionChain,
+      model,
     });
   }
 

--- a/web/html/src/manager/images/image-profiles.tsx
+++ b/web/html/src/manager/images/image-profiles.tsx
@@ -50,6 +50,9 @@ class ImageProfiles extends React.Component<Props, State> {
       imageprofiles: [],
       selectedItems: [],
     };
+  }
+
+  componentDidMount() {
     this.reloadData();
   }
 

--- a/web/html/src/manager/images/image-view.tsx
+++ b/web/html/src/manager/images/image-view.tsx
@@ -88,7 +88,9 @@ class ImageView extends React.Component<ImageViewProps, ImageViewState> {
       imagesRuntime: {},
       selectedItems: [],
     };
+  }
 
+  componentDidMount() {
     this.updateView(getHashId(), getHashTab());
     window.addEventListener("popstate", () => {
       this.updateView(getHashId(), getHashTab());

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,5 @@
+- Fix image building scheduling UI (bsc#1186728)
+
 -------------------------------------------------------------------
 Mon May 24 12:39:25 CEST 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Adds optional chaining for image building UI, fixing https://bugzilla.suse.com/show_bug.cgi?id=1186728  
Also fixes an unrelated lifecycle bug I found on the way.

## GUI diff

No difference, except now you actually see the UI.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: only internal and user invisible changes

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/15076 and https://bugzilla.suse.com/show_bug.cgi?id=1186728

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
