### PR TITLE
Logging for salt SSH

### DIFF
--- a/spacewalk/setup/salt/salt-ssh-logging.conf
+++ b/spacewalk/setup/salt/salt-ssh-logging.conf
@@ -1,0 +1,3 @@
+ssh_minion_opts:
+    log_file: ../../../../../var/log/salt-ssh.log
+    log_level: warning

--- a/spacewalk/setup/spacewalk-setup.changes
+++ b/spacewalk/setup/spacewalk-setup.changes
@@ -1,3 +1,4 @@
+- Enable logging for salt SSH
 - Increase max size for uploaded files to Salt master
 - Bump version to 4.3.0
 

--- a/spacewalk/setup/spacewalk-setup.spec
+++ b/spacewalk/setup/spacewalk-setup.spec
@@ -180,6 +180,7 @@ install -m 0644 share/defaults.d/defaults.conf %{buildroot}/%{_datadir}/spacewal
 install -d -m 755 %{buildroot}/%{_datadir}/spacewalk/setup/cobbler
 install -m 0644 share/cobbler/* %{buildroot}/%{_datadir}/spacewalk/setup/cobbler/
 install -m 0644 salt/susemanager.conf %{buildroot}/%{_sysconfdir}/salt/master.d/
+install -m 0644 salt/salt-ssh-logging.conf %{buildroot}/%{_sysconfdir}/salt/master.d/
 
 # create a directory for misc. Spacewalk things
 install -d -m 755 %{buildroot}/%{misc_path}/spacewalk
@@ -288,6 +289,7 @@ pylint --rcfile /etc/spacewalk-python3-pylint.rc \
 %defattr(-,root,root,-)
 %doc Changes README answers.txt
 %config %{_sysconfdir}/salt/master.d/susemanager.conf
+%config %{_sysconfdir}/salt/master.d/salt-ssh-logging.conf
 %{perl_vendorlib}/*
 %{_bindir}/spacewalk-setup
 %{_bindir}/spacewalk-setup-httpd

--- a/susemanager-utils/susemanager-sls/salt/cleanup_ssh_minion/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/cleanup_ssh_minion/init.sls
@@ -47,3 +47,8 @@ mgr_remove_own_ssh_pub_key:
 mgr_remove_own_ssh_key:
   file.absent:
     - name: {{ home }}/.ssh/mgr_own_id
+
+# Remove logrotate configuration
+mgr_remove_logrotate_configuration:
+  file.absent:
+    - name: /etc/logrotate.d/salt-ssh

--- a/susemanager-utils/susemanager-sls/salt/ssh_bootstrap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/ssh_bootstrap/init.sls
@@ -61,5 +61,22 @@ authorize_own_key:
       - file: ownership_own_ssh_key
       - ssh_auth: no_own_key_authorized
 
+logrotate_configuration:
+  file.managed:
+    - name: /etc/logrotate.d/salt-ssh
+    - user: root
+    - group: root
+    - mode: 644
+    - makedirs: True
+    - contents: |
+        /var/log/salt-ssh.log {
+                su root root
+                weekly
+                missingok
+                rotate 7
+                compress
+                notifempty
+        }
+
 {% include 'channels/gpg-keys.sls' %}
 {% include 'bootstrap/remove_traditional_stack.sls' %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Enable logrotate configuration for Salt SSH minion logs
 - States and pkgset beacon modified for new salt bundle file placement
 - Handle more ocsf2 setups in virt_utils module
 - Add UEFI support for VM creation


### PR DESCRIPTION
## What does this PR change?

Logging for salt SSH (+ log rotation)

In all cases:
- `/var/log/salt-ssh.log` is created when the bootstrap happens and shows some non fatal errors and warnings depending on the system (@meaksh for awareness, but I think ion squad already knows)
- `/etc/logrotate.d/salt-ssh` is installed, and since `logrotate` is installed in all cases, it should rotate the file when the time comes.

### CentOS7
```
NAME="CentOS Linux"
VERSION="7 (Core)"
ID="centos"
ID_LIKE="rhel fedora"
VERSION_ID="7"
PRETTY_NAME="CentOS Linux 7 (Core)"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:centos:centos:7"
HOME_URL="https://www.centos.org/"
BUG_REPORT_URL="https://bugs.centos.org/"

CENTOS_MANTISBT_PROJECT="CentOS-7"
CENTOS_MANTISBT_PROJECT_VERSION="7"
REDHAT_SUPPORT_PRODUCT="centos"
REDHAT_SUPPORT_PRODUCT_VERSION="7"

-rw-r--r--. 1 root root 15518 Aug  4 12:40 /var/log/salt-ssh.log
Usage: logrotate [OPTION...] <configfile>
  -d, --debug               Don't do anything, just test (implies -v)
  -f, --force               Force file rotation
  -m, --mail=command        Command to send mail (instead of `/bin/mail')
  -s, --state=statefile     Path of state file
  -v, --verbose             Display messages during rotation
  -l, --log=STRING          Log file
  --version                 Display version information

Help options:
  -?, --help                Show this help message
  --usage                   Display brief usage message
-rw-r--r--. 1 root root 133 Aug  4 12:27 /etc/logrotate.d/salt-ssh
```
### CentOS8
```
NAME="CentOS Linux"
VERSION="8 (Core)"
ID="centos"
ID_LIKE="rhel fedora"
VERSION_ID="8"
PLATFORM_ID="platform:el8"
PRETTY_NAME="CentOS Linux 8 (Core)"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:centos:centos:8"
HOME_URL="https://www.centos.org/"
BUG_REPORT_URL="https://bugs.centos.org/"

CENTOS_MANTISBT_PROJECT="CentOS-8"
CENTOS_MANTISBT_PROJECT_VERSION="8"
REDHAT_SUPPORT_PRODUCT="centos"
REDHAT_SUPPORT_PRODUCT_VERSION="8"

-rw-r--r--. 1 root root 6647 Aug  4 12:40 /var/log/salt-ssh.log
Usage: logrotate [OPTION...] <configfile>
  -d, --debug               Don't do anything, just test and print debug
                            messages
  -f, --force               Force file rotation
  -m, --mail=command        Command to send mail (instead of `/bin/mail')
  -s, --state=statefile     Path of state file
  -v, --verbose             Display messages during rotation
  -l, --log=logfile         Log file or 'syslog' to log to syslog
      --version             Display version information

Help options:
  -?, --help                Show this help message
      --usage               Display brief usage message
-rw-r--r--. 1 root root 133 Aug  4 12:30 /etc/logrotate.d/salt-ssh
```
### SLE12SP5
```
NAME="SLES"
VERSION="12-SP5"
VERSION_ID="12.5"
PRETTY_NAME="SUSE Linux Enterprise Server 12 SP5"
ID="sles"
ANSI_COLOR="0;32"
CPE_NAME="cpe:/o:suse:sles:12:sp5"
-rw-r--r-- 1 root root 5103 Aug  4 12:40 /var/log/salt-ssh.log
Usage: logrotate [OPTION...] <configfile>
  -d, --debug               Don't do anything, just test (implies -v)
  -f, --force               Force file rotation
  -m, --mail=command        Command to send mail (instead of `/bin/mail')
  -s, --state=statefile     Path of state file
  -v, --verbose             Display messages during rotation
  -l, --log=STRING          Log file or 'syslog' to log to syslog
      --version             Display version information

Help options:
  -?, --help                Show this help message
      --usage               Display brief usage message
-rw-r--r-- 1 root root 133 Aug  4 12:22 /etc/logrotate.d/salt-ssh
```
### SLE15SP3
```
NAME="SLES"
VERSION="15-SP3"
VERSION_ID="15.3"
PRETTY_NAME="SUSE Linux Enterprise Server 15 SP3"
ID="sles"
ID_LIKE="suse"
ANSI_COLOR="0;32"
CPE_NAME="cpe:/o:suse:sles:15:sp3"
DOCUMENTATION_URL="https://documentation.suse.com/"
-rw-r--r-- 1 root root 5129 Aug  4 12:40 /var/log/salt-ssh.log
Usage: logrotate [OPTION...] <configfile>
  -d, --debug               Don't do anything, just test (implies -v)
  -f, --force               Force file rotation
  -m, --mail=command        Command to send mail (instead of `/bin/mail')
  -s, --state=statefile     Path of state file
  -v, --verbose             Display messages during rotation
  -l, --log=logfile         Log file or 'syslog' to log to syslog
      --version             Display version information

Help options:
  -?, --help                Show this help message
      --usage               Display brief usage message
-rw-r--r-- 1 root root 133 Aug  4 12:32 /etc/logrotate.d/salt-ssh
```
### Ubuntu20.04
```
NAME="Ubuntu"
VERSION="20.04.2 LTS (Focal Fossa)"
ID=ubuntu
ID_LIKE=debian
PRETTY_NAME="Ubuntu 20.04.2 LTS"
VERSION_ID="20.04"
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
VERSION_CODENAME=focal
UBUNTU_CODENAME=focal
-rw-r--r-- 1 root root 3772 Aug  4 12:40 /var/log/salt-ssh.log
Usage: logrotate [OPTION...] <configfile>
  -d, --debug               Don't do anything, just test and print debug
                            messages
  -f, --force               Force file rotation
  -m, --mail=command        Command to send mail (instead of `/usr/bin/mail')
  -s, --state=statefile     Path of state file
  -v, --verbose             Display messages during rotation
  -l, --log=logfile         Log file or 'syslog' to log to syslog
      --version             Display version information

Help options:
  -?, --help                Show this help message
      --usage               Display brief usage message
-rw-r--r-- 1 root root 133 Aug  4 12:37 /etc/logrotate.d/salt-ssh
```

Open questions:
- I tested with cloud images for all OS. Should we assume logrotate is always installed, or should we require it at the salt state where we configure it, just in case?
- The log file is owned by `root:root` with mode 644. Is this OK, or do we need to make it 640 or even 600? Keep in mind: no `salt` user or group is available for salt-ssh systems.
- Do we need to document this? I am not sure we document the salt log for regular minions.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- Documentation issue was created: Pending

- [ ] **DONE**

## Test coverage
- No tests: Bootstrap covered already by the testsuite

- [x] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/15356

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
