### PR TITLE
Fix cleanup always being executed on delete system (bsc#1189011)

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/SystemsController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/SystemsController.java
@@ -119,7 +119,7 @@ public class SystemsController {
      */
     public String delete(Request request, Response response, User user) {
         String sidStr = request.params("sid");
-        String noclean = request.queryParams("nocleanup");
+        Boolean noclean = Boolean.parseBoolean(GSON.fromJson(request.body(), Map.class).get("nocleanup").toString());
         long sid;
         try {
             sid = Long.parseLong(sidStr);
@@ -131,7 +131,7 @@ public class SystemsController {
         boolean isEmptyProfile = server.hasEntitlement(EntitlementManager.BOOTSTRAP);
 
         if (server.asMinionServer().isPresent()) {
-            if (!Boolean.parseBoolean(noclean) && !isEmptyProfile) {
+            if (!noclean && !isEmptyProfile) {
                 Optional<List<String>> cleanupErr =
                         saltApi.cleanupMinion(server.asMinionServer().get(), 300);
                 if (cleanupErr.isPresent()) {

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix cleanup always being executed on delete system (bsc#1189011)
 - Warning in Overview page for SLE Micro system (bsc#1188551)
 - Fix system information forwarding to SCC (bsc#1188900)
 - Add UEFI support for VM creation / editing

--- a/web/html/src/manager/systems/delete-system.tsx
+++ b/web/html/src/manager/systems/delete-system.tsx
@@ -32,9 +32,8 @@ class DeleteSystem extends React.Component<Props, State> {
     };
   }
 
-  handleDelete = cleanupErr => {
-    const nocleanupParam = cleanupErr ? { nocleanup: "true" } : {};
-    return Network.post(`/rhn/manager/api/systems/${this.props.serverId}/delete`, $.param(nocleanupParam))
+  handleDelete = (cleanupErr: Boolean) => {
+    return Network.post(`/rhn/manager/api/systems/${this.props.serverId}/delete`, { nocleanup: cleanupErr })
       .then(data => {
         if (data.success && this.props.onDeleteSuccess) {
           this.props.onDeleteSuccess();

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Fix cleanup always being executed on delete system (bsc#1189011)
 - Expose UEFI parameters in the VM creation/editing pages
 - Add virt-tuner templates to VM creation
 - Fix virtualization guests to handle null HostInfo


### PR DESCRIPTION
## What does this PR change?

When trying to delete a minion that is not reachable the user gets proposed to delete without cleanup. However the cleanup was being executed regardless due to a parameter from the frontend not being retrievable.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: **Bugfix**

- [x] **DONE**

## Test coverage

- No tests: **Bugfix**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/15593

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
