### PR TITLE
fix install gpg key on sshpush tunnel

### DIFF
--- a/java/buildconf/test/rhn.conf.postgresql-example
+++ b/java/buildconf/test/rhn.conf.postgresql-example
@@ -111,6 +111,8 @@ web.subscribe_proxy_channel = 0
 # Auditing settings
 web.audit.logdir = /var/lib/spacewalk/systemlogs
 
+web.ssh_push_port_https = 1233
+
 # OSA configuration
 server.jabber_server = linux.fritz.box
 osa-dispatcher.jabber_server = linux.fritz.box

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemDetailsEditAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemDetailsEditAction.java
@@ -40,6 +40,8 @@ import com.redhat.rhn.taskomatic.TaskomaticApiException;
 
 import com.suse.manager.maintenance.MaintenanceManager;
 import com.suse.manager.model.maintenance.MaintenanceSchedule;
+import com.suse.manager.webui.services.pillar.MinionPillarManager;
+
 import org.apache.log4j.Logger;
 import org.apache.struts.action.ActionErrors;
 import org.apache.struts.action.ActionForm;
@@ -333,6 +335,10 @@ public class SystemDetailsEditAction extends RhnAction {
             String message =
                 LocalizationService.getInstance().getMessage("snapshots.entitlements");
             SystemManager.snapshotServer(s, message);
+        }
+        else {
+            // just regenerate the pillar data when nothing has changed
+            s.asMinionServer().ifPresent(m -> MinionPillarManager.INSTANCE.generatePillar(m));
         }
 
         return success;

--- a/java/code/src/com/suse/manager/webui/controllers/utils/AbstractMinionBootstrapper.java
+++ b/java/code/src/com/suse/manager/webui/controllers/utils/AbstractMinionBootstrapper.java
@@ -14,6 +14,7 @@
  */
 package com.suse.manager.webui.controllers.utils;
 
+import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.domain.server.ContactMethod;
@@ -242,6 +243,9 @@ public abstract class AbstractMinionBootstrapper {
                 .orElse(ConfigDefaults.get().getCobblerHost());
 
         pillarData.put("mgr_server", mgrServer);
+        if ("ssh-push-tunnel".equals(contactMethod)) {
+            pillarData.put("mgr_server_https_port", Config.get().getInt("ssh_push_port_https"));
+        }
         pillarData.put("mgr_origin_server", ConfigDefaults.get().getCobblerHost());
         pillarData.put("minion_id", input.getHost());
         pillarData.put("contact_method", contactMethod);

--- a/java/code/src/com/suse/manager/webui/controllers/utils/AbstractMinionBootstrapper.java
+++ b/java/code/src/com/suse/manager/webui/controllers/utils/AbstractMinionBootstrapper.java
@@ -14,6 +14,9 @@
  */
 package com.suse.manager.webui.controllers.utils;
 
+import static com.suse.manager.webui.services.SaltConstants.SALT_SSH_DIR_PATH;
+import static java.util.Optional.of;
+
 import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.localization.LocalizationService;
@@ -24,17 +27,19 @@ import com.redhat.rhn.domain.token.ActivationKey;
 import com.redhat.rhn.domain.token.ActivationKeyFactory;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.token.ActivationKeyManager;
+
 import com.suse.manager.utils.SaltUtils;
 import com.suse.manager.webui.services.iface.SaltApi;
+import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.manager.webui.services.impl.SaltSSHService;
 import com.suse.manager.webui.services.impl.SaltService.KeyStatus;
-import com.suse.manager.webui.services.iface.SystemQuery;
-import com.suse.manager.webui.utils.gson.BootstrapParameters;
 import com.suse.manager.webui.utils.gson.BootstrapHostsJson;
+import com.suse.manager.webui.utils.gson.BootstrapParameters;
 import com.suse.salt.netapi.calls.modules.State;
 import com.suse.salt.netapi.exception.SaltException;
 import com.suse.salt.netapi.results.SSHResult;
 import com.suse.utils.Opt;
+
 import org.apache.log4j.Logger;
 
 import java.io.File;
@@ -46,9 +51,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-
-import static java.util.Optional.of;
-import static com.suse.manager.webui.services.SaltConstants.SALT_SSH_DIR_PATH;
 
 /**
  * Base for bootstrapping systems using salt-ssh.

--- a/java/code/src/com/suse/manager/webui/controllers/utils/test/SSHMinionBootstrapperTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/utils/test/SSHMinionBootstrapperTest.java
@@ -1,12 +1,15 @@
 package com.suse.manager.webui.controllers.utils.test;
 
+import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.token.ActivationKey;
 import com.redhat.rhn.domain.token.test.ActivationKeyTest;
+
 import com.suse.manager.reactor.messaging.RegisterMinionEventMessageAction;
 import com.suse.manager.webui.controllers.utils.ContactMethodUtil;
 import com.suse.manager.webui.controllers.utils.SSHMinionBootstrapper;
+
 import org.jmock.Expectations;
 
 import java.util.Arrays;
@@ -80,13 +83,15 @@ public class SSHMinionBootstrapperTest extends AbstractMinionBootstrapperTestBas
 
     @Override
     protected Map<String, Object> createPillarData(Optional<ActivationKey> key) {
+        String contactMethod = key.map(k -> k.getContactMethod().getLabel()).orElse(getDefaultContactMethod());
         Map<String, Object> pillarData = new HashMap<>();
         pillarData.put("mgr_server", ConfigDefaults.get().getCobblerHost());
+        if (contactMethod.equals("ssh-push-tunnel")) {
+            pillarData.put("mgr_server_https_port", Config.get().getInt("ssh_push_port_https"));
+        }
         pillarData.put("mgr_origin_server", ConfigDefaults.get().getCobblerHost());
         pillarData.put("minion_id", "myhost");
-        pillarData.put("contact_method", key
-                .map(k -> k.getContactMethod().getLabel())
-                .orElse(getDefaultContactMethod()));
+        pillarData.put("contact_method", contactMethod);
         pillarData.put("mgr_sudo_user", "root");
         return pillarData;
     }

--- a/java/code/src/com/suse/manager/webui/services/pillar/MinionGeneralPillarGenerator.java
+++ b/java/code/src/com/suse/manager/webui/services/pillar/MinionGeneralPillarGenerator.java
@@ -62,6 +62,10 @@ public class MinionGeneralPillarGenerator implements MinionPillarGenerator {
 
         pillar.add("contact_method", minion.getContactMethod().getLabel());
         pillar.add("mgr_server", minion.getChannelHost());
+        if ("ssh-push-tunnel".equals(minion.getContactMethod().getLabel())) {
+            pillar.add("mgr_server_https_port", Config.get().getInt("ssh_push_port_https"));
+        }
+
         pillar.add("mgr_origin_server", ConfigDefaults.get().getCobblerHost());
         pillar.add("machine_password", MachinePasswordUtils.machinePassword(minion));
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- define a pillar for the https port when connection as ssh-push with tunnel (bsc#1187441)
 - Fix the unit test coverage reports
 - Fix random NullPointerException when rendering page tabs (bsc#1182769)
 - Add missing task status strings (bsc#1186744)

--- a/susemanager-utils/susemanager-sls/salt/channels/gpg-keys.sls
+++ b/susemanager-utils/susemanager-sls/salt/channels/gpg-keys.sls
@@ -1,3 +1,5 @@
+{%- set mgr_server = salt['pillar.get']('mgr_server')%}
+{%- set port = salt['pillar.get']('mgr_server_https_port', 443)%}
 
 {%- if salt['pillar.get']('mgr_metadata_signing_enabled', false) %}
 {%- if grains['os_family'] == 'Debian' %}
@@ -9,7 +11,7 @@ mgr_debian_repo_keyring:
 {% else %}
 mgr_trust_customer_gpg_key:
   cmd.run:
-    - name: rpm --import https://{{ salt['pillar.get']('mgr_server') }}/pub/mgr-gpg-pub.key
+    - name: rpm --import https://{{mgr_server}}:{{port}}/pub/mgr-gpg-pub.key
     - runas: root
 {%- endif %}
 {%- endif %}
@@ -17,20 +19,20 @@ mgr_trust_customer_gpg_key:
 {%- if grains['os_family'] == 'RedHat' %}
 trust_res_gpg_key:
   cmd.run:
-    - name: rpm --import https://{{ salt['pillar.get']('mgr_server') }}/pub/{{ salt['pillar.get']('gpgkeys:res:file') }}
+    - name: rpm --import https://{{mgr_server}}:{{port}}/pub/{{ salt['pillar.get']('gpgkeys:res:file') }}
     - unless: rpm -q {{ salt['pillar.get']('gpgkeys:res:name') }}
     - runas: root
 
 trust_suse_manager_tools_rhel_gpg_key:
   cmd.run:
 {%- if grains['osmajorrelease']|int == 6 %}
-    - name: rpm --import https://{{ salt['pillar.get']('mgr_server') }}/pub/{{ salt['pillar.get']('gpgkeys:res6tools:file') }}
+    - name: rpm --import https://{{mgr_server}}:{{port}}/pub/{{ salt['pillar.get']('gpgkeys:res6tools:file') }}
     - unless: rpm -q {{ salt['pillar.get']('gpgkeys:res6tools:name') }}
 {%- elif grains['osmajorrelease']|int == 7 %}
-    - name: rpm --import https://{{ salt['pillar.get']('mgr_server') }}/pub/{{ salt['pillar.get']('gpgkeys:res7tools:file') }}
+    - name: rpm --import https://{{mgr_server}}:{{port}}/pub/{{ salt['pillar.get']('gpgkeys:res7tools:file') }}
     - unless: rpm -q {{ salt['pillar.get']('gpgkeys:res7tools:name') }}
 {%- elif grains['osmajorrelease']|int == 8 %}
-    - name: rpm --import https://{{ salt['pillar.get']('mgr_server') }}/pub/{{ salt['pillar.get']('gpgkeys:res8tools:file') }}
+    - name: rpm --import https://{{mgr_server}}:{{port}}/pub/{{ salt['pillar.get']('gpgkeys:res8tools:file') }}
     - unless: rpm -q {{ salt['pillar.get']('gpgkeys:res8tools:name') }}
 {%- elif grains['osmajorrelease']|int == 2 and grains['os'] == 'Amazon' %}
     - name: rpm --import https://{{ salt['pillar.get']('mgr_server') }}/pub/{{ salt['pillar.get']('gpgkeys:res7tools:file') }}
@@ -49,5 +51,5 @@ install_gnupg_debian:
 trust_suse_manager_tools_deb_gpg_key:
   mgrcompat.module_run:
     - name: pkg.add_repo_key
-    - path: https://{{ salt['pillar.get']('mgr_server') }}/pub/{{ salt['pillar.get']('gpgkeys:ubuntutools:file') }}
+    - path: https://{{mgr_server}}:{{port}}/pub/{{ salt['pillar.get']('gpgkeys:ubuntutools:file') }}
 {%- endif %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,6 @@
+- when bootstrapping with ssh-push with tunnel use the port number
+  for fetching GPG keys from the server (bsc#1187441)
+
 -------------------------------------------------------------------
 Thu Jun 10 13:46:47 CEST 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

When bootstrapping with ssh-push with tunnel, we need to use the port number for fetching GPG keys from the server,
as the server is only reachable via this portnumner.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/15195

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
