### PR TITLE
Enable LTSS repo before installing branch server

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -815,7 +815,7 @@ When(/^I enable repositories before installing branch server$/) do
   os_version, os_family = get_os_version($proxy)
 
   # Distribution
-  repos = "os_pool_repo os_update_repo"
+  repos = "os_pool_repo os_update_repo os_ltss_repo"
   puts $proxy.run("zypper mr --enable #{repos}")
 
   # Server Applications
@@ -829,7 +829,7 @@ When(/^I disable repositories after installing branch server$/) do
   os_version, os_family = get_os_version($proxy)
 
   # Distribution
-  repos = "os_pool_repo os_update_repo"
+  repos = "os_pool_repo os_update_repo os_ltss_repo"
   puts $proxy.run("zypper mr --disable #{repos}")
 
   # Server Applications


### PR DESCRIPTION
## What does this PR change?

Enable LTSS repo before installing branch server

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes failure of 4.0 CI, no issue, directly from review
Tracks 4.1: https://github.com/SUSE/spacewalk/pull/15108
4.0: https://github.com/SUSE/spacewalk/pull/15107

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
