### PR TITLE
Fix snippet rhel disable repos

### DIFF
--- a/java/conf/cobbler/snippets/redhat_register_using_salt
+++ b/java/conf/cobbler/snippets/redhat_register_using_salt
@@ -64,7 +64,7 @@ echo "* Disable all repos not provided by SUSE Manager Server."
 for F in /tmp/yum.repos.d/*.repo; do
   test -f "$F" || continue
   basename "$F" | grep -q -E 'spacewalk:|susemanager:' && continue
-  # parse throught the file and make sure each repo section contains 'enabled=0'
+  # parse through the file and make sure each repo section contains 'enabled=0'
   awk '
       BEGIN           {{ saw=0 }}
       /^ *[[]/        {{ if ( saw==1 ) print "enabled=0"; else saw=1 }}

--- a/java/conf/cobbler/snippets/redhat_register_using_salt
+++ b/java/conf/cobbler/snippets/redhat_register_using_salt
@@ -61,10 +61,22 @@ fi
 
 #if not $varExists('dont_disable_local_repos')
 echo "* Disable all repos not provided by SUSE Manager Server."
-zypper ms -d --all
-zypper ms -e --medium-type plugin
-zypper mr -d --all
-zypper mr -e --medium-type plugin
+for F in /tmp/yum.repos.d/*.repo; do
+  test -f "$F" || continue
+  basename "$F" | grep -q -E 'spacewalk:|susemanager:' && continue
+  # parse throught the file and make sure each repo section contains 'enabled=0'
+  awk '
+      BEGIN           {{ saw=0 }}
+      /^ *[[]/        {{ if ( saw==1 ) print "enabled=0"; else saw=1 }}
+      /^ *enabled *=/ {{ print "enabled=0"; saw=2; next }}
+      {{ print }}
+      END             {{ if ( saw==1 ) print "enabled=0" }}
+      ' "$F" > "$F.bootstrap.tmp" && mv "$F.bootstrap.tmp" "$F"
+      test -f  "$F.bootstrap.tmp" && {{
+        echo "*** Error: Failed to process '$F'; check manually if all repos inside are disabled."
+        rm "$F.bootstrap.tmp"
+      }}
+done
 #end if
 
 # end SUSE Manager registration

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- manually disable repositories on redhat like systems
 - Do not update Kickstart session when download after session is complete or failed (bsc#1187621)
 - define a pillar for the https port when connection as ssh-push with tunnel (bsc#1187441)
 - Fix the unit test coverage reports


### PR DESCRIPTION
## What does this PR change?

On a RedHat like system we have yum or dnf, but no zypper. Use the manual way to disable the repos.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/3880
Tracks https://github.com/SUSE/spacewalk/pull/15252 https://github.com/SUSE/spacewalk/pull/15254

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
