### PR TITLE
Bugfix: Prevent "no session" hibernate error on deleting server

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -752,7 +752,7 @@ public class SystemManager extends BaseManager {
         ServerFactory.delete(server);
 
         server.asMinionServer().ifPresent(minion -> {
-            SaltStateGeneratorService.INSTANCE.removeServer(minion);
+            SaltStateGeneratorService.INSTANCE.removeServer(minion.getMinionId(), minion.getMachineId());
             if (deleteSaltKey) {
                 saltApi.deleteKey(minion.getMinionId());
             }

--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -353,8 +353,8 @@ public class RegisterMinionEventMessageAction implements MessageAction {
         else if (!machineId.equals(oldMachineId)) {
             SaltStateGeneratorService.INSTANCE.removeConfigChannelAssignments(registeredMinion);
             SaltActionChainGeneratorService.INSTANCE.removeActionChainSLSFilesForMinion(
-                    registeredMinion, Optional.empty());
-            StatesAPI.removePackageState(registeredMinion);
+                    registeredMinion.getMachineId(), Optional.empty());
+            StatesAPI.removePackageState(registeredMinion.getMachineId());
 
             registeredMinion.setMachineId(machineId);
             registeredMinion.setDigitalServerId(machineId);

--- a/java/code/src/com/suse/manager/webui/controllers/StatesAPI.java
+++ b/java/code/src/com/suse/manager/webui/controllers/StatesAPI.java
@@ -33,7 +33,6 @@ import com.redhat.rhn.domain.rhnpackage.PackageEvr;
 import com.redhat.rhn.domain.rhnpackage.PackageType;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.MinionServerFactory;
-import com.redhat.rhn.domain.server.MinionSummary;
 import com.redhat.rhn.domain.server.ServerGroup;
 import com.redhat.rhn.domain.server.ServerGroupFactory;
 import com.redhat.rhn.domain.state.PackageState;
@@ -644,8 +643,7 @@ public class StatesAPI {
             Path baseDir = Paths.get(
                     SaltConstants.SUMA_STATE_FILES_ROOT_PATH, SaltConstants.SALT_PACKAGES_STATES_DIR);
             Files.createDirectories(baseDir);
-            Path filePath = baseDir.resolve(
-                    getPackagesSlsName(new MinionSummary(server)));
+            Path filePath = baseDir.resolve(getPackagesSlsName(server.getMachineId()));
             SaltStateGenerator saltStateGenerator =
                     new SaltStateGenerator(filePath.toFile());
             saltStateGenerator.generate(new SaltInclude(ApplyStatesEventMessage.CHANNELS),
@@ -659,12 +657,12 @@ public class StatesAPI {
     /**
      * Remove package state file for the given minion
      *
-     * @param minion the minion
+     * @param machineId the salt machineId
      */
-    public static void removePackageState(MinionServer minion) {
+    public static void removePackageState(String machineId) {
         Path baseDir = Paths.get(
                 SaltConstants.SUMA_STATE_FILES_ROOT_PATH, SaltConstants.SALT_PACKAGES_STATES_DIR);
-        Path filePath = baseDir.resolve(getPackagesSlsName(new MinionSummary(minion)));
+        Path filePath = baseDir.resolve(getPackagesSlsName(machineId));
 
         try {
             Files.deleteIfExists(filePath);
@@ -676,11 +674,11 @@ public class StatesAPI {
 
     /**
      * Get the name of the package sls file.
-     * @param server the minion server
+     * @param machineId the salt machineId
      * @return the name of the package sls file
      */
-    public static String getPackagesSlsName(MinionSummary server) {
-        return SaltConstants.SALT_SERVER_PACKAGES_STATE_FILE_PREFIX + server.getMachineId() + ".sls";
+    public static String getPackagesSlsName(String machineId) {
+        return SaltConstants.SALT_SERVER_PACKAGES_STATE_FILE_PREFIX + machineId + ".sls";
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/services/SaltActionChainGeneratorService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltActionChainGeneratorService.java
@@ -24,7 +24,6 @@ import static com.suse.manager.webui.services.impl.SaltSSHService.ACTION_STATES_
 import static com.suse.manager.webui.services.impl.SaltSSHService.DEFAULT_TOPS;
 
 import com.redhat.rhn.domain.action.ActionChain;
-import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.MinionServerFactory;
 import com.redhat.rhn.domain.server.MinionSummary;
 
@@ -396,10 +395,10 @@ public class SaltActionChainGeneratorService {
 
     /**
      * Remove all action chains files for the given minion and action chain.
-     * @param minion the minion
+     * @param machineId
      * @param actionChainId optionally, the id of the action chain
      */
-    public void removeActionChainSLSFilesForMinion(MinionServer minion, Optional<Long> actionChainId) {
+    public void removeActionChainSLSFilesForMinion(String machineId, Optional<Long> actionChainId) {
         Path targetDir = getTargetDir();
         if (!Files.exists(targetDir)) {
             return;
@@ -407,7 +406,7 @@ public class SaltActionChainGeneratorService {
 
         try (DirectoryStream<Path> stream = Files.newDirectoryStream(targetDir,
                 ACTIONCHAIN_SLS_FILE_PREFIX + actionChainId.map(id -> Long.toString(id)).orElse("*") +
-                        "_" + minion.getMachineId() + "_*.sls")) {
+                        "_" + machineId + "_*.sls")) {
             stream.forEach(slsFile -> {
                 deleteSlsAndRefs(targetDir,  slsFile);
             });

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -847,9 +847,8 @@ public class SaltServerActionService {
                                         Optional<String> message) {
         failedActionId.ifPresent(last ->
                 failDependentServerActions(last, minionId, message));
-        MinionServerFactory.findByMinionId(minionId).ifPresent(minion -> {
-            SaltActionChainGeneratorService.INSTANCE.removeActionChainSLSFilesForMinion(minion, actionChainId);
-        });
+        MinionServerFactory.findByMinionId(minionId).ifPresent(minion -> SaltActionChainGeneratorService.INSTANCE
+                .removeActionChainSLSFilesForMinion(minion.getMachineId(), actionChainId));
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/services/SaltStateGeneratorService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltStateGeneratorService.java
@@ -291,6 +291,14 @@ public enum SaltStateGeneratorService {
     }
 
     /**
+     * Remove the config channel assignments for minion server.
+     * @param machineId the salt machineId
+     */
+    public void removeConfigChannelAssignmentsByMachineId(String machineId) {
+        removeConfigChannelAssignments(getServerStateFileName(machineId));
+    }
+
+    /**
      * Remove the config channel assignments for server group.
      * @param group the server group
      */
@@ -298,8 +306,8 @@ public enum SaltStateGeneratorService {
         removeConfigChannelAssignments(getGroupStateFileName(group.getId()));
     }
 
-    private void removeActionChains(MinionServer minion) {
-        SaltActionChainGeneratorService.INSTANCE.removeActionChainSLSFilesForMinion(minion, Optional.empty());
+    private void removeActionChains(String machineId) {
+        SaltActionChainGeneratorService.INSTANCE.removeActionChainSLSFilesForMinion(machineId, Optional.empty());
     }
 
     /**
@@ -419,13 +427,14 @@ public enum SaltStateGeneratorService {
 
     /**
      * Remove pillars and config channels assignments of a server.
-     * @param minion the minion
+     * @param minionId the salt minionId
+     * @param machineId the salt machineId
      */
-    public void removeServer(MinionServer minion) {
-        MinionPillarManager.INSTANCE.removePillar(minion.getMinionId());
-        StatesAPI.removePackageState(minion);
-        removeConfigChannelAssignments(minion);
-        removeActionChains(minion);
+    public void removeServer(String minionId, String machineId) {
+        MinionPillarManager.INSTANCE.removePillar(minionId);
+        StatesAPI.removePackageState(machineId);
+        removeConfigChannelAssignmentsByMachineId(machineId);
+        removeActionChains(machineId);
     }
 
     /**
@@ -441,7 +450,8 @@ public enum SaltStateGeneratorService {
      * @param org the org
      */
     public void removeOrg(Org org) {
-        MinionServerFactory.lookupByOrg(org.getId()).forEach(this::removeServer);
+        MinionServerFactory.lookupByOrg(org.getId())
+                .forEach(m -> removeServer(m.getMinionId(), m.getMachineId()));
         removeConfigChannelAssignments(org);
     }
 

--- a/java/code/src/com/suse/manager/webui/services/impl/SaltSSHService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltSSHService.java
@@ -888,7 +888,7 @@ public class SaltSSHService {
         // add packages/package_<minion_machine_id>
         Set<String> pkgRefs = statesPerMinion.entrySet().stream()
                 .map(entry -> SALT_FS_PREFIX + SaltConstants.SALT_PACKAGES_STATES_DIR + "/" +
-                        StatesAPI.getPackagesSlsName(entry.getKey()))
+                        StatesAPI.getPackagesSlsName(entry.getKey().getMachineId()))
                 .collect(Collectors.toSet());
 
 

--- a/java/code/src/com/suse/manager/webui/services/pillar/MinionPillarManager.java
+++ b/java/code/src/com/suse/manager/webui/services/pillar/MinionPillarManager.java
@@ -128,7 +128,7 @@ public class MinionPillarManager {
 
     /**
      * Removes the corresponding pillar files for the passed minion
-     * @param minionId the minion Id
+     * @param minionId the salt minion Id
      */
     public void removePillar(String minionId) {
         generalPillarFileManager.removePillarFile(minionId);

--- a/java/code/src/com/suse/manager/webui/services/test/SaltActionChainGeneratorServiceTest.java
+++ b/java/code/src/com/suse/manager/webui/services/test/SaltActionChainGeneratorServiceTest.java
@@ -352,7 +352,7 @@ public class SaltActionChainGeneratorServiceTest extends BaseTestCaseWithUser {
 
         service.createActionChainSLSFiles(actionChain, minionSummary1, states, Optional.empty());
 
-        service.removeActionChainSLSFilesForMinion(minion1, Optional.empty());
+        service.removeActionChainSLSFilesForMinion(minion1.getMachineId(), Optional.empty());
 
         Path sls1Path = stateFilesRoot
                 .resolve(ACTIONCHAIN_SLS_FOLDER)


### PR DESCRIPTION
Previously, the salt-related cleanups in SaltStateGeneratorService.INSTANCE.removeServer called hibernate proxy methods on the server entity, which lead to hibernate 'no session' error since the server entity was evicted in the SystemManager.delete method.

Solved by introducing a DTO that carries the data needed for post-evict cleanup.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: bugfix

- [x] **DONE**

## Test coverage
- No tests: there are no tests here

- [x] **DONE**


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
