### PR TITLE
not update Kickstart session when download after session is complete …

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/common/DownloadFile.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/common/DownloadFile.java
@@ -705,7 +705,9 @@ public class DownloadFile extends DownloadAction {
             return manualServeByteRange(request, response, diskPath, range);
         }
         // Update kickstart session
-        if (ksession != null) {
+        if (ksession != null &&
+                (!(ksession.getState().getLabel().equals(KickstartSessionState.COMPLETE) ||
+                        ksession.getState().getLabel().equals(KickstartSessionState.FAILED)))) {
             ksession.setState(newState);
             if (ksession.getPackageFetchCount() == null) {
                 ksession.setPackageFetchCount(0L);

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Do not update Kickstart session when download after session is complete or failed (bsc#1187621)
 - define a pillar for the https port when connection as ssh-push with tunnel (bsc#1187441)
 - Fix the unit test coverage reports
 - Fix random NullPointerException when rendering page tabs (bsc#1182769)


### PR DESCRIPTION

## What does this PR change?

Do not update Kickstart session when download after the session is complete or failed (bsc#1187621)

After auto installation finishes it sets the kickstart session state to finished. However, before applying the high state a zypper refresh is being called before we disable the older repos, meaning the autoinstallation repository is updated.
With this call to the suma server the kick start session is set to the initial state again.

With this change, if the sessions is already completed or failed, the kick start sessions state will not be changed.

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Port of: https://github.com/SUSE/spacewalk/pull/15242

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [x] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
