### PR TITLE
QA: Click on delete profile in a modal dialog

### DIFF
--- a/testsuite/features/secondary/min_salt_minions_page.feature
+++ b/testsuite/features/secondary/min_salt_minions_page.feature
@@ -64,7 +64,7 @@ Feature: Management of minion keys
     Then I should see a "Confirm System Profile Deletion" text
     When I click on "Delete Profile"
     Then I wait until I see "Cleanup timed out. Please check if the machine is reachable." text
-    When I click on "Delete Profile Without Cleanup"
+    When I click on "Delete Profile Without Cleanup" in "An error occurred during cleanup" modal
     And I wait until I see "has been deleted" text
     Then "sle_minion" should not be registered
 


### PR DESCRIPTION
## What does this PR change?

We had a step trying to click an element (Delete profile button) which is inside a modal dialog.
Let's be more concise and specify that this button is inside a modal dialog.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.1
- Manager-4.2

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
