### PR TITLE
Add both centos 8 ISOs for syncing

### DIFF
--- a/testsuite/features/build_validation/add_custom_repositories/add_ceos8_repositories.feature
+++ b/testsuite/features/build_validation/add_custom_repositories/add_ceos8_repositories.feature
@@ -41,7 +41,7 @@ Feature: Adding the CentOS 8 distribution custom repositories
     And I click on "Create Repository"
     Then I should see a "Repository created successfully" text
 
-  Scenario: Add the repository to the custom channel for CentOS 8 DVD
+  Scenario: Add both ISO repositories to the custom channel for CentOS 8 DVD
     When I follow the left menu "Software > Manage > Channels"
     And I follow "Custom Channel for CentOS 8 DVD"
     And I follow "Repositories" in the content area
@@ -50,7 +50,7 @@ Feature: Adding the CentOS 8 distribution custom repositories
     And I click on "Save Repositories"
     Then I should see a "repository information was successfully updated" text
 
-  Scenario: Synchronize the repository in the custom channel for CentOS 8 DVD
+  Scenario: Synchronize the repositories in the custom channel for CentOS 8 DVD
     When I follow the left menu "Software > Manage > Channels"
     And I follow "Custom Channel for CentOS 8 DVD"
     And I follow "Repositories" in the content area

--- a/testsuite/features/build_validation/add_custom_repositories/add_ceos8_repositories.feature
+++ b/testsuite/features/build_validation/add_custom_repositories/add_ceos8_repositories.feature
@@ -23,11 +23,20 @@ Feature: Adding the CentOS 8 distribution custom repositories
     And I click on "Create Channel"
     Then I should see a "Channel Custom Channel for CentOS 8 DVD created" text
 
-  Scenario: Add the CentOS 8 DVD repositories
+  Scenario: Add the CentOS 8 Appstream DVD repository
     When I follow the left menu "Software > Manage > Repositories"
     And I follow "Create Repository"
-    And I enter "centos-8-iso" as "label"
-    And I enter "http://127.0.0.1/centos-8-iso" as "url"
+    And I enter "centos-8-iso-appstream" as "label"
+    And I enter "http://127.0.0.1/centos-8-iso/AppStream" as "url"
+    And I uncheck "metadataSigned"
+    And I click on "Create Repository"
+    Then I should see a "Repository created successfully" text
+
+  Scenario: Add the CentOS 8 DVD BaseOS repository
+    When I follow the left menu "Software > Manage > Repositories"
+    And I follow "Create Repository"
+    And I enter "centos-8-iso-baseos" as "label"
+    And I enter "http://127.0.0.1/centos-8-iso/BaseOS" as "url"
     And I uncheck "metadataSigned"
     And I click on "Create Repository"
     Then I should see a "Repository created successfully" text
@@ -36,7 +45,8 @@ Feature: Adding the CentOS 8 distribution custom repositories
     When I follow the left menu "Software > Manage > Channels"
     And I follow "Custom Channel for CentOS 8 DVD"
     And I follow "Repositories" in the content area
-    And I select the "centos-8-iso" repo
+    And I select the "centos-8-iso-appstream" repo
+    And I select the "centos-8-iso-baseos" repo
     And I click on "Save Repositories"
     Then I should see a "repository information was successfully updated" text
 


### PR DESCRIPTION
## What does this PR change?

Add both centos 8 ISOs for syncing, appstream and baseos. Both are needed according to the documentation and the old url was failing to sync.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes no issue, directly from BV review.
Tracks 4.2:  https://github.com/SUSE/spacewalk/pull/15365
4.1: https://github.com/SUSE/spacewalk/pull/15364

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
