### PR TITLE
Removed Python 2 builds

### DIFF
--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,5 @@
+- Removed Python 2 build.
+- Updated source URL reference.
 - generate SSL private keys FIPS 140-2 compatible (bsc#1187593)
 
 -------------------------------------------------------------------

--- a/spacewalk/certs-tools/spacewalk-certs-tools.spec
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.spec
@@ -17,28 +17,20 @@
 #
 # needsbinariesforbuild
 
-
 # package renaming fun :(
 %define rhn_client_tools spacewalk-client-tools
 %define rhn_setup	 spacewalk-client-setup
 %define rhn_check	 spacewalk-check
 %define rhnsd		 mgr-daemon
-#
+
 %if 0%{?suse_version}
 %global pub_bootstrap_dir /srv/www/htdocs/pub/bootstrap
 %else
 %global pub_bootstrap_dir /var/www/html/pub/bootstrap
 %endif
 %global rhnroot %{_datadir}/rhn
+%global __python /usr/bin/python3
 
-%global __python /usr/bin/python2
-
-%if 0%{?fedora} || 0%{?suse_version} > 1320 || 0%{?rhel} >= 8
-%global build_py3   1
-%global default_py3 1
-%endif
-
-%define pythonX %{?default_py3: python3}%{!?default_py3: python2}
 
 Name:           spacewalk-certs-tools
 Summary:        Spacewalk SSL Key/Cert Tool
@@ -47,10 +39,10 @@ Group:          Applications/Internet
 Version:        4.3.0
 Release:        0
 URL:            https://github.com/uyuni-project/uyuni
-Source0:        https://github.com/spacewalkproject/spacewalk/archive/%{name}-%{version}.tar.gz
+Source0:        https://github.com/uyuni-project/uyuni/archive/%{name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
-Requires(pre):  %{pythonX}-%{name} = %{version}-%{release}
+Requires(pre):  python3-%{name} = %{version}-%{release}
 Requires:       %{rhn_client_tools}
 Requires:       openssl
 Requires:       rpm-build
@@ -62,15 +54,9 @@ BuildRequires:  docbook-utils
 BuildRequires:  filesystem
 Requires:       susemanager-build-keys-web
 %endif
-%if 0%{?build_py3}
 Requires(post): python3-uyuni-common-libs
 Requires(post): python3-rhnlib
 Requires(post): python3-rpm
-%else
-Requires(post): python2-uyuni-common-libs
-Requires(post): rhnlib
-Requires(post): rpm-python
-%endif
 
 Obsoletes:      rhns-certs < 5.3.0
 Obsoletes:      rhns-certs-tools < 5.3.0
@@ -82,22 +68,6 @@ Provides:       rhns-certs-tools = 5.3.0
 This package contains tools to generate the SSL certificates required by
 Spacewalk.
 
-%package -n python2-%{name}
-Summary:        Spacewalk SSL Key/Cert Tool
-Group:          Applications/Internet
-Requires:       %{name} = %{version}-%{release}
-Requires:       python2-rhn-client-tools
-Requires:       python2-uyuni-common-libs
-%if 0%{?suse_version} || 0%{?rhel}
-BuildRequires:  python2
-%else
-BuildRequires:  python
-%endif
-
-%description -n python2-%{name}
-Python 2 specific files for %{name}.
-
-%if 0%{?build_py3}
 %package -n python3-%{name}
 Summary:        Spacewalk SSL Key/Cert Tool
 Group:          Applications/Internet
@@ -110,7 +80,6 @@ BuildRequires:  python3-rpm-macros
 
 %description -n python3-%{name}
 Python 3 specific files for %{name}.
-%endif
 
 %prep
 %setup -q
@@ -128,20 +97,11 @@ sed -i 's|etc/httpd/conf|etc/apache2|g' ssl-howto.txt
 
 %install
 install -d -m 755 $RPM_BUILD_ROOT/%{rhnroot}/certs
-make -f Makefile.certs install PREFIX=$RPM_BUILD_ROOT ROOT=%{rhnroot} \
-    PYTHONPATH=%{python_sitelib} PYTHONVERSION=%{python_version} \
-    MANDIR=%{_mandir} PUB_BOOTSTRAP_DIR=%{pub_bootstrap_dir}
-%if 0%{?rhel}>=8 || 0%{?fedora}
-sed -i '1s|python\b|python2|' $RPM_BUILD_ROOT/%{_bindir}/rhn-ssl-tool-%{python_version} $RPM_BUILD_ROOT/%{_bindir}/rhn-bootstrap-%{python_version}
-%endif
 
-%if 0%{?build_py3}
 sed -i '1s|python\b|python3|' rhn-ssl-tool mgr-package-rpm-certificate-osimage rhn-bootstrap client_config_update.py
-sed -i '1s|python\b|python3|' $RPM_BUILD_ROOT%{pub_bootstrap_dir}/client_config_update.py
 make -f Makefile.certs install PREFIX=$RPM_BUILD_ROOT ROOT=%{rhnroot} \
     PYTHONPATH=%{python3_sitelib} PYTHONVERSION=%{python3_version} \
     MANDIR=%{_mandir} PUB_BOOTSTRAP_DIR=%{pub_bootstrap_dir}
-%endif
 
 %define default_suffix %{?default_py3:-%{python3_version}}%{!?default_py3:-%{python_version}}
 ln -s rhn-ssl-tool%{default_suffix} $RPM_BUILD_ROOT%{_bindir}/rhn-ssl-tool
@@ -156,10 +116,7 @@ ln -s rhn-sudo-ssl-tool $RPM_BUILD_ROOT/%{_bindir}/mgr-sudo-ssl-tool
 ln -s spacewalk-push-register $RPM_BUILD_ROOT/%{_sbindir}/mgr-push-register
 ln -s spacewalk-ssh-push-init $RPM_BUILD_ROOT/%{_sbindir}/mgr-ssh-push-init
 
-%py_compile -O %{buildroot}/%{python_sitelib}
-%if 0%{?build_py3}
 %py3_compile -O %{buildroot}/%{python3_sitelib}
-%endif
 %endif
 
 %post
@@ -199,16 +156,9 @@ esac
 %{_sbindir}/mgr-ssh-push-init
 %endif
 
-%files -n python2-%{name}
-%{python_sitelib}/certs
-%attr(755,root,root) %{_bindir}/rhn-ssl-tool-%{python_version}
-%attr(755,root,root) %{_bindir}/rhn-bootstrap-%{python_version}
-
-%if 0%{?build_py3}
 %files -n python3-%{name}
 %{python3_sitelib}/certs
 %attr(755,root,root) %{_bindir}/rhn-ssl-tool-%{python3_version}
 %attr(755,root,root) %{_bindir}/rhn-bootstrap-%{python3_version}
-%endif
 
 %changelog


### PR DESCRIPTION
## What does this PR change?

Removed Python 2 build/Only build for Python 3. Otherwise build fails due to Python3 only code.

**NOTE/IMPORTANT**: Alternative to #3939 . Reject #3939 if this one is accepted.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: No functional changes

- [X] **DONE**

## Test coverage
- No tests: already covered
Tested build successfully on COPR for
epel-8-x86_64
fedora-33-x86_64
opensuse-leap-15.3-x86_64

- [X] **DONE**

## Links
- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
