### PR TITLE
Fix updating primary net interface on hardware refresh (bsc#1188400)

### DIFF
--- a/java/code/src/com/suse/manager/reactor/hardware/HardwareMapper.java
+++ b/java/code/src/com/suse/manager/reactor/hardware/HardwareMapper.java
@@ -889,11 +889,9 @@ public class HardwareMapper {
                     .findFirst());
         }
 
-        primaryNetIf.ifPresent(netIf -> {
-            // we found an interface with the same addr as the
-            // primary IPv4/v6 addr, make it primary
-            netIf.setPrimary("Y");
-        });
+        // we found an interface with the same addr as the
+        // primary IPv4/v6 addr, make it primary
+        primaryNetIf.ifPresent(server::setPrimaryInterface);
 
     }
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix updating primary net interface on hardware refresh (bsc#1188400)
 - Fix issues when removing archived actions using XMLRPC api (bsc#1181223)
 - Readable error when "mgr-sync add channel" is called with a non-existing label (bsc#1173143)
 - Fix NPE error when scheduling ErrataAction from relevant errata page (bsc#1188289)


### PR DESCRIPTION
The primary net interface of a system is specified in `is_primary ('Y'/null)` column in the `rhnServerNetInterface` table and it has a unique constraint, so there can only be one primary interface (marked `'Y'`) for a system. When the primary interface is changed on the client-side and is retrieved via a hardware refresh, the code tries to mark the new one with `Y` without clearing the old one, which leads to a SQL constraint violation.

This PR makes sure there's only one primary interface marked during the update via hardware refresh.

https://bugzilla.suse.com/1188400

Port of: https://github.com/SUSE/spacewalk/pull/15443

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
