### PR TITLE
Add 'test mode' option to Ansible playbook execution

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/action/salt/PlaybookActionDetails.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/salt/PlaybookActionDetails.hbm.xml
@@ -13,6 +13,7 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         </id>
         <property name="playbookPath" column="playbook_path" type="string" />
         <property name="inventoryPath" column="inventory_path" type="string" />
+        <property name="testMode" column="test_mode" type="yes_no"/>
         <property name="created" type="timestamp" insert="false" update="false" />
         <property name="modified" type="timestamp" insert="false" update="false" />
         <many-to-one name="parentAction" column="action_id" class="com.redhat.rhn.domain.action.Action"

--- a/java/code/src/com/redhat/rhn/domain/action/salt/PlaybookActionDetails.java
+++ b/java/code/src/com/redhat/rhn/domain/action/salt/PlaybookActionDetails.java
@@ -25,6 +25,7 @@ public class PlaybookActionDetails extends ActionChild {
     private long actionId;
     private String playbookPath;
     private String inventoryPath;
+    private boolean testMode;
 
     /**
      * @return the id
@@ -68,5 +69,13 @@ public class PlaybookActionDetails extends ActionChild {
 
     public void setInventoryPath(String inventoryPathIn) {
         this.inventoryPath = inventoryPathIn;
+    }
+
+    public boolean isTestMode() {
+        return testMode;
+    }
+
+    public void setTestMode(boolean testModeIn) {
+        this.testMode = testModeIn;
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/ansible/AnsibleHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/ansible/AnsibleHandler.java
@@ -49,7 +49,6 @@ public class AnsibleHandler extends BaseHandler {
      * @param playbookPath the path to the playbook file
      * @param inventoryPath the path to the inventory file
      * @param controlNodeId the system ID of the control node
-     * @param testMode true if the playbook shall be executed in test mode
      * @param earliestOccurrence earliest occurrence of the execution command
      * @param actionChainLabel label af action chain to use
      * @return the execute playbook action id
@@ -59,14 +58,42 @@ public class AnsibleHandler extends BaseHandler {
      * @xmlrpc.param #param("string", "playbookPath", "path to the playbook file in the control node")
      * @xmlrpc.param #param_desc("string", "inventoryPath", "path to Ansible inventory or empty")
      * @xmlrpc.param #param_desc("int", "controlNodeId", "system ID of the control node")
-     * @xmlrpc.param #param_desc("boolean", "testMode", "'true' if the playbook shall be executed in test mode")
      * @xmlrpc.param #param_desc("dateTime.iso8601", "earliestOccurrence",
      * "earliest the execution command can be sent to the control node. ignored when actionChainLabel is used")
      * @xmlrpc.param #param_desc("string", "actionChainLabel", "label of an action chain to use, or None")
      * @xmlrpc.returntype #param_desc("int", "id", "ID of the playbook execution action created")
      */
+    public Long schedulePlaybook(User loggedInUser, String playbookPath, String inventoryPath, Integer controlNodeId,
+            Date earliestOccurrence, String actionChainLabel) {
+        return schedulePlaybook(loggedInUser, playbookPath, inventoryPath, controlNodeId, earliestOccurrence,
+                actionChainLabel, false);
+    }
+
+    /**
+     * Schedule a playbook execution with test mode option
+     *
+     * @param loggedInUser the current user
+     * @param playbookPath the path to the playbook file
+     * @param inventoryPath the path to the inventory file
+     * @param controlNodeId the system ID of the control node
+     * @param earliestOccurrence earliest occurrence of the execution command
+     * @param actionChainLabel label af action chain to use
+     * @param testMode true if the playbook shall be executed in test mode
+     * @return the execute playbook action id
+     *
+     * @xmlrpc.doc Schedule a playbook execution
+     * @xmlrpc.param #param("string", "sessionKey")
+     * @xmlrpc.param #param("string", "playbookPath", "path to the playbook file in the control node")
+     * @xmlrpc.param #param_desc("string", "inventoryPath", "path to Ansible inventory or empty")
+     * @xmlrpc.param #param_desc("int", "controlNodeId", "system ID of the control node")
+     * @xmlrpc.param #param_desc("dateTime.iso8601", "earliestOccurrence",
+     * "earliest the execution command can be sent to the control node. ignored when actionChainLabel is used")
+     * @xmlrpc.param #param_desc("string", "actionChainLabel", "label of an action chain to use, or None")
+     * @xmlrpc.param #param_desc("boolean", "testMode", "'true' if the playbook shall be executed in test mode")
+     * @xmlrpc.returntype #param_desc("int", "id", "ID of the playbook execution action created")
+     */
     public Long schedulePlaybook(User loggedInUser, String playbookPath, String inventoryPath,
-            Integer controlNodeId, boolean testMode, Date earliestOccurrence, String actionChainLabel) {
+            Integer controlNodeId, Date earliestOccurrence, String actionChainLabel, boolean testMode) {
         try {
             return AnsibleManager.schedulePlaybook(playbookPath, inventoryPath, controlNodeId, testMode,
                     earliestOccurrence, Optional.ofNullable(actionChainLabel), loggedInUser);

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/ansible/AnsibleHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/ansible/AnsibleHandler.java
@@ -49,6 +49,7 @@ public class AnsibleHandler extends BaseHandler {
      * @param playbookPath the path to the playbook file
      * @param inventoryPath the path to the inventory file
      * @param controlNodeId the system ID of the control node
+     * @param testMode true if the playbook shall be executed in test mode
      * @param earliestOccurrence earliest occurrence of the execution command
      * @param actionChainLabel label af action chain to use
      * @return the execute playbook action id
@@ -58,16 +59,17 @@ public class AnsibleHandler extends BaseHandler {
      * @xmlrpc.param #param("string", "playbookPath", "path to the playbook file in the control node")
      * @xmlrpc.param #param_desc("string", "inventoryPath", "path to Ansible inventory or empty")
      * @xmlrpc.param #param_desc("int", "controlNodeId", "system ID of the control node")
+     * @xmlrpc.param #param_desc("boolean", "testMode", "'true' if the playbook shall be executed in test mode")
      * @xmlrpc.param #param_desc("dateTime.iso8601", "earliestOccurrence",
      * "earliest the execution command can be sent to the control node. ignored when actionChainLabel is used")
      * @xmlrpc.param #param_desc("string", "actionChainLabel", "label of an action chain to use, or None")
      * @xmlrpc.returntype #param_desc("int", "id", "ID of the playbook execution action created")
      */
     public Long schedulePlaybook(User loggedInUser, String playbookPath, String inventoryPath,
-            Integer controlNodeId, Date earliestOccurrence, String actionChainLabel) {
+            Integer controlNodeId, boolean testMode, Date earliestOccurrence, String actionChainLabel) {
         try {
-            return AnsibleManager.schedulePlaybook(playbookPath, inventoryPath, controlNodeId, earliestOccurrence,
-                    Optional.ofNullable(actionChainLabel), loggedInUser);
+            return AnsibleManager.schedulePlaybook(playbookPath, inventoryPath, controlNodeId, testMode,
+                    earliestOccurrence, Optional.ofNullable(actionChainLabel), loggedInUser);
         }
         catch (com.redhat.rhn.taskomatic.TaskomaticApiException e) {
             throw new TaskomaticApiException(e.getMessage());

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/ansible/test/AnsibleHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/ansible/test/AnsibleHandlerTest.java
@@ -88,7 +88,7 @@ public class AnsibleHandlerTest extends BaseHandlerTestCase {
         Date scheduleDate = new Date();
 
         Long actionId = handler.schedulePlaybook(admin, "/path/to/myplaybook.yml", "/path/to/hosts",
-                controlNode.getId().intValue(), false, scheduleDate, null);
+                controlNode.getId().intValue(), scheduleDate, null);
         assertNotNull(actionId);
 
         DataResult schedule = ActionManager.recentlyScheduledActions(admin, null, 30);
@@ -114,7 +114,7 @@ public class AnsibleHandlerTest extends BaseHandlerTestCase {
         Date scheduleDate = new Date();
 
         Long actionId = handler.schedulePlaybook(admin, "/path/to/myplaybook.yml", null, controlNode.getId().intValue(),
-                true, scheduleDate, null);
+                scheduleDate, null, true);
         assertNotNull(actionId);
 
         DataResult schedule = ActionManager.recentlyScheduledActions(admin, null, 30);

--- a/java/code/src/com/redhat/rhn/manager/action/ActionChainManager.java
+++ b/java/code/src/com/redhat/rhn/manager/action/ActionChainManager.java
@@ -792,10 +792,12 @@ public class ActionChainManager {
      * @param inventoryPath path to the inventory file in the control node
      * @param actionChain the action chain to add to or null
      * @param earliest action will not be executed before this date
+     * @param testMode true if the playbook shall be executed in test mode
      * @return the action object
      */
     public static PlaybookAction scheduleExecutePlaybook(User scheduler, Long controlNodeId, String playbookPath,
-            String inventoryPath, ActionChain actionChain, Date earliest) throws TaskomaticApiException {
+            String inventoryPath, ActionChain actionChain, Date earliest, boolean testMode)
+            throws TaskomaticApiException {
         String playbookName = FileUtils.getFile(playbookPath).getName();
 
         PlaybookAction action = (PlaybookAction) scheduleActions(scheduler, ActionFactory.TYPE_PLAYBOOK,
@@ -806,6 +808,7 @@ public class ActionChainManager {
         PlaybookActionDetails details = new PlaybookActionDetails();
         details.setPlaybookPath(playbookPath);
         details.setInventoryPath(inventoryPath);
+        details.setTestMode(testMode);
         action.setDetails(details);
         ActionFactory.save(action);
 

--- a/java/code/src/com/redhat/rhn/manager/action/test/ActionChainManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/action/test/ActionChainManagerTest.java
@@ -123,7 +123,7 @@ public class ActionChainManagerTest extends JMockBaseTestCaseWithUser {
         Server server = ServerFactoryTest.createTestServer(user);
         Date earliestAction = new Date();
         PlaybookAction action = ActionChainManager.scheduleExecutePlaybook(user, server.getId(),
-                "/path/to/myplaybook.yml", "/path/to/hosts", null, earliestAction);
+                "/path/to/myplaybook.yml", "/path/to/hosts", null, earliestAction, false);
 
         // Look it up and verify
         PlaybookAction savedAction = (PlaybookAction) ActionFactory.lookupByUserAndId(user, action.getId());
@@ -137,5 +137,31 @@ public class ActionChainManagerTest extends JMockBaseTestCaseWithUser {
         assertNotNull(details);
         assertEquals("/path/to/myplaybook.yml", details.getPlaybookPath());
         assertEquals("/path/to/hosts", details.getInventoryPath());
+    }
+
+    /**
+     * Schedule Ansible playbook application in TEST mode for a control node.
+     *
+     * @throws Exception in case of an error
+     */
+    public void testScheduleAnsiblePlaybookTestMode() throws Exception {
+        Server server = ServerFactoryTest.createTestServer(user);
+        Date earliestAction = new Date();
+        PlaybookAction action = ActionChainManager.scheduleExecutePlaybook(user, server.getId(),
+                "/path/to/myplaybook.yml", null, null, earliestAction, true);
+
+        // Look it up and verify
+        PlaybookAction savedAction = (PlaybookAction) ActionFactory.lookupByUserAndId(user, action.getId());
+        assertNotNull(savedAction);
+        assertEquals("Execute playbook 'myplaybook.yml'", savedAction.getName());
+        assertEquals(ActionFactory.TYPE_PLAYBOOK, savedAction.getActionType());
+        assertEquals(earliestAction, savedAction.getEarliestAction());
+
+        // Verify the details
+        PlaybookActionDetails details = savedAction.getDetails();
+        assertNotNull(details);
+        assertEquals("/path/to/myplaybook.yml", details.getPlaybookPath());
+        assertNull(details.getInventoryPath());
+        assertTrue(details.isTestMode());
     }
 }

--- a/java/code/src/com/redhat/rhn/manager/system/AnsibleManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/AnsibleManager.java
@@ -268,6 +268,7 @@ public class AnsibleManager extends BaseManager {
      * @param playbookPath playbook path
      * @param inventoryPath inventory path
      * @param controlNodeId control node id
+     * @param testMode true if the playbook should be executed as test mode
      * @param earliestOccurrence earliestOccurrence
      * @param actionChainLabel the action chain label
      * @param user the user
@@ -275,7 +276,7 @@ public class AnsibleManager extends BaseManager {
      * @throws TaskomaticApiException if taskomatic is down
      * @throws IllegalArgumentException if playbook path is empty
      */
-    public static Long schedulePlaybook(String playbookPath, String inventoryPath, long controlNodeId,
+    public static Long schedulePlaybook(String playbookPath, String inventoryPath, long controlNodeId, boolean testMode,
             Date earliestOccurrence, Optional<String> actionChainLabel, User user) throws TaskomaticApiException {
         if (StringUtils.isBlank(playbookPath)) {
             throw new IllegalArgumentException("Playbook path cannot be empty.");
@@ -288,7 +289,7 @@ public class AnsibleManager extends BaseManager {
                 .orElse(null);
 
         return ActionChainManager.scheduleExecutePlaybook(user, controlNode.getId(), playbookPath,
-                inventoryPath, actionChain, earliestOccurrence).getId();
+                inventoryPath, actionChain, earliestOccurrence, testMode).getId();
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/system/test/AnsibleManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/test/AnsibleManagerTest.java
@@ -264,7 +264,8 @@ public class AnsibleManagerTest extends BaseTestCaseWithUser {
     public void testSchedulePlaybookBlankPath() throws Exception {
         MinionServer minion = createAnsibleControlNode(user);
         try {
-            AnsibleManager.schedulePlaybook("   ", "/etc/ansible/hosts", minion.getId(), new Date(), Optional.empty(), user);
+            AnsibleManager.schedulePlaybook("   ", "/etc/ansible/hosts", minion.getId(), false, new Date(),
+                    Optional.empty(), user);
             fail("An exception should have been thrown.");
         }
         catch (IllegalArgumentException e) {
@@ -279,7 +280,8 @@ public class AnsibleManagerTest extends BaseTestCaseWithUser {
      */
     public void testSchedulePlaybookNonexistingMinion() throws Exception {
         try {
-            AnsibleManager.schedulePlaybook("/test/site.yml", "/etc/ansible/hosts", -1234, new Date(), Optional.empty(), user);
+            AnsibleManager.schedulePlaybook("/test/site.yml", "/etc/ansible/hosts", -1234, false, new Date(),
+                    Optional.empty(), user);
             fail("An exception should have been thrown.");
         }
         catch (LookupException e) {

--- a/java/code/src/com/suse/manager/webui/controllers/AnsibleController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/AnsibleController.java
@@ -302,6 +302,7 @@ public class AnsibleController {
                     params.getPlaybookPath(),
                     params.getInventoryPath().orElse(null),
                     params.getControlNodeId(),
+                    params.isTestMode(),
                     params.getEarliest().map(AnsibleController::getScheduleDate).orElse(new Date()),
                     params.getActionChainLabel(),
                     user);

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -2333,7 +2333,8 @@ public class SaltServerActionService {
         pillarData.put("playbook_path", playbookPath);
         pillarData.put("inventory_path", inventoryPath);
         pillarData.put("rundir", rundir);
-        return State.apply(singletonList(ANSIBLE_RUNPLAYBOOK), Optional.of(pillarData));
+        return State.apply(singletonList(ANSIBLE_RUNPLAYBOOK), Optional.of(pillarData), Optional.of(true),
+                Optional.of(details.isTestMode()));
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/utils/gson/AnsiblePlaybookExecutionJson.java
+++ b/java/code/src/com/suse/manager/webui/utils/gson/AnsiblePlaybookExecutionJson.java
@@ -28,6 +28,7 @@ public class AnsiblePlaybookExecutionJson {
     private String playbookPath;
     private Optional<String> inventoryPath = Optional.empty();
     private long controlNodeId;
+    private boolean testMode;
     private Optional<LocalDateTime> earliest = Optional.empty();
     private Optional<String> actionChainLabel = Optional.empty();
 
@@ -56,6 +57,15 @@ public class AnsiblePlaybookExecutionJson {
      */
     public long getControlNodeId() {
         return controlNodeId;
+    }
+
+    /**
+     * True if the execution should be in test mode.
+     *
+     * @return testMode
+     */
+    public boolean isTestMode() {
+        return testMode;
     }
 
     /**

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add option to run Ansible playbooks in 'test' mode
 - Add support for Kiwi options
 - New filter template: Live patching based on a system
 - Adapt generated pillar data to run the new Salt scap state

--- a/schema/spacewalk/common/tables/rhnActionPlaybook.sql
+++ b/schema/spacewalk/common/tables/rhnActionPlaybook.sql
@@ -24,6 +24,9 @@ CREATE TABLE rhnActionPlaybook
                                 ON DELETE CASCADE,
     playbook_path       VARCHAR(1024) NOT NULL,
     inventory_path      VARCHAR(1024),
+    test_mode           CHAR(1) DEFAULT ('N') NOT NULL
+                            CONSTRAINT rhn_action_playbook_testmode_ck
+                                CHECK (test_mode IN ('Y', 'N')),
     created             TIMESTAMPTZ
                             DEFAULT (current_timestamp) NOT NULL,
     modified            TIMESTAMPTZ

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- Add 'test' flag to Ansible playbook actions
 - Add Kiwi commandline options to Kiwi profile
 - Handle virtual machines running on pacemaker cluster
 - Bump version to 4.3.0

--- a/schema/spacewalk/upgrade/susemanager-schema-4.3.0-to-susemanager-schema-4.3.1/100-playbook-action-testmode.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.3.0-to-susemanager-schema-4.3.1/100-playbook-action-testmode.sql
@@ -1,0 +1,4 @@
+ALTER TABLE rhnActionPlaybook ADD COLUMN IF NOT EXISTS
+    test_mode CHAR(1) DEFAULT ('N') NOT NULL
+        CONSTRAINT rhn_action_playbook_testmode_ck
+            CHECK (test_mode IN ('Y', 'N'));

--- a/susemanager-utils/susemanager-sls/salt/ansible/runplaybook.sls
+++ b/susemanager-utils/susemanager-sls/salt/ansible/runplaybook.sls
@@ -16,6 +16,7 @@ run_ansible_playbook:
   ansible.playbooks:
     - name: {{ pillar["playbook_path"] }}
     - rundir: {{ pillar["rundir"] }}
+    - test: {{ pillar["test"] }}
 {%- if "inventory_path" in pillar %}
     - ansible_kwargs:
         inventory: {{ pillar["inventory_path"] }}

--- a/web/html/src/manager/minion/ansible/schedule-playbook.tsx
+++ b/web/html/src/manager/minion/ansible/schedule-playbook.tsx
@@ -11,6 +11,7 @@ import { AceEditor } from "components/ace-editor";
 import { PlaybookDetails } from "./accordion-path-content";
 import { Formats, Utils } from "utils/functions";
 import { ActionChainLink, ActionLink } from "components/links";
+import { Toggler } from "components/toggler";
 import { Loading } from "components/utils/Loading";
 
 interface SchedulePlaybookProps {
@@ -21,6 +22,7 @@ interface SchedulePlaybookProps {
 export default function SchedulePlaybook({ playbook, onBack }: SchedulePlaybookProps) {
   const [loading, setLoading] = useState(true);
   const [playbookContent, setPlaybookContent] = useState("");
+  const [isTestMode, setTestMode] = useState(false);
   const [messages, setMessages] = useState<MessageType[]>([]);
   const [inventoryPath, setInventoryPath] = useState<ComboboxItem | null>(null);
   const [inventories, setInventories] = useState<string[]>([]);
@@ -73,6 +75,7 @@ export default function SchedulePlaybook({ playbook, onBack }: SchedulePlaybookP
         playbookPath: playbook.fullPath,
         inventoryPath: inventoryPath?.text,
         controlNodeId: playbook.path.minionServerId,
+        testMode: isTestMode,
         actionChainLabel: actionChain?.text || null,
         earliest: Formats.LocalDateTime(datetime)
       }),
@@ -94,6 +97,12 @@ export default function SchedulePlaybook({ playbook, onBack }: SchedulePlaybookP
 
   const buttons = [
     <div className="btn-group pull-right">
+      <Toggler
+        text={t("Test mode")}
+        value={isTestMode}
+        className="btn"
+        handler={() => setTestMode(!isTestMode)}
+      />
       <Button icon="fa-angle-left" className="btn-default" text={t("Back")} title={t("Back to playbook list")} handler={onBack} />
       <AsyncButton defaultType="btn-success" action={schedule} title={t("Schedule playbook execution")} text={t("Schedule")} />
     </div>,

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Add option to run Ansible playbooks in 'test' mode
 - Add support for Kiwi options
 - New filter template: Live patching based on a system
 - Refresh JWT virtual console token before it expires


### PR DESCRIPTION
## GUI diff
![playbook-test-exec](https://user-images.githubusercontent.com/1103552/124913313-44d63980-dfef-11eb-8b4d-31b40a4e2241.png)

## Documentation
- No documentation needed: minor enhancement

## Test coverage
- Unit tests were added

## Links

Fixes https://github.com/SUSE/spacewalk/issues/14964

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
