### PR TITLE
NPE when scheduling patches from relevant patches page

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
@@ -34,6 +34,7 @@ import com.redhat.rhn.domain.action.config.ConfigUploadAction;
 import com.redhat.rhn.domain.action.config.ConfigUploadMtimeAction;
 import com.redhat.rhn.domain.action.config.DaemonConfigAction;
 import com.redhat.rhn.domain.action.dup.DistUpgradeAction;
+import com.redhat.rhn.domain.action.errata.ActionPackageDetails;
 import com.redhat.rhn.domain.action.errata.ErrataAction;
 import com.redhat.rhn.domain.action.image.DeployImageAction;
 import com.redhat.rhn.domain.action.kickstart.KickstartGuestToolsChannelSubscriptionAction;
@@ -370,7 +371,9 @@ public class ActionFactory extends HibernateFactory {
     public static Action createAction(ActionType typeIn, Date earliest) {
         Action retval;
         if (typeIn.equals(TYPE_ERRATA)) {
-            retval = new ErrataAction();
+            ErrataAction ea = new ErrataAction();
+            ea.setDetails(new ActionPackageDetails(ea, false));
+            retval = ea;
         }
         else if (typeIn.equals(TYPE_SCRIPT_RUN)) {
             retval = new ScriptRunAction();

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix NPE error when scheduling ErrataAction from relevant errata page (bsc#1188289)
 - Add Beijing timezone to selectable timezones (bsc#1188193)
 - Java enablement for Rocky Linux 8
 - Get CPU data for AArch64


### PR DESCRIPTION
## What does this PR change?
Port of: https://github.com/SUSE/spacewalk/pull/15423  
Already approved by @lucidd  

Fix NPE error when scheduling ErrataAction from relevant errata page 


https://github.com/SUSE/spacewalk/issues/15396
https://bugzilla.suse.com/show_bug.cgi?id=1188289



## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: 

- [ ] **DONE**

## Test coverage
- No tests: 

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
