### PR TITLE
Refresh virtualization host pillar due to virtpoller removal

### DIFF
--- a/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
@@ -14,8 +14,6 @@
  */
 package com.suse.manager.webui.services.impl;
 
-import com.google.gson.JsonElement;
-import com.google.gson.reflect.TypeToken;
 import com.redhat.rhn.common.client.ClientCertificate;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.messaging.JavaMailException;
@@ -24,6 +22,7 @@ import com.redhat.rhn.domain.server.MinionServerFactory;
 import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.manager.audit.scap.file.ScapFileManager;
 import com.redhat.rhn.manager.system.SystemManager;
+
 import com.suse.manager.clusters.ClusterProviderParameters;
 import com.suse.manager.reactor.PGEventStream;
 import com.suse.manager.reactor.messaging.ApplyStatesEventMessage;
@@ -40,8 +39,8 @@ import com.suse.manager.webui.services.impl.runner.MgrRunner;
 import com.suse.manager.webui.services.impl.runner.MgrUtilRunner;
 import com.suse.manager.webui.utils.ElementCallJson;
 import com.suse.manager.webui.utils.gson.BootstrapParameters;
-import com.suse.manager.webui.utils.salt.custom.MgrActionChains;
 import com.suse.manager.webui.utils.salt.custom.ClusterOperationsSlsResult;
+import com.suse.manager.webui.utils.salt.custom.MgrActionChains;
 import com.suse.manager.webui.utils.salt.custom.PkgProfileUpdateSlsResult;
 import com.suse.manager.webui.utils.salt.custom.ScheduleMetadata;
 import com.suse.salt.netapi.AuthModule;
@@ -81,6 +80,10 @@ import com.suse.salt.netapi.results.CmdResult;
 import com.suse.salt.netapi.results.Result;
 import com.suse.salt.netapi.results.SSHResult;
 import com.suse.utils.Opt;
+
+import com.google.gson.JsonElement;
+import com.google.gson.reflect.TypeToken;
+
 import org.apache.http.client.config.CookieSpecs;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
@@ -722,6 +725,11 @@ public class SaltService implements SystemQuery, SaltApi {
             LocalCall<Boolean> call = SaltUtil.refreshPillar(Optional.empty(),
                     Optional.empty());
             callAsync(call, minionList);
+
+            // Salt pillar refresh doesn't reload the modules with the new pillar
+            LocalCall<Boolean> modulesRefreshCall = new LocalCall<>("saltutil.refresh_modules",
+                    Optional.empty(), Optional.empty(), new TypeToken<Boolean>() { });
+            callAsync(modulesRefreshCall, minionList);
         }
         catch (SaltException e) {
             throw new RuntimeException(e);

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Refresh virtual host pillar to clear the virtpoller beacon (bsc#1188393)
 - Fix updating primary net interface on hardware refresh (bsc#1188400)
 - Fix issues when removing archived actions using XMLRPC api (bsc#1181223)
 - Readable error when "mgr-sync add channel" is called with a non-existing label (bsc#1173143)

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- Refresh virtual host pillar to clear the virtpoller beacon (bsc#1188393)
 - Add Beijing timezone to selectable timezones (bsc#1188193)
 - Add Rocky Linux 8 key and vendor
 - Add 'test' flag to Ansible playbook actions

--- a/schema/spacewalk/upgrade/susemanager-schema-4.3.0-to-susemanager-schema-4.3.1/100-enable-virthost-pillar-refresh.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.3.0-to-susemanager-schema-4.3.1/100-enable-virthost-pillar-refresh.sql
@@ -1,0 +1,4 @@
+INSERT INTO rhnTaskQueue (org_id, task_name, task_data)
+SELECT id, 'upgrade_satellite_virthost_pillar_refresh', 0
+FROM web_customer
+WHERE id = 1;


### PR DESCRIPTION
## What does this PR change?

Refresh the virtualization host pillars after a migration from a server where `virtpoller` beacon was available.
Removes warning lines like the following from the salt minion logs of the virtual hosts:

```
"2021-07-13 23:13:37,359 [salt.beacons     :140 ][WARNING ][9588] Unable to process beacon virtpoller"
```

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: migration only, too much of a corner case

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/15428

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
