### PR TITLE
Handle more OCFS2 config in virt_utils

### DIFF
--- a/susemanager-utils/susemanager-sls/src/modules/virt_utils.py
+++ b/susemanager-utils/susemanager-sls/src/modules/virt_utils.py
@@ -51,17 +51,18 @@ def get_cluster_filesystem(path):
             ).communicate()[0]
         )
 
-        for resource in crm_conf.findall(".//primitive[@type='Filesystem']/.."):
-            directory = resource.find("./primitive//nvpair[@name='directory']")
-            if directory is None:
-                continue
-            directory_value = directory.get("value")
-            if directory_value:
-                if (
-                    os.path.commonpath([str(resolved), directory_value])
-                    == directory_value
-                ):
-                    return resource.get("id")
+        for resource in crm_conf.findall(".//resources/*"):
+            if resource.find(".//primitive[@type='Filesystem']/") is not None:
+                directory = resource.find(".//primitive//nvpair[@name='directory']")
+                if directory is None:
+                    continue
+                directory_value = directory.get("value")
+                if directory_value:
+                    if (
+                        os.path.commonpath([str(resolved), directory_value])
+                        == directory_value
+                    ):
+                        return resource.get("id")
     except FileNotFoundError as err:
         log.debug("Failed to get cluster resource name for path, %s: %s", path, err)
 

--- a/susemanager-utils/susemanager-sls/src/tests/test_module_virt_utils.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_module_virt_utils.py
@@ -27,13 +27,15 @@ CRM_CONFIG_XML = b"""<?xml version="1.0" ?>
           <nvpair name="clone-max" value="8" id="c-clusterfs-meta_attributes-clone-max"/>
           <nvpair id="c-clusterfs-meta_attributes-target-role" name="target-role" value="Started"/>
         </meta_attributes>
-        <primitive id="clusterfs" class="ocf" provider="heartbeat" type="Filesystem">
-          <instance_attributes id="clusterfs-instance_attributes">
-            <nvpair name="directory" value="/srv/clusterfs" id="clusterfs-instance_attributes-directory"/>
-            <nvpair name="fstype" value="ocfs2" id="clusterfs-instance_attributes-fstype"/>
-            <nvpair name="device" value="/dev/vdc" id="clusterfs-instance_attributes-device"/>
-          </instance_attributes>
-        </primitive>
+        <group id="ocfs2-group">
+          <primitive id="clusterfs" class="ocf" provider="heartbeat" type="Filesystem">
+            <instance_attributes id="clusterfs-instance_attributes">
+              <nvpair name="directory" value="/srv/clusterfs" id="clusterfs-instance_attributes-directory"/>
+              <nvpair name="fstype" value="ocfs2" id="clusterfs-instance_attributes-fstype"/>
+              <nvpair name="device" value="/dev/vdc" id="clusterfs-instance_attributes-device"/>
+            </instance_attributes>
+          </primitive>
+        </group>
       </clone>
       <primitive id="vm01" class="ocf" provider="heartbeat" type="VirtualDomain">
         <instance_attributes id="vm01-instance_attributes">

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Handle more ocsf2 setups in virt_utils module
 - Add UEFI support for VM creation
 - Add virt-tuner templates to VM creation
 - Add missing symlinks to generate the "certs" state for


### PR DESCRIPTION
## What does this PR change?

The OCFS2 primitive may be nested at various levels with a group or not.
Look for children of the <resources> element to get the proper name for
the constraint configuration in VM config.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- Unit tests were changed

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
