### PR TITLE
Make 200-rename-service-pack-migration.sql truely idempotent

### DIFF
--- a/schema/spacewalk/upgrade/susemanager-schema-4.2.10-to-susemanager-schema-4.2.11/200-rename-service-pack-migration.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.2.10-to-susemanager-schema-4.2.11/200-rename-service-pack-migration.sql
@@ -9,4 +9,4 @@
 -- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
 --
 
-UPDATE rhnActionType SET name='Product Migration' WHERE label='distupgrade.upgrade';
+UPDATE rhnActionType SET name='Product Migration' WHERE label='distupgrade.upgrade' AND name!='Product Migration';


### PR DESCRIPTION
## What does this PR change?

If the script updates the row with the same value, postgresql will move
it to the end of the dump. This then breaks the idempotency tests.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
