### PR TITLE
Tests: force zypper ref before installing patterns

### DIFF
--- a/testsuite/features/core/proxy_branch_network.feature
+++ b/testsuite/features/core/proxy_branch_network.feature
@@ -24,6 +24,7 @@ Feature: Setup SUSE Manager for Retail branch network
 @proxy
 @private_net
   Scenario: Install the Retail pattern on the server
+    When I refresh the metadata for "server"
     When I install pattern "suma_retail" on this "server"
     And I wait for "patterns-suma_retail" to be installed on "server"
 

--- a/testsuite/features/core/proxy_register_as_minion_with_gui.feature
+++ b/testsuite/features/core/proxy_register_as_minion_with_gui.feature
@@ -14,6 +14,7 @@ Feature: Setup SUSE Manager proxy
   I want to register the proxy to the server
 
   Scenario: Install proxy software
+    When I refresh the metadata for "proxy"
     # uncomment when product is out:
     # When I install "SUSE-Manager-Proxy" product on the proxy
     And I install proxy pattern on the proxy

--- a/testsuite/features/core/proxy_register_as_minion_with_script.feature
+++ b/testsuite/features/core/proxy_register_as_minion_with_script.feature
@@ -14,6 +14,7 @@ Feature: Setup SUSE Manager proxy
   I want to register the proxy to the server
 
   Scenario: Install proxy software
+    When I refresh the metadata for "proxy"
     # uncomment when product is out:
     # When I install "SUSE-Manager-Proxy" product on the proxy
     And I install proxy pattern on the proxy

--- a/testsuite/features/core/proxy_register_as_trad_with_script.feature
+++ b/testsuite/features/core/proxy_register_as_trad_with_script.feature
@@ -14,6 +14,7 @@ Feature: Setup SUSE Manager proxy
   I want to register the proxy to the server
 
   Scenario: Install proxy software
+    When I refresh the metadata for "proxy"
     # uncomment when product is out:
     # When I install "SUSE-Manager-Proxy" product on the proxy
     And I install proxy pattern on the proxy


### PR DESCRIPTION
## What does this PR change?

Force zypper ref in the tests that install patterns, otherwise if metadata has changed in the repos, tests fail.

## GUI diff

No difference.


- [X] **DONE**

## Documentation
- No documentation needed
- [X] **DONE**

## Test coverage
- No tests

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
