### PR TITLE
Create sle 12 sp5 bootstrap repos

### DIFF
--- a/testsuite/features/build_validation/create_bootstrap_repositories/srv_create_bootstrap_repositories.feature
+++ b/testsuite/features/build_validation/create_bootstrap_repositories/srv_create_bootstrap_repositories.feature
@@ -2,6 +2,9 @@
 # Licensed under the terms of the MIT license.
 
 Feature: Create bootstrap repositories
+  In order to be able to enroll clients with MU repositories
+  As the system administrator
+  I create all bootstrap repos with --custom-repos option
 
 # WORKAROUND: --flush option does not seem to work in case of hash mismatch with same version
   Scenario: Clean up all bootstrap repositories on the server
@@ -34,6 +37,18 @@ Feature: Create bootstrap repositories
 @sle12sp4_ssh_minion
   Scenario: Create the bootstrap repository for a SLES 12 SP4 Salt SSH minion
     When I create the bootstrap repository for "sle12sp4_minion" on the server
+
+@sle12sp5_client
+  Scenario: Create the bootstrap repository for a SLES 12 SP5 traditional client
+    When I create the bootstrap repository for "sle12sp5_client" on the server
+
+@sle12sp5_minion
+  Scenario: Create the bootstrap repository for a SLES 12 SP5 minion
+    When I create the bootstrap repository for "sle12sp5_minion" on the server
+
+@sle12sp5_ssh_minion
+  Scenario: Create the bootstrap repository for a SLES 12 SP5 Salt SSH minion
+    When I create the bootstrap repository for "sle12sp5_minion" on the server
 
 @sle15_client
   Scenario: Create the bootstrap repository for a SLES 15 traditional client


### PR DESCRIPTION
## What does this PR change?

This PR creates the bootstrap repos for SLE 12 SP5 in build validation testsuite.

It also documents why we need to create bootstrap repos when this is already done automatically by reposync.


## Links

Ports:
* 4.1:
* 4.2: https://github.com/SUSE/spacewalk/pull/15579


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
