### PR TITLE
Updated formatting to cloneByDate.py allow pylint pass.

### DIFF
--- a/utils/cloneByDate.py
+++ b/utils/cloneByDate.py
@@ -759,7 +759,7 @@ class ChannelCloner:
 
         # align modular metadata
         md_aligned = self.remote_api.align_modular_metadata(
-                self.from_label, self.to_label);
+            self.from_label, self.to_label)
         if md_aligned == 1:
             print("\nModular metadata aligned")
 
@@ -916,7 +916,7 @@ class RemoteApi:
 
     def align_modular_metadata(self, from_label, to_label):
         return self.client.channel.software.alignMetadata(
-                self.auth_token, from_label, to_label, 'modules')
+            self.auth_token, from_label, to_label, 'modules')
 
     def get_details(self, label):
         self.auth_check()

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,4 +1,5 @@
 - Bump version to 4.3.0
+- Updated cloneByDate.py formatting to allow pylint pass.
 
 -------------------------------------------------------------------
 Fri Jun 18 15:18:20 CEST 2021 - jgonzalez@suse.com


### PR DESCRIPTION
## What does this PR change?

Updated formatting to cloneByDate.py allow pylint pass.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: No functional changes.
- [X] **DONE**

## Test coverage
- No tests: already covered
- [X] **DONE**

## Links
- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
