### PR TITLE
QA: Refactor Capybara visit method calls

### DIFF
--- a/testsuite/features/build_validation/add_custom_repositories/add_ceos7_repositories.feature
+++ b/testsuite/features/build_validation/add_custom_repositories/add_ceos7_repositories.feature
@@ -13,7 +13,7 @@ Feature: Adding the CentOS 7 distribution custom repositories
   Scenario: Add a child channel for CentOS 7 DVD repositories
     When I follow the left menu "Software > Manage > Channels"
     And I follow "Create Channel"
-    When I enter "Custom Channel for CentOS 7 DVD" as "Channel Name"
+    And I enter "Custom Channel for CentOS 7 DVD" as "Channel Name"
     And I enter "centos-7-iso" as "Channel Label"
     And I select the parent channel for the "ceos7_minion" from "Parent Channel"
     And I enter "Custom channel" as "Channel Summary"

--- a/testsuite/features/build_validation/add_custom_repositories/add_ceos8_repositories.feature
+++ b/testsuite/features/build_validation/add_custom_repositories/add_ceos8_repositories.feature
@@ -16,7 +16,7 @@ Feature: Adding the CentOS 8 distribution custom repositories
   Scenario: Add a child channel for CentOS 8 DVD repositories
     When I follow the left menu "Software > Manage > Channels"
     And I follow "Create Channel"
-    When I enter "Custom Channel for CentOS 8 DVD" as "Channel Name"
+    And I enter "Custom Channel for CentOS 8 DVD" as "Channel Name"
     And I enter "centos-8-iso" as "Channel Label"
     And I select "RHEL8-Pool for x86_64" from "Parent Channel"
     And I enter "Custom channel" as "Channel Summary"

--- a/testsuite/features/build_validation/add_custom_repositories/add_maintenance_update_repository.template
+++ b/testsuite/features/build_validation/add_custom_repositories/add_maintenance_update_repository.template
@@ -10,7 +10,7 @@ Feature: Adding a Maintenance Update custom channel and the custom repositories 
   Scenario: Add a child channel for <client>
     When I follow the left menu "Software > Manage > Channels"
     And I follow "Create Channel"
-    When I enter "Custom Channel for <client>" as "Channel Name"
+    And I enter "Custom Channel for <client>" as "Channel Name"
     And I enter "custom_channel_<client>" as "Channel Label"
     And I select the parent channel for the "<client>" from "Parent Channel"
     And I enter "Custom channel" as "Channel Summary"

--- a/testsuite/features/build_validation/retail/deploy_sle11sp3_terminal.feature
+++ b/testsuite/features/build_validation/retail/deploy_sle11sp3_terminal.feature
@@ -14,7 +14,7 @@ Feature: PXE boot a SLES 11 SP3 retail terminal
     When I run "reboot" on "sle11sp3_terminal"
     And I wait at most 180 seconds until Salt master sees "sle11sp3_terminal" as "unaccepted"
     And I accept "sle11sp3_terminal" key in the Salt master
-    And I am on the System Overview page
+    And I follow the left menu "Home > Overview"
     And I wait until I see the name of "sle11sp3_terminal", refreshing the page
     And I follow this "sle11sp3_terminal" link
     And I wait until event "Apply states [util.syncstates, saltboot] scheduled" is completed

--- a/testsuite/features/build_validation/retail/deploy_sle12sp4_terminal.feature
+++ b/testsuite/features/build_validation/retail/deploy_sle12sp4_terminal.feature
@@ -16,7 +16,7 @@ Feature: PXE boot a SLES 12 SP4 retail terminal
     When I run "reboot" on "sle12sp4_terminal"
     And I wait at most 180 seconds until Salt master sees "sle12sp4_terminal" as "unaccepted"
     And I accept "sle12sp4_terminal" key in the Salt master
-    And I am on the System Overview page
+    And I follow the left menu "Home > Overview"
     And I wait until I see the name of "sle12sp4_terminal", refreshing the page
     And I follow this "sle12sp4_terminal" link
     And I wait until event "Apply states [util.syncstates, saltboot] scheduled" is completed

--- a/testsuite/features/build_validation/retail/deploy_sle15sp2_terminal.feature
+++ b/testsuite/features/build_validation/retail/deploy_sle15sp2_terminal.feature
@@ -14,7 +14,7 @@ Feature: PXE boot a SLES 15 SP2 retail terminal
     When I run "reboot" on "sle15sp2_terminal"
     And I wait at most 180 seconds until Salt master sees "sle15sp2_terminal" as "unaccepted"
     And I accept "sle15sp2_terminal" key in the Salt master
-    And I am on the System Overview page
+    And I follow the left menu "Home > Overview"
     And I wait until I see the name of "sle15sp2_terminal", refreshing the page
     And I follow this "sle15sp2_terminal" link
     And I wait until event "Apply states [util.syncstates, saltboot] scheduled" is completed

--- a/testsuite/features/build_validation/retail/sle11sp4_kiwi_image_buildhost.feature
+++ b/testsuite/features/build_validation/retail/sle11sp4_kiwi_image_buildhost.feature
@@ -23,7 +23,7 @@ Feature: Bootstrap a SLES 11 SP4 Salt build host via the GUI
   Scenario: Check the new bootstrapped SLES 11 SP4 build host in System Overview page
     When I follow the left menu "Salt > Keys"
     Then I should see a "accepted" text
-    When I am on the System Overview page
+    When I follow the left menu "Home > Overview"
     And I wait until I see the name of "sle11sp4_buildhost", refreshing the page
     And I wait until onboarding is completed for "sle11sp4_buildhost"
     Then the Salt master can reach "sle11sp4_buildhost"

--- a/testsuite/features/build_validation/retail/sle12sp4_kiwi_image_buildhost.feature
+++ b/testsuite/features/build_validation/retail/sle12sp4_kiwi_image_buildhost.feature
@@ -23,7 +23,7 @@ Feature: Bootstrap a SLES 12 SP4 Salt build host via the GUI
   Scenario: Check the new bootstrapped SLES 12 SP4 build host in System Overview page
     When I follow the left menu "Salt > Keys"
     Then I should see a "accepted" text
-    When I am on the System Overview page
+    When I follow the left menu "Home > Overview"
     And I wait until I see the name of "sle12sp4_buildhost", refreshing the page
     And I wait until onboarding is completed for "sle12sp4_buildhost"
     Then the Salt master can reach "sle12sp4_buildhost"

--- a/testsuite/features/build_validation/retail/sle15sp2_kiwi_image_buildhost.feature
+++ b/testsuite/features/build_validation/retail/sle15sp2_kiwi_image_buildhost.feature
@@ -23,7 +23,7 @@ Feature: Bootstrap a SLES 15 SP2 Salt build host via the GUI
   Scenario: Check the new bootstrapped SLES 15 SP2 build host in System Overview page
     When I follow the left menu "Salt > Keys"
     Then I should see a "accepted" text
-    When I am on the System Overview page
+    When I follow the left menu "Home > Overview"
     And I wait until I see the name of "sle15sp2_buildhost", refreshing the page
     And I wait until onboarding is completed for "sle15sp2_buildhost"
     Then the Salt master can reach "sle15sp2_buildhost"

--- a/testsuite/features/core/srv_channels_add.feature
+++ b/testsuite/features/core/srv_channels_add.feature
@@ -24,7 +24,7 @@ Feature: Adding channels
   Scenario: Add a child channel
     When I follow the left menu "Software > Manage > Channels"
     And I follow "Create Channel"
-    When I enter "Test Child Channel" as "Channel Name"
+    And I enter "Test Child Channel" as "Channel Name"
     And I enter "test_child_channel" as "Channel Label"
     And I select "Test Base Channel" from "Parent Channel"
     And I select "x86_64" from "Architecture:"

--- a/testsuite/features/core/srv_create_repository.feature
+++ b/testsuite/features/core/srv_create_repository.feature
@@ -63,7 +63,7 @@ Feature: Add a repository to a channel
 
   Scenario: Synchronize the repository in the i586 channel
     When I disable source package syncing
-    When I follow the left menu "Software > Manage > Channels"
+    And I follow the left menu "Software > Manage > Channels"
     And I follow "Test-Channel-i586"
     And I follow "Repositories" in the content area
     And I follow "Sync"

--- a/testsuite/features/init_clients/buildhost_bootstrap.feature
+++ b/testsuite/features/init_clients/buildhost_bootstrap.feature
@@ -21,7 +21,7 @@ Feature: Bootstrap a Salt build host via the GUI
   Scenario: Check the new bootstrapped build host in System Overview page
     When I follow the left menu "Salt > Keys"
     Then I should see a "accepted" text
-    When I am on the System Overview page
+    When I follow the left menu "Home > Overview"
     And I wait until I see the name of "build_host", refreshing the page
     And I wait until onboarding is completed for "build_host"
     Then the Salt master can reach "build_host"

--- a/testsuite/features/init_clients/min_centos_salt.feature
+++ b/testsuite/features/init_clients/min_centos_salt.feature
@@ -21,7 +21,7 @@ Feature: Bootstrap a CentOS minion and do some basic operations on it
     And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text
-    And I am on the System Overview page
+    And I follow the left menu "Home > Overview"
     And I wait until I see the name of "ceos_minion", refreshing the page
     And I wait until onboarding is completed for "ceos_minion"
 

--- a/testsuite/features/init_clients/min_ubuntu_salt.feature
+++ b/testsuite/features/init_clients/min_ubuntu_salt.feature
@@ -21,7 +21,7 @@ Feature: Bootstrap an Ubuntu minion and do some basic operations on it
     And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text
-    And I am on the System Overview page
+    And I follow the left menu "Home > Overview"
     And I wait until I see the name of "ubuntu_minion", refreshing the page
     And I wait until onboarding is completed for "ubuntu_minion"
     And I query latest Salt changes on ubuntu system "ubuntu_minion"

--- a/testsuite/features/init_clients/sle_minion.feature
+++ b/testsuite/features/init_clients/sle_minion.feature
@@ -20,7 +20,7 @@ Feature: Bootstrap a Salt minion via the GUI
   Scenario: Check the new bootstrapped minion in System Overview page
     When I follow the left menu "Salt > Keys"
     Then I should see a "accepted" text
-    When I am on the System Overview page
+    When I follow the left menu "Home > Overview"
     And I wait until I see the name of "sle_minion", refreshing the page
     And I wait until onboarding is completed for "sle_minion"
     Then the Salt master can reach "sle_minion"

--- a/testsuite/features/init_clients/sle_ssh_minion.feature
+++ b/testsuite/features/init_clients/sle_ssh_minion.feature
@@ -16,7 +16,7 @@ Feature: Bootstrap a Salt host managed via salt-ssh
     And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text
-    And I am on the System Overview page
+    And I follow the left menu "Home > Overview"
     And I wait until I see the name of "ssh_minion", refreshing the page
     And I wait until onboarding is completed for "ssh_minion"
 

--- a/testsuite/features/secondary/allcli_action_chain.feature
+++ b/testsuite/features/secondary/allcli_action_chain.feature
@@ -53,7 +53,7 @@ Feature: Action chains on several systems at once
     And I cancel all scheduled actions
 
   Scenario: Add an action chain using system set manager for traditional client and Salt minion
-    When I am on the System Overview page
+    When I follow the left menu "Home > Overview"
     And I check the "sle_minion" client
     And I check the "sle_client" client
     And I am on System Set Manager Overview

--- a/testsuite/features/secondary/allcli_config_channel.feature
+++ b/testsuite/features/secondary/allcli_config_channel.feature
@@ -245,7 +245,7 @@ Feature: Management of configuration of all types of clients in a single channel
 
 @sle_client
   Scenario: Re-add Salt Minion via SSM
-    When I am on the System Overview page
+    When I follow the left menu "Home > Overview"
     And I follow "Clear"
     And I check the "sle_client" client
     And I am on System Set Manager Overview
@@ -258,7 +258,7 @@ Feature: Management of configuration of all types of clients in a single channel
 
 @sle_minion
   Scenario: Re-add Traditional Client via SSM
-    When I am on the System Overview page
+    When I follow the left menu "Home > Overview"
     And I follow "Clear"
     And I check the "sle_minion" client
     And I am on System Set Manager Overview

--- a/testsuite/features/secondary/allcli_software_channels.feature
+++ b/testsuite/features/secondary/allcli_software_channels.feature
@@ -9,7 +9,7 @@ Feature: Chanel subscription via SSM
 
 @sle_minion
   Scenario: Change child channels for SLES Minion subscribed to a base channel
-    When I am on the System Overview page
+    When I follow the left menu "Home > Overview"
     And I follow "Clear"
     And I check the "sle_minion" client
     And I should see "1" systems selected for SSM
@@ -35,7 +35,7 @@ Feature: Chanel subscription via SSM
 
 @sle_client
   Scenario: Change child channels for SLES Client subscribed to a base channel
-    When I am on the System Overview page
+    When I follow the left menu "Home > Overview"
     And I follow "Clear"
     And I check the "sle_client" client
     And I should see "1" systems selected for SSM
@@ -139,7 +139,7 @@ Feature: Chanel subscription via SSM
 
 @centos_minion
   Scenario: System default channel can't be determined on the CentOS minion
-    When I am on the System Overview page
+    When I follow the left menu "Home > Overview"
     And I follow "Clear"
     And I check the "ceos_minion" client
     Then I should see "1" systems selected for SSM
@@ -169,7 +169,7 @@ Feature: Chanel subscription via SSM
 
 @ubuntu_minion
   Scenario: System default channel can't be determined on the Ubuntu minion
-    When I am on the System Overview page
+    When I follow the left menu "Home > Overview"
     And I follow "Clear"
     And I check the "ubuntu_minion" client
     Then I should see "1" systems selected for SSM

--- a/testsuite/features/secondary/allcli_software_channels_dependencies.feature
+++ b/testsuite/features/secondary/allcli_software_channels_dependencies.feature
@@ -31,7 +31,7 @@ Feature: Chanel subscription with recommended/required dependencies
     Then I should see the child channel "SLE-Module-Server-Applications15-SP2-Pool for x86_64" "selected"
 
   Scenario: Play with recommended and required child channels selection in SSM
-    When I am on the System Overview page
+    When I follow the left menu "Home > Overview"
     And I check the "sle_minion" client
     And I check the "sle_client" client
     Then I should see "2" systems selected for SSM

--- a/testsuite/features/secondary/min_activationkey.feature
+++ b/testsuite/features/secondary/min_activationkey.feature
@@ -60,7 +60,7 @@ Feature: Bootstrap a Salt minion via the GUI with an activation key
     And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text
-    When I am on the System Overview page
+    And I follow the left menu "Home > Overview"
     And I wait until I see the name of "sle_minion", refreshing the page
     And I wait until onboarding is completed for "sle_minion"
 

--- a/testsuite/features/secondary/min_bootstrap_negative.feature
+++ b/testsuite/features/secondary/min_bootstrap_negative.feature
@@ -75,7 +75,7 @@ Feature: Negative tests for bootstrapping normal minions
      And I select the hostname of "proxy" from "proxies"
      And I click on "Bootstrap"
      And I wait until I see "Successfully bootstrapped host!" text
-     And I am on the System Overview page
+     And I follow the left menu "Home > Overview"
      And I wait until I see the name of "sle_minion", refreshing the page
 
   Scenario: Cleanup: subscribe again to base channel after negative tests

--- a/testsuite/features/secondary/min_bootstrap_script.feature
+++ b/testsuite/features/secondary/min_bootstrap_script.feature
@@ -28,7 +28,7 @@ Feature: Register a Salt minion via Bootstrap-script
     Then I should see "sle_minion" via spacecmd
 
   Scenario: Check if onboarding for the script-bootstrapped minion was successful
-    When I am on the System Overview page
+    When I follow the left menu "Home > Overview"
     And I wait until I see the name of "sle_minion", refreshing the page
     And I wait until onboarding is completed for "sle_minion"
 

--- a/testsuite/features/secondary/min_bootstrap_xmlrpc.feature
+++ b/testsuite/features/secondary/min_bootstrap_xmlrpc.feature
@@ -23,7 +23,7 @@ Feature: Register a Salt minion via XML-RPC API
   Scenario: Check new minion bootstrapped via XML-RPC in System Overview page
     When I follow the left menu "Salt > Keys"
     Then I should see a "accepted" text
-    When I am on the System Overview page
+    When I follow the left menu "Home > Overview"
     And I wait until I see the name of "sle_minion", refreshing the page
     And I wait until onboarding is completed for "sle_minion"
     Then the Salt master can reach "sle_minion"

--- a/testsuite/features/secondary/min_centos_ssh.feature
+++ b/testsuite/features/secondary/min_centos_ssh.feature
@@ -29,7 +29,7 @@ Feature: Bootstrap a SSH-managed CentOS minion and do some basic operations on i
     And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text
-    And I am on the System Overview page
+    And I follow the left menu "Home > Overview"
     And I wait until I see the name of "ceos_ssh_minion", refreshing the page
     And I wait until onboarding is completed for "ceos_ssh_minion"
 
@@ -99,7 +99,7 @@ Feature: Bootstrap a SSH-managed CentOS minion and do some basic operations on i
     And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text
-    And I am on the System Overview page
+    And I follow the left menu "Home > Overview"
     And I wait until I see the name of "ceos_minion", refreshing the page
     And I wait until onboarding is completed for "ceos_minion"
 

--- a/testsuite/features/secondary/min_retracted_patches.feature
+++ b/testsuite/features/secondary/min_retracted_patches.feature
@@ -101,7 +101,7 @@ Feature: Retracted patches
     Then the table row for "rute-dummy-2.1-1.1.x86_64" should contain "retracted" icon
 
   Scenario: SSM: Retracted package should not be available for installation
-    When I am on the System Overview page
+    When I follow the left menu "Home > Overview"
     And I follow "Clear"
     And I check the "sle_minion" client 
     And I am on System Set Manager Overview

--- a/testsuite/features/secondary/min_salt_mgrcompat_state.feature
+++ b/testsuite/features/secondary/min_salt_mgrcompat_state.feature
@@ -50,7 +50,7 @@ Feature: Verify that Salt mgrcompat state works when the new module.run syntax i
     And I wait until onboarding is completed for "sle_minion"
 
   Scenario: Check if onboarding for the minion with the new module.run syntax was successful
-    When I am on the System Overview page
+    When I follow the left menu "Home > Overview"
     And I wait until I see the name of "sle_minion", refreshing the page
     And I wait until onboarding is completed for "sle_minion"
 

--- a/testsuite/features/secondary/min_ubuntu_ssh.feature
+++ b/testsuite/features/secondary/min_ubuntu_ssh.feature
@@ -30,7 +30,7 @@ Feature: Bootstrap a SSH-managed Ubuntu minion and do some basic operations on i
     And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text
-    And I am on the System Overview page
+    And I follow the left menu "Home > Overview"
     And I wait until I see the name of "ubuntu_ssh_minion", refreshing the page
     And I wait until onboarding is completed for "ubuntu_ssh_minion"
 
@@ -99,7 +99,7 @@ Feature: Bootstrap a SSH-managed Ubuntu minion and do some basic operations on i
     And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text
-    And I am on the System Overview page
+    And I follow the left menu "Home > Overview"
     And I wait until I see the name of "ubuntu_minion", refreshing the page
     And I wait until onboarding is completed for "ubuntu_minion"
 

--- a/testsuite/features/secondary/minssh_bootstrap_xmlrpc.feature
+++ b/testsuite/features/secondary/minssh_bootstrap_xmlrpc.feature
@@ -23,7 +23,7 @@ Feature: Register a salt-ssh system via XML-RPC
     And I logout from XML-RPC system namespace
 
   Scenario: Check new XML-RPC bootstrapped salt-ssh system in System Overview page
-     And I am on the System Overview page
+     And I follow the left menu "Home > Overview"
      And I wait until I see the name of "ssh_minion", refreshing the page
      And I wait until onboarding is completed for "ssh_minion"
 

--- a/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
+++ b/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
@@ -197,7 +197,7 @@ Feature: PXE boot a Retail terminal
     When I reboot the PXE boot minion
     And I wait at most 180 seconds until Salt master sees "pxeboot_minion" as "unaccepted"
     And I accept "pxeboot_minion" key in the Salt master
-    And I am on the System Overview page
+    And I follow the left menu "Home > Overview"
     And I wait until I see the name of "pxeboot_minion", refreshing the page
     And I follow this "pxeboot_minion" link
     And I wait until event "Apply states [util.syncstates, saltboot] scheduled by (none)" is completed
@@ -343,7 +343,7 @@ Feature: PXE boot a Retail terminal
     And I bootstrap pxeboot minion via bootstrap script on the proxy
     And I wait at most 180 seconds until Salt master sees "pxeboot_minion" as "unaccepted"
     And I accept key of pxeboot minion in the Salt master
-    Then I am on the System Overview page
+    Then I follow the left menu "Home > Overview"
     And I wait until I see the name of "pxeboot_minion", refreshing the page
 
   Scenario: Check connection from bootstrapped terminal to proxy

--- a/testsuite/features/secondary/srv_clone_channel_npn.feature
+++ b/testsuite/features/secondary/srv_clone_channel_npn.feature
@@ -8,8 +8,8 @@ Feature: Clone a channel
     Given I am authorized for the "Admin" section
 
   Scenario: Clone a channel without patches
-    Given I am on the manage software channels page
-    When I follow "Clone Channel"
+    When I follow the left menu "Software > Manage > Channels"
+    And I follow "Clone Channel"
     And I select "Test-Channel-x86_64" as the origin channel
     And I choose "original"
     And I click on "Clone Channel"
@@ -19,15 +19,15 @@ Feature: Clone a channel
     Then I should see a "Clone of Test-Channel-x86_64" text
 
   Scenario: Check that this channel has no patches
-    Given I am on the manage software channels page
+    When I follow the left menu "Software > Manage > Channels"
     And I follow "Clone of Test-Channel-x86_64"
-    When I follow "Patches" in the content area
+    And I follow "Patches" in the content area
     And I follow "List/Remove Patches"
     Then I should see a "There are no patches associated with this channel." text
 
   Scenario: Clone a channel with patches
-    Given I am on the manage software channels page
-    When I follow "Clone Channel"
+    When I follow the left menu "Software > Manage > Channels"
+    And I follow "Clone Channel"
     And I select "Test-Channel-x86_64" as the origin channel
     And I choose "current"
     And I click on "Clone Channel"
@@ -37,9 +37,9 @@ Feature: Clone a channel
     Then I should see a "Clone 2 of Test-Channel-x86_64" text
 
   Scenario: Check that this channel has patches
-    Given I am on the manage software channels page
+    When I follow the left menu "Software > Manage > Channels"
     And I follow "Clone 2 of Test-Channel-x86_64"
-    When I follow "Patches" in the content area
+    And I follow "Patches" in the content area
     And I follow "List/Remove Patches"
     Then I should see a "CL-hoag-dummy-7890" link
     And I should see a "CL-virgo-dummy-3456" link
@@ -47,8 +47,8 @@ Feature: Clone a channel
     And I should see a "CL-andromeda-dummy-6789" link
 
   Scenario: Clone a channel with selected patches
-    Given I am on the manage software channels page
-    When I follow "Clone Channel"
+    When I follow the left menu "Software > Manage > Channels"
+    And I follow "Clone Channel"
     And I select "Test-Channel-x86_64" as the origin channel
     And I choose "select"
     And I click on "Clone Channel"
@@ -66,7 +66,6 @@ Feature: Clone a channel
     And I should see a "CL-virgo-dummy-3456" link
 
   Scenario: Check that new patches exists
-    Given I am on the patches page
     When I follow the left menu "Patches > Patch List > All"
     And I select "500" from "1154021400_PAGE_SIZE_LABEL"
     Then I should see a "CL-hoag-dummy-7890" link
@@ -75,7 +74,6 @@ Feature: Clone a channel
     And I should see a "CL-andromeda-dummy-6789" link
 
   Scenario: Check CL-hoag-dummy-7890 patches
-    Given I am on the patches page
     When I follow the left menu "Patches > Patch List > All"
     And I select "500" from "1154021400_PAGE_SIZE_LABEL"
     And I follow "CL-hoag-dummy-7890"
@@ -84,7 +82,6 @@ Feature: Clone a channel
     And I should see a "https://bugzilla.opensuse.org/show_bug.cgi?id=704608" link
 
   Scenario: Check CM-virgo-dummy-3456 patches
-    Given I am on the patches page
     When I follow the left menu "Patches > Patch List > All"
     And I select "500" from "1154021400_PAGE_SIZE_LABEL"
     And I follow "CL-virgo-dummy-3456"
@@ -93,9 +90,9 @@ Feature: Clone a channel
     And I should see a "CVE-1999-9998" link
 
   Scenario: Compare channel packages
-    Given I am on the manage software channels page
+    When I follow the left menu "Software > Manage > Channels"
     # bsc#904690 - After migration from SUSE Manager 1.7 to 2.1 attempting to perform a channel package compare returns internal server error
-    When I follow "Clone 2 of Test-Channel-x86_64"
+    And I follow "Clone 2 of Test-Channel-x86_64"
     And I follow "Packages" in the content area
     And I follow "Compare"
     And I select "Clone 3 of Test-Channel-x86_64" from "selected_channel"
@@ -105,8 +102,8 @@ Feature: Clone a channel
     And I should see a "This channel only" text
 
   Scenario: Cleanup: remove cloned channels
-    Given I am on the manage software channels page
-    When I follow "Clone of Test-Channel-x86_64"
+    When I follow the left menu "Software > Manage > Channels"
+    And I follow "Clone of Test-Channel-x86_64"
     And I follow "Delete software channel"
     And I check "unsubscribeSystems"
     And I click on "Delete Channel"

--- a/testsuite/features/secondary/srv_custom_system_info.feature
+++ b/testsuite/features/secondary/srv_custom_system_info.feature
@@ -18,7 +18,7 @@ Feature: Custom system info key-value pairs
     Then I should see a "Successfully added 1 custom key." text
 
   Scenario: Add a value to a system
-    When I am on the System Overview page
+    When I follow the left menu "Home > Overview"
     And I follow this "sle_client" link
     And I follow "Custom Info"
     And I follow "Create Value"
@@ -29,7 +29,7 @@ Feature: Custom system info key-value pairs
     And I should see a "key-value" link
 
   Scenario: Edit the value
-    When I am on the System Overview page
+    When I follow the left menu "Home > Overview"
     And I follow this "sle_client" link
     And I follow "Custom Info"
     And I follow "key-value"

--- a/testsuite/features/secondary/srv_delete_channel_from_ui.feature
+++ b/testsuite/features/secondary/srv_delete_channel_from_ui.feature
@@ -10,8 +10,8 @@ Feature: Delete channels with child or clone is not allowed
     Given I am authorized for the "Admin" section
 
   Scenario: Clone the first channel before deletion from UI test
-    Given I am on the manage software channels page
-    When I follow "Clone Channel"
+    When I follow the left menu "Software > Manage > Channels"
+    And I follow "Clone Channel"
     And I select "Test-Channel-x86_64" as the origin channel
     And I click on "Clone Channel"
     Then I should see a "Create Software Channel" text
@@ -20,8 +20,8 @@ Feature: Delete channels with child or clone is not allowed
     Then I should see a "Clone of Test-Channel-x86_64" text
 
   Scenario: Clone the second channel using first channel as base
-    Given I am on the manage software channels page
-    When I follow "Clone Channel"
+    When I follow the left menu "Software > Manage > Channels"
+    And I follow "Clone Channel"
     And I select "Clone of Test-Channel-x86_64" as the origin channel
     And I click on "Clone Channel"
     Then I should see a "Create Software Channel" text
@@ -30,8 +30,8 @@ Feature: Delete channels with child or clone is not allowed
     Then I should see a "Clone of Clone of Test-Channel-x86_64" text
 
   Scenario: Try to delete channel with clone
-    Given I am on the manage software channels page
-    When I follow "Clone of Test-Channel-x86_64"
+    When I follow the left menu "Software > Manage > Channels"
+    And I follow "Clone of Test-Channel-x86_64"
     And I follow "Delete software channel"
     And I check "unsubscribeSystems"
     And I click on "Delete Channel"
@@ -39,8 +39,8 @@ Feature: Delete channels with child or clone is not allowed
     And I should see a "Unable to delete channel" text
 
   Scenario: Delete channel without clones neither children
-    Given I am on the manage software channels page
-    When I follow "Clone of Clone of Test-Channel-x86_64"
+    When I follow the left menu "Software > Manage > Channels"
+    And I follow "Clone of Clone of Test-Channel-x86_64"
     And I follow "Delete software channel"
     And I check "unsubscribeSystems"
     And I click on "Delete Channel"
@@ -48,8 +48,8 @@ Feature: Delete channels with child or clone is not allowed
     And I should see a "has been deleted" text
 
   Scenario: Clone a child channel to the clone of x86_64 test channel
-    Given I am on the manage software channels page
-    When I follow "Clone Channel"
+    When I follow the left menu "Software > Manage > Channels"
+    And I follow "Clone Channel"
     And I select "Test-Channel-x86_64 Child Channel" as the origin channel
     And I click on "Clone Channel"
     Then I should see a "Create Software Channel" text
@@ -59,8 +59,8 @@ Feature: Delete channels with child or clone is not allowed
     Then I should see a "Clone of Test-Channel-x86_64 Child Channel" text
 
   Scenario: Try delete channel with child
-    Given I am on the manage software channels page
-    When I follow "Clone of Test-Channel-x86_64"
+    When I follow the left menu "Software > Manage > Channels"
+    And I follow "Clone of Test-Channel-x86_64"
     And I follow "Delete software channel"
     And I check "unsubscribeSystems"
     And I click on "Delete Channel"
@@ -69,8 +69,8 @@ Feature: Delete channels with child or clone is not allowed
     And I should see a "must delete those channels first before deleting the parent." text
 
   Scenario: Cleanup: remove cloned child channel
-    Given I am on the manage software channels page
-    When I follow "Clone of Test-Channel-x86_64 Child Channel"
+    When I follow the left menu "Software > Manage > Channels"
+    And I follow "Clone of Test-Channel-x86_64 Child Channel"
     And I follow "Delete software channel"
     And I check "unsubscribeSystems"
     And I click on "Delete Channel"
@@ -78,8 +78,8 @@ Feature: Delete channels with child or clone is not allowed
     And I should see a "has been deleted." text
 
   Scenario: Cleanup: remove cloned parent channel
-    Given I am on the manage software channels page
-    When I follow "Clone of Test-Channel-x86_64"
+    When I follow the left menu "Software > Manage > Channels"
+    And I follow "Clone of Test-Channel-x86_64"
     And I follow "Delete software channel"
     And I check "unsubscribeSystems"
     And I click on "Delete Channel"

--- a/testsuite/features/secondary/srv_delete_channel_with_tool.feature
+++ b/testsuite/features/secondary/srv_delete_channel_with_tool.feature
@@ -10,8 +10,8 @@ Feature: Deleting channels with children or clones is not allowed
     Given I am authorized for the "Admin" section
 
   Scenario: Clone the first channel before deletion from tool test
-    Given I am on the manage software channels page
-    When I follow "Clone Channel"
+    When I follow the left menu "Software > Manage > Channels"
+    And I follow "Clone Channel"
     And I select "Test-Channel-x86_64" as the origin channel
     And I click on "Clone Channel"
     Then I should see a "Create Software Channel" text
@@ -20,8 +20,8 @@ Feature: Deleting channels with children or clones is not allowed
     Then I should see a "Clone of Test-Channel-x86_64" text
 
   Scenario: Clone a second channel using first channel as base
-    Given I am on the manage software channels page
-    When I follow "Clone Channel"
+    When I follow the left menu "Software > Manage > Channels"
+    And I follow "Clone Channel"
     And I select "Clone of Test-Channel-x86_64" as the origin channel
     And I click on "Clone Channel"
     Then I should see a "Create Software Channel" text

--- a/testsuite/features/secondary/srv_distro_cobbler.feature
+++ b/testsuite/features/secondary/srv_distro_cobbler.feature
@@ -59,11 +59,6 @@ Feature: Cobbler and distribution autoinstallation
     Then I should see a "Autoinstallation: fedora_kickstart_profile" text
     And I should see a "Autoinstallation Details" link
 
-  Scenario: Autoinstallation profiles page
-    When I am on the Create Autoinstallation Profile page
-    When I follow the left menu "Systems > Autoinstallation > Profiles"
-    Then I should see a "Distributions" text
-
   Scenario: Upload a profile via the UI
     When I follow the left menu "Systems > Autoinstallation > Profiles"
     And I follow "Upload Kickstart/Autoyast File"

--- a/testsuite/features/secondary/srv_menu.feature
+++ b/testsuite/features/secondary/srv_menu.feature
@@ -311,7 +311,7 @@ Feature: Web UI - Main landing page menu, texts and links
     And I should see a "No Custom Info Keys Found" text
 
   Scenario: Sidebar link destination for Systems => Autoinstallation
-    When I am on Autoinstallation Overview page
+    When I follow the left menu "Systems > Autoinstallation > Overview"
     Then I should see a "Autoinstallation Overview" text
     And I should see a "Profiles" link in the left menu
     And I should see a "Unprovisioned" link in the left menu

--- a/testsuite/features/secondary/srv_patches_page.feature
+++ b/testsuite/features/secondary/srv_patches_page.feature
@@ -11,7 +11,7 @@ Feature: Patches page
     Given I am authorized for the "Admin" section
 
   Scenario: Patches left menu
-    Given I am on the patches page
+    When I follow the left menu "Patches > Patch List > Relevant"
     Then I should see a "Patches Relevant to Your Systems" text
     And I should see a "Relevant" link in the left menu
     And I should see a "All" link in the left menu

--- a/testsuite/features/secondary/srv_power_management.feature
+++ b/testsuite/features/secondary/srv_power_management.feature
@@ -50,8 +50,8 @@ Feature: IPMI Power management
     Then I should see the power is "On"
 
   Scenario: Check power management SSM configuration
-    And I am on the System Overview page
-    When I follow "Clear"
+    When I follow the left menu "Home > Overview"
+    And I follow "Clear"
     And I check the "sle_client" client
     And I am on System Set Manager Overview
     And I follow "Configure power management" in the content area

--- a/testsuite/features/secondary/srv_power_management_redfish.feature
+++ b/testsuite/features/secondary/srv_power_management_redfish.feature
@@ -46,8 +46,8 @@ Feature: Redfish Power management
     Then I should see the power is "On"
 
   Scenario: Check power management SSM configuration for Redfish
-    And I am on the System Overview page
-    When I follow "Clear"
+    When I follow the left menu "Home > Overview"
+    And I follow "Clear"
     And I check the "sle_minion" client
     And I am on System Set Manager Overview
     And I follow "Configure power management" in the content area

--- a/testsuite/features/secondary/srv_test_maintenance_windows.feature
+++ b/testsuite/features/secondary/srv_test_maintenance_windows.feature
@@ -62,7 +62,7 @@ Feature: Maintenance Windows
         Then I should see a "System properties changed" text
 
     Scenario: Assign systems to a multi Schedule using SSM
-        When I am on the System Overview page
+        When I follow the left menu "Home > Overview"
         And I follow "Clear"
         And I check the "sle_client" client
         And I am on System Set Manager Overview
@@ -100,7 +100,7 @@ Feature: Maintenance Windows
         Then I should see a "1 package install has been scheduled for" text
 
     Scenario: Detach systems from Schedules
-        When I am on the System Overview page
+        When I follow the left menu "Home > Overview"
         And I follow "Clear"
         And I check the "sle_client" client
         And I check the "sle_minion" client

--- a/testsuite/features/secondary/trad_centos_client.feature
+++ b/testsuite/features/secondary/trad_centos_client.feature
@@ -114,7 +114,7 @@ Feature: Be able to register a CentOS 7 traditional client and do some basic ope
     And I select the hostname of "proxy" from "proxies"
     And I click on "Bootstrap"
     And I wait until I see "Successfully bootstrapped host!" text
-    And I am on the System Overview page
+    And I follow the left menu "Home > Overview"
     And I wait until I see the name of "ceos_minion", refreshing the page
     And I wait until onboarding is completed for "ceos_minion"
 

--- a/testsuite/features/secondary/trad_check_patches_install.feature
+++ b/testsuite/features/secondary/trad_check_patches_install.feature
@@ -27,7 +27,7 @@ Feature: Display patches
     And I should see a "virgo-dummy-3456" link
 
   Scenario: Check SLES release 6789 patches
-    Given I am on the patches page
+    When I follow the left menu "Patches > Patch List > Relevant"
     And I follow "andromeda-dummy-6789"
     Then I should see a "andromeda-dummy-6789 - Bug Fix Advisory" text
     And I should see a "Test update for andromeda-dummy" text
@@ -36,7 +36,7 @@ Feature: Display patches
     And I should see a "reboot_suggested" text
 
   Scenario: Check packages of SLES release 6789 patches
-    Given I am on the patches page
+    When I follow the left menu "Patches > Patch List > Relevant"
     And I follow "andromeda-dummy-6789"
     And I follow "Packages"
     Then I should see a "Test-Channel-x86_64" link

--- a/testsuite/features/secondary/trad_cve_audit.feature
+++ b/testsuite/features/secondary/trad_cve_audit.feature
@@ -69,7 +69,7 @@ Feature: CVE Audit on traditional clients
     Then I should see a "Affected, at least one patch available in an assigned channel" text
     When I check the "sle_client" client
     Then I should see a "system selected" text
-    When I am on the System Manager System Overview page
+    When I follow the left menu "Systems > Overview"
     Then I should see "sle_client" as link
     And I follow "Clear"
 

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -168,10 +168,6 @@ When(/^I select "(.*?)" as the origin channel$/) do |label|
   step %(I select "#{label}" from "original_id")
 end
 
-When(/^I navigate to "([^"]*)" page$/) do |page|
-  visit("https://#{$server.full_hostname}/#{page}")
-end
-
 # systemspage and clobber
 Given(/^I am on the Systems page$/) do
   steps %(
@@ -255,10 +251,6 @@ When(/^I attach the file "(.*)" to "(.*)"$/) do |path, field|
   attach_file(field, canonical_path)
 end
 
-When(/^I view system with id "([^"]*)"$/) do |arg1|
-  visit Capybara.app_host + '/rhn/systems/details/Overview.do?sid=' + arg1
-end
-
 When(/^I refresh the metadata for "([^"]*)"$/) do |host|
   node = get_target(host)
   _os_version, os_family = get_os_version(node)
@@ -335,10 +327,6 @@ end
 # package steps
 Then(/^I should see package "([^"]*)"$/) do |package|
   step %(I should see a "#{package}" text)
-end
-
-Given(/^I am on the manage software channels page$/) do
-  visit("https://#{$server.full_hostname}/rhn/channels/manage/Manage.do")
 end
 
 Given(/^metadata generation finished for "([^"]*)"$/) do |channel|

--- a/testsuite/features/step_definitions/docker_steps.rb
+++ b/testsuite/features/step_definitions/docker_steps.rb
@@ -31,7 +31,8 @@ Then(/^I wait until the image build "([^"]*)" is completed$/) do |image_name|
 end
 
 Then(/^I am on the image store of the kiwi image for organization "([^"]*)"$/) do |org|
-  step %(I navigate to "os-images/#{org}/" page)
+  # It doesn't exist any navigation step to access this URL, so we must use a visit call (https://github.com/SUSE/spacewalk/issues/15256)
+  visit("https://#{$server.full_hostname}/os-images/#{org}/")
 end
 
 Then(/^I should see the name of the image$/) do

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -537,10 +537,6 @@ Then(/^I am logged in$/) do
   raise 'The welcome message is not shown' unless has_content?(text)
 end
 
-Given(/^I am on the patches page$/) do
-  visit("https://#{$server.full_hostname}/rhn/errata/RelevantErrata.do")
-end
-
 Then(/^I should see an update in the list$/) do
   xpath_query = '//div[@class="table-responsive"]/table/tbody/tr/td/a'
   raise "xpath: #{xpath_query} not found" unless all(:xpath, xpath_query).any?
@@ -552,26 +548,6 @@ end
 
 When(/^I check "([^"]*)" patch$/) do |arg1|
   step %(I check "#{arg1}" in the list)
-end
-
-When(/^I am on System Set Manager Overview$/) do
-  visit("https://#{$server.full_hostname}/rhn/ssm/index.do")
-end
-
-When(/^I am on Autoinstallation Overview page$/) do
-  visit("https://#{$server.full_hostname}/rhn/kickstart/KickstartOverview.do")
-end
-
-When(/^I am on the System Manager System Overview page$/) do
-  visit("https://#{$server.full_hostname}/rhn/systems/ssm/ListSystems.do")
-end
-
-When(/^I am on the Create Autoinstallation Profile page$/) do
-  visit("https://#{$server.full_hostname}/rhn/kickstart/AdvancedModeCreate.do")
-end
-
-When(/^I am on the System Overview page$/) do
-  visit("https://#{$server.full_hostname}/rhn/systems/Overview.do")
 end
 
 Then(/^I should see something$/) do


### PR DESCRIPTION
## What does this PR change?

Refactor Capybara visit method calls, so we use navigation steps if possible.

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage

- Cucumber tests were added

- [x] **DONE**

## Links

Ports:
- Manager-4.1 https://github.com/SUSE/spacewalk/pull/15263

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
