### PR TITLE
Added pidof requirement for RHEL (bsc#1186129)

### DIFF
--- a/spacewalk/admin/spacewalk-admin.changes
+++ b/spacewalk/admin/spacewalk-admin.changes
@@ -1,3 +1,4 @@
+- added pidof requirement for RHEL (bsc#1186129).
 - Bump version to 4.3.0
 
 -------------------------------------------------------------------

--- a/spacewalk/admin/spacewalk-admin.spec
+++ b/spacewalk/admin/spacewalk-admin.spec
@@ -36,7 +36,11 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 Requires:       %{pythonX}
 Requires:       lsof
 Requires:       spacewalk-base
+%if 0%{?suse_version}
 Requires:       sysvinit-tools
+%else
+Requires:       procps-ng
+%endif
 Requires:       perl(MIME::Base64)
 BuildRequires:  /usr/bin/pod2man
 %if 0%{?rhel} >= 7 || 0%{?fedora} || 0%{?suse_version} >= 1210


### PR DESCRIPTION
## What does this PR change?

Use package procps-ng for RHEL. sysvinit-tools is not available.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

Build tested successfully on
epel-7-x86_64 
epel-8-x86_64
opensuse-leap-15.3-x86_64

- [X] **DONE**

## Links

Fixes #
bsc#1186129

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
