### PR TITLE
Use virt-tuner when creating VMs

### DIFF
--- a/java/code/src/com/suse/manager/virtualization/VirtManagerSalt.java
+++ b/java/code/src/com/suse/manager/virtualization/VirtManagerSalt.java
@@ -306,4 +306,13 @@ public class VirtManagerSalt implements VirtManager {
 
         return saltApi.callSync(call, minionId);
     }
+
+    @Override
+    public Optional<List<String>> getTuningTemplates(String minionId) {
+        LocalCall<List<String>> call =
+                new LocalCall<>("virt_utils.virt_tuner_templates", Optional.empty(), Optional.empty(),
+                        new TypeToken<List<String>>() { });
+
+        return saltApi.callSync(call, minionId);
+    }
 }

--- a/java/code/src/com/suse/manager/virtualization/VirtualizationActionHelper.java
+++ b/java/code/src/com/suse/manager/virtualization/VirtualizationActionHelper.java
@@ -236,6 +236,7 @@ public class VirtualizationActionHelper {
             details.setGraphicsType(data.getGraphicsType());
             details.setKernelOptions(data.getKernelOptions());
             details.setClusterDefinitions(data.getClusterDefinitions());
+            details.setTemplate(data.getTemplate());
 
             if (name.isEmpty() && data.getCobblerId() != null && !data.getCobblerId().isEmpty()) {
                 // Create cobbler profile

--- a/java/code/src/com/suse/manager/virtualization/test/TestVirtManager.java
+++ b/java/code/src/com/suse/manager/virtualization/test/TestVirtManager.java
@@ -107,4 +107,9 @@ public class TestVirtManager implements VirtManager {
     public Optional<Map<String, Map<String, JsonElement>>> getVmInfos(String minionId) {
         throw new UnsupportedOperationException();
     }
+
+    @Override
+    public Optional<List<String>> getTuningTemplates(String minionId) {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/java/code/src/com/suse/manager/webui/controllers/virtualization/VirtualGuestsController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/virtualization/VirtualGuestsController.java
@@ -77,6 +77,7 @@ import org.apache.log4j.Logger;
 import org.jose4j.lang.JoseException;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -383,6 +384,7 @@ public class VirtualGuestsController extends AbstractVirtualizationController {
 
         String minionId = host.asMinionServer().orElseThrow(NotFoundException::new).getMinionId();
         Map<String, Boolean> features = virtManager.getFeatures(minionId).orElse(new HashMap<>());
+        List<String> templates = virtManager.getTuningTemplates(minionId).orElse(new ArrayList<>());
 
         /* For the rest of the template */
         MinionController.addActionChains(user, data);
@@ -391,6 +393,7 @@ public class VirtualGuestsController extends AbstractVirtualizationController {
         data.put("inCluster", features.getOrDefault("cluster", false));
         data.put("raCanStartResources",
                 features.getOrDefault("resource_agent_start_resources", false));
+        data.put("templates", GSON.toJson(templates));
 
         KickstartScheduleCommand cmd = new ProvisionVirtualInstanceCommand(host.getId(), user);
         DataResult<KickstartDto> profiles = cmd.getKickstartProfiles();

--- a/java/code/src/com/suse/manager/webui/controllers/virtualization/gson/VirtualGuestsUpdateActionJson.java
+++ b/java/code/src/com/suse/manager/webui/controllers/virtualization/gson/VirtualGuestsUpdateActionJson.java
@@ -40,6 +40,7 @@ public class VirtualGuestsUpdateActionJson extends VirtualGuestsBaseActionJson {
     private String kernelOptions;
     @SerializedName("cluster_definitions")
     private String clusterDefinitions;
+    private String template;
 
     /**
      * @return the domain type (kvm, qemu, linux, xen...)
@@ -207,6 +208,20 @@ public class VirtualGuestsUpdateActionJson extends VirtualGuestsBaseActionJson {
      */
     public void setClusterDefinitions(String clusterDefinitionsIn) {
         clusterDefinitions = clusterDefinitionsIn;
+    }
+
+    /**
+     * @return value of template
+     */
+    public String getTemplate() {
+        return template;
+    }
+
+    /**
+     * @param templateIn value of template
+     */
+    public void setTemplate(String templateIn) {
+        template = templateIn;
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -1789,6 +1789,7 @@ public class SaltServerActionService {
                     pillar.put("os_type", action.getDetails().getOsType());
                     pillar.put("arch", action.getDetails().getArch());
                     pillar.put("cluster_definitions", action.getDetails().getClusterDefinitions());
+                    pillar.put("template", action.getDetails().getTemplate());
 
                     // No need to handle copying the image to the minion, salt does it for us
                     if (!action.getDetails().getDisks().isEmpty() || action.getDetails().isRemoveDisks()) {
@@ -1802,7 +1803,7 @@ public class SaltServerActionService {
                             diskData.put("name", diskName);
                             diskData.put("format", disk.getFormat());
                             if (disk.getSourceFile() != null || disk.getDevice().equals("cdrom")) {
-                                diskData.put("source_file", disk.getSourceFile() != null ? disk.getSourceFile() : "");
+                                diskData.put("source_file", disk.getSourceFile());
                             }
                             diskData.put("pool", disk.getPool());
                             diskData.put("image", disk.getTemplate());
@@ -1825,9 +1826,7 @@ public class SaltServerActionService {
                             ifaceData.put("name", String.format("eth%d", i));
                             ifaceData.put("type", iface.getType());
                             ifaceData.put("source", iface.getSource());
-                            if (iface.getMac() != null) {
-                                ifaceData.put("mac", iface.getMac());
-                            }
+                            ifaceData.put("mac", iface.getMac());
                             return ifaceData;
                         }).collect(Collectors.toList()));
                     }

--- a/java/code/src/com/suse/manager/webui/services/iface/VirtManager.java
+++ b/java/code/src/com/suse/manager/webui/services/iface/VirtManager.java
@@ -160,4 +160,12 @@ public interface VirtManager {
      * @return the infos
      */
     Optional<Map<String, Map<String, JsonElement>>> getVmInfos(String minionId);
+
+    /**
+     * Get the virt-tuner templates that are available on the minion
+     *
+     * @param minionId the minion id
+     * @return the list of the virt-tuner template names
+     */
+    Optional<List<String>> getTuningTemplates(String minionId);
 }

--- a/java/code/src/com/suse/manager/webui/templates/virtualization/guests/create.jade
+++ b/java/code/src/com/suse/manager/webui/templates/virtualization/guests/create.jade
@@ -22,6 +22,7 @@ script(type='text/javascript').
                       saltEntitled: #{isSalt},
                       inCluster: #{inCluster},
                       raCanStartResources: #{raCanStartResources},
+                      templates: !{templates}
                   },
                   actionChains: !{actionChains},
                   timezone: "#{h.renderTimezone()}",

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add virt-tuner templates to VM creation
 - Ensure XMLRPC returns 'issue_date' in ISO format when listing erratas (bsc#1188260)
 - Fix NullPointerException in HardwareMapper.getUpdatedGuestMemory
 - Fix entitlements not being updated during system transfer (bsc#1188032)

--- a/susemanager-utils/susemanager-sls/salt/virt/create-vm.sls
+++ b/susemanager-utils/susemanager-sls/salt/virt/create-vm.sls
@@ -34,8 +34,7 @@ pools-{{ pillar['name'] }}:
 
 {% macro domain_params() -%}
     - name: {{ pillar['name'] }}
-    - cpu: {{ pillar['vcpus'] }}
-    - mem: {{ pillar['mem'] // 1024 }}
+    - {{ salt.virt_utils.domain_parameters(pillar["vcpus"], pillar["mem"], pillar.get("template")) }}
     - os_type: {{ pillar['os_type'] }}
     - arch: {{ pillar['arch'] }}
     - vm_type: {{ pillar['vm_type'] }}

--- a/susemanager-utils/susemanager-sls/salt/virt/create-vm.sls
+++ b/susemanager-utils/susemanager-sls/salt/virt/create-vm.sls
@@ -40,41 +40,13 @@ pools-{{ pillar['name'] }}:
     - arch: {{ pillar['arch'] }}
     - vm_type: {{ pillar['vm_type'] }}
     - disks:
-{%- for disk in pillar['disks'] %}
-      - name: {{ disk['name'] }}
-        model: {{ disk['model'] }}
-    {%- if 'device' in disk %}
-        device: {{ disk['device'] }}
-    {%- endif %}
-    {%- if 'format' in disk %}
-        format: {{ disk['format'] }}
-    {%- endif %}
-    {%- if 'source_file' in disk %}
-        source_file: {{ disk['source_file'] if disk['source_file'] != '' else 'null' }}
-    {%- endif %}
-    {%- if 'pool' in disk %}
-        pool: {{ disk['pool'] }}
-    {%- endif %}
-    {%- if 'size' in disk %}
-        size: {{ disk['size'] }}
-    {%- endif %}
-    {%- if 'image' in disk %}
-        image: {{ disk['image'] }}
-    {%- endif %}
-{%- endfor %}
+        {{ pillar['disks'] }}
 {%- if 'interfaces' in pillar %}
     - interfaces:
-    {%- for nic in pillar['interfaces'] %}
-      - name: {{ nic['name'] }}
-        type: {{ nic['type'] }}
-        source: {{ nic['source'] }}
-        {%- if 'mac' in nic %}
-        mac: {{ nic['mac'] if nic['mac'] != '' else 'null' }}
-        {%- endif %}
-    {%- endfor %}
+        {{ pillar['interfaces'] }}
 {%- endif %}
     - graphics:
-        type: {{ pillar['graphics']['type'] }}
+        {{ pillar['graphics'] }}
 {%- endmacro %}
 
 {%- set cdrom_boot = pillar.get('boot_dev', 'hd').startswith('cdrom') -%}

--- a/susemanager-utils/susemanager-sls/src/modules/virt_utils.py
+++ b/susemanager-utils/susemanager-sls/src/modules/virt_utils.py
@@ -13,6 +13,11 @@ try:
 except ImportError:
     pass
 
+try:
+    import virt_tuner
+except ImportError:
+    virt_tuner = None
+
 from salt.exceptions import CommandExecutionError
 
 log = logging.getLogger(__name__)
@@ -216,3 +221,23 @@ def vm_definition(uuid):
             if cnx:
                 cnx.close()
         return {}
+
+
+def virt_tuner_templates():
+    """
+    Get the virt-tuner templates names
+    """
+    if virt_tuner:
+        return sorted(list(virt_tuner.templates.keys()))
+    return []
+
+
+def domain_parameters(cpu, mem, template):
+    """
+    Return the VM parameters with the potential virt-tuner template applied
+    """
+    params = {"cpu": cpu, "mem": mem}
+    if virt_tuner and template in virt_tuner.templates:
+        template_params = virt_tuner.templates[template].function()
+        params.update(template_params)
+    return params

--- a/susemanager-utils/susemanager-sls/src/tests/test_module_virt_utils.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_module_virt_utils.py
@@ -241,3 +241,33 @@ def test_vm_definition_cluster(libvirt):
                     actual = virt_utils.vm_definition("15c09f1f-6ac7-43b5-83e9-96a63c40fb14")
                     assert actual["definition"] == vm_xml
                     assert actual.get("info") is None
+
+
+@pytest.mark.parametrize("has_virt_tuner", (True, False))
+def test_virt_tuner_templates(has_virt_tuner):
+    """
+    Test the virt_tuner_templates() function
+    """
+    templates = ["template1", "template2"] if has_virt_tuner else []
+    tuner_mock= MagicMock()
+    tuner_mock.templates.keys.return_value = templates
+    virt_utils.virt_tuner = tuner_mock if has_virt_tuner else None
+
+    assert virt_utils.virt_tuner_templates() == templates
+
+
+@pytest.mark.parametrize("has_virt_tuner", (True, False))
+def test_domain_parameters(has_virt_tuner):
+    """
+    Test the domain_parameters() function
+    """
+    template_params = {"cpu": 22, "mem": 512, "foo": "bar"} if has_virt_tuner else {}
+    template_mock = MagicMock()
+    template_mock.function.return_value = template_params
+    tuner_mock= MagicMock()
+    tuner_mock.templates = {"template1": template_mock}
+    virt_utils.virt_tuner = tuner_mock if has_virt_tuner else None
+
+    assert virt_utils.domain_parameters(1, 1234, "template1") == (
+        template_params if has_virt_tuner else {"cpu": 1, "mem": 1234}
+    )

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Add virt-tuner templates to VM creation
 - Add missing symlinks to generate the "certs" state for
   SLE Micro 5.0 and openSUSE MicroOS minions (bsc#1188503)
 - Remove systemid file on salt client cleanup

--- a/web/html/src/manager/virtualization/guests/GuestProperties.tsx
+++ b/web/html/src/manager/virtualization/guests/GuestProperties.tsx
@@ -17,6 +17,7 @@ import { GuestPropertiesTraditional } from "./properties/guest-properties-tradit
 import { VirtualizationDomainsCapsApi } from "./virtualization-domains-caps-api";
 import { VirtualizationListRefreshApi } from "../virtualization-list-refresh-api";
 import { VirtualizationPoolCapsApi } from "../pools/virtualization-pools-capabilities-api";
+import { TemplatesMessages } from "./properties/templates";
 
 type Props = {
   host: any;
@@ -242,6 +243,25 @@ export function GuestProperties(props: Props) {
                                         required={model["in_cluster"]}
                                       />
                                     </>
+                                  )
+                                }
+                                { initialModel.name === undefined && props.host.templates && (
+                                    <Select
+                                      labelClass="col-md-3"
+                                      divClass="col-md-6"
+                                      name="template"
+                                      label={t("Template")}
+                                      options={props.host.templates}
+                                      formatOptionLabel={
+                                        ({value}) => {
+                                          const description = TemplatesMessages[value];
+                                           if (description != null) {
+                                             return `${value} - ${description}`;
+                                           }
+                                           return value;
+                                        }
+                                      }
+                                    />
                                   )
                                 }
                               </Panel>,

--- a/web/html/src/manager/virtualization/guests/create/guests-create.tsx
+++ b/web/html/src/manager/virtualization/guests/create/guests-create.tsx
@@ -43,7 +43,7 @@ class GuestsCreate extends React.Component<Props, State> {
       ),
       {
         type: model.vmType,
-        memory: model.memory * 1024,
+        memory: model.memory,
       },
       nics.length !== 0 ? { interfaces: nics } : undefined,
       disks.length !== 0 ? { disks } : undefined,

--- a/web/html/src/manager/virtualization/guests/edit/guests-edit.tsx
+++ b/web/html/src/manager/virtualization/guests/edit/guests-edit.tsx
@@ -66,7 +66,7 @@ class GuestsEdit extends React.Component<Props> {
         {}
       ),
       {
-        memory: model.memory * 1024,
+        memory: model.memory,
       },
       nicsParams,
       disksParams,

--- a/web/html/src/manager/virtualization/guests/properties/templates.ts
+++ b/web/html/src/manager/virtualization/guests/properties/templates.ts
@@ -1,0 +1,3 @@
+export const TemplatesMessages = {
+  "single": t("Single virtual machine using almost all the host resources"),
+};

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Add virt-tuner templates to VM creation
 - Fix virtualization guests to handle null HostInfo
 - Compare lowercase CPU arch with libvirt domain capabilities
 - Add option to run Ansible playbooks in 'test' mode


### PR DESCRIPTION
## What does this PR change?

Allow selecting a template from the ones supported by the [`virt-tuner`](https://github.com/cbosdo/virt-tuner) tool.

## GUI diff

Before:

![Screen Shot 2021-07-13 at 12 29 31](https://user-images.githubusercontent.com/397931/125273084-d9e97300-e30c-11eb-817b-fc7c585454b0.png)

After:

![Screen Shot 2021-07-13 at 12 28 49](https://user-images.githubusercontent.com/397931/125273119-e1108100-e30c-11eb-8d35-294102c7c3d9.png)

- [X] **DONE**

## Documentation

- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- Unit tests were added

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
