### PR TITLE
CLM cleanup targets on project removal

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/contentmgmt/ContentManagementHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/contentmgmt/ContentManagementHandler.java
@@ -179,7 +179,7 @@ public class ContentManagementHandler extends BaseHandler {
     }
 
     /**
-     * Remove Content Project
+     * Remove Content Project. Do not purge the underlying environment targets (e.g. sw channels).
      *
      * @param loggedInUser the logged in user
      * @param label the label
@@ -194,7 +194,33 @@ public class ContentManagementHandler extends BaseHandler {
     public int removeProject(User loggedInUser, String label) {
         ensureOrgAdmin(loggedInUser);
         try {
-            return contentManager.removeProject(label, loggedInUser);
+            return contentManager.removeProject(label, false, loggedInUser);
+        }
+        catch (EntityNotExistsException e) {
+            throw new EntityNotExistsFaultException(e);
+        }
+    }
+
+    /**
+     * Remove Content Project
+     *
+     * @param loggedInUser the logged in user
+     * @param label the label
+     * @param cleanTargets true if the underlying targets (e.g. sw channels) should be removed
+     * @throws EntityNotExistsFaultException when Project does not exist
+     * @return the number of removed objects
+     *
+     * @xmlrpc.doc Remove Content Project
+     * @xmlrpc.param #session_key()
+     * @xmlrpc.param #param_desc("string", "label", "Content Project label")
+     * @xmlrpc.param #param_desc("boolean", "cleanTargets", "Whether the underlying targets (e.g. sw channels)
+     * should be removed too")
+     * @xmlrpc.returntype #return_int_success()
+     */
+    public int removeProject(User loggedInUser, boolean cleanTargets, String label) {
+        ensureOrgAdmin(loggedInUser);
+        try {
+            return contentManager.removeProject(label, cleanTargets, loggedInUser);
         }
         catch (EntityNotExistsException e) {
             throw new EntityNotExistsFaultException(e);

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/ContentManager.java
@@ -195,16 +195,21 @@ public class ContentManager {
      * Remove Content Project
      *
      * @param label the label
+     * @param cleanTargets true if the linked environment targets (e.g. sw channels) should be removed
      * @param user the user
      * @throws PermissionException if given user does not have required role
      * @throws EntityNotExistsException if Content Project with given label is not found
      * @return the number of objects affected
      */
-    public int removeProject(String label, User user) {
+    public int removeProject(String label, boolean cleanTargets, User user) {
         ensureOrgAdmin(user);
-        return lookupProject(label, user)
-                .map(cp -> ContentProjectFactory.remove(cp))
-                .orElseThrow(() -> new EntityNotExistsException(label));
+        ContentProject project = lookupProject(label, user).orElseThrow(() -> new EntityNotExistsException(label));
+
+        if (cleanTargets) {
+            listProjectEnvironments(label, user).forEach(e -> removeEnvironment(e.getLabel(), label, user));
+        }
+
+        return ContentProjectFactory.remove(project);
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/ProjectApiController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/ProjectApiController.java
@@ -37,6 +37,7 @@ import com.suse.manager.webui.utils.gson.ResultJson;
 
 import org.apache.http.HttpStatus;
 
+import java.util.Map;
 import java.util.Optional;
 
 import spark.Request;
@@ -117,8 +118,9 @@ public class ProjectApiController {
      */
     public static String removeContentProject(Request req, Response res, User user) {
         String projectLabel = req.params("projectId");
+        boolean cleanTargets = (boolean) GSON.fromJson(req.body(), Map.class).get("cleanTargets");
 
-        int removingResult = CONTENT_MGR.removeProject(projectLabel, user);
+        int removingResult = CONTENT_MGR.removeProject(projectLabel, cleanTargets, user);
 
         if (removingResult == 1) {
             String successMessage = LOC.getMessage("contentmanagement.project_deleted", projectLabel);

--- a/web/html/src/manager/content-management/project/project.tsx
+++ b/web/html/src/manager/content-management/project/project.tsx
@@ -31,6 +31,7 @@ type Props = {
 
 const Project = (props: Props) => {
   const [project, setProject] = useState(props.project);
+  const [cleanTargets, setCleanTargets] = useState(false);
   const { onAction, cancelAction: cancelRefreshAction } = useLifecycleActionsApi({ resource: "projects" });
   const roles = useRoles();
   const hasEditingPermissions = isOrgAdmin(roles);
@@ -82,6 +83,20 @@ const Project = (props: Props) => {
     hasErrors;
 
   const hasChannelsWithUnsyncedPatches = project.softwareSources.filter(s => s.hasUnsyncedPatches).length > 0;
+  const deleteDialogContents = (
+    <div className="form-horizontal">
+      <div>
+        {t("Are you sure you want to delete project")} <strong>{projectId}</strong>?
+      </div>
+      <div>
+        <input
+          type="checkbox"
+          id="force"
+          checked={cleanTargets}
+          onChange={event => setCleanTargets(event.target.checked)} />
+        {t("Cleanup project targets (e.g. software channels)?")}
+      </div>
+    </div>);
   return (
     <TopPanel
       title={t("Content Lifecycle Project - {0}", project.properties.name)}
@@ -97,13 +112,9 @@ const Project = (props: Props) => {
       <DeleteDialog
         id="delete-project-modal"
         title={t("Delete Project")}
-        content={
-          <span>
-            {t("Are you sure you want to delete project")} <strong>{projectId}</strong>?
-          </span>
-        }
+        content={deleteDialogContents}
         onConfirm={() =>
-          onAction(project, "delete", project.properties.label)
+          onAction(Object.assign(project, {"cleanTargets": cleanTargets}), "delete", project.properties.label)
             .then(() => {
               window.pageRenderers?.spaengine?.navigate?.(`/rhn/manager/contentmanagement/projects`);
             })


### PR DESCRIPTION
## What does this PR change?

This was a long-time missing feature. It allows to delete the project targets (currently only SW channels) on project removal. This is optional and needs to be confirmed (checkbox in the UI, parameterer in the API). The default behavior is unchanged (targets are not cleaned).

## TODO
- [ ] get some UI help, so that the dialog does not looks so ugly
- [ ] Implement the detection of systems possible to affected channels and reflect this in the UI accordingly
  - [ ] for project removal screen
  - [ ] for environment removal screen
- [x] make sure it behaves correctly on projects with many channels and many assignments
- [x] unify the names (clean vs. remove)

## GUI diff

After:
![ss](https://user-images.githubusercontent.com/1412268/125594465-3c169e48-128c-4376-9bf0-10c6e117f40c.png)


- [x] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- Unit tests were added


- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
