### PR TITLE
Fix cucumber 4 breaking changes

### DIFF
--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -292,16 +292,16 @@ Before('@sle15sp3_client') do
 end
 
 Before('@skip_for_debianlike') do |scenario|
-  filename = scenario.feature.location.file
+  filename = scenario.location.file
   skip_this_scenario if (filename.include? 'ubuntu') || (filename.include? 'debian')
 end
 
 Before('@skip_for_minion') do |scenario|
-  skip_this_scenario if scenario.feature.location.file.include? 'minion'
+  skip_this_scenario if scenario.location.file.include? 'minion'
 end
 
 Before('@skip_for_traditional') do |scenario|
-  skip_this_scenario if scenario.feature.location.file.include? 'client'
+  skip_this_scenario if scenario.location.file.include? 'client'
 end
 
 # do some tests only if we have SCC credentials


### PR DESCRIPTION
## What does this PR change?

In cucumber 4, a scenario does not reference its feature anymore like in Cucumber 3, but references its location directly.

**DO NOT MERGE THIS BEFORE OSCAR'S PR TO UPGRADE TEST SUITE DEPENDENCIES #3932**
(alternatively, directly merge this into #3932)


## Links

Ports:
* 4.1: SUSE/spacewalk#15584
* 4.2: SUSE/spacewalk#15583


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
