### PR TITLE
Check certs auto-update for Salt >= 3002 only

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/certs/SLES12.sls
+++ b/susemanager-utils/susemanager-sls/salt/certs/SLES12.sls
@@ -9,7 +9,9 @@ update-ca-certificates:
     - runas: root
     - onchanges:
       - file: /etc/pki/trust/anchors/RHN-ORG-TRUSTED-SSL-CERT
+{%- if grains['saltversioninfo'][0] >= 3002 %} # Workaround for bsc#1188641
     - unless:
       - fun: service.status
         args:
           - ca-certificates.path
+{%- endif %}


### PR DESCRIPTION
Follow-up to: https://github.com/uyuni-project/uyuni/pull/4019

Salt 3000 has a [bug](https://bugzilla.suse.com/1188641) with `unless` requisite together with execution modules. This PR is a workaround to this case.

See: https://bugzilla.suse.com/1188641

## Test coverage
- No tests: already covered

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
