### PR TITLE
Revert imports order breaking proxy by PR#4029

### DIFF
--- a/proxy/proxy/apacheHandler.py
+++ b/proxy/proxy/apacheHandler.py
@@ -45,9 +45,6 @@ from .rhnConstants import HEADER_ACTUAL_URI, HEADER_EFFECTIVE_URI, \
     HEADER_CHECKSUM, SCHEME_HTTP, SCHEME_HTTPS, URI_PREFIX_KS, \
     URI_PREFIX_KS_CHECKSUM, COMPONENT_BROKER, COMPONENT_REDIRECT
 
-from .broker import rhnBroker
-from .redirect import rhnRedirect
-
 
 def getComponentType(req):
     """
@@ -359,9 +356,11 @@ class apacheHandler(rhnApache):
         log_debug(4, "Component", self._component)
 
         if self._component == COMPONENT_BROKER:
+            from .broker import rhnBroker
             handlerObj = rhnBroker.BrokerHandler(req)
         else:
             # Redirect
+            from .redirect import rhnRedirect
             handlerObj = rhnRedirect.RedirectHandler(req)
 
         try:

--- a/proxy/proxy/apacheServer.py
+++ b/proxy/proxy/apacheServer.py
@@ -20,8 +20,6 @@ from spacewalk.common.rhnLog import initLOG, log_setreq, log_debug
 from spacewalk.common.rhnTB import Traceback
 from spacewalk.common import apache
 
-from .apacheHandler import apacheHandler
-from .apacheHandler import getComponentType
 
 class HandlerWrap:
 
@@ -40,6 +38,7 @@ class HandlerWrap:
         #       req object.
 
         if self.__init:
+            from .apacheHandler import getComponentType
             # We cannot trust the config files to tell us if we are in the
             # broker or in the redirect because we try to always pass
             # upstream all requests
@@ -74,6 +73,7 @@ class HandlerWrap:
     @staticmethod
     def get_handler_factory(_req):
         """ Handler factory. Redefine in your subclasses if so choose """
+        from .apacheHandler import apacheHandler
         return apacheHandler
 
 

--- a/proxy/proxy/rhnAuthCacheClient.py
+++ b/proxy/proxy/rhnAuthCacheClient.py
@@ -18,9 +18,7 @@
 # in this software or its documentation.
 #-------------------------------------------------------------------------------
 
-# Module new has been removed in future Python versions. This needs to be adapted.
-import new # pylint: disable=import-error
-
+## language imports
 import socket
 import sys
 try:
@@ -169,6 +167,7 @@ class Shelf:
                 raise
 
             # Instantiate the exception object
+            import new
             _dict = {'args': args}
             # pylint: disable=bad-option-value,nonstandard-exception
             raise_with_tb(new.instance(getattr(__builtins__, name), _dict), sys.exc_info()[2])


### PR DESCRIPTION
## What does this PR change?

Fixes regression caused by https://github.com/uyuni-project/uyuni/pull/4029

CFG is used there and it's too sensitive to the order of importing

Superseeds https://github.com/uyuni-project/uyuni/pull/4092

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed
