### PR TITLE
Add reverse resolution sanity check

### DIFF
--- a/testsuite/features/core/allcli_sanity.feature
+++ b/testsuite/features/core/allcli_sanity.feature
@@ -7,6 +7,7 @@ Feature: Sanity checks
 
   Scenario: The server is healthy
     Then "server" should have a FQDN
+    And reverse resolution should work for "server"
     And the clock from "server" should be exact
     And service "apache2" is enabled on "server"
     And service "apache2" is active on "server"
@@ -32,54 +33,63 @@ Feature: Sanity checks
 @sle_client
   Scenario: The traditional client is healthy
     Then "sle_client" should have a FQDN
+    And reverse resolution should work for "sle_client"
     And "sle_client" should communicate with the server
     And the clock from "sle_client" should be exact
 
 @sle_minion
   Scenario: The minion is healthy
     Then "sle_minion" should have a FQDN
+    And reverse resolution should work for "sle_minion"
     And "sle_minion" should communicate with the server
     And the clock from "sle_minion" should be exact
 
 @buildhost
   Scenario: The build host is healthy
     Then "build_host" should have a FQDN
+    And reverse resolution should work for "build_host"
     And "build_host" should communicate with the server
     And the clock from "build_host" should be exact
 
 @ssh_minion
   Scenario: The SSH minion is healthy
     Then "ssh_minion" should have a FQDN
+    And reverse resolution should work for "ssh_minion"
     And "ssh_minion" should communicate with the server
     And the clock from "ssh_minion" should be exact
 
 @proxy
   Scenario: The proxy is healthy
     Then "proxy" should have a FQDN
+    And reverse resolution should work for "proxy"
     And "proxy" should communicate with the server
     And the clock from "proxy" should be exact
 
 @centos_minion
   Scenario: The CentOS minion is healthy
     Then "ceos_minion" should have a FQDN
+    And reverse resolution should work for "ceos_minion"
     And "ceos_minion" should communicate with the server
     And the clock from "ceos_minion" should be exact
 
 @ubuntu_minion
   Scenario: The Ubuntu minion is healthy
     Then "ubuntu_minion" should have a FQDN
+    And reverse resolution should work for "ubuntu_minion"
     And "ubuntu_minion" should communicate with the server
     And the clock from "ubuntu_minion" should be exact
 
 @virthost_kvm
   Scenario: The KVM host is healthy
     Then "kvm_server" should have a FQDN
+    And reverse resolution should work for "kvm_server"
     And "kvm_server" should communicate with the server
     And the clock from "kvm_server" should be exact
 
 @virthost_xen
   Scenario: The Xen host is healthy
     Then "xen_server" should have a FQDN
+    And reverse resolution should work for "xen_server"
     And "xen_server" should communicate with the server
     And the clock from "xen_server" should be exact
 

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -9,10 +9,18 @@ require 'nokogiri'
 
 Then(/^"([^"]*)" should have a FQDN$/) do |host|
   node = get_target(host)
-  result, return_code = node.run('hostname -f')
+  result, return_code = node.run('hostname -f', false)
   result.delete!("\n")
   raise 'cannot determine hostname' unless return_code.zero?
   raise 'hostname is not fully qualified' unless result == node.full_hostname
+end
+
+Then(/^reverse resolution should work for "([^"]*)"$/) do |host|
+  node = get_target(host)
+  result, return_code = node.run("getent hosts #{node.ip}", false)
+  result.delete!("\n")
+  raise 'cannot do reverse resolution' unless return_code.zero?
+  raise "reverse resolution returned #{result}, expected to see #{node.full_hostname}" unless result.include? node.full_hostname
 end
 
 Then(/^"([^"]*)" should communicate with the server$/) do |host|


### PR DESCRIPTION
## What does this PR change?

This PR adds a check for reverse resolution of names.

Technical details:
* I used `getent` because it had to work with both DNS and avahi


## Links

Fixes SUSE/spacewalk#15037

Ports:
* 4.0: SUSE/spacewalk#15134
* 4.1: SUSE/spacewalk#15133, SUSE/spacewalk#15167


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
