### PR TITLE
Show error message is server migration goes wrong

### DIFF
--- a/susemanager/bin/server-migrator.sh
+++ b/susemanager/bin/server-migrator.sh
@@ -32,6 +32,10 @@ zypper ar -n "Update repository wiht updates from SUSE Linux Enterprise 15" http
 zypper ar -n "Update repository of openSUSE Backports" http://download.opensuse.org/update/leap/15.3/backports/ repo-backports-update
 zypper ref
 zypper -n dup --allow-vendor-change
+if [ $? -ne 0 ];then
+    echo "Migration went wrong. Please fix the issues and try again."
+    exit -1
+fi
 
 echo
 echo "==================================================================="

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,5 @@
+- Show error message if server migration goes wrong
+
 -------------------------------------------------------------------
 Wed Jun 23 15:58:49 CEST 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

instead of showing the message to run the PostgreSQL migration

## GUI diff

No difference.

Before: Shows message about running pg migration when zypper dup exits with an error

After: Shows message about zypper dup having an error and does not show the  pg migration message

- [X] **DONE**

## Documentation
- No documentation needed

- [X] **DONE**

## Test coverage
- No tests

- [X] **DONE**

## Links



- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
