### PR TITLE
Use the correct product tag for non-beta

### DIFF
--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -12,6 +12,11 @@ Fri Jun 18 12:41:30 CEST 2021 - jgonzalez@suse.com
 - do not check accessibility of free product repositories (bsc#1182817)
 
 -------------------------------------------------------------------
+Thu Jun 17 10:38:51 UTC 2021 - Julio González Gil <jgonzalez@suse.com>
+
+- Use the correct product tag
+
+-------------------------------------------------------------------
 Thu Jun 10 13:46:09 CEST 2021 - jgonzalez@suse.com
 
 - version 4.2.22-1

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -571,8 +571,6 @@ install -m 644 conf/rhn_java_sso.conf $RPM_BUILD_ROOT%{_prefix}/share/rhn/config
 # Adjust product tree tag
 %if 0%{?is_opensuse}
 sed -i -e 's/^java.product_tree_tag =.*$/java.product_tree_tag = Uyuni/' $RPM_BUILD_ROOT%{_prefix}/share/rhn/config-defaults/rhn_java.conf
-%else
-sed -i -e 's/^java.product_tree_tag =.*$/java.product_tree_tag = Beta/' $RPM_BUILD_ROOT%{_prefix}/share/rhn/config-defaults/rhn_java.conf
 %endif
 # Adjust languages
 sed -i -e '/# NOTE: for the RPMs this is defined at the SPEC!/d' $RPM_BUILD_ROOT%{_prefix}/share/rhn/config-defaults/rhn_java.conf


### PR DESCRIPTION
## What does this PR change?

Use the correct product tag for non-beta

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: For now, this is documented at the internal wiki

- [x] **DONE**

## Test coverage
- No tests: We should consider them (https://github.com/SUSE/spacewalk/issues/15248)

- [x] **DONE**

## Links

None

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
