### PR TITLE
spacewalk-X-pylint: Detect pylint executable with minor python version in name

### DIFF
--- a/spacewalk/pylint/spacewalk-pylint
+++ b/spacewalk/pylint/spacewalk-pylint
@@ -2,7 +2,7 @@
 
 PYLINTRC='/etc/spacewalk-pylint.rc'
 
-for bin in /usr/bin/pylint /usr/bin/pylint-2 ; do
+for bin in /usr/bin/pylint /usr/bin/pylint-2* ; do
     # check if pylint works (see bz1456049)
     if "$bin" --version 2>/dev/null ; then
         PYLINT="$bin"

--- a/spacewalk/pylint/spacewalk-pylint.changes
+++ b/spacewalk/pylint/spacewalk-pylint.changes
@@ -1,3 +1,4 @@
+- Detect pylint executable with minor python version in name.
 - Bump version to 4.3.0
 
 -------------------------------------------------------------------

--- a/spacewalk/spacewalk-python2-pylint/spacewalk-python2-pylint
+++ b/spacewalk/spacewalk-python2-pylint/spacewalk-python2-pylint
@@ -2,7 +2,7 @@
 
 PYLINTRC='/etc/spacewalk-python2-pylint.rc'
 
-for bin in /usr/bin/pylint-2 ; do
+for bin in /usr/bin/pylint-2* ; do
     # check if pylint works (see bz1456049)
     if "$bin" --version 2>/dev/null ; then
         PYLINT="$bin"

--- a/spacewalk/spacewalk-python2-pylint/spacewalk-python2-pylint.changes
+++ b/spacewalk/spacewalk-python2-pylint/spacewalk-python2-pylint.changes
@@ -1,3 +1,4 @@
+- Detect pylint executable with minor python version in name.
 - Bump version to 4.3.0
 
 -------------------------------------------------------------------

--- a/spacewalk/spacewalk-python3-pylint/spacewalk-python3-pylint
+++ b/spacewalk/spacewalk-python3-pylint/spacewalk-python3-pylint
@@ -2,7 +2,7 @@
 
 PYLINTRC='/etc/spacewalk-python3-pylint.rc'
 
-for bin in /usr/bin/pylint-3 ; do
+for bin in /usr/bin/pylint-3* ; do
     # check if pylint works (see bz1456049)
     if "$bin" --version 2>/dev/null ; then
         PYLINT="$bin"

--- a/spacewalk/spacewalk-python3-pylint/spacewalk-python3-pylint.changes
+++ b/spacewalk/spacewalk-python3-pylint/spacewalk-python3-pylint.changes
@@ -1,3 +1,4 @@
+- Detect pylint executable with minor python version in name.
 - Bump version to 4.3.0
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Currently, pylint is not detected if it does not exist with only the python major version in the executable filename.
Example:

- pylint-2: Detected
- pylint-3: Detected
- pylint-36: Not detected

This change also picks up minor versions or other variations after the major version.

Background: spacewalk-python3-pylint does not run on SUSE Leap.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: Manually tested. Low risk, minor change, easily revertible.

Packages spacewalk-pylint, spacewalk-python2-pylint and spacewalk-python3-pylint build tested successfully on:
 epel-7-x86_64 
 epel-8-x86_64 
 fedora-33-x86_64 
 fedora-rawhide-x86_64 
 opensuse-leap-15.3-x86_64 

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
