### PR TITLE
Add UEFI support for VM creation UI

### DIFF
--- a/java/code/src/com/suse/manager/virtualization/GuestOsDef.java
+++ b/java/code/src/com/suse/manager/virtualization/GuestOsDef.java
@@ -27,6 +27,8 @@ public class GuestOsDef {
     private String arch;
     private String type;
     private String machine;
+    private String uefiLoader;
+    private String nvramTemplate;
 
     /**
      * @return VM architecture
@@ -80,6 +82,34 @@ public class GuestOsDef {
     }
 
     /**
+     * @return value of uefiLoader
+     */
+    public String getUefiLoader() {
+        return uefiLoader;
+    }
+
+    /**
+     * @param uefiLoaderIn value of uefiLoader
+     */
+    public void setUefiLoader(String uefiLoaderIn) {
+        uefiLoader = uefiLoaderIn;
+    }
+
+    /**
+     * @return value of nvramTemplate
+     */
+    public String getNvramTemplate() {
+        return nvramTemplate;
+    }
+
+    /**
+     * @param nvramTemplateIn value of nvramTemplate
+     */
+    public void setNvramTemplate(String nvramTemplateIn) {
+        nvramTemplate = nvramTemplateIn;
+    }
+
+    /**
      * Parse the libvirt &lt;os&gt; element
      *
      * @param element XML element
@@ -94,6 +124,14 @@ public class GuestOsDef {
         def.setType(typeElement.getTextTrim());
         def.setMachine(typeElement.getAttributeValue("machine"));
 
+        Element loaderElement = element.getChild("loader");
+        if (loaderElement != null) {
+            def.setUefiLoader(loaderElement.getTextTrim());
+            Element nvramElement = element.getChild("nvram");
+            if (nvramElement != null) {
+                def.setNvramTemplate(nvramElement.getAttributeValue("template"));
+            }
+        }
         return def;
     }
 

--- a/java/code/src/com/suse/manager/virtualization/VirtualizationActionHelper.java
+++ b/java/code/src/com/suse/manager/virtualization/VirtualizationActionHelper.java
@@ -237,6 +237,9 @@ public class VirtualizationActionHelper {
             details.setKernelOptions(data.getKernelOptions());
             details.setClusterDefinitions(data.getClusterDefinitions());
             details.setTemplate(data.getTemplate());
+            details.setUefi(data.isUefi());
+            details.setUefiLoader(data.getUefiLoader());
+            details.setNvramTemplate(data.getNvramTemplate());
 
             if (name.isEmpty() && data.getCobblerId() != null && !data.getCobblerId().isEmpty()) {
                 // Create cobbler profile

--- a/java/code/src/com/suse/manager/webui/controllers/virtualization/VirtualGuestsController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/virtualization/VirtualGuestsController.java
@@ -394,6 +394,7 @@ public class VirtualGuestsController extends AbstractVirtualizationController {
         data.put("raCanStartResources",
                 features.getOrDefault("resource_agent_start_resources", false));
         data.put("templates", GSON.toJson(templates));
+        data.put("uefiAutoLoader", features.getOrDefault("uefi_auto_loader", false));
 
         KickstartScheduleCommand cmd = new ProvisionVirtualInstanceCommand(host.getId(), user);
         DataResult<KickstartDto> profiles = cmd.getKickstartProfiles();

--- a/java/code/src/com/suse/manager/webui/controllers/virtualization/gson/VirtualGuestsUpdateActionJson.java
+++ b/java/code/src/com/suse/manager/webui/controllers/virtualization/gson/VirtualGuestsUpdateActionJson.java
@@ -41,6 +41,9 @@ public class VirtualGuestsUpdateActionJson extends VirtualGuestsBaseActionJson {
     @SerializedName("cluster_definitions")
     private String clusterDefinitions;
     private String template;
+    private boolean uefi;
+    private String uefiLoader;
+    private String nvramTemplate;
 
     /**
      * @return the domain type (kvm, qemu, linux, xen...)
@@ -222,6 +225,48 @@ public class VirtualGuestsUpdateActionJson extends VirtualGuestsBaseActionJson {
      */
     public void setTemplate(String templateIn) {
         template = templateIn;
+    }
+
+    /**
+     * @return value of uefi
+     */
+    public boolean isUefi() {
+        return uefi;
+    }
+
+    /**
+     * @param uefiIn value of uefi
+     */
+    public void setUefi(boolean uefiIn) {
+        uefi = uefiIn;
+    }
+
+    /**
+     * @return value of uefiLoader
+     */
+    public String getUefiLoader() {
+        return uefiLoader;
+    }
+
+    /**
+     * @param uefiLoaderIn value of uefiLoader
+     */
+    public void setUefiLoader(String uefiLoaderIn) {
+        uefiLoader = uefiLoaderIn;
+    }
+
+    /**
+     * @return value of nvramTemplate
+     */
+    public String getNvramTemplate() {
+        return nvramTemplate;
+    }
+
+    /**
+     * @param nvramTemplateIn value of nvramTemplate
+     */
+    public void setNvramTemplate(String nvramTemplateIn) {
+        nvramTemplate = nvramTemplateIn;
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/templates/virtualization/guests/create.jade
+++ b/java/code/src/com/suse/manager/webui/templates/virtualization/guests/create.jade
@@ -23,6 +23,7 @@ script(type='text/javascript').
                       inCluster: #{inCluster},
                       raCanStartResources: #{raCanStartResources},
                       templates: !{templates}
+                      uefiAutoLoader: #{uefiAutoLoader},
                   },
                   actionChains: !{actionChains},
                   timezone: "#{h.renderTimezone()}",

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add UEFI support for VM creation / editing
 - Add virt-tuner templates to VM creation
 - Ensure XMLRPC returns 'issue_date' in ISO format when listing erratas (bsc#1188260)
 - Fix NullPointerException in HardwareMapper.getUpdatedGuestMemory

--- a/susemanager-utils/susemanager-sls/salt/virt/create-vm.sls
+++ b/susemanager-utils/susemanager-sls/salt/virt/create-vm.sls
@@ -48,6 +48,12 @@ pools-{{ pillar['name'] }}:
         {{ pillar['graphics'] }}
 {%- endmacro %}
 
+{%- macro uefi() %}
+  {%- for param, value in pillar.get("uefi", {}).items() %}
+        {{ param }}: {{ value }}
+  {%- endfor %}
+{%- endmacro %}
+
 {%- set cdrom_boot = pillar.get('boot_dev', 'hd').startswith('cdrom') -%}
 {%- set ks_boot = pillar.get('boot', {}).get('kernel') is not none -%}
 domain_first_boot_define:
@@ -63,6 +69,7 @@ domain_first_boot_define:
         kernel: /tmp/virt/{{ pillar['name'] }}/kernel
         initrd: /tmp/virt/{{ pillar['name'] }}/initrd
         cmdline: {{ pillar['boot']['kopts'] }}
+        {{ uefi() }}
     - require:
       - file: kernel_cached
       - file: initrd_cached
@@ -72,6 +79,9 @@ domain_first_boot_define:
   {%- if 'disks' in pillar %}
       - virt_utils: pools-{{ pillar['name'] }}
   {%- endif %}
+{%- elif "uefi" in pillar %}
+    - boot:
+        {{ uefi() }}
 {%- endif %}
 
 {%- if cdrom_boot or ks_boot %}
@@ -88,6 +98,10 @@ domain_define:
         kernel: null
         initrd: null
         cmdline: null
+        {{ uefi() }}
+{%- elif "uefi" in pillar %}
+    - boot:
+        {{ uefi() }}
 {%- endif %}
     - require:
       - virt: domain_first_boot_define

--- a/susemanager-utils/susemanager-sls/src/grains/virt.py
+++ b/susemanager-utils/susemanager-sls/src/grains/virt.py
@@ -2,9 +2,17 @@
 Grains for virtualization hosts
 """
 
+import logging
 import subprocess
 from xml.etree import ElementTree
 import salt.modules.virt
+
+try:
+    import libvirt
+except ModuleNotFoundError:
+    libvirt = None
+
+log = logging.getLogger(__name__)
 
 
 def __virtual__():
@@ -31,10 +39,22 @@ def features():
     except Exception:
         start_resources_ra = False
 
+    libvirt_version = -1
+    if libvirt is not None:
+        cnx = libvirt.open()
+        try:
+            libvirt_version = cnx.getLibVersion()
+        except libvirt.libvirtError:
+            log.warn("Failed to get libvirt version")
+        finally:
+            cnx.close()
+
     return {
         "virt_features": {
             "enhanced_network": "network_update" in salt.modules.virt.__dict__,
             "cluster": in_cluster,
             "resource_agent_start_resources": start_resources_ra,
+            # Libvirt has the firmware='efi' support since 5.2, but vital fixes came in 5.3 only
+            "uefi_auto_loader": libvirt_version >= 5003000,
         },
     }

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Add UEFI support for VM creation
 - Add virt-tuner templates to VM creation
 - Add missing symlinks to generate the "certs" state for
   SLE Micro 5.0 and openSUSE MicroOS minions (bsc#1188503)

--- a/testsuite/features/secondary/minkvm_guests.feature
+++ b/testsuite/features/secondary/minkvm_guests.feature
@@ -209,6 +209,30 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I click on "Delete" in "Delete Guest" modal
     Then I should not see a "test-vm2" virtual machine on "kvm_server"
 
+  Scenario: Create a KVM UEFI virtual machine
+    When I follow "Create Guest"
+    And I wait until I see "General" text
+    And I enter "test-vm2" as "name"
+    And I enter "/var/testsuite-data/disk-image-template.qcow2" as "disk0_source_template"
+    And I select "test-net0" from "network0_source"
+    And I check "uefi"
+    And I enter "/usr/share/qemu/ovmf-x86_64-ms.bin" as "uefiLoader"
+    And I enter "/usr/share/qemu/ovmf-x86_64-ms-vars.bin" as "nvramTemplate"
+    And I click on "Create"
+    Then I should see a "Hosted Virtual Systems" text
+    When I wait until I see "test-vm2" text
+    And I wait until table row for "test-vm2" contains button "Stop"
+    And "test-vm2" virtual machine on "kvm_server" should have 1024MB memory and 1 vcpus
+    And "test-vm2" virtual machine on "kvm_server" should have 1 NIC using "test-net0" network
+    And "test-vm2" virtual machine on "kvm_server" should have a "test-vm2_system" virtio disk from pool "test-pool0"
+    And "test-vm2" virtual machine on "kvm_server" should be UEFI enabled
+
+  Scenario: delete a running KVM UEFI virtual machine
+    When I follow "Virtualization" in the content area
+    And I click on "Delete" in row "test-vm2"
+    And I click on "Delete" in "Delete Guest" modal
+    Then I should not see a "test-vm2" virtual machine on "kvm_server"
+
   Scenario: Refresh a virtual storage pool for KVM
     When I follow "Storage"
     And I click on "Refresh" in tree item "test-pool0"

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1453,6 +1453,17 @@ Then(/^"([^"]*)" virtual machine on "([^"]*)" should (not stop|stop) on reboot((
   end
 end
 
+Then(/^"([^"]*)" virtual machine on "([^"]*)" should be UEFI enabled$/) do |vm, host|
+  node = get_target(host)
+  output, _code = node.run("virsh dumpxml #{vm}")
+  tree = Nokogiri::XML(output)
+  has_loader = tree.xpath('//os/loader').size == 1
+  has_nvram = tree.xpath('//os/nvram').size == 1
+  unless has_loader && has_nvram
+    raise "No loader and nvram set: not UEFI enabled"
+  end
+end
+
 When(/^I create empty "([^"]*)" qcow2 disk file on "([^"]*)"$/) do |path, host|
   node = get_target(host)
   node.run("qemu-img create -f qcow2 #{path} 1G")

--- a/web/html/src/manager/virtualization/guests/GuestProperties.tsx
+++ b/web/html/src/manager/virtualization/guests/GuestProperties.tsx
@@ -189,6 +189,29 @@ export function GuestProperties(props: Props) {
                                       .filter((item, index, array) => array.indexOf(item) === index)}
                                   />
                                 )}
+                                <Check
+                                  name="uefi"
+                                  label={t('Enable UEFI')}
+                                  divClass="col-md-6 col-md-offset-3"
+                                />
+                                {model["uefi"] && (
+                                  <>
+                                    <Text
+                                      name="uefiLoader"
+                                      label={t('UEFI firmware path')}
+                                      required={model["uefi"] && !props.host.uefiAutoLoader}
+                                      labelClass="col-md-3"
+                                      divClass="col-md-6"
+                                    />
+                                    <Text
+                                      name="nvramTemplate"
+                                      label={t('NVRAM template path')}
+                                      required={model["uefi"] && !props.host.uefiAutoLoader}
+                                      labelClass="col-md-3"
+                                      divClass="col-md-6"
+                                    />
+                                  </>
+                                )}
                                 {initialModel.vmType === undefined && props.cobblerProfiles !== {} && (
                                   <>
                                     <Select

--- a/web/html/src/manager/virtualization/guests/edit/guests-edit.tsx
+++ b/web/html/src/manager/virtualization/guests/edit/guests-edit.tsx
@@ -31,6 +31,9 @@ class GuestsEdit extends React.Component<Props> {
         osType: definition.os.type,
         arch: definition.os.arch,
         vmType: definition.type,
+        uefi: definition.os.uefiLoader != null,
+        uefiLoader: definition.os.uefiLoader,
+        nvramTemplate: definition.os.nvramTemplate,
       },
       GuestNicsPanel.getModelFromDefinition(definition),
       DiskUtils.getModelFromDefinition(definition)

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Expose UEFI parameters in the VM creation/editing pages
 - Add virt-tuner templates to VM creation
 - Fix virtualization guests to handle null HostInfo
 - Compare lowercase CPU arch with libvirt domain capabilities


### PR DESCRIPTION
## What does this PR change?

Allow users to create UEFI virtual machines from the web interface and edit them.

## GUI diff

Before:

![before](https://user-images.githubusercontent.com/397931/126993716-a3800517-e80a-4f02-b971-e4252e8b5ec8.png)

After:

![after](https://user-images.githubusercontent.com/397931/126993736-0f3a4a4e-a98b-4f82-adec-0a264f636999.png)

- [X] **DONE**

## Documentation
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- Cucumber tests were added
- [X] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/3965

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
