### PR TITLE
Don't capitalize acronym strings

### DIFF
--- a/web/html/src/utils/functions.test.ts
+++ b/web/html/src/utils/functions.test.ts
@@ -28,6 +28,18 @@ test("check order by date function'", () => {
   expect(arr[0]).toEqual(eRaw);
 });
 
+describe("capitalize", () => {
+  test("simple cases", () => {
+    expect(Utils.capitalize("foo")).toEqual("Foo");
+    expect(Utils.capitalize("foo-bar")).toEqual("Foo Bar");
+    expect(Utils.capitalize("fooBar")).toEqual("Foobar");
+  });
+  test("acronym cases", () => {
+    expect(Utils.capitalize("FOO")).toEqual("FOO");
+    expect(Utils.capitalize("FO-O")).toEqual("FO-O");
+  });
+});
+
 describe("cancelable", () => {
   const { cancelable } = Utils;
 

--- a/web/html/src/utils/functions.ts
+++ b/web/html/src/utils/functions.ts
@@ -151,6 +151,11 @@ function sortByDate(aRaw: any, bRaw: any, columnKey: string, sortDirection: numb
  * Replace all "_" and "-" with spaces and capitalize the first letter of each word
  */
 function capitalize(str: string): string {
+  // Don't capitalize a string that is only caps and dashes since that it probably an acronym
+  if (str.match(/^[A-Z_-]+$/g)) {
+    return str;
+  }
+
   return str.replace(new RegExp("_|-", "g"), " ").replace(/\w\S*/g, function(txt) {
     return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();
   });

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Don't capitalize acronyms
 - 'AppStreams with defaults' filter template in CLM
 - Add a link to OS image store dir in image list page
 - Link to CLM filter creation from system details page


### PR DESCRIPTION
## What does this PR change?

Tweak the JS capitalize() function to not capitalize strings only
composed of capital letters and dashes / underscores since those are
probably acronyms. An example would be SR-IOV: we don't want such a
formula name to be capitalized.

## GUI diff

Before:
![Screenshot_2021-08-04 Uyuni - Systems(1)](https://user-images.githubusercontent.com/397931/128198578-d42d1c6d-9e22-46ab-9647-3ec92132d71f.png)

After:
![Screenshot_2021-08-04 Uyuni - Systems(2)](https://user-images.githubusercontent.com/397931/128199017-19df3420-496e-425a-ac8d-8857cbd7d217.png)

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: Harmless UI label change

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
