### PR TITLE
Add missing task status strings

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -24106,6 +24106,12 @@ given channel.</source>
       <trans-unit id="task.status.uuid-cleanup" xml:space="preserve">
         <source>UUID cleanup</source>
       </trans-unit>
+      <trans-unit id="task.status.channel-modular-data-cleanup" xml:space="preserve">
+        <source>Modular Data Cleanup</source>
+      </trans-unit>
+      <trans-unit id="task.status.mgr-forward-registration" xml:space="preserve">
+        <source>Forward Registration</source>
+      </trans-unit>
       <trans-unit id="task.status.message" xml:space="preserve">
         <source>The following is a status report for the various tasks run by the @@PRODUCT_NAME@@ task engine:</source>
       </trans-unit>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+Add missing task status strings (bsc#1186744)
+
 -------------------------------------------------------------------
 Fri Jun 18 12:41:30 CEST 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Adds missing localization strings for recently added taskomatic tasks

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: **Bugfix**

- [x] **DONE**

## Test coverage

- No tests: **Bugfix**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/15091

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
