### PR TITLE
FIPS 140-2 changes

### DIFF
--- a/spacewalk/certs-tools/rhn_ssl_tool.py
+++ b/spacewalk/certs-tools/rhn_ssl_tool.py
@@ -254,7 +254,7 @@ ERROR: a CA private key already exists:
 """ % ca_key)
         sys.exit(errnoGeneralError)
 
-    args = ("/usr/bin/openssl genrsa -passout pass:%s %s -out %s 2048"
+    args = ("/usr/bin/openssl genpkey -pass pass:%s %s -out %s -algorithm rsa -pkeyopt rsa_keygen_bits:2048"
             % ('%s', CRYPTO, repr(cleanupAbsPath(ca_key))))
 
     if verbosity >= 0:

--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,5 @@
+- generate SSL private keys FIPS 140-2 compatible (bsc#1187593)
+
 -------------------------------------------------------------------
 Thu Jun 10 13:45:38 CEST 2021 - jgonzalez@suse.com
 

--- a/spacewalk/certs-tools/sslToolConfig.py
+++ b/spacewalk/certs-tools/sslToolConfig.py
@@ -54,7 +54,7 @@ CA_OPENSSL_CNF_NAME = 'rhn-ca-openssl.cnf'
 SERVER_OPENSSL_CNF_NAME = 'rhn-server-openssl.cnf'
 
 MD = 'sha256'
-CRYPTO = '-des3'
+CRYPTO = '-aes-256-cbc'
 
 
 def getOption(options, opt):


### PR DESCRIPTION
## What does this PR change?

generate private keys FIPS conform using openssl genpkey command with  aes-256-cbc

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/14990

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
