### PR TITLE
spacecmd needs python 3.6

### DIFF
--- a/testsuite/features/build_validation/add_custom_repositories/add_ceos8_repositories.feature
+++ b/testsuite/features/build_validation/add_custom_repositories/add_ceos8_repositories.feature
@@ -62,12 +62,12 @@ Feature: Adding the CentOS 8 distribution custom repositories
     And I click on "Save"
     Then I should see a "ruby-2.7" text
     When I click on "Create Filter"
-    And I enter "python-3.8" as "filter_name"
+    And I enter "python-3.6" as "filter_name"
     And I select "Module (Stream)" from "type"
-    And I enter "python38" as "moduleName"
-    And I enter "3.8" as "moduleStream"
+    And I enter "python36" as "moduleName"
+    And I enter "3.6" as "moduleStream"
     And I click on "Save"
-    Then I should see a "python-3.8" text
+    Then I should see a "python-3.6" text
 
   Scenario: Create a CLM project to remove AppStream metadata
     When I follow the left menu "Content Lifecycle > Projects"
@@ -83,10 +83,10 @@ Feature: Adding the CentOS 8 distribution custom repositories
     And I click on "Save"
     Then I should see a "Custom Channel for CentOS 8 DVD" text
     When I click on "Attach/Detach Filters"
-    And I check "python-3.8: enable module python38:3.8"
+    And I check "python-3.6: enable module python36:3.6"
     And I check "ruby-2.7: enable module ruby:2.7"
     And I click on "Save"
-    Then I should see a "python-3.8: enable module python38:3.8" text
+    Then I should see a "python-3.6: enable module python36:3.6" text
     When I click on "Add Environment"
     And I enter "result" as "name"
     And I enter "result" as "label"


### PR DESCRIPTION
## What does this PR change?

Filter python 3.6 instead of python 3.8 on RH 8-compatible systems.

This is needed in order to be able to install `spacecmd`.


## Links

Ports:
* 4.0: not applicable
* 4.1: SUSE/spacewalk#15175


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
