### PR TITLE
Add some delay after SP migration before scheduling package refresh action (bsc#1187963)

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
+++ b/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
@@ -1145,8 +1145,8 @@ public class ActionManager extends BaseManager {
      */
     public static PackageAction schedulePackageRefresh(Org schedulerOrg, Server server)
             throws TaskomaticApiException {
-	Date earliest = new Date();
-	return schedulePackageRefresh(schedulerOrg, server, earliest);
+        Date earliest = new Date();
+        return schedulePackageRefresh(schedulerOrg, server, earliest);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
+++ b/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
@@ -1144,7 +1144,23 @@ public class ActionManager extends BaseManager {
      * (typically: Taskomatic is down)
      */
     public static PackageAction schedulePackageRefresh(Org schedulerOrg, Server server)
-        throws TaskomaticApiException {
+            throws TaskomaticApiException {
+	Date earliest = new Date();
+	return schedulePackageRefresh(schedulerOrg, server, earliest);
+    }
+
+    /**
+     * Schedule a package list refresh without a user.
+     *
+     * @param schedulerOrg the organization the server belongs to
+     * @param server the server
+     * @param earliest The earliest time this action should be run.
+     * @return the scheduled PackageRefreshListAction
+     * @throws TaskomaticApiException if there was a Taskomatic error
+     * (typically: Taskomatic is down)
+     */
+    public static PackageAction schedulePackageRefresh(Org schedulerOrg, Server server,
+            Date earliest) throws TaskomaticApiException {
         checkSaltOrManagementEntitlement(server.getId());
 
         Action action = ActionFactory.createAction(
@@ -1152,7 +1168,7 @@ public class ActionManager extends BaseManager {
         action.setName(ActionFactory.TYPE_PACKAGES_REFRESH_LIST.getName());
         action.setOrg(schedulerOrg);
         action.setSchedulerUser(null);
-        action.setEarliestAction(new Date());
+        action.setEarliestAction(earliest);
 
         ServerAction sa = new ServerAction();
         sa.setStatus(ActionFactory.STATUS_QUEUED);

--- a/java/code/src/com/suse/manager/reactor/messaging/JobReturnEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/JobReturnEventMessageAction.java
@@ -16,8 +16,10 @@ package com.suse.manager.reactor.messaging;
 
 import com.redhat.rhn.common.messaging.EventMessage;
 import com.redhat.rhn.common.messaging.MessageAction;
+import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionChain;
 import com.redhat.rhn.domain.action.ActionChainFactory;
+import com.redhat.rhn.domain.action.ActionFactory;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.MinionServerFactory;
 import com.redhat.rhn.domain.server.VirtualInstance;
@@ -43,6 +45,8 @@ import com.suse.utils.Json;
 import org.apache.log4j.Logger;
 
 import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Date;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -192,7 +196,16 @@ public class JobReturnEventMessageAction implements MessageAction {
 
         //For all jobs except when action chains are involved
         if (!isActionChainInvolved && handlePackageChanges(jobReturnEvent, function, jobResult)) {
-            schedulePackageRefresh(jobReturnEvent.getMinionId());
+        Date earliest = new Date();
+        if (actionId.isPresent()) {
+            Optional<Action> action = Optional.ofNullable(ActionFactory.lookupById(actionId.get()));
+                if (action.isPresent() && action.get().getActionType().equals(ActionFactory.TYPE_DIST_UPGRADE)) {
+                    Calendar calendar = Calendar.getInstance();
+                    calendar.add(Calendar.SECOND, 30);
+            earliest = calendar.getTime();
+                }
+        }
+            schedulePackageRefresh(jobReturnEvent.getMinionId(), earliest);
         }
 
         // Check if event was triggered in response to state scheduled at minion start-up event
@@ -261,9 +274,18 @@ public class JobReturnEventMessageAction implements MessageAction {
      * @param minionId ID of the minion for which package refresh should be scheduled
      */
     private void schedulePackageRefresh(String minionId) {
+        schedulePackageRefresh(minionId, new Date());
+    }
+
+    /**
+     * Schedule package refresh on the minion
+     * @param minionId ID of the minion for which package refresh should be scheduled
+     * @param earliest The earliest time this action should be run.
+     */
+    private void schedulePackageRefresh(String minionId, Date earliest) {
         MinionServerFactory.findByMinionId(minionId).ifPresent(minionServer -> {
             try {
-                ActionManager.schedulePackageRefresh(minionServer.getOrg(), minionServer);
+                ActionManager.schedulePackageRefresh(minionServer.getOrg(), minionServer, earliest);
             }
             catch (TaskomaticApiException e) {
                 LOG.error(e);

--- a/java/code/src/com/suse/manager/reactor/messaging/JobReturnEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/JobReturnEventMessageAction.java
@@ -196,15 +196,15 @@ public class JobReturnEventMessageAction implements MessageAction {
 
         //For all jobs except when action chains are involved
         if (!isActionChainInvolved && handlePackageChanges(jobReturnEvent, function, jobResult)) {
-        Date earliest = new Date();
-        if (actionId.isPresent()) {
-            Optional<Action> action = Optional.ofNullable(ActionFactory.lookupById(actionId.get()));
+            Date earliest = new Date();
+            if (actionId.isPresent()) {
+                Optional<Action> action = Optional.ofNullable(ActionFactory.lookupById(actionId.get()));
                 if (action.isPresent() && action.get().getActionType().equals(ActionFactory.TYPE_DIST_UPGRADE)) {
                     Calendar calendar = Calendar.getInstance();
                     calendar.add(Calendar.SECOND, 30);
-            earliest = calendar.getTime();
+                    earliest = calendar.getTime();
                 }
-        }
+            }
             schedulePackageRefresh(jobReturnEvent.getMinionId(), earliest);
         }
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- SP migration: wait some seconds before scheduling "package refresh" action after migration is completed (bsc#1187963)
 - cleanup and regenerate system state files when machine id has changed (bsc#1187660)
 - manually disable repositories on redhat like systems
 - Do not update Kickstart session when download after session is complete or failed (bsc#1187621)


### PR DESCRIPTION
## What does this PR change?

This PR adds a 30 seconds delay before triggering a "Package List Refresh" action after a SP migration action is performed on a minion.

The problem before this PR is that the "Package List Refresh" action is scheduled just after the Salt return event is received from the minion when the "distupgrade" state has been executed, and it's as this time when the "salt-minion" services is restarted after the Salt update done during the SP migration.

Therefore, there is a high probability that "Package List Refresh" action is triggered when the minion is not fully reloaded and then the action will be marked as "Failed" due minion is not reachable at the moment.

To workaround this situation, this PR simply schedule "Package Refresh List" action to be triggered 30 seconds in the future, so we give some time for the minion to be fully restarted and accepting jobs.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered in cucumber

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/15284

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
