### PR TITLE
QA: Get rid of SUSE Manager mentions in Uyuni Test Framework

### DIFF
--- a/testsuite/README.md
+++ b/testsuite/README.md
@@ -57,8 +57,8 @@ There are also hints about [Pitfalls in writing the testsuite](documentation/pit
 
 * Release (to be run against a nightly or released *tagged* version of SUSE Manager):
 
-  * [`Manager-4.0`](https://github.com/SUSE/spacewalk/tree/Manager-4.0)
-  * [`Manager-3.2`](https://github.com/SUSE/spacewalk/tree/Manager-3.2)
+  * [`Manager-4.1`](https://github.com/SUSE/spacewalk/tree/Manager-4.1)
+  * [`Manager-4.2`](https://github.com/SUSE/spacewalk/tree/Manager-4.2)
 
 
 # Dummy packages used by the Testsuite

--- a/testsuite/documentation/cucumber-steps.md
+++ b/testsuite/documentation/cucumber-steps.md
@@ -10,7 +10,7 @@
     1. [Buttons](#b5)
     1. [Text input](#b6)
     1. [Operating system](#b7)
-    1. [SUSE Manager utilities](#b8)
+    1. [Uyuni utilities](#b8)
     1. [Registration and channels](#b9)
     1. [Events](#b10)
     1. [Salt](#b11)
@@ -33,8 +33,8 @@ Possible values are currently:
 
 | Test host | Ruby target |  Bash environment variable | Step host name | Sumaform module |
 | --------- | ----------- | -------------------------- | -------------- | --------------- |
-| SUSE Manager server | ```$server``` | ```$SERVER``` |  | ```"suse_manager"``` |
-| SUSE Manager proxy | ```$proxy``` | ```$PROXY``` | ```"proxy"``` | ```"suse_manager_proxy"``` |
+| Uyuni server | ```$server``` | ```$SERVER``` |  | ```"suse_manager"``` |
+| Uyuni proxy | ```$proxy``` | ```$PROXY``` | ```"proxy"``` | ```"suse_manager_proxy"``` |
 | SLES traditional client | ```$client``` | ```$CLIENT``` | ```"sle_client"``` | ```"client"``` |
 | SLES Salt minion | ```$minion``` | ```$MINION``` | ```"sle_minion"``` | ```"minion"``` |
 | SLES Docker and Kiwi build host | ```$build_host``` | ```$BUILD_HOST``` | ```"build_host"``` | ```"minion"``` |
@@ -484,7 +484,7 @@ Note that the text area variant handles the new lines characters while the other
 
 <a name="b8" />
 
-#### SUSE Manager utilities
+#### Uyuni utilities
 
 * Execute mgr-sync
 
@@ -671,7 +671,7 @@ For example:
 
 * Create a test virtual machine on a given host
 
-The virtual machine is created without SUSE Manager, directly on the virtual host
+The virtual machine is created without Uyuni, directly on the virtual host
 using `qemu-img` and `virt-install`
 
 ```cucumber

--- a/testsuite/documentation/guidelines.md
+++ b/testsuite/documentation/guidelines.md
@@ -6,7 +6,7 @@
 * `testsuite/features/step_definition`: definition of real code executed, in Ruby
 * `testsuite/features/support`: general support functions
 * `testsuite/features/upload_files`: various data files uploaded into test machines by the testsuite
-* `testsuite/features/profiles`: Docker and Kiwi profiles picked up from this git repository directly by SUSE Manager
+* `testsuite/features/profiles`: Docker and Kiwi profiles picked up from this git repository directly by Uyuni
 * `testsuite/config`: contains the Cucumber profiles
 
 
@@ -55,7 +55,7 @@ Keep features, scenarios and steps in fluent English.
 
 Avoid "computing style" (abbreviations, snake case and camel case.
 
-Avoid the obvious like "Check", "Test", "SUSE Manager", "Spacewalk", etc.
+Avoid the obvious like "Check", "Test", "Uyuni", "Spacewalk", etc.
 
 Please use the correct capitalization for products (SLES, SUSE, Salt, zypper, Docker, etc.)
 

--- a/testsuite/documentation/optional.md
+++ b/testsuite/documentation/optional.md
@@ -16,7 +16,7 @@ This document here focuses on he test suite side.
 
 ### Testing with a proxy
 
-Using a SUSE Manager proxy with the testsuite is not mandatory.
+Using a Uyuni proxy with the testsuite is not mandatory.
 
 If you do not want a proxy, do not define `$PROXY` environment variable
 before you run the testsuite. That's all.
@@ -276,9 +276,9 @@ Inside of the testsuite, the scenarios that are tagged with one of:
 are executed only if the corresponding virtualization host minion is available.
 
 
-### Testing SUSE Manager for Retail
+### Testing Uyuni for Retail
 
-Testing SUSE Manager for Retail is optional. To test it, you need:
+Testing Uyuni for Retail is optional. To test it, you need:
 * a private network;
 * a PXE boot minion.
 
@@ -335,14 +335,14 @@ Inside of the testsuite, the scenarios that are tagged with
 are executed only if the PXE boot minion is available.
 
 
-## HTTP Proxy for the SUSE Manager server
+## HTTP Proxy for the Uyuni server
 
-Using an HTTP proxy for the SUSE Manager server when testing is not mandatory.
+Using an HTTP proxy for the Uyuni server when testing is not mandatory.
 
 If you do not want an HTTP proxy, do not define `SERVER_HTTP_PROXY`
 environment variable before you run the testsuite. That's all.
 
-If you want to specify an HTTP proxy on SUSE Manager's "Setup Wizard" page,
+If you want to specify an HTTP proxy on Uyuni's "Setup Wizard" page,
 make this variable contain the hostname and port of the proxy:
 ```bash
 export SERVER_HTTP_PROXY = "hostname:port"

--- a/testsuite/documentation/static-run.md
+++ b/testsuite/documentation/static-run.md
@@ -13,8 +13,8 @@ With a static setup, if you break your testing machines, or if you have any trou
 
 Set up the following environment variables:
 
-* `SERVER` the SUSE Manager server you are testing against
-* `PROXY` the SUSE Manager proxy (don't declare this variable if there is no proxy)
+* `SERVER` the Uyuni server you are testing against
+* `PROXY` the Uyuni proxy (don't declare this variable if there is no proxy)
 * `CLIENT` the traditional client
 * `MINION` the Salt minion
 * `BUILD_HOST` the Docker and Kiwi build host

--- a/testsuite/features/core/proxy_branch_network.feature
+++ b/testsuite/features/core/proxy_branch_network.feature
@@ -8,8 +8,8 @@
 @sle_client
 @scope_proxy
 @scope_retail
-Feature: Setup SUSE Manager for Retail branch network
-  In order to deploy SUSE Manager for Retail solution
+Feature: Setup Uyuni for Retail branch network
+  In order to deploy Uyuni for Retail solution
   As the system administrator
   I want to prepare the branch network
 
@@ -30,10 +30,19 @@ Feature: Setup SUSE Manager for Retail branch network
 
 @proxy
 @private_net
+@susemanager
   Scenario: Install the Retail pattern on the server
     When I refresh the metadata for "server"
     When I install pattern "suma_retail" on this "server"
     And I wait for "patterns-suma_retail" to be installed on "server"
+
+@proxy
+@private_net
+@uyuni
+  Scenario: Install the Retail pattern on the server
+    When I refresh the metadata for "server"
+    When I install pattern "uyuni_retail" on this "server"
+    And I wait for "patterns-uyuni_retail" to be installed on "server"
 
 @proxy
 @private_net

--- a/testsuite/features/core/proxy_register_as_minion_with_gui.feature
+++ b/testsuite/features/core/proxy_register_as_minion_with_gui.feature
@@ -8,8 +8,8 @@
 
 @scope_proxy
 @proxy
-Feature: Setup SUSE Manager proxy
-  In order to use a proxy with the SUSE manager server
+Feature: Setup Uyuni proxy
+  In order to use a proxy with the Uyuni server
   As the system administrator
   I want to register the proxy to the server
 

--- a/testsuite/features/core/proxy_register_as_minion_with_script.feature
+++ b/testsuite/features/core/proxy_register_as_minion_with_script.feature
@@ -8,8 +8,8 @@
 
 @scope_proxy
 @proxy
-Feature: Setup SUSE Manager proxy
-  In order to use a proxy with the SUSE manager server
+Feature: Setup Uyuni proxy
+  In order to use a proxy with the Uyuni server
   As the system administrator
   I want to register the proxy to the server
 

--- a/testsuite/features/core/proxy_register_as_trad_with_script.feature
+++ b/testsuite/features/core/proxy_register_as_trad_with_script.feature
@@ -8,8 +8,8 @@
 
 @scope_proxy
 @proxy
-Feature: Setup SUSE Manager proxy
-  In order to use a proxy with the SUSE manager server
+Feature: Setup Uyuni proxy
+  In order to use a proxy with the Uyuni server
   As the system administrator
   I want to register the proxy to the server
 

--- a/testsuite/features/finishing/srv_smdba.feature
+++ b/testsuite/features/finishing/srv_smdba.feature
@@ -1,8 +1,8 @@
-# Copyright (c) 2015-2020 SUSE LLC
+# Copyright (c) 2015-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 Feature: SMBDA database helper tool
-  In order to protect the data in SUSE Manager
+  In order to protect the data in Uyuni
   As a database administrator
   I want to easily take backups and snapshots
 

--- a/testsuite/features/init_clients/sle_client.feature
+++ b/testsuite/features/init_clients/sle_client.feature
@@ -2,7 +2,7 @@
 # Licensed under the terms of the MIT license.
 
 Feature: Register a traditional client
-  In order to register a traditional client to the SUSE Manager server
+  In order to register a traditional client to the Uyuni server
   I want to create, parametrize and run boostrap script from proxy
 
   Scenario: Log in as admin user

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS6_32/images.sh
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS6_32/images.sh
@@ -24,5 +24,5 @@ test -f /.profile && . /.profile
 
 systemctl enable salt-minion.service
 
-# notify SUSE Manager about newly deployed image
+# notify Uyuni about newly deployed image
 systemctl enable image-deployed.service

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS6_32/root/etc/systemd/system/image-deployed.service
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS6_32/root/etc/systemd/system/image-deployed.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Notify SUSE Manager about newly deployed image
+Description=Notify Uyuni about newly deployed image
 Requires=salt-minion.service
 After=salt-minion.service
 

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS6_40/images.sh
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS6_40/images.sh
@@ -24,5 +24,5 @@ test -f /.profile && . /.profile
 
 systemctl enable salt-minion.service
 
-# notify SUSE Manager about newly deployed image
+# notify Uyuni about newly deployed image
 systemctl enable image-deployed.service

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS6_40/root/etc/systemd/system/image-deployed.service
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS6_40/root/etc/systemd/system/image-deployed.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Notify SUSE Manager about newly deployed image
+Description=Notify Uyuni about newly deployed image
 Requires=salt-minion.service
 After=salt-minion.service
 

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS6_head/images.sh
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS6_head/images.sh
@@ -24,5 +24,5 @@ test -f /.profile && . /.profile
 
 systemctl enable salt-minion.service
 
-# notify SUSE Manager about newly deployed image
+# notify Uyuni about newly deployed image
 systemctl enable image-deployed.service

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS6_head/root/etc/systemd/system/image-deployed.service
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS6_head/root/etc/systemd/system/image-deployed.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Notify SUSE Manager about newly deployed image
+Description=Notify Uyuni about newly deployed image
 Requires=salt-minion.service
 After=salt-minion.service
 

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_32/config.xml
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_32/config.xml
@@ -28,8 +28,8 @@
       <file name="drivers/block/virtio_blk.ko" />
     </drivers>
 
-    <!-- remove all the following repositories if you want to get their packages through SUSE Manager;
-         in that case, sync those repos in SUSE Manager, and add them to the activation key;
+    <!-- remove all the following repositories if you want to get their packages through Uyuni;
+         in that case, sync those repos in Uyuni, and add them to the activation key;
          finally, re-enable option  '- -ignore-repos-used-for-build' in file 'kiwi-image-build.sls' -->
     <repository type="rpm-md">  <!-- product -->
         <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP1/x86_64/product/"/>

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_32/images.sh
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_32/images.sh
@@ -24,7 +24,7 @@ test -f /.profile && . /.profile
 
 systemctl enable salt-minion.service
 
-# notify SUSE Manager about newly deployed image
+# notify Uyuni about newly deployed image
 systemctl enable image-deployed.service
 
 # install bootloader and generate boot menu

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_32/root/etc/systemd/system/image-deployed.service
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_32/root/etc/systemd/system/image-deployed.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Notify SUSE Manager about newly deployed image
+Description=Notify Uyuni about newly deployed image
 Requires=salt-minion.service
 After=salt-minion.service
 

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_40/config.xml
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_40/config.xml
@@ -29,8 +29,8 @@
       <file name="drivers/block/virtio_blk.ko" />
     </drivers>
 
-    <!-- remove all the following repositories if you want to get their packages through SUSE Manager;
-         in that case, sync those repos in SUSE Manager, and add them to the activation key;
+    <!-- remove all the following repositories if you want to get their packages through Uyuni;
+         in that case, sync those repos in Uyuni, and add them to the activation key;
          finally, re-enable option  '- -ignore-repos-used-for-build' in file 'kiwi-image-build.sls' -->
     <repository type="rpm-md">  <!-- product -->
         <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP2/x86_64/product/"/>

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_40/images.sh
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_40/images.sh
@@ -24,7 +24,7 @@ test -f /.profile && . /.profile
 
 systemctl enable salt-minion.service
 
-# notify SUSE Manager about newly deployed image
+# notify Uyuni about newly deployed image
 systemctl enable image-deployed.service
 
 # install bootloader and generate boot menu

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_40/root/etc/systemd/system/image-deployed.service
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_40/root/etc/systemd/system/image-deployed.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Notify SUSE Manager about newly deployed image
+Description=Notify Uyuni about newly deployed image
 Requires=salt-minion.service
 After=salt-minion.service
 

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_41/config.xml
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_41/config.xml
@@ -29,8 +29,8 @@
       <file name="drivers/block/virtio_blk.ko" />
     </drivers>
 
-    <!-- remove all the following repositories if you want to get their packages through SUSE Manager;
-         in that case, sync those repos in SUSE Manager, and add them to the activation key;
+    <!-- remove all the following repositories if you want to get their packages through Uyuni;
+         in that case, sync those repos in Uyuni, and add them to the activation key;
          finally, re-enable option  '- -ignore-repos-used-for-build' in file 'kiwi-image-build.sls' -->
     <repository type="rpm-md">  <!-- product -->
         <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP2/x86_64/product/"/>

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_41/images.sh
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_41/images.sh
@@ -24,7 +24,7 @@ test -f /.profile && . /.profile
 
 systemctl enable salt-minion.service
 
-# notify SUSE Manager about newly deployed image
+# notify Uyuni about newly deployed image
 systemctl enable image-deployed.service
 
 # install bootloader and generate boot menu

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_41/root/etc/systemd/system/image-deployed.service
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_41/root/etc/systemd/system/image-deployed.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Notify SUSE Manager about newly deployed image
+Description=Notify Uyuni about newly deployed image
 Requires=salt-minion.service
 After=salt-minion.service
 

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_head/config.xml
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_head/config.xml
@@ -25,8 +25,8 @@
       <file name="drivers/block/virtio_blk.ko" />
     </drivers>
 
-    <!-- remove all the following repositories if you want to get their packages through SUSE Manager;
-         in that case, sync those repos in SUSE Manager, and add them to the activation key;
+    <!-- remove all the following repositories if you want to get their packages through Uyuni;
+         in that case, sync those repos in Uyuni, and add them to the activation key;
          finally, re-enable option  '- -ignore-repos-used-for-build' in file 'kiwi-image-build.sls' -->
     <repository type="rpm-md">  <!-- product -->
         <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP3/x86_64/product/"/>

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_head/images.sh
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_head/images.sh
@@ -24,7 +24,7 @@ test -f /.profile && . /.profile
 
 systemctl enable salt-minion.service
 
-# notify SUSE Manager about newly deployed image
+# notify Uyuni about newly deployed image
 systemctl enable image-deployed.service
 
 # install bootloader and generate boot menu

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_head/root/etc/systemd/system/image-deployed.service
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_head/root/etc/systemd/system/image-deployed.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Notify SUSE Manager about newly deployed image
+Description=Notify Uyuni about newly deployed image
 Requires=salt-minion.service
 After=salt-minion.service
 

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS6_32/images.sh
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS6_32/images.sh
@@ -24,5 +24,5 @@ test -f /.profile && . /.profile
 
 systemctl enable salt-minion.service
 
-# notify SUSE Manager about newly deployed image
+# notify Uyuni about newly deployed image
 systemctl enable image-deployed.service

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS6_32/root/etc/systemd/system/image-deployed.service
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS6_32/root/etc/systemd/system/image-deployed.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Notify SUSE Manager about newly deployed image
+Description=Notify Uyuni about newly deployed image
 Requires=salt-minion.service
 After=salt-minion.service
 

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS6_40/images.sh
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS6_40/images.sh
@@ -24,5 +24,5 @@ test -f /.profile && . /.profile
 
 systemctl enable salt-minion.service
 
-# notify SUSE Manager about newly deployed image
+# notify Uyuni about newly deployed image
 systemctl enable image-deployed.service

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS6_40/root/etc/systemd/system/image-deployed.service
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS6_40/root/etc/systemd/system/image-deployed.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Notify SUSE Manager about newly deployed image
+Description=Notify Uyuni about newly deployed image
 Requires=salt-minion.service
 After=salt-minion.service
 

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS6_head/images.sh
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS6_head/images.sh
@@ -24,5 +24,5 @@ test -f /.profile && . /.profile
 
 systemctl enable salt-minion.service
 
-# notify SUSE Manager about newly deployed image
+# notify Uyuni about newly deployed image
 systemctl enable image-deployed.service

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS6_head/root/etc/systemd/system/image-deployed.service
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS6_head/root/etc/systemd/system/image-deployed.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Notify SUSE Manager about newly deployed image
+Description=Notify Uyuni about newly deployed image
 Requires=salt-minion.service
 After=salt-minion.service
 

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_32/config.xml
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_32/config.xml
@@ -28,8 +28,8 @@
       <file name="drivers/block/virtio_blk.ko" />
     </drivers>
 
-    <!-- remove all the following repositories if you want to get their packages through SUSE Manager;
-         in that case, sync those repos in SUSE Manager, and add them to the activation key;
+    <!-- remove all the following repositories if you want to get their packages through Uyuni;
+         in that case, sync those repos in Uyuni, and add them to the activation key;
          finally, re-enable option  '- -ignore-repos-used-for-build' in file 'kiwi-image-build.sls' -->
     <repository type="rpm-md">  <!-- product -->
         <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP1/x86_64/product/"/>

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_32/images.sh
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_32/images.sh
@@ -24,7 +24,7 @@ test -f /.profile && . /.profile
 
 systemctl enable salt-minion.service
 
-# notify SUSE Manager about newly deployed image
+# notify Uyuni about newly deployed image
 systemctl enable image-deployed.service
 
 # install bootloader and generate boot menu

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_32/root/etc/systemd/system/image-deployed.service
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_32/root/etc/systemd/system/image-deployed.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Notify SUSE Manager about newly deployed image
+Description=Notify Uyuni about newly deployed image
 Requires=salt-minion.service
 After=salt-minion.service
 

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_40/config.xml
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_40/config.xml
@@ -29,8 +29,8 @@
       <file name="drivers/block/virtio_blk.ko" />
     </drivers>
 
-    <!-- remove all the following repositories if you want to get their packages through SUSE Manager;
-         in that case, sync those repos in SUSE Manager, and add them to the activation key;
+    <!-- remove all the following repositories if you want to get their packages through Uyuni;
+         in that case, sync those repos in Uyuni, and add them to the activation key;
          finally, re-enable option  '- -ignore-repos-used-for-build' in file 'kiwi-image-build.sls' -->
     <repository type="rpm-md">  <!-- product -->
         <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP2/x86_64/product/"/>

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_40/images.sh
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_40/images.sh
@@ -24,7 +24,7 @@ test -f /.profile && . /.profile
 
 systemctl enable salt-minion.service
 
-# notify SUSE Manager about newly deployed image
+# notify Uyuni about newly deployed image
 systemctl enable image-deployed.service
 
 # install bootloader and generate boot menu

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_40/root/etc/systemd/system/image-deployed.service
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_40/root/etc/systemd/system/image-deployed.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Notify SUSE Manager about newly deployed image
+Description=Notify Uyuni about newly deployed image
 Requires=salt-minion.service
 After=salt-minion.service
 

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_41/config.xml
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_41/config.xml
@@ -29,8 +29,8 @@
       <file name="drivers/block/virtio_blk.ko" />
     </drivers>
 
-    <!-- remove all the following repositories if you want to get their packages through SUSE Manager;
-         in that case, sync those repos in SUSE Manager, and add them to the activation key;
+    <!-- remove all the following repositories if you want to get their packages through Uyuni;
+         in that case, sync those repos in Uyuni, and add them to the activation key;
          finally, re-enable option  '- -ignore-repos-used-for-build' in file 'kiwi-image-build.sls' -->
     <repository type="rpm-md">  <!-- product -->
         <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP2/x86_64/product/"/>

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_41/images.sh
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_41/images.sh
@@ -24,7 +24,7 @@ test -f /.profile && . /.profile
 
 systemctl enable salt-minion.service
 
-# notify SUSE Manager about newly deployed image
+# notify Uyuni about newly deployed image
 systemctl enable image-deployed.service
 
 # install bootloader and generate boot menu

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_41/root/etc/systemd/system/image-deployed.service
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_41/root/etc/systemd/system/image-deployed.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Notify SUSE Manager about newly deployed image
+Description=Notify Uyuni about newly deployed image
 Requires=salt-minion.service
 After=salt-minion.service
 

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_head/config.xml
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_head/config.xml
@@ -25,8 +25,8 @@
       <file name="drivers/block/virtio_blk.ko" />
     </drivers>
 
-    <!-- remove all the following repositories if you want to get their packages through SUSE Manager;
-         in that case, sync those repos in SUSE Manager, and add them to the activation key;
+    <!-- remove all the following repositories if you want to get their packages through Uyuni;
+         in that case, sync those repos in Uyuni, and add them to the activation key;
          finally, re-enable option  '- -ignore-repos-used-for-build' in file 'kiwi-image-build.sls' -->
     <repository type="rpm-md">  <!-- product -->
         <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP3/x86_64/product/"/>

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_head/images.sh
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_head/images.sh
@@ -24,7 +24,7 @@ test -f /.profile && . /.profile
 
 systemctl enable salt-minion.service
 
-# notify SUSE Manager about newly deployed image
+# notify Uyuni about newly deployed image
 systemctl enable image-deployed.service
 
 # install bootloader and generate boot menu

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_head/root/etc/systemd/system/image-deployed.service
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_head/root/etc/systemd/system/image-deployed.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Notify SUSE Manager about newly deployed image
+Description=Notify Uyuni about newly deployed image
 Requires=salt-minion.service
 After=salt-minion.service
 

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS6_32/images.sh
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS6_32/images.sh
@@ -24,5 +24,5 @@ test -f /.profile && . /.profile
 
 systemctl enable salt-minion.service
 
-# notify SUSE Manager about newly deployed image
+# notify Uyuni about newly deployed image
 systemctl enable image-deployed.service

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS6_32/root/etc/systemd/system/image-deployed.service
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS6_32/root/etc/systemd/system/image-deployed.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Notify SUSE Manager about newly deployed image
+Description=Notify Uyuni about newly deployed image
 Requires=salt-minion.service
 After=salt-minion.service
 

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS6_40/images.sh
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS6_40/images.sh
@@ -24,5 +24,5 @@ test -f /.profile && . /.profile
 
 systemctl enable salt-minion.service
 
-# notify SUSE Manager about newly deployed image
+# notify Uyuni about newly deployed image
 systemctl enable image-deployed.service

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS6_40/root/etc/systemd/system/image-deployed.service
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS6_40/root/etc/systemd/system/image-deployed.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Notify SUSE Manager about newly deployed image
+Description=Notify Uyuni about newly deployed image
 Requires=salt-minion.service
 After=salt-minion.service
 

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS6_head/images.sh
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS6_head/images.sh
@@ -24,5 +24,5 @@ test -f /.profile && . /.profile
 
 systemctl enable salt-minion.service
 
-# notify SUSE Manager about newly deployed image
+# notify Uyuni about newly deployed image
 systemctl enable image-deployed.service

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS6_head/root/etc/systemd/system/image-deployed.service
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS6_head/root/etc/systemd/system/image-deployed.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Notify SUSE Manager about newly deployed image
+Description=Notify Uyuni about newly deployed image
 Requires=salt-minion.service
 After=salt-minion.service
 

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_32/config.xml
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_32/config.xml
@@ -28,8 +28,8 @@
       <file name="drivers/block/virtio_blk.ko" />
     </drivers>
 
-    <!-- remove all the following repositories if you want to get their packages through SUSE Manager;
-         in that case, sync those repos in SUSE Manager, and add them to the activation key;
+    <!-- remove all the following repositories if you want to get their packages through Uyuni;
+         in that case, sync those repos in Uyuni, and add them to the activation key;
          finally, re-enable option  '- -ignore-repos-used-for-build' in file 'kiwi-image-build.sls' -->
     <repository type="rpm-md">  <!-- product -->
         <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP1/x86_64/product/"/>

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_32/images.sh
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_32/images.sh
@@ -24,7 +24,7 @@ test -f /.profile && . /.profile
 
 systemctl enable salt-minion.service
 
-# notify SUSE Manager about newly deployed image
+# notify Uyuni about newly deployed image
 systemctl enable image-deployed.service
 
 # install bootloader and generate boot menu

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_32/root/etc/systemd/system/image-deployed.service
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_32/root/etc/systemd/system/image-deployed.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Notify SUSE Manager about newly deployed image
+Description=Notify Uyuni about newly deployed image
 Requires=salt-minion.service
 After=salt-minion.service
 

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_40/config.xml
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_40/config.xml
@@ -29,8 +29,8 @@
       <file name="drivers/block/virtio_blk.ko" />
     </drivers>
 
-    <!-- remove all the following repositories if you want to get their packages through SUSE Manager;
-         in that case, sync those repos in SUSE Manager, and add them to the activation key;
+    <!-- remove all the following repositories if you want to get their packages through Uyuni;
+         in that case, sync those repos in Uyuni, and add them to the activation key;
          finally, re-enable option  '- -ignore-repos-used-for-build' in file 'kiwi-image-build.sls' -->
     <repository type="rpm-md">  <!-- product -->
         <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP2/x86_64/product/"/>

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_40/images.sh
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_40/images.sh
@@ -24,7 +24,7 @@ test -f /.profile && . /.profile
 
 systemctl enable salt-minion.service
 
-# notify SUSE Manager about newly deployed image
+# notify Uyuni about newly deployed image
 systemctl enable image-deployed.service
 
 # install bootloader and generate boot menu

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_40/root/etc/systemd/system/image-deployed.service
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_40/root/etc/systemd/system/image-deployed.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Notify SUSE Manager about newly deployed image
+Description=Notify Uyuni about newly deployed image
 Requires=salt-minion.service
 After=salt-minion.service
 

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_41/config.xml
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_41/config.xml
@@ -29,8 +29,8 @@
       <file name="drivers/block/virtio_blk.ko" />
     </drivers>
 
-    <!-- remove all the following repositories if you want to get their packages through SUSE Manager;
-         in that case, sync those repos in SUSE Manager, and add them to the activation key;
+    <!-- remove all the following repositories if you want to get their packages through Uyuni;
+         in that case, sync those repos in Uyuni, and add them to the activation key;
          finally, re-enable option  '- -ignore-repos-used-for-build' in file 'kiwi-image-build.sls' -->
     <repository type="rpm-md">  <!-- product -->
         <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP2/x86_64/product/"/>

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_41/images.sh
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_41/images.sh
@@ -24,7 +24,7 @@ test -f /.profile && . /.profile
 
 systemctl enable salt-minion.service
 
-# notify SUSE Manager about newly deployed image
+# notify Uyuni about newly deployed image
 systemctl enable image-deployed.service
 
 # install bootloader and generate boot menu

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_41/root/etc/systemd/system/image-deployed.service
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_41/root/etc/systemd/system/image-deployed.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Notify SUSE Manager about newly deployed image
+Description=Notify Uyuni about newly deployed image
 Requires=salt-minion.service
 After=salt-minion.service
 

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_head/config.xml
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_head/config.xml
@@ -25,8 +25,8 @@
       <file name="drivers/block/virtio_blk.ko" />
     </drivers>
 
-    <!-- remove all the following repositories if you want to get their packages through SUSE Manager;
-         in that case, sync those repos in SUSE Manager, and add them to the activation key;
+    <!-- remove all the following repositories if you want to get their packages through Uyuni;
+         in that case, sync those repos in Uyuni, and add them to the activation key;
          finally, re-enable option  '- -ignore-repos-used-for-build' in file 'kiwi-image-build.sls' -->
     <repository type="rpm-md">  <!-- product -->
         <source path="http://download.suse.de/ibs/SUSE/Products/SLE-Product-SLES/15-SP3/x86_64/product/"/>

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_head/images.sh
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_head/images.sh
@@ -24,7 +24,7 @@ test -f /.profile && . /.profile
 
 systemctl enable salt-minion.service
 
-# notify SUSE Manager about newly deployed image
+# notify Uyuni about newly deployed image
 systemctl enable image-deployed.service
 
 # install bootloader and generate boot menu

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_head/root/etc/systemd/system/image-deployed.service
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_head/root/etc/systemd/system/image-deployed.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Notify SUSE Manager about newly deployed image
+Description=Notify Uyuni about newly deployed image
 Requires=salt-minion.service
 After=salt-minion.service
 

--- a/testsuite/features/secondary/allcli_reboot.feature
+++ b/testsuite/features/secondary/allcli_reboot.feature
@@ -8,7 +8,7 @@
 #   (thus making changes in the behaviour of the system after the reboot)
 
 @scope_onboarding
-Feature: Reboot systems managed by SUSE Manager
+Feature: Reboot systems managed by Uyuni
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section

--- a/testsuite/features/secondary/buildhost_osimage_build_image.feature
+++ b/testsuite/features/secondary/buildhost_osimage_build_image.feature
@@ -3,7 +3,7 @@
 #
 # This feature relies on having properly configured
 #   /etc/rhn/rhn.conf
-# file on your SUSE Manager server.
+# file on your Uyuni server.
 #
 # For the scope of these tests, we configure it as follows:
 #   java.kiwi_os_image_building_enabled = true
@@ -56,7 +56,7 @@ Feature: Build OS images
     And I apply state "image-sync" to "proxy"
     Then the image should exist on "proxy"
 
-  Scenario: Cleanup: remove the image from SUSE Manager server
+  Scenario: Cleanup: remove the image from Uyuni server
     Given I am authorized for the "Images" section
     When I follow the left menu "Images > Image List"
     And I wait until I do not see "There are no entries to show." text

--- a/testsuite/features/secondary/min_centos_monitoring.feature
+++ b/testsuite/features/secondary/min_centos_monitoring.feature
@@ -8,7 +8,7 @@
 @scope_monitoring
 @scope_res
 Feature: Monitor SUMA environment with Prometheus on a CentOS Salt minion
-  In order to monitor SUSE Manager server
+  In order to monitor Uyuni server
   As an authorized user
   I want to enable Prometheus exporters
 

--- a/testsuite/features/secondary/min_monitoring.feature
+++ b/testsuite/features/secondary/min_monitoring.feature
@@ -7,7 +7,7 @@
 @sle_minion
 @scope_monitoring
 Feature: Monitor SUMA environment with Prometheus on a SLE Salt minion
-  In order to monitor SUSE Manager server
+  In order to monitor Uyuni server
   As an authorized user
   I want to enable Prometheus exporters
 

--- a/testsuite/features/secondary/min_salt_install_with_staging.feature
+++ b/testsuite/features/secondary/min_salt_install_with_staging.feature
@@ -3,7 +3,7 @@
 #
 # This feature relies on having properly configured
 #   /etc/rhn/rhn.conf
-# file on your SUSE Manager server.
+# file on your Uyuni server.
 #
 # For the scope of these tests, we configure it as follows:
 #   java.salt_content_staging_window = 0.033 (2 minutes)

--- a/testsuite/features/secondary/min_ubuntu_salt_install_with_staging.feature
+++ b/testsuite/features/secondary/min_ubuntu_salt_install_with_staging.feature
@@ -3,7 +3,7 @@
 #
 # This feature relies on having properly configured
 #   /etc/rhn/rhn.conf
-# file on your SUSE Manager server.
+# file on your Uyuni server.
 #
 # For the scope of these tests, we configure it as follows:
 #   java.salt_content_staging_window = 0.033 (2 minutes)

--- a/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
+++ b/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
@@ -10,7 +10,7 @@
 @pxeboot_minion
 @scope_cobbler
 Feature: PXE boot a terminal with Cobbler
-  In order to automate client system installations in SUSE Manager
+  In order to automate client system installations in Uyuni
   As the system administrator
   I want to PXE boot one host with Cobbler
 

--- a/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
+++ b/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
@@ -18,7 +18,7 @@
 @pxeboot_minion
 @scope_retail
 Feature: PXE boot a Retail terminal
-  In order to use SUSE Manager for Retail solution
+  In order to use Uyuni for Retail solution
   As the system administrator
   I PXE boot one of the terminals
   I perform a mass import of several virtual terminals and one real minion

--- a/testsuite/features/secondary/srv_clone_channel_npn.feature
+++ b/testsuite/features/secondary/srv_clone_channel_npn.feature
@@ -91,7 +91,6 @@ Feature: Clone a channel
 
   Scenario: Compare channel packages
     When I follow the left menu "Software > Manage > Channels"
-    # bsc#904690 - After migration from SUSE Manager 1.7 to 2.1 attempting to perform a channel package compare returns internal server error
     And I follow "Clone 2 of Test-Channel-x86_64"
     And I follow "Packages" in the content area
     And I follow "Compare"

--- a/testsuite/features/secondary/srv_mainpage.feature
+++ b/testsuite/features/secondary/srv_mainpage.feature
@@ -32,7 +32,7 @@ Feature: Main landing page options and preferences
     And I follow "SUSE MANAGER LICENSE AGREEMENT"
     Then I should see a "SUSE Manager License Agreement" text
 
-  Scenario: Log into SUSE Manager
+  Scenario: Log into Uyuni
     Given I am not authorized
     When I go to the home page
     And I enter "testing" as "username"
@@ -40,7 +40,7 @@ Feature: Main landing page options and preferences
     And I click on "Sign In"
     Then I should be logged in
 
-  Scenario: Log out of SUSE Manager
+  Scenario: Log out of Uyuni
     Given I am authorized
     When I sign out
     Then I should not be authorized

--- a/testsuite/features/secondary/srv_salt.feature
+++ b/testsuite/features/secondary/srv_salt.feature
@@ -3,7 +3,7 @@
 
 @scope_salt
 Feature: Salt is configured and running
-  In order to operate SUSE Manager based on Salt
+  In order to operate Uyuni based on Salt
   I want to use general Salt functionality and system registration
 
   Scenario: salt-api is properly configured

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -334,7 +334,7 @@ Before('@uyuni') do
   skip_this_scenario unless $product == 'Uyuni'
 end
 
-# do test only if HTTP proxy for SUSE Manager is defined
+# do test only if HTTP proxy for Uyuni is defined
 Before('@server_http_proxy') do
   skip_this_scenario unless $server_http_proxy
 end

--- a/testsuite/index.js
+++ b/testsuite/index.js
@@ -16,7 +16,7 @@ var options = {
   storeScreenshots: true,
   noInlineScreenshots: true,
   ignoreBadJsonFile: true,
-  name: 'SUSE Manager Testsuite',
+  name: 'Uyuni Testsuite',
   brandTitle: ' ',
   // metadata: {
   //   "App Version":"",

--- a/testsuite/run_sets/core.yml
+++ b/testsuite/run_sets/core.yml
@@ -12,14 +12,14 @@
 - features/core/srv_organization_credentials.feature
 - features/core/srv_user_preferences.feature
 
-# initialize SUSE Manager server
+# initialize Uyuni server
 - features/core/srv_channels_add.feature
 - features/core/srv_create_repository.feature
 - features/core/srv_create_activationkey.feature
 - features/core/srv_osimage.feature
 - features/core/srv_docker.feature
 
-# initialize SUSE Manager proxy
+# initialize Uyuni proxy
   # one of: proxy_register_as_trad_with_script.feature
   #         proxy_register_as_minion_with_script.feature
   #         proxy_register_as_minion_with_gui.feature

--- a/testsuite/run_sets/refhost.yml
+++ b/testsuite/run_sets/refhost.yml
@@ -10,7 +10,7 @@
 
 - features/core/allcli_sanity.feature
 - features/core/first_settings.feature
-# initialize SUSE Manager server
+# initialize Uyuni server
 - features/core/srv_channels_add.feature
 - features/core/srv_create_repository.feature
 - features/core/srv_create_activationkey.feature

--- a/testsuite/run_sets/sle-updates.yml
+++ b/testsuite/run_sets/sle-updates.yml
@@ -9,7 +9,7 @@
 # IMMUTABLE ORDER
 
 - features/core/first_settings.feature
-# initialize SUSE Manager server
+# initialize Uyuni server
 - features/core/srv_channels_add.feature
 - features/core/srv_create_repository.feature
 - features/core/srv_create_activationkey.feature

--- a/testsuite/run_sets/virtualization.yml
+++ b/testsuite/run_sets/virtualization.yml
@@ -10,7 +10,7 @@
 
 - features/core/allcli_sanity.feature
 - features/core/first_settings.feature
-# initialize SUSE Manager server
+# initialize Uyuni server
 - features/core/srv_channels_add.feature
 - features/core/srv_create_repository.feature
 - features/core/srv_create_activationkey.feature


### PR DESCRIPTION
## What does this PR change?

 Get rid of SUSE Manager mentions in Uyuni Test Framework

Related to https://github.com/SUSE/spacewalk/issues/10078

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

No ports

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
