### PR TITLE
spacewalk-proxy: Enterprise Linux modifications

### DIFF
--- a/proxy/installer/fetch-certificate.py
+++ b/proxy/installer/fetch-certificate.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python -u
+#pylint: disable=invalid-name
 
 import os
 import sys
-import time
 import argparse
 
 
@@ -47,8 +47,8 @@ if __name__ == "__main__":
                 with open(args.destination, 'wb') as _file:
                     _file.write(data['data'].encode('utf8'))
                     print("Certificate saved to: {0}".format(args.destination))
-            except Exception as ex:
-                print("Unable to write to destination: " + ex.message)
+            except Exception as ex: # pylint: disable=broad-except
+                print("Unable to write to destination: " + ex.message) # pylint: disable=no-member
                 sys.exit(1)
             sys.exit(0)
     print("Certificate not received from server. Exit.")

--- a/proxy/installer/rhn-proxy-activate.py
+++ b/proxy/installer/rhn-proxy-activate.py
@@ -39,7 +39,7 @@ except ImportError:     # python3
     raw_input = input
 
 # lib imports
-from optparse import Option, OptionParser
+from optparse import Option, OptionParser # pylint: disable=deprecated-module
 from rhn import rpclib, SSL
 
 from up2date_client import config # pylint: disable=E0012, C0413

--- a/proxy/installer/spacewalk-proxy-installer.changes
+++ b/proxy/installer/spacewalk-proxy-installer.changes
@@ -1,3 +1,4 @@
+- Improved for Enterprise Linux build.
 - Modified for Pylint pass.
 - Removed Python 2 build.
 - Add new refresh_pattern to the squid.conf to fix a case where the repodata

--- a/proxy/installer/spacewalk-proxy-installer.changes
+++ b/proxy/installer/spacewalk-proxy-installer.changes
@@ -1,3 +1,4 @@
+- Removed Python 2 build.
 - Add new refresh_pattern to the squid.conf to fix a case where the repodata
   was invalid due to being cached (bsc#1186026)
 - Bump version to 4.3.0

--- a/proxy/installer/spacewalk-proxy-installer.changes
+++ b/proxy/installer/spacewalk-proxy-installer.changes
@@ -1,3 +1,4 @@
+- Modified for Pylint pass.
 - Removed Python 2 build.
 - Add new refresh_pattern to the squid.conf to fix a case where the repodata
   was invalid due to being cached (bsc#1186026)

--- a/proxy/installer/spacewalk-proxy-installer.spec
+++ b/proxy/installer/spacewalk-proxy-installer.spec
@@ -24,12 +24,6 @@
 
 %define apacheconfdir %{_sysconfdir}/apache2
 
-%if 0%{?suse_version} > 1320 || 0%{?fedora}
-# SLE15 and Fedora builds on Python 3
-%global build_py3   1
-%endif
-%define pythonX %{?build_py3:python3}%{!?build_py3:python2}
-
 Name:           spacewalk-proxy-installer
 Summary:        Spacewalk Proxy Server Installer
 License:        GPL-2.0-only
@@ -67,8 +61,8 @@ Requires:       chkconfig
 Requires:       libxslt
 Requires:       spacewalk-certs-tools >= 1.6.4
 %if 0%{?pylint_check}
-BuildRequires:  %{pythonX}-rhn-client-tools
-BuildRequires:  spacewalk-%{pythonX}-pylint
+BuildRequires:  python3-rhn-client-tools
+BuildRequires:  spacewalk-python3-pylint
 %endif
 BuildRequires:  /usr/bin/docbook2man
 
@@ -131,12 +125,10 @@ install -m 644 configure-proxy.sh.8.gz $RPM_BUILD_ROOT%{_mandir}/man8/
 install -m 640 jabberd/sm.xml jabberd/c2s.xml $RPM_BUILD_ROOT%{_usr}/share/rhn/installer/jabberd
 
 # Fixing shebang for Python 3
-%if 0%{?build_py3}
 for i in $(find . -type f);
 do
     sed -i '1s=^#!/usr/bin/\(python\|env python\)[0-9.]*=#!/usr/bin/python3=' $i;
 done
-%endif
 install -m 755 rhn-proxy-activate.py $RPM_BUILD_ROOT/%{_usr}/sbin/rhn-proxy-activate
 install -m 755 fetch-certificate.py  $RPM_BUILD_ROOT/%{_usr}/sbin/fetch-certificate
 
@@ -148,7 +140,7 @@ install -m 0644 suse-manager-proxy.xml %{buildroot}/%{_prefix}/lib/firewalld/ser
 %check
 %if 0%{?pylint_check}
 # check coding style
-spacewalk-%{pythonX}-pylint .
+spacewalk-python3-pylint .
 %endif
 
 %files

--- a/proxy/proxy/apacheHandler.py
+++ b/proxy/proxy/apacheHandler.py
@@ -34,17 +34,19 @@ from spacewalk.common.rhnApache import rhnApache
 from spacewalk.common.rhnTB import Traceback
 from spacewalk.common.rhnException import rhnFault, rhnException
 from spacewalk.common import rhnFlags, apache
-from uyuni.common.rhnLib import setHeaderValue
 from spacewalk.common import byterange
-
 from rhn import rpclib, connections
 from rhn.UserDictCase import UserDictCase
+from uyuni.common.rhnLib import setHeaderValue
+from proxy.rhnProxyAuth import get_proxy_auth
+
+
 from .rhnConstants import HEADER_ACTUAL_URI, HEADER_EFFECTIVE_URI, \
     HEADER_CHECKSUM, SCHEME_HTTP, SCHEME_HTTPS, URI_PREFIX_KS, \
     URI_PREFIX_KS_CHECKSUM, COMPONENT_BROKER, COMPONENT_REDIRECT
 
-# local imports
-from proxy.rhnProxyAuth import get_proxy_auth
+from .broker import rhnBroker
+from .redirect import rhnRedirect
 
 
 def getComponentType(req):
@@ -317,7 +319,7 @@ class apacheHandler(rhnApache):
         uriParts = oldURI.split('/')
         numParts = 0
         for part in uriParts:
-            if len(part) is not 0:  # Account for double slashes ("//")
+            if len(part) != 0:  # Account for double slashes ("//")
                 numParts += 1
                 if numParts > 2:
                     newURI += "/" + part
@@ -357,11 +359,9 @@ class apacheHandler(rhnApache):
         log_debug(4, "Component", self._component)
 
         if self._component == COMPONENT_BROKER:
-            from .broker import rhnBroker
             handlerObj = rhnBroker.BrokerHandler(req)
         else:
             # Redirect
-            from .redirect import rhnRedirect
             handlerObj = rhnRedirect.RedirectHandler(req)
 
         try:
@@ -586,7 +586,7 @@ class apacheHandler(rhnApache):
     @staticmethod
     def _response_fault_get(req, response):
         req.headers_out["X-RHN-Fault-Code"] = str(response.faultCode)
-        faultString = base64.encodestring(response.faultString.encode()).decode().strip()
+        faultString = base64.encodestring(response.faultString.encode()).decode().strip() # pylint: disable=deprecated-method
         # Split the faultString into multiple lines
         for line in faultString.split('\n'):
             req.headers_out.add("X-RHN-Fault-String", line.strip())

--- a/proxy/proxy/apacheServer.py
+++ b/proxy/proxy/apacheServer.py
@@ -20,6 +20,8 @@ from spacewalk.common.rhnLog import initLOG, log_setreq, log_debug
 from spacewalk.common.rhnTB import Traceback
 from spacewalk.common import apache
 
+from .apacheHandler import apacheHandler
+from .apacheHandler import getComponentType
 
 class HandlerWrap:
 
@@ -38,7 +40,6 @@ class HandlerWrap:
         #       req object.
 
         if self.__init:
-            from .apacheHandler import getComponentType
             # We cannot trust the config files to tell us if we are in the
             # broker or in the redirect because we try to always pass
             # upstream all requests
@@ -73,7 +74,6 @@ class HandlerWrap:
     @staticmethod
     def get_handler_factory(_req):
         """ Handler factory. Redefine in your subclasses if so choose """
-        from .apacheHandler import apacheHandler
         return apacheHandler
 
 

--- a/proxy/proxy/broker/rhnBroker.py
+++ b/proxy/proxy/broker/rhnBroker.py
@@ -28,19 +28,19 @@ except ImportError:
 
 # common module imports
 from rhn.UserDictCase import UserDictCase
-from uyuni.common.rhnLib import parseUrl
 from spacewalk.common.rhnConfig import CFG
 from spacewalk.common.rhnLog import log_debug, log_error
 from spacewalk.common.rhnException import rhnFault
 from spacewalk.common import rhnFlags, apache
 from spacewalk.common.rhnTranslate import _
 from spacewalk.common import suseLib
+from uyuni.common.rhnLib import parseUrl
 
 # local module imports
 from proxy.rhnShared import SharedHandler
 from proxy.rhnConstants import URI_PREFIX_KS_CHECKSUM
-from . import rhnRepository
 import proxy.rhnProxyAuth
+from . import rhnRepository
 
 
 # the version should not be never decreased, never mind that spacewalk has different versioning
@@ -332,7 +332,7 @@ class BrokerHandler(SharedHandler):
                              "Please contact your system administrator."))
 
         # Support for yum byte-range
-        if (status != apache.OK) and (status != apache.HTTP_PARTIAL_CONTENT):
+        if status not in (apache.OK, apache.HTTP_PARTIAL_CONTENT):
             log_debug(1, "Leaving handler with status code %s" % status)
             return status
 
@@ -517,7 +517,7 @@ class BrokerHandler(SharedHandler):
             log_debug(3, "Client server ID not found in headers")
             # XXX: no client server ID in headers, should we care?
             #raise rhnFault(1000, _("Client Server ID not found in headers!"))
-            return
+            return None
         serverId = 'X-RHN-Server-ID'
 
         self.clientServerId = headers[serverId]

--- a/proxy/proxy/broker/rhnBroker.py
+++ b/proxy/proxy/broker/rhnBroker.py
@@ -313,14 +313,14 @@ class BrokerHandler(SharedHandler):
                 log_debug(0, msg)
             elif error == '1004':
                 log_debug(1,
-                    "SUSE Manager Proxy Session Token expired, acquiring new one.")
+                          "SUSE Manager Proxy Session Token expired, acquiring new one.")
             else: # this should never happen.
                 msg = "SUSE Manager Proxy login failed, error code is %s" % error
                 log_error(msg)
                 log_debug(0, msg)
                 raise rhnFault(1000,
-                  _("SUSE Manager Proxy error (issues with proxy login). "
-                    "Please contact your system administrator."))
+                               _("SUSE Manager Proxy error (issues with proxy login). "
+                                 "Please contact your system administrator."))
 
             # Forced refresh of the proxy token
             rhnFlags.get('outputTransportOptions')['X-RHN-Proxy-Auth'] = self.proxyAuth.check_cached_token(1)
@@ -328,8 +328,8 @@ class BrokerHandler(SharedHandler):
             # The token could not be aquired
             log_debug(0, "Unable to acquire proxy authentication token")
             raise rhnFault(1000,
-              _("SUSE Manager Proxy error (unable to acquire proxy auth token). "
-                "Please contact your system administrator."))
+                           _("SUSE Manager Proxy error (unable to acquire proxy auth token). "
+                             "Please contact your system administrator."))
 
         # Support for yum byte-range
         if (status != apache.OK) and (status != apache.HTTP_PARTIAL_CONTENT):

--- a/proxy/proxy/broker/rhnRepository.py
+++ b/proxy/proxy/broker/rhnRepository.py
@@ -145,7 +145,7 @@ class Repository(rhnRepository.Repository):
                 pkgFilename, self.channelName, self.clientInfo)
         except xmlrpclib.Fault as e:
             raise_with_tb(rhnFault(1000,
-                           _("Error retrieving source package: %s") % str(e)), sys.exc_info()[2])
+                                   _("Error retrieving source package: %s") % str(e)), sys.exc_info()[2])
 
         if not retval:
             raise rhnFault(17, _("Invalid SRPM package requested: %s")
@@ -239,7 +239,7 @@ class Repository(rhnRepository.Repository):
         except xmlrpclib.ProtocolError as e:
             errcode, errmsg = rpclib.reportError(e.headers)
             raise_with_tb(rhnFault(1000, "SpacewalkProxy error (xmlrpclib.ProtocolError): "
-                           "errode=%s; errmsg=%s" % (errcode, errmsg)), sys.exc_info()[2])
+                                   "errode=%s; errmsg=%s" % (errcode, errmsg)), sys.exc_info()[2])
 
         # Hash the list
         _hash = {}

--- a/proxy/proxy/broker/rhnRepository.py
+++ b/proxy/proxy/broker/rhnRepository.py
@@ -28,7 +28,6 @@ except ImportError:
     # python 2
     import cPickle
 import sys
-import types
 from operator import truth
 try:
     #  python 2
@@ -37,17 +36,17 @@ except ImportError:
     #  python3
     import xmlrpc.client as xmlrpclib
 
+## local imports
+from rhn import rpclib
 ## common imports
-from uyuni.common.rhnLib import parseRPMName
 from spacewalk.common.rhnLog import log_debug
 from spacewalk.common.rhnException import rhnFault
 from spacewalk.common.rhnConfig import CFG
 from spacewalk.common import rhnRepository
 from spacewalk.common.rhnTranslate import _
+from uyuni.common.rhnLib import parseRPMName
 from uyuni.common.usix import raise_with_tb
 
-## local imports
-from rhn import rpclib
 
 
 PKG_LIST_DIR = os.path.join(CFG.PKG_DIR, 'list')
@@ -81,7 +80,7 @@ class Repository(rhnRepository.Repository):
         self.httpProxyPassword = httpProxyPassword
         self.caChain = caChain
 
-    def getPackagePath(self, pkgFilename, redirect=0):
+    def getPackagePath(self, pkgFilename, redirect=0): # pylint: disable=unused-argument
         """ OVERLOADS getPackagePath in common/rhnRepository.
             Returns complete path to an RPM file.
         """

--- a/proxy/proxy/pm/rhn_package_manager.py
+++ b/proxy/proxy/pm/rhn_package_manager.py
@@ -45,7 +45,7 @@ try:
 except ImportError:
     #  python3
     import xmlrpc.client as xmlrpclib
-from optparse import Option, OptionParser
+from optparse import Option, OptionParser # pylint: disable=deprecated-module
 
 # RHN imports
 from spacewalk.common.rhnConfig import CFG, initCFG
@@ -98,7 +98,8 @@ def main():
     # Process the command line arguments
     optionParser = OptionParser(option_list=optionsTable, usage="USAGE: %prog [OPTION] [<package>]")
     options, files = optionParser.parse_args()
-    upload = UploadClass(options, files=files)
+    # Below line needs fixing. Together with replacement of optparse.
+    upload = UploadClass(options, files=files) # pylint: disable=too-many-function-args,unexpected-keyword-arg
 
     if options.usage:
         optionParser.print_usage()

--- a/proxy/proxy/redirect/rhnRedirect.py
+++ b/proxy/proxy/redirect/rhnRedirect.py
@@ -29,10 +29,8 @@ from spacewalk.common.rhnConfig import CFG
 from spacewalk.common.rhnLog import log_debug, log_error
 from spacewalk.common.rhnTB import Traceback
 from spacewalk.common import rhnFlags, apache
-from uyuni.common import rhnLib
-
-# rhnlib imports
 from rhn import connections
+from uyuni.common import rhnLib
 
 # local module imports
 from proxy.rhnShared import SharedHandler
@@ -95,7 +93,7 @@ class RedirectHandler(SharedHandler):
 
         log_debug(4, 'Initiating communication with server...')
         status = self._serverCommo()       # part 2
-        if (status != apache.OK) and (status != apache.HTTP_PARTIAL_CONTENT):
+        if status not in (apache.OK, apache.HTTP_PARTIAL_CONTENT):
             log_debug(3, "Leaving handler with status code %s" % status)
             return status
 
@@ -114,8 +112,7 @@ class RedirectHandler(SharedHandler):
         # In case of a 302, redirect the original request to the location
         # specified in the response.
 
-        if status == apache.HTTP_MOVED_TEMPORARILY or \
-           status == apache.HTTP_MOVED_PERMANENTLY:
+        if status in (apache.HTTP_MOVED_TEMPORARILY, apache.HTTP_MOVED_PERMANENTLY):
 
             log_debug(1, "Received redirect response: ", status)
 
@@ -147,8 +144,7 @@ class RedirectHandler(SharedHandler):
             #
             # We'll keep redirecting until we've received HTTP_OK or an error.
 
-            while redirectStatus == apache.HTTP_MOVED_PERMANENTLY or \
-                    redirectStatus == apache.HTTP_MOVED_TEMPORARILY:
+            while redirectStatus in (apache.HTTP_MOVED_PERMANENTLY, apache.HTTP_MOVED_TEMPORARILY):
 
                 # We've been told to redirect again.  We'll pass a special
                 # argument to ensure that if we end up back at the server, we
@@ -157,7 +153,7 @@ class RedirectHandler(SharedHandler):
                 log_debug(1, "Redirected again!  Code=", redirectStatus)
                 redirectStatus = self.__redirectToNextLocation(True)
 
-            if (redirectStatus != apache.HTTP_OK) and (redirectStatus != apache.HTTP_PARTIAL_CONTENT):
+            if redirectStatus not in (apache.HTTP_OK, apache.HTTP_PARTIAL_CONTENT):
 
                 # We must have run out of retry attempts.  Fail over to Hosted
                 # to perform the request.
@@ -360,7 +356,7 @@ class RedirectHandler(SharedHandler):
             # will be closed when the caller pops the context.
             return apache.HTTP_SERVICE_UNAVAILABLE
 
-        except socket.error as se:
+        except socket.error as se: # pylint: disable=duplicate-except
             # Some socket error occurred.  Possibly a read error.
             log_error("Redirect request failed.", redirectLocation, se)
             Traceback(mail=0)

--- a/proxy/proxy/rhnAuthCacheClient.py
+++ b/proxy/proxy/rhnAuthCacheClient.py
@@ -18,7 +18,9 @@
 # in this software or its documentation.
 #-------------------------------------------------------------------------------
 
-## language imports
+# Module new has been removed in future Python versions. This needs to be adapted.
+import new # pylint: disable=import-error
+
 import socket
 import sys
 try:
@@ -167,7 +169,6 @@ class Shelf:
                 raise
 
             # Instantiate the exception object
-            import new
             _dict = {'args': args}
             # pylint: disable=bad-option-value,nonstandard-exception
             raise_with_tb(new.instance(getattr(__builtins__, name), _dict), sys.exc_info()[2])

--- a/proxy/proxy/rhnAuthProtocol.py
+++ b/proxy/proxy/rhnAuthProtocol.py
@@ -48,7 +48,7 @@ def readSocket(fd, n):
     return result
 
 
-def send(fd, methodname=None, fault=None, *params):
+def send(fd, *params, methodname=None, fault=None):
     if methodname:
         buff = dumps(params, methodname=methodname)
     elif fault:

--- a/proxy/proxy/rhnProxyAuth.py
+++ b/proxy/proxy/rhnProxyAuth.py
@@ -89,8 +89,8 @@ class ProxyAuth:
         if not os.access(ProxyAuth.__systemid_filename, os.R_OK):
             log_error("unable to access %s" % ProxyAuth.__systemid_filename)
             raise rhnFault(1000,
-                      _("SUSE Manager Proxy error (SUSE Manager Proxy systemid has wrong permissions?). "
-                        "Please contact your system administrator."))
+                           _("SUSE Manager Proxy error (SUSE Manager Proxy systemid has wrong permissions?). "
+                             "Please contact your system administrator."))
 
         mtime = None
         try:
@@ -98,8 +98,8 @@ class ProxyAuth:
         except IOError as e:
             log_error("unable to stat %s: %s" % (ProxyAuth.__systemid_filename, repr(e)))
             raise_with_tb(rhnFault(1000,
-                      _("SUSE Manager Proxy error (SUSE Manager Proxy systemid has wrong permissions?). "
-                        "Please contact your system administrator.")), sys.exc_info()[2])
+                                   _("SUSE Manager Proxy error (SUSE Manager Proxy systemid has wrong permissions?). "
+                                     "Please contact your system administrator.")), sys.exc_info()[2])
 
         if not self.__systemid_mtime:
             ProxyAuth.__systemid_mtime = mtime
@@ -115,8 +115,8 @@ class ProxyAuth:
         except IOError as e:
             log_error("unable to read %s" % ProxyAuth.__systemid_filename)
             raise_with_tb(rhnFault(1000,
-                      _("SUSE Manager Proxy error (SUSE Manager Proxy systemid has wrong permissions?). "
-                        "Please contact your system administrator.")), sys.exc_info()[2])
+                                   _("SUSE Manager Proxy error (SUSE Manager Proxy systemid has wrong permissions?). "
+                                     "Please contact your system administrator.")), sys.exc_info()[2])
 
         # get serverid
         sysid, _cruft = xmlrpclib.loads(ProxyAuth.__systemid)
@@ -175,8 +175,8 @@ problems, isn't running, or the token is somehow corrupt.
 """) % self.__serverid
             Traceback("ProxyAuth.set_cached_token", extra=text)
             raise_with_tb(rhnFault(1000,
-                      _("SUSE Manager Proxy error (auth caching issue). "
-                        "Please contact your system administrator.")), sys.exc_info()[2])
+                                   _("SUSE Manager Proxy error (auth caching issue). "
+                                     "Please contact your system administrator.")), sys.exc_info()[2])
         log_debug(4, "successfully returning")
         return token
 
@@ -317,8 +317,8 @@ problems, isn't running, or the token is somehow corrupt.
                 # And raise a Proxy Error - the server made its point loud and
                 # clear
                 raise_with_tb(rhnFault(1000,
-                          _("SUSE Manager Proxy error (during proxy login). "
-                            "Please contact your system administrator.")), sys.exc_info()[2])
+                                       _("SUSE Manager Proxy error (during proxy login). "
+                                         "Please contact your system administrator.")), sys.exc_info()[2])
             except Exception as e:
                 token = None
                 log_error("Unhandled exception", e)
@@ -332,12 +332,12 @@ problems, isn't running, or the token is somehow corrupt.
             if error:
                 if error[0] in ('xmlrpclib.ProtocolError', 'socket.error', 'socket'):
                     raise rhnFault(1000,
-                                _("SUSE Manager Proxy error (error: %s). "
-                                  "Please contact your system administrator.") % error[0])
+                                   _("SUSE Manager Proxy error (error: %s). "
+                                     "Please contact your system administrator.") % error[0])
                 if error[0] in ('rhn.SSL.SSL.SSLError', 'socket.sslerror'):
                     raise rhnFault(1000,
-                                _("SUSE Manager Proxy error (SSL issues? Error: %s). "
-                                  "Please contact your system administrator.") % error[0])
+                                   _("SUSE Manager Proxy error (SSL issues? Error: %s). "
+                                     "Please contact your system administrator.") % error[0])
                 else:
                     raise rhnFault(1002, err_text='%s' % e)
             else:
@@ -416,9 +416,9 @@ problems, isn't running, or the token is somehow corrupt.
             if not os.access(CFG.CA_CHAIN, os.R_OK):
                 log_error('ERROR: missing or cannot access (for ca_chain): %s' % CFG.CA_CHAIN)
                 raise rhnFault(1000,
-                          _("SUSE Manager Proxy error (file access issues). "
-                            "Please contact your system administrator. "
-                            "Please refer to SUSE Manager Proxy logs."))
+                               _("SUSE Manager Proxy error (file access issues). "
+                                 "Please contact your system administrator. "
+                                 "Please refer to SUSE Manager Proxy logs."))
             serverObj.add_trusted_cert(CFG.CA_CHAIN)
         serverObj.add_header('X-RHN-Client-Version', 2)
         return serverObj

--- a/proxy/proxy/rhnProxyAuth.py
+++ b/proxy/proxy/rhnProxyAuth.py
@@ -29,28 +29,24 @@ import sys
 # pylint: disable=E0611
 from hashlib import sha1
 
-# common imports
-from uyuni.common.rhnLib import parseUrl
+#sys.path.append('/usr/share/rhn')
+from rhn import rpclib
+from rhn import SSL
 from spacewalk.common.rhnTB import Traceback
 from spacewalk.common.rhnLog import log_debug, log_error
 from spacewalk.common.rhnConfig import CFG
 from spacewalk.common.rhnException import rhnFault
 from spacewalk.common import rhnCache
 from spacewalk.common.rhnTranslate import _
+from up2date_client import config # pylint: disable=E0012, C0413
+from uyuni.common.rhnLib import parseUrl
 from uyuni.common.usix import raise_with_tb
-
-# local imports
-from rhn import rpclib
-from rhn import SSL
 from . import rhnAuthCacheClient
 
 if hasattr(socket, 'sslerror'):
-    socket_error = socket.sslerror
+    socket_error = socket.sslerror # pylint: disable=no-member
 else:
     from ssl import socket_error
-
-sys.path.append('/usr/share/rhn')
-from up2date_client import config # pylint: disable=E0012, C0413
 
 # To avoid doing unnecessary work, keep ProxyAuth object global
 __PROXY_AUTH = None
@@ -123,7 +119,7 @@ class ProxyAuth:
         ProxyAuth.__serverid = sysid[0]['system_id'][3:]
 
         log_debug(7, 'SystemId: "%s[...snip  snip...]%s"'
-                  % (ProxyAuth.__systemid[:20], ProxyAuth.__systemid[-20:]))
+                  % (ProxyAuth.__systemid[:20], ProxyAuth.__systemid[-20:])) # pylint: disable=unsubscriptable-object
         log_debug(7, 'ServerId: %s' % ProxyAuth.__serverid)
 
         # ids were updated
@@ -167,7 +163,7 @@ class ProxyAuth:
         # Cache the token.
         try:
             shelf[self.__cache_proxy_key()] = token
-        except:
+        except: # pylint: disable=bare-except
             text = _("""\
 Caching of authentication token for proxy id %s failed!
 Either the authentication caching daemon is experiencing
@@ -270,7 +266,7 @@ problems, isn't running, or the token is somehow corrupt.
                         # rather big problem: http proxy not running.
                         log_error("*** ERROR ***: %s" % error[1])
                         Traceback(mail=0)
-                    except socket_error as e:
+                    except socket_error as e:                             # pylint: disable=duplicate-except
                         error = ['socket.sslerror',
                                  '(%s) %s' % (CFG.HTTP_PROXY, e)]
                         # rather big problem: http proxy not running.
@@ -319,7 +315,7 @@ problems, isn't running, or the token is somehow corrupt.
                 raise_with_tb(rhnFault(1000,
                                        _("SUSE Manager Proxy error (during proxy login). "
                                          "Please contact your system administrator.")), sys.exc_info()[2])
-            except Exception as e:
+            except Exception as e: # pylint: disable=broad-except
                 token = None
                 log_error("Unhandled exception", e)
                 Traceback(mail=0)
@@ -338,10 +334,8 @@ problems, isn't running, or the token is somehow corrupt.
                     raise rhnFault(1000,
                                    _("SUSE Manager Proxy error (SSL issues? Error: %s). "
                                      "Please contact your system administrator.") % error[0])
-                else:
-                    raise rhnFault(1002, err_text='%s' % e)
-            else:
-                raise rhnFault(1001)
+                raise rhnFault(1002, err_text='%s' % e)
+            raise rhnFault(1001)
         if self.hostname:
             token = token + ':' + self.hostname
         log_debug(6, "New proxy token: %s" % token)
@@ -471,8 +465,7 @@ class AuthLocalBackend:
         if not os.path.normpath(key_path).startswith(self._cache_prefix):
             raise ValueError("Path traversal detected for X-RHN-Server-ID. " +
                              "User is trying to set a path as server-id.")
-        else:
-            return key_path
+        return key_path
 
     def __len__(self):
         pass

--- a/proxy/proxy/rhnShared.py
+++ b/proxy/proxy/rhnShared.py
@@ -232,7 +232,7 @@ class SharedHandler:
             Traceback("SharedHandler._serverCommo", self.req, mail=0)
             raise_with_tb(rhnFault(1000, _(
                 "SUSE Manager Proxy error: connection with the SUSE Manager server failed")), sys.exc_info()[2])
-        except socket.error:
+        except socket.error: # pylint: disable=duplicate-except
             # maybe self.req.read() failed?
             Traceback("SharedHandler._serverCommo", self.req)
             raise_with_tb(rhnFault(1000, _(
@@ -252,7 +252,7 @@ class SharedHandler:
             and send them back to the client with an error status.  This method
             should return apache.OK if everything went according to plan.
         """
-        if (status != apache.HTTP_OK) and (status != apache.HTTP_PARTIAL_CONTENT):
+        if status not in (apache.HTTP_OK, apache.HTTP_PARTIAL_CONTENT):
             # Non 200 response; have to treat it differently
             log_debug(2, "Forwarding status %s" % status)
             # Copy the incoming headers to headers_out

--- a/proxy/proxy/rhnShared.py
+++ b/proxy/proxy/rhnShared.py
@@ -147,8 +147,8 @@ class SharedHandler:
             log_error("Error opening connection", self.rhnParent, e)
             Traceback(mail=0)
             raise_with_tb(rhnFault(1000,
-                           _("SUSE Manager Proxy could not successfully connect its SUSE Manager parent. "
-                             "Please contact your system administrator.")), sys.exc_info()[2])
+                                   _("SUSE Manager Proxy could not successfully connect its SUSE Manager parent. "
+                                     "Please contact your system administrator.")), sys.exc_info()[2])
 
         # At this point the server should be okay
         log_debug(3, "Connected to parent: %s " % self.rhnParent)

--- a/proxy/proxy/spacewalk-proxy.changes
+++ b/proxy/proxy/spacewalk-proxy.changes
@@ -1,3 +1,4 @@
+- Fix build on Enterprise Linux
 - Fix traceback on handling sslerror (bsc#1187673)
 - Bump version to 4.3.0
 

--- a/proxy/proxy/spacewalk-proxy.changes
+++ b/proxy/proxy/spacewalk-proxy.changes
@@ -1,3 +1,4 @@
+- Modified for pylint pass.
 - Fix build on Enterprise Linux
 - Fix traceback on handling sslerror (bsc#1187673)
 - Bump version to 4.3.0

--- a/proxy/proxy/spacewalk-proxy.spec
+++ b/proxy/proxy/spacewalk-proxy.spec
@@ -95,11 +95,12 @@ Requires:       spacewalk-ssl-cert-check
 %if 0%{?suse_version}
 Requires:       apache2-prefork
 Requires:       http_proxy
+Requires:       apache2-mod_wsgi-python3
 %else
 Requires:       mod_ssl
 Requires:       squid
+Requires:       python3-mod_wsgi
 %endif
-Requires:       apache2-mod_wsgi-python3
 Requires(post): %{name}-common
 Conflicts:      %{name}-redirect < %{version}-%{release}
 Conflicts:      %{name}-redirect > %{version}-%{release}
@@ -137,11 +138,13 @@ Requires(pre):  uyuni-base-common
 BuildRequires:  uyuni-base-common
 %if 0%{?suse_version}
 BuildRequires:  apache2
+Requires:       apache2-mod_wsgi-python3
 %else
+BuildRequires:  httpd
 Requires:       mod_ssl
+Requires:       python3-mod_wsgi
 %endif
 Requires:       %{name}-broker >= %{version}
-Requires:       apache2-mod_wsgi-python3
 Requires:       curl
 Requires:       spacewalk-backend >= 1.7.24
 Requires(pre):  policycoreutils
@@ -220,7 +223,11 @@ touch $RPM_BUILD_ROOT/%{httpdconf}/cobbler-proxy.conf
 ln -sf rhn-proxy $RPM_BUILD_ROOT%{_sbindir}/spacewalk-proxy
 
 pushd %{buildroot}
+%if 0%{?suse_version}
 %py3_compile -O %{buildroot}
+%else
+%py_byte_compile %{python3} %{buildroot}
+%endif
 popd
 
 install -m 0750 salt-broker/salt-broker %{buildroot}/%{_bindir}/


### PR DESCRIPTION
## What does this PR change?

Multiple changes to spacewalk-proxy and spacewalk-proxy-installer packages to build on Enterprise Linux 8.

- Python modifications to pass pylint.
- Spec file adaptions and improvements.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered
Part of build process. Pylint tests on RHEL based systems.

spacewalk-proxy build tested ok on
 opensuse-leap-15.3-x86_64 

spacewalk-proxy-installer build tested ok  with PR #4039 (running pylint) for
 epel-8-x86_64 
 opensuse-leap-15.3-x86_64 

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
