### PR TITLE
Remove systemid file on salt client cleanup

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/cleanup_minion/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/cleanup_minion/init.sls
@@ -20,3 +20,7 @@ mgrchannels_repo_clean_keyring:
   file.absent:
     - name: /usr/share/keyrings/mgr-archive-keyring.gpg
 {%- endif %}
+
+mgr_mark_no_longer_managed:
+  file.absent:
+    - name: /etc/sysconfig/rhn/systemid

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Remove systemid file on salt client cleanup
 - Skip 'update-ca-certificates' run if the certs are updated automatically
 - Fix parameters for 'runplaybook' state (bsc#1188395)
 - Parameterised apache document root.


### PR DESCRIPTION
## What does this PR change?

Remove `systemid` file on salt client cleanup when salt client is removed from Uyuni

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/14621

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
