### PR TITLE
Check the reposync went smoothly

### DIFF
--- a/testsuite/features/build_validation/reposync/srv_wait_for_product_reposync.feature
+++ b/testsuite/features/build_validation/reposync/srv_wait_for_product_reposync.feature
@@ -15,3 +15,6 @@ Feature: Wait for reposync activity to finish after adding products
 
   Scenario: Wait for running reposyncs to finish after adding products
     When I wait until all spacewalk-repo-sync finished
+
+  Scenario: Verify the reposync went fine
+    Then the reposync logs should not report errors

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -328,6 +328,11 @@ When(/^I kill all running spacewalk\-repo\-sync, excepted the ones needed to boo
   end
 end
 
+Then(/^the reposync logs should not report errors$/) do
+  result, code = $server.run('grep "ERROR:" /var/log/rhn/reposync/*.log', false)
+  raise "Errors during reposync:\n#{result}" if code.zero?
+end
+
 Then(/^"([^"]*)" package should have been stored$/) do |pkg|
   $server.run("find /var/spacewalk/packages -name #{pkg}")
 end


### PR DESCRIPTION
## What does this PR change?

We are currently waiting that the reposyncs finish, but then we don't check they went well.

This PR checks for the absence of `ERROR:` in reposync logs.

For now, it's BV only. We don't use mirrors in NUE's CI, so it's very easy to get errors of package checksum that does not match the one in the metadata.


## Links

Ports:
* 4.0: SUSE/spacewalk#15161
* 4.1: SUSE/spacewalk#15160, SUSE/spacewalk#15167


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
