### PR TITLE
Ansible replace raw json call

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/ansible/test/AnsibleHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/ansible/test/AnsibleHandlerTest.java
@@ -42,10 +42,9 @@ import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
 import com.redhat.rhn.testing.TestUtils;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonElement;
 import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.salt.netapi.calls.LocalCall;
+import com.suse.salt.netapi.utils.Xor;
 
 import org.jmock.Expectations;
 import org.jmock.Mockery;
@@ -259,8 +258,8 @@ public class AnsibleHandlerTest extends BaseHandlerTestCase {
 
         SaltApi saltApi = CONTEXT.mock(SaltApi.class);
         CONTEXT.checking(new Expectations() {{
-            allowing(saltApi).rawJsonCall(with(any(LocalCall.class)), with(controlNode.getMinionId()));
-            will(returnValue(Optional.of(new Gson().fromJson("playbook-content", JsonElement.class))));
+            allowing(saltApi).callSync(with(any(LocalCall.class)), with(controlNode.getMinionId()));
+            will(returnValue(Optional.of(Xor.right("playbook-content"))));
         }});
         AnsibleManager.setSaltApi(saltApi);
         assertEquals(

--- a/java/code/src/com/redhat/rhn/manager/system/AnsibleManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/AnsibleManager.java
@@ -36,16 +36,14 @@ import com.redhat.rhn.manager.BaseManager;
 import com.redhat.rhn.manager.action.ActionChainManager;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonElement;
 import com.google.gson.reflect.TypeToken;
 import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.utils.salt.custom.AnsiblePlaybookSlsResult;
 import com.suse.salt.netapi.calls.LocalCall;
+import com.suse.salt.netapi.utils.Xor;
 
 import org.apache.commons.lang3.StringUtils;
 
-import java.lang.reflect.Type;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.util.Date;
@@ -56,7 +54,6 @@ import java.util.Optional;
 public class AnsibleManager extends BaseManager {
 
     private static SaltApi saltApi = GlobalInstanceHolder.SALT_API;
-    private static final Gson GSON = new Gson();
 
     /**
      * Lookup ansible path by id
@@ -254,20 +251,15 @@ public class AnsibleManager extends BaseManager {
         }
 
         Path localPath = path.getPath().resolve(playbookRelPath);
-        LocalCall<String> call = new LocalCall<>(
+        LocalCall<Xor<Boolean, String>> call = new LocalCall<>(
                 "cp.get_file_str",
                 of(List.of(localPath.toString())),
                 empty(),
                 new TypeToken<>() { }
         );
 
-        Optional<JsonElement> rawResult = saltApi.rawJsonCall(call, path.getMinionServer().getMinionId());
-        return rawResult.map(r -> {
-            if (r.isJsonPrimitive() && r.getAsJsonPrimitive().isBoolean() && !r.getAsJsonPrimitive().getAsBoolean()) {
-                throw new IllegalStateException("no result");
-            }
-            return GSON.fromJson(r, new TypeToken<String>() { }.getType());
-        });
+        Optional<Xor<Boolean, String>> result = saltApi.callSync(call, path.getMinionServer().getMinionId());
+        return result.map(r -> r.right().orElseThrow(() -> new IllegalStateException("no result")));
     }
 
     /**
@@ -322,14 +314,18 @@ public class AnsibleManager extends BaseManager {
             throw new IllegalArgumentException(String.format("Path id %d not a Playbook path", path.getId()));
         }
 
-        TypeToken<Map<String, Map<String, AnsiblePlaybookSlsResult>>> type = new TypeToken<>() { };
-        LocalCall<Map<String, Map<String, AnsiblePlaybookSlsResult>>> discoverCall = new LocalCall<>(
+        LocalCall<Xor<String, Map<String, Map<String, AnsiblePlaybookSlsResult>>>> discoverCall = new LocalCall<>(
                 "ansible.discover_playbooks",
                 of(List.of(path.getPath().toString())),
                 empty(),
-                type);
-        Optional<JsonElement> jsonResult = saltApi.rawJsonCall(discoverCall, path.getMinionServer().getMinionId());
-        return jsonResult.map(j -> parseJsonResponse(j, type.getType()));
+                new TypeToken<>() { });
+
+        return saltApi.callSync(discoverCall, path.getMinionServer().getMinionId())
+                .map(res -> res.fold(
+                        error -> {
+                            throw new IllegalStateException(error);
+                        },
+                        success -> success));
     }
 
     /**
@@ -352,14 +348,18 @@ public class AnsibleManager extends BaseManager {
             throw new IllegalArgumentException(String.format("Path %d not an Inventory path", path.getId()));
         }
 
-        TypeToken<Map<String, Map<String, Object>>> type = new TypeToken<>() { };
-        LocalCall<Map<String, Map<String, Object>>> call = new LocalCall<>(
+        LocalCall<Xor<String, Map<String, Map<String, Object>>>> call = new LocalCall<>(
                 "ansible.targets",
                 empty(),
                 of(Map.of("inventory", path.getPath().toString())),
-                type);
-        Optional<JsonElement> jsonResult = saltApi.rawJsonCall(call, path.getMinionServer().getMinionId());
-        return jsonResult.map(j -> parseJsonResponse(j, type.getType()));
+                new TypeToken<>() { });
+
+        return saltApi.callSync(call, path.getMinionServer().getMinionId())
+                .map(res -> res.fold(
+                        error -> {
+                            throw new IllegalStateException(error);
+                        },
+                        success -> success));
     }
 
     private static MinionServer lookupAnsibleControlNode(long systemId, User user) {
@@ -372,24 +372,6 @@ public class AnsibleManager extends BaseManager {
         }
 
         return controlNode.asMinionServer().orElseThrow(() -> new LookupException(controlNode + " is not a minion"));
-    }
-
-    private static <T> T parseJsonResponse(JsonElement j, Type type) {
-        // this method assumes the returned string describes an error
-        // only use it for parsing non-string (success) values
-        if (type.getClass().isAssignableFrom(String.class)) {
-            throw new RuntimeException("Can't parse into string");
-        }
-
-        if (j.isJsonPrimitive() && j.getAsJsonPrimitive().isString()) {
-            throw new IllegalStateException(j.getAsString());
-        }
-        else {
-            if (j.isJsonObject()) {
-                j.getAsJsonObject().remove("retcode");
-            }
-            return GSON.fromJson(j, type);
-        }
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/system/test/AnsibleManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/test/AnsibleManagerTest.java
@@ -38,6 +38,7 @@ import com.google.gson.JsonElement;
 import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.utils.salt.custom.AnsiblePlaybookSlsResult;
 import com.suse.salt.netapi.calls.LocalCall;
+import com.suse.salt.netapi.utils.Xor;
 
 import org.jmock.Expectations;
 import org.jmock.Mockery;
@@ -213,6 +214,49 @@ public class AnsibleManagerTest extends BaseTestCaseWithUser {
     }
 
     /**
+     * Tests fetching playbook contents
+     */
+    public void testFetchPlaybook() throws Exception {
+        MinionServer controlNode = createAnsibleControlNode(user);
+        AnsiblePath path = AnsibleManager.createAnsiblePath("playbook", controlNode.getId(), "/root/playbooks", user);
+
+        SaltApi saltApi = CONTEXT.mock(SaltApi.class);
+        CONTEXT.checking(new Expectations() {{
+            allowing(saltApi).callSync(with(any(LocalCall.class)), with(controlNode.getMinionId()));
+            will(returnValue(Optional.of(Xor.right("suchplaybookwow"))));
+        }});
+        AnsibleManager.setSaltApi(saltApi);
+
+
+        assertEquals(
+                Optional.of("suchplaybookwow"),
+                AnsibleManager.fetchPlaybookContents(path.getId(), "site.yml", user));
+    }
+
+    /**
+     * Tests fetching playbook contents
+     */
+    public void testFetchPlaybookSaltNoResult() throws Exception {
+        MinionServer controlNode = createAnsibleControlNode(user);
+        AnsiblePath path = AnsibleManager.createAnsiblePath("playbook", controlNode.getId(), "/root/playbooks", user);
+
+        SaltApi saltApi = CONTEXT.mock(SaltApi.class);
+        CONTEXT.checking(new Expectations() {{
+            allowing(saltApi).callSync(with(any(LocalCall.class)), with(controlNode.getMinionId()));
+            will(returnValue(Optional.of(Xor.left(false))));
+        }});
+        AnsibleManager.setSaltApi(saltApi);
+
+        try {
+            AnsibleManager.fetchPlaybookContents(path.getId(), "site.yml", user);
+            fail("An exception should have been thrown.");
+        }
+        catch (IllegalStateException e) {
+            assertEquals("no result", e.getMessage());
+        }
+    }
+
+    /**
      * Test scheduling playbook with an empty path
      *
      * @throws Exception
@@ -252,19 +296,43 @@ public class AnsibleManagerTest extends BaseTestCaseWithUser {
         MinionServer controlNode = createAnsibleControlNode(user);
         AnsiblePath playbookPath = AnsibleManager.createAnsiblePath("playbook", controlNode.getId(), "/tmp/test", user);
 
-        Optional<Map<String, Map<String, AnsiblePlaybookSlsResult>>> expected = Optional.of(Map.of("/tmp/test", Map.of("site.yml",
-                new AnsiblePlaybookSlsResult("/tmp/test/site.yml", "/tmp/test/hosts"))));
+        Map<String, Map<String, AnsiblePlaybookSlsResult>> expected = Map.of("/tmp/test", Map.of("site.yml",
+                new AnsiblePlaybookSlsResult("/tmp/test/site.yml", "/tmp/test/hosts")));
 
         SaltApi saltApi = CONTEXT.mock(SaltApi.class);
         CONTEXT.checking(new Expectations() {{
-            allowing(saltApi).rawJsonCall(with(any(LocalCall.class)), with(controlNode.getMinionId()));
-            will(returnValue(Optional.of(new Gson().fromJson(
-                    "{'/tmp/test': {'site.yml': {'fullpath': '/tmp/test/site.yml', 'custom_inventory': '/tmp/test/hosts'}}}", JsonElement.class))));
+            allowing(saltApi).callSync(with(any(LocalCall.class)), with(controlNode.getMinionId()));
+            will(returnValue(Optional.of(Xor.right(expected))));
         }});
         AnsibleManager.setSaltApi(saltApi);
 
         Optional<Map<String, Map<String, AnsiblePlaybookSlsResult>>> result = AnsibleManager.discoverPlaybooks(playbookPath.getId(), user);
-        assertEquals(expected, result);
+        assertEquals(Optional.of(expected), result);
+    }
+
+    /**
+     * Test discover playbooks
+     *
+     * @throws Exception
+     */
+    public void testDiscoverPlaybooksSaltError() throws Exception {
+        MinionServer controlNode = createAnsibleControlNode(user);
+        AnsiblePath playbookPath = AnsibleManager.createAnsiblePath("playbook", controlNode.getId(), "/tmp/test", user);
+
+        SaltApi saltApi = CONTEXT.mock(SaltApi.class);
+        CONTEXT.checking(new Expectations() {{
+            allowing(saltApi).callSync(with(any(LocalCall.class)), with(controlNode.getMinionId()));
+            will(returnValue(Optional.of(Xor.left("error"))));
+        }});
+        AnsibleManager.setSaltApi(saltApi);
+
+        try {
+            AnsibleManager.discoverPlaybooks(playbookPath.getId(), user);
+            fail("An exception should have been thrown.");
+        }
+        catch (IllegalStateException e) {
+            assertEquals("error", e.getMessage());
+        }
     }
 
     /**
@@ -306,19 +374,41 @@ public class AnsibleManagerTest extends BaseTestCaseWithUser {
         MinionServer controlNode = createAnsibleControlNode(user);
         AnsiblePath inventoryPath = AnsibleManager.createAnsiblePath("inventory", controlNode.getId(), "/tmp/test/hosts", user);
 
-        Optional<Map<String, Map<String, Object>>> expected =
-                Optional.of(Map.of("minion",  Map.of("all", Map.of("children", List.of("host1", "host2")))));
+        Map<String, Map<String, Map<String, List<String>>>> expected =
+                Map.of("minion",  Map.of("all", Map.of("children", List.of("host1", "host2"))));
 
         SaltApi saltApi = CONTEXT.mock(SaltApi.class);
         CONTEXT.checking(new Expectations() {{
-            allowing(saltApi).rawJsonCall(with(any(LocalCall.class)), with(controlNode.getMinionId()));
-            will(returnValue(Optional.of(new Gson().fromJson(
-                    "{'minion': {'all': {'children': ['host1', 'host2']}}}", JsonElement.class))));
+            allowing(saltApi).callSync(with(any(LocalCall.class)), with(controlNode.getMinionId()));
+            will(returnValue(Optional.of(Xor.right(expected))));
         }});
         AnsibleManager.setSaltApi(saltApi);
 
         Optional<Map<String, Map<String, Object>>> result = AnsibleManager.introspectInventory(inventoryPath.getId(), user);
-        assertEquals(expected, result);
+        assertEquals(Optional.of(expected), result);
+    }
+
+    /**
+     * Test introspect inventory
+     */
+    public void testIntrospectInventorySaltError() throws Exception {
+        MinionServer controlNode = createAnsibleControlNode(user);
+        AnsiblePath inventoryPath = AnsibleManager.createAnsiblePath("inventory", controlNode.getId(), "/tmp/test/hosts", user);
+
+        SaltApi saltApi = CONTEXT.mock(SaltApi.class);
+        CONTEXT.checking(new Expectations() {{
+            allowing(saltApi).callSync(with(any(LocalCall.class)), with(controlNode.getMinionId()));
+            will(returnValue(Optional.of(Xor.left("error desc"))));
+        }});
+        AnsibleManager.setSaltApi(saltApi);
+
+        try {
+            AnsibleManager.introspectInventory(inventoryPath.getId(), user);
+            fail("An exception should have been thrown.");
+        }
+        catch (IllegalStateException e) {
+            assertEquals("error desc", e.getMessage());
+        }
     }
 
     /**


### PR DESCRIPTION
## What does this PR change?

Using low-level `rawJsonCall` is discouraged, unless there is a good reason for using it. In `AnsibleManager` this wasn't the case.
Rewritten to use parsing into `Xor`structure (the salt calls in `AnsibleManager` always return different types in success/error scenarios, so that we can use `Xor` here).

## GUI diff

No difference.


- [x] **DONE**

## Documentation
internal stuff

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links
https://github.com/SUSE/spacewalk/issues/14920


- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [x] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
