### PR TITLE
Skip product install on leap

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/packages/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/packages/init.sls
@@ -1,4 +1,4 @@
-{%- if grains['os_family'] == 'Suse' and grains['osmajorrelease']|int > 11 %}
+{%- if grains['os_family'] == 'Suse' and grains['osmajorrelease']|int > 11 and not grains['oscodename'] == 'openSUSE Leap 15.3'%}
 mgr_install_products:
   product.all_installed:
     - refresh: True

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- exclude openSUSE Leap 15.3 from product installation (bsc#1186858)
 - Accept GPG key in Amazon Linux 2 for res7tools channel (bsc#1187102)
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Leap has SLES product packages in its repos which cannot be installed.
For now do not run the product install check on Leap 15.3. As this product is free, it is not important for subscription matching.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/15105
Tracks

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
