### PR TITLE
Move client scenario to right feature

### DIFF
--- a/testsuite/features/finishing/allcli_debug.feature
+++ b/testsuite/features/finishing/allcli_debug.feature
@@ -6,6 +6,6 @@ Feature: Debug the clients after the testsuite has run
   Scenario: Extract the logs from all our clients
     When I extract the log files from all our active nodes
 
-@client
+@sle_client
   Scenario: Check spacewalk upd2date logs on client
     When the up2date logs on client should contain no Traceback error

--- a/testsuite/features/finishing/allcli_debug.feature
+++ b/testsuite/features/finishing/allcli_debug.feature
@@ -5,3 +5,7 @@ Feature: Debug the clients after the testsuite has run
 
   Scenario: Extract the logs from all our clients
     When I extract the log files from all our active nodes
+
+@client
+  Scenario: Check spacewalk upd2date logs on client
+    When the up2date logs on client should contain no Traceback error

--- a/testsuite/features/finishing/srv_debug.feature
+++ b/testsuite/features/finishing/srv_debug.feature
@@ -6,9 +6,6 @@ Feature: Debug the server after the testsuite has run
   Scenario: Call spacewalk-debug on server
     When I execute spacewalk-debug on the server
 
-  Scenario: Check spacewalk upd2date logs on client
-    Then the up2date logs on client should contain no Traceback error
-
   Scenario: Check the tomcat logs on server
     Then the tomcat logs should not contain errors
 


### PR DESCRIPTION
## What does this PR change?

Move client scenario to right feature, it should not run on server debug when it's for all client debug.

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes no issue, directly from BV review
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
