### PR TITLE
spacewalk-utils: Updated code to pass pylint

### DIFF
--- a/utils/cloneByDate.py
+++ b/utils/cloneByDate.py
@@ -511,7 +511,7 @@ class ChannelTreeCloner:
         self.process_deps(dep_results)
 
     def process_deps(self, deps):
-        list_to_set = lambda x: set([tuple(y) for y in x])  # pylint: disable=consider-using-set-comprehension
+        list_to_set = lambda x: set([tuple(y) for y in x])  # pylint: disable=bad-option-value,consider-using-set-comprehension
         needed_list = dict((channel[0], [])
                            for channel in list(self.channel_map.values()))
         for cloner in self.cloners:

--- a/utils/migrateSystemProfile.py
+++ b/utils/migrateSystemProfile.py
@@ -100,7 +100,7 @@ def main():
             server_id = [int(server_id)]
         try:
             migrate_system(sessionKey, int(to_org_id), server_id)
-        except Exception:  # pylint: disable=try-except-raise
+        except Exception:  # pylint: disable=bad-option-value,try-except-raise
             raise
 
     if DEBUG:

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,4 @@
+- Modified to pass pylint checks.
 - Enable uyuni proxy stable leap 15.3
 - Add Rocky Linux 8 repositories
 - Fix a typo at the AlmaLinux 8 Uyuni client tools for devel


### PR DESCRIPTION
## What does this PR change?

Updated code to pass pylint checks on Leap and Enerprise Linux

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- Pylint check added.

Build tested successfully for
 epel-8-x86_64 
 opensuse-leap-15.3-x86_64 

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
