### PR TITLE
Fix traceback on handling sslerror (bsc#1187673)

### DIFF
--- a/proxy/proxy/rhnProxyAuth.py
+++ b/proxy/proxy/rhnProxyAuth.py
@@ -44,6 +44,10 @@ from rhn import rpclib
 from rhn import SSL
 from . import rhnAuthCacheClient
 
+if hasattr(socket, 'sslerror'):
+    socket_error = socket.sslerror
+else:
+    from ssl import socket_error
 
 sys.path.append('/usr/share/rhn')
 from up2date_client import config # pylint: disable=E0012, C0413
@@ -253,7 +257,7 @@ problems, isn't running, or the token is somehow corrupt.
         for _i in range(self.__nRetries):
             try:
                 token = server.proxy.login(self.__systemid)
-            except (socket.error, socket.sslerror) as e:
+            except (socket.error, socket_error) as e:
                 if CFG.HTTP_PROXY:
                     # socket error, check to see if your HTTP proxy is running...
                     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -266,7 +270,7 @@ problems, isn't running, or the token is somehow corrupt.
                         # rather big problem: http proxy not running.
                         log_error("*** ERROR ***: %s" % error[1])
                         Traceback(mail=0)
-                    except socket.sslerror as e:
+                    except socket_error as e:
                         error = ['socket.sslerror',
                                  '(%s) %s' % (CFG.HTTP_PROXY, e)]
                         # rather big problem: http proxy not running.

--- a/proxy/proxy/spacewalk-proxy.changes
+++ b/proxy/proxy/spacewalk-proxy.changes
@@ -1,3 +1,4 @@
+- Fix traceback on handling sslerror (bsc#1187673)
 - Bump version to 4.3.0
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Fixes sslerror handling

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Links

Fixes bsc#1187673

## Changelogs

- Fix traceback on handling sslerror (bsc#1187673)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
