### PR TITLE
spacewalk-setup-jabber: Ignore post installation error messages

### DIFF
--- a/spacewalk/spacewalk-setup-jabberd/spacewalk-setup-jabberd.changes
+++ b/spacewalk/spacewalk-setup-jabberd/spacewalk-setup-jabberd.changes
@@ -1,3 +1,4 @@
+- Hide post installation errors.
 - Bump version to 4.3.0
 
 -------------------------------------------------------------------

--- a/spacewalk/spacewalk-setup-jabberd/spacewalk-setup-jabberd.spec
+++ b/spacewalk/spacewalk-setup-jabberd/spacewalk-setup-jabberd.spec
@@ -83,6 +83,6 @@ make test
 %{_sysconfdir}/pki/spacewalk
 
 %post
-/usr/share/spacewalk/setup/jabberd/manage_database -s >/dev/null ||:
+/usr/share/spacewalk/setup/jabberd/manage_database -s 2>/dev/null ||:
 
 %changelog


### PR DESCRIPTION
## What does this PR change?

`manage_database` will send irrelevant error messages during post installation, should Uyuni not be installed already. Let's not show the messages as they are expected. It seems currently only stdout messages are hidden.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered
Build tested successfully on
 epel-8-x86_64 
 fedora-33-x86_64 
 fedora-rawhide-x86_64
 opensuse-leap-15.3-x86_64 

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
