### PR TITLE
Filter template: Live patching based on a system

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/product/SUSEProductFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/product/SUSEProductFactory.java
@@ -668,6 +668,10 @@ public class SUSEProductFactory extends HibernateFactory {
 
     /**
      * Get all root SUSE products that support live patching
+     *
+     * The query selects all the root products that has a live patching extension product.
+     * It selects only installed products by checking if they have a channel present.
+     *
      * @return the stream of products
      */
     public static Stream<SUSEProduct> getLivePatchSupportedProducts() {
@@ -682,18 +686,21 @@ public class SUSEProductFactory extends HibernateFactory {
     }
 
     /**
-     * Get all 'kernel-default' versions contained in a product tree
+     * Get all kernel versions contained in a product tree
+     *
+     * The query selects the EVRs of every kernel package that is included in any channel of the product tree.
+     *
      * @param product the root product
      * @return the stream of EVRs
      */
     public static Stream<PackageEvr> getKernelVersionsInProduct(SUSEProduct product) {
         return HibernateFactory.getSession().createQuery(
-                "SELECT pkg.packageEvr " +
+                "SELECT DISTINCT pkg.packageEvr " +
                 "FROM SUSEProductExtension x " +
                 "JOIN SUSEProduct ext ON x.extensionProduct = ext " +
                 "JOIN SUSEProductChannel pc ON pc.product = ext " +
                 "JOIN pc.channel.packages pkg " +
-                "WHERE pkg.packageName.name = 'kernel-default' " +
+                "WHERE pkg.packageName.name LIKE 'kernel-default%' " +
                 "AND x.rootProduct = :product", PackageEvr.class)
                 .setParameter("product", product)
                 .getResultStream();

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/LivePatchingApiController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/LivePatchingApiController.java
@@ -14,18 +14,25 @@
  */
 package com.suse.manager.webui.controllers.contentmanagement.handlers;
 
+import com.redhat.rhn.common.hibernate.LookupException;
 import com.redhat.rhn.domain.product.SUSEProduct;
 import com.redhat.rhn.domain.product.SUSEProductFactory;
 import com.redhat.rhn.domain.rhnpackage.PackageEvr;
+import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.manager.system.SystemManager;
 import com.suse.manager.model.products.Product;
 import com.suse.manager.webui.utils.gson.ResultJson;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
 import spark.Request;
 import spark.Response;
 import spark.Spark;
 
 import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.suse.manager.webui.utils.SparkApplicationHelper.json;
@@ -49,6 +56,7 @@ public class LivePatchingApiController {
 
         /**
          * Initialize an object from an EVR
+         *
          * @param evr the kernel EVR
          */
         public KernelVersion(PackageEvr evr) {
@@ -57,12 +65,36 @@ public class LivePatchingApiController {
         }
     }
 
+    /**
+     * JSON object for basic system ID and it's running kernel version
+     */
+    public static class System {
+        private Long id;
+        private String name;
+        private String kernel;
+
+        /**
+         * Initialize an object from a server
+         *
+         * @param server the server
+         */
+        public System(Server server) {
+            this.id = server.getId();
+            this.name = server.getName();
+            this.kernel = server.getRunningKernel();
+        }
+    }
+
     /** Init routes for ContentManagement Live Patching Api.*/
     public static void initRoutes() {
         get("/manager/api/contentmanagement/livepatching/products",
                 withUser(LivePatchingApiController::getSuseProducts));
-        get("/manager/api/contentmanagement/livepatching/kernels/:productId",
-                withUser(LivePatchingApiController::getKernelVersions));
+        get("/manager/api/contentmanagement/livepatching/systems",
+                withUser(LivePatchingApiController::getSlesSystems));
+        get("/manager/api/contentmanagement/livepatching/kernels/product/:productId",
+                withUser(LivePatchingApiController::getProductKernels));
+        get("/manager/api/contentmanagement/livepatching/kernels/system/:systemId",
+                withUser(LivePatchingApiController::getSystemKernels));
     }
 
     /**
@@ -81,6 +113,23 @@ public class LivePatchingApiController {
     }
 
     /**
+     * Get all SLES systems available to user
+     *
+     * @param req the http request
+     * @param res the http response
+     * @param user the current user
+     * @return the JSON data
+     */
+    public static String getSlesSystems(Request req, Response res, User user) {
+        String query = StringUtils.defaultString(req.queryParams("q"));
+        List<System> slesSystems = ServerFactory.querySlesSystems(query, 20, user)
+                .map(System::new)
+                .collect(Collectors.toList());
+
+        return json(res, ResultJson.success(slesSystems));
+    }
+
+    /**
      * Get all kernel versions contained in a SUSE root product
      *
      * @param req the http request
@@ -88,11 +137,14 @@ public class LivePatchingApiController {
      * @param user the current user
      * @return the JSON data
      */
-    public static String getKernelVersions(Request req, Response res, User user) {
+    public static String getProductKernels(Request req, Response res, User user) {
         SUSEProduct product;
         try {
             long productId = Long.parseLong(req.params("productId"));
             product = SUSEProductFactory.getProductById(productId);
+            if (product == null) {
+                throw Spark.halt(HttpStatus.SC_NOT_FOUND);
+            }
         }
         catch (NumberFormatException e) {
             throw Spark.halt(HttpStatus.SC_BAD_REQUEST);
@@ -105,5 +157,39 @@ public class LivePatchingApiController {
                         .map(KernelVersion::new);
 
         return json(res, ResultJson.success(kernelsInProductTree.collect(toList())));
+    }
+
+    /**
+     * Get all kernel versions installed in a system
+     *
+     * @param req the http request
+     * @param res the http response
+     * @param user the current user
+     * @return the JSON data
+     */
+    public static String getSystemKernels(Request req, Response res, User user) {
+        Server server;
+        try {
+            long systemId = Long.parseLong(req.params("systemId"));
+            server = ServerFactory.lookupByIdAndOrg(systemId, user.getOrg());
+            if (server == null) {
+                throw Spark.halt(HttpStatus.SC_NOT_FOUND);
+            }
+            SystemManager.ensureAvailableToUser(user, systemId);
+        }
+        catch (NumberFormatException e) {
+            throw Spark.halt(HttpStatus.SC_BAD_REQUEST);
+        }
+        catch (LookupException e) {
+            throw Spark.halt(HttpStatus.SC_BAD_REQUEST, e.getLocalizedTitle());
+        }
+
+        // Get kernel versions ordered from latest to earliest
+        Stream<KernelVersion> kernelsInSystem =
+                ServerFactory.getInstalledKernelVersions(server)
+                        .sorted(Comparator.reverseOrder())
+                        .map(KernelVersion::new);
+
+        return json(res, ResultJson.success(kernelsInSystem.collect(toList())));
     }
 }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- New filter template: Live patching based on a system
 - Adapt generated pillar data to run the new Salt scap state
 - Handle virtual machines running on pacemaker cluster
 - SP migration: wait some seconds before scheduling "package refresh" action after migration is completed (bsc#1187963)

--- a/web/html/src/manager/content-management/list-filters/templates/index.tsx
+++ b/web/html/src/manager/content-management/list-filters/templates/index.tsx
@@ -22,11 +22,10 @@ const TemplateForm = (props: FilterFormProps) => {
 
 export default (props: FilterFormProps) => {
   const templates = [
-    // TODO: To be implemented
-    // {
-    //   label: t("Live patching based on a specific system"),
-    //   value: Template.LivePatchingSystem,
-    // },
+    {
+      label: t("Live patching based on a specific system"),
+      value: Template.LivePatchingSystem,
+    },
     {
       label: t("Live patching based on a SUSE product"),
       value: Template.LivePatchingProduct,
@@ -39,7 +38,7 @@ export default (props: FilterFormProps) => {
         name="template"
         labelClass="col-md-3"
         divClass="col-md-6"
-        defaultValue={Template.LivePatchingProduct}
+        defaultValue={Template.LivePatchingSystem}
         options={templates}
       />
       <TemplateForm {...props} />

--- a/web/html/src/manager/content-management/list-filters/templates/live-patching.tsx
+++ b/web/html/src/manager/content-management/list-filters/templates/live-patching.tsx
@@ -12,6 +12,12 @@ type Product = {
   label: string;
 };
 
+type System = {
+  id: number;
+  name: string;
+  kernel: string;
+};
+
 type Kernel = {
   id: number;
   version: string;
@@ -28,11 +34,17 @@ function getProducts(): Promise<Product[]> {
     .then((res: JsonResult<Product[]>) => res.success ? res.data : Promise.reject(res));
 }
 
-function getProductKernels(productId: number): Promise<Kernel[]> {
-  return Network.get(`/rhn/manager/api/contentmanagement/livepatching/kernels/${productId}`).promise
+function getSystems(query: string): Promise<System[]> {
+  return Network.get(`/rhn/manager/api/contentmanagement/livepatching/systems?q=${query}`).promise
+    .then((res: JsonResult<System[]>) => res.success ? res.data : Promise.reject(res));
+}
+
+function getKernels(id: number, type: string): Promise<Kernel[]> {
+  return Network.get(`/rhn/manager/api/contentmanagement/livepatching/kernels/${type}/${id}`).promise
     .then((res: JsonResult<Kernel[]>) => res.success ? res.data : Promise.reject(res))
     .then(res => {
-      res[0].latest = true;
+      if (res.length > 0)
+        res[0].latest = true;
       return res;
     });
 }
@@ -45,7 +57,7 @@ export default (props: FilterFormProps & { template: Template }) => {
 
   const formContext = React.useContext(FormContext);
   const setModelValue = formContext.setModelValue;
-  const clientId = formContext.model.clientId;
+  const systemId = formContext.model.systemId;
   const productId = formContext.model.productId;
   const [products, setProducts] = useState<Product[]>([]);
   const [kernels, setKernels] = useState<Kernel[]>([]);
@@ -57,11 +69,8 @@ export default (props: FilterFormProps & { template: Template }) => {
   }, []);
 
   useEffect(() => {
-    if (clientId) {
-      //TODO: To be implemented with "Live Patching for a system" template
-      throw new Error("Not implemented");
-    } else if (productId) {
-      getProductKernels(productId).then(result => {
+    if (systemId || productId) {
+      getKernels(systemId ?? productId, systemId ? "system" : "product").then(result => {
         setKernels(result);
 
         const latestKernel = result.find(item => Boolean(item.latest));
@@ -74,11 +83,18 @@ export default (props: FilterFormProps & { template: Template }) => {
       setModelValue?.("kernelId", null);
     }
   }, [
-    template, // If the template changes, reset what we previously had
-    clientId,
+    systemId,
     productId,
     setModelValue,
   ]);
+
+  useEffect(() => {
+    // If the template changes, reset what we previously had
+    setModelValue?.("systemId", null);
+    setModelValue?.("productId", null);
+    setModelValue?.("kernelId", null);
+    setKernels([]);
+  }, [template, setModelValue]);
 
   return (
     <>
@@ -89,11 +105,22 @@ export default (props: FilterFormProps & { template: Template }) => {
             label={t("Product")}
             labelClass="col-md-3"
             divClass="col-md-6"
-            required
-            disabled={props.editing}
             options={products}
             getOptionValue={product => product.id}
             getOptionLabel={product => product.label}
+          />
+        </>
+      )}
+      {template === Template.LivePatchingSystem && (
+        <>
+          <Select
+            loadOptions={getSystems}
+            name="systemId"
+            label={t("System")}
+            labelClass="col-md-3"
+            divClass="col-md-6"
+            getOptionValue={system => system.id}
+            getOptionLabel={system => `${system.name} (${system.kernel})`}
           />
         </>
       )}
@@ -102,8 +129,8 @@ export default (props: FilterFormProps & { template: Template }) => {
         label={t("Kernel")}
         labelClass="col-md-3"
         divClass="col-md-6"
-        required={!!(clientId || productId)}
-        disabled={!clientId && !productId}
+        required={!!(systemId || productId)}
+        disabled={!systemId && !productId}
         options={kernels}
         getOptionValue={kernel => kernel.id}
         getOptionLabel={kernel => `${kernel.version}${kernel.latest ? ` (${t("latest")})` : ""}`}

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- New filter template: Live patching based on a system
 - Refresh JWT virtual console token before it expires
 - Handle virtual machines running on pacemaker cluster
 - Fix bugged search in formula catalog


### PR DESCRIPTION
New filter template: "Live patching based on a system" in CLM

## GUI diff
![system-filter-template-1](https://user-images.githubusercontent.com/1103552/123112889-64d9fa80-d43e-11eb-9411-c790f862ff0e.png)
![system-filter-template-2](https://user-images.githubusercontent.com/1103552/123112895-65729100-d43e-11eb-8704-996ab1b95515.png)

## Documentation
- Documentation issue was created: https://github.com/SUSE/spacewalk/issues/15205

## Test coverage
- Unit tests were added

## Links

Fixes https://github.com/SUSE/spacewalk/issues/14098

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
