### PR TITLE
Speed up adding products via Web UI (bsc#1187727)

### DIFF
--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Speed up adding products via Web UI (bsc#1187727)
 - cleanup and regenerate system state files when machine id has changed (bsc#1187660)
 - manually disable repositories on redhat like systems
 - Do not update Kickstart session when download after session is complete or failed (bsc#1187621)


### PR DESCRIPTION
## What does this PR change?

Adding multiple products via the product wizard was too slow and lead to http timeout (10 minutes).

Products are added in a sequence and each step took approximately one second longer than the previous one, making the complexity `O(n^2)` (n = number of added products), which made it impossible to add more than ~35 products. This was caused by flushing hibernate cache, that grew with each step.

Solved by executing part of the code without auto flushing. Now adding a product takes approximately 3 seconds and this number doesn't grow with the number of products added (`O(n)`). Roughly said, the 10-minute timeout now allows adding ~200 products with a single UI action.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
bugfix

- [x] **DONE**

## Test coverage
- No tests: only affects performance

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/15245

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
