### PR TITLE
QA: Wait until the SCC credentials is not shown

### DIFF
--- a/testsuite/features/secondary/srv_scc_user_credentials.feature
+++ b/testsuite/features/secondary/srv_scc_user_credentials.feature
@@ -38,4 +38,4 @@ Feature: SCC user credentials in the Setup Wizard
     And I wait for the trash icon to appear for "SCC user"
     And I ask to delete the credentials for "SCC user"
     And I click on "Delete" in "Are you sure you want to delete these credentials?" modal
-    Then I should not see a "SCC user" text
+    Then I wait until I do not see "SCC user" text

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -976,7 +976,7 @@ When(/^I click on "([^"]*)" in "([^"]*)" modal$/) do |btn, title|
   end
 
   within(:xpath, path) do
-    click_button(btn, wait: 0)
+    click_button(btn, wait: 5)
   end
 end
 


### PR DESCRIPTION
## What does this PR change?

This scenario removing SCC credentials works locally but fails often in CI, so we will make it even more reliable by giving an extra timeout.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed

- [x] **DONE**

## Test coverage

- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.1

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
