### PR TITLE
Revert acceptance tests pr optimization scc

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -306,15 +306,11 @@ end
 #
 # This function is written as a state machine. It bails out if no process is seen during
 # 30 seconds in a row, or if the whitelisted reposyncs last more than 7200 seconds in a row.
-# 7200 is the default value but it can be shortened by setting the TEST_REPOSYNC_TIMEOUT
-# environment variable.
 When(/^I kill all running spacewalk\-repo\-sync, excepted the ones needed to bootstrap$/) do
   do_not_kill = compute_list_to_leave_running
   reposync_not_running_streak = 0
   reposync_left_running_streak = 0
-  reposync_timeout = 7200
-  reposync_timeout = 600 if $type_environment && $type_environment == 'PULL_REQUEST_TESTING'
-  while reposync_not_running_streak <= 30 && reposync_left_running_streak <= reposync_timeout
+  while reposync_not_running_streak <= 30 && reposync_left_running_streak <= 7200
     command_output, _code = $server.run('ps axo pid,cmd | grep spacewalk-repo-sync | grep -v grep', false)
     if command_output.empty?
       reposync_not_running_streak += 1
@@ -355,9 +351,7 @@ end
 
 When(/^I wait until the channel "([^"]*)" has been synced$/) do |channel|
   begin
-    reposync_timeout = 7200
-    reposync_timeout = 600 if $type_environment && $type_environment='PULL_REQUEST_TESTING'
-    repeat_until_timeout(timeout: reposync_timeout, message: 'Channel not fully synced') do
+    repeat_until_timeout(timeout: 7200, message: 'Channel not fully synced') do
       _result, code = $server.run("test -f /var/cache/rhn/repodata/#{channel}/repomd.xml", false)
       break if code.zero?
       sleep 10

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -306,7 +306,7 @@ end
 #
 # This function is written as a state machine. It bails out if no process is seen during
 # 30 seconds in a row, or if the whitelisted reposyncs last more than 7200 seconds in a row.
-# 7200 is the default value but it can be shortened by setting the type_environment
+# 7200 is the default value but it can be shortened by setting the TEST_REPOSYNC_TIMEOUT
 # environment variable.
 When(/^I kill all running spacewalk\-repo\-sync, excepted the ones needed to bootstrap$/) do
   do_not_kill = compute_list_to_leave_running

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -17,7 +17,6 @@ require 'multi_test'
 # SimpleCov.start
 
 server = ENV['SERVER']
-$type_environment = ENV['TYPE_ENVIRONMENT']
 $debug_mode = true if ENV['DEBUG']
 $long_tests_enabled = true if ENV['LONG_TESTS'] == 'true'
 puts "Executing long running tests" if $long_tests_enabled


### PR DESCRIPTION
## What does this PR change?

see https://github.com/uyuni-project/uyuni/pull/3931#issuecomment-874119905

## GUI diff

No difference.


- [X] **DONE**

## Documentation
- No documentation needed

- [X] **DONE**

## Test coverage
- No tests

- [X] **DONE**

## Links

no links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
