### PR TITLE
Rollback incorrect data-tree fix

### DIFF
--- a/web/html/src/manager/visualization/data-tree.ts
+++ b/web/html/src/manager/visualization/data-tree.ts
@@ -172,6 +172,17 @@ function updateDetailBox(d) {
     .attr("colspan", 2)
     .text(data.name);
 
+  if (Utils.isSystemType(d)) {
+    table
+      .append("tr")
+      .append("td")
+      .attr("colspan", 2)
+      .append("a")
+      .attr("href", "/rhn/systems/details/Overview.do?sid=" + data.rawId)
+      .attr("target", "_blank")
+      .html('<i class="fa fa-link"></i>System details page');
+  }
+
   const typeRow = table.append("tr");
   typeRow.append("td").text("Type");
   typeRow


### PR DESCRIPTION
## What does this PR change?

Roll back an incorrect fix I made in https://github.com/uyuni-project/uyuni/pull/3839

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
