### PR TITLE
Force reanalysis of rhnChannelPackage earlier (bsc#1186704)

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Channel_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Channel_queries.xml
@@ -1189,4 +1189,34 @@ ORDER BY CC.modified DESC
     </query>
 </callable-mode>
 
+<callable-mode name="analyze_errata_packages">
+    <query>
+        ANALYZE rhnErrataPackage
+    </query>
+</callable-mode>
+
+<callable-mode name="analyze_channel_errata">
+    <query>
+        ANALYZE rhnChannelErrata
+    </query>
+</callable-mode>
+
+<callable-mode name="analyze_errata_cloned">
+    <query>
+        ANALYZE rhnErrataCloned
+    </query>
+</callable-mode>
+
+<callable-mode name="analyze_errata">
+    <query>
+        ANALYZE rhnErrata
+    </query>
+</callable-mode>
+
+<callable-mode name="analyze_serverNeededCache">
+    <query>
+        ANALYZE rhnServerNeededCache
+    </query>
+</callable-mode>
+
 </datasource_modes>

--- a/java/code/src/com/redhat/rhn/domain/channel/ChannelFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/ChannelFactory.java
@@ -1392,6 +1392,46 @@ public class ChannelFactory extends HibernateFactory {
     }
 
     /**
+     * Analyzes the rhnErrataPackage table, useful to update statistics after massive changes.
+     */
+    public static void analyzeErrataPackages() {
+        var m = ModeFactory.getCallableMode("Channel_queries", "analyze_errata_packages");
+        m.execute(new HashMap<>(), new HashMap<>());
+    }
+
+    /**
+     * Analyzes the rhnChannelErrata table, useful to update statistics after massive changes.
+     */
+    public static void analyzeChannelErrata() {
+        var m = ModeFactory.getCallableMode("Channel_queries", "analyze_channel_errata");
+        m.execute(new HashMap<>(), new HashMap<>());
+    }
+
+    /**
+     * Analyzes the rhnErrataCloned table, useful to update statistics after massive changes.
+     */
+    public static void analyzeErrataCloned() {
+        var m = ModeFactory.getCallableMode("Channel_queries", "analyze_errata_cloned");
+        m.execute(new HashMap<>(), new HashMap<>());
+    }
+
+    /**
+     * Analyzes the rhnErrata table, useful to update statistics after massive changes.
+     */
+    public static void analyzeErrata() {
+        var m = ModeFactory.getCallableMode("Channel_queries", "analyze_errata");
+        m.execute(new HashMap<>(), new HashMap<>());
+    }
+
+    /**
+     * Analyzes the rhnServerNeededCache table, useful to update statistics after massive changes.
+     */
+    public static void analyzeServerNeededCache() {
+        var m = ModeFactory.getCallableMode("Channel_queries", "analyze_serverNeededCache");
+        m.execute(new HashMap<>(), new HashMap<>());
+    }
+
+    /**
      * Sets channel modules data from given channel.
      *
      * @param from the source Channel

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Run database table analyze in most used tables of CLM for better performance (bsc#1186704)
+
 -------------------------------------------------------------------
 Tue Jun 01 11:47:32 CEST 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
refactoring to run tables analyze in CLM

Signed-off-by: Ricardo Mateus <rmateus@suse.com>

## What does this PR change?

During build validation tests a CLM project was created to flat centos repository. The build action of that project cause Postgres to be using 100% CPU and got stuck in one specific query. Run that query outside CLM process was really fast and uses all expected indexes.
As a side-effect, Uyuni server got completely unusable, and UI unresponsible.

This PR aims to solve this performance problem by running a database table analyze in the more used CLM tables during build.

Fix For: https://bugzilla.suse.com/show_bug.cgi?id=1186704

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes: https://github.com/SUSE/spacewalk/issues/15070

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
