### PR TITLE
Reintroduce "Makefile" for backend server unit tests

### DIFF
--- a/backend/server/test/unit-test/Makefile
+++ b/backend/server/test/unit-test/Makefile
@@ -1,0 +1,8 @@
+TESTS       = \
+        test_rhnLib_timestamp.py
+
+all:	$(addprefix test-,$(TESTS))
+
+test-%:
+	@echo Running $*
+	PYTHONPATH=$(PYTHONPATH):../../../ $(PYTHON_BIN) $*


### PR DESCRIPTION
## What does this PR change?

This PR is re-introducing the `Makefile` for `backend/server/tests/unit-tests/` (droped in https://github.com/uyuni-project/uyuni/pull/3830) in order to have those tests running and prevent the issue that we're currently facing when building "spacewalk-backend" package:

```console
[  291s] make -C server/test/unit-test PYTHON_BIN=python3
[  291s] make[1]: Entering directory '/home/abuild/rpmbuild/BUILD/spacewalk-backend-git-83.877b53f/server/test/unit-test'
[  291s] make[1]: *** No targets specified and no makefile found.  Stop.
[  291s] make[1]: Leaving directory '/home/abuild/rpmbuild/BUILD/spacewalk-backend-git-83.877b53f/server/test/unit-test'
[  291s] make: *** [Makefile.backend:40: test] Error 2
[  291s] error: Bad exit status from /var/tmp/rpm-tmp.Hdt6kU (%check)
```

I've removed parts of the `Makefile` so now it only contains the parts that are needed in order to avoid the problems we have while building the package.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
