### PR TITLE
openscap: allow passing extra parameters to XCCDF scans on minions

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/action/scap/ScapAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/scap/ScapAction.java
@@ -60,7 +60,7 @@ public class ScapAction extends Action {
             retval.append("</br>");
             retval.append(ls.getMessage("system.event.scapOvalFiles"));
             retval.append(StringEscapeUtils.escapeHtml4(scapActionDetails.getOvalfiles()));
-	}
+        }
         return retval.toString();
     }
 

--- a/java/code/src/com/redhat/rhn/domain/action/scap/ScapAction.java
+++ b/java/code/src/com/redhat/rhn/domain/action/scap/ScapAction.java
@@ -56,6 +56,11 @@ public class ScapAction extends Action {
         retval.append(ls.getMessage("system.event.scapParams"));
         retval.append(scapActionDetails.getParameters() == null ? "" :
             StringEscapeUtils.escapeHtml4(scapActionDetails.getParametersContents()));
+        if (scapActionDetails.getOvalfiles() != null) {
+            retval.append("</br>");
+            retval.append(ls.getMessage("system.event.scapOvalFiles"));
+            retval.append(StringEscapeUtils.escapeHtml4(scapActionDetails.getOvalfiles()));
+	}
         return retval.toString();
     }
 

--- a/java/code/src/com/redhat/rhn/domain/action/scap/ScapActionDetails.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/scap/ScapActionDetails.hbm.xml
@@ -13,6 +13,7 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
                 </id>
 
                 <property name="path" type="string" column="path" />
+                <property name="ovalfiles" type="string" column="ovalfiles" />
                 <property name="parameters" type="binary" column="parameters" />
                 <many-to-one name="parentAction" column="action_id"
                         class="com.redhat.rhn.domain.action.Action" outer-join="true"

--- a/java/code/src/com/redhat/rhn/domain/action/scap/ScapActionDetails.java
+++ b/java/code/src/com/redhat/rhn/domain/action/scap/ScapActionDetails.java
@@ -24,6 +24,7 @@ public class ScapActionDetails extends ActionChild {
 
     private Long id;
     private String path;
+    private String ovalfiles;
     private byte[] parameters;
 
     /**
@@ -37,11 +38,13 @@ public class ScapActionDetails extends ActionChild {
      * ScapActionDetails constructor.
      * @param pathIn New setting for the path.
      * @param parametersIn New setting for the parameters.
+     * @param ovalFilesIn New setting for the OVAL files.
      */
-    public ScapActionDetails(String pathIn, String parametersIn) {
+    public ScapActionDetails(String pathIn, String parametersIn, String ovalFilesIn) {
         super();
         this.setPath(pathIn);
         this.setParameters(parametersIn);
+        this.setOvalfiles(ovalFilesIn);
     }
 
     /**
@@ -58,6 +61,22 @@ public class ScapActionDetails extends ActionChild {
      */
     public String getPath() {
         return path;
+    }
+
+    /**
+     * Set the paths to OVAL files.
+     * @param ovalFilesIn New setting for the ovalFiles.
+     */
+    public void setOvalfiles(String ovalFilesIn) {
+        ovalfiles = ovalFilesIn;
+    }
+
+    /**
+     * Get the paths to OVAL files.
+     * @return The ovalFiles settings.
+     */
+    public String getOvalfiles() {
+        return ovalfiles;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/action/audit/ssm/BaseSsmScheduleXccdfAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/audit/ssm/BaseSsmScheduleXccdfAction.java
@@ -37,6 +37,7 @@ public abstract class BaseSsmScheduleXccdfAction
     protected static final String DATE = "date";
     protected static final String PATH = "path";
     protected static final String PARAMS = "params";
+    protected static final String OVALFILES = "ovalfiles";
     protected static final String LOCALIZED_DATE = "localizedDate";
     protected static final String READONLY = "readonly";
     protected static final String TRUE = "true";

--- a/java/code/src/com/redhat/rhn/frontend/action/audit/ssm/SsmScheduleXccdfConfirmAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/audit/ssm/SsmScheduleXccdfConfirmAction.java
@@ -81,6 +81,7 @@ public class SsmScheduleXccdfConfirmAction extends BaseSsmScheduleXccdfAction {
                     context.getCurrentUser(),
                     (String) form.get(PATH),
                     (String) form.get(PARAMS),
+                    (String) form.get(OVALFILES),
                     getStrutsDelegate().readScheduleDate(form, DATE, DatePicker.YEAR_RANGE_POSITIVE));
         }
         catch (MissingEntitlementException e) {

--- a/java/code/src/com/redhat/rhn/frontend/action/audit/ssm/validation/scheduleXccdfForm.xsd
+++ b/java/code/src/com/redhat/rhn/frontend/action/audit/ssm/validation/scheduleXccdfForm.xsd
@@ -14,4 +14,9 @@
 			<maxLength value="2048"/>
 		</simpleType>
 	</attribute>
+	<attribute name="ovalfiles">
+		<simpleType baseType="string">
+			<maxLength value="8192"/>
+		</simpleType>
+	</attribute>
 </schema>

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/audit/ScheduleXccdfAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/audit/ScheduleXccdfAction.java
@@ -94,11 +94,12 @@ public class ScheduleXccdfAction extends ScapSetupAction {
     private ActionMessages processForm(User user, Server server, DynaActionForm f) {
         String params = (String) f.get("params");
         String path = (String) f.get("path");
+        String ovalfiles = (String) f.get("ovalfiles");
         Date earliest = getStrutsDelegate().readScheduleDate(f, "date",
                 DatePicker.YEAR_RANGE_POSITIVE);
         try {
             ScapAction action = ActionManager.scheduleXccdfEval(user, server,
-                path, params, earliest);
+                path, params, ovalfiles, earliest);
 
             ActionMessages msgs = new ActionMessages();
             msgs.add(ActionMessages.GLOBAL_MESSAGE, new ActionMessage("message.xccdfeval",
@@ -119,6 +120,7 @@ public class ScheduleXccdfAction extends ScapSetupAction {
             HttpServletRequest request) {
         request.setAttribute("path", form.get("path"));
         request.setAttribute("params", form.get("params"));
+        request.setAttribute("ovalfiles", form.get("ovalfiles"));
         Date earliest = strutsDelegate.readScheduleDate(form, "date",
                 DatePicker.YEAR_RANGE_POSITIVE);
         DatePicker datePicker = strutsDelegate.prepopulateDatePicker(request,

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/audit/validation/scheduleXccdfForm.xsd
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/audit/validation/scheduleXccdfForm.xsd
@@ -14,4 +14,9 @@
 			<maxLength value="2048"/>
 		</simpleType>
 	</attribute>
+	<attribute name="ovalfiles">
+		<simpleType baseType="string">
+			<maxLength value="8192"/>
+		</simpleType>
+	</attribute>
 </schema>

--- a/java/code/src/com/redhat/rhn/frontend/dto/XccdfTestResultDto.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/XccdfTestResultDto.java
@@ -33,6 +33,7 @@ public class XccdfTestResultDto extends XccdfTestResultCounts {
     private String profile;
     private Date completed;
     private String path;
+    private String ovalfiles;
 
     private Long comparableId = null;
     private String diffIcon = null;
@@ -157,6 +158,22 @@ public class XccdfTestResultDto extends XccdfTestResultCounts {
      */
     public void setPath(String pathIn) {
         this.path = pathIn;
+    }
+
+    /**
+     * Returns the ovalfiles of xccdf document
+     * @return the path
+     */
+    public String getOvalfiles() {
+        return this.ovalfiles;
+    }
+
+    /**
+     * Sets the ovalfiles of xccdf document
+     * @param ovalFilesIn to set
+     */
+    public void setOvalfiles(String ovalFilesIn) {
+        this.ovalfiles = ovalFilesIn;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -12456,6 +12456,12 @@ the &lt;strong&gt;@@ENTERPRISE_LINUX_NAME@@ System Administration Guide.&lt;/str
           <context context-type="sourcefile">Page for a new SCAP scan schedule</context>
         </context-group>
         </trans-unit>
+        <trans-unit id="system.audit.schedulexccdf.jsp.ovalFiles">
+        <source>Optional OVAL Files (comma separated)</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">Page for a new SCAP scan schedule</context>
+        </context-group>
+        </trans-unit>
         <trans-unit id="system.audit.schedulexccdf.jsp.xccdfEval">
           <source>/usr/bin/oscap xccdf eval</source>
         <context-group name="ctx">
@@ -13408,6 +13414,12 @@ the &lt;strong&gt;@@ENTERPRISE_LINUX_NAME@@ System Administration Guide.&lt;/str
         </trans-unit>
         <trans-unit id="system.event.scapPath">
           <source>&lt;strong&gt;Path to XCCDF document: &lt;/strong&gt; </source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">System Events Pages</context>
+        </context-group>
+        </trans-unit>
+        <trans-unit id="system.event.scapOvalFiles">
+          <source>&lt;strong&gt;OVAL files (comma separated): &lt;/strong&gt; </source>
         <context-group name="ctx">
           <context context-type="sourcefile">System Events Pages</context>
         </context-group>

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/XccdfTestResultDtoSerializer.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/XccdfTestResultDtoSerializer.java
@@ -32,6 +32,7 @@ import com.redhat.rhn.frontend.xmlrpc.serializer.util.SerializerHelper;
  *   #prop_desc("int", "xid", "XCCDF TestResult ID")
  *   #prop_desc("string", "profile", "XCCDF Profile")
  *   #prop_desc("string", "path", "Path to XCCDF document")
+ *   #prop_desc("string", "ovalfiles", "Optional OVAL files")
  *   #prop_desc($date, "completed", "Scan completion time")
  * #struct_end()
  */
@@ -54,6 +55,7 @@ public class XccdfTestResultDtoSerializer extends RhnXmlRpcCustomSerializer {
         addToHelper(helper, "xid", dto.getXid());
         addToHelper(helper, "profile", dto.getProfile());
         addToHelper(helper, "path", dto.getPath());
+        addToHelper(helper, "ovalfiles", dto.getOvalfiles());
         addToHelper(helper, "completed", dto.getCompleted());
         helper.writeTo(output);
     }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/XccdfTestResultSerializer.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/XccdfTestResultSerializer.java
@@ -37,6 +37,7 @@ import com.redhat.rhn.frontend.xmlrpc.serializer.util.SerializerHelper;
  *   #prop_desc("int", "sid", "serverId")
  *   #prop_desc("int", "action_id", "Id of the parent action.")
  *   #prop_desc("string", "path", "Path to XCCDF document")
+ *   #prop_desc("string", "ovalfiles", "Optional OVAL Files")
  *   #prop_desc("string", "oscap_parameters", "oscap command-line arguments.")
  *   #prop_desc("string", "test_result", "Identifier of XCCDF TestResult.")
  *   #prop_desc("string", "benchmark", "Identifier of XCCDF Benchmark.")
@@ -73,6 +74,7 @@ public class XccdfTestResultSerializer extends RhnXmlRpcCustomSerializer {
         addToHelper(helper, "xid", testResult.getId());
         addToHelper(helper, "sid", testResult.getServer().getId());
         addToHelper(helper, "path", actionDetails.getPath());
+        addToHelper(helper, "ovalfiles", actionDetails.getOvalfiles());
         addToHelper(helper, "oscap_parameters", actionDetails.getParametersContents());
         addToHelper(helper, "test_result", testResult.getIdentifier());
         addToHelper(helper, "benchmark", benchmark.getIdentifier());

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/scap/SystemScapHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/scap/SystemScapHandler.java
@@ -176,6 +176,7 @@ public class SystemScapHandler extends BaseHandler {
      * @xmlrpc.param #array_single("int", "serverId")
      * @xmlrpc.param #param("string", "Path to xccdf content on targeted systems.")
      * @xmlrpc.param #param("string", "Additional parameters for oscap tool.")
+     * @xmlrpc.param #param("string", "Additional OVAL files for oscap tool.")
      * @xmlrpc.param #param_desc("dateTime.iso8601","date",
      *                       "The date to schedule the action")
      * @xmlrpc.returntype #param_desc("int", "id", "ID if SCAP action created")

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/scap/SystemScapHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/scap/SystemScapHandler.java
@@ -134,7 +134,7 @@ public class SystemScapHandler extends BaseHandler {
     public int scheduleXccdfScan(User loggedInUser, List serverIds,
             String xccdfPath, String oscapParams) {
         return scheduleXccdfScan(loggedInUser, serverIds, xccdfPath,
-                oscapParams, new Date());
+                oscapParams, null, new Date());
     }
 
     /**
@@ -143,6 +143,7 @@ public class SystemScapHandler extends BaseHandler {
      * @param serverIds The list of server ids,
      * @param xccdfPath The path to xccdf document.
      * @param oscapParams The additional params for oscap tool.
+     * @param ovalFiles Optional OVAL files for oscap tool.
      * @param date The date of earliest occurence.
      * @return ID of new SCAP action.
      *
@@ -156,7 +157,7 @@ public class SystemScapHandler extends BaseHandler {
      * @xmlrpc.returntype #param_desc("int", "id", "ID if SCAP action created")
      */
     public int scheduleXccdfScan(User loggedInUser, List serverIds,
-             String xccdfPath, String oscapParams, Date date) {
+             String xccdfPath, String oscapParams, String ovalFiles, Date date) {
         if (serverIds.isEmpty()) {
             throw new InvalidSystemException();
         }
@@ -168,7 +169,7 @@ public class SystemScapHandler extends BaseHandler {
 
         try {
             ScapAction action = ActionManager.scheduleXccdfEval(loggedInUser,
-                    longServerIds, xccdfPath, oscapParams, date);
+                    longServerIds, xccdfPath, oscapParams, ovalFiles, date);
             return action.getId().intValue();
         }
         catch (MissingEntitlementException e) {
@@ -226,6 +227,6 @@ public class SystemScapHandler extends BaseHandler {
             String xccdfPath, String oscapParams, Date date) {
         List serverIds = new ArrayList();
         serverIds.add(sid);
-        return scheduleXccdfScan(loggedInUser, serverIds, xccdfPath, oscapParams, date);
+        return scheduleXccdfScan(loggedInUser, serverIds, xccdfPath, oscapParams, null, date);
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/scap/SystemScapHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/scap/SystemScapHandler.java
@@ -143,6 +143,30 @@ public class SystemScapHandler extends BaseHandler {
      * @param serverIds The list of server ids,
      * @param xccdfPath The path to xccdf document.
      * @param oscapParams The additional params for oscap tool.
+     * @param date The date of earliest occurence.
+     * @return ID of new SCAP action.
+     *
+     * @xmlrpc.doc Schedule OpenSCAP scan.
+     * @xmlrpc.param #session_key()
+     * @xmlrpc.param #array_single("int", "serverId")
+     * @xmlrpc.param #param("string", "Path to xccdf content on targeted systems.")
+     * @xmlrpc.param #param("string", "Additional parameters for oscap tool.")
+     * @xmlrpc.param #param_desc("dateTime.iso8601","date",
+     *                       "The date to schedule the action")
+     * @xmlrpc.returntype #param_desc("int", "id", "ID if SCAP action created")
+     */
+    public int scheduleXccdfScan(User loggedInUser, List serverIds,
+            String xccdfPath, String oscapParams, Date date) {
+        return scheduleXccdfScan(loggedInUser, serverIds, xccdfPath,
+                oscapParams, null, date);
+    }
+
+    /**
+     * Run OpenSCAP XCCDF Evaluation on a given list of servers
+     * @param loggedInUser The current user
+     * @param serverIds The list of server ids,
+     * @param xccdfPath The path to xccdf document.
+     * @param oscapParams The additional params for oscap tool.
      * @param ovalFiles Optional OVAL files for oscap tool.
      * @param date The date of earliest occurence.
      * @return ID of new SCAP action.

--- a/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
+++ b/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
@@ -2020,9 +2020,26 @@ public class ActionManager extends BaseManager {
      */
     public static ScapAction scheduleXccdfEval(User scheduler, Server srvr, String path,
             String parameters, Date earliestAction) throws TaskomaticApiException {
+        return scheduleXccdfEval(scheduler, srvr, path, parameters, null, earliestAction);
+    }
+
+    /**
+     * Schedules Xccdf evaluation.
+     * @param scheduler User scheduling the action.
+     * @param srvr Server for which the action affects.
+     * @param path Path for the Xccdf content.
+     * @param parameters Additional parameters for oscap tool.
+     * @param ovalFiles Optional OVAL files for oscap tool.
+     * @param earliestAction Date of earliest action to be executed.
+     * @return scheduled Scap Action
+     * @throws TaskomaticApiException if there was a Taskomatic error
+     * (typically: Taskomatic is down)
+     */
+    public static ScapAction scheduleXccdfEval(User scheduler, Server srvr, String path,
+            String parameters, String ovalFiles, Date earliestAction) throws TaskomaticApiException {
         Set<Long> serverIds = new HashSet<Long>();
         serverIds.add(srvr.getId());
-        return scheduleXccdfEval(scheduler, serverIds, path, parameters, earliestAction);
+        return scheduleXccdfEval(scheduler, serverIds, path, parameters, ovalFiles, earliestAction);
     }
 
     /**
@@ -2031,6 +2048,7 @@ public class ActionManager extends BaseManager {
      * @param serverIds Set of server identifiers for which the action affects.
      * @param path Path for the Xccdf content.
      * @param parameters Additional parameters for oscap tool.
+     * @param ovalFiles Optional OVAL files for oscap tool.
      * @param earliestAction Date of earliest action to be executed.
      * @return scheduled Scap Action
      * @throws TaskomaticApiException if there was a Taskomatic error
@@ -2038,7 +2056,7 @@ public class ActionManager extends BaseManager {
      * @throws MissingCapabilityException if scripts cannot be run
      */
     public static ScapAction scheduleXccdfEval(User scheduler, Set<Long> serverIds,
-            String path, String parameters, Date earliestAction)
+            String path, String parameters, String ovalFiles, Date earliestAction)
         throws TaskomaticApiException {
         if (serverIds.isEmpty()) {
             return null;
@@ -2061,7 +2079,7 @@ public class ActionManager extends BaseManager {
             }
         }
 
-        ScapActionDetails scapDetails = new ScapActionDetails(path, parameters);
+        ScapActionDetails scapDetails = new ScapActionDetails(path, parameters, ovalFiles);
         ScapAction action = (ScapAction) scheduleAction(scheduler,
                 ActionFactory.TYPE_SCAP_XCCDF_EVAL,
                 ActionFactory.TYPE_SCAP_XCCDF_EVAL.getName(),

--- a/java/code/src/com/redhat/rhn/manager/audit/ScapManager.java
+++ b/java/code/src/com/redhat/rhn/manager/audit/ScapManager.java
@@ -340,7 +340,25 @@ public class ScapManager extends BaseManager {
             String parameters, Date earliest) throws TaskomaticApiException {
         HashSet<Long> systemIds = idsInDataResultToSet(scapCapableSystemsInSsm(scheduler));
         return ActionManager.scheduleXccdfEval(
-                scheduler, systemIds, path, parameters, earliest);
+                scheduler, systemIds, path, parameters, null, earliest);
+    }
+
+    /**
+     * Schedule scap.xccdf_eval action for systems in user's SSM.
+     * @param scheduler user which commits the schedule
+     * @param path path to xccdf document on systems file system
+     * @param parameters additional parameters for xccdf scan
+     * @param ovalFiles optional paths to OVAL files for xccdf scan
+     * @param earliest time of earliest action occurence
+     * @return the newly created ScapAction
+     * @throws TaskomaticApiException if there was a Taskomatic error
+     * (typically: Taskomatic is down)
+     */
+    public static ScapAction scheduleXccdfEvalInSsm(User scheduler, String path,
+            String parameters, String ovalFiles, Date earliest) throws TaskomaticApiException {
+        HashSet<Long> systemIds = idsInDataResultToSet(scapCapableSystemsInSsm(scheduler));
+        return ActionManager.scheduleXccdfEval(
+                scheduler, systemIds, path, parameters, ovalFiles, earliest);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/audit/scap/TestResultDiffer.java
+++ b/java/code/src/com/redhat/rhn/manager/audit/scap/TestResultDiffer.java
@@ -55,6 +55,9 @@ public class TestResultDiffer {
         result.add(buildItem("system.audit.xccdfdetails.jsp.path",
                 first.getScapActionDetails().getPath(),
                 second.getScapActionDetails().getPath()));
+        result.add(buildItem("system.audit.xccdfdetails.jsp.ovalfiles",
+                first.getScapActionDetails().getOvalfiles(),
+                second.getScapActionDetails().getOvalfiles()));
         result.add(buildItem("system.audit.schedulexccdf.jsp.arguments",
                 first.getScapActionDetails().getParametersContents(),
                 second.getScapActionDetails().getParametersContents()));

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -1608,6 +1608,8 @@ public class SaltServerActionService {
         Map<String, Object> pillar = new HashMap<>();
         Matcher profile_matcher = Pattern.compile("--profile ((\\w|\\.|_|-)+)").matcher(scapActionDetails.getParametersContents());
         Matcher rule_matcher = Pattern.compile("--rule ((\\w|\\.|_|-)+)").matcher(scapActionDetails.getParametersContents());
+        Matcher tailoring_file_matcher = Pattern.compile("--tailoring-file ((\\w|\\.|_|-)+)").matcher(scapActionDetails.getParametersContents());
+        Matcher tailoring_id_matcher = Pattern.compile("--tailoring-id ((\\w|\\.|_|-)+)").matcher(scapActionDetails.getParametersContents());
 
         pillar.put("xccdffile", scapActionDetails.getPath());
         if (profile_matcher.find()) {
@@ -1615,6 +1617,12 @@ public class SaltServerActionService {
         }
         if (rule_matcher.find()) {
             pillar.put("rule", rule_matcher.group(1));
+        }
+        if (tailoring_file_matcher.find()) {
+            pillar.put("tailoring_file", tailoring_file_matcher.group(1));
+        }
+        if (tailoring_id_matcher.find()) {
+            pillar.put("tailoring_id", tailoring_id_matcher.group(1));
         }
         if (scapActionDetails.getParametersContents().matches(".*--fetch-remote-resources.*")) {
             pillar.put("fetch_remote_resources", true);

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -206,9 +206,12 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.Stack;
 import java.util.function.Function;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+
 
 /**
  * Takes {@link Action} objects to be executed via salt.
@@ -1602,10 +1605,26 @@ public class SaltServerActionService {
     private Map<LocalCall<?>, List<MinionSummary>> scapXccdfEvalAction(
             List<MinionSummary> minionSummaries, ScapActionDetails scapActionDetails) {
         Map<LocalCall<?>, List<MinionSummary>> ret = new HashMap<>();
-        String parameters = "eval " +
-            scapActionDetails.getParametersContents() + " " + scapActionDetails.getPath();
+        Map<String, Object> pillar = new HashMap<>();
+        Matcher profile_matcher = Pattern.compile("--profile ((\\w|\\.|_|-)+)").matcher(scapActionDetails.getParametersContents());
+        Matcher rule_matcher = Pattern.compile("--rule ((\\w|\\.|_|-)+)").matcher(scapActionDetails.getParametersContents());
+
+        pillar.put("xccdffile", scapActionDetails.getPath());
+        if (profile_matcher.find()) {
+            pillar.put("profile", profile_matcher.group(1));
+        }
+        if (rule_matcher.find()) {
+            pillar.put("rule", rule_matcher.group(1));
+        }
+        if (scapActionDetails.getParametersContents().matches(".*--fetch-remote-resources.*")) {
+            pillar.put("fetch_remote_resources", true);
+        }
+        if (scapActionDetails.getParametersContents().matches(".*--remediate.*")) {
+            pillar.put("remediate", true);
+        }
+
         ret.put(State.apply(singletonList("scap"),
-                Optional.of(singletonMap("mgr_scap_params", (Object)parameters))),
+                Optional.of(singletonMap("mgr_scap_params", (Object)pillar))),
                 minionSummaries);
         return ret;
     }

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -1615,6 +1615,10 @@ public class SaltServerActionService {
         Matcher tailoringIdMatcher = Pattern.compile("--tailoring-id ((\\w|\\.|_|-)+)")
                 .matcher(scapActionDetails.getParametersContents());
 
+        String oldParameters = "eval " +
+                scapActionDetails.getParametersContents() + " " + scapActionDetails.getPath();
+        pillar.put("old_parameters", oldParameters);
+
         pillar.put("xccdffile", scapActionDetails.getPath());
         if (scapActionDetails.getOvalfiles() != null) {
             pillar.put("ovalfiles", Arrays.asList(scapActionDetails.getOvalfiles().split("\\s*,\\s*")));

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -1606,23 +1606,30 @@ public class SaltServerActionService {
             List<MinionSummary> minionSummaries, ScapActionDetails scapActionDetails) {
         Map<LocalCall<?>, List<MinionSummary>> ret = new HashMap<>();
         Map<String, Object> pillar = new HashMap<>();
-        Matcher profile_matcher = Pattern.compile("--profile ((\\w|\\.|_|-)+)").matcher(scapActionDetails.getParametersContents());
-        Matcher rule_matcher = Pattern.compile("--rule ((\\w|\\.|_|-)+)").matcher(scapActionDetails.getParametersContents());
-        Matcher tailoring_file_matcher = Pattern.compile("--tailoring-file ((\\w|\\.|_|-)+)").matcher(scapActionDetails.getParametersContents());
-        Matcher tailoring_id_matcher = Pattern.compile("--tailoring-id ((\\w|\\.|_|-)+)").matcher(scapActionDetails.getParametersContents());
+        Matcher profileMatcher = Pattern.compile("--profile ((\\w|\\.|_|-)+)")
+                .matcher(scapActionDetails.getParametersContents());
+        Matcher ruleMatcher = Pattern.compile("--rule ((\\w|\\.|_|-)+)")
+                .matcher(scapActionDetails.getParametersContents());
+        Matcher tailoringFileMatcher = Pattern.compile("--tailoring-file ((\\w|\\.|_|-)+)")
+                .matcher(scapActionDetails.getParametersContents());
+        Matcher tailoringIdMatcher = Pattern.compile("--tailoring-id ((\\w|\\.|_|-)+)")
+                .matcher(scapActionDetails.getParametersContents());
 
         pillar.put("xccdffile", scapActionDetails.getPath());
-        if (profile_matcher.find()) {
-            pillar.put("profile", profile_matcher.group(1));
+        if (scapActionDetails.getOvalfiles() != null) {
+            pillar.put("ovalfiles", Arrays.asList(scapActionDetails.getOvalfiles().split("\\s*,\\s*")));
         }
-        if (rule_matcher.find()) {
-            pillar.put("rule", rule_matcher.group(1));
+        if (profileMatcher.find()) {
+            pillar.put("profile", profileMatcher.group(1));
         }
-        if (tailoring_file_matcher.find()) {
-            pillar.put("tailoring_file", tailoring_file_matcher.group(1));
+        if (ruleMatcher.find()) {
+            pillar.put("rule", ruleMatcher.group(1));
         }
-        if (tailoring_id_matcher.find()) {
-            pillar.put("tailoring_id", tailoring_id_matcher.group(1));
+        if (tailoringFileMatcher.find()) {
+            pillar.put("tailoring_file", tailoringFileMatcher.group(1));
+        }
+        if (tailoringIdMatcher.find()) {
+            pillar.put("tailoring_id", tailoringIdMatcher.group(1));
         }
         if (scapActionDetails.getParametersContents().matches(".*--fetch-remote-resources.*")) {
             pillar.put("fetch_remote_resources", true);

--- a/java/code/webapp/WEB-INF/pages/common/fragments/audit/schedule-xccdf.jspf
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/audit/schedule-xccdf.jspf
@@ -31,6 +31,14 @@
 </div>
 <div class="form-group">
     <label class="col-md-3 control-label">
+        <bean:message key="system.audit.schedulexccdf.jsp.ovalFiles"/>
+    </label>
+    <div class="col-md-6">
+        <html:text property="ovalfiles" size="60" styleId="ovalfiles" styleClass="form-control" readonly="${readonly}"/>
+    </div>
+</div>
+<div class="form-group">
+    <label class="col-md-3 control-label">
         <bean:message key="system.audit.schedulexccdf.jsp.nosoonerthan"/>:
     </label>
     <div class="col-md-6">

--- a/java/code/webapp/WEB-INF/pages/systems/details/audit/xccdfdetails.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/details/audit/xccdfdetails.jsp
@@ -45,7 +45,7 @@
     </a>
   </c:if>
 
-  <a href="/rhn/systems/details/audit/ScheduleXccdf.do?sid=${param.sid}&path=${testResult.scapActionDetails.path}&params=${testResult.scapActionDetails.parametersContents}">
+  <a href="/rhn/systems/details/audit/ScheduleXccdf.do?sid=${param.sid}&path=${testResult.scapActionDetails.path}&params=${testResult.scapActionDetails.parametersContents}&ovalfiles=${testResult.scapActionDetails.ovalfiles}">
     <rhn:icon type="header-refresh" title="system.audit.xccdfdetails.jsp.reschedule" />
     <bean:message key="system.audit.xccdfdetails.jsp.reschedule"/>
   </a>
@@ -62,6 +62,10 @@
   <tr>
     <th><bean:message key="system.audit.xccdfdetails.jsp.path"/>:</th>
     <td><c:out value="${testResult.scapActionDetails.path}"/></td>
+  </tr>
+  <tr>
+    <th><bean:message key="system.audit.xccdfdetails.jsp.ovalfiles"/>:</th>
+    <td><c:out value="${testResult.scapActionDetails.ovalfiles}"/></td>
   </tr>
   <tr>
     <th><bean:message key="system.audit.schedulexccdf.jsp.arguments"/>:</th>

--- a/java/code/webapp/WEB-INF/struts-config.xml
+++ b/java/code/webapp/WEB-INF/struts-config.xml
@@ -804,6 +804,7 @@
         type="com.redhat.rhn.frontend.struts.ScrubbingDynaActionForm">
         <form-property name="params" type="java.lang.String"/>
         <form-property name="path" type="java.lang.String"/>
+        <form-property name="ovalfiles" type="java.lang.String"/>
         <form-property name="submitted" type="java.lang.Boolean"/>
         <!-- fields needed by datePicker -->
         <form-property name="schedule_type" type="java.lang.String"/>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Adapt generated pillar data to run the new Salt scap state
 - Handle virtual machines running on pacemaker cluster
 - SP migration: wait some seconds before scheduling "package refresh" action after migration is completed (bsc#1187963)
 - cleanup and regenerate system state files when machine id has changed (bsc#1187660)

--- a/schema/spacewalk/common/tables/rhnActionScap.sql
+++ b/schema/spacewalk/common/tables/rhnActionScap.sql
@@ -24,6 +24,7 @@ CREATE TABLE rhnActionScap
                              REFERENCES rhnAction (id)
                              ON DELETE CASCADE,
     path             VARCHAR(2048) NOT NULL,
+    ovalfiles        VARCHAR(8192) NOT NULL,
     parameters       BYTEA
 )
 

--- a/schema/spacewalk/common/tables/rhnActionScap.sql
+++ b/schema/spacewalk/common/tables/rhnActionScap.sql
@@ -24,7 +24,7 @@ CREATE TABLE rhnActionScap
                              REFERENCES rhnAction (id)
                              ON DELETE CASCADE,
     path             VARCHAR(2048) NOT NULL,
-    ovalfiles        VARCHAR(8192) NOT NULL,
+    ovalfiles        VARCHAR(8192),
     parameters       BYTEA
 )
 

--- a/schema/spacewalk/upgrade/susemanager-schema-4.3.0-to-susemanager-schema-4.3.1/0001-rhnActionScap-add-ovalfiles-attribute.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.3.0-to-susemanager-schema-4.3.1/0001-rhnActionScap-add-ovalfiles-attribute.sql
@@ -1,0 +1,2 @@
+ALTER TABLE rhnActionScap ADD COLUMN IF NOT EXISTS
+    ovalfiles   VARCHAR(8192);

--- a/schema/spacewalk/upgrade/susemanager-schema-4.3.0-to-susemanager-schema-4.3.1/0001-rhnScapAction-add-ovalfiles-attribute.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.3.0-to-susemanager-schema-4.3.1/0001-rhnScapAction-add-ovalfiles-attribute.sql
@@ -1,0 +1,2 @@
+ALTER TABLE rhnScapAction ADD COLUMN IF NOT EXISTS
+    ovalfiles   VARCHAR(8192);

--- a/schema/spacewalk/upgrade/susemanager-schema-4.3.0-to-susemanager-schema-4.3.1/0001-rhnScapAction-add-ovalfiles-attribute.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.3.0-to-susemanager-schema-4.3.1/0001-rhnScapAction-add-ovalfiles-attribute.sql
@@ -1,2 +1,0 @@
-ALTER TABLE rhnScapAction ADD COLUMN IF NOT EXISTS
-    ovalfiles   VARCHAR(8192);

--- a/susemanager-utils/susemanager-sls/salt/scap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/scap/init.sls
@@ -2,7 +2,7 @@ mgr_scap:
   mgrcompat.module_run:
 {%- if "openscap.xccdf_eval" not in salt %}
     - name: openscap.xccdf
-    - params: {{ pillar.get('mgr_scap_params') }}
+    - params: {{ pillar.get('mgr_scap_params')['old_parameters'] }}
 {%- else %}
     - name: openscap.xccdf_eval
     - xccdffile: {{ pillar['mgr_scap_params']['xccdffile'] }}

--- a/susemanager-utils/susemanager-sls/salt/scap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/scap/init.sls
@@ -1,4 +1,23 @@
 mgr_scap:
   mgrcompat.module_run:
-    - name: openscap.xccdf
-    - params: {{ pillar.get('mgr_scap_params') }}
+    - name: openscap.xccdf_eval
+    - xccdffile: {{ pillar['mgr_scap_params']['xccdffile'] }}
+    - kwargs:
+        results: results.xml
+        report: report.html
+        oval_results: True
+        {%- if "profile" in pillar.get('mgr_scap_params') %}
+        profile: {{ pillar['mgr_scap_params']['profile'] }}
+        {%- endif %}
+        {%- if "ovalfiles" in pillar.get('mgr_scap_params') %}
+        ovalfiles: {{ pillar['mgr_scap_params']['ovalfiles'] }}
+        {%- endif %}
+        {%- if "rule" in pillar.get('mgr_scap_params') %}
+        rule: {{ pillar['mgr_scap_params']['rule'] }}
+        {%- endif %}
+        {%- if "remediate" in pillar.get('mgr_scap_params') %}
+        remediate: {{ pillar['mgr_scap_params']['remediate'] }}
+        {%- endif %}
+        {%- if "fetch_remote_resources" in pillar.get('mgr_scap_params') %}
+        fetch_remote_resources: {{ pillar['mgr_scap_params']['fetch_remote_resources'] }}
+        {%- endif %}

--- a/susemanager-utils/susemanager-sls/salt/scap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/scap/init.sls
@@ -1,16 +1,23 @@
 mgr_scap:
   mgrcompat.module_run:
+{%- if "openscap.xccdf_eval" not in salt %}
+    - name: openscap.xccdf
+    - params: {{ pillar.get('mgr_scap_params') }}
+{%- else %}
     - name: openscap.xccdf_eval
     - xccdffile: {{ pillar['mgr_scap_params']['xccdffile'] }}
+    {%- if "ovalfiles" in pillar.get('mgr_scap_params') %}
+    - ovalfiles:
+      {%- for oval in pillar['mgr_scap_params']['ovalfiles'] %}
+        - {{ oval }}
+      {%- endfor %}
+    {%- endif %}
     - kwargs:
         results: results.xml
         report: report.html
         oval_results: True
         {%- if "profile" in pillar.get('mgr_scap_params') %}
         profile: {{ pillar['mgr_scap_params']['profile'] }}
-        {%- endif %}
-        {%- if "ovalfiles" in pillar.get('mgr_scap_params') %}
-        ovalfiles: {{ pillar['mgr_scap_params']['ovalfiles'] }}
         {%- endif %}
         {%- if "rule" in pillar.get('mgr_scap_params') %}
         rule: {{ pillar['mgr_scap_params']['rule'] }}
@@ -21,3 +28,4 @@ mgr_scap:
         {%- if "fetch_remote_resources" in pillar.get('mgr_scap_params') %}
         fetch_remote_resources: {{ pillar['mgr_scap_params']['fetch_remote_resources'] }}
         {%- endif %}
+{% endif %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Fix Salt scap state to use new 'xccdf_eval' function
 - Fix deleting stopped virtual network (bsc#1186281)
 - Handle virtual machines running on pacemaker cluster
 - fix product detection for native RHEL products (bsc#1187397)


### PR DESCRIPTION
## What does this PR change?

This PR fixes the Salt "scap" state that is used by Uyuni to schedule XCCDF scans on minions to use the new introduced `xccdf_eval` function.

This function allows to pass more attributes to the final `oscap` execution, like: `--fetch-remote-resources`, `--rule`, `--remediate`, `--tailoring-file`, `--tailoring-id`, etc.

**IMPORTANT:** This PR depends on the following changes for Salt: https://github.com/openSUSE/salt/pull/386

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/3222

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql" 
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
