### PR TITLE
Remove `from None` from exception raising

### DIFF
--- a/uyuni/common-libs/common/rhn_rpm.py
+++ b/uyuni/common-libs/common/rhn_rpm.py
@@ -261,7 +261,7 @@ class RPM_Package(A_Package):
             header_store = struct_lead[12:16]
             (header_store_value, ) = struct.unpack('>I', header_store)
         except:
-            raise InvalidPackageError from None
+            raise InvalidPackageError
 
         # The total size of the header. Each index entry is 16 bytes long.
         header_size = 8 + 4 + 4 + header_index_value * 16 + header_store_value
@@ -331,7 +331,7 @@ def get_header_struct_size(package_file):
         header_store = package_file.read(4)
         (header_store_value, ) = struct.unpack('>I', header_store)
     except:
-        raise InvalidPackageError from None
+        raise InvalidPackageError
 
     # The total size of the header. Each index entry is 16 bytes long.
     header_size = 8 + 4 + 4 + header_index_value * 16 + header_store_value


### PR DESCRIPTION
## What does this PR change?

Fixes improper syntax for Python 2 pushed with https://github.com/uyuni-project/uyuni/pull/3920

```
[  101s] Bytecompiling .py files below /home/abuild/rpmbuild/BUILDROOT/uyuni-common-libs-4.3.0-3.1.uyuni.x86_64/usr/lib/python2.7 using /usr/bin/python2.7
[  101s] Compiling /home/abuild/rpmbuild/BUILDROOT/uyuni-common-libs-4.3.0-3.1.uyuni.x86_64/usr/lib/python2.7/site-packages/uyuni/common/rhn_rpm.py ...
[  101s]   File "/usr/lib/python2.7/site-packages/uyuni/common/rhn_rpm.py", line 264
[  101s]     raise InvalidPackageError from None
[  101s]                                  ^
[  101s] SyntaxError: invalid syntax
```

## GUI diff

No difference.

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "susemanager_unittests"
