### PR TITLE
Rocky Linux 8 Java enablement

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/channel/ChannelFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/channel/ChannelFactory.java
@@ -1337,7 +1337,7 @@ public class ChannelFactory extends HibernateFactory {
     public static ContentSource findVendorContentSourceByRepo(String repoUrl) {
         Criteria criteria = getSession().createCriteria(ContentSource.class);
         criteria.add(Restrictions.isNull("org"));
-        if (repoUrl.contains("mirrorlist.centos.org")) {
+        if (repoUrl.contains("mirrorlist.centos.org") || repoUrl.contains("mirrors.rockylinux.org")) {
             criteria.add(Restrictions.eq("sourceUrl", repoUrl));
         }
         else {

--- a/java/code/src/com/redhat/rhn/domain/server/MinionServer.java
+++ b/java/code/src/com/redhat/rhn/domain/server/MinionServer.java
@@ -152,7 +152,7 @@ public class MinionServer extends Server implements SaltConfigurable {
     @Override
     public boolean doesOsSupportsMonitoring() {
         return isSLES12() || isSLES15() || isLeap15() || isUbuntu1804() || isUbuntu2004() || isRedHat6() ||
-                isRedHat7() || isRedHat8() || isAlibaba2() || isAmazon2();
+                isRedHat7() || isRedHat8() || isAlibaba2() || isAmazon2() || isRocky8();
     }
 
     /**
@@ -216,6 +216,10 @@ public class MinionServer extends Server implements SaltConfigurable {
 
     private boolean isAmazon2() {
         return ServerConstants.AMAZON.equals(getOsFamily()) && getRelease().equals("2");
+    }
+
+    private boolean isRocky8() {
+        return ServerConstants.ROCKY.equals(getOs()) && getRelease().startsWith("8.");
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/server/ServerConstants.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerConstants.java
@@ -32,6 +32,7 @@ public class ServerConstants {
     public static final String ALIBABA = "Alibaba Cloud Linux (Aliyun Linux)";
     public static final String ALMA = "AlmaLinux";
     public static final String AMAZON = "Amazon Linux";
+    public static final String ROCKY = "Rocky";
 
     private ServerConstants() {
 

--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -861,7 +861,8 @@ public class RegisterMinionEventMessageAction implements MessageAction {
                 "oel".equalsIgnoreCase(grains.getValueAsString("os")) ||
                 "alibaba cloud (aliyun)".equalsIgnoreCase(grains.getValueAsString("os")) ||
                 "almalinux".equalsIgnoreCase(grains.getValueAsString("os")) ||
-                "amazon".equalsIgnoreCase(grains.getValueAsString("os"))) {
+                "amazon".equalsIgnoreCase(grains.getValueAsString("os")) ||
+                "rocky".equalsIgnoreCase(grains.getValueAsString("os"))) {
             MinionList target = new MinionList(Arrays.asList(minionId));
             Optional<Result<String>> whatprovidesRes = saltApi.runRemoteCommand(target,
                     "rpm -q --whatprovides --queryformat \"%{NAME}\\n\" redhat-release")

--- a/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegistrationUtils.java
@@ -358,7 +358,8 @@ public class RegistrationUtils {
                  "oel".equalsIgnoreCase(grains.getValueAsString(OS)) ||
                  "alibaba cloud (aliyun)".equalsIgnoreCase(grains.getValueAsString(OS)) ||
                  "almalinux".equalsIgnoreCase(grains.getValueAsString(OS)) ||
-                 "amazon".equalsIgnoreCase(grains.getValueAsString(OS))) {
+                 "amazon".equalsIgnoreCase(grains.getValueAsString(OS)) ||
+                 "rocky".equalsIgnoreCase(grains.getValueAsString(OS))) {
 
             Optional<RedhatProductInfo> redhatProductInfo = systemQuery.redhatProductInfo(server.getMinionId());
 
@@ -366,7 +367,7 @@ public class RegistrationUtils {
                     redhatProductInfo.flatMap(x -> RhelUtils.detectRhelProduct(
                             server, x.getWhatProvidesRes(), x.getRhelReleaseContent(), x.getCentosReleaseContent(),
                             x.getOracleReleaseContent(), x.getAlibabaReleaseContent(), x.getAlmaReleaseContent(),
-                            x.getAmazonReleaseContent()));
+                            x.getAmazonReleaseContent(), x.getRockyReleaseContent()));
             return Opt.stream(rhelProduct).flatMap(rhel -> {
                 if (rhel.getSuseProduct().isPresent()) {
                     return Opt.stream(rhel.getSuseProduct());

--- a/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/test/RegisterMinionActionTest.java
@@ -1001,6 +1001,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                             Optional.empty(),
                             Optional.empty(),
                             Optional.empty(),
+                            Optional.empty(),
                             Optional.empty()
                     ))));
 
@@ -1048,6 +1049,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                     will(returnValue(Optional.of(new RedhatProductInfo(
                             Optional.empty(),
                             Optional.of("Red Hat Enterprise Linux Server release 7.2 (Maipo)"),
+                            Optional.empty(),
                             Optional.empty(),
                             Optional.empty(),
                             Optional.empty(),
@@ -1111,6 +1113,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                         will(returnValue(Optional.of(new RedhatProductInfo(
                                 Optional.empty(),
                                 Optional.of("Red Hat Enterprise Linux Server release 7.2 (Maipo)"),
+                                Optional.empty(),
                                 Optional.empty(),
                                 Optional.empty(),
                                 Optional.empty(),
@@ -1187,6 +1190,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                             Optional.empty(),
                             Optional.empty(),
                             Optional.empty(),
+                            Optional.empty(),
                             Optional.of("sles_es-release-server-7.2-9.el7.2.1.x86_64")
                     ))));
                 }},
@@ -1246,6 +1250,7 @@ public class RegisterMinionActionTest extends JMockBaseTestCaseWithUser {
                     will(returnValue(Optional.of(new RedhatProductInfo(
                             Optional.empty(),
                             Optional.of("Red Hat Enterprise Linux Server release 7.2 (Maipo)"),
+                            Optional.empty(),
                             Optional.empty(),
                             Optional.empty(),
                             Optional.empty(),

--- a/java/code/src/com/suse/manager/reactor/utils/RhelUtils.java
+++ b/java/code/src/com/suse/manager/reactor/utils/RhelUtils.java
@@ -98,7 +98,7 @@ public class RhelUtils {
     }
 
     /**
-     * The content of the /etc/redhat|centos|oracle|almalinux|alinux|system-release file.
+     * The content of the /etc/redhat|centos|oracle|almalinux|alinux|system|rocky-release file.
      */
     public static class ReleaseFile {
 
@@ -152,7 +152,7 @@ public class RhelUtils {
     }
 
     /**
-     * Parse the /etc/redhat|centos|oracle|almalinux|alinux|system-release
+     * Parse the /etc/redhat|centos|oracle|almalinux|alinux|system|rocky-release
      * @param releaseFile the content of the release file
      * @return the parsed content of the release file
      */
@@ -218,13 +218,15 @@ public class RhelUtils {
      * @param alibabaReleaseFile the content of /etc/alinux-release
      * @param almaReleaseFile the content of /etc/almalinux-release
      * @param amazonReleaseFile the content of /etc/system-release
+     * @param rockyReleaseFile the content of /etc/rocky-release
      * @return the {@link RhelProduct}
      */
     public static Optional<RhelProduct> detectRhelProduct(
             Set<Channel> channels, String arch, Optional<String> resReleasePackage,
             Optional<String> rhelReleaseFile, Optional<String> centosReleaseFile,
             Optional<String> oracleReleaseFile, Optional<String> alibabaReleaseFile,
-            Optional<String> almaReleaseFile, Optional<String> amazonReleaseFile) {
+            Optional<String> almaReleaseFile, Optional<String> amazonReleaseFile,
+            Optional<String> rockyReleaseFile) {
 
         // check first if it has RES channels assigned or the RES release package installed
         boolean hasRESChannels = channels.stream()
@@ -280,6 +282,11 @@ public class RhelUtils {
             return amazonReleaseFile.map(v -> detectPlainRHEL(v, arch, "AmazonLinux"));
         }
 
+        // next check if Rocky Linux
+        if (rockyReleaseFile.filter(StringUtils::isNotBlank).isPresent()) {
+            return rockyReleaseFile.map(v -> detectPlainRHEL(v, arch, "RockyLinux"));
+        }
+
         // next check if Centos
         if (centosReleaseFile.filter(StringUtils::isNotBlank).isPresent()) {
             return centosReleaseFile.map(v -> detectPlainRHEL(v, arch, "CentOS"));
@@ -312,13 +319,15 @@ public class RhelUtils {
      * @param alibabaReleaseFile the content of /etc/alinux-release
      * @param almaReleaseFile the content of /etc/almalinux-release
      * @param amazonReleaseFile the content of /etc/system-release
+     * @param rockyReleaseFile the content of /etc/rocky-release
      * @return the {@link RhelProduct}
      */
     public static Optional<RhelProduct> detectRhelProduct(
             Server server, Optional<String> resReleasePackage,
             Optional<String> rhelReleaseFile, Optional<String> centosReleaseFile,
             Optional<String> oracleReleaseFile, Optional<String> alibabaReleaseFile,
-            Optional<String> almaReleaseFile, Optional<String> amazonReleaseFile) {
+            Optional<String> almaReleaseFile, Optional<String> amazonReleaseFile,
+            Optional<String> rockyReleaseFile) {
         return detectRhelProduct(
                 server.getChannels(),
                 server.getServerArch().getLabel().replace("-redhat-linux", ""),
@@ -328,7 +337,8 @@ public class RhelUtils {
                 oracleReleaseFile,
                 alibabaReleaseFile,
                 almaReleaseFile,
-                amazonReleaseFile
+                amazonReleaseFile,
+                rockyReleaseFile
         );
     }
 
@@ -352,13 +362,15 @@ public class RhelUtils {
      * @param alibabaReleaseFile the content of /etc/alinux-release
      * @param almaReleaseFile the content of /etc/almalinux-release
      * @param amazonReleaseFile the content of /etc/system-release
+     * @param rockyReleaseFile the content of /etc/rocky-release
      * @return the {@link RhelProduct}
      */
     public static Optional<RhelProduct> detectRhelProduct(
             ImageInfo image, Optional<String> resReleasePackage,
             Optional<String> rhelReleaseFile, Optional<String> centosReleaseFile,
             Optional<String> oracleReleaseFile, Optional<String> alibabaReleaseFile,
-            Optional<String> almaReleaseFile, Optional<String> amazonReleaseFile) {
+            Optional<String> almaReleaseFile, Optional<String> amazonReleaseFile,
+            Optional<String> rockyReleaseFile) {
         return detectRhelProduct(
                 image.getChannels(),
                 image.getImageArch().getLabel().replace("-redhat-linux", ""),
@@ -368,7 +380,8 @@ public class RhelUtils {
                 oracleReleaseFile,
                 alibabaReleaseFile,
                 almaReleaseFile,
-                amazonReleaseFile
+                amazonReleaseFile,
+                rockyReleaseFile
         );
     }
 

--- a/java/code/src/com/suse/manager/reactor/utils/RhelUtils.java
+++ b/java/code/src/com/suse/manager/reactor/utils/RhelUtils.java
@@ -166,7 +166,7 @@ public class RhelUtils {
         if (matcher.matches()) {
             String name =
                     matcher.group(1).replaceAll("(?i)linux", "").replaceAll(" ", "");
-            if (name.startsWith("Alma") || name.startsWith("Amazon")) {
+            if (name.startsWith("Alma") || name.startsWith("Amazon") || name.startsWith("Rocky")) {
                 name = matcher.group(1).replaceAll(" ", "");
             }
             String majorVersion = StringUtils.substringBefore(matcher.group(2), ".");
@@ -284,7 +284,7 @@ public class RhelUtils {
 
         // next check if Rocky Linux
         if (rockyReleaseFile.filter(StringUtils::isNotBlank).isPresent()) {
-            return rockyReleaseFile.map(v -> detectPlainRHEL(v, arch, "RockyLinux"));
+            return rockyReleaseFile.map(v -> detectPlainRHEL(v, arch, "Rocky"));
         }
 
         // next check if Centos

--- a/java/code/src/com/suse/manager/reactor/utils/test/RhelUtilsTest.java
+++ b/java/code/src/com/suse/manager/reactor/utils/test/RhelUtilsTest.java
@@ -146,7 +146,7 @@ public class RhelUtilsTest extends JMockBaseTestCaseWithUser {
     public void testParseReleaseFileRocky() {
         Optional<RhelUtils.ReleaseFile> os = RhelUtils.parseReleaseFile(ROCKY_RELEASE);
         assertTrue(os.isPresent());
-        assertEquals("Rocky", os.get().getName());
+        assertEquals("RockyLinux", os.get().getName());
         assertEquals("8", os.get().getMajorVersion());
         assertEquals("4", os.get().getMinorVersion());
         assertEquals("Green Obsidian", os.get().getRelease());
@@ -308,7 +308,7 @@ public class RhelUtilsTest extends JMockBaseTestCaseWithUser {
                 null,
                 prod -> {
                     assertFalse(prod.get().getSuseProduct().isPresent());
-                    assertEquals("Rocky", prod.get().getName());
+                    assertEquals("RockyLinux", prod.get().getName());
                     assertEquals("Green Obsidian", prod.get().getRelease());
                     assertEquals("8", prod.get().getVersion());
                 });

--- a/java/code/src/com/suse/manager/reactor/utils/test/RhelUtilsTest.java
+++ b/java/code/src/com/suse/manager/reactor/utils/test/RhelUtilsTest.java
@@ -65,6 +65,8 @@ public class RhelUtilsTest extends JMockBaseTestCaseWithUser {
             "AlmaLinux release 8.3 (Purple Manul)";
     private static String AMAZON_RELEASE =
             "Amazon Linux release 2 (Karoo)";
+    private static String ROCKY_RELEASE =
+            "Rocky Linux release 8.4 (Green Obsidian)";
 
     @FunctionalInterface
     private interface SetupMinionConsumer {
@@ -141,6 +143,15 @@ public class RhelUtilsTest extends JMockBaseTestCaseWithUser {
         assertEquals("Karoo", os.get().getRelease());
     }
 
+    public void testParseReleaseFileRocky() {
+        Optional<RhelUtils.ReleaseFile> os = RhelUtils.parseReleaseFile(ROCKY_RELEASE);
+        assertTrue(os.isPresent());
+        assertEquals("Rocky", os.get().getName());
+        assertEquals("8", os.get().getMajorVersion());
+        assertEquals("4", os.get().getMinorVersion());
+        assertEquals("Green Obsidian", os.get().getRelease());
+    }
+
     public void testParseReleaseFileNonMatching() {
         Optional<RhelUtils.ReleaseFile> os = RhelUtils.parseReleaseFile("GarbageOS 1.0 (Trash can)");
         assertFalse(os.isPresent());
@@ -166,6 +177,9 @@ public class RhelUtilsTest extends JMockBaseTestCaseWithUser {
         String amazonReleaseContent = map.get("cmd_|-amazonrelease_|-cat /etc/system-release_|-run")
                 .getChanges(CmdResult.class)
                 .getStdout();
+        String rockyReleaseContent = map.get("cmd_|-rockyrelease_|-cat /etc/rocky-release_|-run")
+                .getChanges(CmdResult.class)
+                .getStdout();
         String rhelReleaseContent = map.get("cmd_|-rhelrelease_|-cat /etc/redhat-release_|-run")
                 .getChanges(CmdResult.class)
                 .getStdout();
@@ -184,7 +198,8 @@ public class RhelUtilsTest extends JMockBaseTestCaseWithUser {
                 Optional.ofNullable(oracleReleaseContent),
                 Optional.ofNullable(alibabaReleaseContent),
                 Optional.ofNullable(almaReleaseContent),
-                Optional.ofNullable(amazonReleaseContent));
+                Optional.ofNullable(amazonReleaseContent),
+                Optional.ofNullable(rockyReleaseContent));
         assertTrue(prod.isPresent());
         response.accept(prod);
 
@@ -285,6 +300,17 @@ public class RhelUtilsTest extends JMockBaseTestCaseWithUser {
                     assertEquals("AmazonLinux", prod.get().getName());
                     assertEquals("Karoo", prod.get().getRelease());
                     assertEquals("2", prod.get().getVersion());
+                });
+    }
+
+    public void testDetectRhelProductRocky() throws Exception {
+        doTestDetectRhelProduct("dummy_packages_redhatprodinfo_rockylinux.json",
+                null,
+                prod -> {
+                    assertFalse(prod.get().getSuseProduct().isPresent());
+                    assertEquals("Rocky", prod.get().getName());
+                    assertEquals("Green Obsidian", prod.get().getRelease());
+                    assertEquals("8", prod.get().getVersion());
                 });
     }
 

--- a/java/code/src/com/suse/manager/reactor/utils/test/dummy_packages_redhatprodinfo_alibaba.json
+++ b/java/code/src/com/suse/manager/reactor/utils/test/dummy_packages_redhatprodinfo_alibaba.json
@@ -77,5 +77,15 @@
     "duration": 233.474,
     "__run_num__": 3,
     "changes": {}
+  },
+  "cmd_|-rockyrelease_|-cat /etc/rocky-release_|-run": {
+    "comment": "Command \"cat /etc/rocky-release\" run",
+    "name": "cat /etc/rocky-release",
+    "start_time": "14:04:57.667941",
+    "skip_watch": true,
+    "result": true,
+    "duration": 233.474,
+    "__run_num__": 3,
+    "changes": {}
   }
 }

--- a/java/code/src/com/suse/manager/reactor/utils/test/dummy_packages_redhatprodinfo_almalinux.json
+++ b/java/code/src/com/suse/manager/reactor/utils/test/dummy_packages_redhatprodinfo_almalinux.json
@@ -72,5 +72,15 @@
     "duration": 233.474,
     "__run_num__": 3,
     "changes": {}
+  },
+  "cmd_|-rockyrelease_|-cat /etc/rocky-release_|-run": {
+    "comment": "Command \"cat /etc/rocky-release\" run",
+    "name": "cat /etc/rocky-release",
+    "start_time": "14:04:57.667941",
+    "skip_watch": true,
+    "result": true,
+    "duration": 233.474,
+    "__run_num__": 3,
+    "changes": {}
   }
 }

--- a/java/code/src/com/suse/manager/reactor/utils/test/dummy_packages_redhatprodinfo_centos.json
+++ b/java/code/src/com/suse/manager/reactor/utils/test/dummy_packages_redhatprodinfo_centos.json
@@ -63,6 +63,16 @@
     "__run_num__": 3,
     "changes": {}
   },
+  "cmd_|-rockyrelease_|-cat /etc/rocky-release_|-run": {
+    "comment": "Command \"cat /etc/rocky-release\" run",
+    "name": "cat /etc/rocky-release",
+    "start_time": "14:04:57.667941",
+    "skip_watch": true,
+    "result": true,
+    "duration": 233.474,
+    "__run_num__": 3,
+    "changes": {}
+  },
   "cmd_|-rhelrelease_|-cat /etc/redhat-release_|-run": {
     "comment": "Command \"cat /etc/redhat-release\" run",
     "name": "cat /etc/redhat-release",

--- a/java/code/src/com/suse/manager/reactor/utils/test/dummy_packages_redhatprodinfo_centos2.json
+++ b/java/code/src/com/suse/manager/reactor/utils/test/dummy_packages_redhatprodinfo_centos2.json
@@ -76,5 +76,15 @@
     "duration": 233.474,
     "__run_num__": 3,
     "changes": {}
+  },
+  "cmd_|-rockyrelease_|-cat /etc/rocky-release_|-run": {
+    "comment": "Command \"cat /etc/rocky-release\" run",
+    "name": "cat /etc/rocky-release",
+    "start_time": "14:04:57.667941",
+    "skip_watch": true,
+    "result": true,
+    "duration": 233.474,
+    "__run_num__": 3,
+    "changes": {}
   }
 }

--- a/java/code/src/com/suse/manager/reactor/utils/test/dummy_packages_redhatprodinfo_oracle.json
+++ b/java/code/src/com/suse/manager/reactor/utils/test/dummy_packages_redhatprodinfo_oracle.json
@@ -76,5 +76,15 @@
     "duration": 233.474,
     "__run_num__": 3,
     "changes": {}
+  },
+  "cmd_|-rockyrelease_|-cat /etc/rocky-release_|-run": {
+    "comment": "Command \"cat /etc/rocky-release\" run",
+    "name": "cat /etc/rocky-release",
+    "start_time": "14:04:57.667941",
+    "skip_watch": true,
+    "result": true,
+    "duration": 233.474,
+    "__run_num__": 3,
+    "changes": {}
   }
 }

--- a/java/code/src/com/suse/manager/reactor/utils/test/dummy_packages_redhatprodinfo_res.json
+++ b/java/code/src/com/suse/manager/reactor/utils/test/dummy_packages_redhatprodinfo_res.json
@@ -76,5 +76,15 @@
     "duration": 233.474,
     "__run_num__": 3,
     "changes": {}
+  },
+  "cmd_|-rockyrelease_|-cat /etc/rocky-release_|-run": {
+    "comment": "Command \"cat /etc/rocky-release\" run",
+    "name": "cat /etc/rocky-release",
+    "start_time": "14:04:57.667941",
+    "skip_watch": true,
+    "result": true,
+    "duration": 233.474,
+    "__run_num__": 3,
+    "changes": {}
   }
 }

--- a/java/code/src/com/suse/manager/reactor/utils/test/dummy_packages_redhatprodinfo_rhel.json
+++ b/java/code/src/com/suse/manager/reactor/utils/test/dummy_packages_redhatprodinfo_rhel.json
@@ -72,5 +72,15 @@
     "duration": 233.474,
     "__run_num__": 3,
     "changes": {}
+  },
+  "cmd_|-rockyrelease_|-cat /etc/rocky-release_|-run": {
+    "comment": "Command \"cat /etc/rocky-release\" run",
+    "name": "cat /etc/rocky-release",
+    "start_time": "14:04:57.667941",
+    "skip_watch": true,
+    "result": true,
+    "duration": 233.474,
+    "__run_num__": 3,
+    "changes": {}
   }
 }

--- a/java/code/src/com/suse/manager/reactor/utils/test/dummy_packages_redhatprodinfo_rockylinux.json
+++ b/java/code/src/com/suse/manager/reactor/utils/test/dummy_packages_redhatprodinfo_rockylinux.json
@@ -42,11 +42,16 @@
   "cmd_|-rhelrelease_|-cat /etc/redhat-release_|-run": {
     "comment": "Command \"cat /etc/redhat-release\" run",
     "name": "cat /etc/redhat-release",
-    "start_time": "07:57:57.138995",
+    "start_time": "14:04:57.435091",
     "result": true,
-    "duration": 242.195,
+    "duration": 232.599,
     "__run_num__": 0,
-    "changes": {}
+    "changes": {
+      "pid": 860,
+      "retcode": 0,
+      "stderr": "",
+      "stdout": "CentOS Linux release 7.2.1511 (Core)"
+    }
   },
   "cmd_|-almarelease_|-cat /etc/almalinux-release_|-run": {
     "comment": "Command \"cat /etc/almalinux-release\" run",
@@ -66,12 +71,7 @@
     "result": true,
     "duration": 233.474,
     "__run_num__": 3,
-    "changes": {
-      "pid": 784,
-      "retcode": 0,
-      "stderr": "",
-      "stdout": "Amazon Linux release 2 (Karoo)"
-    }
+    "changes": {}
   },
   "cmd_|-rockyrelease_|-cat /etc/rocky-release_|-run": {
     "comment": "Command \"cat /etc/rocky-release\" run",
@@ -81,6 +81,11 @@
     "result": true,
     "duration": 233.474,
     "__run_num__": 3,
-    "changes": {}
+    "changes": {
+      "pid": 784,
+      "retcode": 0,
+      "stderr": "",
+      "stdout": "Rocky Linux release 8.4 (Green Obsidian)"
+    }
   }
 }

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -1299,6 +1299,11 @@ public class SaltUtils {
                                 .map(StateApplyResult::getChanges)
                                 .filter(res -> res.getStdout() != null)
                                 .map(CmdResult::getStdout);
+                Optional<String> rockyReleaseFile =
+                        Optional.ofNullable(ret.getRockyReleaseFile())
+                                .map(StateApplyResult::getChanges)
+                                .filter(res -> res.getStdout() != null)
+                                .map(CmdResult::getStdout);
                 Optional<String> resReleasePkg =
                         Optional.ofNullable(ret.getWhatProvidesResReleasePkg())
                                 .map(StateApplyResult::getChanges)
@@ -1307,11 +1312,11 @@ public class SaltUtils {
                 if (rhelReleaseFile.isPresent() || centosReleaseFile.isPresent() ||
                         oracleReleaseFile.isPresent() || alibabaReleaseFile.isPresent() ||
                         almaReleaseFile.isPresent() || amazonReleaseFile.isPresent() ||
-                        resReleasePkg.isPresent()) {
+                        rockyReleaseFile.isPresent() || resReleasePkg.isPresent()) {
                     Set<InstalledProduct> products = getInstalledProductsForRhel(
                             imageInfo, resReleasePkg,
                             rhelReleaseFile, centosReleaseFile, oracleReleaseFile, alibabaReleaseFile,
-                            almaReleaseFile, amazonReleaseFile);
+                            almaReleaseFile, amazonReleaseFile, rockyReleaseFile);
                     imageInfo.setInstalledProducts(products);
                 }
             }
@@ -1395,6 +1400,11 @@ public class SaltUtils {
                 .map(StateApplyResult::getChanges)
                 .filter(ret -> ret.getStdout() != null)
                 .map(CmdResult::getStdout);
+        Optional<String> rockyReleaseFile =
+                Optional.ofNullable(result.getRockyReleaseFile())
+                .map(StateApplyResult::getChanges)
+                .filter(ret -> ret.getStdout() != null)
+                .map(CmdResult::getStdout);
         Optional<String> resReleasePkg =
                 Optional.ofNullable(result.getWhatProvidesResReleasePkg())
                 .map(StateApplyResult::getChanges)
@@ -1406,11 +1416,11 @@ public class SaltUtils {
         if (rhelReleaseFile.isPresent() || centosReleaseFile.isPresent() ||
                 oracleReleaseFile.isPresent() || alibabaReleaseFile.isPresent() ||
                 almaReleaseFile.isPresent() || amazonReleaseFile.isPresent() ||
-                resReleasePkg.isPresent()) {
+                rockyReleaseFile.isPresent() || resReleasePkg.isPresent()) {
             Set<InstalledProduct> products = getInstalledProductsForRhel(
                     server, resReleasePkg,
                     rhelReleaseFile, centosReleaseFile, oracleReleaseFile, alibabaReleaseFile,
-                    almaReleaseFile, amazonReleaseFile);
+                    almaReleaseFile, amazonReleaseFile, rockyReleaseFile);
             server.setInstalledProducts(products);
         }
         else if ("ubuntu".equalsIgnoreCase(grains.getValueAsString("os"))) {
@@ -1817,12 +1827,14 @@ public class SaltUtils {
            Optional<String> oracleReleaseFile,
            Optional<String> alibabaReleaseFile,
            Optional<String> almaReleaseFile,
-           Optional<String> amazonReleaseFile) {
+           Optional<String> amazonReleaseFile,
+           Optional<String> rockyReleaseFile) {
 
         Optional<RhelUtils.RhelProduct> rhelProductInfo =
                 RhelUtils.detectRhelProduct(server, resPackage,
                         rhelReleaseFile, centosRelaseFile, oracleReleaseFile,
-                        alibabaReleaseFile, almaReleaseFile, amazonReleaseFile);
+                        alibabaReleaseFile, almaReleaseFile, amazonReleaseFile,
+                        rockyReleaseFile);
 
         if (!rhelProductInfo.isPresent()) {
             LOG.warn("Could not determine RHEL product type for minion: " +
@@ -1858,12 +1870,14 @@ public class SaltUtils {
             Optional<String> oracleReleaseFile,
             Optional<String> alibabaReleaseFile,
             Optional<String> almaReleaseFile,
-            Optional<String> amazonReleaseFile) {
+            Optional<String> amazonReleaseFile,
+            Optional<String> rockyReleaseFile) {
 
          Optional<RhelUtils.RhelProduct> rhelProductInfo =
                  RhelUtils.detectRhelProduct(image, resPackage,
                          rhelReleaseFile, centosReleaseFile, oracleReleaseFile,
-                         alibabaReleaseFile, almaReleaseFile, amazonReleaseFile);
+                         alibabaReleaseFile, almaReleaseFile, amazonReleaseFile,
+                         rockyReleaseFile);
 
          if (!rhelProductInfo.isPresent()) {
              LOG.warn("Could not determine RHEL product type for image: " +

--- a/java/code/src/com/suse/manager/webui/services/iface/RedhatProductInfo.java
+++ b/java/code/src/com/suse/manager/webui/services/iface/RedhatProductInfo.java
@@ -21,6 +21,7 @@ import java.util.Optional;
  */
 public class RedhatProductInfo {
 
+    private final Optional<String> rockyReleaseContent;
     private final Optional<String> amazonReleaseContent;
     private final Optional<String> almaReleaseContent;
     private final Optional<String> alibabaReleaseContent;
@@ -36,12 +37,14 @@ public class RedhatProductInfo {
      * @param alibabaReleaseContentIn alibaba release content
      * @param almaReleaseContentIn alma release content
      * @param amazonReleaseContentIn amazon release content
+     * @param rockyReleaseContentIn rocky release content
      * @param whatProvidesResIn what provides res result
      */
     public RedhatProductInfo(Optional<String> centosReleaseContentIn, Optional<String> rhelReleaseContentIn,
             Optional<String> oracleReleaseContentIn, Optional<String> alibabaReleaseContentIn,
             Optional<String> almaReleaseContentIn, Optional<String> amazonReleaseContentIn,
-            Optional<String> whatProvidesResIn) {
+            Optional<String> rockyReleaseContentIn, Optional<String> whatProvidesResIn) {
+        this.rockyReleaseContent = rockyReleaseContentIn;
         this.amazonReleaseContent = amazonReleaseContentIn;
         this.almaReleaseContent = almaReleaseContentIn;
         this.alibabaReleaseContent = alibabaReleaseContentIn;
@@ -49,6 +52,13 @@ public class RedhatProductInfo {
         this.centosReleaseContent = centosReleaseContentIn;
         this.rhelReleaseContent = rhelReleaseContentIn;
         this.whatProvidesRes = whatProvidesResIn;
+    }
+
+    /**
+     * @return rockylinux release content
+     */
+    public Optional<String> getRockyReleaseContent() {
+        return rockyReleaseContent;
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
@@ -1029,13 +1029,16 @@ public class SaltService implements SystemQuery, SaltApi {
                     Optional<String> amazonReleaseContent = Optional
                             .ofNullable(result.get(PkgProfileUpdateSlsResult.PKG_PROFILE_AMAZON_RELEASE)
                             .getChanges(CmdResult.class).getStdout());
+                    Optional<String> rockyReleaseContent = Optional
+                            .ofNullable(result.get(PkgProfileUpdateSlsResult.PKG_PROFILE_ROCKY_RELEASE)
+                            .getChanges(CmdResult.class).getStdout());
                     Optional<String> whatProvidesRes = Optional
                             .ofNullable(result.get(PkgProfileUpdateSlsResult.PKG_PROFILE_WHATPROVIDES_SLES_RELEASE)
                             .getChanges(CmdResult.class).getStdout());
 
                     return new RedhatProductInfo(centosReleaseContent, rhelReleaseContent,
                             oracleReleaseContent, alibabaReleaseContent, almaReleaseContent,
-                            amazonReleaseContent, whatProvidesRes);
+                            amazonReleaseContent, rockyReleaseContent, whatProvidesRes);
                 });
     }
 

--- a/java/code/src/com/suse/manager/webui/utils/salt/custom/PkgProfileUpdateSlsResult.java
+++ b/java/code/src/com/suse/manager/webui/utils/salt/custom/PkgProfileUpdateSlsResult.java
@@ -46,6 +46,8 @@ public class PkgProfileUpdateSlsResult {
             "cmd_|-almarelease_|-cat /etc/almalinux-release_|-run";
     public static final String PKG_PROFILE_AMAZON_RELEASE =
             "cmd_|-amazonrelease_|-cat /etc/system-release_|-run";
+    public static final String PKG_PROFILE_ROCKY_RELEASE =
+            "cmd_|-rockyrelease_|-cat /etc/rocky-release_|-run";
     public static final String PKG_PROFILE_WHATPROVIDES_SLES_RELEASE =
             "cmd_|-respkgquery_|-rpm -q --whatprovides 'sles_es-release-server'_|-run";
 
@@ -79,6 +81,9 @@ public class PkgProfileUpdateSlsResult {
 
     @SerializedName(PKG_PROFILE_AMAZON_RELEASE)
     private StateApplyResult<CmdResult> amazonReleaseFile;
+
+    @SerializedName(PKG_PROFILE_ROCKY_RELEASE)
+    private StateApplyResult<CmdResult> rockyReleaseFile;
 
     @SerializedName(PKG_PROFILE_WHATPROVIDES_SLES_RELEASE)
     private StateApplyResult<CmdResult> whatProvidesResReleasePkg;
@@ -155,6 +160,13 @@ public class PkgProfileUpdateSlsResult {
      */
     public StateApplyResult<CmdResult> getAmazonReleaseFile() {
         return amazonReleaseFile;
+    }
+
+    /**
+     * @return the content of the file /etc/rocky-release
+     */
+    public StateApplyResult<CmdResult> getRockyReleaseFile() {
+        return rockyReleaseFile;
     }
 
     /**

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Java enablement for Rocky Linux 8
 - Get CPU data for AArch64
 - Add option to run Ansible playbooks in 'test' mode
 - Add support for Kiwi options

--- a/schema/spacewalk/common/data/rhnPackageKey.sql
+++ b/schema/spacewalk/common/data/rhnPackageKey.sql
@@ -170,5 +170,8 @@ insert into rhnPackageKey (id, key_id, key_type_id, provider_id) (select sequenc
 -- Amazon Linux 2
 insert into rhnPackageKey (id, key_id, key_type_id, provider_id) (select sequence_nextval('rhn_pkey_id_seq'), '11cf1f95c87f5b1a', lookup_package_key_type('gpg'), lookup_package_provider('Amazon') from dual where not exists (select 1 from rhnPackageKey where key_id = '11cf1f95c87f5b1a'));
 
+-- Rocky Linux 8
+insert into rhnPackageKey (id, key_id, key_type_id, provider_id) (select sequence_nextval('rhn_pkey_id_seq'), '15af5dac6d745a60', lookup_package_key_type('gpg'), lookup_package_provider('Rocky Linux') from dual where not exists (select 1 from rhnPackageKey where key_id = '15af5dac6d745a60'));
+
 commit;
 

--- a/schema/spacewalk/common/data/rhnPackageProvider.sql
+++ b/schema/spacewalk/common/data/rhnPackageProvider.sql
@@ -43,5 +43,7 @@ insert into rhnPackageProvider (id, name) values
 (sequence_nextval('rhn_package_provider_id_seq'), 'AlmaLinux' );
 insert into rhnPackageProvider (id, name) values
 (sequence_nextval('rhn_package_provider_id_seq'), 'Amazon' );
+insert into rhnPackageProvider (id, name) values
+(sequence_nextval('rhn_package_provider_id_seq'), 'Rocky Linux' );
 
 commit;

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- Add Rocky Linux 8 key and vendor
 - Add 'test' flag to Ansible playbook actions
 - Add Kiwi commandline options to Kiwi profile
 - Handle virtual machines running on pacemaker cluster

--- a/schema/spacewalk/upgrade/susemanager-schema-4.3.0-to-susemanager-schema-4.3.1/100-rocky.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.3.0-to-susemanager-schema-4.3.1/100-rocky.sql
@@ -1,0 +1,9 @@
+insert into rhnPackageProvider (id, name)
+    (select sequence_nextval('rhn_package_provider_id_seq'), 'Rocky Linux' from dual
+    where not exists (select 1 from rhnPackageProvider where name = 'Rocky Linux'));
+
+-- Alma Linux 8
+insert into rhnPackageKey (id, key_id, key_type_id, provider_id)
+    (select sequence_nextval('rhn_pkey_id_seq'), '15af5dac6d745a60', lookup_package_key_type('gpg'),
+    lookup_package_provider('Rocky Linux') from dual
+    where not exists (select 1 from rhnPackageKey where key_id = '15af5dac6d745a60'));


### PR DESCRIPTION
## What does this PR change?

Java enablement for Rocky Linux 8.

## Works
- package provider detection:
![image](https://user-images.githubusercontent.com/4226070/124917113-bc0dcc80-dff3-11eb-8568-854ab8aed619.png)

 ## Does not work
- product detection:
![image](https://user-images.githubusercontent.com/4226070/124917205-d47de700-dff3-11eb-8f7a-39a7315b8e8e.png)

**NOTE:** This will only work when we enable Rocky Linux as a SUSE Product it seems. Honestly I think this should work even for things that are not defined as SUSE Products (but that's not to be fixed at this PR)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- Issue: https://github.com/SUSE/spacewalk/issues/15322

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Related:
- https://github.com/uyuni-project/uyuni/pull/3681
- https://github.com/uyuni-project/uyuni/pull/3959

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
