### PR TITLE
Fix product migration when scheduled from the event page (bsc#1187066)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/systems/SPMigrationAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/SPMigrationAction.java
@@ -542,6 +542,7 @@ public class SPMigrationAction extends RhnAction {
 
         request.setAttribute(BASE_CHANNEL, baseChannel);
         request.setAttribute(CHILD_CHANNELS, childChannels);
+        request.setAttribute(ALLOW_VENDOR_CHANGE, details.isAllowVendorChange());
 
         return CONFIRM;
     }

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -652,8 +652,7 @@ public class SaltUtils {
         else if (action.getActionType().equals(ActionFactory.TYPE_DIST_UPGRADE)) {
             DistUpgradeAction dupAction = (DistUpgradeAction) action;
             DistUpgradeActionDetails actionDetails = dupAction.getDetails();
-            if (serverAction.getStatus().equals(ActionFactory.STATUS_FAILED) || actionDetails.isDryRun()) {
-                // Collect changed channel list to revert the channel change
+            if (actionDetails.isDryRun()) {
                 Map<Boolean, List<Channel>> collect = actionDetails.getChannelTasks()
                         .stream().collect(Collectors.partitioningBy(
                                 ct -> ct.getTask() == DistUpgradeChannelTask.SUBSCRIBE,
@@ -671,15 +670,20 @@ public class SaltUtils {
                 MessageQueue.publish(
                         new ApplyStatesEventMessage(serverAction.getServerId(), false,
                                 ApplyStatesEventMessage.CHANNELS));
+                String message = parseDryRunMessage(jsonResult);
+                serverAction.setResultMsg(message);
             }
             else {
+                String message = parseMigrationMessage(jsonResult);
+                serverAction.setResultMsg(message);
+
                 // Make sure grains are updated after dist upgrade
                 serverAction.getServer().asMinionServer().ifPresent(minionServer -> {
                     MinionList minionTarget = new MinionList(minionServer.getMinionId());
                     saltApi.syncGrains(minionTarget);
                 });
             }
-            serverAction.setResultMsg(parseMigrationMessage(jsonResult, actionDetails.isDryRun()));
+
         }
         else if (action.getActionType().equals(ActionFactory.TYPE_SCAP_XCCDF_EVAL)) {
             handleScapXccdfEval(serverAction, jsonResult, action);
@@ -898,11 +902,7 @@ public class SaltUtils {
         }
     }
 
-    private String parseMigrationMessage(JsonElement jsonResult, boolean isDryRun) {
-        if (isDryRun) {
-            return parseDryRunMessage(jsonResult);
-        }
-
+    private String parseMigrationMessage(JsonElement jsonResult) {
         try {
             DistUpgradeSlsResult distUpgradeSlsResult = Json.GSON.fromJson(
                     jsonResult, DistUpgradeSlsResult.class);

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Fix product migration when scheduled from the event page (bsc#1187066)
+
 -------------------------------------------------------------------
 Wed Jun 09 10:19:43 CEST 2021 - jgonzalez@suse.com
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,5 +1,3 @@
-- Fix product migration when scheduled from the event page (bsc#1187066)
-
 -------------------------------------------------------------------
 Wed Jun 09 10:19:43 CEST 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
Problems fixed:
 - Pass 'allowVendorChange' correctly when the migration is scheduled from the completed event page of a dry-run
 - ~~Revert client's assigned channels when migration is failed for some reason~~ (needs more consideration in the future)

## Test coverage
- Cucumber tests needed

- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/15131

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
