### PR TITLE
Add findutils to Kiwi bootstrap packages

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/images/kiwi-image-build.sls
+++ b/susemanager-utils/susemanager-sls/salt/images/kiwi-image-build.sls
@@ -43,9 +43,13 @@ mgr_buildimage_prepare_activation_key_in_source:
 {%- set kiwi = 'kiwi-ng' %}
 
 {%- set kiwi_options = pillar.get('kiwi_options', '') %}
+{%- set bootstrap_packages = ['findutils', 'rhn-org-trusted-ssl-cert-osimage'] %}
 
 {%- macro kiwi_params() -%}
-  --ignore-repos-used-for-build --add-repo file:{{ common_repo }},rpm-dir,common_repo,90,false,false --add-bootstrap-package rhn-org-trusted-ssl-cert-osimage {{ ' ' }}
+  --ignore-repos-used-for-build --add-repo file:{{ common_repo }},rpm-dir,common_repo,90,false,false
+{% for pkg in bootstrap_packages -%}
+  --add-bootstrap-package {{ pkg }}
+{% endfor -%}
 {%- for repo in pillar.get('kiwi_repositories') -%}
   --add-repo {{ repo }},rpm-md,key_repo{{ loop.index }},90,false,false {{ ' ' }}
 {%- endfor -%}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Add findutils to Kiwi bootstrap packages
 - Add support for Kiwi options
 - Fix Salt scap state to use new 'xccdf_eval' function
 - Fix deleting stopped virtual network (bsc#1186281)


### PR DESCRIPTION
## What does this PR change?

rhn-org-trusted-ssl-cert-osimage requires findutils for correct function of post-install script.
This pull request adds the package explicitly, in case it is missing from bootstrap section of Kiwi config.xml.

Adding it to sls file allows straightforward update, without need to regenerate any package.

## GUI diff

No difference.

## Documentation
- No documentation needed: no user visible change, it just makes the image building more robust

## Test coverage
- No tests: already covered by cucumber tests

## Links

Part of implementation of https://github.com/SUSE/spacewalk/issues/14570

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
