### PR TITLE
Fix NPE in HardwareMapper

### DIFF
--- a/java/code/src/com/suse/manager/reactor/hardware/HardwareMapper.java
+++ b/java/code/src/com/suse/manager/reactor/hardware/HardwareMapper.java
@@ -559,8 +559,8 @@ public class HardwareMapper {
                 virtualInstance.getHostSystem().hasEntitlement(EntitlementManager.FOREIGN);
         long newMemory = memory;
         // Only foreign system (s390 and VHM) and systems with no memory set should have updated memory
-        if (!isForeign && 0 != virtualInstance.getTotalMemory() &&
-                virtualInstance.getTotalMemory() != null) {
+        if (!isForeign && virtualInstance.getTotalMemory() != null &&
+                0 != virtualInstance.getTotalMemory()) {
             newMemory = virtualInstance.getTotalMemory();
         }
         return newMemory;

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix NullPointerException in HardwareMapper.getUpdatedGuestMemory
 - Fix entitlements not being updated during system transfer (bsc#1188032)
 - Simplify the VM creation action in DB
 - Refresh virtual host pillar to clear the virtpoller beacon (bsc#1188393)


### PR DESCRIPTION
## What does this PR change?

Fix this `NullPointerException`:

```
2021-07-23 14:18:14,338 [salt-event-thread-7] ERROR com.suse.manager.reactor.PGEventListener - Unexpected exception while executing a MessageAction
java.lang.NullPointerException
        at com.suse.manager.reactor.hardware.HardwareMapper.getUpdatedGuestMemory(HardwareMapper.java:562)
        at com.suse.manager.reactor.hardware.HardwareMapper.updateVirtualInstance(HardwareMapper.java:698)
        at com.suse.manager.reactor.hardware.HardwareMapper.lambda$mapVirtualizationInfo$5(HardwareMapper.java:683)
        at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
        at com.suse.manager.reactor.hardware.HardwareMapper.mapVirtualizationInfo(HardwareMapper.java:682)
        at com.suse.manager.utils.SaltUtils.handleHardwareProfileUpdate(SaltUtils.java:1724)
        at com.suse.manager.utils.SaltUtils.lambda$updateServerAction$24(SaltUtils.java:647)
        at java.base/java.util.Optional.ifPresent(Optional.java:183)
        at com.suse.manager.utils.SaltUtils.updateServerAction(SaltUtils.java:646)
        at com.suse.manager.webui.services.SaltServerActionService.lambda$handleAction$157(SaltServerActionService.java:2680)
        at java.base/java.util.Optional.ifPresent(Optional.java:183)
        at com.suse.manager.webui.services.SaltServerActionService.lambda$handleAction$158(SaltServerActionService.java:2654)
```

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered
- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
