### PR TITLE
Fix var name to be clearer

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -306,14 +306,14 @@ end
 #
 # This function is written as a state machine. It bails out if no process is seen during
 # 30 seconds in a row, or if the whitelisted reposyncs last more than 7200 seconds in a row.
-# 7200 is the default value but it can be shortened by setting the type_environment
+# 7200 is the default value but it can be shortened by setting the tests_type
 # environment variable.
 When(/^I kill all running spacewalk\-repo\-sync, excepted the ones needed to bootstrap$/) do
   do_not_kill = compute_list_to_leave_running
   reposync_not_running_streak = 0
   reposync_left_running_streak = 0
   reposync_timeout = 7200
-  reposync_timeout = 600 if $type_environment && $type_environment == 'PULL_REQUEST_TESTING'
+  reposync_timeout = 600 if $tests_type && $tests_type == 'PULL_REQUEST_TESTING'
   while reposync_not_running_streak <= 30 && reposync_left_running_streak <= reposync_timeout
     command_output, _code = $server.run('ps axo pid,cmd | grep spacewalk-repo-sync | grep -v grep', false)
     if command_output.empty?
@@ -356,7 +356,7 @@ end
 When(/^I wait until the channel "([^"]*)" has been synced$/) do |channel|
   begin
     reposync_timeout = 7200
-    reposync_timeout = 600 if $type_environment && $type_environment='PULL_REQUEST_TESTING'
+    reposync_timeout = 600 if $tests_type && $tests_type='PULL_REQUEST_TESTING'
     repeat_until_timeout(timeout: reposync_timeout, message: 'Channel not fully synced') do
       _result, code = $server.run("test -f /var/cache/rhn/repodata/#{channel}/repomd.xml", false)
       break if code.zero?

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -17,7 +17,7 @@ require 'multi_test'
 # SimpleCov.start
 
 server = ENV['SERVER']
-$type_environment = ENV['TYPE_ENVIRONMENT']
+$tests_type = ENV['TESTS_TYPE']
 $debug_mode = true if ENV['DEBUG']
 $long_tests_enabled = true if ENV['LONG_TESTS'] == 'true'
 puts "Executing long running tests" if $long_tests_enabled


### PR DESCRIPTION
type_environments was too fuzzy plus wrong (should've been
environments_type )

Signed-off-by: Jordi Massaguer Pla <jmassaguerpla@suse.de>

## What does this PR change?

**add description**

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
