### PR TITLE
Add linter rule for no raw Date usage

### DIFF
--- a/susemanager-frontend/susemanager-nodejs-sdk-devel/package.json
+++ b/susemanager-frontend/susemanager-nodejs-sdk-devel/package.json
@@ -41,6 +41,7 @@
     "eslint-plugin-flowtype": "^5.2.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-jsx-a11y": "^6.4.1",
+    "eslint-plugin-local-rules": "^1.1.0",
     "eslint-plugin-react-hooks": "^4.2.0",
     "eslint-plugin-react": "^7.21.5",
     "eslint": "7.15.0",

--- a/susemanager-frontend/yarn.lock
+++ b/susemanager-frontend/yarn.lock
@@ -7643,6 +7643,11 @@ eslint-plugin-jsx-a11y@^6.4.1:
     jsx-ast-utils "^3.1.0"
     language-tags "^1.0.5"
 
+eslint-plugin-local-rules@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-local-rules/-/eslint-plugin-local-rules-1.1.0.tgz#5f934f685b08c96eed40b92aee7b02f03cf55f7b"
+  integrity sha512-FdPyzxakUKgZkeNM3x/vvRcB6nCjTNbui5gWALhvcaH1R6aCiD37fWtdesagcyBpEe9S9XRHAJ8CJ4rUJ3K9tQ==
+
 eslint-plugin-react-hooks@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz#8c229c268d468956334c943bb45fc860280f5556"

--- a/web/html/src/.eslintrc.js
+++ b/web/html/src/.eslintrc.js
@@ -8,7 +8,8 @@ module.exports = {
 
   plugins: [
     "react-hooks",
-    "@typescript-eslint"
+    "@typescript-eslint",
+    "eslint-plugin-local-rules"
   ],
 
   env: {
@@ -26,6 +27,8 @@ module.exports = {
     "react-hooks/rules-of-hooks": "error",
     "eqeqeq": "error",
     "radix": ["error", "always"],
+    // TODO: Eventually this should be "error"
+    "local-rules/no-raw-date": "warn",
     // TODO: Eventually we should enforce this as well
     // "no-eq-null": "error",
     // TODO: This needs to be reworked with Typescript support in mind

--- a/web/html/src/.eslintrc.js
+++ b/web/html/src/.eslintrc.js
@@ -28,7 +28,7 @@ module.exports = {
     "eqeqeq": "error",
     "radix": ["error", "always"],
     // TODO: Eventually this should be "error"
-    "local-rules/no-raw-date": "warn",
+    "local-rules/no-raw-date": "off",
     // TODO: Eventually we should enforce this as well
     // "no-eq-null": "error",
     // TODO: This needs to be reworked with Typescript support in mind

--- a/web/html/src/eslint-local-rules/README.md
+++ b/web/html/src/eslint-local-rules/README.md
@@ -1,5 +1,8 @@
 # Local ESLint rules
 
-TODO: Write
+This directory contains local linter rules to enforce project-specific rules. This is a great option if you want to discourage or forbid certain types of practices.
 
-See https://github.com/cletusw/eslint-plugin-local-rules for more information
+Recommended reading:  
+
+ - https://eslint.org/docs/developer-guide/working-with-rules
+ - https://github.com/cletusw/eslint-plugin-local-rules

--- a/web/html/src/eslint-local-rules/README.md
+++ b/web/html/src/eslint-local-rules/README.md
@@ -1,0 +1,5 @@
+# Local ESLint rules
+
+TODO: Write
+
+See https://github.com/cletusw/eslint-plugin-local-rules for more information

--- a/web/html/src/eslint-local-rules/index.js
+++ b/web/html/src/eslint-local-rules/index.js
@@ -1,0 +1,36 @@
+module.exports = {
+  "no-raw-date": {
+    // See https://eslint.org/docs/developer-guide/working-with-rules#rule-basics
+    meta: {
+      type: "problem",
+      docs: {
+        description: "disallow raw Javascript Date use",
+        category: "Possible Errors",
+        recommended: true,
+      },
+      fixable: false,
+      schema: [],
+    },
+    create: function(context) {
+      return {
+        Identifier: function(node) {
+          if (node.name === "Date" && node.parent.type === "NewExpression") {
+            const args = (node.parent.arguments || []).map(arg => arg.raw).filter(Boolean);
+            context.report({
+              node: node.parent,
+              message: "Don't use raw Javascript Date instances",
+              suggest: [
+                {
+                  desc: "Use `moment()` instead",
+                  fix: function(fixer) {
+                    return fixer.replaceText(node.parent, `moment(${args.join(', ')})`)
+                  },
+                },
+              ],
+            });
+          }
+        },
+      };
+    },
+  },
+};

--- a/web/html/src/eslint-local-rules/index.js
+++ b/web/html/src/eslint-local-rules/index.js
@@ -1,36 +1,5 @@
+const noRawDate = require("./no-raw-date");
+
 module.exports = {
-  "no-raw-date": {
-    // See https://eslint.org/docs/developer-guide/working-with-rules#rule-basics
-    meta: {
-      type: "problem",
-      docs: {
-        description: "disallow raw Javascript Date use",
-        category: "Possible Errors",
-        recommended: true,
-      },
-      fixable: false,
-      schema: [],
-    },
-    create: function(context) {
-      return {
-        Identifier: function(node) {
-          if (node.name === "Date" && node.parent.type === "NewExpression") {
-            const args = (node.parent.arguments || []).map(arg => arg.raw).filter(Boolean);
-            context.report({
-              node: node.parent,
-              message: "Don't use raw Javascript Date instances",
-              suggest: [
-                {
-                  desc: "Use `moment()` instead",
-                  fix: function(fixer) {
-                    return fixer.replaceText(node.parent, `moment(${args.join(', ')})`)
-                  },
-                },
-              ],
-            });
-          }
-        },
-      };
-    },
-  },
+  "no-raw-date": noRawDate,
 };

--- a/web/html/src/eslint-local-rules/no-raw-date.js
+++ b/web/html/src/eslint-local-rules/no-raw-date.js
@@ -1,0 +1,34 @@
+module.exports = {
+  // See https://eslint.org/docs/developer-guide/working-with-rules#rule-basics
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Disallow using raw Javascript Date instances",
+      category: "Possible Errors",
+      recommended: true,
+    },
+    fixable: false,
+    schema: [],
+  },
+  create: function(context) {
+    return {
+      Identifier: function(node) {
+        if (node.name === "Date" && node.parent.type === "NewExpression") {
+          const args = (node.parent.arguments || []).map(arg => arg.raw).filter(Boolean);
+          context.report({
+            node: node.parent,
+            message: "Don't use raw Javascript Date instances",
+            suggest: [
+              {
+                desc: "Use `moment()` instead",
+                fix: function(fixer) {
+                  return fixer.replaceText(node.parent, `moment(${args.join(", ")})`);
+                },
+              },
+            ],
+          });
+        }
+      },
+    };
+  },
+};


### PR DESCRIPTION
## What does this PR change?

Part of [SUSE/spacewalk#15112](https://github.com/SUSE/spacewalk/issues/15112), adds support for disallowing using raw Date instances in the frontend code.  
Also lays the ground for other similar additions in the future.  

<img width="715" alt="Screenshot 2021-06-08 at 11 48 21" src="https://user-images.githubusercontent.com/3171718/121154428-445b4f00-c847-11eb-911b-d6daf6bac603.png">

<img width="455" alt="Screenshot 2021-06-08 at 11 48 26" src="https://user-images.githubusercontent.com/3171718/121154460-49200300-c847-11eb-8dff-9b41a0a0d96c.png">

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: only internal and user invisible changes

- [x] **DONE**

## Links

Part of https://github.com/SUSE/spacewalk/issues/15112

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
