### PR TITLE
Align scenario names between branches

### DIFF
--- a/testsuite/features/build_validation/add_custom_repositories/add_ceos8_repositories.feature
+++ b/testsuite/features/build_validation/add_custom_repositories/add_ceos8_repositories.feature
@@ -32,7 +32,7 @@ Feature: Adding the CentOS 8 distribution custom repositories
     And I click on "Create Repository"
     Then I should see a "Repository created successfully" text
 
-  Scenario: Add the CentOS 8 DVD BaseOS repository
+  Scenario: Add the CentOS 8 BaseOS DVD repository
     When I follow the left menu "Software > Manage > Repositories"
     And I follow "Create Repository"
     And I enter "centos-8-iso-baseos" as "label"
@@ -41,7 +41,7 @@ Feature: Adding the CentOS 8 distribution custom repositories
     And I click on "Create Repository"
     Then I should see a "Repository created successfully" text
 
-  Scenario: Add both ISO repositories to the custom channel for CentOS 8 DVD
+  Scenario: Add both repositories to the custom channel for CentOS 8 DVD
     When I follow the left menu "Software > Manage > Channels"
     And I follow "Custom Channel for CentOS 8 DVD"
     And I follow "Repositories" in the content area


### PR DESCRIPTION
## What does this PR change?

Fix backport: use same scenario names between master, Manager-4.2, and Manager-4.1 branches.


## Links

No ports, uyuni only.


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
