### PR TITLE
Spacewalk CMD: Remove whoami from the exclude login regex (bsc#1188977)

### DIFF
--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,5 @@
+- Remove whoami from the list of unauthenticated commands (bsc#1188977)
+
 -------------------------------------------------------------------
 Mon Aug 09 10:56:30 CEST 2021 - jgonzalez@suse.com
 

--- a/spacecmd/src/spacecmd/shell.py
+++ b/spacecmd/src/spacecmd/shell.py
@@ -143,7 +143,7 @@ class SpacewalkShell(Cmd):
             sys.exit(0)
 
         # don't attempt to login for some commands
-        if re.match('help|login|logout|whoami|history|clear', line, re.I):
+        if re.match('help|login|logout|history|clear', line, re.I):
             # login required for clear_caches or it fails with:
             # "SpacewalkShell instance has no attribute 'system_cache_file'"
             if not re.match('clear_caches', line, re.I):

--- a/spacecmd/tests/test_misc.py
+++ b/spacecmd/tests/test_misc.py
@@ -705,6 +705,39 @@ class TestSCMisc:
         assert shell.do_clear_caches.called
         assert_args_expect(shell.do_clear_caches.call_args_list, [(("", ), {})])
 
+    def test_whoami_negative(self, shell):
+        """
+        Test whoami
+
+        :param shell:
+        :return:
+        """
+        mprint = MagicMock()
+        logger = MagicMock()
+        with patch("spacecmd.misc.print", mprint), \
+            patch.object(shell, "current_user", None), \
+            patch("spacecmd.misc.logging", logger):
+            spacecmd.misc.do_whoami(shell, "")
+
+        assert not mprint.called
+        assert logger.warning.called
+
+    def test_whoami_positive(self, shell):
+        """
+        Test whoami
+
+        :param shell:
+        :return:
+        """
+        mprint = MagicMock()
+        logger = MagicMock()
+        with patch("spacecmd.misc.print", mprint), \
+                patch("spacecmd.misc.logging", logger):
+            spacecmd.misc.do_whoami(shell, "")
+
+        assert mprint.called
+        assert not logger.warning.called
+
     def test_whoamitalkingto(self, shell):
         """
         Test to display what server is connected.

--- a/spacecmd/tests/test_shell.py
+++ b/spacecmd/tests/test_shell.py
@@ -97,7 +97,7 @@ class TestSCShell:
         options.nohistory = True
         shell = SpacewalkShell(options, "", None)
         shell.config["server"] = ""
-        for cmd in ["help", "login", "logout", "whoami", "history", "clear"]:
+        for cmd in ["help", "login", "logout", "history", "clear"]:
             assert shell.precmd(cmd) == cmd
 
     @patch("spacecmd.shell.atexit", MagicMock())


### PR DESCRIPTION
## What does this PR change?

Excludes the `spacecmd whoami` command from the list of commands which doesn't require a login.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage

- Unit tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/15585
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests" 
