### PR TITLE
Regen sls files when chaning machine

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -357,6 +357,7 @@ public class RegisterMinionEventMessageAction implements MessageAction {
             StatesAPI.removePackageState(registeredMinion);
 
             registeredMinion.setMachineId(machineId);
+            registeredMinion.setDigitalServerId(machineId);
             ServerFactory.save(registeredMinion);
 
             ServerStateRevision serverRev = StateFactory

--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -45,6 +45,8 @@ import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.server.ServerGroupFactory;
 import com.redhat.rhn.domain.server.ServerHistoryEvent;
 import com.redhat.rhn.domain.server.ServerPath;
+import com.redhat.rhn.domain.state.ServerStateRevision;
+import com.redhat.rhn.domain.state.StateFactory;
 import com.redhat.rhn.domain.token.ActivationKey;
 import com.redhat.rhn.domain.token.ActivationKeyFactory;
 import com.redhat.rhn.domain.user.User;
@@ -54,6 +56,9 @@ import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.manager.system.SystemManager;
 
 import com.suse.manager.reactor.utils.ValueMap;
+import com.suse.manager.webui.controllers.StatesAPI;
+import com.suse.manager.webui.services.SaltActionChainGeneratorService;
+import com.suse.manager.webui.services.SaltStateGeneratorService;
 import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.SystemQuery;
 import com.suse.manager.webui.services.impl.MinionPendingRegistrationService;
@@ -346,8 +351,24 @@ public class RegisterMinionEventMessageAction implements MessageAction {
                     oldMinionId + "' has been updated to '" + minionId + "'");
         }
         else if (!machineId.equals(oldMachineId)) {
+            SaltStateGeneratorService.INSTANCE.removeConfigChannelAssignments(registeredMinion);
+            SaltActionChainGeneratorService.INSTANCE.removeActionChainSLSFilesForMinion(
+                    registeredMinion, Optional.empty());
+            StatesAPI.removePackageState(registeredMinion);
+
             registeredMinion.setMachineId(machineId);
             ServerFactory.save(registeredMinion);
+
+            ServerStateRevision serverRev = StateFactory
+                    .latestStateRevision(registeredMinion)
+                    .orElseGet(() -> {
+                        ServerStateRevision rev = new ServerStateRevision();
+                        rev.setServer(registeredMinion);
+                        return rev;
+                    });
+            SaltStateGeneratorService.INSTANCE.generateConfigState(serverRev);
+            StatesAPI.generateServerPackageState(registeredMinion);
+
             SystemManager.addHistoryEvent(registeredMinion, "Minion migrated", "The machine-id of Minion '" +
                     minionId + "' has been updated from '" + oldMachineId + "' to '" + machineId + "'");
         }

--- a/java/code/src/com/suse/manager/webui/controllers/StatesAPI.java
+++ b/java/code/src/com/suse/manager/webui/controllers/StatesAPI.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2015 SUSE LLC
+ * Copyright (c) 2015--2021 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -123,7 +123,6 @@ public class StatesAPI {
     private final ServerGroupManager serverGroupManager;
 
     private static final Gson GSON = new GsonBuilder().create();
-    public static final String SALT_PACKAGE_FILES = "packages";
 
     /** ID of the state that installs the SUSE Manager repo file in SUSE systems. */
     public static final String ZYPPER_SUMA_CHANNEL_REPO_FILE
@@ -643,7 +642,7 @@ public class StatesAPI {
 
         try {
             Path baseDir = Paths.get(
-                    SaltConstants.SUMA_STATE_FILES_ROOT_PATH, SALT_PACKAGE_FILES);
+                    SaltConstants.SUMA_STATE_FILES_ROOT_PATH, SaltConstants.SALT_PACKAGES_STATES_DIR);
             Files.createDirectories(baseDir);
             Path filePath = baseDir.resolve(
                     getPackagesSlsName(new MinionSummary(server)));
@@ -658,12 +657,31 @@ public class StatesAPI {
     }
 
     /**
+     * Remove package state file for the given minion
+     *
+     * @param minion the minion
+     */
+    public static void removePackageState(MinionServer minion) {
+        Path baseDir = Paths.get(
+                SaltConstants.SUMA_STATE_FILES_ROOT_PATH, SaltConstants.SALT_PACKAGES_STATES_DIR);
+        Path filePath = baseDir.resolve(getPackagesSlsName(new MinionSummary(minion)));
+
+        try {
+            Files.deleteIfExists(filePath);
+        }
+        catch (IOException e) {
+            LOG.error(e.getMessage(), e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
      * Get the name of the package sls file.
      * @param server the minion server
      * @return the name of the package sls file
      */
     public static String getPackagesSlsName(MinionSummary server) {
-        return "packages_" + server.getDigitalServerId() + ".sls";
+        return SaltConstants.SALT_SERVER_PACKAGES_STATE_FILE_PREFIX + server.getDigitalServerId() + ".sls";
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/controllers/StatesAPI.java
+++ b/java/code/src/com/suse/manager/webui/controllers/StatesAPI.java
@@ -671,7 +671,6 @@ public class StatesAPI {
         }
         catch (IOException e) {
             LOG.error(e.getMessage(), e);
-            throw new RuntimeException(e);
         }
     }
 

--- a/java/code/src/com/suse/manager/webui/controllers/StatesAPI.java
+++ b/java/code/src/com/suse/manager/webui/controllers/StatesAPI.java
@@ -680,7 +680,7 @@ public class StatesAPI {
      * @return the name of the package sls file
      */
     public static String getPackagesSlsName(MinionSummary server) {
-        return SaltConstants.SALT_SERVER_PACKAGES_STATE_FILE_PREFIX + server.getDigitalServerId() + ".sls";
+        return SaltConstants.SALT_SERVER_PACKAGES_STATE_FILE_PREFIX + server.getMachineId() + ".sls";
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/services/SaltConstants.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltConstants.java
@@ -47,6 +47,10 @@ public class SaltConstants {
 
     public static final String ORG_STATES_DIRECTORY_PREFIX = "manager_org_";
 
+    public static final String SALT_SERVER_PACKAGES_STATE_FILE_PREFIX = "packages_";
+
+    public static final String SALT_PACKAGES_STATES_DIR = "packages";
+
     public static final String LEGACY_STATES_BACKUP = "/srv/susemanager/legacy_states";
 
     public static final String SCRIPTS_DIR = "scripts";

--- a/java/code/src/com/suse/manager/webui/services/SaltStateGeneratorService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltStateGeneratorService.java
@@ -423,6 +423,7 @@ public enum SaltStateGeneratorService {
      */
     public void removeServer(MinionServer minion) {
         MinionPillarManager.INSTANCE.removePillar(minion.getMinionId());
+        StatesAPI.removePackageState(minion);
         removeConfigChannelAssignments(minion);
         removeActionChains(minion);
     }

--- a/java/code/src/com/suse/manager/webui/services/impl/SaltSSHService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltSSHService.java
@@ -30,6 +30,7 @@ import com.suse.manager.webui.controllers.StatesAPI;
 import com.suse.manager.webui.controllers.utils.ContactMethodUtil;
 import com.suse.manager.webui.services.FutureUtils;
 import com.suse.manager.webui.services.SaltActionChainGeneratorService;
+import com.suse.manager.webui.services.SaltConstants;
 import com.suse.manager.webui.services.impl.runner.MgrUtilRunner;
 import com.suse.manager.webui.utils.ActionSaltState;
 import com.suse.manager.webui.utils.SaltModuleRun;
@@ -91,7 +92,6 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import static com.suse.manager.webui.controllers.StatesAPI.SALT_PACKAGE_FILES;
 import static com.suse.manager.webui.services.SaltActionChainGeneratorService.ACTIONCHAIN_SLS_FOLDER;
 import static com.suse.manager.webui.services.SaltConstants.SALT_FS_PREFIX;
 import static java.util.Collections.singletonList;
@@ -887,7 +887,8 @@ public class SaltSSHService {
 
         // add packages/package_<minion_machine_id>
         Set<String> pkgRefs = statesPerMinion.entrySet().stream()
-                .map(entry -> SALT_FS_PREFIX + SALT_PACKAGE_FILES + "/" + StatesAPI.getPackagesSlsName(entry.getKey()))
+                .map(entry -> SALT_FS_PREFIX + SaltConstants.SALT_PACKAGES_STATES_DIR + "/" +
+                        StatesAPI.getPackagesSlsName(entry.getKey()))
                 .collect(Collectors.toSet());
 
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- cleanup and regenerate system state files when machine id has changed (bsc#1187660)
 - manually disable repositories on redhat like systems
 - Do not update Kickstart session when download after session is complete or failed (bsc#1187621)
 - define a pillar for the https port when connection as ssh-push with tunnel (bsc#1187441)


### PR DESCRIPTION
## What does this PR change?

When a system change its machine id, we need to remove old SLS files and regenerate them as they have the machine id in their name.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **unable to test file changes as they are disabled in tests**

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/15231
Tracks https://github.com/SUSE/spacewalk/pull/15278

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
