### PR TITLE
Revert "Use a different repository for Salt for Uyuni"

### DIFF
--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -650,13 +650,11 @@ When(/^I install Salt packages from "(.*?)"$/) do |host|
 end
 
 When(/^I enable repositories before installing Salt on this "([^"]*)"$/) do |host|
-  repo = $product == 'Uyuni' ? 'salt3002_repo_repo' : 'tools_additional_repo'
-  step %(I enable repository "#{repo}" on this "#{host}" without error control)
+  step %(I enable repository "tools_additional_repo" on this "#{host}" without error control)
 end
 
 When(/^I disable repositories after installing Salt on this "([^"]*)"$/) do |host|
-  repo = $product == 'Uyuni' ? 'salt3002_repo_repo' : 'tools_additional_repo'
-  step %(I disable repository "#{repo}" on this "#{host}" without error control)
+  step %(I disable repository "tools_additional_repo" on this "#{host}" without error control)
 end
 
 # minion bootstrap steps


### PR DESCRIPTION
## What does this PR change?

This reverts commit 5f5c10e5f518bd8620e62335198b7fe05001e4bc, as agreed at https://github.com/SUSE/susemanager-ci/pull/297

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Testsuite
- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Related: https://github.com/SUSE/spacewalk/issues/14997

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
