### PR TITLE
Use the right repositories for the AlmaLinux 8 Uyuni client tools

### DIFF
--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,5 @@
+- Use the right URLs for the AlmaLinux 8 Uyuni client tools
+
 -------------------------------------------------------------------
 Mon May 24 18:32:50 CEST 2021 - jgonzalez@suse.com
 

--- a/schema/spacewalk/upgrade/susemanager-schema-4.2.14-to-susemanager-schema-4.2.15/000-almalinux-fix-uyuni-tools-repositories.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.2.14-to-susemanager-schema-4.2.15/000-almalinux-fix-uyuni-tools-repositories.sql
@@ -1,0 +1,6 @@
+UPDATE rhnContentSource
+SET source_url = 'https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/EL8-Uyuni-Client-Tools/EL_8/'
+WHERE label = 'External - Uyuni Client Tools for AlmaLinux 8 (x86_64) (Development)';
+UPDATE rhnContentSource
+SET source_url = 'https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/EL8-Uyuni-Client-Tools/EL_8/'
+WHERE label = 'External - Uyuni Client Tools for AlmaLinux 8 (x86_64)';

--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -2952,16 +2952,16 @@ repo_url = https://repo.almalinux.org/almalinux/8/HighAvailability/%(arch)s/os/
 name     = Uyuni Client Tools for %(base_channel_name)s
 archs    = %(_x86_archs)s
 base_channels = almalinux8-%(arch)s
-gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS8-Uyuni-Client-Tools/CentOS_8/repodata/repomd.xml.key
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/EL8-Uyuni-Client-Tools/EL_8/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS8-Uyuni-Client-Tools/CentOS_8/
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/EL8-Uyuni-Client-Tools/EL_8/
 
 [almalinux8-uyuni-client-devel]
 name     = Uyuni Client Tools for %(base_channel_name)s (Development)
 archs    = %(_x86_archs)s
 base_channels = almalinux8-%(arch)s
-gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/CentOS8-Uyuni-Client-Tools/CentOS_8/repodata/repomd.xml.key
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/EL8-Uyuni-Client-Tools/EL_8/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/CentOS8-Uyuni-Client-Tools/CentOS_8/
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/EL8-Uyuni-Client-Tools/CEL_8/

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,4 @@
+- Use the right URLs for the AlmaLinux 8 Uyuni client tools
 - Add SLE Updates and Backport Updates repositories for openSUSE
   Leap 15.3
 


### PR DESCRIPTION
## What does this PR change?

We were supposed to use the EL8 client tools, not CentOS8, but since EL8 arrrived later to OBS, we didn't remember to change it.

This PR takes care of this, for new installations, and for existing installations.

## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed: Bugfix

- [x] **DONE**

## Test coverage
- No tests: We tested AlmaLinux8, thing is that the CentOS8 client tools work as well, as they use the same sources.

- [x] **DONE**

## Links

None

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
