### PR TITLE
susemanager: Modified postgresql configuration handling

### DIFF
--- a/susemanager/bin/mgr-setup
+++ b/susemanager/bin/mgr-setup
@@ -204,13 +204,29 @@ setup_db_postgres() {
         # Create the PostgreSQL data folder, should it not exist.
         if [ ! -f $DATADIR/PG_VERSION ]; then
             rm -Rf ${DATADIR}
+            POSTGRES_LANG=en_US.UTF-8
+
+            # Define LC_CTYPE in postgres user profile. (Used during any DB creation)
+            PGHOME=$(getent passwd postgres | awk -F: '{print $6}')
+            . $PGHOME/.i18n 2>/dev/null
+            if [ -z $LC_CTYPE ]; then
+                grep "^LC_CTYPE" $PGHOME/.i18n > /dev/null 2>&1
+                if [ $? = 0 ]; then
+                    sed -i -e "s/^LC_CTYPE.*$/LC_CTYPE=${POSTGRES_LANG}/" $PGHOME/.i18n
+                else
+                    echo -e "LC_CTYPE=${POSTGRES_LANG}\nexport LC_CTYPE" >> $PGHOME/.i18n
+                fi
+            fi
+
             echo "Initializing PostgreSQL $VERSION at location ${DATADIR}"
-            runuser -l postgres -c "/usr/bin/initdb --auth=ident $DATADIR" &> initlog || {
+            # Redundant locale flag for clarity
+            runuser -l postgres -c "/usr/bin/initdb --locale=${POSTGRES_LANG} --auth=ident $DATADIR" &> initlog || {
                 echo "Initialisation failed. See $PWD/initlog ."
                 exit 1
             }
         fi
     else
+        # Define POSTGRES_LANG in system wide config. (Used during any DB creation)
         . /etc/sysconfig/postgresql
         if [ -z $POSTGRES_LANG ]; then
             grep "^POSTGRES_LANG" /etc/sysconfig/postgresql > /dev/null 2>&1

--- a/susemanager/bin/mgr-setup
+++ b/susemanager/bin/mgr-setup
@@ -210,6 +210,16 @@ setup_db_postgres() {
                 exit 1
             }
         fi
+    else
+        . /etc/sysconfig/postgresql
+        if [ -z $POSTGRES_LANG ]; then
+            grep "^POSTGRES_LANG" /etc/sysconfig/postgresql > /dev/null 2>&1
+            if [ $? = 0 ]; then
+                sed -i -e "s/^POSTGRES_LANG.*$/POSTGRES_LANG=\"en_US.UTF-8\"/" /etc/sysconfig/postgresql
+            else
+                echo "POSTGRES_LANG=\"en_US.UTF-8\"" >> /etc/sysconfig/postgresql
+            fi
+        fi
     fi
     systemctl start postgresql
     su - postgres -c "createdb -E UTF8 $MANAGER_DB_NAME ; echo \"CREATE ROLE $MANAGER_USER PASSWORD '$MANAGER_PASS' SUPERUSER NOCREATEDB NOCREATEROLE INHERIT LOGIN;\" | psql"

--- a/susemanager/bin/pg-migrate-x-to-y.sh
+++ b/susemanager/bin/pg-migrate-x-to-y.sh
@@ -150,10 +150,14 @@ mkdir /var/lib/pgsql/data
 chown postgres:postgres /var/lib/pgsql/data
 
 echo "$(timestamp)   Initialize new postgresql $NEW_VERSION database..."
-. /etc/sysconfig/postgresql
+. /etc/sysconfig/postgresql 2>/dev/null # Load locale for SUSE
+PGHOME=$(getent passwd postgres | awk -F: '{print $6}')
+. $PGHOME/.i18n 2>/dev/null # Load locale for Enterprise Linux
 if [ -z $POSTGRES_LANG ]; then
     POSTGRES_LANG="en_US.UTF-8"
+    [ ! -z $LC_CTYPE ] && POSTGRES_LANG=$LC_CTYPE
 fi
+
 su -s /bin/bash - postgres -c "initdb -D /var/lib/pgsql/data --locale=$POSTGRES_LANG"
 if [ $? -eq 0 ]; then
     echo "$(timestamp)   Successfully initialized new postgresql $NEW_VERSION database."

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- Moved postgresql config from spec to mgr-setup.
 - Improve the error management for the PostgreSQL migration script (bsc#1188297)
 - Add the salt bundle support to mgr-create-bootstrap-repo
 - Add bootstrap repository definitions for Rocky Linux 8

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- Improved non-SUSE postgresql config handling.
 - Moved postgresql config from spec to mgr-setup.
 - Improve the error management for the PostgreSQL migration script (bsc#1188297)
 - Add the salt bundle support to mgr-create-bootstrap-repo

--- a/susemanager/susemanager.spec
+++ b/susemanager/susemanager.spec
@@ -274,16 +274,6 @@ sed -i 's/su wwwrun www/su apache apache/' /etc/logrotate.d/susemanager-tools
 %endif
 
 %posttrans
-# make sure our database will use correct encoding
-. /etc/sysconfig/postgresql
-if [ -z $POSTGRES_LANG ]; then
-    grep "^POSTGRES_LANG" /etc/sysconfig/postgresql > /dev/null 2>&1
-    if [ $? = 0 ]; then
-        sed -i -e "s/^POSTGRES_LANG.*$/POSTGRES_LANG=\"en_US.UTF-8\"/" /etc/sysconfig/postgresql
-    else
-        echo "POSTGRES_LANG=\"en_US.UTF-8\"" >> /etc/sysconfig/postgresql
-    fi
-fi
 
 %postun
 %if 0%{?suse_version}


### PR DESCRIPTION
## What does this PR change?

**Moved postgresql config from spec to mgr-setup**:
The involved variable POSTGRES_LANG is only used during database initalisation. So the changes in %posttrans would only be relevant for new databases/upgrades. The Uyuni setup now checks for the right locale.

**Improved non-SUSE postgresql config handling**:

1. Set the environment locale for the postgres user during Uyuni setup.
2. Explicitly initialise the database with the required locale.
3. Load and double check the locale during a postgres upgrade.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

Build tested successfully on
 epel-8-x86_64
 opensuse-leap-15.3-x86_64

Manually tested upgrade from Leap 15.2 to 15.3 and Postgresql 13 using the scripts.
Manually tested installation on Alma8

- [X] **DONE**

## Links
Fixes: #3067 (one part of it)

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
