### PR TITLE
fix db migrations script from 12 to 13

### DIFF
--- a/susemanager/bin/pg-migrate-12-to-13.sh
+++ b/susemanager/bin/pg-migrate-12-to-13.sh
@@ -92,8 +92,8 @@ else
     echo "`date +"%H:%M:%S"`   Initialization of new postgresql $NEW_VERSION database failed!"
     echo "`date +"%H:%M:%S"`   Trying to restore previous state..."
     mv /var/lib/pgsql/data /var/lib/pgsql/data-new-failed
-    mv /var/lib/pgsql/data-pg10 /var/lib/pgsql/data
-    /usr/sbin/update-alternatives --set postgresql /usr/lib/postgresql10
+    mv /var/lib/pgsql/data-pg${OLD_VERSION} /var/lib/pgsql/data
+    /usr/sbin/update-alternatives --set postgresql /usr/lib/postgresql${OLD_VERSION}
     exit 1
 fi
 

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,5 @@
+- Fix database database migration script from PostgreSQL 12 to 13
+
 -------------------------------------------------------------------
 Wed Jun 02 11:08:38 CEST 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

This fixes the db migration script from 12 to 13. There was a hardcoded 10 in the path which should have been OLDVERSION variables instead.

## GUI diff

No difference.


- [X] **DONE**

## Documentation
- No documentation needed
- [X] **DONE**

## Test coverage
- No tests

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
