### PR TITLE
Add support for Kiwi options

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/image/KiwiProfile.java
+++ b/java/code/src/com/redhat/rhn/domain/image/KiwiProfile.java
@@ -32,6 +32,25 @@ import javax.persistence.Table;
 public class KiwiProfile extends ImageProfile {
 
     private String path;
+    private String kiwiOptions;
+
+    /**
+     * @return the Kiwi options
+     */
+    @Column(name = "kiwi_options")
+    public String getKiwiOptions() {
+        if (kiwiOptions == null) {
+            return "";
+        }
+        return kiwiOptions;
+    }
+
+    /**
+     * @param kiwiOptionsIn the kiwi options to set
+     */
+    public void setKiwiOptions(String kiwiOptionsIn) {
+        this.kiwiOptions = kiwiOptionsIn;
+    }
 
     /**
      * @return the path
@@ -59,6 +78,7 @@ public class KiwiProfile extends ImageProfile {
         return new EqualsBuilder()
                 .appendSuper(super.equals(castOther))
                 .append(path, castOther.path)
+                .append(kiwiOptions, castOther.kiwiOptions)
                 .isEquals();
     }
 
@@ -69,6 +89,7 @@ public class KiwiProfile extends ImageProfile {
         return new HashCodeBuilder()
                 .appendSuper(super.hashCode())
                 .append(path)
+                .append(kiwiOptions)
                 .toHashCode();
     }
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/profile/ImageProfileHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/profile/ImageProfileHandler.java
@@ -107,6 +107,7 @@ public class ImageProfileHandler extends BaseHandler {
      * @param storeLabel the image store label
      * @param path the path or git uri to the source
      * @param activationKey the activation key which defines the channels
+     * @param kiwiOptions command line options passed to Kiwi
      * @return 1 on success
      *
      * @xmlrpc.doc Create a new Image Profile
@@ -116,10 +117,11 @@ public class ImageProfileHandler extends BaseHandler {
      * @xmlrpc.param #param("string", "storeLabel")
      * @xmlrpc.param #param("string", "path")
      * @xmlrpc.param #param_desc("string", "activationKey", "Optional")
+     * @xmlrpc.param #param("string", "kiwiOptions")
      * @xmlrpc.returntype #return_int_success()
      */
     public int create(User loggedInUser, String label, String type, String storeLabel,
-            String path, String activationKey) {
+            String path, String activationKey, String kiwiOptions) {
         ensureImageAdmin(loggedInUser);
 
         if (StringUtils.isEmpty(label)) {
@@ -180,6 +182,7 @@ public class ImageProfileHandler extends BaseHandler {
         else if (ImageProfile.TYPE_KIWI.equals(type)) {
             KiwiProfile kiwiProfile = new KiwiProfile();
             kiwiProfile.setPath(path);
+            kiwiProfile.setKiwiOptions(kiwiOptions);
             profile = kiwiProfile;
         }
         else {
@@ -199,6 +202,30 @@ public class ImageProfileHandler extends BaseHandler {
         ImageProfileFactory.save(profile);
 
         return 1;
+    }
+
+    /**
+     * Create a new Image Profile
+     * @param loggedInUser the current User
+     * @param label the label
+     * @param type the profile type label
+     * @param storeLabel the image store label
+     * @param path the path or git uri to the source
+     * @param activationKey the activation key which defines the channels
+     * @return 1 on success
+     *
+     * @xmlrpc.doc Create a new Image Profile
+     * @xmlrpc.param #param("string", "sessionKey")
+     * @xmlrpc.param #param("string", "label")
+     * @xmlrpc.param #param("string", "type")
+     * @xmlrpc.param #param("string", "storeLabel")
+     * @xmlrpc.param #param("string", "path")
+     * @xmlrpc.param #param_desc("string", "activationKey", "Optional")
+     * @xmlrpc.returntype #return_int_success()
+     */
+    public int create(User loggedInUser, String label, String type, String storeLabel,
+            String path, String activationKey) {
+        return create(loggedInUser, label, type, storeLabel, path, activationKey, "");
     }
 
     /**
@@ -278,6 +305,18 @@ public class ImageProfileHandler extends BaseHandler {
                 default:
                     throw new InvalidParameterException("The type " + profile.getImageType() +
                             " doesn't support 'Path' property");
+            }
+        }
+        if (details.containsKey("kiwiOptions")) {
+            String kiwiOptions = (String) details.get("kiwiOptions");
+
+            switch (profile.getImageType()) {
+                case ImageProfile.TYPE_KIWI:
+                    profile.asKiwiProfile().get().setKiwiOptions(kiwiOptions);
+                    break;
+                default:
+                    throw new InvalidParameterException("The type " + profile.getImageType() +
+                            " doesn't support 'kiwiOptions' property");
             }
         }
         if (details.containsKey("activationKey")) {

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/profile/test/ImageProfileHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/profile/test/ImageProfileHandlerTest.java
@@ -89,7 +89,7 @@ public class ImageProfileHandlerTest extends BaseHandlerTestCase {
         ImageStore store = createImageStore("mystore", admin, ImageStoreFactory.TYPE_OS_IMAGE);
         ActivationKey key = createActivationKey(admin);
         int result = handler.create(admin, "myprofile", ImageProfile.TYPE_KIWI,
-                "mystore", "/path/to/kiwiconfig", key.getKey());
+                "mystore", "/path/to/kiwiconfig", key.getKey(), "--profile test1");
 
         assertEquals(1, result);
 
@@ -99,6 +99,7 @@ public class ImageProfileHandlerTest extends BaseHandlerTestCase {
         assertEquals(key.getToken(), profile.getToken());
         assertEquals(store, profile.getTargetStore());
         assertEquals("/path/to/kiwiconfig", profile.asKiwiProfile().get().getPath());
+        assertEquals("--profile test1", profile.asKiwiProfile().get().getKiwiOptions());
     }
 
     public final void testListImageProfiles() throws Exception {
@@ -129,6 +130,7 @@ public class ImageProfileHandlerTest extends BaseHandlerTestCase {
         assertEquals(ImageProfile.TYPE_KIWI, p2.getImageType());
         assertEquals("myosimagestore", p2.getTargetStore().getLabel());
         assertEquals("/path/to/kiwiconfig", p2.getPath());
+        assertEquals("", p2.getKiwiOptions());
     }
 
     public final void testCreateImageProfile() throws Exception {

--- a/java/code/src/com/suse/manager/webui/controllers/ImageProfileController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/ImageProfileController.java
@@ -326,6 +326,7 @@ public class ImageProfileController {
             else if (p instanceof KiwiProfile) {
                 KiwiProfile kp = (KiwiProfile) p;
                 kp.setPath(reqData.getPath());
+                kp.setKiwiOptions(reqData.getKiwiOptions());
             }
 
             if (!ImageProfileFactory.getStoreTypeForProfile(p).equals(store.getStoreType())) {
@@ -376,6 +377,7 @@ public class ImageProfileController {
         else if (ImageProfile.TYPE_KIWI.equals(reqData.getImageType())) {
             KiwiProfile kiwiProfile = new KiwiProfile();
             kiwiProfile.setPath(reqData.getPath());
+            kiwiProfile.setKiwiOptions(reqData.getKiwiOptions());
             profile = kiwiProfile;
         }
         else {

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -1525,6 +1525,7 @@ public class SaltServerActionService {
                     profile.asKiwiProfile().ifPresent(kiwiProfile -> {
                         pillar.put("source", kiwiProfile.getPath());
                         pillar.put("build_id", "build" + actionId);
+                        pillar.put("kiwi_options", kiwiProfile.getKiwiOptions());
                         List<String> repos = new ArrayList<>();
                         final ActivationKey activationKey = ActivationKeyFactory.lookupByToken(profile.getToken());
                         Set<Channel> channels = activationKey.getChannels();

--- a/java/code/src/com/suse/manager/webui/utils/gson/ImageProfileCreateRequest.java
+++ b/java/code/src/com/suse/manager/webui/utils/gson/ImageProfileCreateRequest.java
@@ -24,6 +24,7 @@ public class ImageProfileCreateRequest {
 
     private String label;
     private String path;
+    private String kiwiOptions;
     private String imageType;
     private String imageStore;
     private String activationKey;
@@ -41,6 +42,13 @@ public class ImageProfileCreateRequest {
      */
     public String getPath() {
         return path;
+    }
+
+    /**
+     * @return the Kiwi options
+     */
+    public String getKiwiOptions() {
+        return kiwiOptions;
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/utils/gson/ImageProfileJson.java
+++ b/java/code/src/com/suse/manager/webui/utils/gson/ImageProfileJson.java
@@ -34,6 +34,7 @@ public class ImageProfileJson {
     private String label;
     private String imageType;
     private String path;
+    private String kiwiOptions;
     private String store;
     private ActivationKeyJson activationKey;
     private ChannelsJson channels;
@@ -95,6 +96,19 @@ public class ImageProfileJson {
         this.path = pathIn;
     }
 
+    /**
+     * @return the Kiwi options
+     */
+    public String getKiwiOptions() {
+        return kiwiOptions;
+    }
+
+    /**
+     * @param kiwiOptionsIn the kiwi options to set
+     */
+    public void setKiwiOptions(String kiwiOptionsIn) {
+        this.kiwiOptions = kiwiOptionsIn;
+    }
     /**
      * @return the store
      */
@@ -175,6 +189,7 @@ public class ImageProfileJson {
         }
         else if (profile instanceof KiwiProfile) {
             json.setPath(((KiwiProfile) profile).getPath());
+            json.setKiwiOptions(((KiwiProfile) profile).getKiwiOptions());
         }
 
         json.setCustomData(profile.getCustomDataValues().stream().collect(Collectors.toMap(

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add support for Kiwi options
 - New filter template: Live patching based on a system
 - Adapt generated pillar data to run the new Salt scap state
 - Handle virtual machines running on pacemaker cluster

--- a/schema/spacewalk/common/tables/suseKiwiProfile.sql
+++ b/schema/spacewalk/common/tables/suseKiwiProfile.sql
@@ -19,7 +19,8 @@ CREATE TABLE suseKiwiProfile
                   CONSTRAINT suse_kiwi_prid_fk
                      REFERENCES suseImageProfile (profile_id)
                      ON DELETE CASCADE,
-    path        VARCHAR(1024) NOT NULL
+    path        VARCHAR(1024) NOT NULL,
+    kiwi_options VARCHAR(1024)
 )
 
 ;

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- Add Kiwi commandline options to Kiwi profile
 - Handle virtual machines running on pacemaker cluster
 - Bump version to 4.3.0
 

--- a/schema/spacewalk/upgrade/susemanager-schema-4.3.0-to-susemanager-schema-4.3.1/004-suseKiwiProfile.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.3.0-to-susemanager-schema-4.3.1/004-suseKiwiProfile.sql
@@ -1,0 +1,2 @@
+alter table suseKiwiProfile add column if not exists
+    kiwi_options  VARCHAR(1024);

--- a/susemanager-utils/susemanager-sls/salt/images/kiwi-image-build.sls
+++ b/susemanager-utils/susemanager-sls/salt/images/kiwi-image-build.sls
@@ -42,10 +42,7 @@ mgr_buildimage_prepare_activation_key_in_source:
 #
 {%- set kiwi = 'kiwi-ng' %}
 
-{%- set profile_opt = '' %}
-{%- if pillar.get('kiwi_profile') %}
-{%-   set profile_opt = '--profile ' + pillar.get('kiwi_profile') %}
-{%- endif %}
+{%- set kiwi_options = pillar.get('kiwi_options', '') %}
 
 {%- macro kiwi_params() -%}
   --ignore-repos-used-for-build --add-repo file:{{ common_repo }},rpm-dir,common_repo,90,false,false --add-bootstrap-package rhn-org-trusted-ssl-cert-osimage {{ ' ' }}
@@ -56,14 +53,14 @@ mgr_buildimage_prepare_activation_key_in_source:
 
 mgr_buildimage_kiwi_prepare:
   cmd.run:
-    - name: "{{ kiwi }} --logfile={{ root_dir }}/prepare.log --shared-cache-dir={{ cache_dir }} {{ profile_opt }} system prepare --description {{ source_dir }} --root {{ chroot_dir }} {{ kiwi_params() }}"
+    - name: "{{ kiwi }} --logfile={{ root_dir }}/prepare.log --shared-cache-dir={{ cache_dir }} {{ kiwi_options }} system prepare --description {{ source_dir }} --root {{ chroot_dir }} {{ kiwi_params() }}"
     - require:
       - mgrcompat: mgr_buildimage_prepare_source
       - file: mgr_buildimage_prepare_activation_key_in_source
 
 mgr_buildimage_kiwi_create:
   cmd.run:
-    - name: "{{ kiwi }} --logfile={{ root_dir }}/create.log --shared-cache-dir={{ cache_dir }} {{ profile_opt }} system create --root {{ chroot_dir }} --target-dir  {{ dest_dir }}"
+    - name: "{{ kiwi }} --logfile={{ root_dir }}/create.log --shared-cache-dir={{ cache_dir }} {{ kiwi_options }} system create --root {{ chroot_dir }} --target-dir  {{ dest_dir }}"
     - require:
       - cmd: mgr_buildimage_kiwi_prepare
 

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Add support for Kiwi options
 - Fix Salt scap state to use new 'xccdf_eval' function
 - Fix deleting stopped virtual network (bsc#1186281)
 - Handle virtual machines running on pacemaker cluster

--- a/web/html/src/manager/images/image-profile-edit.tsx
+++ b/web/html/src/manager/images/image-profile-edit.tsx
@@ -97,6 +97,7 @@ class CreateImageProfile extends React.Component<Props, State> {
             label: data.label,
             activationKey: data.activationKey ? data.activationKey.key : undefined,
             path: data.path,
+            kiwiOptions: data.kiwiOptions,
             imageType: data.imageType,
             imageStore: data.store,
           },
@@ -359,6 +360,22 @@ class CreateImageProfile extends React.Component<Props, State> {
             divClass="col-md-6"
           />
         );
+        typeInputs.push(
+          <Text
+            key="kiwiOptions"
+            name="kiwiOptions"
+            label={t("Kiwi options")}
+            hint={
+              <span>
+                Kiwi command line options
+                <br />
+                Example: <em>--profile jeos</em>
+              </span>
+            }
+            labelClass="col-md-3"
+            divClass="col-md-6"
+          />
+        );
         typeInputs.push(this.renderTokenSelect(true));
         break;
       default:
@@ -388,6 +405,7 @@ class CreateImageProfile extends React.Component<Props, State> {
 
     return (
       <Select
+        key="activationKey"
         name="activationKey"
         label={t("Activation Key")}
         invalidHint={t("Activation key is required for kiwi images.")}

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Add support for Kiwi options
 - New filter template: Live patching based on a system
 - Refresh JWT virtual console token before it expires
 - Handle virtual machines running on pacemaker cluster


### PR DESCRIPTION
## What does this PR change?

This PR adds support for Kiwi options, including --profile. This is necessary for building unmodified image sources from Build Service.

--profile option can be specified multiple times, there is also --type option with similar use, so this PR stores the unmodified Kiwi command line in DB, to allow more flexibility.

Additional validation can be implemented later in front end.


## GUI diff

Before:

After:

- Kiwi options field has been added to kiwi profile page

- [X] **DONE**

## Documentation

WIP

- [ ] **DONE**

## Test coverage

- Added to unit tests

- [x] **DONE**

## Links

This is minimal implementation of https://github.com/SUSE/spacewalk/issues/9264
Part of https://github.com/SUSE/spacewalk/issues/14570


- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
