### PR TITLE
Fix for spacewalk-koan tests

### DIFF
--- a/client/tools/spacewalk-koan/Makefile.spacewalk-koan
+++ b/client/tools/spacewalk-koan/Makefile.spacewalk-koan
@@ -16,7 +16,7 @@ include $(TOP)/Makefile.defs
 INSTALL_DATA    = $(INSTALL_BIN)
 
 # Docker tests variables
-DOCKER_IMAGE          = suma-head-spacewalkkoan
+DOCKER_IMAGE          = systemsmanagement/uyuni/master/docker/containers/uyuni-master-spacewalkkoan
 DOCKER_REGISTRY       = registry.opensuse.org
 DOCKER_RUN_EXPORT     = "PYTHONPATH=/manager/client/tools/"
 DOCKER_VOLUMES        = -v "$(CURDIR)/../../../:/manager"

--- a/client/tools/spacewalk-koan/spacewalk-koan.changes
+++ b/client/tools/spacewalk-koan/spacewalk-koan.changes
@@ -1,3 +1,6 @@
+- Fix for spacewalk-koan tests after switching to the new
+  Docker images
+
 -------------------------------------------------------------------
 Wed Nov 25 12:22:45 CET 2020 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Fix for spacewalk-koan tests

They were still using the old container.

## GUI diff

No difference.

Before:

After:

- [x] **DONE**

## Documentation
- No documentation needed: fix for tests

- [x] **DONE**

## Test coverage
- Fix for tests

- [x] **DONE**

## Links

Related https://github.com/SUSE/spacewalk/issues/15238

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
