### PR TITLE
susemanager: Package 'snapper' is now optional

### DIFF
--- a/susemanager/bin/mgr-setup
+++ b/susemanager/bin/mgr-setup
@@ -259,7 +259,7 @@ check_mksubvolume() {
     then
         echo "'mksubvolume' not found. Installing package 'snapper'"
         $(command -v zypper || command -v dnf) --quiet install -y snapper
-        if ! [ $? -eq 0 ]; then
+        if [ $? -ne 0 ]; then
             echo "Please install the package 'snapper' manually."
             exit 1
         fi

--- a/susemanager/bin/mgr-setup
+++ b/susemanager/bin/mgr-setup
@@ -254,12 +254,25 @@ host $MANAGER_DB_NAME $MANAGER_USER ::1/128 md5
     systemctl restart postgresql
 }
 
+check_mksubvolume() {
+    if ! command -v mksubvolume &> /dev/null
+    then
+        echo "'mksubvolume' not found. Installing package 'snapper'"
+        $(command -v zypper || command -v dnf) --quiet install -y snapper
+        if ! [ $? -eq 0 ]; then
+            echo "Please install the package 'snapper' manually."
+            exit 1
+        fi
+    fi
+}
+
 check_btrfs_dirs() {
 DIR="/var/spacewalk"
 if [ ! -d $DIR ]; then
     FSTYPE=`df -T \`dirname $DIR\` | tail -1 | awk '{print $2}'`
     echo -n "Filesystem type for $DIR is $FSTYPE - "
     if [ $FSTYPE == "btrfs" ]; then
+        check_mksubvolume
         echo "creating nCoW subvolume."
         mksubvolume --nocow $DIR
     else
@@ -279,6 +292,7 @@ if [ $FSTYPE == "btrfs" ]; then
     TESTDIR=`basename $DIR`
     btrfs subvolume list /var | grep "$TESTDIR" > /dev/null
     if [ ! $? -eq 0 ]; then
+        check_mksubvolume
         echo "creating subvolume."
         mv $DIR ${DIR}.sav
         mksubvolume $DIR

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,6 @@
+
+- Package 'snapper' is now optional.
+
 -------------------------------------------------------------------
 Fri Aug 13 12:23:43 CEST 2021 - jgonzalez@suse.com
 

--- a/susemanager/susemanager.spec
+++ b/susemanager/susemanager.spec
@@ -109,9 +109,9 @@ Requires(pre):  uyuni-base-server
 Requires:       firewalld
 %endif
 Requires:       postfix
-# mgr-setup want to call mksubvolume
 Requires:       reprepro
-Requires:       snapper
+# mgr-setup want to call mksubvolume for btrfs filesystems
+Recommends:     snapper
 # mgr-setup calls dig
 Requires:       bind-utils
 %define python_sitelib %(%{pythonX} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")


### PR DESCRIPTION
## What does this PR change?

Package `snapper` is required during setup for creating btrfs volumes using `mksubvolume`.
This change makes the `snapper` package optional.
Should the package be required and not installed at setup time, it will automatically be installed.
A friendly message is displayed should the automatic installation fail.

Background: Snapper and btrfs-progs are not available on Enterprise Linux 8. Making the packages optional allows system admins decide whether they would like to install 3rd party packages, create their own package or not use btrfs.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: Manually tested.

Code works on Leap and AlmaLinux. Installation tested manually with and without package on AlmaLinux installation.
Build has been tested successfully on
 epel-8-x86_64 
 opensuse-leap-15.3-x86_64 

- [X] **DONE**

## Links

Fixes #3586 

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
