### PR TITLE
Add Raspbian 9/10 and Fedora 33/34 repos

### DIFF
--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -3020,3 +3020,165 @@ gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/EL8-Uyuni-Client-Tools/EL_8/
+
+[raspbian-9-pool-armhf-uyuni]
+label    = raspbian-9-pool-armhf-uyuni
+checksum = sha256
+archs    = arm-deb
+repo_type = deb
+name     = Raspbian 9 (stretch) pool for armhf for Uyuni
+gpgkey_url =
+gpgkey_id =
+gpgkey_fingerprint =
+repo_url = https://archive.raspbian.org/raspbian/dists/stretch/main/binary-armhf/
+
+[raspbian-9-armhf-contrib-uyuni]
+label    = raspbian-9-armhf-contrib-uyuni
+name     = Raspbian 9 (stretch) armhf Contrib for Uyuni
+archs    = arm-deb
+repo_type = deb
+checksum = sha256
+base_channels = raspbian-9-pool-armhf-uyuni
+repo_url = https://archive.raspbian.org/raspbian/dists/stretch/contrib/binary-armhf/
+
+[raspbian-9-armhf-firmware-uyuni]
+label    = raspbian-9-armhf-firmware-uyuni
+name     = Raspbian 9 (stretch) armhf Firmware for Uyuni
+archs    = arm-deb
+repo_type = deb
+checksum = sha256
+base_channels = raspbian-9-pool-armhf-uyuni
+repo_url = https://archive.raspbian.org/raspbian/dists/stretch/firmware/binary-armhf/
+
+[raspbian-9-armhf-non-free-uyuni]
+label    = raspbian-9-armhf-non-free-uyuni
+name     = Raspbian 9 (stretch) armhf Non-Free for Uyuni
+archs    = arm-deb
+repo_type = deb
+checksum = sha256
+base_channels = raspbian-9-pool-armhf-uyuni
+repo_url = https://archive.raspbian.org/raspbian/dists/stretch/non-free/binary-armhf/
+
+[raspbian-9-armhf-rpi-uyuni]
+label    = raspbian-9-armhf-rpi-uyuni
+name     = Raspbian 9 (stretch) armhf RPi for Uyuni
+archs    = arm-deb
+repo_type = deb
+checksum = sha256
+base_channels = raspbian-9-pool-armhf-uyuni
+repo_url = https://archive.raspbian.org/raspbian/dists/stretch/rpi/binary-armhf/
+
+[raspbian-10-pool-armhf-uyuni]
+label    = raspbian-10-pool-armhf-uyuni
+checksum = sha256
+archs    = arm-deb
+repo_type = deb
+name     = Raspbian 10 (buster) pool for armhf for Uyuni
+gpgkey_url =
+gpgkey_id =
+gpgkey_fingerprint =
+repo_url = https://archive.raspbian.org/raspbian/dists/buster/main/binary-armhf/
+
+[raspbian-10-armhf-contrib-uyuni]
+label    = raspbian-10-armhf-contrib-uyuni
+name     = Raspbian 10 (buster) armhf Contrib for Uyuni
+archs    = arm-deb
+repo_type = deb
+checksum = sha256
+base_channels = raspbian-10-pool-armhf-uyuni
+repo_url = https://archive.raspbian.org/raspbian/dists/buster/contrib/binary-armhf/
+
+[raspbian-10-armhf-firmware-uyuni]
+label    = raspbian-10-armhf-firmware-uyuni
+name     = Raspbian 10 (buster) armhf Firmware for Uyuni
+archs    = arm-deb
+repo_type = deb
+checksum = sha256
+base_channels = raspbian-10-pool-armhf-uyuni
+repo_url = https://archive.raspbian.org/raspbian/dists/buster/firmware/binary-armhf/
+
+[raspbian-10-armhf-non-free-uyuni]
+label    = raspbian-10-armhf-non-free-uyuni
+name     = Raspbian 10 (buster) armhf Non-Free for Uyuni
+archs    = arm-deb
+repo_type = deb
+checksum = sha256
+base_channels = raspbian-10-pool-armhf-uyuni
+repo_url = https://archive.raspbian.org/raspbian/dists/buster/non-free/binary-armhf/
+
+[raspbian-10-armhf-rpi-uyuni]
+label    = raspbian-10-armhf-rpi-uyuni
+name     = Raspbian 10 (buster) armhf RPi for Uyuni
+archs    = arm-deb
+repo_type = deb
+checksum = sha256
+base_channels = raspbian-10-pool-armhf-uyuni
+repo_url = https://archive.raspbian.org/raspbian/dists/buster/rpi/binary-armhf/
+
+[fedora33]
+archs    = x86_64, s390x, aarch64, ppc64le
+checksum = sha256
+name     = Fedora 33 (%(arch)s)
+gpgkey_url = https://getfedora.org/static/fedora.gpg
+gpgkey_id = 9570FF31
+gpgkey_fingerprint = 963A 2BEB 0200 9608 FE67  EA42 49FD 7749 9570 FF31
+repo_url = https://mirrors.fedoraproject.org/metalink?repo=fedora-33&arch=%(arch)s
+dist_map_release = 33
+
+[fedora33-modular]
+label    = %(base_channel)s-modular
+name     = Fedora 33 Modular (%(arch)s)
+archs    = x86_64, s390x, aarch64, ppc64le
+checksum = sha256
+base_channels = fedora33-%(arch)s
+repo_url = https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-33&arch=%(arch)s
+
+[fedora33-updates]
+label    = %(base_channel)s-updates
+name     = Fedora 33 Updates (%(arch)s)
+archs    = x86_64, s390x, aarch64, ppc64le
+checksum = sha256
+base_channels = fedora33-%(arch)s
+repo_url = https://mirrors.fedoraproject.org/metalink?repo=updates-released-f33&arch=%(arch)s
+
+[fedora33-updates-modular]
+label    = %(base_channel)s-updates-modular
+name     = Fedora 33 Updates Modular (%(arch)s)
+archs    = x86_64, s390x, aarch64, ppc64le
+checksum = sha256
+base_channels = fedora33-%(arch)s
+repo_url = https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-f33&arch=%(arch)s
+
+[fedora34]
+archs    = x86_64, s390x, aarch64, ppc64le
+checksum = sha256
+name     = Fedora 34 (%(arch)s)
+gpgkey_url = https://getfedora.org/static/fedora.gpg
+gpgkey_id = 45719A39
+gpgkey_fingerprint = 8C5B A699 0BDB 26E1 9F2A  1A80 1161 AE69 4571 9A39
+repo_url = https://mirrors.fedoraproject.org/metalink?repo=fedora-34&arch=%(arch)s
+dist_map_release = 34
+
+[fedora34-modular]
+label    = %(base_channel)s-modular
+name     = Fedora 34 Modular (%(arch)s)
+archs    = x86_64, s390x, aarch64, ppc64le
+checksum = sha256
+base_channels = fedora34-%(arch)s
+repo_url = https://mirrors.fedoraproject.org/metalink?repo=fedora-modular-34&arch=%(arch)s
+
+[fedora34-updates]
+label    = %(base_channel)s-updates
+name     = Fedora 34 Updates (%(arch)s)
+archs    = x86_64, s390x, aarch64, ppc64le
+checksum = sha256
+base_channels = fedora34-%(arch)s
+repo_url = https://mirrors.fedoraproject.org/metalink?repo=updates-released-f34&arch=%(arch)s
+
+[fedora34-updates-modular]
+label    = %(base_channel)s-updates-modular
+name     = Fedora 34 Updates Modular (%(arch)s)
+archs    = x86_64, s390x, aarch64, ppc64le
+checksum = sha256
+base_channels = fedora34-%(arch)s
+repo_url = https://mirrors.fedoraproject.org/metalink?repo=updates-released-modular-f34&arch=%(arch)s

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,5 @@
+- Add Fedora 33 and 34 repositories
+- Add Raspbian 9 and 10 repositories
 - Enable uyuni proxy stable leap 15.3
 - Add Rocky Linux 8 repositories
 - Fix a typo at the AlmaLinux 8 Uyuni client tools for devel


### PR DESCRIPTION
## What does this PR change?

Adds Raspian 9 and 10 and Fedora 33 and 34 repos to `spacewalk-common-channells`

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Changelogs

- Add Fedora 33 and 34 repositories
- Add Raspbian 9 and 10 repositories

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
