### PR TITLE
Testsuite - dhcp workaround fix

### DIFF
--- a/testsuite/features/core/proxy_branch_network.feature
+++ b/testsuite/features/core/proxy_branch_network.feature
@@ -15,10 +15,10 @@ Feature: Setup SUSE Manager for Retail branch network
 
 @proxy
 @private_net
-  # WORKAROUND
   Scenario: Remove dhcp packages on the proxy
+    # WORKAROUND
     When I remove package "dhcp dhcp-client" from this "proxy"
-  # End of WORKAROUND
+    # End of WORKAROUND
 
 @proxy
 @private_net


### PR DESCRIPTION
## What does this PR change?

Fix of typo in #3918

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
