### PR TITLE
Kiwi profiles: Use 4.2 tools on 4.0 and 4.1

### DIFF
--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_40/config.xml
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_40/config.xml
@@ -63,7 +63,7 @@
         <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Manager-Tools/15/x86_64/update/"/>
     </repository>
     <repository type="rpm-md">
-        <source path="http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.1:/SLE15-SUSE-Manager-Tools/SLE_15/"/>
+        <source path="http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.2:/SLE15-SUSE-Manager-Tools/SLE_15/"/>
     </repository>
 
     <packages type="image">

--- a/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_41/config.xml
+++ b/testsuite/features/profiles/Kiwi/POS_Image-JeOS7_41/config.xml
@@ -63,7 +63,7 @@
         <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Manager-Tools/15/x86_64/update/"/>
     </repository>
     <repository type="rpm-md">
-        <source path="http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.1:/SLE15-SUSE-Manager-Tools/SLE_15/"/>
+        <source path="http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.2:/SLE15-SUSE-Manager-Tools/SLE_15/"/>
     </repository>
 
     <packages type="image">

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_40/config.xml
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_40/config.xml
@@ -63,7 +63,7 @@
         <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Manager-Tools/15/x86_64/update/"/>
     </repository>
     <repository type="rpm-md">
-        <source path="http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.1:/SLE15-SUSE-Manager-Tools/SLE_15/"/>
+        <source path="http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.2:/SLE15-SUSE-Manager-Tools/SLE_15/"/>
     </repository>
 
     <packages type="image">

--- a/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_41/config.xml
+++ b/testsuite/features/profiles/internal_nue/Kiwi/POS_Image-JeOS7_41/config.xml
@@ -63,7 +63,7 @@
         <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Manager-Tools/15/x86_64/update/"/>
     </repository>
     <repository type="rpm-md">
-        <source path="http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.1:/SLE15-SUSE-Manager-Tools/SLE_15/"/>
+        <source path="http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.2:/SLE15-SUSE-Manager-Tools/SLE_15/"/>
     </repository>
 
     <packages type="image">

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_40/config.xml
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_40/config.xml
@@ -63,7 +63,7 @@
         <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Manager-Tools/15/x86_64/update/"/>
     </repository>
     <repository type="rpm-md">
-        <source path="http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.1:/SLE15-SUSE-Manager-Tools/SLE_15/"/>
+        <source path="http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.2:/SLE15-SUSE-Manager-Tools/SLE_15/"/>
     </repository>
 
     <packages type="image">

--- a/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_41/config.xml
+++ b/testsuite/features/profiles/internal_prv/Kiwi/POS_Image-JeOS7_41/config.xml
@@ -63,7 +63,7 @@
         <source path="http://download.suse.de/ibs/SUSE/Updates/SLE-Manager-Tools/15/x86_64/update/"/>
     </repository>
     <repository type="rpm-md">
-        <source path="http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.1:/SLE15-SUSE-Manager-Tools/SLE_15/"/>
+        <source path="http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/4.2:/SLE15-SUSE-Manager-Tools/SLE_15/"/>
     </repository>
 
     <packages type="image">


### PR DESCRIPTION
## What does this PR change?

SLE15-SUSE-Manager-Tools are published in 4.2 branch now. This PR fixes the URLs in the Kiwi profiles accordingly.


## Links

Ports:
* 4.1:
* 4.2: SUSE/spacewalk#15570

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
