### PR TITLE
Proxy: Add second refresh pattern for repodata

### DIFF
--- a/proxy/installer/spacewalk-proxy-installer.changes
+++ b/proxy/installer/spacewalk-proxy-installer.changes
@@ -1,3 +1,5 @@
+- Add new refresh_pattern to the squid.conf to fix a case where the repodata
+  was invalid due to being cached (bsc#1186026)
 - Bump version to 4.3.0
 
 -------------------------------------------------------------------

--- a/proxy/installer/squid.conf
+++ b/proxy/installer/squid.conf
@@ -24,6 +24,7 @@ memory_replacement_policy heap GDSF
 
 # cache repodata only few minutes and then query parent whether it is fresh
 refresh_pattern /XMLRPC/GET-REQ/.*/repodata/.*$ 0 1% 1440 reload-into-ims refresh-ims
+refresh_pattern /ks/.*/repodata/.*$ 0 1% 1440 reload-into-ims refresh-ims
 # salt minions get the repodata via a different URL
 refresh_pattern /rhn/manager/download/.*/repodata/.*$ 0 1% 1440 reload-into-ims refresh-ims
 # bootstrap repos needs to be handled as well


### PR DESCRIPTION
## What does this PR change?

This is required to not fetch out of data repodata. Change was suggested by @jmozd.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/14875
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
