### PR TITLE
RFC: Formik as a replacement for `InputBase`

### DIFF
--- a/susemanager-frontend/susemanager-nodejs-sdk-devel/package.json
+++ b/susemanager-frontend/susemanager-nodejs-sdk-devel/package.json
@@ -80,6 +80,7 @@
     "@hot-loader/react-dom": "^17.0.1",
     "@novnc/novnc": "^1.0.0",
     "@spice-project/spice-html5": "^0.2.1",
+    "formik": "^2.2.9",
     "gettext-parser": "^4.0.4",
     "html-react-parser": "^0.10.0",
     "immer": "^8.0.1",

--- a/susemanager-frontend/yarn.lock
+++ b/susemanager-frontend/yarn.lock
@@ -6907,6 +6907,11 @@ deep-object-diff@^1.1.0:
   resolved "https://registry.yarnpkg.com/deep-object-diff/-/deep-object-diff-1.1.0.tgz#d6fabf476c2ed1751fc94d5ca693d2ed8c18bc5a"
   integrity sha512-b+QLs5vHgS+IoSNcUE4n9HP2NwcHj7aqnJWsjPtuG75Rh5TOaGt0OjAYInh77d5T16V5cRDC+Pw/6ZZZiETBGw==
 
+deepmerge@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.2.1.tgz#5d3ff22a01c00f645405a2fbc17d0778a1801170"
+  integrity sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==
+
 deepmerge@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
@@ -8349,6 +8354,19 @@ format@^0.2.0:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/format/-/format-0.2.2.tgz#d6170107e9efdc4ed30c9dc39016df942b5cb58b"
   integrity sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs=
+
+formik@^2.2.9:
+  version "2.2.9"
+  resolved "https://registry.yarnpkg.com/formik/-/formik-2.2.9.tgz#8594ba9c5e2e5cf1f42c5704128e119fc46232d0"
+  integrity sha512-LQLcISMmf1r5at4/gyJigGn0gOwFbeEAlji+N9InZF6LIMXnFNkO42sCI8Jt84YZggpD4cPWObAZaxpEFtSzNA==
+  dependencies:
+    deepmerge "^2.1.1"
+    hoist-non-react-statics "^3.3.0"
+    lodash "^4.17.21"
+    lodash-es "^4.17.21"
+    react-fast-compare "^2.0.1"
+    tiny-warning "^1.0.2"
+    tslib "^1.10.0"
 
 forwarded@~0.1.2:
   version "0.1.2"
@@ -10982,6 +11000,11 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
+lodash-es@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
+  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
+
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
@@ -11037,7 +11060,7 @@ lodash.uniq@4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.17.21, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20:
+lodash@4.17.21, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -13298,6 +13321,11 @@ react-error-overlay@^6.0.3:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.9.tgz#3c743010c9359608c375ecd6bc76f35d93995b0a"
   integrity sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==
 
+react-fast-compare@^2.0.1:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
+  integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
+
 react-fast-compare@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.2.0.tgz#641a9da81b6a6320f270e89724fb45a0b39e43bb"
@@ -15381,6 +15409,11 @@ tiny-emitter@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
   integrity sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
+
+tiny-warning@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
+  integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
 
 tmp@^0.0.33:
   version "0.0.33"

--- a/web/html/src/components/input/FormikForm.stories.tsx
+++ b/web/html/src/components/input/FormikForm.stories.tsx
@@ -1,39 +1,39 @@
 import * as React from 'react';
-import { Form } from './Form';
+import FormikForm from './FormikForm';
 import { Text } from './Text';
 import { SubmitButton } from 'components/buttons';
 
 export default {
-  component: Form,
-  title: 'Forms/Form'
+  component: FormikForm,
+  title: 'Forms/FormikForm'
 };
 
 let model = {
   firstname: 'John',
 };
 
+//Form props:
+//divClass="col-md-12"
+//formDirection="form-horizontal"
 export const Example = () => (
-  <Form
+  <FormikForm
     model={model}
-    onChange={newModel => {model['firstname'] = newModel['firstname']}}
-    onSubmit={() => alert(`Hello ${model['firstname']}`)}
-    onSubmitInvalid={(data, evt) => alert("Submit clicked, but form invalid")}
-    divClass="col-md-12"
-    formDirection="form-horizontal"
+    onSubmit={(foo) => console.log(foo)}
   >
     <Text
       name="firstname"
       label={t('First Name')}
       required
-      invalidHint={t('Minimum 2 characters')}
+      // invalidHint={t('Minimum 2 characters')}
       labelClass="col-md-3"
+      disabled
       divClass="col-md-6"
-      validators={[(value => (value.length > 2))]}
+      // validators={[(value => (value.length > 2))]}
     />
     <SubmitButton
       id="submit-btn"
       className="btn-success"
       text={t("Submit")}
     />
-  </Form>
+  </FormikForm>
 )

--- a/web/html/src/components/input/FormikForm.stories.tsx
+++ b/web/html/src/components/input/FormikForm.stories.tsx
@@ -12,13 +12,12 @@ let model = {
   firstname: 'John',
 };
 
-//Form props:
-//divClass="col-md-12"
-//formDirection="form-horizontal"
 export const Example = () => (
   <FormikForm
     model={model}
     onSubmit={(foo) => console.log(foo)}
+    divClass="col-md-12"
+    formDirection="form-horizontal"
   >
     <Text
       name="firstname"

--- a/web/html/src/components/input/FormikForm.stories.tsx
+++ b/web/html/src/components/input/FormikForm.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import FormikForm from './FormikForm';
-import { Text } from './Text';
+import { Text } from './FormikText';
 import { SubmitButton } from 'components/buttons';
 
 export default {

--- a/web/html/src/components/input/FormikForm.stories.tsx
+++ b/web/html/src/components/input/FormikForm.stories.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { Form } from './Form';
+import { Text } from './Text';
+import { SubmitButton } from 'components/buttons';
+
+export default {
+  component: Form,
+  title: 'Forms/Form'
+};
+
+let model = {
+  firstname: 'John',
+};
+
+export const Example = () => (
+  <Form
+    model={model}
+    onChange={newModel => {model['firstname'] = newModel['firstname']}}
+    onSubmit={() => alert(`Hello ${model['firstname']}`)}
+    onSubmitInvalid={(data, evt) => alert("Submit clicked, but form invalid")}
+    divClass="col-md-12"
+    formDirection="form-horizontal"
+  >
+    <Text
+      name="firstname"
+      label={t('First Name')}
+      required
+      invalidHint={t('Minimum 2 characters')}
+      labelClass="col-md-3"
+      divClass="col-md-6"
+      validators={[(value => (value.length > 2))]}
+    />
+    <SubmitButton
+      id="submit-btn"
+      className="btn-success"
+      text={t("Submit")}
+    />
+  </Form>
+)

--- a/web/html/src/components/input/FormikForm.stories.tsx
+++ b/web/html/src/components/input/FormikForm.stories.tsx
@@ -24,11 +24,11 @@ export const Example = () => (
       name="firstname"
       label={t('First Name')}
       required
-      // invalidHint={t('Minimum 2 characters')}
       labelClass="col-md-3"
       disabled
       divClass="col-md-6"
-      // validators={[(value => (value.length > 2))]}
+      validators={[(value => (value.length > 2))]}
+      invalidHint={t('Minimum 2 characters')}
     />
     <SubmitButton
       id="submit-btn"

--- a/web/html/src/components/input/FormikForm.tsx
+++ b/web/html/src/components/input/FormikForm.tsx
@@ -46,25 +46,22 @@ export default class FormikForm extends React.PureComponent<Props> {
 
   render() {
     return (
-      <React.Fragment>
-        <p>Foo</p>
-        <Formik
-          initialValues={this.props.model ?? {}}
-          onSubmit={this.onSubmit}
-          className={this.props.className}
-          title={this.props.title}
-        >
-          {formikProps => (
-            <Form>
-              <div
-                className={`${this.props.formDirection || ""} ${this.props.divClass ? ` ${this.props.divClass}` : ""}`}
-              >
-                {React.Children.toArray(this.props.children).map(child => cloneReactElement(child, { ...formikProps }))}
-              </div>
-            </Form>
-          )}
-        </Formik>
-      </React.Fragment>
+      <Formik
+        initialValues={this.props.model ?? {}}
+        onSubmit={this.onSubmit}
+        className={this.props.className}
+        title={this.props.title}
+      >
+        {formikProps => (
+          <Form>
+            <div
+              className={`${this.props.formDirection || ""} ${this.props.divClass ? ` ${this.props.divClass}` : ""}`}
+            >
+              {React.Children.toArray(this.props.children).map(child => cloneReactElement(child, { ...formikProps }))}
+            </div>
+          </Form>
+        )}
+      </Formik>
     );
   }
 }

--- a/web/html/src/components/input/FormikForm.tsx
+++ b/web/html/src/components/input/FormikForm.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { Formik, Form, Field, ErrorMessage } from "formik";
+import { cloneReactElement } from "components/utils";
 
 type FormikProps = React.ComponentProps<typeof Formik>;
 type ModelType = {
@@ -19,6 +20,21 @@ type Props = {
 
   /** Children elements of the form. Usually includes fields and a submit button */
   children: React.ReactNode;
+
+  /** TODO: This is only used in stories, deprecate it */
+  onSubmitInvalid?: Function;
+
+  /** CSS class of the form */
+  className?: string;
+
+  /** TODO: Merge with below? CSS class of the div right within the form */
+  divClass?: string;
+
+  /** CSS class name for the form direction style */
+  formDirection?: string;
+
+  /** TODO: Check if used: Accessible title of the form */
+  title?: string;
 };
 
 export default class FormikForm extends React.PureComponent<Props> {
@@ -30,14 +46,25 @@ export default class FormikForm extends React.PureComponent<Props> {
 
   render() {
     return (
-      <Formik initialValues={this.props.model ?? {}} onSubmit={this.onSubmit}>
-        {(formikProps) => {
-          <Form>
-            {/* TODO: Pass props to children too? See https://formik.org/docs/api/formik#formik-render-methods-and-props */}
-            {this.props.children}
-          </Form>;
-        }}
-      </Formik>
+      <React.Fragment>
+        <p>Foo</p>
+        <Formik
+          initialValues={this.props.model ?? {}}
+          onSubmit={this.onSubmit}
+          className={this.props.className}
+          title={this.props.title}
+        >
+          {formikProps => (
+            <Form>
+              <div
+                className={`${this.props.formDirection || ""} ${this.props.divClass ? ` ${this.props.divClass}` : ""}`}
+              >
+                {React.Children.toArray(this.props.children).map(child => cloneReactElement(child, { ...formikProps }))}
+              </div>
+            </Form>
+          )}
+        </Formik>
+      </React.Fragment>
     );
   }
 }

--- a/web/html/src/components/input/FormikForm.tsx
+++ b/web/html/src/components/input/FormikForm.tsx
@@ -1,0 +1,43 @@
+import * as React from "react";
+import { Formik, Form, Field, ErrorMessage } from "formik";
+
+type FormikProps = React.ComponentProps<typeof Formik>;
+type ModelType = {
+  [field: string]: any;
+};
+
+type Props = {
+  /**
+   * Object storing the data of the form.
+   * Each field name in the form needs to map to a property of this
+   * object. The value is the one displayed in the form
+   */
+  model?: ModelType; // TODO: Rename initialModel or initialValues
+
+  /** Function to trigger when the Submit button is clicked */
+  onSubmit?: FormikProps["onSubmit"];
+
+  /** Children elements of the form. Usually includes fields and a submit button */
+  children: React.ReactNode;
+};
+
+export default class FormikForm extends React.PureComponent<Props> {
+  onSubmit: FormikProps["onSubmit"] = async (values, helpers) => {
+    // For backwards compatibility, this.props.onSubmit is optional
+    await this.props.onSubmit?.(values, helpers);
+    helpers.setSubmitting(false);
+  };
+
+  render() {
+    return (
+      <Formik initialValues={this.props.model ?? {}} onSubmit={this.onSubmit}>
+        {(formikProps) => {
+          <Form>
+            {/* TODO: Pass props to children too? See https://formik.org/docs/api/formik#formik-render-methods-and-props */}
+            {this.props.children}
+          </Form>;
+        }}
+      </Formik>
+    );
+  }
+}

--- a/web/html/src/components/input/FormikInputBase.tsx
+++ b/web/html/src/components/input/FormikInputBase.tsx
@@ -71,7 +71,6 @@ const InputBase = <Value,>(props: InputBaseProps<Value>) => {
 
   const validate = async (input: Value) => {
     const results = await Promise.all(validators.map(validator => validator(input)));
-    console.log(validators, results.filter(Boolean));
     // Show the first error we find by default, usually this will be the required validation
     return results.filter(Boolean)[0];
   };

--- a/web/html/src/components/input/FormikInputBase.tsx
+++ b/web/html/src/components/input/FormikInputBase.tsx
@@ -1,0 +1,105 @@
+import * as React from "react";
+import { Field, FieldProps, FieldAttributes } from "formik";
+import _isNil from "lodash/isNil";
+
+import { FormGroup } from "./FormGroup";
+import { Label } from "./Label";
+
+type SimpleValidator<Value> = (value: Value) => boolean | Promise<boolean>;
+type FormikValidator<Value> = (value: Value) => void | string | Promise<void | string>;
+
+export type InputBaseProps<Value> = Omit<FieldAttributes<unknown>, "validate"> & {
+  /** CSS class for the <input> element */
+  inputClass?: string;
+
+  /** Label to display for the field */
+  label?: string;
+
+  /** CSS class to use for the label */
+  labelClass?: string;
+
+  /** CSS class to use for the <div> element wrapping the field input part */
+  divClass?: string;
+
+  /** Indicates whether the field is required in the form */
+  required?: boolean;
+
+  /** An array of validators to run against the input, either sync or async, resolve with `true` for valid & `false` for invalid */
+  validators?: SimpleValidator<Value> | SimpleValidator<Value>[];
+
+  /** Hint to display on a validation error */
+  invalidHint?: string;
+};
+
+function isCallable(input: any): input is (...args: any[]) => any {
+  return typeof input === "function";
+}
+
+const isEmptyValue = (input: any) => {
+  if (typeof input === "string") {
+    return input.trim() === "";
+  }
+  return _isNil(input);
+};
+
+const requiredValidator = <Value,>(label?: string) => {
+  return (input: Value) => {
+    if (isEmptyValue(input)) {
+      return label ? t(`${label} is required.`) : t("required");
+    }
+  };
+};
+
+const InputBase = <Value,>(props: InputBaseProps<Value>) => {
+  const { label, labelClass, divClass, invalidHint, ...propsToPass } = props;
+
+  const validators: FormikValidator<Value>[] = [];
+  if (props.required) {
+    validators.push(requiredValidator(props.label));
+  }
+
+  if (props.validators) {
+    const simpleValidators = Array.isArray(props.validators) ? props.validators : [props.validators];
+    const mergedValidator = async (input: Value) => {
+      const results = await Promise.all(simpleValidators.map(item => item(input)));
+      if (results.some(result => result === false)) {
+        return invalidHint || "Not valid";
+      }
+    };
+    validators.push(mergedValidator);
+  }
+
+  const validate = async (input: Value) => {
+    const results = await Promise.all(validators.map(validator => validator(input)));
+    console.log(validators, results.filter(Boolean));
+    // Show the first error we find by default, usually this will be the required validation
+    return results.filter(Boolean)[0];
+  };
+
+  return (
+    <Field {...propsToPass} validate={validate}>
+      {(fieldProps: FieldProps<Value>) => {
+        const isError = Boolean(fieldProps.meta.touched && fieldProps.meta.error);
+        return (
+          <FormGroup isError={isError} key={`${props.name}-group`} className={props.className}>
+            {props.label && (
+              <Label
+                name={props.label}
+                className={props.labelClass}
+                required={props.required}
+                key={`${props.name}-label`}
+                htmlFor={typeof props.name === "string" ? props.name : undefined}
+              />
+            )}
+            <div className={props.divClass}>
+              {isCallable(props.children) ? props.children(fieldProps) : props.children}
+              {isError && <div className="help-block">{fieldProps.meta.error}</div>}
+            </div>
+          </FormGroup>
+        );
+      }}
+    </Field>
+  );
+};
+
+export default InputBase;

--- a/web/html/src/components/input/FormikText.tsx
+++ b/web/html/src/components/input/FormikText.tsx
@@ -1,0 +1,38 @@
+import * as React from "react";
+import { FieldProps } from "formik";
+import InputBase, { InputBaseProps } from "./FormikInputBase";
+
+type Props<Value> = InputBaseProps<Value> & {
+  maxLength: number;
+};
+
+export const Text = <Value extends string>(props: Props<Value>) => {
+  const { inputClass, ...propsToPass } = props;
+  return (
+    <InputBase {...propsToPass}>
+      {({ field }: FieldProps<Value>) => (
+        <input id={field.name} className={`form-control${props.inputClass ? ` ${props.inputClass}` : ""}`} {...field} />
+      )}
+    </InputBase>
+  );
+};
+
+const defaultProps: Partial<Props<string>> = {
+  type: "text",
+  maxLength: undefined,
+  placeholder: undefined,
+  inputClass: undefined,
+  defaultValue: undefined,
+  // TODO: Fix these
+  // label: undefined,
+  // hint: undefined,
+  // labelClass: undefined,
+  // divClass: undefined,
+  className: undefined,
+  required: false,
+  disabled: false,
+  // invalidHint: undefined,
+  onChange: undefined,
+};
+
+Text.defaultProps = defaultProps;

--- a/web/html/src/components/input/Text.tsx
+++ b/web/html/src/components/input/Text.tsx
@@ -1,67 +1,49 @@
 import * as React from "react";
-import { InputBase, InputBaseProps } from "./InputBase";
-import { FormContext } from "./Form";
+import { Field, FieldProps, FieldAttributes } from "formik";
 
-type Props = InputBaseProps & {
-  /** <input> type */
-  type?: string;
-
-  /** Maximum number of characters of the input field */
-  maxLength?: number;
-
-  /** Value placeholder to display when no value is entered */
-  placeholder?: string;
-
+type Props = FieldAttributes<unknown> & {
   /** CSS class for the <input> element */
   inputClass?: string;
-
-  /** name of the field to map in the form model */
-  name: string;
 };
 
-export const Text = (props: Props) => {
-  const { type, maxLength, placeholder, inputClass, ...propsToPass } = props;
-  const formContext = React.useContext(FormContext);
+export const Text = <Value extends string>(props: Props) => {
+  const { inputClass, ...propsToPass } = props;
   return (
-    <InputBase {...propsToPass}>
-      {({ setValue, onBlur }) => {
-        const onChange = (event: any) => {
-          setValue(event.target.name, event.target.value);
-        };
-        const fieldValue = (formContext.model || {})[props.name] || props.defaultValue || "";
-        return (
+    <Field {...propsToPass}>
+      {({
+        field, // { name, value, onChange, onBlur }
+        form: { touched, errors }, // also values, setXXXX, handleXXXX, dirty, isValid, status, etc.
+        meta,
+      }: FieldProps<Value>) => (
+        <div>
           <input
-            className={`form-control${inputClass ? ` ${inputClass}` : ""}`}
-            type={type || "text"}
-            name={props.name}
-            id={props.name}
-            value={fieldValue}
-            onChange={onChange}
-            disabled={props.disabled}
-            onBlur={onBlur}
-            placeholder={placeholder}
-            maxLength={maxLength}
-            title={props.title}
+            id={field.name}
+            className={`form-control${props.inputClass ? ` ${props.inputClass}` : ""}`}
+            {...field}
           />
-        );
-      }}
-    </InputBase>
+          {meta.touched && meta.error && <div className="error">{meta.error}</div>}
+        </div>
+      )}
+    </Field>
   );
 };
 
-Text.defaultProps = {
+const defaultProps: Partial<Props> = {
   type: "text",
   maxLength: undefined,
   placeholder: undefined,
   inputClass: undefined,
   defaultValue: undefined,
-  label: undefined,
-  hint: undefined,
-  labelClass: undefined,
-  divClass: undefined,
+  // TODO: Fix these
+  // label: undefined,
+  // hint: undefined,
+  // labelClass: undefined,
+  // divClass: undefined,
   className: undefined,
   required: false,
   disabled: false,
-  invalidHint: undefined,
+  // invalidHint: undefined,
   onChange: undefined,
 };
+
+Text.defaultProps = defaultProps;

--- a/web/html/src/components/input/Text.tsx
+++ b/web/html/src/components/input/Text.tsx
@@ -1,38 +1,67 @@
 import * as React from "react";
-import { FieldProps } from "formik";
-import InputBase, { InputBaseProps } from "./FormikInputBase";
+import { InputBase, InputBaseProps } from "./InputBase";
+import { FormContext } from "./Form";
 
-type Props<Value> = InputBaseProps<Value> & {
-  maxLength: number;
+type Props = InputBaseProps & {
+  /** <input> type */
+  type?: string;
+
+  /** Maximum number of characters of the input field */
+  maxLength?: number;
+
+  /** Value placeholder to display when no value is entered */
+  placeholder?: string;
+
+  /** CSS class for the <input> element */
+  inputClass?: string;
+
+  /** name of the field to map in the form model */
+  name: string;
 };
 
-export const Text = <Value extends string>(props: Props<Value>) => {
-  const { inputClass, ...propsToPass } = props;
+export const Text = (props: Props) => {
+  const { type, maxLength, placeholder, inputClass, ...propsToPass } = props;
+  const formContext = React.useContext(FormContext);
   return (
     <InputBase {...propsToPass}>
-      {({ field }: FieldProps<Value>) => (
-        <input id={field.name} className={`form-control${props.inputClass ? ` ${props.inputClass}` : ""}`} {...field} />
-      )}
+      {({ setValue, onBlur }) => {
+        const onChange = (event: any) => {
+          setValue(event.target.name, event.target.value);
+        };
+        const fieldValue = (formContext.model || {})[props.name] || props.defaultValue || "";
+        return (
+          <input
+            className={`form-control${inputClass ? ` ${inputClass}` : ""}`}
+            type={type || "text"}
+            name={props.name}
+            id={props.name}
+            value={fieldValue}
+            onChange={onChange}
+            disabled={props.disabled}
+            onBlur={onBlur}
+            placeholder={placeholder}
+            maxLength={maxLength}
+            title={props.title}
+          />
+        );
+      }}
     </InputBase>
   );
 };
 
-const defaultProps: Partial<Props<string>> = {
+Text.defaultProps = {
   type: "text",
   maxLength: undefined,
   placeholder: undefined,
   inputClass: undefined,
   defaultValue: undefined,
-  // TODO: Fix these
-  // label: undefined,
-  // hint: undefined,
-  // labelClass: undefined,
-  // divClass: undefined,
+  label: undefined,
+  hint: undefined,
+  labelClass: undefined,
+  divClass: undefined,
   className: undefined,
   required: false,
   disabled: false,
-  // invalidHint: undefined,
+  invalidHint: undefined,
   onChange: undefined,
 };
-
-Text.defaultProps = defaultProps;

--- a/web/html/src/components/input/Text.tsx
+++ b/web/html/src/components/input/Text.tsx
@@ -1,52 +1,15 @@
 import * as React from "react";
-import { Field, FieldProps, FieldAttributes, FieldConfig } from "formik";
-import { FormGroup } from "./FormGroup";
-import { Label } from "./Label";
+import { FieldProps, FieldAttributes } from "formik";
+import InputBase, { InputBaseProps } from "./FormikInputBase";
 
-type Props = FieldAttributes<unknown> & {
-  /** CSS class for the <input> element */
-  inputClass?: string;
+type Props<Value> = InputBaseProps<Value> & {
+  maxLength: number,
 };
 
-function isCallable(input: any): input is (...args: any[]) => any {
-  return typeof input === "function";
-}
-
-const FieldWrapper = <Value extends unknown>(props: Props) => {
-  const { label, labelClass, divClass, ...propsToPass } = props;
-  return (
-    <Field {...propsToPass}>
-      {(fieldProps: FieldProps<Value>) => {
-        // TODO: Check
-        const isError = !!fieldProps.form.errors[fieldProps.field.name];
-        // TODO: Implement
-        const hints = null;
-        return (
-          <FormGroup isError={isError} key={`${props.name}-group`} className={props.className}>
-            {props.label && (
-              <Label
-                name={props.label}
-                className={props.labelClass}
-                required={props.required}
-                key={`${props.name}-label`}
-                htmlFor={typeof props.name === "string" ? props.name : undefined}
-              />
-            )}
-            <div className={props.divClass}>
-              {isCallable(props.children) ? props.children(fieldProps) : props.children}
-              {hints && <div className="help-block">{hints}</div>}
-            </div>
-          </FormGroup>
-        );
-      }}
-    </Field>
-  );
-};
-
-export const Text = <Value extends string>(props: Props) => {
+export const Text = <Value extends string>(props: Props<Value>) => {
   const { inputClass, ...propsToPass } = props;
   return (
-    <FieldWrapper {...propsToPass}>
+    <InputBase {...propsToPass}>
       {({
         field, // { name, value, onChange, onBlur }
         form: { touched, errors }, // also values, setXXXX, handleXXXX, dirty, isValid, status, etc.
@@ -58,14 +21,13 @@ export const Text = <Value extends string>(props: Props) => {
             className={`form-control${props.inputClass ? ` ${props.inputClass}` : ""}`}
             {...field}
           />
-          {meta.touched && meta.error && <div className="error">{meta.error}</div>}
         </div>
       )}
-    </FieldWrapper>
+    </InputBase>
   );
 };
 
-const defaultProps: Partial<Props> = {
+const defaultProps: Partial<Props<string>> = {
   type: "text",
   maxLength: undefined,
   placeholder: undefined,

--- a/web/html/src/components/input/Text.tsx
+++ b/web/html/src/components/input/Text.tsx
@@ -1,15 +1,52 @@
 import * as React from "react";
-import { Field, FieldProps, FieldAttributes } from "formik";
+import { Field, FieldProps, FieldAttributes, FieldConfig } from "formik";
+import { FormGroup } from "./FormGroup";
+import { Label } from "./Label";
 
 type Props = FieldAttributes<unknown> & {
   /** CSS class for the <input> element */
   inputClass?: string;
 };
 
+function isCallable(input: any): input is (...args: any[]) => any {
+  return typeof input === "function";
+}
+
+const FieldWrapper = <Value extends unknown>(props: Props) => {
+  const { label, labelClass, divClass, ...propsToPass } = props;
+  return (
+    <Field {...propsToPass}>
+      {(fieldProps: FieldProps<Value>) => {
+        // TODO: Check
+        const isError = !!fieldProps.form.errors[fieldProps.field.name];
+        // TODO: Implement
+        const hints = null;
+        return (
+          <FormGroup isError={isError} key={`${props.name}-group`} className={props.className}>
+            {props.label && (
+              <Label
+                name={props.label}
+                className={props.labelClass}
+                required={props.required}
+                key={`${props.name}-label`}
+                htmlFor={typeof props.name === "string" ? props.name : undefined}
+              />
+            )}
+            <div className={props.divClass}>
+              {isCallable(props.children) ? props.children(fieldProps) : props.children}
+              {hints && <div className="help-block">{hints}</div>}
+            </div>
+          </FormGroup>
+        );
+      }}
+    </Field>
+  );
+};
+
 export const Text = <Value extends string>(props: Props) => {
   const { inputClass, ...propsToPass } = props;
   return (
-    <Field {...propsToPass}>
+    <FieldWrapper {...propsToPass}>
       {({
         field, // { name, value, onChange, onBlur }
         form: { touched, errors }, // also values, setXXXX, handleXXXX, dirty, isValid, status, etc.
@@ -24,7 +61,7 @@ export const Text = <Value extends string>(props: Props) => {
           {meta.touched && meta.error && <div className="error">{meta.error}</div>}
         </div>
       )}
-    </Field>
+    </FieldWrapper>
   );
 };
 

--- a/web/html/src/components/input/Text.tsx
+++ b/web/html/src/components/input/Text.tsx
@@ -1,27 +1,17 @@
 import * as React from "react";
-import { FieldProps, FieldAttributes } from "formik";
+import { FieldProps } from "formik";
 import InputBase, { InputBaseProps } from "./FormikInputBase";
 
 type Props<Value> = InputBaseProps<Value> & {
-  maxLength: number,
+  maxLength: number;
 };
 
 export const Text = <Value extends string>(props: Props<Value>) => {
   const { inputClass, ...propsToPass } = props;
   return (
     <InputBase {...propsToPass}>
-      {({
-        field, // { name, value, onChange, onBlur }
-        form: { touched, errors }, // also values, setXXXX, handleXXXX, dirty, isValid, status, etc.
-        meta,
-      }: FieldProps<Value>) => (
-        <div>
-          <input
-            id={field.name}
-            className={`form-control${props.inputClass ? ` ${props.inputClass}` : ""}`}
-            {...field}
-          />
-        </div>
+      {({ field }: FieldProps<Value>) => (
+        <input id={field.name} className={`form-control${props.inputClass ? ` ${props.inputClass}` : ""}`} {...field} />
       )}
     </InputBase>
   );


### PR DESCRIPTION
## What does this PR change?

Currently, [`InputBase.tsx`](https://github.com/uyuni-project/uyuni/blob/master/web/html/src/components/input/InputBase.tsx), the wrapper we use for all of our input components, is in a bit of a rough spot. Because history, it does very many things at once, is tricky to reason about and leads to a fair few bugs (which I'm trying to fix right now).  

To sidestep the whole issue, I propose we adopt [Formik](https://formik.org/docs/overview), by and far the most common way to do forms in React. The interfaces it uses are very, very similar to the ones we have, except we avoid maintaining custom code and get the benefit of a library that's very widely used.  

My proposal is the following: scratch `InputBase` and switch in Formik while keeping the externally consumable input components functionally the same. There might be some small differences, but I would expect them to be less worrisome than the bugs we have right now.  

To demonstrate the idea and gather some feedback I've made a functional demo. To review, please compare the following pairs of files:  

 - [`InputBase.tsx`](https://github.com/uyuni-project/uyuni/blob/master/web/html/src/components/input/InputBase.tsx) vs [`FormikInputBase.tsx`](https://github.com/Etheryte/uyuni/blob/1c1aee2ec4fc1668b1ccd033b7430bae4c1f2b25/web/html/src/components/input/FormikInputBase.tsx)
 - [`Form.tsx`](https://github.com/uyuni-project/uyuni/blob/master/web/html/src/components/input/Form.tsx) vs [`FormikForm.tsx`](https://github.com/Etheryte/uyuni/blob/1c1aee2ec4fc1668b1ccd033b7430bae4c1f2b25/web/html/src/components/input/FormikForm.tsx)
 - [`Text.tsx`](https://github.com/uyuni-project/uyuni/blob/master/web/html/src/components/input/Text.tsx) vs [`FormikText.tsx`](https://github.com/Etheryte/uyuni/blob/1c1aee2ec4fc1668b1ccd033b7430bae4c1f2b25/web/html/src/components/input/FormikText.tsx)

Consuming of the form works in the same manner as before, except the passed model should be considered an initial value and the submit event should be used to receive the result, see [`FormikForm.stories.tsx`](https://github.com/Etheryte/uyuni/blob/1c1aee2ec4fc1668b1ccd033b7430bae4c1f2b25/web/html/src/components/input/FormikForm.stories.tsx).  

I've filled in some holes with todos to avoid putting considerable time into this before getting feedback, please feel free to ignore those for now.  
The demo story looks visually identical to the regular form one, it only covers the text input for now.

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
