### PR TITLE
Add SLE Updates and Backport Updates repositories for openSUSE Leap 15.3

### DIFF
--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -1073,6 +1073,22 @@ checksum = sha256
 base_channels = opensuse_leap15_3-%(arch)s
 repo_url = http://download.opensuse.org/update/leap/15.3/non-oss/
 
+[opensuse_leap15_3-sle-updates]
+label    = %(base_channel)s-sle-updates
+name     = Update repository with updates from SUSE Linux Enterprise 15 (%(arch)s)
+archs    = x86_64, aarch64
+checksum = sha256
+base_channels = opensuse_leap15_3-%(arch)s
+repo_url = http://download.opensuse.org/update/leap/15.3/sle/
+
+[opensuse_leap15_3-backports-updates]
+label    = %(base_channel)s-backports-updates
+name     = Update repository of openSUSE Backports (%(arch)s)
+archs    = x86_64, aarch64
+checksum = sha256
+base_channels = opensuse_leap15_3-%(arch)s
+repo_url = http://download.opensuse.org/update/leap/15.3/backports/
+
 # This is expected. openSUSE Leap 15.0 client tools are valid for all openSUSE Leap 15.X releases
 [opensuse_leap15_3-uyuni-client]
 name     = Uyuni Client Tools for %(base_channel_name)s

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,6 @@
+- Add SLE Updates and Backport Updates repositories for openSUSE
+  Leap 15.3
+
 -------------------------------------------------------------------
 Fri Jun 04 12:43:25 CEST 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Add SLE Updates and Backport Updates repositories for openSUSE Leap 15.3

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- Documentation PR was created:https://github.com/uyuni-project/uyuni-docs/pull/995

- [x] **DONE**

## Test coverage
- No tests: spacewalk-common-channels not covered by tests

- [x] **DONE**

## Links

None

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
