### PR TITLE
added an improved error message if exitcode isnt 0

### DIFF
--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,6 @@
+- added error message when re-running configure-proxy.sh and
+  chosing the option not to import the existing certificates
+
 -------------------------------------------------------------------
 Wed Jun 09 10:20:18 CEST 2021 - jgonzalez@suse.com
 

--- a/spacewalk/certs-tools/sslToolConfig.py
+++ b/spacewalk/certs-tools/sslToolConfig.py
@@ -471,9 +471,12 @@ def figureSerial(caCertFilename, serialFilename, indexFilename):
                                            '-serial', '-in', caCertFilename])
     out = sstr(outstream.read())
     outstream.close()
-    errstream.read()
+    sslerrmsg = ("non-zero exitcode.\n"
+                "If you ran configure-proxy.sh, try copying again the certs from the SUSE Manager Server\n"
+                f"exit-code: {ret}\n"
+                f"error: {sstr(errstream.read())}\n")
     errstream.close()
-    assert not ret
+    assert not ret, sslerrmsg
     caSerial = out.strip().split('=')
     assert len(caSerial) > 1
     caSerial = caSerial[1]


### PR DESCRIPTION
   Without this patch, customers will just see a
   stacktrace when answering the wrong option during
   configure-proxy process.

## GUI diff

Before:
```
ERROR: unhandled exception occurred:
Traceback (most recent call last):
  File "/usr/bin/rhn-ssl-tool", line 52, in <module>
    sys.exit(mod.main() or 0)
  File "/usr/lib/python3.6/site-packages/certs/rhn_ssl_tool.py", line 1335, in main
    ret = _main() or 0
  File "/usr/lib/python3.6/site-packages/certs/rhn_ssl_tool.py", line 1300, in _main
    genServerCert(getCAPassword(options, confirmYN=0), DEFS, options.verbose)
  File "/usr/lib/python3.6/site-packages/certs/rhn_ssl_tool.py", line 557, in genServerCert
    ser = figureSerial(ca_cert, serial, index_txt)
  File "/usr/lib/python3.6/site-packages/certs/sslToolConfig.py", line 480, in figureSerial
    assert not ret
AssertionError
SSL key generation failed! Installation interrupted.
```
After:
```
Traceback (most recent call last):
  File "/usr/bin/rhn-ssl-tool", line 52, in <module>
    sys.exit(mod.main() or 0)
  File "/usr/lib/python3.6/site-packages/certs/rhn_ssl_tool.py", line 1335, in main
    ret = _main() or 0
  File "/usr/lib/python3.6/site-packages/certs/rhn_ssl_tool.py", line 1300, in _main
    genServerCert(getCAPassword(options, confirmYN=0), DEFS, options.verbose)
  File "/usr/lib/python3.6/site-packages/certs/rhn_ssl_tool.py", line 557, in genServerCert
    ser = figureSerial(ca_cert, serial, index_txt)
  File "/usr/lib/python3.6/site-packages/certs/sslToolConfig.py", line 483, in figureSerial
    assert not ret, sslerrmsg
AssertionError: non-zero exitcode. 
If you ran configure-proxy.sh, try copying again the certs from the SUSE Manager Server
exit-code: 1
error: unable to load certificate
139930308985472:error:0909006C:PEM routines:get_name:no start line:crypto/pem/pem_lib.c:745:Expecting: TRUSTED CERTIFICATE

SSL key generation failed! Installation interrupted.
```


- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
