### PR TITLE
BV: Add support for sle12sp5

### DIFF
--- a/testsuite/features/build_validation/init_clients/sle12sp5_client.feature
+++ b/testsuite/features/build_validation/init_clients/sle12sp5_client.feature
@@ -1,0 +1,46 @@
+# Copyright (c) 2015-2021 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+@sle12sp5_client
+Feature: Bootstrap a SLES 12 SP5 traditional client
+
+  Scenario: Clean up sumaform leftovers on a SLES 12 SP5 traditional client
+    When I perform a full salt minion cleanup on "sle12sp5_client"
+
+  Scenario: Register a SLES 12 SP5 traditional client
+    When I bootstrap traditional client "sle12sp5_client" using bootstrap script with activation key "1-sle12sp5_client_key" from the proxy
+    And I install package "spacewalk-client-setup mgr-cfg-actions" on this "sle12sp5_client"
+    And I run "mgr-actions-control --enable-all" on "sle12sp5_client"
+    Then I should see "sle12sp5_client" via spacecmd
+
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
+  Scenario: The onboarding of SLES 12 SP5 traditional client is completed
+    When I wait until onboarding is completed for "sle12sp5_client"
+
+  Scenario: Check registration values of SLES 12 SP5 traditional client
+    Given I update the profile of "sle12sp5_client"
+    When I am on the Systems overview page of this "sle12sp5_client"
+    And I wait until I see "Software Updates Available" text or "System is up to date" text
+    Then I should see a "System Status" text
+    And I should see a "Edit These Properties" link
+    And I should see a "[Management]" text
+    And I should see a "Add to SSM" link
+    And I should see a "Delete System" link
+    And I should see a "Initial Registration Parameters:" text
+    And I should see a "OS: sles-release" text
+
+@proxy
+  Scenario: Check connection from SLES 12 SP5 traditional to proxy
+    Given I am on the Systems overview page of this "sle12sp5_client"
+    When I follow "Details" in the content area
+    And I follow "Connection" in the content area
+    Then I should see "proxy" short hostname
+
+@proxy
+  Scenario: Check registration on proxy of SLES 12 SP5 traditional
+    Given I am on the Systems overview page of this "proxy"
+    When I follow "Details" in the content area
+    And I follow "Proxy" in the content area
+    Then I should see "sle12sp5_client" hostname

--- a/testsuite/features/build_validation/init_clients/sle12sp5_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle12sp5_minion.feature
@@ -1,0 +1,47 @@
+# Copyright (c) 2020-2021 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+@sle12sp5_minion
+Feature: Bootstrap a SLES 12 SP5 Salt minion
+
+  Scenario: Clean up sumaform leftovers on a SLES 12 SP5 Salt minion
+    When I perform a full salt minion cleanup on "sle12sp5_minion"
+
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
+  Scenario: Bootstrap a SLES 12 SP5 minion
+    When I follow the left menu "Systems > Bootstrapping"
+    Then I should see a "Bootstrap Minions" text
+    When I enter the hostname of "sle12sp5_minion" as "hostname"
+    And I enter "22" as "port"
+    And I enter "root" as "user"
+    And I enter "linux" as "password"
+    And I select "1-sle12sp5_minion_key" from "activationKeys"
+    And I select the hostname of "proxy" from "proxies"
+    And I click on "Bootstrap"
+    And I wait until I see "Successfully bootstrapped host!" text
+    And I wait until onboarding is completed for "sle12sp5_minion"
+
+  Scenario: Check the new bootstrapped SLES 12 SP5 minion in System Overview page
+    When I follow the left menu "Salt > Keys"
+    Then I should see a "accepted" text
+    And the Salt master can reach "sle12sp5_minion"
+
+@proxy
+  Scenario: Check connection from SLES 12 SP5 minion to proxy
+    Given I am on the Systems overview page of this "sle12sp5_minion"
+    When I follow "Details" in the content area
+    And I follow "Connection" in the content area
+    Then I should see "proxy" short hostname
+
+@proxy
+  Scenario: Check registration on proxy of SLES 12 SP5 minion
+    Given I am on the Systems overview page of this "proxy"
+    When I follow "Details" in the content area
+    And I follow "Proxy" in the content area
+    Then I should see "sle12sp5_minion" hostname
+
+  Scenario: Check events history for failures on SLES 12 SP5 minion
+    Given I am on the Systems overview page of this "sle12sp5_minion"
+    Then I check for failed events on history event page

--- a/testsuite/features/build_validation/init_clients/sle12sp5_ssh_minion.feature
+++ b/testsuite/features/build_validation/init_clients/sle12sp5_ssh_minion.feature
@@ -1,0 +1,41 @@
+# Copyright (c) 2020-2021 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+@sle12sp5_ssh_minion
+Feature: Bootstrap a SLES 12 SP5 Salt SSH minion
+
+  Scenario: Clean up sumaform leftovers on a SLES 12 SP5 Salt SSH minion
+    When I perform a full salt minion cleanup on "sle12sp5_ssh_minion"
+
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
+  Scenario: Bootstrap a SLES 12 SP5 system managed via salt-ssh
+    When I follow the left menu "Systems > Bootstrapping"
+    Then I should see a "Bootstrap Minions" text
+    When I check "manageWithSSH"
+    And I enter the hostname of "sle12sp5_ssh_minion" as "hostname"
+    And I enter "linux" as "password"
+    And I select "1-sle12sp5_ssh_minion_key" from "activationKeys"
+    And I select the hostname of "proxy" from "proxies"
+    And I click on "Bootstrap"
+    And I wait until I see "Successfully bootstrapped host!" text
+    And I wait until onboarding is completed for "sle12sp5_ssh_minion"
+
+@proxy
+  Scenario: Check connection from SLES 12 SP5 SSH minion to proxy
+    Given I am on the Systems overview page of this "sle12sp5_ssh_minion"
+    When I follow "Details" in the content area
+    And I follow "Connection" in the content area
+    Then I should see "proxy" short hostname
+
+@proxy
+  Scenario: Check registration on proxy of SLES 12 SP5 SSH minion
+    Given I am on the Systems overview page of this "proxy"
+    When I follow "Details" in the content area
+    And I follow "Proxy" in the content area
+    Then I should see "sle12sp5_ssh_minion" hostname
+
+  Scenario: Check events history for failures on SLES 12 SP5 SSH minion
+    Given I am on the Systems overview page of this "sle12sp5_ssh_minion"
+    Then I check for failed events on history event page

--- a/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
+++ b/testsuite/features/build_validation/reposync/srv_sync_all_products.feature
@@ -44,6 +44,15 @@ Feature: Synchronize products in the products page of the Setup Wizard
     When I click the Add Product button
     And I wait until I see "SUSE Linux Enterprise Server 12 SP4 x86_64" product has been added
 
+  Scenario: Add SUSE Linux Enterprise Server 12 SP5
+    When I follow the left menu "Admin > Setup Wizard > Products"
+    And I wait until I do not see "Loading" text
+    And I enter "SUSE Linux Enterprise Server 12 SP5" as the filtered product description
+    And I select "SUSE Linux Enterprise Server 12 SP5 x86_64" as a product
+    Then I should see the "SUSE Linux Enterprise Server 12 SP5 x86_64" selected
+    When I click the Add Product button
+    And I wait until I see "SUSE Linux Enterprise Server 12 SP5 x86_64" product has been added
+
   Scenario: Add SUSE Linux Enterprise Server 15
     When I follow the left menu "Admin > Setup Wizard > Products"
     And I wait until I do not see "Loading" text

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -236,6 +236,18 @@ Before('@sle12sp4_client') do
   skip_this_scenario unless $sle12sp4_client
 end
 
+Before('@sle12sp5_ssh_minion') do
+  skip_this_scenario unless $sle12sp5_ssh_minion
+end
+
+Before('@sle12sp5_minion') do
+  skip_this_scenario unless $sle12sp5_minion
+end
+
+Before('@sle12sp5_client') do
+  skip_this_scenario unless $sle12sp5_client
+end
+
 Before('@sle15_ssh_minion') do
   skip_this_scenario unless $sle15_ssh_minion
 end

--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -76,11 +76,11 @@ if $build_validation
   $sle15sp3_buildhost = twopence_init("ssh:#{ENV['SLE15SP3_BUILDHOST']}") if ENV['SLE15SP3_BUILDHOST']
   $sle15sp3_terminal = twopence_init("ssh:#{ENV['SLE15SP3_TERMINAL']}") if ENV['SLE15SP3_TERMINAL']
   # As we share core features for all the environments, we share also those vm twopence objects
-  $client = $sle12sp4_client
-  $minion = $sle12sp4_minion
-  $ssh_minion = $sle12sp4_ssh_minion
-  $ceos_minion = $ceos7_ssh_minion
-  $ubuntu_minion = $ubuntu1804_minion
+  $client = $sle12sp5_client
+  $minion = $sle12sp5_minion
+  $ssh_minion = $sle12sp5_ssh_minion
+  $ceos_minion = $ceos8_ssh_minion
+  $ubuntu_minion = $ubuntu2004_minion
   $nodes += [$sle11sp4_client, $sle11sp4_minion, $sle11sp4_ssh_minion,
              $sle12sp4_client, $sle12sp4_minion, $sle12sp4_ssh_minion,
              $sle12sp5_client, $sle12sp5_minion, $sle12sp5_ssh_minion,

--- a/testsuite/run_sets/build_validation_init_clients.yml
+++ b/testsuite/run_sets/build_validation_init_clients.yml
@@ -14,6 +14,9 @@
 - features/build_validation/init_clients/sle12sp4_minion.feature
 - features/build_validation/init_clients/sle12sp4_ssh_minion.feature
 - features/build_validation/init_clients/sle12sp4_client.feature
+- features/build_validation/init_clients/sle12sp4_minion.feature
+- features/build_validation/init_clients/sle12sp4_ssh_minion.feature
+- features/build_validation/init_clients/sle12sp4_client.feature
 - features/build_validation/init_clients/sle15_minion.feature
 - features/build_validation/init_clients/sle15_ssh_minion.feature
 - features/build_validation/init_clients/sle15_client.feature


### PR DESCRIPTION
## What does this PR change?

Add Cucumber features to support SLES12SP5 onboarding and test. This is a partial PR, the rest was made some time ago [here](https://github.com/uyuni-project/uyuni/pull/3338) 

**Depends on** : Support inside sumaform (https://github.com/uyuni-project/sumaform/pull/899)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Ports:
- Manager-4.0
- Manager-4.1

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
