### PR TITLE
Testsuite: Catch cobbler test failures earlier

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -641,7 +641,8 @@ When(/^I configure tftp on the "([^"]*)"$/) do |host|
 end
 
 When(/^I synchronize the tftp configuration on the proxy with the server$/) do
-  $server.run('cobbler sync')
+  out, _code = $server.run('cobbler sync')
+  raise 'cobbler sync failt' if out.include? 'Push failed'
 end
 
 When(/^I set the default PXE menu entry to the "([^"]*)" on the "([^"]*)"$/) do |entry, host|


### PR DESCRIPTION
## What does this PR change?

Raise an error as soon as we find a problem with this step.

This step fails silently at head.  Instead, we want to report this failure as soon as it happens.

## Links

https://github.com/SUSE/spacewalk/issues/5838
### Ports:
- Manager-4.1:
- 
## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)
