### PR TITLE
Fix a typo so mgr-create-bootstrap-script can exit gracefully when interrupted!

### DIFF
--- a/susemanager/src/mgr-create-bootstrap-repo
+++ b/susemanager/src/mgr-create-bootstrap-repo
@@ -753,7 +753,7 @@ if __name__ == '__main__':
         sys.exit(abs(main() or 0))
     except KeyboardInterrupt:
         sys.stderr.write("\nProcess has been interrupted.\n")
-        sys.exist(1)
+        sys.exit(1)
     except SystemExit as e:
         releaseLOCK()
         sys.exit(e.code)

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- Fix a typo so mgr-create-bootstrap-script can exit gracefully when interrupted (bsc#1188073)
 - porting the package to python3 with proper placement
   compiled python files
 


### PR DESCRIPTION
## What does this PR change?

Fix a typo so mgr-create-bootstrap-script can exit gracefully when interrupted!

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: just a typo fix

- [x] **DONE**

## Test coverage
- No tests: typo has been fixed


- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
