### PR TITLE
QA: Change CentOS OpenSCAP profile

### DIFF
--- a/testsuite/features/secondary/min_centos_openscap_audit.feature
+++ b/testsuite/features/secondary/min_centos_openscap_audit.feature
@@ -18,7 +18,6 @@ Feature: OpenSCAP audit of CentOS Salt minion
     And I enable client tools repositories on "ceos_minion"
     And I refresh the metadata for "ceos_minion"
     And I install OpenSCAP dependencies on "ceos_minion"
-    And I fix CentOS 7 OpenSCAP files on "ceos_minion"
     And I follow "Software" in the content area
     And I click on "Update Package List"
     And I wait until event "Package List Refresh" is completed
@@ -29,7 +28,7 @@ Feature: OpenSCAP audit of CentOS Salt minion
     And I follow "Schedule" in the content area
     And I wait at most 30 seconds until I do not see "This system does not yet have OpenSCAP scan capability." text, refreshing the page
     And I enter "--profile standard" as "params"
-    And I enter "/usr/share/xml/scap/ssg/content/ssg-rhel7-xccdf.xml" as "path"
+    And I enter "/usr/share/xml/scap/ssg/content/ssg-centos7-xccdf.xml" as "path"
     And I click on "Schedule"
     Then I should see a "XCCDF scan has been scheduled" text
     And I wait at most 500 seconds until event "OpenSCAP xccdf scanning" is completed

--- a/testsuite/features/secondary/trad_centos_client.feature
+++ b/testsuite/features/secondary/trad_centos_client.feature
@@ -29,7 +29,6 @@ Feature: Be able to register a CentOS 7 traditional client and do some basic ope
     And I enable client tools repositories on "ceos_client"
     And I install the traditional stack utils on "ceos_client"
     And I install OpenSCAP dependencies on "ceos_client"
-    And I fix CentOS 7 OpenSCAP files on "ceos_client"
     And I register "ceos_client" as traditional client
     And I run "rhn-actions-control --enable-all" on "ceos_client"
 
@@ -66,7 +65,7 @@ Feature: Be able to register a CentOS 7 traditional client and do some basic ope
     And I follow "Schedule" in the content area
     And I wait at most 30 seconds until I do not see "This system does not yet have OpenSCAP scan capability." text, refreshing the page
     And I enter "--profile standard" as "params"
-    And I enter "/usr/share/xml/scap/ssg/content/ssg-rhel7-xccdf.xml" as "path"
+    And I enter "/usr/share/xml/scap/ssg/content/ssg-centos7-xccdf.xml" as "path"
     And I click on "Schedule"
     And I run "rhn_check -vvv" on "ceos_client"
     Then I should see a "XCCDF scan has been scheduled" text

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -868,14 +868,6 @@ When(/^I (install|remove) OpenSCAP dependencies (on|from) "([^"]*)"$/) do |actio
   step %(I #{action} packages "#{pkgs}" #{where} this "#{host}")
 end
 
-# On CentOS 7, OpenSCAP files are for RedHat and need a small adaptation for CentOS
-When(/^I fix CentOS 7 OpenSCAP files on "([^"]*)"$/) do |host|
-  node = get_target(host)
-  script = '/<\/rear-matter>/a  <platform idref="cpe:/o:centos:centos:7"/>'
-  file = "/usr/share/xml/scap/ssg/content/ssg-rhel7-xccdf.xml"
-  node.run("sed -i '#{script}' #{file}")
-end
-
 When(/^I install package(?:s)? "([^"]*)" on this "([^"]*)"((?: without error control)?)$/) do |package, host, error_control|
   node = get_target(host)
   if host.include? 'ceos'


### PR DESCRIPTION
## What does this PR change?

Change to CentOS OpenSCAP profile, as it's currently using RedHat profile plus a hack.

Related to  https://github.com/SUSE/spacewalk/issues/14758

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.0  https://github.com/SUSE/spacewalk/pull/15115
- Manager-4.1 https://github.com/SUSE/spacewalk/pull/15114

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
