### PR TITLE
Fix message in postgresql migration

### DIFF
--- a/susemanager/bin/pg-migrate-10-to-13.sh
+++ b/susemanager/bin/pg-migrate-10-to-13.sh
@@ -122,7 +122,7 @@ fi
 cp /var/lib/pgsql/data-pg$OLD_VERSION/pg_hba.conf /var/lib/pgsql/data
 chown postgres:postgres /var/lib/pgsql/data/*
 
-echo "`date +"%H:%M:%S"`   Starting spacewalk services..."
+echo "`date +"%H:%M:%S"`   Starting PostgreSQL service..."
 systemctl start postgresql
 echo "Reindexing database. This may take a while, please do not cancel it!"
 database=$(sed -n "s/^\s*db_name\s*=\s*\([^ ]*\)\s*$/\1/p" /etc/rhn/rhn.conf)
@@ -131,4 +131,5 @@ if [ ${?} -ne 0 ]; then
     echo "The reindexing failed. Please review the PostgreSQL logs at /var/lib/pgsql/data/log"
     exit 1
 fi
+echo "`date +"%H:%M:%S"`   Starting spacewalk services..."
 spacewalk-service start

--- a/susemanager/bin/pg-migrate-12-to-13.sh
+++ b/susemanager/bin/pg-migrate-12-to-13.sh
@@ -122,7 +122,7 @@ fi
 cp /var/lib/pgsql/data-pg$OLD_VERSION/pg_hba.conf /var/lib/pgsql/data
 chown postgres:postgres /var/lib/pgsql/data/*
 
-echo "`date +"%H:%M:%S"`   Starting spacewalk services..."
+echo "`date +"%H:%M:%S"`   Starting PostgreSQL service..."
 systemctl start postgresql
 echo "Reindexing database. This may take a while, please do not cancel it!"
 database=$(sed -n "s/^\s*db_name\s*=\s*\([^ ]*\)\s*$/\1/p" /etc/rhn/rhn.conf)
@@ -131,4 +131,5 @@ if [ ${?} -ne 0 ]; then
     echo "The reindexing failed. Please review the PostgreSQL logs at /var/lib/pgsql/data/log"
     exit 1
 fi
+echo "`date +"%H:%M:%S"`   Starting spacewalk services..."
 spacewalk-service start

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,5 @@
+- Fix message in database migration (bsc#1187451)
+
 -------------------------------------------------------------------
 Wed Jun 16 10:59:25 CEST 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

The message was stating "Starting spacewalk services" when it was only
starting postgresql.

This was a confusing message, because spacewalk services were started
later, after reindexing the database


## GUI diff

Before: When running the susemanager/bin/pg-migrate-10-to-13.sh or susemanager/bin/pg-migrate-12-to13.sh, you could see "Starting spacewalk services" before "Reindexing the database"

After: You see the message "Starting PostgreSQL services" before "Reindexing the database" and after reindexing the database you see "Starting spacewalk services" 


- [X] **DONE**

## Documentation
- No documentation needed. This is bug fix in a message, no need to document it.

- [X] **DONE**

## Test coverage
- No tests. No need to add tests, this is just a fix in a message.

- [X] **DONE**

## Links

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1187451

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
