### PR TITLE
Use a different repository for Salt for Uyuni

### DIFF
--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -650,11 +650,13 @@ When(/^I install Salt packages from "(.*?)"$/) do |host|
 end
 
 When(/^I enable repositories before installing Salt on this "([^"]*)"$/) do |host|
-  step %(I enable repository "tools_additional_repo" on this "#{host}" without error control)
+  repo = $product == 'Uyuni' ? 'salt3002_repo_repo' : 'tools_additional_repo'
+  step %(I enable repository "#{repo}" on this "#{host}" without error control)
 end
 
 When(/^I disable repositories after installing Salt on this "([^"]*)"$/) do |host|
-  step %(I disable repository "tools_additional_repo" on this "#{host}" without error control)
+  repo = $product == 'Uyuni' ? 'salt3002_repo_repo' : 'tools_additional_repo'
+  step %(I disable repository "#{repo}" on this "#{host}" without error control)
 end
 
 # minion bootstrap steps


### PR DESCRIPTION
## What does this PR change?

On Uyuni, Salt was downgraded after SP migration. This was because the repositories where latest Salt is are not the same for Uyuni.


## Links

Fixes  SUSE/spacewalk#15117

Ports:
* 4.0:
* 4.1:

Note: it could be made as uyuni-branch only, I'm porting only to avoid branches diverge.


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
