### PR TITLE
Fix database corruption after migrating to PostgreSQL13

### DIFF
--- a/susemanager/bin/pg-migrate-10-to-13.sh
+++ b/susemanager/bin/pg-migrate-10-to-13.sh
@@ -124,6 +124,8 @@ chown postgres:postgres /var/lib/pgsql/data/*
 
 echo "`date +"%H:%M:%S"`   Starting spacewalk services..."
 systemctl start postgresql
+echo "Reindexing database. This may take a while, please do not cancel it!"
+database=$(sed -n "s/^\s*db_name\s*=\s*\([^ ]*\)\s*$/\1/p" /etc/rhn/rhn.conf)
+spacewalk-sql --select-mode - <<<"REINDEX DATABASE ${database};"
 spacewalk-service start
-
 

--- a/susemanager/bin/pg-migrate-10-to-13.sh
+++ b/susemanager/bin/pg-migrate-10-to-13.sh
@@ -92,8 +92,8 @@ else
     echo "`date +"%H:%M:%S"`   Initialization of new postgresql $NEW_VERSION database failed!"
     echo "`date +"%H:%M:%S"`   Trying to restore previous state..."
     mv /var/lib/pgsql/data /var/lib/pgsql/data-new-failed
-    mv /var/lib/pgsql/data-pg$OLD_VERSION /var/lib/pgsql/data
-    /usr/sbin/update-alternatives --set postgresql /usr/lib/postgresql$OLD_VERSION
+    mv /var/lib/pgsql/data-pg${OLD_VERSION} /var/lib/pgsql/data
+    /usr/sbin/update-alternatives --set postgresql /usr/lib/postgresql${OLD_VERSION}
     exit 1
 fi
 
@@ -127,5 +127,8 @@ systemctl start postgresql
 echo "Reindexing database. This may take a while, please do not cancel it!"
 database=$(sed -n "s/^\s*db_name\s*=\s*\([^ ]*\)\s*$/\1/p" /etc/rhn/rhn.conf)
 spacewalk-sql --select-mode - <<<"REINDEX DATABASE ${database};"
+if [ ${?} -ne 0 ]; then
+    echo "The reindexing failed. Please review the PostgreSQL logs at /var/lib/pgsql/data/log"
+    exit 1
+fi
 spacewalk-service start
-

--- a/susemanager/bin/pg-migrate-12-to-13.sh
+++ b/susemanager/bin/pg-migrate-12-to-13.sh
@@ -124,6 +124,8 @@ chown postgres:postgres /var/lib/pgsql/data/*
 
 echo "`date +"%H:%M:%S"`   Starting spacewalk services..."
 systemctl start postgresql
+echo "Reindexing database. This may take a while, please do not cancel it!"
+database=$(sed -n "s/^\s*db_name\s*=\s*\([^ ]*\)\s*$/\1/p" /etc/rhn/rhn.conf)
+spacewalk-sql --select-mode - <<<"REINDEX DATABASE ${database};"
 spacewalk-service start
-
 

--- a/susemanager/bin/pg-migrate-12-to-13.sh
+++ b/susemanager/bin/pg-migrate-12-to-13.sh
@@ -127,5 +127,8 @@ systemctl start postgresql
 echo "Reindexing database. This may take a while, please do not cancel it!"
 database=$(sed -n "s/^\s*db_name\s*=\s*\([^ ]*\)\s*$/\1/p" /etc/rhn/rhn.conf)
 spacewalk-sql --select-mode - <<<"REINDEX DATABASE ${database};"
+if [ ${?} -ne 0 ]; then
+    echo "The reindexing failed. Please review the PostgreSQL logs at /var/lib/pgsql/data/log"
+    exit 1
+fi
 spacewalk-service start
-

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,5 @@
+- Fix database corruption after migrating the server to PostgreSQL 13 (bsc#1187217)
+ 
 -------------------------------------------------------------------
 Mon Jun 14 17:33:40 CEST 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?
These reindexes the database when running the migration to prevent corruption.


## GUI diff

- [X] **DONE**

## Documentation
- No documentation needed

- [X] **DONE**

## Test coverage
- No tests

- [X] **DONE**

## Links

Related: https://github.com/SUSE/spacewalk/issues/15127
fixes bsc#1187217

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
