### PR TITLE
QA: Parametrize timeouts from env. variables

### DIFF
--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -25,8 +25,8 @@ puts "Executing long running tests" if $long_tests_enabled
 # the tests return much before that delay in case of success
 $stdout.sync = true
 STARTTIME = Time.new.to_i
-Capybara.default_max_wait_time = 10
-DEFAULT_TIMEOUT = 250
+Capybara.default_max_wait_time = ENV['CAPYBARA_TIMEOUT'] ? ENV['CAPYBARA_TIMEOUT'].to_i : 10
+DEFAULT_TIMEOUT = ENV['DEFAULT_TIMEOUT'] ? ENV['DEFAULT_TIMEOUT'].to_i : 250
 
 # QAM and Build Validation pipelines will provide a json file including all custom (MI) repositories
 custom_repos_path = File.dirname(__FILE__) + '/../upload_files/' + 'custom_repositories.json'
@@ -34,11 +34,6 @@ if File.exist?(custom_repos_path)
   custom_repos_file = File.read(custom_repos_path)
   $custom_repositories = JSON.parse(custom_repos_file)
   $build_validation = true
-  # HACK
-  # Build Validations will require longer timeouts due to the low performance of our VMs
-  # if we ever improve this fact, we can reduce these timeouts.
-  Capybara.default_max_wait_time = 30
-  DEFAULT_TIMEOUT = 1800
 end
 
 def enable_assertions


### PR DESCRIPTION
## What does this PR change?

Instead of parametrizing the timeouts through code, depending of the kind of tests.
We moved this responsibility outside the test framework, having as default values those used on CI.
So, after this PR, we might provide a mechanism on the Jenkins Pipelines to set the desired new default timeout.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.1
- Manager-4.2

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
