### PR TITLE
Let react be happy with unique children keys

### DIFF
--- a/web/html/src/manager/images/image-profile-edit.tsx
+++ b/web/html/src/manager/images/image-profile-edit.tsx
@@ -297,7 +297,7 @@ class CreateImageProfile extends React.Component<Props, State> {
         divClass="col-md-6"
         hint={this.state.storeUri}
         invalidHint={
-          <span>
+          <span key="invalidHint">
             Target Image Store is required.&nbsp;
             <a href={"/rhn/manager/cm/imagestores/create?url_bounce=" + this.getBounceUrl()}>Create a new one</a>.
           </span>
@@ -316,7 +316,7 @@ class CreateImageProfile extends React.Component<Props, State> {
             label={t("Dockerfile URL")}
             required
             hint={
-              <span>
+              <span key="hint">
                 Git URL pointing to the directory containing the Dockerfile
                 <br />
                 Example: <em>https://mygit.com#&lt;branchname&gt;:path/to/dockerfile</em>
@@ -342,7 +342,7 @@ class CreateImageProfile extends React.Component<Props, State> {
             label={t("Config URL")}
             required
             hint={
-              <span>
+              <span key="hint">
                 Git URL pointing to the directory containing the Kiwi config files
                 <br />
                 Example: <em>https://mygit.com#&lt;branchname&gt;:path/to/kiwi/config</em>
@@ -364,7 +364,7 @@ class CreateImageProfile extends React.Component<Props, State> {
             name="kiwiOptions"
             label={t("Kiwi options")}
             hint={
-              <span>
+              <span key="hint">
                 Kiwi command line options
                 <br />
                 Example: <em>--profile jeos</em>
@@ -424,7 +424,7 @@ class CreateImageProfile extends React.Component<Props, State> {
 
       return (
         key && (
-          <FormGroup>
+          <FormGroup key={key.label}>
             <Label className="col-md-3" name={key.label} />
             <div className="col-md-6">
               <div className="input-group">
@@ -460,7 +460,7 @@ class CreateImageProfile extends React.Component<Props, State> {
     });
 
     const select = (
-      <FormGroup>
+      <FormGroup key="custom-info-values-formgroup">
         <Label className="col-md-3" name={t("Custom Info Values")} />
         <div className="col-md-6">
           <ReactSelect


### PR DESCRIPTION
## What does this PR change?

Let react be happy with unique children keys: address react warnings

![Screenshot from 2021-07-21 16-24-12](https://user-images.githubusercontent.com/7080830/126505162-45c6352a-cb08-4b9e-bada-0afade2e099e.png)


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: 

- [x] **DONE**

## Test coverage
- No tests: 

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
