### PR TITLE
Retracted patch icon should be red

### DIFF
--- a/branding/css/theme.less
+++ b/branding/css/theme.less
@@ -766,6 +766,9 @@ div:not([class~="alert"]) i.fa {
 .errata-critical {
   color: #cc0000;
 }
+.errata-retracted {
+  color: #cc0000;
+}
 
 code {
   white-space: normal;

--- a/branding/css/uyuni-theme.less
+++ b/branding/css/uyuni-theme.less
@@ -1143,6 +1143,9 @@ time:hover {
 .errata-critical {
   color: @red;
 }
+.errata-retracted {
+  color: @red;
+}
 
 /**
 * Simulate bootstrap 4 rule behavior


### PR DESCRIPTION
## What does this PR change?

What the title says.
Previously, the css class was not updated in all css files.

## GUI diff

Before:
![before](https://user-images.githubusercontent.com/1412268/122512809-bbdc6b80-d009-11eb-8c46-d0b379959251.png)

After:
![after](https://user-images.githubusercontent.com/1412268/122512813-bf6ff280-d009-11eb-9e52-14470989bc8b.png)


- [x] **DONE**

## Documentation
Docs not affected.

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
