### PR TITLE
spacewalk-proxy: Adapted SPEC file to install on Enterprise Linux

### DIFF
--- a/proxy/proxy/spacewalk-proxy.changes
+++ b/proxy/proxy/spacewalk-proxy.changes
@@ -1,3 +1,4 @@
+- Adapted directory and file ownerships
 - Modified for pylint pass.
 - Fix build on Enterprise Linux
 - Fix traceback on handling sslerror (bsc#1187673)

--- a/proxy/proxy/spacewalk-proxy.spec
+++ b/proxy/proxy/spacewalk-proxy.spec
@@ -77,7 +77,6 @@ Requires:       spacewalk-backend >= 1.7.24
 Requires:       spacewalk-setup-jabberd
 %if 0%{?fedora} || 0%{?rhel}
 Requires:       sos
-Requires:       spacewalk-proxy-selinux
 Requires(preun): initscripts
 %endif
 BuildRequires:  /usr/bin/docbook2man
@@ -337,18 +336,32 @@ fi > /dev/null 2>&1
 exit 0
 
 %pre salt
+%if !0%{?rhel}
 %service_add_pre salt-broker.service
+%endif
 
 %post salt
+%if 0%{?rhel}
+%systemd_post salt-broker.service
+%else
 %service_add_post salt-broker.service
+%endif
 systemctl enable salt-broker.service > /dev/null 2>&1 || :
 systemctl start salt-broker.service > /dev/null 2>&1 || :
 
 %preun salt
+%if 0%{?rhel}
+%systemd_preun salt-broker.service
+%else
 %service_del_preun salt-broker.service
+%endif
 
 %postun salt
+%if 0%{?rhel}
+%systemd_postun salt-broker.service
+%else
 %service_del_postun salt-broker.service
+%endif
 
 %preun broker
 if [ $1 -eq 0 ] ; then
@@ -387,7 +400,11 @@ fi
 %{destdir}/broker/rhnRepository.py*
 %attr(750,%{apache_user},%{apache_group}) %dir %{_var}/spool/rhn-proxy
 %attr(750,%{apache_user},%{apache_group}) %dir %{_var}/spool/rhn-proxy/list
+%if 0%{?rhel}
+%dir %{_var}/log/rhn
+%else
 %attr(770,root,%{apache_group}) %dir %{_var}/log/rhn
+%endif
 %config(noreplace) %{_sysconfdir}/logrotate.d/rhn-proxy-broker
 # config files
 %attr(644,root,%{apache_group}) %{_prefix}/share/rhn/config-defaults/rhn_proxy_broker.conf
@@ -399,7 +416,11 @@ fi
 %dir %{destdir}
 %{destdir}/redirect/__init__.py*
 %{destdir}/redirect/rhnRedirect.py*
+%if 0%{?rhel}
+%dir %{_var}/log/rhn
+%else
 %attr(770,root,%{apache_group}) %dir %{_var}/log/rhn
+%endif
 %config(noreplace) %{_sysconfdir}/logrotate.d/rhn-proxy-redirect
 # config files
 %attr(644,root,%{apache_group}) %{_prefix}/share/rhn/config-defaults/rhn_proxy_redirect.conf
@@ -421,7 +442,11 @@ fi
 %{destdir}/rhnAuthProtocol.py*
 %attr(750,%{apache_user},%{apache_group}) %dir %{_var}/spool/rhn-proxy
 %attr(750,%{apache_user},%{apache_group}) %dir %{_var}/spool/rhn-proxy/list
+%if 0%{?rhel}
+%dir %{_var}/log/rhn
+%else
 %attr(770,root,%{apache_group}) %dir %{_var}/log/rhn
+%endif
 # config files
 %attr(640,root,%{apache_group}) %config(noreplace) %{rhnconf}/rhn.conf
 %attr(644,root,%{apache_group}) %{_prefix}/share/rhn/config-defaults/rhn_proxy.conf


### PR DESCRIPTION
## What does this PR change?

Adapted log folder ownership to avoid conflicts on Enterprise Linux during installation.
Modified post/pre installation sections for RHEL based systems.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered
Tested during build and installation process.
Build successfully on OBS (manual copy/paste of spec file content)
Installed successfully on AlmaLinux 8

- [x] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
