### PR TITLE
Update sslToolConfig.py

### DIFF
--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,4 @@
+- Re-added Python 2 compatibility to sslToolConfig.py.
 - generate SSL private keys FIPS 140-2 compatible (bsc#1187593)
 
 -------------------------------------------------------------------

--- a/spacewalk/certs-tools/sslToolConfig.py
+++ b/spacewalk/certs-tools/sslToolConfig.py
@@ -473,8 +473,8 @@ def figureSerial(caCertFilename, serialFilename, indexFilename):
     outstream.close()
     sslerrmsg = ("non-zero exitcode.\n"
                 "If you ran configure-proxy.sh, try copying again the certs from the SUSE Manager Server\n"
-                f"exit-code: {ret}\n"
-                f"error: {sstr(errstream.read())}\n")
+                f"exit-code: {}\n"
+                f"error: {}\n".format(ret, sstr(errstream.read())) )
     errstream.close()
     assert not ret, sslerrmsg
     caSerial = out.strip().split('=')


### PR DESCRIPTION
Updated added lines to also build on Python 2

## What does this PR change?

Lines were added that only build on Python 3. This PR updates them to also build on Python 2

**NOTE/IMPORTANT**: Alternative to #3940 . Reject #3940 if this one is accepted.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: No functional changes.

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
