### PR TITLE
fix wrong gpgkey fingerprint for sdl8

### DIFF
--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -234,7 +234,7 @@ archs    = x86_64
 name     = Springdale Linux 8 BaseOS (%(arch)s)
 gpgkey_url = http://springdale.princeton.edu/data/springdale/7/%(arch)s/os/RPM-GPG-KEY-springdale
 gpgkey_id = 41A40948
-gpgkey_fingerprint = 2266 6129 E0CD 0062 8D44 C6CF 16CF C333 41A4 094
+gpgkey_fingerprint = 2266 6129 E0CD 0062 8D44 C6CF 16CF C333 41A4 0948
 repo_url = http://springdale.princeton.edu/data/springdale/8/%(arch)s/os/BaseOS/mirrorlist
 dist_map_release = 8
 

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,4 +1,4 @@
-- Fix the GPG key finger print for Springdale Linux 8
+- Fix the GPG key fingerprint for Springdale Linux 8
 - Bump version to 4.3.0
 
 -------------------------------------------------------------------

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,4 @@
+- Fix the GPG key finger print for Springdale Linux 8
 - Bump version to 4.3.0
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

The command spacewalk-common-channels fails on creating sdl8 channel, cause of a typo in the gpg key fingerprint. The PR fix the typo.

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
