### PR TITLE
Remove 'test' pillar parameter from 'runplaybook' state (bsc#1188395)

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/ansible/runplaybook.sls
+++ b/susemanager-utils/susemanager-sls/salt/ansible/runplaybook.sls
@@ -2,7 +2,7 @@
 # SLS to trigger a playbook execution on an Ansible control node
 #
 # This SLS requires pillar data to render properly.
-# 
+#
 # Example (inventory is optional):
 #
 # pillar = {
@@ -16,7 +16,6 @@ run_ansible_playbook:
   ansible.playbooks:
     - name: {{ pillar["playbook_path"] }}
     - rundir: {{ pillar["rundir"] }}
-    - test: {{ pillar["test"] }}
 {%- if "inventory_path" in pillar %}
     - ansible_kwargs:
         inventory: {{ pillar["inventory_path"] }}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Fix parameters for 'runplaybook' state (bsc#1188395)
 - Parameterised apache document root.
 - Add support for bootstrapping Raspbian 9 and 10
 - Add support for bootstrapping with salt bundle


### PR DESCRIPTION
Removes nonexistent `test` parameter from `runplaybook` state.

https://bugzilla.suse.com/1188395

Port of: https://github.com/SUSE/spacewalk/pull/15420

## GUI diff

No difference.

## Documentation
- No documentation needed: Bugfix

## Test coverage
- No tests: already covered

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
