### PR TITLE
WIP: Revert spacewalk proxy enterprise linux modifications

### DIFF
--- a/proxy/installer/fetch-certificate.py
+++ b/proxy/installer/fetch-certificate.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python -u
-#pylint: disable=invalid-name
 
 import os
 import sys
+import time
 import argparse
 
 
@@ -47,8 +47,8 @@ if __name__ == "__main__":
                 with open(args.destination, 'wb') as _file:
                     _file.write(data['data'].encode('utf8'))
                     print("Certificate saved to: {0}".format(args.destination))
-            except Exception as ex: # pylint: disable=broad-except
-                print("Unable to write to destination: " + ex.message) # pylint: disable=no-member
+            except Exception as ex:
+                print("Unable to write to destination: " + ex.message)
                 sys.exit(1)
             sys.exit(0)
     print("Certificate not received from server. Exit.")

--- a/proxy/installer/rhn-proxy-activate.py
+++ b/proxy/installer/rhn-proxy-activate.py
@@ -39,7 +39,7 @@ except ImportError:     # python3
     raw_input = input
 
 # lib imports
-from optparse import Option, OptionParser # pylint: disable=deprecated-module
+from optparse import Option, OptionParser
 from rhn import rpclib, SSL
 
 from up2date_client import config # pylint: disable=E0012, C0413

--- a/proxy/installer/spacewalk-proxy-installer.changes
+++ b/proxy/installer/spacewalk-proxy-installer.changes
@@ -1,4 +1,3 @@
-- Improved for Enterprise Linux build.
 - Modified for Pylint pass.
 - Add new refresh_pattern to the squid.conf to fix a case where the repodata
   was invalid due to being cached (bsc#1186026)

--- a/proxy/installer/spacewalk-proxy-installer.changes
+++ b/proxy/installer/spacewalk-proxy-installer.changes
@@ -1,6 +1,5 @@
 - Improved for Enterprise Linux build.
 - Modified for Pylint pass.
-- Removed Python 2 build.
 - Add new refresh_pattern to the squid.conf to fix a case where the repodata
   was invalid due to being cached (bsc#1186026)
 - Bump version to 4.3.0

--- a/proxy/installer/spacewalk-proxy-installer.changes
+++ b/proxy/installer/spacewalk-proxy-installer.changes
@@ -1,4 +1,4 @@
-- Modified for Pylint pass.
+- Removed Python 2 build.
 - Add new refresh_pattern to the squid.conf to fix a case where the repodata
   was invalid due to being cached (bsc#1186026)
 - Bump version to 4.3.0

--- a/proxy/installer/spacewalk-proxy-installer.spec
+++ b/proxy/installer/spacewalk-proxy-installer.spec
@@ -25,6 +25,12 @@
 %define apacheconfdir %{_sysconfdir}/apache2
 %endif
 
+%if 0%{?suse_version} > 1320 || 0%{?fedora}
+# SLE15 and Fedora builds on Python 3
+%global build_py3   1
+%endif
+%define pythonX %{?build_py3:python3}%{!?build_py3:python2}
+
 Name:           spacewalk-proxy-installer
 Summary:        Spacewalk Proxy Server Installer
 License:        GPL-2.0-only
@@ -59,8 +65,8 @@ Requires:       rhnlib
 Requires:       libxslt
 Requires:       spacewalk-certs-tools >= 1.6.4
 %if 0%{?pylint_check}
-BuildRequires:  python3-rhn-client-tools
-BuildRequires:  spacewalk-python3-pylint
+BuildRequires:  %{pythonX}-rhn-client-tools
+BuildRequires:  spacewalk-%{pythonX}-pylint
 %endif
 BuildRequires:  /usr/bin/docbook2man
 
@@ -121,17 +127,19 @@ install -m 640 jabberd/sm.xml jabberd/c2s.xml $RPM_BUILD_ROOT%{_usr}/share/rhn/i
 install -m 0644 suse-manager-proxy.xml %{buildroot}/%{_prefix}/lib/firewalld/services
 
 # Fixing shebang for Python 3
+%if 0%{?build_py3}
 for i in $(find . -type f);
 do
     sed -i '1s=^#!/usr/bin/\(python\|env python\)[0-9.]*=#!/usr/bin/python3=' $i;
 done
+%endif
 install -m 755 rhn-proxy-activate.py $RPM_BUILD_ROOT/%{_usr}/sbin/rhn-proxy-activate
 install -m 755 fetch-certificate.py  $RPM_BUILD_ROOT/%{_usr}/sbin/fetch-certificate
 
 %check
 %if 0%{?pylint_check}
 # check coding style
-spacewalk-python3-pylint .
+spacewalk-%{pythonX}-pylint .
 %endif
 
 %files

--- a/proxy/installer/spacewalk-proxy-installer.spec
+++ b/proxy/installer/spacewalk-proxy-installer.spec
@@ -18,11 +18,8 @@
 
 
 #!BuildIgnore:  udev-mini libudev-mini1
-%if 0%{?fedora} || 0%{?rhel} 
+%if 0%{?fedora} || 0%{?rhel} >= 7
 %{!?pylint_check: %global pylint_check 1}
-%define apacheconfdir %{_sysconfdir}/httpd
-%else
-%define apacheconfdir %{_sysconfdir}/apache2
 %endif
 
 %if 0%{?suse_version} > 1320 || 0%{?fedora}
@@ -42,25 +39,28 @@ Source0:        https://github.com/spacewalkproject/spacewalk/archive/%{name}-%{
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
 
-Requires:       firewalld
 Requires:       mgr-cfg
 Requires:       mgr-cfg-actions
 Requires:       mgr-cfg-client
 Requires:       mgr-cfg-management
-Requires(pre):  spacewalk-proxy-common
-Requires:       spacewalk-proxy-salt
 %if 0%{?suse_version}
 Requires:       aaa_base
 Requires:       apache2
 Requires:       glibc
+Requires(pre):  spacewalk-proxy-common
+Requires:       firewalld
+Requires:       spacewalk-proxy-salt
 %else
-Requires:       chkconfig
 Requires:       glibc-common
+
+%if 0%{?fedora}
 Requires:       hostname
-Requires:       httpd
+%endif
+%if 0%{?rhel} > 5
 Requires:       net-tools
-Requires:       rhn-client-tools > 2.8.4
-Requires:       rhnlib
+%endif
+
+Requires:       chkconfig
 %endif
 Requires:       libxslt
 Requires:       spacewalk-certs-tools >= 1.6.4
@@ -69,6 +69,11 @@ BuildRequires:  %{pythonX}-rhn-client-tools
 BuildRequires:  spacewalk-%{pythonX}-pylint
 %endif
 BuildRequires:  /usr/bin/docbook2man
+
+%if 0%{?fedora} || 0%{?rhel} > 5
+Requires:       rhn-client-tools > 2.8.4
+Requires:       rhnlib
+%endif
 
 Obsoletes:      proxy-installer < 5.3.0
 Provides:       proxy-installer = 5.3.0
@@ -112,8 +117,6 @@ mkdir -p $RPM_BUILD_ROOT/%{_bindir}
 mkdir -p $RPM_BUILD_ROOT/%{_mandir}/man8
 mkdir -p $RPM_BUILD_ROOT/%{_usr}/sbin
 mkdir -p $RPM_BUILD_ROOT/%{_usr}/share/rhn/installer/jabberd
-mkdir -p %{buildroot}/%{_prefix}/lib/firewalld/services
-
 install -m 755 -d $RPM_BUILD_ROOT%{defaultdir}
 install -m 644 squid.conf $RPM_BUILD_ROOT%{defaultdir}
 install -m 644 rhn.conf $RPM_BUILD_ROOT%{defaultdir}
@@ -124,7 +127,6 @@ install -m 644 get_system_id.xslt $RPM_BUILD_ROOT%{_usr}/share/rhn/
 install -m 644 rhn-proxy-activate.8.gz $RPM_BUILD_ROOT%{_mandir}/man8/
 install -m 644 configure-proxy.sh.8.gz $RPM_BUILD_ROOT%{_mandir}/man8/
 install -m 640 jabberd/sm.xml jabberd/c2s.xml $RPM_BUILD_ROOT%{_usr}/share/rhn/installer/jabberd
-install -m 0644 suse-manager-proxy.xml %{buildroot}/%{_prefix}/lib/firewalld/services
 
 # Fixing shebang for Python 3
 %if 0%{?build_py3}
@@ -135,6 +137,11 @@ done
 %endif
 install -m 755 rhn-proxy-activate.py $RPM_BUILD_ROOT/%{_usr}/sbin/rhn-proxy-activate
 install -m 755 fetch-certificate.py  $RPM_BUILD_ROOT/%{_usr}/sbin/fetch-certificate
+
+%if 0%{?suse_version} > 1320
+mkdir -p %{buildroot}/%{_prefix}/lib/firewalld/services
+install -m 0644 suse-manager-proxy.xml %{buildroot}/%{_prefix}/lib/firewalld/services
+%endif
 
 %check
 %if 0%{?pylint_check}
@@ -161,6 +168,8 @@ spacewalk-%{pythonX}-pylint .
 %dir %{_usr}/share/rhn/proxy-template
 %dir %{_usr}/share/rhn
 %dir %{_usr}/share/rhn/installer/jabberd
+%if 0%{?suse_version} > 1320
 %{_prefix}/lib/firewalld/services/suse-manager-proxy.xml
+%endif
 
 %changelog

--- a/proxy/proxy/apacheHandler.py
+++ b/proxy/proxy/apacheHandler.py
@@ -34,19 +34,17 @@ from spacewalk.common.rhnApache import rhnApache
 from spacewalk.common.rhnTB import Traceback
 from spacewalk.common.rhnException import rhnFault, rhnException
 from spacewalk.common import rhnFlags, apache
+from uyuni.common.rhnLib import setHeaderValue
 from spacewalk.common import byterange
+
 from rhn import rpclib, connections
 from rhn.UserDictCase import UserDictCase
-from uyuni.common.rhnLib import setHeaderValue
-from proxy.rhnProxyAuth import get_proxy_auth
-
-
 from .rhnConstants import HEADER_ACTUAL_URI, HEADER_EFFECTIVE_URI, \
     HEADER_CHECKSUM, SCHEME_HTTP, SCHEME_HTTPS, URI_PREFIX_KS, \
     URI_PREFIX_KS_CHECKSUM, COMPONENT_BROKER, COMPONENT_REDIRECT
 
-from .broker import rhnBroker
-from .redirect import rhnRedirect
+# local imports
+from proxy.rhnProxyAuth import get_proxy_auth
 
 
 def getComponentType(req):
@@ -319,7 +317,7 @@ class apacheHandler(rhnApache):
         uriParts = oldURI.split('/')
         numParts = 0
         for part in uriParts:
-            if len(part) != 0:  # Account for double slashes ("//")
+            if len(part) is not 0:  # Account for double slashes ("//")
                 numParts += 1
                 if numParts > 2:
                     newURI += "/" + part
@@ -359,9 +357,11 @@ class apacheHandler(rhnApache):
         log_debug(4, "Component", self._component)
 
         if self._component == COMPONENT_BROKER:
+            from .broker import rhnBroker
             handlerObj = rhnBroker.BrokerHandler(req)
         else:
             # Redirect
+            from .redirect import rhnRedirect
             handlerObj = rhnRedirect.RedirectHandler(req)
 
         try:
@@ -586,7 +586,7 @@ class apacheHandler(rhnApache):
     @staticmethod
     def _response_fault_get(req, response):
         req.headers_out["X-RHN-Fault-Code"] = str(response.faultCode)
-        faultString = base64.encodestring(response.faultString.encode()).decode().strip() # pylint: disable=deprecated-method
+        faultString = base64.encodestring(response.faultString.encode()).decode().strip()
         # Split the faultString into multiple lines
         for line in faultString.split('\n'):
             req.headers_out.add("X-RHN-Fault-String", line.strip())

--- a/proxy/proxy/apacheServer.py
+++ b/proxy/proxy/apacheServer.py
@@ -20,8 +20,6 @@ from spacewalk.common.rhnLog import initLOG, log_setreq, log_debug
 from spacewalk.common.rhnTB import Traceback
 from spacewalk.common import apache
 
-from .apacheHandler import apacheHandler
-from .apacheHandler import getComponentType
 
 class HandlerWrap:
 
@@ -40,6 +38,7 @@ class HandlerWrap:
         #       req object.
 
         if self.__init:
+            from .apacheHandler import getComponentType
             # We cannot trust the config files to tell us if we are in the
             # broker or in the redirect because we try to always pass
             # upstream all requests
@@ -74,6 +73,7 @@ class HandlerWrap:
     @staticmethod
     def get_handler_factory(_req):
         """ Handler factory. Redefine in your subclasses if so choose """
+        from .apacheHandler import apacheHandler
         return apacheHandler
 
 

--- a/proxy/proxy/broker/rhnBroker.py
+++ b/proxy/proxy/broker/rhnBroker.py
@@ -313,14 +313,14 @@ class BrokerHandler(SharedHandler):
                 log_debug(0, msg)
             elif error == '1004':
                 log_debug(1,
-                          "SUSE Manager Proxy Session Token expired, acquiring new one.")
+                    "SUSE Manager Proxy Session Token expired, acquiring new one.")
             else: # this should never happen.
                 msg = "SUSE Manager Proxy login failed, error code is %s" % error
                 log_error(msg)
                 log_debug(0, msg)
                 raise rhnFault(1000,
-                               _("SUSE Manager Proxy error (issues with proxy login). "
-                                 "Please contact your system administrator."))
+                  _("SUSE Manager Proxy error (issues with proxy login). "
+                    "Please contact your system administrator."))
 
             # Forced refresh of the proxy token
             rhnFlags.get('outputTransportOptions')['X-RHN-Proxy-Auth'] = self.proxyAuth.check_cached_token(1)
@@ -328,8 +328,8 @@ class BrokerHandler(SharedHandler):
             # The token could not be aquired
             log_debug(0, "Unable to acquire proxy authentication token")
             raise rhnFault(1000,
-                           _("SUSE Manager Proxy error (unable to acquire proxy auth token). "
-                             "Please contact your system administrator."))
+              _("SUSE Manager Proxy error (unable to acquire proxy auth token). "
+                "Please contact your system administrator."))
 
         # Support for yum byte-range
         if status not in (apache.OK, apache.HTTP_PARTIAL_CONTENT):

--- a/proxy/proxy/broker/rhnBroker.py
+++ b/proxy/proxy/broker/rhnBroker.py
@@ -28,19 +28,19 @@ except ImportError:
 
 # common module imports
 from rhn.UserDictCase import UserDictCase
+from uyuni.common.rhnLib import parseUrl
 from spacewalk.common.rhnConfig import CFG
 from spacewalk.common.rhnLog import log_debug, log_error
 from spacewalk.common.rhnException import rhnFault
 from spacewalk.common import rhnFlags, apache
 from spacewalk.common.rhnTranslate import _
 from spacewalk.common import suseLib
-from uyuni.common.rhnLib import parseUrl
 
 # local module imports
 from proxy.rhnShared import SharedHandler
 from proxy.rhnConstants import URI_PREFIX_KS_CHECKSUM
-import proxy.rhnProxyAuth
 from . import rhnRepository
+import proxy.rhnProxyAuth
 
 
 # the version should not be never decreased, never mind that spacewalk has different versioning
@@ -332,7 +332,7 @@ class BrokerHandler(SharedHandler):
                 "Please contact your system administrator."))
 
         # Support for yum byte-range
-        if status not in (apache.OK, apache.HTTP_PARTIAL_CONTENT):
+        if (status != apache.OK) and (status != apache.HTTP_PARTIAL_CONTENT):
             log_debug(1, "Leaving handler with status code %s" % status)
             return status
 
@@ -517,7 +517,7 @@ class BrokerHandler(SharedHandler):
             log_debug(3, "Client server ID not found in headers")
             # XXX: no client server ID in headers, should we care?
             #raise rhnFault(1000, _("Client Server ID not found in headers!"))
-            return None
+            return
         serverId = 'X-RHN-Server-ID'
 
         self.clientServerId = headers[serverId]

--- a/proxy/proxy/broker/rhnRepository.py
+++ b/proxy/proxy/broker/rhnRepository.py
@@ -28,6 +28,7 @@ except ImportError:
     # python 2
     import cPickle
 import sys
+import types
 from operator import truth
 try:
     #  python 2
@@ -36,17 +37,17 @@ except ImportError:
     #  python3
     import xmlrpc.client as xmlrpclib
 
-## local imports
-from rhn import rpclib
 ## common imports
+from uyuni.common.rhnLib import parseRPMName
 from spacewalk.common.rhnLog import log_debug
 from spacewalk.common.rhnException import rhnFault
 from spacewalk.common.rhnConfig import CFG
 from spacewalk.common import rhnRepository
 from spacewalk.common.rhnTranslate import _
-from uyuni.common.rhnLib import parseRPMName
 from uyuni.common.usix import raise_with_tb
 
+## local imports
+from rhn import rpclib
 
 
 PKG_LIST_DIR = os.path.join(CFG.PKG_DIR, 'list')
@@ -80,7 +81,7 @@ class Repository(rhnRepository.Repository):
         self.httpProxyPassword = httpProxyPassword
         self.caChain = caChain
 
-    def getPackagePath(self, pkgFilename, redirect=0): # pylint: disable=unused-argument
+    def getPackagePath(self, pkgFilename, redirect=0):
         """ OVERLOADS getPackagePath in common/rhnRepository.
             Returns complete path to an RPM file.
         """

--- a/proxy/proxy/broker/rhnRepository.py
+++ b/proxy/proxy/broker/rhnRepository.py
@@ -144,7 +144,7 @@ class Repository(rhnRepository.Repository):
                 pkgFilename, self.channelName, self.clientInfo)
         except xmlrpclib.Fault as e:
             raise_with_tb(rhnFault(1000,
-                                   _("Error retrieving source package: %s") % str(e)), sys.exc_info()[2])
+                           _("Error retrieving source package: %s") % str(e)), sys.exc_info()[2])
 
         if not retval:
             raise rhnFault(17, _("Invalid SRPM package requested: %s")
@@ -238,7 +238,7 @@ class Repository(rhnRepository.Repository):
         except xmlrpclib.ProtocolError as e:
             errcode, errmsg = rpclib.reportError(e.headers)
             raise_with_tb(rhnFault(1000, "SpacewalkProxy error (xmlrpclib.ProtocolError): "
-                                   "errode=%s; errmsg=%s" % (errcode, errmsg)), sys.exc_info()[2])
+                           "errode=%s; errmsg=%s" % (errcode, errmsg)), sys.exc_info()[2])
 
         # Hash the list
         _hash = {}

--- a/proxy/proxy/pm/rhn_package_manager.py
+++ b/proxy/proxy/pm/rhn_package_manager.py
@@ -45,7 +45,7 @@ try:
 except ImportError:
     #  python3
     import xmlrpc.client as xmlrpclib
-from optparse import Option, OptionParser # pylint: disable=deprecated-module
+from optparse import Option, OptionParser
 
 # RHN imports
 from spacewalk.common.rhnConfig import CFG, initCFG
@@ -98,8 +98,7 @@ def main():
     # Process the command line arguments
     optionParser = OptionParser(option_list=optionsTable, usage="USAGE: %prog [OPTION] [<package>]")
     options, files = optionParser.parse_args()
-    # Below line needs fixing. Together with replacement of optparse.
-    upload = UploadClass(options, files=files) # pylint: disable=too-many-function-args,unexpected-keyword-arg
+    upload = UploadClass(options, files=files)
 
     if options.usage:
         optionParser.print_usage()

--- a/proxy/proxy/rhnAuthCacheClient.py
+++ b/proxy/proxy/rhnAuthCacheClient.py
@@ -18,9 +18,7 @@
 # in this software or its documentation.
 #-------------------------------------------------------------------------------
 
-# Module new has been removed in future Python versions. This needs to be adapted.
-import new # pylint: disable=import-error
-
+## language imports
 import socket
 import sys
 try:
@@ -169,6 +167,7 @@ class Shelf:
                 raise
 
             # Instantiate the exception object
+            import new
             _dict = {'args': args}
             # pylint: disable=bad-option-value,nonstandard-exception
             raise_with_tb(new.instance(getattr(__builtins__, name), _dict), sys.exc_info()[2])

--- a/proxy/proxy/rhnAuthProtocol.py
+++ b/proxy/proxy/rhnAuthProtocol.py
@@ -48,7 +48,7 @@ def readSocket(fd, n):
     return result
 
 
-def send(fd, *params, methodname=None, fault=None):
+def send(fd, methodname=None, fault=None, *params):
     if methodname:
         buff = dumps(params, methodname=methodname)
     elif fault:

--- a/proxy/proxy/rhnProxyAuth.py
+++ b/proxy/proxy/rhnProxyAuth.py
@@ -85,8 +85,8 @@ class ProxyAuth:
         if not os.access(ProxyAuth.__systemid_filename, os.R_OK):
             log_error("unable to access %s" % ProxyAuth.__systemid_filename)
             raise rhnFault(1000,
-                           _("SUSE Manager Proxy error (SUSE Manager Proxy systemid has wrong permissions?). "
-                             "Please contact your system administrator."))
+                      _("SUSE Manager Proxy error (SUSE Manager Proxy systemid has wrong permissions?). "
+                        "Please contact your system administrator."))
 
         mtime = None
         try:
@@ -94,8 +94,8 @@ class ProxyAuth:
         except IOError as e:
             log_error("unable to stat %s: %s" % (ProxyAuth.__systemid_filename, repr(e)))
             raise_with_tb(rhnFault(1000,
-                                   _("SUSE Manager Proxy error (SUSE Manager Proxy systemid has wrong permissions?). "
-                                     "Please contact your system administrator.")), sys.exc_info()[2])
+                      _("SUSE Manager Proxy error (SUSE Manager Proxy systemid has wrong permissions?). "
+                        "Please contact your system administrator.")), sys.exc_info()[2])
 
         if not self.__systemid_mtime:
             ProxyAuth.__systemid_mtime = mtime
@@ -111,8 +111,8 @@ class ProxyAuth:
         except IOError as e:
             log_error("unable to read %s" % ProxyAuth.__systemid_filename)
             raise_with_tb(rhnFault(1000,
-                                   _("SUSE Manager Proxy error (SUSE Manager Proxy systemid has wrong permissions?). "
-                                     "Please contact your system administrator.")), sys.exc_info()[2])
+                      _("SUSE Manager Proxy error (SUSE Manager Proxy systemid has wrong permissions?). "
+                        "Please contact your system administrator.")), sys.exc_info()[2])
 
         # get serverid
         sysid, _cruft = xmlrpclib.loads(ProxyAuth.__systemid)
@@ -171,8 +171,8 @@ problems, isn't running, or the token is somehow corrupt.
 """) % self.__serverid
             Traceback("ProxyAuth.set_cached_token", extra=text)
             raise_with_tb(rhnFault(1000,
-                                   _("SUSE Manager Proxy error (auth caching issue). "
-                                     "Please contact your system administrator.")), sys.exc_info()[2])
+                      _("SUSE Manager Proxy error (auth caching issue). "
+                        "Please contact your system administrator.")), sys.exc_info()[2])
         log_debug(4, "successfully returning")
         return token
 
@@ -328,14 +328,16 @@ problems, isn't running, or the token is somehow corrupt.
             if error:
                 if error[0] in ('xmlrpclib.ProtocolError', 'socket.error', 'socket'):
                     raise rhnFault(1000,
-                                   _("SUSE Manager Proxy error (error: %s). "
-                                     "Please contact your system administrator.") % error[0])
+                                _("SUSE Manager Proxy error (error: %s). "
+                                  "Please contact your system administrator.") % error[0])
                 if error[0] in ('rhn.SSL.SSL.SSLError', 'socket.sslerror'):
                     raise rhnFault(1000,
-                                   _("SUSE Manager Proxy error (SSL issues? Error: %s). "
-                                     "Please contact your system administrator.") % error[0])
-                raise rhnFault(1002, err_text='%s' % e)
-            raise rhnFault(1001)
+                                _("SUSE Manager Proxy error (SSL issues? Error: %s). "
+                                  "Please contact your system administrator.") % error[0])
+                else:
+                    raise rhnFault(1002, err_text='%s' % e)
+            else:
+                raise rhnFault(1001)
         if self.hostname:
             token = token + ':' + self.hostname
         log_debug(6, "New proxy token: %s" % token)
@@ -410,9 +412,9 @@ problems, isn't running, or the token is somehow corrupt.
             if not os.access(CFG.CA_CHAIN, os.R_OK):
                 log_error('ERROR: missing or cannot access (for ca_chain): %s' % CFG.CA_CHAIN)
                 raise rhnFault(1000,
-                               _("SUSE Manager Proxy error (file access issues). "
-                                 "Please contact your system administrator. "
-                                 "Please refer to SUSE Manager Proxy logs."))
+                          _("SUSE Manager Proxy error (file access issues). "
+                            "Please contact your system administrator. "
+                            "Please refer to SUSE Manager Proxy logs."))
             serverObj.add_trusted_cert(CFG.CA_CHAIN)
         serverObj.add_header('X-RHN-Client-Version', 2)
         return serverObj

--- a/proxy/proxy/rhnProxyAuth.py
+++ b/proxy/proxy/rhnProxyAuth.py
@@ -29,24 +29,28 @@ import sys
 # pylint: disable=E0611
 from hashlib import sha1
 
-#sys.path.append('/usr/share/rhn')
-from rhn import rpclib
-from rhn import SSL
+# common imports
+from uyuni.common.rhnLib import parseUrl
 from spacewalk.common.rhnTB import Traceback
 from spacewalk.common.rhnLog import log_debug, log_error
 from spacewalk.common.rhnConfig import CFG
 from spacewalk.common.rhnException import rhnFault
 from spacewalk.common import rhnCache
 from spacewalk.common.rhnTranslate import _
-from up2date_client import config # pylint: disable=E0012, C0413
-from uyuni.common.rhnLib import parseUrl
 from uyuni.common.usix import raise_with_tb
+
+# local imports
+from rhn import rpclib
+from rhn import SSL
 from . import rhnAuthCacheClient
 
 if hasattr(socket, 'sslerror'):
-    socket_error = socket.sslerror # pylint: disable=no-member
+    socket_error = socket.sslerror
 else:
     from ssl import socket_error
+
+sys.path.append('/usr/share/rhn')
+from up2date_client import config # pylint: disable=E0012, C0413
 
 # To avoid doing unnecessary work, keep ProxyAuth object global
 __PROXY_AUTH = None
@@ -119,7 +123,7 @@ class ProxyAuth:
         ProxyAuth.__serverid = sysid[0]['system_id'][3:]
 
         log_debug(7, 'SystemId: "%s[...snip  snip...]%s"'
-                  % (ProxyAuth.__systemid[:20], ProxyAuth.__systemid[-20:])) # pylint: disable=unsubscriptable-object
+                  % (ProxyAuth.__systemid[:20], ProxyAuth.__systemid[-20:]))
         log_debug(7, 'ServerId: %s' % ProxyAuth.__serverid)
 
         # ids were updated
@@ -163,7 +167,7 @@ class ProxyAuth:
         # Cache the token.
         try:
             shelf[self.__cache_proxy_key()] = token
-        except: # pylint: disable=bare-except
+        except:
             text = _("""\
 Caching of authentication token for proxy id %s failed!
 Either the authentication caching daemon is experiencing
@@ -266,7 +270,7 @@ problems, isn't running, or the token is somehow corrupt.
                         # rather big problem: http proxy not running.
                         log_error("*** ERROR ***: %s" % error[1])
                         Traceback(mail=0)
-                    except socket_error as e:                             # pylint: disable=duplicate-except
+                    except socket_error as e:
                         error = ['socket.sslerror',
                                  '(%s) %s' % (CFG.HTTP_PROXY, e)]
                         # rather big problem: http proxy not running.
@@ -315,7 +319,7 @@ problems, isn't running, or the token is somehow corrupt.
                 raise_with_tb(rhnFault(1000,
                                        _("SUSE Manager Proxy error (during proxy login). "
                                          "Please contact your system administrator.")), sys.exc_info()[2])
-            except Exception as e: # pylint: disable=broad-except
+            except Exception as e:
                 token = None
                 log_error("Unhandled exception", e)
                 Traceback(mail=0)
@@ -467,7 +471,8 @@ class AuthLocalBackend:
         if not os.path.normpath(key_path).startswith(self._cache_prefix):
             raise ValueError("Path traversal detected for X-RHN-Server-ID. " +
                              "User is trying to set a path as server-id.")
-        return key_path
+        else:
+            return key_path
 
     def __len__(self):
         pass

--- a/proxy/proxy/rhnShared.py
+++ b/proxy/proxy/rhnShared.py
@@ -232,7 +232,7 @@ class SharedHandler:
             Traceback("SharedHandler._serverCommo", self.req, mail=0)
             raise_with_tb(rhnFault(1000, _(
                 "SUSE Manager Proxy error: connection with the SUSE Manager server failed")), sys.exc_info()[2])
-        except socket.error: # pylint: disable=duplicate-except
+        except socket.error:
             # maybe self.req.read() failed?
             Traceback("SharedHandler._serverCommo", self.req)
             raise_with_tb(rhnFault(1000, _(
@@ -252,7 +252,7 @@ class SharedHandler:
             and send them back to the client with an error status.  This method
             should return apache.OK if everything went according to plan.
         """
-        if status not in (apache.HTTP_OK, apache.HTTP_PARTIAL_CONTENT):
+        if (status != apache.HTTP_OK) and (status != apache.HTTP_PARTIAL_CONTENT):
             # Non 200 response; have to treat it differently
             log_debug(2, "Forwarding status %s" % status)
             # Copy the incoming headers to headers_out

--- a/proxy/proxy/rhnShared.py
+++ b/proxy/proxy/rhnShared.py
@@ -147,8 +147,8 @@ class SharedHandler:
             log_error("Error opening connection", self.rhnParent, e)
             Traceback(mail=0)
             raise_with_tb(rhnFault(1000,
-                                   _("SUSE Manager Proxy could not successfully connect its SUSE Manager parent. "
-                                     "Please contact your system administrator.")), sys.exc_info()[2])
+                           _("SUSE Manager Proxy could not successfully connect its SUSE Manager parent. "
+                             "Please contact your system administrator.")), sys.exc_info()[2])
 
         # At this point the server should be okay
         log_debug(3, "Connected to parent: %s " % self.rhnParent)

--- a/proxy/proxy/spacewalk-proxy.changes
+++ b/proxy/proxy/spacewalk-proxy.changes
@@ -1,6 +1,5 @@
 - Adapted directory and file ownerships
 - Modified for pylint pass.
-- Fix build on Enterprise Linux
 - Fix traceback on handling sslerror (bsc#1187673)
 - Bump version to 4.3.0
 

--- a/proxy/proxy/spacewalk-proxy.changes
+++ b/proxy/proxy/spacewalk-proxy.changes
@@ -1,5 +1,5 @@
 - Adapted directory and file ownerships
-- Modified for pylint pass.
+- Fix build on Enterprise Linux
 - Fix traceback on handling sslerror (bsc#1187673)
 - Bump version to 4.3.0
 

--- a/proxy/proxy/spacewalk-proxy.spec
+++ b/proxy/proxy/spacewalk-proxy.spec
@@ -94,12 +94,11 @@ Requires:       spacewalk-ssl-cert-check
 %if 0%{?suse_version}
 Requires:       apache2-prefork
 Requires:       http_proxy
-Requires:       apache2-mod_wsgi-python3
 %else
 Requires:       mod_ssl
 Requires:       squid
-Requires:       python3-mod_wsgi
 %endif
+Requires:       apache2-mod_wsgi-python3
 Requires(post): %{name}-common
 Conflicts:      %{name}-redirect < %{version}-%{release}
 Conflicts:      %{name}-redirect > %{version}-%{release}
@@ -137,13 +136,11 @@ Requires(pre):  uyuni-base-common
 BuildRequires:  uyuni-base-common
 %if 0%{?suse_version}
 BuildRequires:  apache2
-Requires:       apache2-mod_wsgi-python3
 %else
-BuildRequires:  httpd
 Requires:       mod_ssl
-Requires:       python3-mod_wsgi
 %endif
 Requires:       %{name}-broker >= %{version}
+Requires:       apache2-mod_wsgi-python3
 Requires:       curl
 Requires:       spacewalk-backend >= 1.7.24
 Requires(pre):  policycoreutils
@@ -222,11 +219,7 @@ touch $RPM_BUILD_ROOT/%{httpdconf}/cobbler-proxy.conf
 ln -sf rhn-proxy $RPM_BUILD_ROOT%{_sbindir}/spacewalk-proxy
 
 pushd %{buildroot}
-%if 0%{?suse_version}
 %py3_compile -O %{buildroot}
-%else
-%py_byte_compile %{python3} %{buildroot}
-%endif
 popd
 
 install -m 0750 salt-broker/salt-broker %{buildroot}/%{_bindir}/


### PR DESCRIPTION
## What does this PR change?

I run the acceptance tests on this PR https://github.com/uyuni-project/uyuni/pull/4029/files and some tests fail. Specifically with this error:

```
[2021-08-04T10:06:13.087Z]        - Download (curl) error for 'https://suma-pr3-pxy.mgr.prv.suse.net:443/rhn/manager/download/sle-product-sles15-sp3-updates-x86_64/content?eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjE2NTk2MDc0NTgsImlhdCI6MTYyODA3MTQ1OCwibmJmIjoxNjI4MDcxMzM4LCJqdGkiOiJjMHdSRDU0MlBzZElGX1ZPWldacXZRIiwib3JnIjoxLCJvbmx5Q2hhbm5lbHMiOlsic2xlLXByb2R1Y3Qtc2xlczE1LXNwMy11cGRhdGVzLXg4Nl82NCJdfQ.IN0fPfukK8HrmJo5K1E9Zx1Nv9HXSXYxW8vx6_uIGb0':
[2021-08-04T10:06:13.087Z]       Error code: HTTP response: 500
[2021-08-04T10:06:13.087Z]       Error message: The requested URL returned error: 500 Internal Server Error
[2021-08-04T10:06:13.087Z]       
[2021-08-04T10:06:13.087Z]       
[2021-08-04T10:06:13.087Z]       Please check if the URIs defined for this repository are pointing to a valid repository.
[2021-08-04T10:06:13.087Z]       Skipping repository 'SLE-Product-SLES15-SP3-Updates for x86_64' because of the above error.
[2021-08-04T10:06:13.087Z]       Repository 'tools_pool_repo' is up to date.
[2021-08-04T10:06:13.087Z]       Repository 'tools_update_repo' is up to date.
[2021-08-04T10:06:13.087Z]       Some of the repositories have not been refreshed because of an error.
[2021-08-04T10:06:13.087Z]        (RuntimeError)
[2021-08-04T10:06:13.087Z]       ./features/support/lavanda.rb:53:in `run'
[2021-08-04T10:06:13.087Z]       ./features/step_definitions/common_steps.rb:773:in `/^I enable repositories before installing Docker$/'
[2021-08-04T10:06:13.087Z]       features/init_clients/buildhost_bootstrap.feature:71:in `And I enable repositories before installing Docker'
```

Given that PR was modifying the proxy, and the fact that the tests that fail are when syncing with the proxy, I want to test if reverting that PR makes the tests succeed.

If so, then we can look at what/where exactly the problem is.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed
- [X] **DONE**

## Test coverage
- No tests

- [X] **DONE**

## Links

N/A

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
