### PR TITLE
CI: remove all tarballs and add new ones

### DIFF
--- a/rel-eng/push-packages-to-obs.sh
+++ b/rel-eng/push-packages-to-obs.sh
@@ -296,8 +296,12 @@ while read PKG_NAME; do
         else
           $OSC linkpac -c -f $OBS_PROJ $PKG_NAME $OBS_TEST_PROJECT
           $OSC co $OBS_TEST_PROJECT $PKG_NAME
+          cd $OBS_TEST_PROJECT/$PKG_NAME/
+          $OSC rm *
+          cd -
           cp -v * $OBS_TEST_PROJECT/$PKG_NAME  
           cd $OBS_TEST_PROJECT/$PKG_NAME
+          $OSC add *
       	  $OSC ci -m "Git submitt $GIT_BRANCH($GIT_CURR_HEAD)"
           cd -
         fi  

--- a/rel-eng/push-packages-to-obs.sh
+++ b/rel-eng/push-packages-to-obs.sh
@@ -302,7 +302,7 @@ while read PKG_NAME; do
           cp -v * $OBS_TEST_PROJECT/$PKG_NAME  
           cd $OBS_TEST_PROJECT/$PKG_NAME
           $OSC add *
-      	  $OSC ci -m "Git submitt $GIT_BRANCH($GIT_CURR_HEAD)"
+          $OSC ci -m "Git submitt $GIT_BRANCH($GIT_CURR_HEAD)"
           cd -
         fi  
       else


### PR DESCRIPTION
## What does this PR change?

When building packages for Pull Requests, we did not take into account
that tarball file names could change, like foo-git123-456789.cpio to
foo-git234-567890.cpio.

This commit removes all previous files and add the new ones.



## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed
- [X] **DONE**

## Test coverage
- No tests

- [X] **DONE**

## Links

N/A
- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
