### PR TITLE
BV test suite : detail fixes

### DIFF
--- a/testsuite/features/build_validation/add_custom_repositories/add_ceos8_repositories.feature
+++ b/testsuite/features/build_validation/add_custom_repositories/add_ceos8_repositories.feature
@@ -3,6 +3,9 @@
 
 @ceos8_minion
 Feature: Adding the CentOS 8 distribution custom repositories
+  In order to use CentOS 8 channels with Red Hat "modules"
+  As a SUSE Manager administrator
+  I want to filter them out to remove the modules information
 
   Scenario: Download the iso of CentOS 8 DVD and mount it on the server
     When I mount as "centos-8-iso" the ISO from "http://minima-mirror-bv.mgr.prv.suse.net/pub/centos/8/isos/x86_64/CentOS-8.2.2004-x86_64-dvd1.iso" in the server
@@ -15,7 +18,7 @@ Feature: Adding the CentOS 8 distribution custom repositories
     And I follow "Create Channel"
     When I enter "Custom Channel for CentOS 8 DVD" as "Channel Name"
     And I enter "centos-8-iso" as "Channel Label"
-    And I select the parent channel for the "ceos8_minion" from "Parent Channel"
+    And I select "RHEL8-Pool for x86_64" from "Parent Channel"
     And I enter "Custom channel" as "Channel Summary"
     And I click on "Create Channel"
     Then I should see a "Channel Custom Channel for CentOS 8 DVD created" text
@@ -49,15 +52,16 @@ Feature: Adding the CentOS 8 distribution custom repositories
     When I wait until the channel "centos-8-iso" has been synced
 
   Scenario: Create CLM filters to remove AppStream metadata
+    Given I am authorized for the "Admin" section
     When I follow the left menu "Content Lifecycle > Filters"
-    And I follow "Create Filter"
+    And I click on "Create Filter"
     And I enter "ruby-2.7" as "filter_name"
     And I select "Module (Stream)" from "type"
     And I enter "ruby" as "moduleName"
     And I enter "2.7" as "moduleStream"
     And I click on "Save"
     Then I should see a "ruby-2.7" text
-    When I follow "Create Filter"
+    When I click on "Create Filter"
     And I enter "python-3.8" as "filter_name"
     And I select "Module (Stream)" from "type"
     And I enter "python38" as "moduleName"
@@ -89,7 +93,7 @@ Feature: Adding the CentOS 8 distribution custom repositories
     And I enter "Filtered channels without AppStream channels" as "description"
     And I click on "Save"
     Then I should see a "not built" text
-    When I click on "Build (9)"
+    When I click on "Build (11)"
     And I enter "Initial build" as "message"
     And I click the environment build button
     Then I should see a "Version 1: Initial build" text

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -210,11 +210,11 @@ CHANNEL_TO_SYNC_BY_BASE_CHANNEL = { 'SLE-Product-SUSE-Manager-Proxy-4.2-Pool' =>
                                     'SLES15-SP2-Pool' => 'SLE-15-SP2-x86_64',
                                     'SLES15-SP3-Pool' => 'SLE-15-SP3-x86_64',
                                     'RHEL x86_64 Server 7' => 'RES7-x86_64',
-                                    'RHEL8-Pool for x86_64' => 'SLE-ES8-x86_64',
+                                    'no-appstream-result-RHEL8-Pool for x86_64' => 'SLE-ES8-x86_64',
                                     'ubuntu-18.04-pool' => 'ubuntu-18.04-amd64',
                                     'ubuntu-2004-amd64-main' => 'ubuntu-20.04-amd64',
-                                    'debian-9-pool' => 'debian-9-pool-amd64',
-                                    'debian-10-pool' => 'debian-10-pool-amd64' }.freeze
+                                    'debian-9-pool' => 'debian9-amd64',
+                                    'debian-10-pool' => 'debian10-amd64' }.freeze
 
 PARENT_CHANNEL_TO_SYNC_BY_BASE_CHANNEL = { 'SLE-Product-SUSE-Manager-Proxy-4.2-Pool' => 'sle-product-suse-manager-proxy-4.2-pool-x86_64',
                                            'SLES11-SP3-Pool' => nil,
@@ -226,7 +226,7 @@ PARENT_CHANNEL_TO_SYNC_BY_BASE_CHANNEL = { 'SLE-Product-SUSE-Manager-Proxy-4.2-P
                                            'SLES15-SP2-Pool' => 'sle-product-sles15-sp2-pool-x86_64',
                                            'SLES15-SP3-Pool' => 'sle-product-sles15-sp3-pool-x86_64',
                                            'RHEL x86_64 Server 7' => 'rhel-x86_64-server-7',
-                                           'RHEL8-Pool for x86_64' => nil,
+                                           'no-appstream-result-RHEL8-Pool for x86_64' => nil,
                                            'ubuntu-18.04-pool' => nil,
                                            'ubuntu-2004-amd64-main' => nil,
                                            'debian-9-pool' => 'debian-9-pool-amd64',
@@ -272,7 +272,7 @@ PKGARCH_BY_CLIENT = { 'proxy' => 'x86_64',
                       'debian9_minion' => 'amd64',
                       'debian9_ssh_minion' => 'amd64',
                       'debian10_minion' => 'amd64',
-                      'debian10_ssh_minion' => 'ams64' }.freeze
+                      'debian10_ssh_minion' => 'amd64' }.freeze
 
 CHANNEL_TO_SYNCH_BY_OS_VERSION = {
   # 'default' is required for auto-installation tests.


### PR DESCRIPTION
## What does this PR change?

Detail fixes to:
* the feature to create CLM filters for RedHat appstream data
* the bootstrap repo constants for CentOS 8, Debian 9, and Debian 10


## Links

Ports:
* 4.0: SUSE/spacewalk#15163
* 4.1: SUSE/spacewalk#15162, SUSE/spacewalk#15167

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
