### PR TITLE
Add Beijing timezone to selectable timezones (bsc#1188193)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/database/StringResource_en_US.xml
@@ -378,6 +378,12 @@
           <context context-type="sourcefile">/rhn/account/UserDetails</context>
         </context-group>
       </trans-unit>
+       <trans-unit id="Asia/Beijing" xml:space="preserve">
+        <source>(GMT+0800) China</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/account/UserDetails</context>
+        </context-group>
+      </trans-unit>
       <!-- Monitoring "Config Macro" records - used to configure the monitoring sat -->
       <trans-unit id="MAIL_MX" xml:space="preserve">
         <source>Local mail exchanger</source>

--- a/java/code/src/com/redhat/rhn/manager/user/test/UserManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/user/test/UserManagerTest.java
@@ -15,15 +15,6 @@
 
 package com.redhat.rhn.manager.user.test;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import com.redhat.rhn.common.ObjectCreateWrapperException;
 import com.redhat.rhn.common.db.datasource.DataResult;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
@@ -63,6 +54,15 @@ import com.redhat.rhn.testing.RhnBaseTestCase;
 import com.redhat.rhn.testing.TestStatics;
 import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /** JUnit test case for the User
  *  class.
@@ -598,8 +598,8 @@ public class UserManagerTest extends RhnBaseTestCase {
 
         assertEquals(UserManager.getTimeZone("GMT"), lst.get(0));
         assertEquals("GMT", lst.get(0).getOlsonName());
-        assertEquals("America/Sao_Paulo", lst.get(5).getOlsonName());
-        assertEquals(UserManager.getTimeZone("America/Sao_Paulo"), lst.get(5));
+        assertEquals("Atlantic/South_Georgia", lst.get(5).getOlsonName());
+        assertEquals(UserManager.getTimeZone("Atlantic/South_Georgia"), lst.get(5));
 
         assertEquals("Europe/Paris", lst.get(lst.size() - 1).getOlsonName());
         assertEquals(UserManager.getTimeZone("Europe/Paris"), lst.get(lst.size() - 1));

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add Beijing timezone to selectable timezones (bsc#1188193)
 - Java enablement for Rocky Linux 8
 - Get CPU data for AArch64
 - Add option to run Ansible playbooks in 'test' mode

--- a/schema/spacewalk/common/data/rhnTimezone.sql
+++ b/schema/spacewalk/common/data/rhnTimezone.sql
@@ -323,4 +323,10 @@ values
   (sequence_nextval('rhn_timezone_id_seq'),
    'Asia/Kuala_Lumpur', 'Malaysia');
 
+insert into rhnTimezone
+  (id, olson_name, display_name)
+values
+  (sequence_nextval('rhn_timezone_id_seq'),
+   'Asia/Beijing', 'China');
+
 commit;

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- Add Beijing timezone to selectable timezones (bsc#1188193)
 - Add Rocky Linux 8 key and vendor
 - Add 'test' flag to Ansible playbook actions
 - Add Kiwi commandline options to Kiwi profile

--- a/schema/spacewalk/upgrade/susemanager-schema-4.3.0-to-susemanager-schema-4.3.1/002-new-timezones.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.3.0-to-susemanager-schema-4.3.1/002-new-timezones.sql
@@ -1,0 +1,7 @@
+insert into rhnTimezone(id, olson_name, display_name) ( 
+  select sequence_nextval('rhn_timezone_id_seq'), 'Asia/Beijing', 'China'
+    from dual
+   where not exists (
+	select 1 from rhnTimezone where olson_name = 'Asia/Beijing'
+   )
+);


### PR DESCRIPTION
## What does this PR change?

Add Beijing timezone to selectable timezones (bsc#1188193)

## GUI diff

No difference.

## Documentation
N/A

## Test coverage
- No tests: code with no test

- [ ] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/15395
bsc#1188193

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql" (Test skipped, there are no changes to test)
- [x] Re-run test "java_pgsql_tests"   
- [x] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"  
- [ ] Re-run test "susemanager_unittests" (Test skipped, there are no changes to test)
- [x] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests" (Test skipped, there are no changes to test)
