### PR TITLE
Mark SSH minion actions when they're picked up (bsc#1188505)

### DIFF
--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Mark SSH minion actions when they're picked up (bsc#1188505)
 - Properly handle virtual networks without defined bridge (bsc#1189167)
 - Fix cleanup always being executed on delete system (bsc#1189011)
 - Warning in Overview page for SLE Micro system (bsc#1188551)


### PR DESCRIPTION
Prior to this change, SSH minion actions stayed as "Queued" until they finish. This PR sets the actions as "Picked up" as soon as the execution starts.

See: https://bugzilla.suse.com/1188505

## Documentation
- No documentation needed: Bugfix

## Test coverage
- No tests: already covered

## Links

https://github.com/SUSE/spacewalk/issues/15496

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
