### PR TITLE
Remove beta tag from client tools reposync

### DIFF
--- a/testsuite/features/reposync/srv_sync_products.feature
+++ b/testsuite/features/reposync/srv_sync_products.feature
@@ -75,9 +75,9 @@ Feature: Synchronize products in the products page of the Setup Wizard
     Then I should see a "Basesystem Module 15 SP3 x86_64" text
     And I should see that the "Basesystem Module 15 SP3 x86_64" product is "recommended"
     When I select "SUSE Linux Enterprise Server 15 SP3 x86_64" as a product
-    # Drop following 2 lines if you wish to re-enable testing with beta client tools for SLE15
+    # Drop following 2 lines if you wish to re-enable testing with client tools for SLE15
     And I open the sub-list of the product "Basesystem Module 15 SP3 x86_64"
-    And I deselect "SUSE Manager Client Tools Beta for SLE 15 x86_64 (BETA)" as a SUSE Manager product
+    And I deselect "SUSE Manager Client Tools for SLE 15 x86_64" as a SUSE Manager product
     Then I should see the "SUSE Linux Enterprise Server 15 SP3 x86_64" selected
     And I should see the "Basesystem Module 15 SP3 x86_64" selected
     When I click the Add Product button


### PR DESCRIPTION
## What does this PR change?

Remove beta tag from client tools reposync

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes no issue, directly from CI review
Tracks 4.2: https://github.com/SUSE/spacewalk/pull/15330
4.1 is not needed apparently there is no BETA in there

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
