### PR TITLE
WIP: Fix disabling monitoring if exporters could not be extracted

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/formula/FormulaFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/formula/FormulaFactory.java
@@ -911,6 +911,13 @@ public class FormulaFactory {
     @SuppressWarnings("unchecked")
     public static Map<String, Object> disableMonitoring(Map<String, Object> formData) {
         Map<String, Object> exporters = (Map<String, Object>) formData.get("exporters");
+        // If we cannot extract the exporters from the form data the form data file might
+        // come from an older version of the prometheus-exporters formula package and we will
+        // use the example file instead
+        if (exporters == null) {
+            formData = FormulaFactory.getPillarExample(PROMETHEUS_EXPORTERS);
+            exporters = (Map<String, Object>) formData.get("exporters");
+        }
         for (Object exporter : exporters.values()) {
             Map<String, Object> exporterMap = (Map<String, Object>) exporter;
             exporterMap.put("enabled", false);
@@ -943,6 +950,12 @@ public class FormulaFactory {
     @SuppressWarnings("unchecked")
     private static boolean hasMonitoringDataEnabled(Map<String, Object> formData) {
         Map<String, Object> exporters = (Map<String, Object>) formData.get("exporters");
+        // If we cannot extract the exporters from the form data the form data file might
+        // come from an older version of the prometheus-exporters formula package and we will
+        // use the example file instead
+        if (exporters == null) {
+            exporters = (Map<String, Object>) FormulaFactory.getPillarExample(PROMETHEUS_EXPORTERS).get("exporters");
+        }
         return exporters.values().stream()
                 .map(exporter -> (Map<String, Object>) exporter)
                 .anyMatch(exporter -> (boolean) exporter.get("enabled"));

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix disabling monitoring if exporters could not be extracted from file (bsc#1188136)
 - Fix NPE error when scheduling ErrataAction from relevant errata page (bsc#1188289)
 - Add Beijing timezone to selectable timezones (bsc#1188193)
 - Java enablement for Rocky Linux 8


### PR DESCRIPTION
## What does this PR change?

**Note:** We are looking into another way to address the underlying issue, so do not review for now!
Fixes being unable to disable monitoring if the exporters could not be read from the form data file.

## GUI diff

No difference.

- [x] **DONE**

## Test coverage

- No tests: **Bugfix**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/15350

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
