### PR TITLE
Apply the logrotate configuration for ssh for existing minions as well

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/services/salt-minion.sls
+++ b/susemanager-utils/susemanager-sls/salt/services/salt-minion.sls
@@ -49,6 +49,25 @@ mgr_salt_minion:
     - order: last
 {% endif %}
 
+{%- if salt['pillar.get']('contact_method') in ['ssh-push', 'ssh-push-tunnel'] %}
+logrotate_configuration:
+  file.managed:
+    - name: /etc/logrotate.d/salt-ssh
+    - user: root
+    - group: root
+    - mode: 644
+    - makedirs: True
+    - contents: |
+        /var/log/salt-ssh.log {
+                su root root
+                weekly
+                missingok
+                rotate 7
+                compress
+                notifempty
+        }
+{% endif %}
+
 {# ensure /etc/sysconfig/rhn/systemid is created to indicate minion is managed by SUSE Manager #}
 /etc/sysconfig/rhn/systemid:
   file.managed:

--- a/susemanager-utils/susemanager-sls/salt/ssh_bootstrap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/ssh_bootstrap/init.sls
@@ -61,22 +61,5 @@ authorize_own_key:
       - file: ownership_own_ssh_key
       - ssh_auth: no_own_key_authorized
 
-logrotate_configuration:
-  file.managed:
-    - name: /etc/logrotate.d/salt-ssh
-    - user: root
-    - group: root
-    - mode: 644
-    - makedirs: True
-    - contents: |
-        /var/log/salt-ssh.log {
-                su root root
-                weekly
-                missingok
-                rotate 7
-                compress
-                notifempty
-        }
-
 {% include 'channels/gpg-keys.sls' %}
 {% include 'bootstrap/remove_traditional_stack.sls' %}


### PR DESCRIPTION
## What does this PR change?

https://github.com/uyuni-project/uyuni/pull/4080 only added the logrotate configuration for new ssh minions.

This fix will add it in all cases.

I removed `/etc/logrotate.d/salt-ssh` from a CentOS7 existing salt-ssh minion, ran the highstate and:
```
[root@sshminion-centos7 logrotate.d]# cat salt-ssh 
/var/log/salt-ssh.log {
        su root root
        weekly
        missingok
        rotate 7
        compress
        notifempty
}
```

Since the config is part of `services/salt-minion.sls`, the configuration will also be added by the bootstrap, as the state file is used for ssh and non-ssh minions.

TBH: We should refactor this and avoid calling it `services/salt-minion.sls` and rather something like `common/salt.sls`. But then again, we should consider a refactor of many other states such as the bootstrap states :-)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Bugfix

- [x] **DONE**

## Test coverage
- No tests: We don't have tests for logrotation

- [x] **DONE**

## Links

https://github.com/uyuni-project/uyuni/pull/4080
https://github.com/SUSE/spacewalk/issues/15356

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
