### PR TITLE
Improve the error management for the PostgreSQL migration script (bsc#1188297)

### DIFF
--- a/susemanager/bin/pg-migrate-x-to-y.sh
+++ b/susemanager/bin/pg-migrate-x-to-y.sh
@@ -4,6 +4,10 @@ NV=""
 OV=""
 FAST_UPGRADE=""
 
+timestamp () {
+  echo $(date +"%H:%M:%S")
+}
+
 while getopts "s:d:f" o;do
     case "${o}" in
         s)
@@ -30,38 +34,52 @@ shift $((OPTIND-1))
 
 NEW_VERSION=$(rpm -qi postgresql-server | grep Version | cut -d: -f2 | sed -e "s/ //g")
 if [ $NEW_VERSION == "" ];then
-    echo "`date +"%H:%M:%S"`    ERROR: There is no postgresql-server package installed"
+    echo "$(timestamp)    ERROR: There is no postgresql-server package installed"
     exit 1
 fi
 
-echo "`date +"%H:%M:%S"`    You have postgresql-server $NEW_VERSION installed."
+echo "$(timestamp)    You have postgresql-server $NEW_VERSION installed."
 OLD_VERSION=$(cat /var/lib/pgsql/data/PG_VERSION)
 if [ $OLD_VERSION == "" ];then
-    echo "`date +"%H:%M:%S"`    ERROR: There is no postgresql server configured"
+    echo "$(timestamp)    ERROR: There is no postgresql server configured"
     exit 1
 fi
-echo "`date +"%H:%M:%S"`    You have postgresql server $OLD_VERSION configured."
+echo "$(timestamp)    You have postgresql server $OLD_VERSION configured."
 
 if [ "$NV" != "" ];then
     if [ "$NEW_VERSION" != "$NV" ];then
-        echo "`date +"%H:%M:%S"`   ERROR: Latest installed version is $NEW_VERSION, which does not match $NV, the option you provided with -d."
+        echo "$(timestamp)   ERROR: Latest installed version is $NEW_VERSION, which does not match $NV, the option you provided with -d."
         exit 1
     fi
 fi
 
 if [ "$OV" != "" ];then
     if [ "$OLD_VERSION" != "$OV" ];then
-        echo "`date +"%H:%M:%S"`   ERROR: Configured version is $OLD_VERSION, which does not match $OV, the option you provided with -s."
+        echo "$(timestamp)   ERROR: Configured version is $OLD_VERSION, which does not match $OV, the option you provided with -s."
         exit 1
     fi
+fi
+
+if [ -d "/var/lib/pgsql/data-new-failed" ]; then
+    echo "$(timestamp)   /var/lib/pgsql/data-new-failed already exists!"
+    echo "$(timestamp)   Most likely this is the result of a previous failed migration."
+    echo "$(timestamp)   Verify if you still need this directory and remove it otherwise."
+    exit 1
+fi
+
+if [ -d "/var/lib/pgsql/data-pg${OLD_VERSION}" ]; then
+    echo "$(timestamp)   /var/lib/pgsql/data-pg${OLD_VERSION} already exists!"
+    echo "$(timestamp)   Most likely this is the result of a previous failed migration and a failed rollback!"
+    echo "$(timestamp)   It is strongly recommend that you a restore backup before trying again!"
+    exit 1
 fi
 
 DIR=/var/lib/pgsql
 
 if [ "$FAST_UPGRADE" !=  "" ]; then
-    echo "`date +"%H:%M:%S"`   Performing fast upgrade..."
+    echo "$(timestamp)   Performing fast upgrade..."
 else
-    echo -n "`date +"%H:%M:%S"`   Checking diskspace... "
+    echo -n "$(timestamp)   Checking diskspace... "
     FREESPACE=`df $DIR | awk '{v=$4} END {print v}'`
     USEDSPACE=`du -s $DIR | awk '{v=$1} END {print v}'`
 
@@ -74,12 +92,12 @@ else
         FREESPACE=`expr $FREESPACE / 1024 / 1024`
 
         echo
-        echo "`date +"%H:%M:%S"`   Insufficient diskspace in $DIR ($NEEDSPACE GB needed, $FREESPACE GB available)!"
+        echo "$(timestamp)   Insufficient diskspace in $DIR ($NEEDSPACE GB needed, $FREESPACE GB available)!"
         echo
-        echo "`date +"%H:%M:%S"`   A fast migration does not need this additional diskspace, because"
-        echo "`date +"%H:%M:%S"`   database files will be hardlinked instead of copied."
+        echo "$(timestamp)   A fast migration does not need this additional diskspace, because"
+        echo "$(timestamp)   database files will be hardlinked instead of copied."
         echo
-        echo "`date +"%H:%M:%S"`   If you have a backup of the database, run \"$0 fast\""
+        echo "$(timestamp)   If you have a backup of the database, run \"$0 fast\""
         echo
         exit 1
     else
@@ -87,88 +105,100 @@ else
     fi
 fi
 
-echo "`date +"%H:%M:%S"`   Shut down spacewalk services..."
+echo "$(timestamp)   Shut down spacewalk services..."
 spacewalk-service stop
-systemctl stop postgresql
+if [ ${?} -ne 0 ]; then
+    echo "$(timestamp)   At least one spacewalk service failed to stop!"
+    echo "$(timestamp)   Please check the logs at /var/log/rhn and /var/log/tomcat"
+    exit 1
+fi
 
-echo "`date +"%H:%M:%S"`   Checking postgresql version..."
+systemctl stop postgresql
+if [ ${?} -ne 0 ]; then
+    echo "$(timestamp)   PostgresSQL failed to stop!"
+    echo "$(timestamp)   Please check systemd logs for PostreSQL"
+    exit 1
+fi
+
+echo "$(timestamp)   Checking postgresql version..."
 rpm -q postgresql$NEW_VERSION-server > /dev/null 2>&1
 if [ $? -eq 0 ]; then
-    echo "`date +"%H:%M:%S"`   postgresql $NEW_VERSION is already installed. Good."
+    echo "$(timestamp)   postgresql $NEW_VERSION is already installed. Good."
 else
-    echo "`date +"%H:%M:%S"`   Installing postgresql $NEW_VERSION..."
+    echo "$(timestamp)   Installing postgresql $NEW_VERSION..."
     zypper --non-interactive in postgresql$NEW_VERSION postgresql$NEW_VERSION-contrib postgresql$NEW_VERSION-server
 
     if [ ! $? -eq 0 ]; then
-        echo "`date +"%H:%M:%S"`   Installation of postgresql $NEW_VERSION failed!"
+        echo "$(timestamp)   Installation of postgresql $NEW_VERSION failed!"
         exit 1
     fi
 fi
 
-echo "`date +"%H:%M:%S"`   Ensure postgresql $NEW_VERSION is being used as default..."
+echo "$(timestamp)   Ensure postgresql $NEW_VERSION is being used as default..."
 /usr/sbin/update-alternatives --set postgresql /usr/lib/postgresql$NEW_VERSION
 if [ $? -eq 0 ]; then
-    echo "`date +"%H:%M:%S"`   Successfully switched to new postgresql version $NEW_VERSION."
+    echo "$(timestamp)   Successfully switched to new postgresql version $NEW_VERSION."
 else
-    echo "`date +"%H:%M:%S"`   Could not switch to new postgresql version $NEW_VERSION!"
+    echo "$(timestamp)   Could not switch to new postgresql version $NEW_VERSION!"
     exit 1
 fi
 
-echo "`date +"%H:%M:%S"`   Create new database directory..."
+echo "$(timestamp)   Create a backup at /var/lib/pgsql/data-pg$OLD_VERSION..."
 mv /var/lib/pgsql/data /var/lib/pgsql/data-pg$OLD_VERSION
+echo "$(timestamp)   Create new database directory..."
 mkdir /var/lib/pgsql/data
 chown postgres:postgres /var/lib/pgsql/data
 
-echo "`date +"%H:%M:%S"`   Initialize new postgresql $NEW_VERSION database..."
+echo "$(timestamp)   Initialize new postgresql $NEW_VERSION database..."
 . /etc/sysconfig/postgresql
 if [ -z $POSTGRES_LANG ]; then
     POSTGRES_LANG="en_US.UTF-8"
 fi
 su -s /bin/bash - postgres -c "initdb -D /var/lib/pgsql/data --locale=$POSTGRES_LANG"
 if [ $? -eq 0 ]; then
-    echo "`date +"%H:%M:%S"`   Successfully initialized new postgresql $NEW_VERSION database."
+    echo "$(timestamp)   Successfully initialized new postgresql $NEW_VERSION database."
 else
-    echo "`date +"%H:%M:%S"`   Initialization of new postgresql $NEW_VERSION database failed!"
-    echo "`date +"%H:%M:%S"`   Trying to restore previous state..."
+    echo "$(timestamp)   Initialization of new postgresql $NEW_VERSION database failed!"
+    echo "$(timestamp)   Trying to restore previous state..."
     mv /var/lib/pgsql/data /var/lib/pgsql/data-new-failed
     mv /var/lib/pgsql/data-pg${OLD_VERSION} /var/lib/pgsql/data
     /usr/sbin/update-alternatives --set postgresql /usr/lib/postgresql${OLD_VERSION}
     exit 1
 fi
 
-echo "`date +"%H:%M:%S"`   Upgrade database to new version postgresql $NEW_VERSION..."
+echo "$(timestamp)   Upgrade database to new version postgresql $NEW_VERSION..."
 su -s /bin/bash - postgres -c "pg_upgrade --old-bindir=/usr/lib/postgresql$OLD_VERSION/bin --new-bindir=/usr/lib/postgresql$NEW_VERSION/bin --old-datadir=/var/lib/pgsql/data-pg$OLD_VERSION --new-datadir=/var/lib/pgsql/data $FAST_UPGRADE"
 if [ $? -eq 0 ]; then
-    echo "`date +"%H:%M:%S"`   Successfully upgraded database to postgresql $NEW_VERSION."
+    echo "$(timestamp)   Successfully upgraded database to postgresql $NEW_VERSION."
 else
-    echo "`date +"%H:%M:%S"`   Upgrading database to version $NEW_VERSION failed!"
-    echo "`date +"%H:%M:%S"`   Trying to restore previous state..."
+    echo "$(timestamp)   Upgrading database to version $NEW_VERSION failed!"
+    echo "$(timestamp)   Trying to restore previous state..."
     mv /var/lib/pgsql/data /var/lib/pgsql/data-new-failed
     mv /var/lib/pgsql/data-pg$OLD_VERSION /var/lib/pgsql/data
     /usr/sbin/update-alternatives --set postgresql /usr/lib/postgresql$OLD_VERSION
     exit 1
 fi
 
-echo "`date +"%H:%M:%S"`   Tune new postgresql configuration..."
+echo "$(timestamp)   Tune new postgresql configuration..."
 smdba system-check autotuning
 if [ $? -eq 0 ]; then
-    echo "`date +"%H:%M:%S"`   Successfully tuned new postgresql configuration."
+    echo "$(timestamp)   Successfully tuned new postgresql configuration."
 else
-    echo "`date +"%H:%M:%S"`   Tuning of new postgresql configuration failed!"
+    echo "$(timestamp)   Tuning of new postgresql configuration failed!"
     exit 1
 fi
 
 cp /var/lib/pgsql/data-pg$OLD_VERSION/pg_hba.conf /var/lib/pgsql/data
 chown postgres:postgres /var/lib/pgsql/data/*
 
-echo "`date +"%H:%M:%S"`   Starting PostgreSQL service..."
+echo "$(timestamp)   Starting PostgreSQL service..."
 systemctl start postgresql
-echo "`date +"%H:%M:%S"`   Reindexing database. This may take a while, please do not cancel it!"
+echo "$(timestamp)   Reindexing database. This may take a while, please do not cancel it!"
 database=$(sed -n "s/^\s*db_name\s*=\s*\([^ ]*\)\s*$/\1/p" /etc/rhn/rhn.conf)
 spacewalk-sql --select-mode - <<<"REINDEX DATABASE ${database};"
 if [ ${?} -ne 0 ]; then
-    echo "`date +"%H:%M:%S"`   The reindexing failed. Please review the PostgreSQL logs at /var/lib/pgsql/data/log"
+    echo "$(timestamp)   The reindexing failed. Please review the PostgreSQL logs at /var/lib/pgsql/data/log"
     exit 1
 fi
-echo "`date +"%H:%M:%S"`   Starting spacewalk services..."
+echo "$(timestamp)   Starting spacewalk services..."
 spacewalk-service start

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,4 @@
+- Improve the error management for the PostgreSQL migration script (bsc#1188297)
 - Add the salt bundle support to mgr-create-bootstrap-repo
 - Add bootstrap repository definitions for Rocky Linux 8
 - Add sanity checks in database migration and infere options from system


### PR DESCRIPTION
## What does this PR change?

- Abort if the directories for migration or failed migrations exist.
- Abort if any spacewalk service or the PostgreSQL service did not stop correctly.

Extra: Instead of calling `date` a thousand times, we now use a function, to increase readability.

It tested the changes by migrating Uyuni 2021.05 to Uyuni 2021.06 and this worked fine.

Besides the code changes, the important thing about this PR are the error messages. Can we improve them somehow or are my proposals good enough?

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: The script itself suggest the user what to do.

- [x] **DONE**

## Test coverage
- No tests: Script not part of the automated tests.

- [x] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/15397

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
