### PR TITLE
QA: Add more logs to debug portus image building in case of failure

### DIFF
--- a/testsuite/features/secondary/buildhost_docker_auth_registry.feature
+++ b/testsuite/features/secondary/buildhost_docker_auth_registry.feature
@@ -14,6 +14,7 @@ Feature: Build image with authenticated registry
     And I check "useCredentials"
     And I enter URI, username and password for portus
     And I click on "create-btn"
+    Then I wait until I see "portus" text
 
   Scenario: Create a profile for the authenticated image store as Docker admin
     When I follow the left menu "Images > Profiles"
@@ -23,6 +24,7 @@ Feature: Build image with authenticated registry
     And I select "1-DOCKER-TEST" from "activationKey"
     And I enter "Docker/authprofile" relative to profiles as "path"
     And I click on "create-btn"
+    Then I wait until I see "portus_profile" text
 
   Scenario: Build an image in the authenticated image store
     When I follow the left menu "Images > Build"
@@ -33,6 +35,8 @@ Feature: Build image with authenticated registry
     Then I wait until I see "portus_profile" text
     # Verify the status of images in the authenticated image store
     When I wait at most 600 seconds until container "portus_profile" is built successfully
+    And I refresh the page
+    Then table row for "portus_profile" should contain "1"
 
   Scenario: Cleanup: remove Docker profile for the authenticated image store
     When I follow the left menu "Images > Profiles"

--- a/testsuite/features/step_definitions/docker_steps.rb
+++ b/testsuite/features/step_definitions/docker_steps.rb
@@ -41,6 +41,7 @@ end
 When(/^I wait at most (\d+) seconds until container "([^"]*)" is built successfully$/) do |timeout, name|
   cont_op.login('admin', 'admin')
   images_list = cont_op.list_images
+  puts "List of images: #{images_list}"
   image_id = 0
   images_list.each do |element|
     if element['name'] == name
@@ -52,6 +53,7 @@ When(/^I wait at most (\d+) seconds until container "([^"]*)" is built successfu
 
   repeat_until_timeout(timeout: timeout.to_i, message: 'image build did not complete') do
     idetails = cont_op.get_image_details(image_id)
+    puts "Image Details: #{idetails}"
     break if idetails['buildStatus'] == 'completed' && idetails['inspectStatus'] == 'completed'
     raise 'image build failed.' if idetails['buildStatus'] == 'failed'
     raise 'image inspect failed.' if idetails['inspectStatus'] == 'failed'

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -1049,3 +1049,13 @@ end
 When(/^I close the modal dialog$/) do
   find(:xpath, "//*[contains(@class, 'modal-header')]/button[contains(@class, 'close')]").click
 end
+
+When(/^I refresh the page$/) do
+  begin
+    accept_prompt do
+      execute_script 'window.location.reload()'
+    end
+  rescue Capybara::ModalNotFound
+    # ignored
+  end
+end


### PR DESCRIPTION
## What does this PR change?

 Add more logs to debug portus image building in case of failure

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage

- Cucumber tests were added

- [x] **DONE**

## Links

Ports:
- Manager-4.1

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
