### PR TITLE
Ensure XMLRPC returns "issue_date" in ISO format when listing erratas (bsc#1188260)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/dto/ErrataOverview.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/ErrataOverview.java
@@ -274,7 +274,7 @@ public class ErrataOverview extends BaseDto {
      * @throws ParseException when issueDateIn can't be parsed
      */
     public void setIssueDate(String issueDateIn) throws ParseException {
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-mm-dd");
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
         issueDate = sdf.parse(issueDateIn);
     }
     /**

--- a/java/code/src/com/redhat/rhn/frontend/dto/ErrataOverview.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/ErrataOverview.java
@@ -227,6 +227,16 @@ public class ErrataOverview extends BaseDto {
         return LocalizationService.getInstance().formatShortDate(updateDate);
     }
     /**
+     * @return Returns the advisoryLastUpdated in ISO format (YYYY-MM-DD).
+     */
+    public String getUpdateDateIsoFormat() {
+        if (updateDate == null) {
+            return null;
+        }
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+        return sdf.format(updateDate);
+    }
+    /**
      * @return Returns the advisoryLastUpdated.
      */
     public Date getUpdateDateObj() {

--- a/java/code/src/com/redhat/rhn/frontend/dto/ErrataOverview.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/ErrataOverview.java
@@ -248,6 +248,16 @@ public class ErrataOverview extends BaseDto {
         return LocalizationService.getInstance().formatShortDate(issueDate);
     }
     /**
+     * @return Returns the issueDate in ISO format (YYYY-MM-DD).
+     */
+    public String getIssueDateIsoFormat() {
+        if (issueDate == null) {
+            return null;
+        }
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+        return sdf.format(issueDate);
+    }
+    /**
      * @return Returns the advisoryLastUpdated.
      */
     public Date getIssueDateObj() {

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/ErrataOverviewSerializer.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/ErrataOverviewSerializer.java
@@ -61,8 +61,8 @@ public class ErrataOverviewSerializer extends RhnXmlRpcCustomSerializer {
 
         helper.add("id", errata.getId());
         helper.add("issue_date", errata.getIssueDateIsoFormat());
-        helper.add("date", errata.getUpdateDate());
-        helper.add("update_date", errata.getUpdateDate());
+        helper.add("date", errata.getUpdateDateIsoFormat());
+        helper.add("update_date", errata.getUpdateDateIsoFormat());
         helper.add("advisory_synopsis", errata.getAdvisorySynopsis());
         helper.add("advisory_type", errata.getAdvisoryType());
         helper.add("advisory_status", errata.getAdvisoryStatus().getMetadataValue());

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/ErrataOverviewSerializer.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/ErrataOverviewSerializer.java
@@ -60,7 +60,7 @@ public class ErrataOverviewSerializer extends RhnXmlRpcCustomSerializer {
         SerializerHelper helper = new SerializerHelper(serializer);
 
         helper.add("id", errata.getId());
-        helper.add("issue_date", errata.getIssueDate());
+        helper.add("issue_date", errata.getIssueDateIsoFormat());
         helper.add("date", errata.getUpdateDate());
         helper.add("update_date", errata.getUpdateDate());
         helper.add("advisory_synopsis", errata.getAdvisorySynopsis());

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Ensure XMLRPC returns 'issue_date' in ISO format when listing erratas (bsc#1188260)
 - Fix NullPointerException in HardwareMapper.getUpdatedGuestMemory
 - Fix entitlements not being updated during system transfer (bsc#1188032)
 - Simplify the VM creation action in DB


### PR DESCRIPTION
## What does this PR change?

We got a report of a traceback when calling `softwarechannel_errata_merge` command of "spacecmd":

```
# spacecmd softwarechannel_errata_merge sle-module-basesystem15-sp3-updates-x86_64 testchannel
ERROR: time data '1/24/19' does not match format '%Y-%m-%d'
```

The logic on "spacecmd" is expecting the "issue_date" for the erratas listed using the XMLRPC are returned in ISO format, but this is not the currently the case. At the moment the "issue_date" format is different depending on the locale configuration of the Uyuni web UI.

This is not what we should expect from the XMLRPC where we probably want a fixed format for the dates.

So, this PR fixes the `ErrataOverviewSerializer` to ensure the "Date" attributes are returned in ISO format and not as the format defined by the locale configuration on the Uyuni server. This way, `spacecmd softwarechannel_errata_merge` is able to run successfully.

Additonally this PR fixes another issue with a wrong format in `Errata.setIssueDate` where "month" was messed with "minute".

Java / XMLRPC API experts, do you think this is the way to do it? Thanks

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/15383

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
