### PR TITLE
Readable error when "mgr-sync add channel" is called with a no-existing label (bsc#1173143)

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/content/test/ContentSyncManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/content/test/ContentSyncManagerTest.java
@@ -23,6 +23,7 @@ import com.redhat.rhn.domain.channel.ChannelFactory;
 import com.redhat.rhn.domain.channel.ChannelFamily;
 import com.redhat.rhn.domain.channel.ChannelFamilyFactory;
 import com.redhat.rhn.domain.channel.ContentSource;
+import com.redhat.rhn.domain.channel.test.ChannelFactoryTest;
 import com.redhat.rhn.domain.channel.test.ChannelFamilyFactoryTest;
 import com.redhat.rhn.domain.common.ManagerInfoFactory;
 import com.redhat.rhn.domain.credentials.Credentials;
@@ -577,6 +578,18 @@ public class ContentSyncManagerTest extends BaseTestCaseWithUser {
         List<ProductTreeEntry> staticTreeChanged = JsonParser.GSON.fromJson(inReaderTree, new TypeToken<List<ProductTreeEntry>>() {}.getType());
 
         ContentSyncManager csm = new ContentSyncManager();
+
+        try {
+            Channel channelWithWrongLabel = ChannelFactoryTest.createTestChannel(user.getOrg());
+            //force use an non-existing label (mgr-sync from CLI can cause it)
+            channelWithWrongLabel.setLabel("non-existing-label");
+            ContentSyncManager.updateChannel(channelWithWrongLabel);
+            fail("update non-existing-channel should fail");
+        }
+        catch (ContentSyncException e) {
+            assertContains(e.getMessage(), "No product tree entry found for label:");
+        }
+
         csm.updateSUSEProducts(productsChanged, upgradePaths, staticTreeChanged, Collections.emptyList());
         HibernateFactory.getSession().flush();
         HibernateFactory.getSession().clear();
@@ -1370,6 +1383,15 @@ public class ContentSyncManagerTest extends BaseTestCaseWithUser {
         HibernateFactory.getSession().clear();
 
         ContentSyncManager csm = new ContentSyncManager();
+
+        try {
+            csm.addChannel("non-existing-channel", null);
+            fail("adding non-existing-channel should fail");
+        }
+        catch (ContentSyncException e) {
+            assertContains(e.getMessage(), "No product tree entry found for label:");
+        }
+
         try {
             csm.addChannel("sles12-updates-x86_64", null);
             fail("adding sles12-updates-x86_64 should not work here");

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Readable error when "mgr-sync add channel" is called with a non-existing label (bsc#1173143)
 - Fix NPE error when scheduling ErrataAction from relevant errata page (bsc#1188289)
 - Add Beijing timezone to selectable timezones (bsc#1188193)
 - Java enablement for Rocky Linux 8


### PR DESCRIPTION
## What does this PR change?
Readable error when "mgr-sync add channel" is called with a no-existing label

## GUI diff
N/A

## Documentation
N/A

## Test coverage
N/A

## Links

Fixes #
bsc#1173143

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql" (Test skipped, there are no changes to test)
- [ ] Re-run test "java_pgsql_tests"   
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql" (Test skipped, there are no changes to test)
- [ ] Re-run test "susemanager_unittests" (Test skipped, there are no changes to test)
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests" (Test skipped, there are no changes to test)
