### PR TITLE
Fix architectures in Release file for deb repos

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/DebReleaseWriter.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/DebReleaseWriter.java
@@ -17,6 +17,7 @@ package com.redhat.rhn.taskomatic.task.repomd;
 
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.channel.ChannelArch;
+import com.redhat.rhn.domain.rhnpackage.PackageArch;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.log4j.Logger;
 

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/DebReleaseWriter.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/DebReleaseWriter.java
@@ -99,7 +99,10 @@ public class DebReleaseWriter {
     }
 
     private String toArchString(ChannelArch channelArch) {
-        return channelArch.getLabel().replaceAll("channel-", "").replaceAll("-deb", "");
+        return (String)channelArch.getCompatiblePackageArches().stream()
+                .map(a -> ((PackageArch)a).getLabel().replaceAll("-deb", ""))
+                .filter(a -> !("all".equals(a) || "src".equals(a)))
+                .collect(Collectors.joining(" "));
     }
 
     @FunctionalInterface

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- List all compatible package architectures to Release file for deb repos
 - Warning in Overview page for SLE Micro system (bsc#1188551)
 - Fix system information forwarding to SCC (bsc#1188900)
 - Add UEFI support for VM creation / editing


### PR DESCRIPTION
https://github.com/uyuni-project/uyuni/issues/4077

## What does this PR change?

Fix architectures in Release file for deb repos

Only channel architecture is used as an architecture for Release file, bul all compatible architectures should be listed (rhnChannelPackageArchCompat and rhnPackageArch).
