### PR TITLE
add tests for the iss v2 tool

### DIFF
--- a/testsuite/features/secondary/srv_handle_channels_with_ISS_v2.feature
+++ b/testsuite/features/secondary/srv_handle_channels_with_ISS_v2.feature
@@ -1,0 +1,73 @@
+# Copyright (c) 2021 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+Feature: Export and import channels with new ISS implementation
+  Distribute software between servers
+  Run export and import with ISS v2
+
+  Scenario: Install inter server sync package
+    When I install packages "inter-server-sync" on this "server"
+    Then "inter-server-sync" should be installed on "server"
+
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
+  Scenario: Clone a channel with patches
+    When I follow the left menu "Software > Manage > Channels"
+    And I follow "Clone Channel"
+    And I select "Test-Channel-x86_64" as the origin channel
+    And I choose "current"
+    And I click on "Clone Channel"
+    And I should see a "Create Software Channel" text
+    And I should see a "Current state of the channel" text
+    And I click on "Clone Channel"
+    Then I should see a "Clone of Test-Channel-x86_64" text
+
+  Scenario: Check that this channel has patches
+    When I follow the left menu "Software > Manage > Channels"
+    And I follow "Clone of Test-Channel-x86_64"
+    And I follow "Patches" in the content area
+    And I follow "List/Remove Patches"
+    Then I should see a "CL-hoag-dummy-7890" link
+    And I should see a "CL-virgo-dummy-3456" link
+    And I should see a "CL-milkyway-dummy-2345" link
+    And I should see a "CL-andromeda-dummy-6789" link
+
+  Scenario: Export data with ISS v2
+    When I ensure folder "/tmp/export_iss_v2" doesn't exists
+    Then Export folder "/tmp/export_iss_v2" doesn't exists on server
+    When I export "clone-test-channel-x86_64" with ISS v2 to "/tmp/export_iss_v2"
+    Then "/tmp/export_iss_v2" folder on server is ISS v2 export directory
+
+  Scenario: Cleanup: remove cloned channels
+    When I follow the left menu "Software > Manage > Channels"
+    And I follow "Clone of Test-Channel-x86_64"
+    And I follow "Delete software channel"
+    And I check "unsubscribeSystems"
+    And I click on "Delete Channel"
+    Then I should see a "Clone of Test-Channel-x86_64" text
+
+  Scenario: Import data with ISS v2
+    When I import data with ISS v2 from "/tmp/export_iss_v2"
+
+  Scenario: Check that this channel was imported and has patches
+    When I follow the left menu "Software > Manage > Channels"
+    And I follow "Clone of Test-Channel-x86_64"
+    And I follow "Patches" in the content area
+    And I follow "List/Remove Patches"
+    Then I should see a "CL-hoag-dummy-7890" link
+    And I should see a "CL-virgo-dummy-3456" link
+    And I should see a "CL-milkyway-dummy-2345" link
+    And I should see a "CL-andromeda-dummy-6789" link
+
+  Scenario: Cleanup: remove imported channel
+    When I follow the left menu "Software > Manage > Channels"
+    When I follow "Clone of Test-Channel-x86_64"
+    And I follow "Delete software channel"
+    And I check "unsubscribeSystems"
+    And I click on "Delete Channel"
+    Then I should see a "Clone of Test-Channel-x86_64" text
+
+  Scenario: Cleanup: remove ISS v2 export folder
+    When I ensure folder "/tmp/export_iss_v2" doesn't exists
+    Then Export folder "/tmp/export_iss_v2" doesn't exists on server

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -1675,3 +1675,24 @@ And(/^I copy vCenter configuration file on server$/) do
   return_code = file_inject($server, base_dir + 'vCenter.json', '/var/tmp/vCenter.json')
   raise 'File injection failed' unless return_code.zero?
 end
+
+When(/^I export "([^"]*)" with ISS v2 to "([^"]*)"$/) do |channel, path|
+  node = get_target("server")
+  node.run("inter-server-sync export --channels=#{channel} --outputDir=#{path}")
+end
+
+When(/^I import data with ISS v2 from "([^"]*)"$/) do |path|
+  node = get_target("server")
+  node.run("inter-server-sync import --importDir=#{path}")
+end
+
+Then(/^"(.*?)" folder on server is ISS v2 export directory$/) do |folder|
+  raise "Folder #{folder} not found" unless file_exists?($server, folder + "/sql_statements.sql")
+end
+
+Then(/^Export folder "(.*?)" doesn't exists on server$/) do |folder|
+     raise "Folder exists" if folder_exists?($server, folder)
+end
+When(/^I ensure folder "(.*?)" doesn't exists$/) do |folder|
+    folder_delete($server, folder) if folder_exists?($server, folder)
+end

--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -192,9 +192,21 @@ def file_exists?(node, file)
   code.zero? && local.zero?
 end
 
+# This function tests whether a folder exists on a node
+def folder_exists?(node, file)
+  _out, local, _remote, code = node.test_and_store_results_together("test -d #{file}", 'root', 500)
+  code.zero? && local.zero?
+end
+
 # This function deletes a file from a node
 def file_delete(node, file)
   _out, _local, _remote, code = node.test_and_store_results_together("rm  #{file}", 'root', 500)
+  code
+end
+
+# This function deletes a file from a node
+def folder_delete(node, folder)
+  _out, _local, _remote, code = node.test_and_store_results_together("rm -rf #{folder}", 'root', 500)
   code
 end
 

--- a/testsuite/run_sets/secondary.yml
+++ b/testsuite/run_sets/secondary.yml
@@ -19,6 +19,7 @@
 - features/secondary/srv_delete_channel_with_tool.feature
 - features/secondary/srv_test_maintenance_windows.feature
 - features/secondary/srv_user_configuration_salt_states.feature
+- features/secondary/srv_handle_channels_with_ISS_v2.feature
 - features/secondary/buildhost_osimage_build_image.feature
 - features/secondary/allcli_reboot.feature
 - features/secondary/trad_config_channel.feature


### PR DESCRIPTION
Signed-off-by: Ricardo Mateus <rmateus@suse.com>

## What does this PR change?

Add integration tests for the new ISS v2 tool.

The steps of this test are:
- install inter-server-sync package on server
- Clone an existing channel with packages and patches
- Export it with ISS v2
- Remove the cloned channel
- Import with ISS v2
- Check if the imported channel has the data


## GUI diff

No difference.
It's a command-line tool for now.

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/15211


- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
