### PR TITLE
warn inside overview page in SLE Micro (bsc#1188551)

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/server/MinionServer.java
+++ b/java/code/src/com/redhat/rhn/domain/server/MinionServer.java
@@ -149,6 +149,16 @@ public class MinionServer extends Server implements SaltConfigurable {
         return !isSLES10() && !isSLES11();
     }
 
+    /**
+     * Return <code>true</code> if OS on this system supports Transactional Update,
+     * <code>false</code> otherwise.
+     *
+     * @return <code>true</code> if OS supports Transactional Update
+     */
+    public boolean doesOsSupportsTransactionalUpdate() {
+        return isSLEMicro();
+    }
+
     @Override
     public boolean doesOsSupportsMonitoring() {
         return isSLES12() || isSLES15() || isLeap15() || isUbuntu1804() || isUbuntu2004() || isRedHat6() ||
@@ -174,6 +184,13 @@ public class MinionServer extends Server implements SaltConfigurable {
      */
     private boolean isSLES11() {
         return ServerConstants.SLES.equals(getOs()) && getRelease().startsWith("11");
+    }
+
+    /**
+     * @return true if the installer type is of SLE Micro
+     */
+    private boolean isSLEMicro() {
+        return ServerConstants.SLEMICRO.equals(getOs());
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/server/ServerConstants.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerConstants.java
@@ -26,6 +26,7 @@ public class ServerConstants {
      */
     public static final String FEATURE_KICKSTART = "ftr_kickstart";
     public static final String SLES = "SLES";
+    public static final String SLEMICRO = "SLE Micro";
     public static final String LEAP = "Leap";
     public static final String UBUNTU = "Ubuntu";
     public static final String REDHAT = "RedHat";

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemOverviewAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemOverviewAction.java
@@ -129,6 +129,12 @@ public class SystemOverviewAction extends RhnAction {
             createErrorMessage(request, "packagelist.jsp.modulespresent", null);
         }
 
+        s.asMinionServer().ifPresent(minion -> {
+            if (minion.doesOsSupportsTransactionalUpdate()) {
+                createErrorMessage(request, "overview.jsp.transactionalupdate.reboot", null);
+            }
+        });
+
         request.setAttribute("rebootRequired", rebootRequired);
         request.setAttribute("unentitled", s.getEntitlements().isEmpty());
         request.setAttribute("entitlements", entitlements);

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -24825,6 +24825,9 @@ given channel.</source>
       <trans-unit id="sdc.channels.info.change" xml:space="preserve">
         <source>When subscribing to a channel that contains a product, the product package will automatically be installed on traditionally registered systems. On salt managed systems please apply a highstate as soon as possible.</source>
       </trans-unit>
+      <trans-unit id="overview.jsp.transactionalupdate.reboot" xml:space="preserve">
+        <source>OS with transactional updates: please reboot after any packages and/or channels changes.</source>
+      </trans-unit>
       <trans-unit id="channelOverview.jsp.tasks.modifyCreate.state" xml:space="preserve">
         <source>Create configuration file</source>
         <context-group name="ctx">

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Warning in Overview page for SLE Micro system (bsc#1188551)
 - Fix system information forwarding to SCC (bsc#1188900)
 - Add UEFI support for VM creation / editing
 - Add virt-tuner templates to VM creation


### PR DESCRIPTION
## What does this PR change?

Add a a warning in the overview page if the system is a SLE Micro.

## GUI diff

Before:
![Screenshot from 2021-08-02 10-41-46](https://user-images.githubusercontent.com/4320859/127831527-8e5e88fb-b7d8-4696-abf9-b4c5f01e8f2a.png)

After:
![Screenshot from 2021-08-02 10-37-28](https://user-images.githubusercontent.com/4320859/127830978-07277b30-e54e-4316-8abc-24c3a03b99f1.png)
- [x] **DONE**

## Documentation
- Documentation issue was created: https://github.com/SUSE/spacewalk/issues/15576

- [x] **DONE**

## Test coverage
- No tests: code with no test

- [x] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/15508
[bsc#1188551
](https://bugzilla.suse.com/show_bug.cgi?id=1188551)

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
