### PR TITLE
Scap: Increase max size for uploaded files to Salt master

### DIFF
--- a/spacewalk/setup/salt/susemanager.conf
+++ b/spacewalk/setup/salt/susemanager.conf
@@ -90,3 +90,4 @@ rosters:
 
 # Allow minions to upload files to master
 file_recv: True
+file_recv_max_size: 300

--- a/spacewalk/setup/spacewalk-setup.changes
+++ b/spacewalk/setup/spacewalk-setup.changes
@@ -1,3 +1,4 @@
+- Increase max size for uploaded files to Salt master
 - Bump version to 4.3.0
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

This PR increases the maximum size allowed for files that are uploaded to the Salt master by Salt minion to avoid having issues with uploading the Scap results from running "Scap Audit" action using the profiles included in the `scap-security-guide` package of SLE15SP3, where report size is higher than default 100MB):

Results from Scap action:
```
Error processing SCAP results file /var/spacewalk/systems/1/1000010000/actions/299/results.xml: /var/spacewalk/systems/1/1000010000/actions/299/results.xml (No such file or directory)
```

While in salt minion logs:

```
2021-07-29 16:59:41,361 [salt.loaded.int.module.cp:856 ][ERROR   ][1514] cp.push Failed transfer failed. Ensure master has 'file_recv' set to 'True' and that the file is not larger than the 'file_recv_size_max' setting on the master.
```

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **bugfix**
- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
