### PR TITLE
Fix SCC system forwarding (bsc#1188900)

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/task/ForwardRegistrationTask.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/ForwardRegistrationTask.java
@@ -46,7 +46,7 @@ public class ForwardRegistrationTask extends RhnJavaJob {
         }
         try {
             if (Config.get().getString(ContentSyncManager.RESOURCE_PATH) == null) {
-                int waitTime = ThreadLocalRandom.current().nextInt(1, 7 * 60);
+                int waitTime = ThreadLocalRandom.current().nextInt(0, 15 * 60);
                 if (log.isDebugEnabled()) {
                     // no waiting when debug is on
                     waitTime = 1;

--- a/java/code/src/com/suse/scc/SCCSystemRegistrationManager.java
+++ b/java/code/src/com/suse/scc/SCCSystemRegistrationManager.java
@@ -74,10 +74,15 @@ public class SCCSystemRegistrationManager {
                             SCCCachingFactory.deleteRegCacheItem(cacheItem);
                         }
                         catch (SCCClientException e) {
-                            LOG.error("Error deregistering system " + cacheItem.getId(), e);
+                            LOG.error("SCC error while deregistering system " + cacheItem.getId(), e);
                             if (forceDBDeletion || e.getHttpStatusCode() == 404) {
                                 SCCCachingFactory.deleteRegCacheItem(cacheItem);
                             }
+                            cacheItem.setRegistrationErrorTime(new Date());
+                        }
+                        catch (Exception e) {
+                            LOG.error("Error deregistering system " + cacheItem.getId(), e);
+                            cacheItem.setRegistrationErrorTime(new Date());
                         }
                     },
                     () -> {

--- a/java/code/src/com/suse/scc/SCCSystemRegistrationManager.java
+++ b/java/code/src/com/suse/scc/SCCSystemRegistrationManager.java
@@ -110,7 +110,7 @@ public class SCCSystemRegistrationManager {
                 cacheItem.setRegistrationErrorTime(null);
                 cacheItem.setCredentials(itemCredentials);
             }
-            catch (SCCClientException e) {
+            catch (Exception e) {
                 LOG.error("Error registering system " + cacheItem.getId(), e);
                 cacheItem.setRegistrationErrorTime(new Date());
             }

--- a/java/code/src/com/suse/scc/model/SCCMinProductJson.java
+++ b/java/code/src/com/suse/scc/model/SCCMinProductJson.java
@@ -54,7 +54,12 @@ public class SCCMinProductJson {
         this.identifier = product.getName();
         this.version = product.getVersion();
         this.releaseType = product.getRelease();
-        this.arch = product.getArch().getLabel();
+        if (product.getArch() != null) {
+            this.arch = product.getArch().getLabel();
+        }
+        else {
+            this.arch = null;
+        }
     }
 
     /**

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix system information forwarding to SCC (bsc#1188900)
 - Add UEFI support for VM creation / editing
 - Add virt-tuner templates to VM creation
 - Ensure XMLRPC returns 'issue_date' in ISO format when listing erratas (bsc#1188260)


### PR DESCRIPTION
## What does this PR change?

The SCC Team has reported load spikes after this feature got enabled. According to my investigation:
 - an unexpected `Exception`s during the transmission of system data could result in the `ROLLBACK` of the transaction, thereby requiring a full re-sync of all systems at the next round
 - one such `Exception` (an NPE) was actually visible in the logs of our internal server `manager.mgr.suse.de`
 - randomization of wait time to 7 minutes might not be sufficient to spread the load well (mean is 3.5 minutes)
 - the delayed retry mechanism (waiting for one week) was not really working for systems to delete

This PR addresses the concerns above in separate patches.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**
- [x] **DONE**

## Test coverage
- No tests: **SCC performance is not really tested, patches were tested manually on our internal server**

- [x] **DONE**

## Links

https://bugzilla.suse.com/show_bug.cgi?id=1188900

Downstream PRs to appear below

- [x] **DONE**

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
