### PR TITLE
Fix entitlement update during system transfer

### DIFF
--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix entitlements not being updated during system transfer (bsc#1188032)
 - Simplify the VM creation action in DB
 - Refresh virtual host pillar to clear the virtpoller beacon (bsc#1188393)
 - Fix updating primary net interface on hardware refresh (bsc#1188400)


### PR DESCRIPTION
## What does this PR change?

Fixes entitlements not being updated when transferring systems between organizations

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: **Bugfix**

- [x] **DONE**

## Test coverage

- No tests: **Bugfix**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/15304

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
