### PR TITLE
Handle possibly null HostInfo in virtual guests page

### DIFF
--- a/web/html/src/manager/virtualization/guests/list/guests-list.renderer.tsx
+++ b/web/html/src/manager/virtualization/guests/list/guests-list.renderer.tsx
@@ -9,7 +9,7 @@ type RendererProps = {
   saltEntitled: boolean;
   foreignEntitled: boolean;
   isAdmin: boolean;
-  hostInfo: HostInfo;
+  hostInfo?: HostInfo;
 };
 
 export const renderer = (id: string, { serverId, pageSize, saltEntitled, foreignEntitled, isAdmin, hostInfo }: RendererProps) => {

--- a/web/html/src/manager/virtualization/guests/list/guests-list.tsx
+++ b/web/html/src/manager/virtualization/guests/list/guests-list.tsx
@@ -21,7 +21,7 @@ type Props = {
   saltEntitled: boolean;
   foreignEntitled: boolean;
   isAdmin: boolean;
-  hostInfo: HostInfo;
+  hostInfo?: HostInfo;
 };
 
 export function GuestsList(props: Props) {
@@ -89,7 +89,7 @@ export function GuestsList(props: Props) {
 
   return (
     <>
-      <HypervisorCheck saltVirtHost={!props.foreignEntitled && props.saltEntitled} hypervisor={props.hostInfo.hypervisor}/>
+      <HypervisorCheck saltVirtHost={!props.foreignEntitled && props.saltEntitled} hypervisor={props.hostInfo?.hypervisor || ""}/>
 
       <ListTab
         serverId={props.serverId}
@@ -248,7 +248,7 @@ export function GuestsList(props: Props) {
               });
             }}
             onClose={() => setMigrateVm(undefined)}
-            clusterNodes={props.hostInfo.cluster_other_nodes}
+            clusterNodes={props.hostInfo?.cluster_other_nodes}
           />
         )
       }

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Fix virtualization guests to handle null HostInfo
 - Compare lowercase CPU arch with libvirt domain capabilities
 - Add option to run Ansible playbooks in 'test' mode
 - Add support for Kiwi options


### PR DESCRIPTION
## What does this PR change?

If the hypervisor can't be detected by Salt and no CRM cluster is setup on the virtual host minion we get a `null` `HostInfo` in the VMs page. Handle this gracefully.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: corner case

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
