### PR TITLE
Update to postgresql13 for non-SUSE environments

### DIFF
--- a/spacewalk/package/spacewalk.changes
+++ b/spacewalk/package/spacewalk.changes
@@ -1,3 +1,4 @@
+- Update to postgresql13 for non-SUSE environments.
 - Bump version to 4.3.0
 
 -------------------------------------------------------------------

--- a/spacewalk/package/spacewalk.spec
+++ b/spacewalk/package/spacewalk.spec
@@ -132,8 +132,8 @@ Conflicts:      postgresql-contrib-implementation >= 13
 Requires:       postgresql >= 12
 Requires:       postgresql-contrib >= 12
 # we do not support postgresql versions > 13.x yet
-Conflicts:      postgresql >= 13
-Conflicts:      postgresql-contrib >= 13
+Conflicts:      postgresql >= 14
+Conflicts:      postgresql-contrib >= 14
 %endif # if suse_version
 
 %description postgresql


### PR DESCRIPTION
## What does this PR change?

Update to postgresql13 for non-SUSE environments (allow EL8 to use PostgreSQL 13)

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
