### PR TITLE
Number of sources reduced in CLM for centos8

### DIFF
--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -5,7 +5,6 @@ reviewers:
       - ktsamis
       - atighineanu
       - maximenoel8
-      - lkotek
       - srbarrios
       - Bischoff
       - calancha

--- a/testsuite/features/build_validation/add_custom_repositories/add_ceos8_repositories.feature
+++ b/testsuite/features/build_validation/add_custom_repositories/add_ceos8_repositories.feature
@@ -103,7 +103,7 @@ Feature: Adding the CentOS 8 distribution custom repositories
     And I enter "Filtered channels without AppStream channels" as "description"
     And I click on "Save"
     Then I should see a "not built" text
-    When I click on "Build (11)"
+    When I click on "Build (9)"
     And I enter "Initial build" as "message"
     And I click the environment build button
     Then I should see a "Version 1: Initial build" text


### PR DESCRIPTION
## What does this PR change?

Fix for removing Appstream modules.

Piggyback: remove @lkotek from reviewers.


## Links

Ports:
* 4.1: SUSE/spacewalk#15544
* 4.2: SUSE/spacewalk#15543


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
