### PR TITLE
Use correct API endpoint in spacecmd list_proxies

### DIFF
--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,4 @@
+- Use correct API endpoint in list_proxies (bsc#1188042)
 - Add schedule_deletearchived to bulk delete archived actions (bsc#1181223)
 - make spacecmd aware of retracted patches/packages
 - Bump version to 4.3.0

--- a/spacecmd/src/spacecmd/misc.py
+++ b/spacecmd/src/spacecmd/misc.py
@@ -174,7 +174,7 @@ def help_list_proxies(self):
 
 
 def do_list_proxies(self, args):
-    proxies = self.client.satellite.listProxies(self.session)
+    proxies = self.client.proxy.listProxies(self.session)
     print(proxies)
     return 0
 

--- a/spacecmd/tests/test_misc.py
+++ b/spacecmd/tests/test_misc.py
@@ -51,10 +51,14 @@ class TestSCMisc:
         :return:
         """
         mprint = MagicMock()
-        with patch("spacecmd.misc.print", mprint) as prt:
+        shell.client.proxy.listProxies.return_value = "Print me"
+
+        with patch("spacecmd.misc.print", mprint):
             spacecmd.misc.do_list_proxies(shell, "")
+
         assert mprint.called
-        assert shell.client.satellite.listProxies.called
+        assert_expect(mprint.call_args_list, "Print me")
+        assert shell.client.proxy.listProxies.called
 
     def test_get_session(self, shell):
         """


### PR DESCRIPTION
## What does this PR change?

The "Satellite" XMLRPC handler was removed, but spacecmd was still using it. The correct endpoint is "proxy.listProxies".


## GUI diff

No difference.

## Documentation
- No documentation needed: user invisible change

## Test coverage

There is an existing [unit test](https://github.com/uyuni-project/uyuni/blob/master/spacecmd/tests/test_misc.py#L46-L57) for this function, but I think it is rather pointless. I would prefer to remove it, but first I want to hear your opinion.

- [x] **DONE**

## Links

Related to https://github.com/SUSE/spacewalk/issues/15313
Fixes bsc#1188042


- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
