### PR TITLE
Clean up network request parameters

### DIFF
--- a/web/html/src/components/FormulaForm.tsx
+++ b/web/html/src/components/FormulaForm.tsx
@@ -166,7 +166,7 @@ class FormulaForm extends React.Component<Props, State> {
         content: data.values,
       };
 
-      Network.post(this.props.saveUrl, JSON.stringify(formData)).then(
+      Network.post(this.props.saveUrl, formData).then(
         function(this: FormulaForm, data) {
           if (data instanceof Array) {
             this.setState({ messages: data.map(msg => this.getMessageText(msg)), errors: [] });

--- a/web/html/src/components/FormulaForm.tsx
+++ b/web/html/src/components/FormulaForm.tsx
@@ -97,7 +97,7 @@ class FormulaForm extends React.Component<Props, State> {
     if (this.props.getDataPromise) {
       dataPromise = this.props.getDataPromise();
     } else {
-      dataPromise = Network.get(this.props.dataUrl).promise;
+      dataPromise = Network.get(this.props.dataUrl);
     }
 
     dataPromise.then(data => {
@@ -166,7 +166,7 @@ class FormulaForm extends React.Component<Props, State> {
         content: data.values,
       };
 
-      Network.post(this.props.saveUrl, JSON.stringify(formData), "application/json").promise.then(
+      Network.post(this.props.saveUrl, JSON.stringify(formData)).then(
         function(this: FormulaForm, data) {
           if (data instanceof Array) {
             this.setState({ messages: data.map(msg => this.getMessageText(msg)), errors: [] });

--- a/web/html/src/components/action-schedule.tsx
+++ b/web/html/src/components/action-schedule.tsx
@@ -78,8 +78,7 @@ class ActionSchedule extends React.Component<ActionScheduleProps, ActionSchedule
         systemIds: this.state.systemIds,
         actionType: this.state.actionType,
       });
-      Network.post("/rhn/manager/api/maintenance/upcoming-windows", postData, "application/json")
-        .promise.then(data => {
+      Network.post("/rhn/manager/api/maintenance/upcoming-windows", postData).then(data => {
           const multiMaintWindows = data.data.maintenanceWindowsMultiSchedules;
           const maintenanceWindows = data.data.maintenanceWindows;
 

--- a/web/html/src/components/action-schedule.tsx
+++ b/web/html/src/components/action-schedule.tsx
@@ -74,10 +74,10 @@ class ActionSchedule extends React.Component<ActionScheduleProps, ActionSchedule
 
   UNSAFE_componentWillMount = () => {
     if (this.state.systemIds && this.state.actionType) {
-      const postData = JSON.stringify({
+      const postData = {
         systemIds: this.state.systemIds,
         actionType: this.state.actionType,
-      });
+      };
       Network.post("/rhn/manager/api/maintenance/upcoming-windows", postData).then(data => {
           const multiMaintWindows = data.data.maintenanceWindowsMultiSchedules;
           const maintenanceWindows = data.data.maintenanceWindows;

--- a/web/html/src/components/config-channels.tsx
+++ b/web/html/src/components/config-channels.tsx
@@ -72,7 +72,7 @@ class ConfigChannels extends React.Component<ConfigChannelsProps, ConfigChannels
   }
 
   init() {
-    Network.get(this.props.matchUrl()).promise.then(data => {
+    Network.get(this.props.matchUrl()).then(data => {
       this.setState({
         channels: data,
         search: {
@@ -102,7 +102,7 @@ class ConfigChannels extends React.Component<ConfigChannelsProps, ConfigChannels
 
   save() {
     const channels = this.state.assigned;
-    const request = this.props.saveRequest(channels).promise.then(
+    const request = this.props.saveRequest(channels).then(
       (data, textStatus, jqXHR) => {
         const newSearchResults = this.state.search.results.map(channel => {
           const changed = this.state.changed.get(channelKey(channel));
@@ -143,7 +143,7 @@ class ConfigChannels extends React.Component<ConfigChannelsProps, ConfigChannels
   search() {
     return Promise.resolve().then( () => {
       if (this.state.filter !== this.state.search.filter) {
-        Network.get(this.props.matchUrl(this.state.filter)).promise.then(data => {
+        Network.get(this.props.matchUrl(this.state.filter)).then(data => {
           this.setState({
             search: {
               filter: this.state.filter,
@@ -249,7 +249,7 @@ class ConfigChannels extends React.Component<ConfigChannelsProps, ConfigChannels
   }
 
   showPopUp(channel) {
-    Network.get("/rhn/manager/api/states/" + channel.id + "/content").promise.then(data => {
+    Network.get("/rhn/manager/api/states/" + channel.id + "/content").then(data => {
       this.setState({
         showSaltState: Object.assign({}, channel, { content: data }),
       });

--- a/web/html/src/components/formula-selection.tsx
+++ b/web/html/src/components/formula-selection.tsx
@@ -55,7 +55,7 @@ class FormulaSelection extends React.Component<Props, State> {
   }
 
   init() {
-    Network.get(this.props.dataUrl).promise.then(data => {
+    Network.get(this.props.dataUrl).then(data => {
       const groupDict = { groupless: [] };
       const formulaDict: any = {};
       data.formulas.forEach(function(e) {

--- a/web/html/src/core/channels/api/use-channels-tree-api.ts
+++ b/web/html/src/core/channels/api/use-channels-tree-api.ts
@@ -48,7 +48,7 @@ const useChannelsTreeApi = (): UseChannelsType => {
   const [isChannelsTreeLoaded, setIsChannelsTreeLoaded] = useState(false);
 
   const fetchChannelsTree = (): Promise<ChannelsTreeType> => {
-    return Network.get(`/rhn/manager/api/channels?filterClm=true`).promise.then(data => {
+    return Network.get(`/rhn/manager/api/channels?filterClm=true`).then(data => {
       const channelsTree = flattenChannelsTree(data.data);
       setChannelsTree(channelsTree);
       setIsChannelsTreeLoaded(true);

--- a/web/html/src/core/channels/api/use-mandatory-channels-api.ts
+++ b/web/html/src/core/channels/api/use-mandatory-channels-api.ts
@@ -48,12 +48,8 @@ const useMandatoryChannelsApi = (): UseMandatoryChannelsApiReturnType => {
 
     const mandatoryChannelsNotCached = needDepsInfoChannels.filter(channelId => !mandatoryChannelsRaw[channelId]);
     if (mandatoryChannelsNotCached.length > 0) {
-      Network.post(
-        "/rhn/manager/api/admin/mandatoryChannels",
-        JSON.stringify(mandatoryChannelsNotCached),
-        "application/json"
-      )
-        .promise.then((data: JsonResult<Map<number, Array<number>>>) => {
+      Network.post("/rhn/manager/api/admin/mandatoryChannels", JSON.stringify(mandatoryChannelsNotCached))
+        .then((data: JsonResult<Map<number, Array<number>>>) => {
           const allTheNewMandatoryChannelsData = Object.assign({}, mandatoryChannelsRaw, data.data);
           let dependencies: ChannelsDependencies = processChannelDependencies(allTheNewMandatoryChannelsData);
 

--- a/web/html/src/core/channels/api/use-mandatory-channels-api.ts
+++ b/web/html/src/core/channels/api/use-mandatory-channels-api.ts
@@ -48,7 +48,7 @@ const useMandatoryChannelsApi = (): UseMandatoryChannelsApiReturnType => {
 
     const mandatoryChannelsNotCached = needDepsInfoChannels.filter(channelId => !mandatoryChannelsRaw[channelId]);
     if (mandatoryChannelsNotCached.length > 0) {
-      Network.post("/rhn/manager/api/admin/mandatoryChannels", JSON.stringify(mandatoryChannelsNotCached))
+      Network.post("/rhn/manager/api/admin/mandatoryChannels", mandatoryChannelsNotCached)
         .then((data: JsonResult<Map<number, Array<number>>>) => {
           const allTheNewMandatoryChannelsData = Object.assign({}, mandatoryChannelsRaw, data.data);
           let dependencies: ChannelsDependencies = processChannelDependencies(allTheNewMandatoryChannelsData);

--- a/web/html/src/manager/admin/config/use-monitoring-api.ts
+++ b/web/html/src/manager/admin/config/use-monitoring-api.ts
@@ -40,7 +40,7 @@ const useMonitoringApi = () => {
   }> => {
     setAction("checking");
     return Network.get("/rhn/manager/api/admin/config/monitoring")
-      .promise.then((data: JsonResult<ExportersResultType>) => {
+      .then((data: JsonResult<ExportersResultType>) => {
         setExportersStatus(data.data.exporters);
         setExportersMessages(data.data.messages);
         setRestartNeeded(isRestartNeeded(data.data));
@@ -54,12 +54,8 @@ const useMonitoringApi = () => {
 
   const changeStatus = (toEnable: boolean) => {
     setAction(toEnable ? "enabling" : "disabling");
-    return Network.post(
-      "/rhn/manager/api/admin/config/monitoring",
-      JSON.stringify({ enable: toEnable }),
-      "application/json"
-    )
-      .promise.then((data: JsonResult<ExportersResultType>) => {
+    return Network.post("/rhn/manager/api/admin/config/monitoring", JSON.stringify({ enable: toEnable }))
+      .then((data: JsonResult<ExportersResultType>) => {
         if (data.data.exporters) {
           setExportersStatus(data.data.exporters);
           setExportersMessages(data.data.messages);

--- a/web/html/src/manager/admin/config/use-monitoring-api.ts
+++ b/web/html/src/manager/admin/config/use-monitoring-api.ts
@@ -54,7 +54,7 @@ const useMonitoringApi = () => {
 
   const changeStatus = (toEnable: boolean) => {
     setAction(toEnable ? "enabling" : "disabling");
-    return Network.post("/rhn/manager/api/admin/config/monitoring", JSON.stringify({ enable: toEnable }))
+    return Network.post("/rhn/manager/api/admin/config/monitoring", { enable: toEnable })
       .then((data: JsonResult<ExportersResultType>) => {
         if (data.data.exporters) {
           setExportersStatus(data.data.exporters);

--- a/web/html/src/manager/admin/setup/products/products-scc-dialog.tsx
+++ b/web/html/src/manager/admin/setup/products/products-scc-dialog.tsx
@@ -108,8 +108,8 @@ class SCCDialog extends React.Component<Props> {
         steps: stepList,
       });
 
-      Network.post(currentStep.url, undefined, "application/json")
-        .promise.then(data => {
+      Network.post(currentStep.url)
+        .then(data => {
           // set the result for the i-step
           currentStep.success = data;
           currentStep.inProgress = false;

--- a/web/html/src/manager/admin/setup/products/products.tsx
+++ b/web/html/src/manager/admin/setup/products/products.tsx
@@ -89,7 +89,7 @@ const _COLS = {
 };
 
 function reloadData() {
-  return Network.get("/rhn/manager/api/admin/products", "application/json").promise;
+  return Network.get("/rhn/manager/api/admin/products");
 }
 
 /**
@@ -186,10 +186,9 @@ class ProductsPageWrapper extends React.Component {
     currentObject.setState({ addingProducts: true });
     Network.post(
       "/rhn/manager/admin/setup/products",
-      JSON.stringify(currentObject.state.selectedItems.map(i => i.identifier)),
-      "application/json"
+      JSON.stringify(currentObject.state.selectedItems.map(i => i.identifier))
     )
-      .promise.then(data => {
+      .then(data => {
         // returned data format is { productId : isFailedFlag }
         let failedProducts = currentObject.state.selectedItems.filter(i => data[i.identifier]);
         let resultMessages: MessageType[] | null = null;
@@ -217,8 +216,8 @@ class ProductsPageWrapper extends React.Component {
     currentObject.state.scheduledItems.concat([id]);
     var scheduleResyncItemsNew = currentObject.state.scheduleResyncItems.concat([id]);
     currentObject.setState({ scheduleResyncItems: scheduleResyncItemsNew });
-    Network.post("/rhn/manager/admin/setup/products", JSON.stringify([id]), "application/json")
-      .promise.then(data => {
+    Network.post("/rhn/manager/admin/setup/products", JSON.stringify([id]))
+      .then(data => {
         if (!data[id]) {
           currentObject.setState({
             errors: MessagesUtils.success("The product '" + name + "' sync has been scheduled successfully"),

--- a/web/html/src/manager/admin/setup/products/products.tsx
+++ b/web/html/src/manager/admin/setup/products/products.tsx
@@ -186,7 +186,7 @@ class ProductsPageWrapper extends React.Component {
     currentObject.setState({ addingProducts: true });
     Network.post(
       "/rhn/manager/admin/setup/products",
-      JSON.stringify(currentObject.state.selectedItems.map(i => i.identifier))
+      currentObject.state.selectedItems.map(i => i.identifier)
     )
       .then(data => {
         // returned data format is { productId : isFailedFlag }
@@ -216,7 +216,7 @@ class ProductsPageWrapper extends React.Component {
     currentObject.state.scheduledItems.concat([id]);
     var scheduleResyncItemsNew = currentObject.state.scheduleResyncItems.concat([id]);
     currentObject.setState({ scheduleResyncItems: scheduleResyncItemsNew });
-    Network.post("/rhn/manager/admin/setup/products", JSON.stringify([id]))
+    Network.post("/rhn/manager/admin/setup/products", [id])
       .then(data => {
         if (!data[id]) {
           currentObject.setState({

--- a/web/html/src/manager/admin/task-engine-status/taskotop.tsx
+++ b/web/html/src/manager/admin/task-engine-status/taskotop.tsx
@@ -31,8 +31,8 @@ class TaskoTop extends React.Component<Props> {
 
   refreshServerData = () => {
     var currentObject = this;
-    Network.get("/rhn/manager/api/admin/runtime-status/data", "application/json")
-      .promise.then(data => {
+    Network.get("/rhn/manager/api/admin/runtime-status/data")
+      .then(data => {
         currentObject.setState({
           serverData: data,
           error: null,

--- a/web/html/src/manager/audit/cveaudit/cveaudit.tsx
+++ b/web/html/src/manager/audit/cveaudit/cveaudit.tsx
@@ -53,9 +53,8 @@ function cveAudit(cveId, target, statuses) {
       cveIdentifier: cveId,
       target: target,
       statuses: statuses,
-    }),
-    "application/json"
-  ).promise;
+    })
+  );
 }
 
 type Props = {};

--- a/web/html/src/manager/audit/cveaudit/cveaudit.tsx
+++ b/web/html/src/manager/audit/cveaudit/cveaudit.tsx
@@ -47,14 +47,11 @@ const YEARS = (function() {
 })();
 
 function cveAudit(cveId, target, statuses) {
-  return Network.post(
-    "/rhn/manager/api/audit/cve",
-    JSON.stringify({
-      cveIdentifier: cveId,
-      target: target,
-      statuses: statuses,
-    })
-  );
+  return Network.post("/rhn/manager/api/audit/cve", {
+    cveIdentifier: cveId,
+    target: target,
+    statuses: statuses,
+  });
 }
 
 type Props = {};

--- a/web/html/src/manager/audit/subscription-matching/subscription-matching-matcher-run-panel.tsx
+++ b/web/html/src/manager/audit/subscription-matching/subscription-matching-matcher-run-panel.tsx
@@ -127,7 +127,7 @@ type MatcherScheduleButtonProps = {
 
 class MatcherScheduleButton extends React.Component<MatcherScheduleButtonProps> {
   onClick = () => {
-    Network.post("/rhn/manager/api/subscription-matching/schedule-matcher-run").promise.catch(() =>
+    Network.post("/rhn/manager/api/subscription-matching/schedule-matcher-run").catch(() =>
       this.props.onError()
     );
     this.props.onScheduled();

--- a/web/html/src/manager/audit/subscription-matching/subscription-matching-pins.tsx
+++ b/web/html/src/manager/audit/subscription-matching/subscription-matching-pins.tsx
@@ -52,7 +52,7 @@ class Pins extends React.Component<PinsProps> {
   };
 
   onRemovePin = pinId => {
-    Network.post("/rhn/manager/api/subscription-matching/pins/" + pinId + "/delete").promise.then(data =>
+    Network.post("/rhn/manager/api/subscription-matching/pins/" + pinId + "/delete").then(data =>
       this.props.onPinChanged(data)
     );
   };
@@ -69,7 +69,7 @@ class Pins extends React.Component<PinsProps> {
     Network.post("/rhn/manager/api/subscription-matching/pins", {
       system_id: systemId,
       subscription_id: subscriptionId,
-    }).promise.then(data => this.props.onPinChanged(data));
+    }).then(data => this.props.onPinChanged(data));
     jQuery("#addPinPopUp").modal("hide"); //to trigger popup close action
     this.closePopUp();
   };

--- a/web/html/src/manager/audit/subscription-matching/subscription-matching.tsx
+++ b/web/html/src/manager/audit/subscription-matching/subscription-matching.tsx
@@ -36,8 +36,8 @@ class SubscriptionMatching extends React.Component<SubscriptionMatchingProps> {
   }
 
   refreshServerData = () => {
-    this.refreshRequest = Network.get("/rhn/manager/api/subscription-matching/data", "application/json");
-    this.refreshRequest.promise
+    this.refreshRequest = Network.get("/rhn/manager/api/subscription-matching/data");
+    this.refreshRequest
       .then(data => {
         this.setState({
           serverData: data,

--- a/web/html/src/manager/clusters/shared/api/use-clusters-api.tsx
+++ b/web/html/src/manager/clusters/shared/api/use-clusters-api.tsx
@@ -151,7 +151,7 @@ const useClustersApi = () => {
   ): Promise<any> => {
     return Network.post(
       `/rhn/manager/api/cluster/provider/${provider}/formula/${formula}/form`,
-      JSON.stringify(context)
+      context
     )
       .then((data: JsonResult<any>) => {
         return Promise.resolve({
@@ -181,7 +181,7 @@ const useClustersApi = () => {
   };
 
   const saveClusterFormulaData = (clusterId: number, formula: string, data: FormulaValuesType): Promise<any> => {
-    return Network.post(`/rhn/manager/api/cluster/${clusterId}/formula/${formula}/data`, JSON.stringify(data)).catch(
+    return Network.post(`/rhn/manager/api/cluster/${clusterId}/formula/${formula}/data`, data).catch(
       handleResponseError
     );
   };
@@ -196,14 +196,14 @@ const useClustersApi = () => {
   ): Promise<number> => {
     return Network.post(
       "/rhn/manager/api/cluster/new/add",
-      JSON.stringify({
+      {
         name: name,
         label: label,
         description: description,
         managementNodeId: managementNodeId,
         provider: providerLabel,
         managementSettings: managementSettings,
-      })
+      }
     )
       .then((data: JsonResult<number>) => {
         return data.data;
@@ -220,11 +220,11 @@ const useClustersApi = () => {
   ): Promise<number> => {
     return Network.post(
       `/rhn/manager/api/cluster/${clusterId}/join`,
-      JSON.stringify({
+      {
         earliest: earliest,
         serverIds: serverIds,
         formula: joinFormula,
-      })
+      }
     )
       .then((data: JsonResult<number>) => {
         return data.data;
@@ -241,11 +241,11 @@ const useClustersApi = () => {
   ): Promise<number> => {
     return Network.post(
       `/rhn/manager/api/cluster/${clusterId}/remove-node`,
-      JSON.stringify({
+      {
         earliest: earliest,
         serverIds: serverIds,
         formula: removeFormula,
-      })
+      }
     )
       .then((data: JsonResult<number>) => {
         return data.data;
@@ -256,9 +256,9 @@ const useClustersApi = () => {
   const scheduleUpgradeCluster = (clusterId: number, earliest: Date, actionChain?: string | null): Promise<number> => {
     return Network.post(
       `/rhn/manager/api/cluster/${clusterId}/upgrade`,
-      JSON.stringify({
+      {
         earliest: earliest,
-      })
+      }
     )
       .then((data: JsonResult<number>) => {
         return data.data;
@@ -267,7 +267,7 @@ const useClustersApi = () => {
   };
 
   const saveClusterProps = (clusterId: number, cluster: EditableClusterPropsType): Promise<any> => {
-    return Network.post(`/rhn/manager/api/cluster/${clusterId}`, JSON.stringify(cluster))
+    return Network.post(`/rhn/manager/api/cluster/${clusterId}`, cluster)
       .then((data: JsonResult<number>) => {
         return true;
       })

--- a/web/html/src/manager/clusters/shared/api/use-clusters-api.tsx
+++ b/web/html/src/manager/clusters/shared/api/use-clusters-api.tsx
@@ -122,7 +122,7 @@ const useClustersApi = () => {
 
   const fetchClusterNodes = (clusterId: number): Promise<ClusterNodesResultType> => {
     return Network.get(`/rhn/manager/api/cluster/${clusterId}/nodes`)
-      .promise.then((data: JsonResult<ClusterNodesResultType>) => {
+      .then((data: JsonResult<ClusterNodesResultType>) => {
         return data.data;
       })
       .catch(handleResponseError);
@@ -130,7 +130,7 @@ const useClustersApi = () => {
 
   const fetchManagementNodes = (provider: string): Promise<Array<ServerType>> => {
     return Network.get(`/rhn/manager/api/cluster/provider/${provider}/management-nodes`)
-      .promise.then((data: JsonResult<Array<ServerType>>) => {
+      .then((data: JsonResult<Array<ServerType>>) => {
         return data.data;
       })
       .catch(handleResponseError);
@@ -138,7 +138,7 @@ const useClustersApi = () => {
 
   const fetchNodesToJoin = (clusterId: number): Promise<Array<ServerType>> => {
     return Network.get(`/rhn/manager/api/cluster/${clusterId}/nodes-to-join`)
-      .promise.then((data: JsonResult<Array<ServerType>>) => {
+      .then((data: JsonResult<Array<ServerType>>) => {
         return data.data;
       })
       .catch(handleResponseError);
@@ -151,10 +151,9 @@ const useClustersApi = () => {
   ): Promise<any> => {
     return Network.post(
       `/rhn/manager/api/cluster/provider/${provider}/formula/${formula}/form`,
-      JSON.stringify(context),
-      "application/json"
+      JSON.stringify(context)
     )
-      .promise.then((data: JsonResult<any>) => {
+      .then((data: JsonResult<any>) => {
         return Promise.resolve({
           formula_name: provider,
           formula_list: [],
@@ -167,7 +166,7 @@ const useClustersApi = () => {
 
   const fetchClusterFormulaData = (clusterId: number, formula: string): Promise<any> => {
     return Network.get(`/rhn/manager/api/cluster/${clusterId}/formula/${formula}/data`)
-      .promise.then((data: JsonResult<any>) => {
+      .then((data: JsonResult<any>) => {
         return data.data;
       })
       .catch(handleResponseError);
@@ -175,18 +174,16 @@ const useClustersApi = () => {
 
   const fetchClusterUpgradePlan = (clusterId: number): Promise<string> => {
     return Network.get(`/rhn/manager/api/cluster/${clusterId}/upgrade-plan`)
-      .promise.then((data: JsonResult<string>) => {
+      .then((data: JsonResult<string>) => {
         return data.data;
       })
       .catch(handleResponseError);
   };
 
   const saveClusterFormulaData = (clusterId: number, formula: string, data: FormulaValuesType): Promise<any> => {
-    return Network.post(
-      `/rhn/manager/api/cluster/${clusterId}/formula/${formula}/data`,
-      JSON.stringify(data),
-      "application/json"
-    ).promise.catch(handleResponseError);
+    return Network.post(`/rhn/manager/api/cluster/${clusterId}/formula/${formula}/data`, JSON.stringify(data)).catch(
+      handleResponseError
+    );
   };
 
   const addCluster = (
@@ -206,10 +203,9 @@ const useClustersApi = () => {
         managementNodeId: managementNodeId,
         provider: providerLabel,
         managementSettings: managementSettings,
-      }),
-      "application/json"
+      })
     )
-      .promise.then((data: JsonResult<number>) => {
+      .then((data: JsonResult<number>) => {
         return data.data;
       })
       .catch(handleResponseError);
@@ -228,10 +224,9 @@ const useClustersApi = () => {
         earliest: earliest,
         serverIds: serverIds,
         formula: joinFormula,
-      }),
-      "application/json"
+      })
     )
-      .promise.then((data: JsonResult<number>) => {
+      .then((data: JsonResult<number>) => {
         return data.data;
       })
       .catch(handleResponseError);
@@ -250,10 +245,9 @@ const useClustersApi = () => {
         earliest: earliest,
         serverIds: serverIds,
         formula: removeFormula,
-      }),
-      "application/json"
+      })
     )
-      .promise.then((data: JsonResult<number>) => {
+      .then((data: JsonResult<number>) => {
         return data.data;
       })
       .catch(handleResponseError);
@@ -264,40 +258,33 @@ const useClustersApi = () => {
       `/rhn/manager/api/cluster/${clusterId}/upgrade`,
       JSON.stringify({
         earliest: earliest,
-      }),
-      "application/json"
+      })
     )
-      .promise.then((data: JsonResult<number>) => {
+      .then((data: JsonResult<number>) => {
         return data.data;
       })
       .catch(handleResponseError);
   };
 
   const saveClusterProps = (clusterId: number, cluster: EditableClusterPropsType): Promise<any> => {
-    return Network.post(`/rhn/manager/api/cluster/${clusterId}`, JSON.stringify(cluster), "application/json")
-      .promise.then((data: JsonResult<number>) => {
+    return Network.post(`/rhn/manager/api/cluster/${clusterId}`, JSON.stringify(cluster))
+      .then((data: JsonResult<number>) => {
         return true;
       })
       .catch(handleResponseError);
   };
 
   const deleteCluster = (clusterId: number): Promise<any> => {
-    return Network.del(`/rhn/manager/api/cluster/${clusterId}`, null, "application/json").promise.catch(
-      handleResponseError
-    );
+    return Network.del(`/rhn/manager/api/cluster/${clusterId}`, null).catch(handleResponseError);
   };
 
   const refreshGroupNodes = (clusterId: number): Promise<any> => {
-    return Network.post(
-      `/rhn/manager/api/cluster/${clusterId}/refresh-group-nodes`,
-      null,
-      "application/json"
-    ).promise.catch(handleResponseError);
+    return Network.post(`/rhn/manager/api/cluster/${clusterId}/refresh-group-nodes`, null).catch(handleResponseError);
   };
 
   const fetchClusterProps = (clusterId: number): Promise<ClusterType> => {
     return Network.get(`/rhn/manager/api/cluster/${clusterId}`)
-      .promise.then((data: JsonResult<ClusterType>) => {
+      .then((data: JsonResult<ClusterType>) => {
         return data.data;
       })
       .catch(handleResponseError);

--- a/web/html/src/manager/content-management/list-filters/appstreams/appstreams.tsx
+++ b/web/html/src/manager/content-management/list-filters/appstreams/appstreams.tsx
@@ -12,8 +12,8 @@ export default function AppStreams() {
 
   const enableBrowse = () => {
     setLoading(true);
-    Network.get("/rhn/manager/api/channels/modular", "application/json")
-      .promise.then(channels => {
+    Network.get("/rhn/manager/api/channels/modular")
+      .then(channels => {
         setChannels(channels.data);
         setLoading(false);
         setBrowse(true);

--- a/web/html/src/manager/content-management/list-filters/templates/live-patching.tsx
+++ b/web/html/src/manager/content-management/list-filters/templates/live-patching.tsx
@@ -30,17 +30,17 @@ function handleResponseErrors(res) {
 }
 
 function getProducts(): Promise<Product[]> {
-  return Network.get("/rhn/manager/api/contentmanagement/livepatching/products").promise
+  return Network.get("/rhn/manager/api/contentmanagement/livepatching/products")
     .then((res: JsonResult<Product[]>) => res.success ? res.data : Promise.reject(res));
 }
 
 function getSystems(query: string): Promise<System[]> {
-  return Network.get(`/rhn/manager/api/contentmanagement/livepatching/systems?q=${query}`).promise
+  return Network.get(`/rhn/manager/api/contentmanagement/livepatching/systems?q=${query}`)
     .then((res: JsonResult<System[]>) => res.success ? res.data : Promise.reject(res));
 }
 
 function getKernels(id: number, type: string): Promise<Kernel[]> {
-  return Network.get(`/rhn/manager/api/contentmanagement/livepatching/kernels/${type}/${id}`).promise
+  return Network.get(`/rhn/manager/api/contentmanagement/livepatching/kernels/${type}/${id}`)
     .then((res: JsonResult<Kernel[]>) => res.success ? res.data : Promise.reject(res))
     .then(res => {
       if (res.length > 0)

--- a/web/html/src/manager/content-management/shared/api/use-lifecycle-actions-api.ts
+++ b/web/html/src/manager/content-management/shared/api/use-lifecycle-actions-api.ts
@@ -55,7 +55,7 @@ const useLifecycleActionsApi = (props: Props): returnUseProjectActionsApi => {
       if (action === "get" || !networkAction[action]) {
         networkRequest = networkAction.get(apiUrl);
       } else {
-        networkRequest = networkAction[action](apiUrl, JSON.stringify(actionBodyRequest));
+        networkRequest = networkAction[action](apiUrl, actionBodyRequest);
       }
       setOnGoingNetworkRequest(networkRequest);
 

--- a/web/html/src/manager/content-management/shared/api/use-lifecycle-actions-api.ts
+++ b/web/html/src/manager/content-management/shared/api/use-lifecycle-actions-api.ts
@@ -53,13 +53,13 @@ const useLifecycleActionsApi = (props: Props): returnUseProjectActionsApi => {
 
       let networkRequest: ReturnType<NetworkMethod>;
       if (action === "get" || !networkAction[action]) {
-        networkRequest = networkAction.get(apiUrl, "application/json");
+        networkRequest = networkAction.get(apiUrl);
       } else {
-        networkRequest = networkAction[action](apiUrl, JSON.stringify(actionBodyRequest), "application/json");
+        networkRequest = networkAction[action](apiUrl, JSON.stringify(actionBodyRequest));
       }
       setOnGoingNetworkRequest(networkRequest);
 
-      return networkRequest.promise
+      return networkRequest
         .then(response => {
           setIsLoading(false);
 

--- a/web/html/src/manager/groups/config-channels/group-config-channels.tsx
+++ b/web/html/src/manager/groups/config-channels/group-config-channels.tsx
@@ -18,11 +18,11 @@ function matchUrl(target) {
 function applyRequest(component) {
   return Network.post(
     "/rhn/manager/api/states/apply",
-    JSON.stringify({
+    {
       id: window.groupId,
       type: "GROUP",
       states: ["custom_groups"],
-    }),
+    },
   ).then(data => {
     component.setState({
       messages: MessagesUtils.info(
@@ -35,11 +35,11 @@ function applyRequest(component) {
 function saveRequest(states) {
   return Network.post(
     "/rhn/manager/api/states/save",
-    JSON.stringify({
+    {
       id: window.groupId,
       type: "GROUP",
       channels: states,
-    })
+    }
   );
 }
 

--- a/web/html/src/manager/groups/config-channels/group-config-channels.tsx
+++ b/web/html/src/manager/groups/config-channels/group-config-channels.tsx
@@ -23,8 +23,7 @@ function applyRequest(component) {
       type: "GROUP",
       states: ["custom_groups"],
     }),
-    "application/json"
-  ).promise.then(data => {
+  ).then(data => {
     component.setState({
       messages: MessagesUtils.info(
         t("Applying the config channels has been scheduled for each minion server in this group")
@@ -40,8 +39,7 @@ function saveRequest(states) {
       id: window.groupId,
       type: "GROUP",
       channels: states,
-    }),
-    "application/json"
+    })
   );
 }
 

--- a/web/html/src/manager/groups/formula/group-formula-selection.renderer.tsx
+++ b/web/html/src/manager/groups/formula/group-formula-selection.renderer.tsx
@@ -28,7 +28,7 @@ export const renderer = (renderId, { groupId, warningMessage }) => {
     formData.id = groupId;
     formData.selected = selectedFormulas;
 
-    return Network.post("/rhn/manager/api/formulas/select", JSON.stringify(formData)).then(
+    return Network.post("/rhn/manager/api/formulas/select", formData).then(
       data => {
         component.setState({
           messages: data.map(msg => getMessageText(msg)),

--- a/web/html/src/manager/groups/formula/group-formula-selection.renderer.tsx
+++ b/web/html/src/manager/groups/formula/group-formula-selection.renderer.tsx
@@ -28,7 +28,7 @@ export const renderer = (renderId, { groupId, warningMessage }) => {
     formData.id = groupId;
     formData.selected = selectedFormulas;
 
-    return Network.post("/rhn/manager/api/formulas/select", JSON.stringify(formData), "application/json").promise.then(
+    return Network.post("/rhn/manager/api/formulas/select", JSON.stringify(formData)).then(
       data => {
         component.setState({
           messages: data.map(msg => getMessageText(msg)),

--- a/web/html/src/manager/images/image-build.tsx
+++ b/web/html/src/manager/images/image-build.tsx
@@ -205,7 +205,7 @@ class BuildImage extends React.Component<Props, State> {
   onBuild(model) {
     Network.post(
       "/rhn/manager/api/cm/build/" + this.state.model.profileId,
-      JSON.stringify(model)
+      model
     ).then(data => {
       if (data.success) {
         const msg = MessagesUtils.info(

--- a/web/html/src/manager/images/image-build.tsx
+++ b/web/html/src/manager/images/image-build.tsx
@@ -84,7 +84,7 @@ class BuildImage extends React.Component<Props, State> {
   }
 
   getProfiles() {
-    Network.get("/rhn/manager/api/cm/imageprofiles").promise.then(res => {
+    Network.get("/rhn/manager/api/cm/imageprofiles").then(res => {
       this.setState({
         profiles: res,
       });
@@ -98,7 +98,7 @@ class BuildImage extends React.Component<Props, State> {
   getProfileDetails(profileId) {
     if (!profileId) return true;
 
-    Network.get("/rhn/manager/api/cm/imageprofiles/" + profileId).promise.then(res => {
+    Network.get("/rhn/manager/api/cm/imageprofiles/" + profileId).then(res => {
       if (res.success) {
         var data = res.data;
 
@@ -125,7 +125,7 @@ class BuildImage extends React.Component<Props, State> {
   }
 
   getBuildHosts(type) {
-    Network.get("/rhn/manager/api/cm/build/hosts/" + type, "application/json").promise.then(res => {
+    Network.get("/rhn/manager/api/cm/build/hosts/" + type).then(res => {
       this.setState({
         hosts: res,
       });
@@ -205,9 +205,8 @@ class BuildImage extends React.Component<Props, State> {
   onBuild(model) {
     Network.post(
       "/rhn/manager/api/cm/build/" + this.state.model.profileId,
-      JSON.stringify(model),
-      "application/json"
-    ).promise.then(data => {
+      JSON.stringify(model)
+    ).then(data => {
       if (data.success) {
         const msg = MessagesUtils.info(
           this.state.model.actionChain ? (

--- a/web/html/src/manager/images/image-import.tsx
+++ b/web/html/src/manager/images/image-import.tsx
@@ -191,7 +191,7 @@ class ImageImport extends React.Component {
         name: this.state.model.name,
         version: this.state.model.version,
       };
-      return Network.post("/rhn/manager/api/cm/images/import", JSON.stringify(importObj))
+      return Network.post("/rhn/manager/api/cm/images/import", importObj)
         .then(data => {
           if (data.success) {
             Utils.urlBounce("/rhn/manager/cm/images");

--- a/web/html/src/manager/images/image-import.tsx
+++ b/web/html/src/manager/images/image-import.tsx
@@ -98,8 +98,8 @@ class ImageImport extends React.Component {
 
   getImageStores() {
     const type = "registry";
-    Network.get("/rhn/manager/api/cm/imagestores/type/" + type, "application/json")
-      .promise.then(data => {
+    Network.get("/rhn/manager/api/cm/imagestores/type/" + type)
+      .then(data => {
         this.setState({
           imageStores: data,
         });
@@ -109,7 +109,7 @@ class ImageImport extends React.Component {
 
   getBuildHosts() {
     Network.get("/rhn/manager/api/cm/build/hosts/container_build_host")
-      .promise.then(data => {
+      .then(data => {
         this.setState({
           hosts: data,
         });
@@ -119,7 +119,7 @@ class ImageImport extends React.Component {
 
   getActivationKeys() {
     Network.get("/rhn/manager/api/cm/activationkeys")
-      .promise.then(data => {
+      .then(data => {
         this.setState({
           activationkeys: data,
         });
@@ -135,7 +135,7 @@ class ImageImport extends React.Component {
       return;
     }
 
-    Network.get("/rhn/manager/api/cm/imageprofiles/channels/" + token).promise.then(res => {
+    Network.get("/rhn/manager/api/cm/imageprofiles/channels/" + token).then(res => {
       // Prevent out-of-order async results
       if (res.activationKey !== this.state.model.activationKey) return false;
 
@@ -191,8 +191,8 @@ class ImageImport extends React.Component {
         name: this.state.model.name,
         version: this.state.model.version,
       };
-      return Network.post("/rhn/manager/api/cm/images/import", JSON.stringify(importObj), "application/json")
-        .promise.then(data => {
+      return Network.post("/rhn/manager/api/cm/images/import", JSON.stringify(importObj))
+        .then(data => {
           if (data.success) {
             Utils.urlBounce("/rhn/manager/cm/images");
           } else {

--- a/web/html/src/manager/images/image-profile-edit.tsx
+++ b/web/html/src/manager/images/image-profile-edit.tsx
@@ -202,7 +202,7 @@ class CreateImageProfile extends React.Component<Props, State> {
     model.path = model.path.trim();
     return Network.post(
       "/rhn/manager/api/cm/imageprofiles/update/" + window.profileId,
-      JSON.stringify(model)
+      model
     ).then(data => {
       if (data.success) {
         Utils.urlBounce("/rhn/manager/cm/imageprofiles");
@@ -231,7 +231,7 @@ class CreateImageProfile extends React.Component<Props, State> {
     model.path = model.path.trim();
     return Network.post(
       "/rhn/manager/api/cm/imageprofiles/create",
-      JSON.stringify(model)
+      model
     ).then(data => {
       if (data.success) {
         Utils.urlBounce("/rhn/manager/cm/imageprofiles");

--- a/web/html/src/manager/images/image-profile-edit.tsx
+++ b/web/html/src/manager/images/image-profile-edit.tsx
@@ -89,7 +89,7 @@ class CreateImageProfile extends React.Component<Props, State> {
   }
 
   setValues(id) {
-    Network.get("/rhn/manager/api/cm/imageprofiles/" + id).promise.then(res => {
+    Network.get("/rhn/manager/api/cm/imageprofiles/" + id).then(res => {
       if (res.success) {
         var data = res.data;
         this.setState({
@@ -127,7 +127,7 @@ class CreateImageProfile extends React.Component<Props, State> {
       return;
     }
 
-    Network.get("/rhn/manager/api/cm/imageprofiles/channels/" + token).promise.then(res => {
+    Network.get("/rhn/manager/api/cm/imageprofiles/channels/" + token).then(res => {
       // Prevent out-of-order async results
       if (!DEPRECATED_unsafeEquals(res.activationKey, this.state.model.activationKey)) return false;
 
@@ -147,7 +147,7 @@ class CreateImageProfile extends React.Component<Props, State> {
   }
 
   handleImageStoreChange(name, storeLabel) {
-    Network.get("/rhn/manager/api/cm/imagestores/find/" + storeLabel).promise.then(res => {
+    Network.get("/rhn/manager/api/cm/imagestores/find/" + storeLabel).then(res => {
       this.setState({
         storeUri: res.success && res.data.uri,
       });
@@ -187,7 +187,7 @@ class CreateImageProfile extends React.Component<Props, State> {
 
     // Check for uniqueness
     return Network.get("/rhn/manager/api/cm/imageprofiles/find/" + label)
-      .promise.then(res => !res.success && isValid)
+      .then(res => !res.success && isValid)
       .catch(() => false);
   }
 
@@ -202,9 +202,8 @@ class CreateImageProfile extends React.Component<Props, State> {
     model.path = model.path.trim();
     return Network.post(
       "/rhn/manager/api/cm/imageprofiles/update/" + window.profileId,
-      JSON.stringify(model),
-      "application/json"
-    ).promise.then(data => {
+      JSON.stringify(model)
+    ).then(data => {
       if (data.success) {
         Utils.urlBounce("/rhn/manager/cm/imageprofiles");
       } else {
@@ -232,9 +231,8 @@ class CreateImageProfile extends React.Component<Props, State> {
     model.path = model.path.trim();
     return Network.post(
       "/rhn/manager/api/cm/imageprofiles/create",
-      JSON.stringify(model),
-      "application/json"
-    ).promise.then(data => {
+      JSON.stringify(model)
+    ).then(data => {
       if (data.success) {
         Utils.urlBounce("/rhn/manager/cm/imageprofiles");
       } else {
@@ -270,7 +268,7 @@ class CreateImageProfile extends React.Component<Props, State> {
   }
 
   getImageStores(type) {
-    return Network.get("/rhn/manager/api/cm/imagestores/type/" + type, "application/json").promise.then(data => {
+    return Network.get("/rhn/manager/api/cm/imagestores/type/" + type).then(data => {
       // Preselect store after retrieval
       const model = Object.assign({}, this.state.model, { imageStore: data[0] && data[0].label });
       const storeUri = data[0] && data[0].uri;

--- a/web/html/src/manager/images/image-profiles.tsx
+++ b/web/html/src/manager/images/image-profiles.tsx
@@ -64,7 +64,7 @@ class ImageProfiles extends React.Component<Props, State> {
   }
 
   reloadData() {
-    Network.get("/rhn/manager/api/cm/imageprofiles").promise.then(data => {
+    Network.get("/rhn/manager/api/cm/imageprofiles").then(data => {
       this.setState({
         imageprofiles: data,
       });
@@ -93,9 +93,8 @@ class ImageProfiles extends React.Component<Props, State> {
   deleteProfiles(idList) {
     return Network.post(
       "/rhn/manager/api/cm/imageprofiles/delete",
-      JSON.stringify(idList),
-      "application/json"
-    ).promise.then(data => {
+      JSON.stringify(idList)
+    ).then(data => {
       if (data.success) {
         this.setState({
           messages: (

--- a/web/html/src/manager/images/image-profiles.tsx
+++ b/web/html/src/manager/images/image-profiles.tsx
@@ -93,7 +93,7 @@ class ImageProfiles extends React.Component<Props, State> {
   deleteProfiles(idList) {
     return Network.post(
       "/rhn/manager/api/cm/imageprofiles/delete",
-      JSON.stringify(idList)
+      idList
     ).then(data => {
       if (data.success) {
         this.setState({

--- a/web/html/src/manager/images/image-store-edit.tsx
+++ b/web/html/src/manager/images/image-store-edit.tsx
@@ -67,7 +67,7 @@ class CreateImageStore extends React.Component<Props, State> {
   }
 
   setValues(id) {
-    Network.get("/rhn/manager/api/cm/imagestores/" + id).promise.then(res => {
+    Network.get("/rhn/manager/api/cm/imagestores/" + id).then(res => {
       if (res.success) {
         var data = res.data;
         this.setState({
@@ -86,7 +86,7 @@ class CreateImageStore extends React.Component<Props, State> {
     }
 
     return Network.get("/rhn/manager/api/cm/imagestores/find/" + label)
-      .promise.then(res => !res.success)
+      .then(res => !res.success)
       .catch(() => false);
   }
 
@@ -99,9 +99,8 @@ class CreateImageStore extends React.Component<Props, State> {
     model.uri = model.uri.trim();
     return Network.post(
       "/rhn/manager/api/cm/imagestores/update/" + window.storeId,
-      JSON.stringify(model),
-      "application/json"
-    ).promise.then(data => {
+      JSON.stringify(model)
+    ).then(data => {
       if (data.success) {
         Utils.urlBounce("/rhn/manager/cm/imagestores");
       } else {
@@ -127,9 +126,8 @@ class CreateImageStore extends React.Component<Props, State> {
     model.uri = model.uri.trim();
     return Network.post(
       "/rhn/manager/api/cm/imagestores/create",
-      JSON.stringify(model),
-      "application/json"
-    ).promise.then(data => {
+      JSON.stringify(model)
+    ).then(data => {
       if (data.success) {
         Utils.urlBounce("/rhn/manager/cm/imagestores");
       } else {

--- a/web/html/src/manager/images/image-store-edit.tsx
+++ b/web/html/src/manager/images/image-store-edit.tsx
@@ -99,7 +99,7 @@ class CreateImageStore extends React.Component<Props, State> {
     model.uri = model.uri.trim();
     return Network.post(
       "/rhn/manager/api/cm/imagestores/update/" + window.storeId,
-      JSON.stringify(model)
+      model
     ).then(data => {
       if (data.success) {
         Utils.urlBounce("/rhn/manager/cm/imagestores");
@@ -126,7 +126,7 @@ class CreateImageStore extends React.Component<Props, State> {
     model.uri = model.uri.trim();
     return Network.post(
       "/rhn/manager/api/cm/imagestores/create",
-      JSON.stringify(model)
+      model
     ).then(data => {
       if (data.success) {
         Utils.urlBounce("/rhn/manager/cm/imagestores");

--- a/web/html/src/manager/images/image-stores.tsx
+++ b/web/html/src/manager/images/image-stores.tsx
@@ -64,7 +64,7 @@ class ImageStores extends React.Component<Props, State> {
   }
 
   reloadData() {
-    Network.get("/rhn/manager/api/cm/imagestores").promise.then(data => {
+    Network.get("/rhn/manager/api/cm/imagestores").then(data => {
       this.setState({
         imagestores: data,
       });
@@ -93,9 +93,8 @@ class ImageStores extends React.Component<Props, State> {
   deleteStores(idList) {
     return Network.post(
       "/rhn/manager/api/cm/imagestores/delete",
-      JSON.stringify(idList),
-      "application/json"
-    ).promise.then(data => {
+      JSON.stringify(idList)
+    ).then(data => {
       if (data.success) {
         this.setState({
           messages: (

--- a/web/html/src/manager/images/image-stores.tsx
+++ b/web/html/src/manager/images/image-stores.tsx
@@ -93,7 +93,7 @@ class ImageStores extends React.Component<Props, State> {
   deleteStores(idList) {
     return Network.post(
       "/rhn/manager/api/cm/imagestores/delete",
-      JSON.stringify(idList)
+      idList
     ).then(data => {
       if (data.success) {
         this.setState({

--- a/web/html/src/manager/images/image-view.tsx
+++ b/web/html/src/manager/images/image-view.tsx
@@ -199,7 +199,7 @@ class ImageView extends React.Component<ImageViewProps, ImageViewState> {
 
   getImageInfoList() {
     let listPromise = Network.get("/rhn/manager/api/cm/images")
-      .promise.then(data => this.setState({ selected: undefined, images: data }))
+      .then(data => this.setState({ selected: undefined, images: data }))
       .catch(this.handleResponseError);
     let updatedData: any = {};
     if (this.props.runtimeInfoEnabled) {
@@ -207,12 +207,12 @@ class ImageView extends React.Component<ImageViewProps, ImageViewState> {
       this.setState({ imagesRuntime: {} });
       //Get a list of cluster ids
       Network.get("/rhn/manager/api/cm/clusters")
-        .promise.then(data => {
+        .then(data => {
           const runtimeUrl = "/rhn/manager/api/cm/runtime/";
           //Get runtime data for each individual cluster
           data.forEach(cluster => {
             const clusterPromise = Network.get(runtimeUrl + cluster.id)
-              .promise.then(data =>
+              .then(data =>
                 this.setState({
                   imagesRuntime: this.mergeRuntimeList(data.data, updatedData),
                 })
@@ -247,7 +247,7 @@ class ImageView extends React.Component<ImageViewProps, ImageViewState> {
     else url = "/rhn/manager/api/cm/images/" + id;
 
     let detailsPromise = Network.get(url)
-      .promise.then(data => {
+      .then(data => {
         this.setState({ selected: data });
       })
       .catch(this.handleResponseError);
@@ -257,7 +257,7 @@ class ImageView extends React.Component<ImageViewProps, ImageViewState> {
       const runtimePromises: any[] = [];
       //Get a list of cluster ids
       Network.get("/rhn/manager/api/cm/clusters")
-        .promise.then(data => {
+        .then(data => {
           const runtimeUrl =
             tab === "runtime" ? "/rhn/manager/api/cm/runtime/details/" : "/rhn/manager/api/cm/runtime/";
           //Get runtime data for each individual cluster
@@ -271,7 +271,7 @@ class ImageView extends React.Component<ImageViewProps, ImageViewState> {
           }
           data.forEach(cluster => {
             const clusterPromise = Network.get(runtimeUrl + cluster.id + "/" + id)
-              .promise.then(data =>
+              .then(data =>
                 this.setState({
                   selectedRuntime: this.mergeRuntimeData(data.data, updatedData),
                 })
@@ -298,8 +298,8 @@ class ImageView extends React.Component<ImageViewProps, ImageViewState> {
   }
 
   deleteImages(idList) {
-    return Network.post("/rhn/manager/api/cm/images/delete", JSON.stringify(idList), "application/json")
-      .promise.then(() => {
+    return Network.post("/rhn/manager/api/cm/images/delete", JSON.stringify(idList))
+      .then(() => {
         // Waits for the 'Back' action if not in the list page
         const backAction = this.state.selected ? this.handleBackAction() : Promise.resolve();
         backAction.then(() =>
@@ -316,10 +316,9 @@ class ImageView extends React.Component<ImageViewProps, ImageViewState> {
   inspectImage(id, earliest) {
     return Network.post(
       "/rhn/manager/api/cm/images/inspect/" + id,
-      JSON.stringify({ imageId: id, earliest: earliest }),
-      "application/json"
+      JSON.stringify({ imageId: id, earliest: earliest })
     )
-      .promise.then(() => {
+      .then(() => {
         this.reloadData();
         this.setState({
           messages: MessagesUtils.info(t("Image inspect has been scheduled.")),
@@ -331,10 +330,9 @@ class ImageView extends React.Component<ImageViewProps, ImageViewState> {
   buildImage(profile, version, host, earliest) {
     return Network.post(
       "/rhn/manager/api/cm/build/" + profile,
-      JSON.stringify({ version: version, buildHostId: host, earliest: earliest }),
-      "application/json"
+      JSON.stringify({ version: version, buildHostId: host, earliest: earliest })
     )
-      .promise.then(() => {
+      .then(() => {
         //The image id is changed so this page is not available anymore.
         this.handleBackAction();
         this.setState({

--- a/web/html/src/manager/images/image-view.tsx
+++ b/web/html/src/manager/images/image-view.tsx
@@ -298,7 +298,7 @@ class ImageView extends React.Component<ImageViewProps, ImageViewState> {
   }
 
   deleteImages(idList) {
-    return Network.post("/rhn/manager/api/cm/images/delete", JSON.stringify(idList))
+    return Network.post("/rhn/manager/api/cm/images/delete", idList)
       .then(() => {
         // Waits for the 'Back' action if not in the list page
         const backAction = this.state.selected ? this.handleBackAction() : Promise.resolve();
@@ -316,7 +316,7 @@ class ImageView extends React.Component<ImageViewProps, ImageViewState> {
   inspectImage(id, earliest) {
     return Network.post(
       "/rhn/manager/api/cm/images/inspect/" + id,
-      JSON.stringify({ imageId: id, earliest: earliest })
+      { imageId: id, earliest: earliest }
     )
       .then(() => {
         this.reloadData();
@@ -330,7 +330,7 @@ class ImageView extends React.Component<ImageViewProps, ImageViewState> {
   buildImage(profile, version, host, earliest) {
     return Network.post(
       "/rhn/manager/api/cm/build/" + profile,
-      JSON.stringify({ version: version, buildHostId: host, earliest: earliest })
+      { version: version, buildHostId: host, earliest: earliest }
     )
       .then(() => {
         //The image id is changed so this page is not available anymore.

--- a/web/html/src/manager/login/use-login-api.ts
+++ b/web/html/src/manager/login/use-login-api.ts
@@ -43,7 +43,7 @@ const useLoginApi = () => {
       password: password.trim(),
     };
 
-    return Network.post("/rhn/manager/api/login", JSON.stringify(formData)).then(
+    return Network.post("/rhn/manager/api/login", formData).then(
       data => {
         setLoginApiState(state => {
           state.success = data.success;

--- a/web/html/src/manager/login/use-login-api.ts
+++ b/web/html/src/manager/login/use-login-api.ts
@@ -43,7 +43,7 @@ const useLoginApi = () => {
       password: password.trim(),
     };
 
-    return Network.post("/rhn/manager/api/login", JSON.stringify(formData), "application/json").promise.then(
+    return Network.post("/rhn/manager/api/login", JSON.stringify(formData)).then(
       data => {
         setLoginApiState(state => {
           state.success = data.success;

--- a/web/html/src/manager/maintenance/api/maintenance-windows-api.ts
+++ b/web/html/src/manager/maintenance/api/maintenance-windows-api.ts
@@ -6,13 +6,13 @@ import Network from "utils/network";
  */
 function list(type: "schedule" | "calendar") {
   const endpoint = "/rhn/manager/api/maintenance/" + type + "/list";
-  return Network.get(endpoint, "application/json").promise;
+  return Network.get(endpoint);
 }
 
 /* Returns a list of all calendarNames the user has access to */
 function calendarNames() {
   const endpoint = "/rhn/manager/api/maintenance/calendar/names";
-  return Network.get(endpoint, "application/json").promise;
+  return Network.get(endpoint);
 }
 
 /* Returns the details of a schedule or calendar with given id
@@ -21,7 +21,7 @@ function calendarNames() {
  */
 function details(id: string, type: "schedule" | "calendar") {
   const endpoint = "/rhn/manager/api/maintenance/" + type + "/" + id + "/details";
-  return Network.get(endpoint, "application/json").promise;
+  return Network.get(endpoint);
 }
 
 export default {

--- a/web/html/src/manager/maintenance/calendar/web-calendar.tsx
+++ b/web/html/src/manager/maintenance/calendar/web-calendar.tsx
@@ -77,7 +77,7 @@ const WebCalendar = (props: WebCalendarProps) => {
     if (operation === "initial" || needsUpdate(date)) {
       const startOfWeek = getApi().currentDataManager.data.dateEnv.weekDow;
       const endpoint = `/rhn/manager/api/maintenance/events/${operation}/${props.type}/${startOfWeek}/${date.valueOf()}/${props.id}`;
-      return Network.get(endpoint, "application/json").promise
+      return Network.get(endpoint)
         .then(events => {
           setEvents(processEvents(events));
           navigateTo(operation);
@@ -97,7 +97,7 @@ const WebCalendar = (props: WebCalendarProps) => {
     }
     const startOfWeek = getApi().currentDataManager.data.dateEnv.weekDow;
     const endpoint = `/rhn/manager/api/maintenance/events/skipBack/${props.type}/${startOfWeek}/${date.valueOf()}/${props.id}`;
-    return Network.get(endpoint, "application/json").promise
+    return Network.get(endpoint)
       .then(events => {
         if (events.length === 0) {
           props.messages(MessagesUtils.info(t("There are no more past maintenance windows")));
@@ -127,7 +127,7 @@ const WebCalendar = (props: WebCalendarProps) => {
     }
     const startOfWeek = getApi().currentDataManager.data.dateEnv.weekDow;
     const endpoint = `/rhn/manager/api/maintenance/events/skipNext/${props.type}/${startOfWeek}/${date.valueOf()}/${props.id}`;
-    return Network.get(endpoint, "application/json").promise
+    return Network.get(endpoint)
       .then(events => {
         if (events.length === 0) {
           props.messages(MessagesUtils.info(t("There are no more future maintenance windows")));

--- a/web/html/src/manager/maintenance/details/schedule-details.tsx
+++ b/web/html/src/manager/maintenance/details/schedule-details.tsx
@@ -141,7 +141,7 @@ const SystemPicker = (props: SystemPickerProps) => {
 
   useEffect(() => {
     Network.get(`/rhn/manager/api/maintenance/schedule/${props.scheduleId}/systems`)
-      .promise.then(setSelectedSystems)
+      .then(setSelectedSystems)
       .catch(xhr => props.onMessage(Network.responseErrorMessage(xhr)));
   }, [props.scheduleId]);
 
@@ -152,7 +152,7 @@ const SystemPicker = (props: SystemPickerProps) => {
       "application/json",
       false
     )
-      .promise.then(() =>
+      .then(() =>
         props.onMessage(
           MessagesUtils.success(t("Maintenance schedule has been assigned to {0} system(s)", selectedSystems.length))
         )

--- a/web/html/src/manager/maintenance/details/schedule-details.tsx
+++ b/web/html/src/manager/maintenance/details/schedule-details.tsx
@@ -148,9 +148,7 @@ const SystemPicker = (props: SystemPickerProps) => {
   const onAssign = () => {
     return Network.post(
       `/rhn/manager/api/maintenance/schedule/${props.scheduleId}/setsystems`,
-      JSON.stringify({ systemIds: selectedSystems, cancelActions: isCancelActions }),
-      "application/json",
-      false
+      JSON.stringify({ systemIds: selectedSystems, cancelActions: isCancelActions })
     )
       .then(() =>
         props.onMessage(

--- a/web/html/src/manager/maintenance/details/schedule-details.tsx
+++ b/web/html/src/manager/maintenance/details/schedule-details.tsx
@@ -148,7 +148,7 @@ const SystemPicker = (props: SystemPickerProps) => {
   const onAssign = () => {
     return Network.post(
       `/rhn/manager/api/maintenance/schedule/${props.scheduleId}/setsystems`,
-      JSON.stringify({ systemIds: selectedSystems, cancelActions: isCancelActions })
+      { systemIds: selectedSystems, cancelActions: isCancelActions }
     )
       .then(() =>
         props.onMessage(

--- a/web/html/src/manager/maintenance/maintenance-windows.tsx
+++ b/web/html/src/manager/maintenance/maintenance-windows.tsx
@@ -105,7 +105,7 @@ const MaintenanceWindows = () => {
   };
 
   const update = itemIn => {
-    return Network.post("/rhn/manager/api/maintenance/" + window.type + "/save", JSON.stringify(itemIn))
+    return Network.post("/rhn/manager/api/maintenance/" + window.type + "/save", itemIn)
       .then(_ => {
         const successMsg = (
           <span>
@@ -126,7 +126,7 @@ const MaintenanceWindows = () => {
   };
 
   const deleteItem = itemIn => {
-    return Network.del("/rhn/manager/api/maintenance/" + window.type + "/delete", JSON.stringify(itemIn))
+    return Network.del("/rhn/manager/api/maintenance/" + window.type + "/delete", itemIn)
       .then(_ => {
         setMessages(
           MessagesUtils.info(
@@ -143,7 +143,7 @@ const MaintenanceWindows = () => {
   };
 
   const refreshCalendar = itemIn => {
-    return Network.post("/rhn/manager/api/maintenance/calendar/refresh", JSON.stringify(itemIn))
+    return Network.post("/rhn/manager/api/maintenance/calendar/refresh", itemIn)
       .then(_ => {
         const msgs = messages.concat(MessagesUtils.info(t("Calendar successfully refreshed")));
         setAction(undefined);

--- a/web/html/src/manager/maintenance/maintenance-windows.tsx
+++ b/web/html/src/manager/maintenance/maintenance-windows.tsx
@@ -105,8 +105,8 @@ const MaintenanceWindows = () => {
   };
 
   const update = itemIn => {
-    return Network.post("/rhn/manager/api/maintenance/" + window.type + "/save", JSON.stringify(itemIn), "application/json")
-      .promise.then(_ => {
+    return Network.post("/rhn/manager/api/maintenance/" + window.type + "/save", JSON.stringify(itemIn))
+      .then(_ => {
         const successMsg = (
           <span>
             {t(
@@ -126,8 +126,8 @@ const MaintenanceWindows = () => {
   };
 
   const deleteItem = itemIn => {
-    return Network.del("/rhn/manager/api/maintenance/" + window.type + "/delete", JSON.stringify(itemIn), "application/json")
-      .promise.then(_ => {
+    return Network.del("/rhn/manager/api/maintenance/" + window.type + "/delete", JSON.stringify(itemIn))
+      .then(_ => {
         setMessages(
           MessagesUtils.info(
             (window.type === "schedule" ? "Schedule " : "Calendar ") + "'" + itemIn.name + "' has been deleted."
@@ -143,8 +143,8 @@ const MaintenanceWindows = () => {
   };
 
   const refreshCalendar = itemIn => {
-    return Network.post("/rhn/manager/api/maintenance/calendar/refresh", JSON.stringify(itemIn), "application/json")
-      .promise.then(_ => {
+    return Network.post("/rhn/manager/api/maintenance/calendar/refresh", JSON.stringify(itemIn))
+      .then(_ => {
         const msgs = messages.concat(MessagesUtils.info(t("Calendar successfully refreshed")));
         setAction(undefined);
         setMessages(msgs.slice(-messagesCounterLimit));

--- a/web/html/src/manager/maintenance/ssm/schedule-picker.tsx
+++ b/web/html/src/manager/maintenance/ssm/schedule-picker.tsx
@@ -45,7 +45,7 @@ export function WithMaintenanceSchedules(props: WithMaintenanceSchedulesProps) {
       };
     }
 
-    return Network.post(uri, JSON.stringify(data), "application/json", false)
+    return Network.post(uri, JSON.stringify(data), "application/json")
       .then(() => props.onMessage(MessagesUtils.success(successMsg)))
       .catch(xhr => props.onMessage(MessagesUtils.error(Network.errorMessageByStatus(xhr.status))));
   };

--- a/web/html/src/manager/maintenance/ssm/schedule-picker.tsx
+++ b/web/html/src/manager/maintenance/ssm/schedule-picker.tsx
@@ -46,12 +46,12 @@ export function WithMaintenanceSchedules(props: WithMaintenanceSchedulesProps) {
     }
 
     return Network.post(uri, JSON.stringify(data), "application/json", false)
-      .promise.then(() => props.onMessage(MessagesUtils.success(successMsg)))
+      .then(() => props.onMessage(MessagesUtils.success(successMsg)))
       .catch(xhr => props.onMessage(MessagesUtils.error(Network.errorMessageByStatus(xhr.status))));
   };
 
   useEffect(() => {
-    Network.get("/rhn/manager/api/maintenance/schedule/list").promise.then(setSchedules);
+    Network.get("/rhn/manager/api/maintenance/schedule/list").then(setSchedules);
   }, []);
 
   return props.children(schedules, onAssign);

--- a/web/html/src/manager/maintenance/ssm/schedule-picker.tsx
+++ b/web/html/src/manager/maintenance/ssm/schedule-picker.tsx
@@ -45,7 +45,7 @@ export function WithMaintenanceSchedules(props: WithMaintenanceSchedulesProps) {
       };
     }
 
-    return Network.post(uri, JSON.stringify(data), "application/json")
+    return Network.post(uri, data)
       .then(() => props.onMessage(MessagesUtils.success(successMsg)))
       .catch(xhr => props.onMessage(MessagesUtils.error(Network.errorMessageByStatus(xhr.status))));
   };

--- a/web/html/src/manager/minion/ansible/accordion-path-content.tsx
+++ b/web/html/src/manager/minion/ansible/accordion-path-content.tsx
@@ -69,7 +69,7 @@ class AccordionPathContent extends React.Component<PropsType, StateType> {
       if (this.state.content === null) {
         this.setState({ loading: true });
         Network.get(getURL(path))
-        .promise.then(blob => {
+        .then(blob => {
           if (blob.success) {
             this.setState({ content:
               isPlaybook(path) ?

--- a/web/html/src/manager/minion/ansible/ansible-control-node.tsx
+++ b/web/html/src/manager/minion/ansible/ansible-control-node.tsx
@@ -41,7 +41,7 @@ export class AnsibleControlNode extends React.Component<PropsType, StateType> {
     };
 
     Network.get("/rhn/manager/api/systems/details/ansible/paths/" + props.minionServerId)
-    .promise.then(blob => {
+    .then(blob => {
       if (blob.success) {
         const data: AnsiblePath[] = blob.data;
         this.setState({ playbooksPaths: data.filter(p => p.type === "playbook"), inventoriesPaths: data.filter(p => p.type === "inventory"), loading: false });
@@ -64,9 +64,8 @@ export class AnsibleControlNode extends React.Component<PropsType, StateType> {
   deletePath(path: AnsiblePath) {
     Network.post(
       "/rhn/manager/api/systems/details/ansible/paths/delete",
-      path.id?.toString(),
-      "application/json"
-    ).promise.then(blob => {
+      path.id?.toString()
+    ).then(blob => {
       if (blob.success) {
         if (path.type === "playbook") {
           this.setState({ playbooksPaths: this.state.playbooksPaths.filter(p => p.id !== path.id) });
@@ -101,8 +100,7 @@ export class AnsibleControlNode extends React.Component<PropsType, StateType> {
         path: editPath?.path,
         id: editPath?.id
       }),
-      "application/json"
-    ).promise.then(blob => {
+    ).then(blob => {
       if (blob.success) {
         const newPath = createNewAnsiblePath({ id: editPath.id, minionServerId: editPath.minionServerId, type: editPath.type, path: editPath.path});
         if (type === "playbook") {
@@ -127,8 +125,7 @@ export class AnsibleControlNode extends React.Component<PropsType, StateType> {
         type: type,
         path: newPath
       }),
-      "application/json"
-    ).promise.then(blob => {
+    ).then(blob => {
       if (blob.success) {
         const newAnsiblePath = { id: blob.data.pathId, minionServerId: this.state.minionServerId, type: type, path: newPath};
         if (type === "playbook") {

--- a/web/html/src/manager/minion/ansible/ansible-control-node.tsx
+++ b/web/html/src/manager/minion/ansible/ansible-control-node.tsx
@@ -94,12 +94,12 @@ export class AnsibleControlNode extends React.Component<PropsType, StateType> {
     const editPath: Partial<AnsiblePath> = type === "playbook" ? this.state.editPlaybookPath : this.state.editInventoryPath;
     Network.post(
       "/rhn/manager/api/systems/details/ansible/paths/save",
-      JSON.stringify({
+      {
         minionServerId: editPath?.minionServerId,
         type: editPath?.type,
         path: editPath?.path,
         id: editPath?.id
-      }),
+      },
     ).then(blob => {
       if (blob.success) {
         const newPath = createNewAnsiblePath({ id: editPath.id, minionServerId: editPath.minionServerId, type: editPath.type, path: editPath.path});
@@ -120,11 +120,11 @@ export class AnsibleControlNode extends React.Component<PropsType, StateType> {
     const newPath = type === "playbook" ? this.state.newPlaybookPath : this.state.newInventoryPath;
     Network.post(
       "/rhn/manager/api/systems/details/ansible/paths/save",
-      JSON.stringify({
+      {
         minionServerId: this.state.minionServerId,
         type: type,
         path: newPath
-      }),
+      },
     ).then(blob => {
       if (blob.success) {
         const newAnsiblePath = { id: blob.data.pathId, minionServerId: this.state.minionServerId, type: type, path: newPath};

--- a/web/html/src/manager/minion/ansible/ansible-path-content.tsx
+++ b/web/html/src/manager/minion/ansible/ansible-path-content.tsx
@@ -35,7 +35,7 @@ class AnsiblePathContent extends React.Component<PropsType, StateType> {
     };
 
     Network.get("/rhn/manager/api/systems/details/ansible/paths/" + props.pathContentType + "/" + props.minionServerId)
-    .promise.then(blob => {
+    .then(blob => {
       if (blob.success) {
         this.setState({ pathList: blob.data, loading: false});
       }

--- a/web/html/src/manager/minion/ansible/schedule-playbook.tsx
+++ b/web/html/src/manager/minion/ansible/schedule-playbook.tsx
@@ -35,7 +35,7 @@ export default function SchedulePlaybook({ playbook, onBack }: SchedulePlaybookP
 
   useEffect(() => {
     const getInventoryPaths = () => {
-      return Network.get(`/rhn/manager/api/systems/details/ansible/paths/inventory/${playbook.path.minionServerId}`).promise
+      return Network.get(`/rhn/manager/api/systems/details/ansible/paths/inventory/${playbook.path.minionServerId}`)
         .then((res: JsonResult<AnsiblePath[]>) => res.success ? res.data : Promise.reject(res))
         .then(inv => inv.map(i => i.path))
         .then(inv => {
@@ -53,8 +53,7 @@ export default function SchedulePlaybook({ playbook, onBack }: SchedulePlaybookP
           pathId: playbook.path.id,
           playbookRelPathStr: playbook.name
         }),
-        "application/json"
-      ).promise
+      )
         .then((res: JsonResult<string>) => res.success ? res.data : Promise.reject(res))
         .then(setPlaybookContent)
         .catch(res =>
@@ -79,8 +78,7 @@ export default function SchedulePlaybook({ playbook, onBack }: SchedulePlaybookP
         actionChainLabel: actionChain?.text || null,
         earliest: Formats.LocalDateTime(datetime)
       }),
-      "application/json"
-    ).promise
+    )
       .then((res: JsonResult<number>) => res.success ? res.data : Promise.reject(res))
       .then(actionId =>
         setMessages(MsgUtils.info(<ScheduleMessage id={actionId} actionChain={actionChain?.text}/>)))

--- a/web/html/src/manager/minion/ansible/schedule-playbook.tsx
+++ b/web/html/src/manager/minion/ansible/schedule-playbook.tsx
@@ -49,10 +49,10 @@ export default function SchedulePlaybook({ playbook, onBack }: SchedulePlaybookP
 
     const getPlaybookContents = () => {
       return Network.post("/rhn/manager/api/systems/details/ansible/paths/playbook-contents",
-        JSON.stringify({
+        {
           pathId: playbook.path.id,
           playbookRelPathStr: playbook.name
-        }),
+        },
       )
         .then((res: JsonResult<string>) => res.success ? res.data : Promise.reject(res))
         .then(setPlaybookContent)
@@ -70,14 +70,14 @@ export default function SchedulePlaybook({ playbook, onBack }: SchedulePlaybookP
 
   const schedule = () => {
     return Network.post("/rhn/manager/api/systems/details/ansible/schedule-playbook",
-      JSON.stringify({
+      {
         playbookPath: playbook.fullPath,
         inventoryPath: inventoryPath?.text,
         controlNodeId: playbook.path.minionServerId,
         testMode: isTestMode,
         actionChainLabel: actionChain?.text || null,
         earliest: Formats.LocalDateTime(datetime)
-      }),
+      },
     )
       .then((res: JsonResult<number>) => res.success ? res.data : Promise.reject(res))
       .then(actionId =>

--- a/web/html/src/manager/minion/config-channels/minion-config-channels.tsx
+++ b/web/html/src/manager/minion/config-channels/minion-config-channels.tsx
@@ -22,9 +22,8 @@ function applyRequest(component) {
       id: window.serverId,
       type: "SERVER",
       states: ["custom"],
-    }),
-    "application/json"
-  ).promise.then(data => {
+    })
+  ).then(data => {
     component.setState({
       messages: MessagesUtils.info(
         <span>
@@ -43,8 +42,7 @@ function saveRequest(states) {
       id: window.serverId,
       type: "SERVER",
       channels: states,
-    }),
-    "application/json"
+    })
   );
 }
 

--- a/web/html/src/manager/minion/config-channels/minion-config-channels.tsx
+++ b/web/html/src/manager/minion/config-channels/minion-config-channels.tsx
@@ -18,11 +18,11 @@ function matchUrl(target?: string) {
 function applyRequest(component) {
   return Network.post(
     "/rhn/manager/api/states/apply",
-    JSON.stringify({
+    {
       id: window.serverId,
       type: "SERVER",
       states: ["custom"],
-    })
+    }
   ).then(data => {
     component.setState({
       messages: MessagesUtils.info(
@@ -38,11 +38,11 @@ function applyRequest(component) {
 function saveRequest(states) {
   return Network.post(
     "/rhn/manager/api/states/save",
-    JSON.stringify({
+    {
       id: window.serverId,
       type: "SERVER",
       channels: states,
-    })
+    }
   );
 }
 

--- a/web/html/src/manager/minion/formula/minion-formula-selection.renderer.tsx
+++ b/web/html/src/manager/minion/formula/minion-formula-selection.renderer.tsx
@@ -28,7 +28,7 @@ export const renderer = (renderId, { serverId, warningMessage }) => {
     formData.id = serverId;
     formData.selected = selectedFormulas;
 
-    return Network.post("/rhn/manager/api/formulas/select", JSON.stringify(formData)).then(
+    return Network.post("/rhn/manager/api/formulas/select", formData).then(
       data => {
         component.setState({
           messages: data.map(msg => getMessageText(msg)),

--- a/web/html/src/manager/minion/formula/minion-formula-selection.renderer.tsx
+++ b/web/html/src/manager/minion/formula/minion-formula-selection.renderer.tsx
@@ -28,7 +28,7 @@ export const renderer = (renderId, { serverId, warningMessage }) => {
     formData.id = serverId;
     formData.selected = selectedFormulas;
 
-    return Network.post("/rhn/manager/api/formulas/select", JSON.stringify(formData), "application/json").promise.then(
+    return Network.post("/rhn/manager/api/formulas/select", JSON.stringify(formData)).then(
       data => {
         component.setState({
           messages: data.map(msg => getMessageText(msg)),

--- a/web/html/src/manager/minion/packages/use-package-states.api.tsx
+++ b/web/html/src/manager/minion/packages/use-package-states.api.tsx
@@ -30,10 +30,10 @@ const usePackageStatesApi = () => {
         }
         return Network.post(
           "/rhn/manager/api/states/packages/save",
-          JSON.stringify({
+          {
             sid: action.serverId,
             packageStates: toSave,
-          })
+          }
         ).then((data: Array<Package>) => {
           updateAfterSave(data, changed);
           setMessages(MessagesUtils.info(t("Package states have been saved.")));
@@ -42,11 +42,11 @@ const usePackageStatesApi = () => {
       case "Apply": {
         return Network.post(
           "/rhn/manager/api/states/apply",
-          JSON.stringify({
+          {
             id: action.serverId,
             type: "SERVER",
             states: ["packages"],
-          })
+          }
         ).then(data => {
           setMessages(
             MessagesUtils.info(

--- a/web/html/src/manager/minion/packages/use-package-states.api.tsx
+++ b/web/html/src/manager/minion/packages/use-package-states.api.tsx
@@ -33,9 +33,8 @@ const usePackageStatesApi = () => {
           JSON.stringify({
             sid: action.serverId,
             packageStates: toSave,
-          }),
-          "application/json"
-        ).promise.then((data: Array<Package>) => {
+          })
+        ).then((data: Array<Package>) => {
           updateAfterSave(data, changed);
           setMessages(MessagesUtils.info(t("Package states have been saved.")));
         });
@@ -47,9 +46,8 @@ const usePackageStatesApi = () => {
             id: action.serverId,
             type: "SERVER",
             states: ["packages"],
-          }),
-          "application/json"
-        ).promise.then(data => {
+          })
+        ).then(data => {
           setMessages(
             MessagesUtils.info(
               <span>
@@ -63,7 +61,7 @@ const usePackageStatesApi = () => {
         });
       }
       case "GetServerPackages": {
-        return Network.get("/rhn/manager/api/states/packages?sid=" + action.serverId).promise.then(
+        return Network.get("/rhn/manager/api/states/packages?sid=" + action.serverId).then(
           (data: Array<Package>) => {
             updateAfterServerGetPackages(data);
           }
@@ -72,7 +70,7 @@ const usePackageStatesApi = () => {
       case "Search": {
         return Network.get(
           "/rhn/manager/api/states/packages/match?sid=" + action.serverId + "&target=" + action.filter
-        ).promise.then((data: Array<Package>) => {
+        ).then((data: Array<Package>) => {
           updateAfterSearch(data);
           return null;
         });

--- a/web/html/src/manager/notifications/notification-messages.tsx
+++ b/web/html/src/manager/notifications/notification-messages.tsx
@@ -171,7 +171,7 @@ class NotificationMessages extends React.Component<Props, State> {
 
     return Network.post(
       "/rhn/manager/notification-messages/update-messages-status",
-      JSON.stringify(dataRequest)
+      dataRequest
     )
       .then(data => {
         const newMessage = { severity: data.severity, text: data.text };
@@ -203,7 +203,7 @@ class NotificationMessages extends React.Component<Props, State> {
   };
 
   deleteNotifications = ids => {
-    return Network.post("/rhn/manager/notification-messages/delete", JSON.stringify(ids))
+    return Network.post("/rhn/manager/notification-messages/delete", ids)
       .then(data => {
         const newMessage = { severity: data.severity, text: data.text };
         this.setState((prevState, props) => ({

--- a/web/html/src/manager/notifications/notification-messages.tsx
+++ b/web/html/src/manager/notifications/notification-messages.tsx
@@ -44,7 +44,7 @@ const _MESSAGE_TYPE = {
 };
 
 function reloadData(dataUrlSlice: string) {
-  return Network.get("/rhn/manager/notification-messages/" + dataUrlSlice, "application/json").promise;
+  return Network.get("/rhn/manager/notification-messages/" + dataUrlSlice);
 }
 
 type Props = {};
@@ -171,10 +171,9 @@ class NotificationMessages extends React.Component<Props, State> {
 
     return Network.post(
       "/rhn/manager/notification-messages/update-messages-status",
-      JSON.stringify(dataRequest),
-      "application/json"
+      JSON.stringify(dataRequest)
     )
-      .promise.then(data => {
+      .then(data => {
         const newMessage = { severity: data.severity, text: data.text };
         this.setState((prevState, props) => ({
           // serverData = prev serverData without those are changed + those changed with the changes
@@ -204,8 +203,8 @@ class NotificationMessages extends React.Component<Props, State> {
   };
 
   deleteNotifications = ids => {
-    return Network.post("/rhn/manager/notification-messages/delete", JSON.stringify(ids), "application/json")
-      .promise.then(data => {
+    return Network.post("/rhn/manager/notification-messages/delete", JSON.stringify(ids))
+      .then(data => {
         const newMessage = { severity: data.severity, text: data.text };
         this.setState((prevState, props) => ({
           serverData: prevState.serverData.filter(m => !ids.includes(m.id)),
@@ -337,8 +336,8 @@ class NotificationMessages extends React.Component<Props, State> {
   };
 
   retryOnboarding = minionId => {
-    return Network.post("/rhn/manager/notification-messages/retry-onboarding/" + minionId, undefined, "application/json")
-      .promise.then(data => {
+    return Network.post("/rhn/manager/notification-messages/retry-onboarding/" + minionId)
+      .then(data => {
         const newMessage = { severity: data.severity, text: data.text };
         this.setState((prevState, props) => ({ messages: prevState.messages.concat([newMessage]) }));
       })
@@ -346,8 +345,8 @@ class NotificationMessages extends React.Component<Props, State> {
   };
 
   retryReposync = channelId => {
-    return Network.post("/rhn/manager/notification-messages/retry-reposync/" + channelId, undefined, "application/json")
-      .promise.then(data => {
+    return Network.post("/rhn/manager/notification-messages/retry-reposync/" + channelId)
+      .then(data => {
         const newMessage = { severity: data.severity, text: data.text };
         this.setState((prevState, props) => ({ messages: prevState.messages.concat([newMessage]) }));
       })

--- a/web/html/src/manager/organizations/config-channels/org-config-channels.tsx
+++ b/web/html/src/manager/organizations/config-channels/org-config-channels.tsx
@@ -22,9 +22,8 @@ function applyRequest(component) {
       id: window.orgId,
       type: "ORG",
       states: ["custom_org"],
-    }),
-    "application/json"
-  ).promise.then(data => {
+    })
+  ).then(data => {
     console.log("apply action queued:" + data);
     component.setState({
       messages: MessagesUtils.info(
@@ -41,8 +40,7 @@ function saveRequest(states) {
       id: window.orgId,
       type: "ORG",
       channels: states,
-    }),
-    "application/json"
+    })
   );
 }
 

--- a/web/html/src/manager/organizations/config-channels/org-config-channels.tsx
+++ b/web/html/src/manager/organizations/config-channels/org-config-channels.tsx
@@ -18,11 +18,11 @@ function matchUrl(target?: string) {
 function applyRequest(component) {
   return Network.post(
     "/rhn/manager/api/states/apply",
-    JSON.stringify({
+    {
       id: window.orgId,
       type: "ORG",
       states: ["custom_org"],
-    })
+    }
   ).then(data => {
     console.log("apply action queued:" + data);
     component.setState({
@@ -36,11 +36,11 @@ function applyRequest(component) {
 function saveRequest(states) {
   return Network.post(
     "/rhn/manager/api/states/save",
-    JSON.stringify({
+    {
       id: window.orgId,
       type: "ORG",
       channels: states,
-    })
+    }
   );
 }
 

--- a/web/html/src/manager/salt/formula-catalog/org-formula-catalog.tsx
+++ b/web/html/src/manager/salt/formula-catalog/org-formula-catalog.tsx
@@ -28,7 +28,7 @@ class FormulaCatalog extends React.Component<Props, State> {
   }
 
   refreshServerData = () => {
-    Network.get("/rhn/manager/api/formula-catalog/data").promise.then(data => {
+    Network.get("/rhn/manager/api/formula-catalog/data").then(data => {
       this.setState({ serverData: data });
     });
   };

--- a/web/html/src/manager/salt/formula-catalog/org-formula-details.tsx
+++ b/web/html/src/manager/salt/formula-catalog/org-formula-details.tsx
@@ -27,7 +27,7 @@ class FormulaDetail extends React.Component<Props, State> {
   }
 
   getServerData = () => {
-    Network.get("/rhn/manager/api/formula-catalog/formula/" + window.formulaName + "/data").promise.then(data => {
+    Network.get("/rhn/manager/api/formula-catalog/formula/" + window.formulaName + "/data").then(data => {
       this.setState({ metadata: data });
     });
   };

--- a/web/html/src/manager/salt/keys/key-management.tsx
+++ b/web/html/src/manager/salt/keys/key-management.tsx
@@ -10,19 +10,19 @@ import { Highlight } from "components/table/Highlight";
 import SpaRenderer from "core/spa/spa-renderer";
 
 function listKeys() {
-  return Network.get("/rhn/manager/api/systems/keys").promise;
+  return Network.get("/rhn/manager/api/systems/keys");
 }
 
 function acceptKey(key: string) {
-  return Network.post("/rhn/manager/api/systems/keys/" + key + "/accept").promise;
+  return Network.post("/rhn/manager/api/systems/keys/" + key + "/accept");
 }
 
 function deleteKey(key: string) {
-  return Network.post("/rhn/manager/api/systems/keys/" + key + "/delete").promise;
+  return Network.post("/rhn/manager/api/systems/keys/" + key + "/delete");
 }
 
 function rejectKey(key: string) {
-  return Network.post("/rhn/manager/api/systems/keys/" + key + "/reject").promise;
+  return Network.post("/rhn/manager/api/systems/keys/" + key + "/reject");
 }
 
 function actionsFor(id, state, update, enabled) {

--- a/web/html/src/manager/state/highstate-summary.tsx
+++ b/web/html/src/manager/state/highstate-summary.tsx
@@ -38,7 +38,7 @@ export default function HighstateSummary({ minionId }) {
 
   useEffect(() => {
     setLoading(true);
-    Network.get(`/rhn/manager/api/states/summary?sid=${minionId}`).promise
+    Network.get(`/rhn/manager/api/states/summary?sid=${minionId}`)
       .then(data => data.map(toDisplayValues))
       .then(setSummary)
       .then(() => setLoading(false));
@@ -68,7 +68,7 @@ function HighstateOutput({ minionId }) {
   const [highstate, setHighstate] = useState("");
 
   function requestHighstate(id: number) {
-    return Network.get(`/rhn/manager/api/states/highstate?sid=${id}`).promise;
+    return Network.get(`/rhn/manager/api/states/highstate?sid=${id}`);
   }
 
   if (!highstate) {

--- a/web/html/src/manager/state/highstate.tsx
+++ b/web/html/src/manager/state/highstate.tsx
@@ -54,10 +54,9 @@ class Highstate extends React.Component<HighstateProps, HighstateState> {
         earliest: Formats.LocalDateTime(this.state.earliest),
         actionChain: this.state.actionChain ? this.state.actionChain.text : null,
         test: this.state.test,
-      }),
-      "application/json"
+      })
     )
-      .promise.then(data => {
+      .then(data => {
         const msg = MessagesUtils.info(
           this.state.actionChain ? (
             <span>

--- a/web/html/src/manager/state/highstate.tsx
+++ b/web/html/src/manager/state/highstate.tsx
@@ -49,12 +49,12 @@ class Highstate extends React.Component<HighstateProps, HighstateState> {
   applyHighstate = () => {
     const request = Network.post(
       "/rhn/manager/api/states/applyall",
-      JSON.stringify({
+      {
         ids: window.minions?.map(m => m.id),
         earliest: Formats.LocalDateTime(this.state.earliest),
         actionChain: this.state.actionChain ? this.state.actionChain.text : null,
         test: this.state.test,
-      })
+      }
     )
       .then(data => {
         const msg = MessagesUtils.info(

--- a/web/html/src/manager/state/recurring-states.tsx
+++ b/web/html/src/manager/state/recurring-states.tsx
@@ -107,8 +107,8 @@ class RecurringStates extends React.Component<Props, State> {
   getRecurringScheduleList = () => {
     const entityParams = inferEntityParams();
     const endpoint = "/rhn/manager/api/recurringactions" + entityParams;
-    return Network.get(endpoint, "application/json")
-      .promise.then(schedules => {
+    return Network.get(endpoint)
+      .then(schedules => {
         this.setState({
           action: undefined,
           selected: undefined,
@@ -140,8 +140,8 @@ class RecurringStates extends React.Component<Props, State> {
   }
 
   updateSchedule(schedule) {
-    return Network.post("/rhn/manager/api/recurringactions/save", JSON.stringify(schedule), "application/json")
-      .promise.then(_ => {
+    return Network.post("/rhn/manager/api/recurringactions/save", JSON.stringify(schedule))
+      .then(_ => {
         const successMsg = (
           <span>{t("Schedule successfully" + (this.state.action === "create" ? " created." : " updated."))}</span>
         );
@@ -162,7 +162,7 @@ class RecurringStates extends React.Component<Props, State> {
 
   deleteSchedule(item) {
     return Network.del("/rhn/manager/api/recurringactions/" + item.recurringActionId + "/delete")
-      .promise.then(_ => {
+      .then(_ => {
         this.setState({
           messages: MessagesUtils.info("Schedule '" + item.scheduleName + "' has been deleted."),
         });

--- a/web/html/src/manager/state/recurring-states.tsx
+++ b/web/html/src/manager/state/recurring-states.tsx
@@ -140,7 +140,7 @@ class RecurringStates extends React.Component<Props, State> {
   }
 
   updateSchedule(schedule) {
-    return Network.post("/rhn/manager/api/recurringactions/save", JSON.stringify(schedule))
+    return Network.post("/rhn/manager/api/recurringactions/save", schedule)
       .then(_ => {
         const successMsg = (
           <span>{t("Schedule successfully" + (this.state.action === "create" ? " created." : " updated."))}</span>

--- a/web/html/src/manager/systems/activation-key/activation-key-channels-api.tsx
+++ b/web/html/src/manager/systems/activation-key/activation-key-channels-api.tsx
@@ -69,7 +69,7 @@ class ActivationKeyChannelsApi extends React.Component<ActivationKeyChannelsProp
     this.setState({ loading: true });
 
     future = Network.get(`/rhn/manager/api/activation-keys/base-channels`)
-      .promise.then(data => {
+      .then(data => {
         this.setState({
           availableBaseChannels: Array.from(data.data).map((channel: any) => channel.base),
           loading: false,
@@ -85,7 +85,7 @@ class ActivationKeyChannelsApi extends React.Component<ActivationKeyChannelsProp
       this.setState({ loading: true });
 
       future = Network.get(`/rhn/manager/api/activation-keys/${this.props.activationKeyId}/channels`)
-        .promise.then(data => {
+        .then(data => {
           const currentSelectedBaseId = data.data.base ? data.data.base.id : this.props.defaultBaseId;
           const currentChildSelectedIds = data.data.children ? data.data.children.map(c => c.id) : [];
           this.props.onNewBaseChannel({ currentSelectedBaseId, currentChildSelectedIds });
@@ -117,7 +117,7 @@ class ActivationKeyChannelsApi extends React.Component<ActivationKeyChannelsProp
     } else {
       this.setState({ loadingChildren: true });
       future = Network.get(`/rhn/manager/api/activation-keys/base-channels/${baseId}/child-channels`)
-        .promise.then(data => {
+        .then(data => {
           this.setState({
             availableChannels: data.data,
             fetchedData: this.state.fetchedData.set(baseId, data.data),

--- a/web/html/src/manager/systems/bootstrap/bootstrap-minions.tsx
+++ b/web/html/src/manager/systems/bootstrap/bootstrap-minions.tsx
@@ -186,7 +186,7 @@ class BootstrapMinions extends React.Component<Props, State> {
 
     const request = Network.post(
       this.state.manageWithSSH ? "/rhn/manager/api/systems/bootstrap-ssh" : "/rhn/manager/api/systems/bootstrap",
-      JSON.stringify(formData)
+      formData
     ).then(
       data => {
         this.setState({

--- a/web/html/src/manager/systems/bootstrap/bootstrap-minions.tsx
+++ b/web/html/src/manager/systems/bootstrap/bootstrap-minions.tsx
@@ -186,9 +186,8 @@ class BootstrapMinions extends React.Component<Props, State> {
 
     const request = Network.post(
       this.state.manageWithSSH ? "/rhn/manager/api/systems/bootstrap-ssh" : "/rhn/manager/api/systems/bootstrap",
-      JSON.stringify(formData),
-      "application/json"
-    ).promise.then(
+      JSON.stringify(formData)
+    ).then(
       data => {
         this.setState({
           success: data.success,

--- a/web/html/src/manager/systems/delete-system.tsx
+++ b/web/html/src/manager/systems/delete-system.tsx
@@ -35,7 +35,7 @@ class DeleteSystem extends React.Component<Props, State> {
   handleDelete = cleanupErr => {
     const nocleanupParam = cleanupErr ? { nocleanup: "true" } : {};
     return Network.post(`/rhn/manager/api/systems/${this.props.serverId}/delete`, $.param(nocleanupParam))
-      .promise.then(data => {
+      .then(data => {
         if (data.success && this.props.onDeleteSuccess) {
           this.props.onDeleteSuccess();
         } else {

--- a/web/html/src/manager/systems/ssm/ssm-subscribe-channels.tsx
+++ b/web/html/src/manager/systems/ssm/ssm-subscribe-channels.tsx
@@ -305,8 +305,8 @@ class ChildChannelPage extends React.Component<ChildChannelProps, ChildChannelSt
     const childrenIds = Array.from(
       this.props.childChannels.flatMap(dto => dto.childChannels.map(channel => channel.id))
     );
-    Network.post("/rhn/manager/api/admin/mandatoryChannels", JSON.stringify(childrenIds), "application/json")
-      .promise.then((response: JsonResult<Map<number, Array<number>>>) => {
+    Network.post("/rhn/manager/api/admin/mandatoryChannels", JSON.stringify(childrenIds))
+      .then((response: JsonResult<Map<number, Array<number>>>) => {
         const channelDeps = ChannelUtils.processChannelDependencies(response.data);
         this.setState({
           requiredChannels: channelDeps.requiredChannels,
@@ -890,7 +890,7 @@ class SsmChannelPage extends React.Component<SsmChannelProps, SsmChannelState> {
 
   componentDidMount() {
     Network.get(`/rhn/manager/systems/ssm/channels/bases`)
-      .promise.then((data: JsonResult<Array<SsmAllowedBaseChannelsJson>>) => {
+      .then((data: JsonResult<Array<SsmAllowedBaseChannelsJson>>) => {
         this.setState({
           allowedBaseChannels: data.data,
           baseChanges: {
@@ -953,10 +953,9 @@ class SsmChannelPage extends React.Component<SsmChannelProps, SsmChannelState> {
   onGotoChildChannels = () => {
     return Network.post(
       "/rhn/manager/systems/ssm/channels/allowed-changes",
-      JSON.stringify(this.state.baseChanges),
-      "application/json"
+      JSON.stringify(this.state.baseChanges)
     )
-      .promise.then((data: JsonResult<Array<SsmAllowedChildChannelsDto>>) => {
+      .then((data: JsonResult<Array<SsmAllowedChildChannelsDto>>) => {
         // group the allowed changes by the new base in order to show child channels only once
         const groupByNewBase: Map<string, SsmAllowedChildChannelsDto> = new Map();
         const finalChanges: Array<ChannelChangeDto> = [];
@@ -1038,8 +1037,8 @@ class SsmChannelPage extends React.Component<SsmChannelProps, SsmChannelState> {
       actionChain: this.state.actionChain ? this.state.actionChain.text : null,
       changes: this.state.finalChanges,
     };
-    return Network.post("/rhn/manager/systems/ssm/channels", JSON.stringify(req, replacer), "application/json")
-      .promise.then((data: JsonResult<SsmScheduleChannelChangesResultJson>) => {
+    return Network.post("/rhn/manager/systems/ssm/channels", JSON.stringify(req, replacer))
+      .then((data: JsonResult<SsmScheduleChannelChangesResultJson>) => {
         const msg = MessagesUtils.info(
           this.state.actionChain ? (
             <span>

--- a/web/html/src/manager/systems/ssm/ssm-subscribe-channels.tsx
+++ b/web/html/src/manager/systems/ssm/ssm-subscribe-channels.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 import { AsyncButton, Button } from "components/buttons";
 import { ActionSchedule } from "components/action-schedule";
 import Network from "utils/network";
-import { replacer } from "utils/json";
 import { Utils, Formats } from "utils/functions";
 import { Messages } from "components/messages";
 import { Table } from "components/table/Table";
@@ -305,7 +304,7 @@ class ChildChannelPage extends React.Component<ChildChannelProps, ChildChannelSt
     const childrenIds = Array.from(
       this.props.childChannels.flatMap(dto => dto.childChannels.map(channel => channel.id))
     );
-    Network.post("/rhn/manager/api/admin/mandatoryChannels", JSON.stringify(childrenIds))
+    Network.post("/rhn/manager/api/admin/mandatoryChannels", childrenIds)
       .then((response: JsonResult<Map<number, Array<number>>>) => {
         const channelDeps = ChannelUtils.processChannelDependencies(response.data);
         this.setState({
@@ -953,7 +952,7 @@ class SsmChannelPage extends React.Component<SsmChannelProps, SsmChannelState> {
   onGotoChildChannels = () => {
     return Network.post(
       "/rhn/manager/systems/ssm/channels/allowed-changes",
-      JSON.stringify(this.state.baseChanges)
+      this.state.baseChanges
     )
       .then((data: JsonResult<Array<SsmAllowedChildChannelsDto>>) => {
         // group the allowed changes by the new base in order to show child channels only once
@@ -1037,7 +1036,7 @@ class SsmChannelPage extends React.Component<SsmChannelProps, SsmChannelState> {
       actionChain: this.state.actionChain ? this.state.actionChain.text : null,
       changes: this.state.finalChanges,
     };
-    return Network.post("/rhn/manager/systems/ssm/channels", JSON.stringify(req, replacer))
+    return Network.post("/rhn/manager/systems/ssm/channels", req)
       .then((data: JsonResult<SsmScheduleChannelChangesResultJson>) => {
         const msg = MessagesUtils.info(
           this.state.actionChain ? (

--- a/web/html/src/manager/systems/subscribe-channels/subscribe-channels.tsx
+++ b/web/html/src/manager/systems/subscribe-channels/subscribe-channels.tsx
@@ -181,7 +181,7 @@ class SystemChannels extends React.Component<SystemChannelsProps, SystemChannels
       if (mandatoryChannelsNotCached.length > 0) {
         Network.post(
           "/rhn/manager/api/admin/mandatoryChannels",
-          JSON.stringify(mandatoryChannelsNotCached)
+          mandatoryChannelsNotCached
         )
           .then((data: JsonResult<Map<number, Array<number>>>) => {
             const allTheNewMandatoryChannelsData = Object.assign({}, this.state.mandatoryChannelsRaw, data.data);
@@ -348,12 +348,12 @@ class SystemChannels extends React.Component<SystemChannelsProps, SystemChannels
     let selectedChildrenList = this.getSelectedChildren();
     return Network.post(
       `/rhn/manager/api/systems/${this.props.serverId}/channels`,
-      JSON.stringify({
+      {
         base: this.state.selectedBase,
         children: selectedChildrenList,
         earliest: Formats.LocalDateTime(this.state.earliest),
         actionChain: this.state.actionChain ? this.state.actionChain.text : null,
-      })
+      }
     )
       .then(data => {
         if (data.success) {

--- a/web/html/src/manager/systems/subscribe-channels/subscribe-channels.tsx
+++ b/web/html/src/manager/systems/subscribe-channels/subscribe-channels.tsx
@@ -88,7 +88,7 @@ class SystemChannels extends React.Component<SystemChannelsProps, SystemChannels
 
   updateView = () => {
     Network.get(`/rhn/manager/api/systems/${this.props.serverId}/channels`)
-      .promise.then(data => {
+      .then(data => {
         const base: ChannelDto = data.data && data.data.base ? data.data.base : this.getNoBase();
         const childrenIds = data.data.children ? data.data.children.map(c => c.id) : [];
         this.setState({
@@ -108,7 +108,7 @@ class SystemChannels extends React.Component<SystemChannelsProps, SystemChannels
       .catch(this.handleResponseError);
 
     Network.get(`/rhn/manager/api/systems/${this.props.serverId}/channels-available-base`)
-      .promise.then(data => {
+      .then(data => {
         this.setState({
           availableBase: data.data,
         });
@@ -127,7 +127,7 @@ class SystemChannels extends React.Component<SystemChannelsProps, SystemChannels
       Network.get(
         `/rhn/manager/api/systems/${this.props.serverId}/channels/${newBaseId}/accessible-children${queryString}`
       )
-        .promise.then((data: JsonResult<Array<ChannelDto>>) => {
+        .then((data: JsonResult<Array<ChannelDto>>) => {
           const newChildren = new Map(
             data.data.sort((a, b) => a.name.localeCompare(b.name)).map(channel => [channel.id, channel])
           );
@@ -181,10 +181,9 @@ class SystemChannels extends React.Component<SystemChannelsProps, SystemChannels
       if (mandatoryChannelsNotCached.length > 0) {
         Network.post(
           "/rhn/manager/api/admin/mandatoryChannels",
-          JSON.stringify(mandatoryChannelsNotCached),
-          "application/json"
+          JSON.stringify(mandatoryChannelsNotCached)
         )
-          .promise.then((data: JsonResult<Map<number, Array<number>>>) => {
+          .then((data: JsonResult<Map<number, Array<number>>>) => {
             const allTheNewMandatoryChannelsData = Object.assign({}, this.state.mandatoryChannelsRaw, data.data);
             let { requiredChannels, requiredByChannels } = ChannelUtils.processChannelDependencies(
               allTheNewMandatoryChannelsData
@@ -354,10 +353,9 @@ class SystemChannels extends React.Component<SystemChannelsProps, SystemChannels
         children: selectedChildrenList,
         earliest: Formats.LocalDateTime(this.state.earliest),
         actionChain: this.state.actionChain ? this.state.actionChain.text : null,
-      }),
-      "application/json"
+      })
     )
-      .promise.then(data => {
+      .then(data => {
         if (data.success) {
           const msg = MessagesUtils.info(
             this.state.actionChain ? (

--- a/web/html/src/manager/systems/virtualhostmanager/virtualhostmanager-details.tsx
+++ b/web/html/src/manager/systems/virtualhostmanager/virtualhostmanager-details.tsx
@@ -40,7 +40,7 @@ class VirtualHostManagerDetails extends React.Component<Props, State> {
 
   UNSAFE_componentWillMount() {
     Network.get("/rhn/manager/api/vhms/" + this.props.data.id + "/nodes")
-      .promise.then(data => {
+      .then(data => {
         this.setState({ nodes: data.data });
       })
       .catch(this.handleResponseError);
@@ -49,10 +49,9 @@ class VirtualHostManagerDetails extends React.Component<Props, State> {
   onRefresh() {
     return Network.post(
       "/rhn/manager/api/vhms/" + this.props.data.id + "/refresh",
-      JSON.stringify(this.props.data.id),
-      "application/json"
+      JSON.stringify(this.props.data.id)
     )
-      .promise.then(data => {
+      .then(data => {
         if (data.success) {
           this.setState({
             messages: MessagesUtils.info(t("Refreshing the data for this Virtual Host Manager has been triggered.")),

--- a/web/html/src/manager/systems/virtualhostmanager/virtualhostmanager-details.tsx
+++ b/web/html/src/manager/systems/virtualhostmanager/virtualhostmanager-details.tsx
@@ -49,7 +49,7 @@ class VirtualHostManagerDetails extends React.Component<Props, State> {
   onRefresh() {
     return Network.post(
       "/rhn/manager/api/vhms/" + this.props.data.id + "/refresh",
-      JSON.stringify(this.props.data.id)
+      this.props.data.id
     )
       .then(data => {
         if (data.success) {

--- a/web/html/src/manager/systems/virtualhostmanager/virtualhostmanager-edit.tsx
+++ b/web/html/src/manager/systems/virtualhostmanager/virtualhostmanager-edit.tsx
@@ -59,7 +59,7 @@ class VirtualHostManagerEdit extends React.Component<Props, State> {
 
   UNSAFE_componentWillMount() {
     Network.get("/rhn/manager/api/vhms/module/" + this.props.type.toLowerCase() + "/params")
-      .promise.then(data => {
+      .then(data => {
         this.setState({ vhmParams: data.data });
       })
       .catch(this.handleResponseError);
@@ -91,7 +91,7 @@ class VirtualHostManagerEdit extends React.Component<Props, State> {
 
   setKubeconfigContexts(id) {
     Network.get("/rhn/manager/api/vhms/kubeconfig/" + id + "/contexts")
-      .promise.then(data => {
+      .then(data => {
         this.setState({
           model: Object.assign(this.state.model, { contexts: data.data }),
         });
@@ -114,12 +114,12 @@ class VirtualHostManagerEdit extends React.Component<Props, State> {
         // Remove '<default>' placeholder for submit
         formData.set("module_context", "");
       }
-      request = Network.post("/rhn/manager/api/vhms/update/kubernetes", formData, undefined, false);
+      request = Network.post("/rhn/manager/api/vhms/update/kubernetes", formData, "application/x-www-form-urlencoded", false);
     } else {
-      request = Network.post("/rhn/manager/api/vhms/update/" + this.state.model.id, jQuery(this.form).serialize());
+      request = Network.post("/rhn/manager/api/vhms/update/" + this.state.model.id, jQuery(this.form).serialize(), "application/x-www-form-urlencoded");
     }
 
-    return request.promise
+    return request
       .then(data => {
         Utils.urlBounce("/rhn/manager/vhms");
       })
@@ -137,12 +137,12 @@ class VirtualHostManagerEdit extends React.Component<Props, State> {
         // Remove '<default>' placeholder for submit
         formData.set("module_context", "");
       }
-      request = Network.post("/rhn/manager/api/vhms/create/kubernetes", formData, undefined, false);
+      request = Network.post("/rhn/manager/api/vhms/create/kubernetes", formData, "application/x-www-form-urlencoded", false);
     } else {
-      request = Network.post("/rhn/manager/api/vhms/create", jQuery(this.form).serialize());
+      request = Network.post("/rhn/manager/api/vhms/create", jQuery(this.form).serialize(), "application/x-www-form-urlencoded");
     }
 
-    return request.promise
+    return request
       .then(data => {
         Utils.urlBounce("/rhn/manager/vhms");
       })
@@ -273,8 +273,8 @@ class VirtualHostManagerEdit extends React.Component<Props, State> {
     let kubeconfig = event.target.files[0];
     let formData = new FormData();
     formData.append("kubeconfig", kubeconfig);
-    Network.post("/rhn/manager/api/vhms/kubeconfig/validate", formData, undefined, false)
-      .promise.then(res => {
+    Network.post("/rhn/manager/api/vhms/kubeconfig/validate", formData, "application/x-www-form-urlencoded", false)
+      .then(res => {
         const data = res.data;
         if (data.currentContext === "") {
           // Replace unnamed context with '<default>' to differ it from empty choice

--- a/web/html/src/manager/systems/virtualhostmanager/virtualhostmanager.tsx
+++ b/web/html/src/manager/systems/virtualhostmanager/virtualhostmanager.tsx
@@ -94,18 +94,18 @@ class VirtualHostManager extends React.Component<Props, State> {
   }
 
   getVhmDetails(id, action?: any) {
-    return Network.get("/rhn/manager/api/vhms/" + id).promise.catch(this.handleResponseError);
+    return Network.get("/rhn/manager/api/vhms/" + id).catch(this.handleResponseError);
   }
 
   getVhmList() {
     return Network.get("/rhn/manager/api/vhms")
-      .promise.then(data => this.setState({ action: undefined, selected: undefined, vhms: data.data }))
+      .then(data => this.setState({ action: undefined, selected: undefined, vhms: data.data }))
       .catch(this.handleResponseError);
   }
 
   getAvailableModules() {
     return Network.get("/rhn/manager/api/vhms/modules")
-      .promise.then(data => this.setState({ availableModules: data }))
+      .then(data => this.setState({ availableModules: data }))
       .catch(this.handleResponseError);
   }
 
@@ -116,7 +116,7 @@ class VirtualHostManager extends React.Component<Props, State> {
   deleteVhm(item) {
     if (!item) return false;
     return Network.del("/rhn/manager/api/vhms/delete/" + item.id)
-      .promise.then(data => {
+      .then(data => {
         this.handleBackAction();
         this.setState({
           messages: MessagesUtils.info("Virtual Host Manager has been deleted."),

--- a/web/html/src/manager/virtualization/ActionApi.tsx
+++ b/web/html/src/manager/virtualization/ActionApi.tsx
@@ -31,7 +31,7 @@ export function ActionApi(props: Props) {
   const [messages, setMessages] = React.useState<Array<MessageType>>([]);
 
   const onAction = (urlModifier: (arg0: string) => string, action: string, parameters: any) => {
-    Network.post(urlModifier(props.urlTemplate), JSON.stringify(parameters)).then(
+    Network.post(urlModifier(props.urlTemplate), parameters).then(
       response => {
         if (Object.values(response).includes("Failed")) {
           setMessages(MessagesUtils.error(t(`Failed to trigger ${action}`)));

--- a/web/html/src/manager/virtualization/ActionApi.tsx
+++ b/web/html/src/manager/virtualization/ActionApi.tsx
@@ -31,7 +31,7 @@ export function ActionApi(props: Props) {
   const [messages, setMessages] = React.useState<Array<MessageType>>([]);
 
   const onAction = (urlModifier: (arg0: string) => string, action: string, parameters: any) => {
-    Network.post(urlModifier(props.urlTemplate), JSON.stringify(parameters), "application/json").promise.then(
+    Network.post(urlModifier(props.urlTemplate), JSON.stringify(parameters)).then(
       response => {
         if (Object.values(response).includes("Failed")) {
           setMessages(MessagesUtils.error(t(`Failed to trigger ${action}`)));

--- a/web/html/src/manager/virtualization/guests/console/guests-console.tsx
+++ b/web/html/src/manager/virtualization/guests/console/guests-console.tsx
@@ -213,9 +213,8 @@ class GuestsConsole extends React.Component<Props, State> {
     this.isRefreshing = true;
     Network.post(
       `/rhn/manager/api/systems/details/virtualization/guests/consoleToken/${this.props.guestUuid}`,
-      this.state.currentToken,
-      "application/json"
-    ).promise.then(
+      this.state.currentToken
+    ).then(
       response => {
         this.isRefreshing = false;
         this.popupSubmit = undefined;

--- a/web/html/src/manager/virtualization/guests/console/guests-console.tsx
+++ b/web/html/src/manager/virtualization/guests/console/guests-console.tsx
@@ -250,8 +250,7 @@ class GuestsConsole extends React.Component<Props, State> {
   };
 
   updateGuestData = () => {
-    Network.get(`/rhn/manager/api/systems/details/virtualization/guests/${this.state.hostId}/guest/${this.props.guestUuid}`,
-      'application/json').promise
+    Network.get(`/rhn/manager/api/systems/details/virtualization/guests/${this.state.hostId}/guest/${this.props.guestUuid}`)
       .then((response) => {
         this.setState({
           graphicsType: response.graphics?.type,

--- a/web/html/src/manager/virtualization/guests/virtualization-domains-caps-api.ts
+++ b/web/html/src/manager/virtualization/guests/virtualization-domains-caps-api.ts
@@ -26,9 +26,8 @@ class VirtualizationDomainsCapsApi extends React.Component<Props, State> {
 
   componentDidMount() {
     Network.get(
-      `/rhn/manager/api/systems/details/virtualization/guests/${this.props.hostId}/domains_capabilities`,
-      "application/json"
-    ).promise.then(
+      `/rhn/manager/api/systems/details/virtualization/guests/${this.props.hostId}/domains_capabilities`
+    ).then(
       response => {
         this.setState({
           osTypes: response.osTypes,

--- a/web/html/src/manager/virtualization/guests/virtualization-guest-definition-api.ts
+++ b/web/html/src/manager/virtualization/guests/virtualization-guest-definition-api.ts
@@ -25,9 +25,8 @@ class VirtualizationGuestDefinitionApi extends React.Component<Props, State> {
 
   componentDidMount() {
     Network.get(
-      `/rhn/manager/api/systems/details/virtualization/guests/${this.props.hostid}/guest/${this.props.guestUuid}`,
-      "application/json"
-    ).promise.then(
+      `/rhn/manager/api/systems/details/virtualization/guests/${this.props.hostid}/guest/${this.props.guestUuid}`
+    ).then(
       response => {
         this.setState({ definition: response });
       },

--- a/web/html/src/manager/virtualization/nets/virtualization-network-definition-api.tsx
+++ b/web/html/src/manager/virtualization/nets/virtualization-network-definition-api.tsx
@@ -23,8 +23,7 @@ export function VirtualizationNetworkDefinitionApi(props: Props) {
   React.useEffect(() => {
     Network.get(
       `/rhn/manager/api/systems/details/virtualization/nets/${props.hostid}/net/${props.networkName}`,
-      "application/json"
-    ).promise.then(
+    ).then(
       response => {
         setDefinition(response);
       },

--- a/web/html/src/manager/virtualization/nets/virtualization-network-devs-api.ts
+++ b/web/html/src/manager/virtualization/nets/virtualization-network-devs-api.ts
@@ -14,9 +14,8 @@ export function VirtualizationNetworkDevsApi(props: Props) {
   React.useEffect(() => {
     let subscribded = true;
     Network.get(
-      `/rhn/manager/api/systems/details/virtualization/nets/${props.hostId}/devices`,
-      "application/json"
-    ).promise.then(
+      `/rhn/manager/api/systems/details/virtualization/nets/${props.hostId}/devices`
+    ).then(
       response => {
         if (subscribded) {
           setNetDevices(response);

--- a/web/html/src/manager/virtualization/pools/virtualization-pool-definition-api.tsx
+++ b/web/html/src/manager/virtualization/pools/virtualization-pool-definition-api.tsx
@@ -22,9 +22,8 @@ export function VirtualizationPoolDefinitionApi(props: Props) {
 
   React.useEffect(() => {
     Network.get(
-      `/rhn/manager/api/systems/details/virtualization/pools/${props.hostid}/pool/${props.poolName}`,
-      "application/json"
-    ).promise.then(
+      `/rhn/manager/api/systems/details/virtualization/pools/${props.hostid}/pool/${props.poolName}`
+    ).then(
       response => {
         setDefinition(response);
       },

--- a/web/html/src/manager/virtualization/pools/virtualization-pools-capabilities-api.ts
+++ b/web/html/src/manager/virtualization/pools/virtualization-pools-capabilities-api.ts
@@ -14,9 +14,8 @@ export function VirtualizationPoolCapsApi(props: Props) {
   React.useEffect(() => {
     let subscribded = true;
     Network.get(
-      `/rhn/manager/api/systems/details/virtualization/pools/${props.hostId}/capabilities`,
-      "application/json"
-    ).promise.then(
+      `/rhn/manager/api/systems/details/virtualization/pools/${props.hostId}/capabilities`
+    ).then(
       response => {
         if (subscribded) {
           setCapabilities(response);

--- a/web/html/src/manager/virtualization/virtualization-list-refresh-api.ts
+++ b/web/html/src/manager/virtualization/virtualization-list-refresh-api.ts
@@ -14,10 +14,9 @@ export function VirtualizationListRefreshApi(props: Props) {
 
   const refreshServerData = React.useCallback(() => {
     Network.get(
-      `/rhn/manager/api/systems/details/virtualization/${props.type}/${props.serverId}/data`,
-      "application/json"
+      `/rhn/manager/api/systems/details/virtualization/${props.type}/${props.serverId}/data`
     )
-      .promise.then(data => {
+      .then(data => {
         setData(data);
         setError(undefined);
       })

--- a/web/html/src/manager/visualization/hierarchy.tsx
+++ b/web/html/src/manager/visualization/hierarchy.tsx
@@ -235,7 +235,7 @@ class Hierarchy extends React.Component {
 
   componentDidMount() {
     // Get data & put everything together in the graph!
-    Network.get(window.endpoint, "application/json").promise.then(
+    Network.get(window.endpoint).then(
       data => jQuery(document).ready(() => displayHierarchy(data)),
       xhr => d3.select("#svg-wrapper").text(t("There was an error fetching data from the server."))
     );

--- a/web/html/src/utils/data-providers/paged-data-endpoint.ts
+++ b/web/html/src/utils/data-providers/paged-data-endpoint.ts
@@ -48,9 +48,8 @@ export default class PagedDataEndpoint {
             this.curReq.cancel("The request is cancelled due to subsequent calls");
         }
         this.curReq = Network.get(this.uri.toString());
-        const promise = this.curReq.promise;
-        promise.finally(() => (this.curReq = null));
-        callback(promise);
+        this.curReq.finally(() => (this.curReq = null));
+        callback(this.curReq);
     }
 
     /**

--- a/web/html/src/utils/functions.test.ts
+++ b/web/html/src/utils/functions.test.ts
@@ -42,6 +42,11 @@ describe("cancelable", () => {
     expect(instance instanceof Promise).toEqual(true);
   });
 
+  test("has generic chainable properties like finally", () => {
+    const instance = cancelable(new Promise(() => undefined));
+    expect(instance.finally).toBeDefined();
+  });
+
   test("chaining off the promise property", async () => {
     const onSuccess = jest.fn();
     const onCancel = jest.fn();

--- a/web/html/src/utils/network.ts
+++ b/web/html/src/utils/network.ts
@@ -23,7 +23,7 @@ export type JsonResult<T> = {
  * 
  * See: https://stackoverflow.com/a/51445345/1470607
  */
-type CommonMimeTypes = "application/json" | "application/xml";
+type CommonMimeTypes = "application/json" | "application/xml" | "application/x-www-form-urlencoded";
 type DataType<T> = T & (T extends CommonMimeTypes ? never : T);
 
 function request(
@@ -31,15 +31,14 @@ function request(
     type: "GET" | "POST" | "DELETE" | "PUT",
     headers: Record<string, string>,
     data: any,
-    /** NB! The default contentType for jQuery.ajax() is 'application/x-www-form-urlencoded; charset=UTF-8' */
-    contentType?: string,
+    contentType: string,
     processData: boolean = true
 ): Cancelable {
     const a = jQuery.ajax({
         url: url,
         data: data,
         type: type,
-        contentType: contentType,
+        contentType: `${contentType}; charset=UTF-8`,
         processData: processData,
         beforeSend: xhr => {
             if (headers !== undefined) {
@@ -52,15 +51,15 @@ function request(
     return Utils.cancelable(Promise.resolve(a), () => a.abort());
 }
 
-function post<T>(url: string, data?: DataType<T>, contentType?: string, processData: boolean = true): Cancelable {
+function post<T>(url: string, data?: DataType<T>, contentType: string = "application/json", processData: boolean = true): Cancelable {
     return request(url, "POST", {"X-CSRF-Token": csrfToken}, data, contentType, processData);
 }
 
-function del<T>(url: string, data?: DataType<T>, contentType?: string, processData: boolean = true): Cancelable {
+function del<T>(url: string, data?: DataType<T>, contentType: string = "application/json", processData: boolean = true): Cancelable {
     return request(url, "DELETE", {"X-CSRF-Token": csrfToken}, data, contentType, processData);
 }
 
-function put<T>(url: string, data?: DataType<T>, contentType?: string, processData: boolean = true): Cancelable {
+function put<T>(url: string, data?: DataType<T>, contentType: string = "application/json", processData: boolean = true): Cancelable {
     return request(url, "PUT", {"X-CSRF-Token": csrfToken}, data, contentType, processData);
 }
 

--- a/web/html/src/utils/network.ts
+++ b/web/html/src/utils/network.ts
@@ -1,8 +1,8 @@
-import {Utils} from "../utils/functions";
-import {Utils as MessagesUtils} from "../components/messages";
+import {MessageType, Utils as MessagesUtils} from "components/messages";
+import {Utils} from "utils/functions";
+import {Cancelable} from "utils/functions";
 
-import {Cancelable} from "../utils/functions";
-import {MessageType} from "components/messages";
+import { replacer } from "./json";
 
 declare var csrfToken: string;
 
@@ -34,6 +34,12 @@ function request(
     contentType: string,
     processData: boolean = true
 ): Cancelable {
+    const isRegularObject = typeof data === "object" && !(data instanceof FormData);
+    const isNumber = typeof data === 'number';
+    if ((isRegularObject || isNumber) && processData === true) {
+        data = JSON.stringify(data, replacer);
+    }
+
     const a = jQuery.ajax({
         url: url,
         data: data,


### PR DESCRIPTION
## What does this PR change?

In preparation for date handling in [SUSE/spacewalk#15112](https://github.com/SUSE/spacewalk/issues/15112), this PR cleans up network request params usages. `"application/json"` is made the default content type since it's used almost everywhere, and object stringification is moved into the network layer so every consumer doesn't manually have to do it.

This is definitely easier to review commit-by-commit, the core changes are in [`web/html/src/utils/network.ts`](https://github.com/uyuni-project/uyuni/pull/3952/files#diff-d676e5c8ecc78dcc81a470162fd49edef2b1a77d02ab7707cfaf3d4dba661f00), the other changes flow from that.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Part of https://github.com/SUSE/spacewalk/issues/15112

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
