### PR TITLE
Revert moving import new statement to the top

### DIFF
--- a/proxy/proxy/rhnAuthCacheClient.py
+++ b/proxy/proxy/rhnAuthCacheClient.py
@@ -19,7 +19,6 @@
 #-------------------------------------------------------------------------------
 
 # Module new has been removed in future Python versions. This needs to be adapted.
-import new # pylint: disable=import-error
 
 import socket
 import sys
@@ -169,6 +168,7 @@ class Shelf:
                 raise
 
             # Instantiate the exception object
+            import new
             _dict = {'args': args}
             # pylint: disable=bad-option-value,nonstandard-exception
             raise_with_tb(new.instance(getattr(__builtins__, name), _dict), sys.exc_info()[2])


### PR DESCRIPTION
## What does this PR change?

This is a bit ugly... "import new" is not valid anymore for python3, but
instead we should use the types module and adapt the code.

The "import new" was "hidden" into a "try" block, so we were not seeing
the error.

This commit
https://github.com/uyuni-project/uyuni/pull/4029/commits/8fbd8fbdaee77945f95280540fe84c4b04266c3a

moved it to the top of the file and "voilà" the error
appeared and the proxy is broken.

This commit moves it back "under the carpet" to fix the proxy and hopes
it will be fixed later.



## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed

- [X] **DONE**

## Test coverage
- No tests

- [X] **DONE**

## Links

N/A

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
