### PR TITLE
Skip 'update-ca-certificates' run if the certs are updated automatically

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/certs/SLES12.sls
+++ b/susemanager-utils/susemanager-sls/salt/certs/SLES12.sls
@@ -9,3 +9,7 @@ update-ca-certificates:
     - runas: root
     - onchanges:
       - file: /etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT
+    - unless:
+      - fun: service.status
+        args:
+          - ca-certificates.path

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Skip 'update-ca-certificates' run if the certs are updated automatically
 - Fix parameters for 'runplaybook' state (bsc#1188395)
 - Parameterised apache document root.
 - Add support for bootstrapping Raspbian 9 and 10


### PR DESCRIPTION
In SLES15SP3, the directory `/etc/pki/trust/anchors` is watched via the `ca-certificates.path` systemd unit, and as soon as its contents changed, the system-wide certificates are updated automatically. In `certs` state, we run `update-ca-certificates` right after deploying certs. These two processes create a race condition that in rare cases leads to an error.

See https://bugzilla.suse.com/1188500

This PR updates the `certs` state to run `update-ca-certificates` only if this systemd unit does not exist or is not running.

Corresponding sumaform fix for the testsuite: https://github.com/uyuni-project/sumaform/pull/926

## Example "certs" state output
**`ca-certificates.path` running (the state is skipped):**
```
----------
          ID: update-ca-certificates
    Function: cmd.run
        Name: /usr/sbin/update-ca-certificates
      Result: True
     Comment: unless condition is true
     Started: 00:23:46.289726
    Duration: 1996.236 ms
     Changes:   
```
**`ca-certificates.path` is dead or does not exist:**
```
          ID: update-ca-certificates
    Function: cmd.run
        Name: /usr/sbin/update-ca-certificates
      Result: True
     Comment: Command "/usr/sbin/update-ca-certificates" run
     Started: 00:24:28.358217
    Duration: 2016.635 ms
     Changes:   
              ----------
              pid:
                  11368
              retcode:
                  0
              stderr:
              stdout:
```

## Documentation
- No documentation needed: internal change

## Test coverage
- No tests: already covered

## Links

Fixes https://github.com/SUSE/spacewalk/issues/15453

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
