### PR TITLE
QA: Remove obsolete scenario "Do not use jsession id"

### DIFF
--- a/testsuite/features/secondary/srv_security.feature
+++ b/testsuite/features/secondary/srv_security.feature
@@ -24,8 +24,3 @@ Feature: Basic web security measures and recommendations
   Scenario: Obsolete and problematic headers for static content
     Given I retrieve any static resource
     Then the response header "X-WebKit-CSP" should not be present
-
-  Scenario: Do not use jsession id
-    Given I am not authorized
-    Then the login form does not contain a jsessionid
-

--- a/testsuite/features/step_definitions/security_steps.rb
+++ b/testsuite/features/step_definitions/security_steps.rb
@@ -34,8 +34,3 @@ Then(/^the response header "(.*?)" should not be present$/) do |arg1|
   refute_includes(@headers.keys, arg1.downcase,
                   "Header '#{arg1}' present in '#{@url}'")
 end
-
-Then(/^the login form does not contain a jsessionid$/) do
-  form = find(:xpath, '//form[@name="loginForm"]')
-  refute_includes(form['action'], 'jsessionid=', 'URL rewriting is enabled: jsessionid present')
-end


### PR DESCRIPTION
## What does this PR change?

Remove obsolete scenario "Do not use jsession id".
The current login form works differently.

The current workflow is:
- We hit the Sign In button
- An ajax request hit the routing on the server side
- If we don't have the csrf token we deny the request

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.1 https://github.com/SUSE/spacewalk/pull/15188

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
