### PR TITLE
spacecmd: add 'schedule_deletearchived' to bulk delete archived actions (bsc#1181223)

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/product/SUSEProductUpgrade.java
+++ b/java/code/src/com/redhat/rhn/domain/product/SUSEProductUpgrade.java
@@ -31,6 +31,12 @@ public class SUSEProductUpgrade extends BaseDomainHelper implements Serializable
     private SUSEProduct toProduct;
 
     /**
+     * Default constructor
+     */
+    public SUSEProductUpgrade() {
+    }
+
+    /**
      * Constructor taking two {@link SUSEProduct}s.
      * @param from original product
      * @param to target product

--- a/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
+++ b/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
@@ -438,7 +438,7 @@ public class ActionManager extends BaseManager {
         }
         // now, delete them
         for (Action action : actions) {
-            ActionFactory.remove(action);
+            deleteActionsByIdAndType(action.getId(), action.getActionType().getId());
         }
     }
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix issues when removing archived actions using XMLRPC api (bsc#1181223)
 - Readable error when "mgr-sync add channel" is called with a non-existing label (bsc#1173143)
 - Fix NPE error when scheduling ErrataAction from relevant errata page (bsc#1188289)
 - Add Beijing timezone to selectable timezones (bsc#1188193)

--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,4 @@
+- Add schedule_deletearchived to bulk delete archived actions (bsc#1181223)
 - make spacecmd aware of retracted patches/packages
 - Bump version to 4.3.0
 

--- a/spacecmd/src/spacecmd/schedule.py
+++ b/spacecmd/src/spacecmd/schedule.py
@@ -452,3 +452,50 @@ def help_schedule_list(self):
 
 def do_schedule_list(self, args):
     return self.print_schedule_summary('all', args)
+
+####################
+
+def help_schedule_deletearchived(self):
+    print(_('schedule_deletearchived: Delete all archived actions'))
+    print(_('usage: schedule_deletearchived'))
+
+def do_schedule_deletearchived(self, args):
+    """
+    This method removes all of the archived actions.
+    """
+    user_already_prompted = False
+    while True:
+        # Needs to happen in a loop, since we can only fetch in batches. 10k is the default.
+        actions = self.client.schedule.listArchivedActions(self.session)
+        logging.debug("actions: {}".format(actions))
+        if actions:
+            if not user_already_prompted:
+                if len(actions) >= 10000:
+                    action_length = ">10000"
+                else:
+                    action_length = len(actions)
+                user_answer = prompt_user(_("Do you want to delete all ({}) archived actions? [y/N]").format(action_length))
+                if user_answer not in ("y", "Y", "yes", "Yes", "YES"):
+                    break
+                else:
+                    user_already_prompted = True
+
+            # Collect IDs of actions that should be deleted
+            action_ids = [action.get('id') for action in actions]
+
+            # Remove duplicates if any
+            # set needs to be cast to list, since set cannot be marshalled
+            action_ids = list(set(action_ids))
+
+            if action_ids:
+                # Process deletion in batches
+                BATCH_SIZE = 50
+                for i in range(0, len(action_ids), BATCH_SIZE):
+                    # Pass list of actions that should be deleted
+                    self.client.schedule.deleteActions(self.session, action_ids[i:i + BATCH_SIZE])
+                    processed = i + BATCH_SIZE if i + BATCH_SIZE <= len(action_ids) else len(action_ids)
+                    print("Deleted {} actions of {}".format(processed, len(action_ids)))
+        else:
+            if not user_already_prompted:
+                print(_("No archived actions found."))
+            break

--- a/spacecmd/tests/test_schedule.py
+++ b/spacecmd/tests/test_schedule.py
@@ -14,6 +14,114 @@ class TestSCSchedule:
     Test suite for "schedule" module.
     """
 
+    def test_schedule_deletearchived_without_archived(self, shell):
+        """
+        Test do_schedule_deletearchived with no archived actions.
+
+        :param shell:
+        :return:
+        """
+
+        shell.help_schedule_deletearchived = MagicMock()
+        shell.client.schedule.listArchivedActions = MagicMock(return_value=[])
+        shell.client.schedule.deleteActions = MagicMock()
+        logger = MagicMock()
+
+        spacecmd.schedule.do_schedule_deletearchived(shell, "")
+
+        assert shell.client.schedule.listArchivedActions.called
+        assert not shell.client.schedule.deleteActions.called
+
+    @patch('spacecmd.utils.input', create=True, new=MagicMock(return_value='y'))
+    @patch('spacecmd.utils.raw_input', create=True, new=MagicMock(return_value='y'))
+    def test_schedule_deletearchived_with_archived(self, shell):
+        """
+        Test do_schedule_deletearchived with archived actions.
+
+        :param shell:
+        :return:
+        """
+        archived_dummy_actions = [{'id': 1}, {'id': 2}, {'id': 3}]
+
+        shell.help_schedule_deletearchived = MagicMock()
+        shell.client.schedule.listArchivedActions = MagicMock()
+        shell.client.schedule.listArchivedActions.side_effect = [archived_dummy_actions] + [[]]
+        shell.client.schedule.deleteActions = MagicMock()
+        logger = MagicMock()
+
+        spacecmd.schedule.do_schedule_deletearchived(shell, "")
+
+        assert shell.client.schedule.deleteActions.call_count == 1
+        assert shell.client.schedule.deleteActions.call_args[0][1] == [1, 2, 3]
+
+    @patch('spacecmd.utils.input', create=True, new=MagicMock(return_value='n'))
+    @patch('spacecmd.utils.raw_input', create=True, new=MagicMock(return_value='n'))
+    def test_schedule_deletearchived_with_archived_but_user_answer_is_no(self, shell):
+        """
+        Test do_schedule_deletearchived with archived actions and the user answers with
+        no "n".
+
+        :param shell:
+        :return:
+        """
+        archived_dummy_actions = [{'id': 1}, {'id': 2}, {'id': 3}]
+
+        shell.help_schedule_deletearchived = MagicMock()
+        shell.client.schedule.listArchivedActions = MagicMock()
+        shell.client.schedule.listArchivedActions.side_effect = [archived_dummy_actions] + [[]]
+        shell.client.schedule.deleteActions = MagicMock()
+        logger = MagicMock()
+
+        spacecmd.schedule.do_schedule_deletearchived(shell, "")
+
+        assert shell.client.schedule.deleteActions.call_count == 0
+
+    @patch('spacecmd.utils.input', create=True, new=MagicMock(return_value=''))
+    @patch('spacecmd.utils.raw_input', create=True, new=MagicMock(return_value=''))
+    def test_schedule_deletearchived_with_archived_but_no_user_answer(self, shell):
+        """
+        Test do_schedule_deletearchived with archived actions, but the user gives no answer.
+        This should default to no.
+
+        :param shell:
+        :return:
+        """
+        archived_dummy_actions = [{'id': 1}, {'id': 2}, {'id': 3}]
+
+        shell.help_schedule_deletearchived = MagicMock()
+        shell.client.schedule.listArchivedActions = MagicMock()
+        shell.client.schedule.listArchivedActions.side_effect = [archived_dummy_actions] + [[]]
+        shell.client.schedule.deleteActions = MagicMock()
+        logger = MagicMock()
+
+        spacecmd.schedule.do_schedule_deletearchived(shell, "")
+
+        assert shell.client.schedule.deleteActions.call_count == 0
+
+    @patch('spacecmd.utils.input', create=True, new=MagicMock(return_value='y'))
+    @patch('spacecmd.utils.raw_input', create=True, new=MagicMock(return_value='y'))
+    def test_schedule_deletearchived_with_archived_batched(self, shell):
+        """
+        Test do_schedule_deletearchived with archived actions
+        and in a batched way.
+
+        :param shell:
+        :return:
+        """
+        archived_dummy_actions = [{'id': 1}, {'id': 2}, {'id': 3}]
+
+        shell.help_schedule_deletearchived = MagicMock()
+        shell.client.schedule.listArchivedActions = MagicMock()
+        shell.client.schedule.listArchivedActions.side_effect = [archived_dummy_actions] + [archived_dummy_actions] + [[]]
+        shell.client.schedule.deleteActions = MagicMock()
+        logger = MagicMock()
+
+        spacecmd.schedule.do_schedule_deletearchived(shell, "")
+
+        assert shell.client.schedule.listArchivedActions.called
+        assert shell.client.schedule.deleteActions.call_count == 2
+        assert shell.client.schedule.deleteActions.call_args[0][1] == [1, 2, 3]
+
     def test_schedule_cancel_noargs(self, shell):
         """
         Test do_schedule_cancel without arguments.


### PR DESCRIPTION
## What does this PR change?

This PR introduces a new command, `schedule_deletearchived` for `spacecmd`, to allow the user to bulk remove archived actions. Also fixes some related issues we figured out while testing this:

As you can see in the implementation, the new `schedule_deletearchived` command is making use of the already existing `schedule.deleteActions` endpoint from the XMLRPC api.

While making use of `schedule.deleteActions` endpoint we've realized of some problems regarding to removing actions:

1) Hibernate exception about missing default constructor:
```
ERROR: redstone.xmlrpc.XmlRpcFault: unhandled internal exception: org.hibernate.InstantiationException: No default constructor for entity:  : com.redhat.rhn.domain.product.SUSEProductUpgrade
```

2) Removing certain actions using `ActionFactory.remove` leads into 500 error due cascade deletion: 

Easy to reproduce:
1) Archive a "Subscribe to channel" action
2) Use spacecmd to delete this action like this:

```
spacecmd {SSM:0}> api schedule.deleteActions --args "[ACTION_ID]"
ERROR: <ProtocolError for myserver/rpc/api: 500 500>
```

If you then look at the `rhn_web_ui.log` you will see an error like this:

```
Caused by: org.postgresql.util.PSQLException: ERROR: update or delete on table "rhnchannel" violates foreign key constraint "rhn_sc_cid_fk" on table "rhnserverchannel"
  Detail: Key (id)=(107) is still referenced from table "rhnserverchannel".
```

So, aparently it's trying to do a deletion from the referenced "rhnchannel" table, which in this case is completely wrong.

We do have a custom SQL queries that we use to delete actions, which by the way are the ones used when we delete the archived actions from the UI, so this PR fixes this problem by switching the `schedule.deleteActions` endpoint to not use `HibernateFactory.remove` but instead this custom SQL queries as done by the UI.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/14196

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
