### PR TITLE
Wait until file is created by cobbler

### DIFF
--- a/testsuite/features/secondary/srv_distro_cobbler.feature
+++ b/testsuite/features/secondary/srv_distro_cobbler.feature
@@ -131,8 +131,8 @@ Feature: Cobbler and distribution autoinstallation
 
   Scenario: Test for PXE environment files
     Given cobblerd is running
-    Then file "/srv/tftpboot/pxelinux.cfg/default" should exist on server
-    When I wait until file "/srv/tftpboot/pxelinux.cfg/default" contains "ks=.*fedora_kickstart_profile:1" on server
+    When I wait until file "/srv/tftpboot/pxelinux.cfg/default" exists on server
+    And I wait until file "/srv/tftpboot/pxelinux.cfg/default" contains "ks=.*fedora_kickstart_profile:1" on server
     And I wait until file "/srv/tftpboot/pxelinux.cfg/default" contains "ks=.*fedora_kickstart_profile_upload:1" on server
     And I wait until file "/srv/tftpboot/images/fedora_kickstart_distro:1:SUSETest/initrd.img" exists on server
     And I wait until file "/srv/tftpboot/images/fedora_kickstart_distro:1:SUSETest/vmlinuz" exists on server


### PR DESCRIPTION
## What does this PR change?

Sometimes the cobbler feature fails testing the presence of `/srv/tftpboot/pxelinux.cfg/default`.

Our hypothesis is that we simply don't wait long enough. This PR addresses this problem.

The feature `srv_distro_cobbler.feature` will soon be replaced with a better one, but we would like to make sure this is not a product issue before we remove it.


## Links

Ports:
* 4.1: SUSE/spacewalk#15525
* 4.2: SUSE/spacewalk#15524


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
