### PR TITLE
Allow passing a date limit for "schedule_deletearchived" on spacecmd (bsc#1181223)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/schedule/ScheduleHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/schedule/ScheduleHandler.java
@@ -220,6 +220,25 @@ public class ScheduleHandler extends BaseHandler {
     }
 
     /**
+     * List all the scheduled actions that have been archived.
+     * @param loggedInUser The current user
+     * @return Returns a list of actions with details
+     *
+     * @xmlrpc.doc Returns a list of actions that have been archived.
+     * @xmlrpc.param #session_key()
+     * @xmlrpc.returntype
+     * #array_begin()
+     *   $ScheduleActionSerializer
+     * #array_end()
+     */
+    public Object[] listAllArchivedActions(User loggedInUser) {
+        // the second argument is "PageControl". This is not needed for the api usage;
+        // therefore, null will be used.
+        DataResult dr = ActionManager.allArchivedActions(loggedInUser, null);
+        return dr.toArray();
+    }
+
+    /**
      * List the systems that have completed a specific action.
      * @param loggedInUser The current user
      * @param actionId The id of the action.

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/schedule/ScheduleHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/schedule/ScheduleHandler.java
@@ -234,8 +234,7 @@ public class ScheduleHandler extends BaseHandler {
     public Object[] listAllArchivedActions(User loggedInUser) {
         // the second argument is "PageControl". This is not needed for the api usage;
         // therefore, null will be used.
-        DataResult dr = ActionManager.allArchivedActions(loggedInUser, null);
-        return dr.toArray();
+        return ActionManager.allArchivedActions(loggedInUser, null).toArray();
     }
 
     /**
@@ -387,5 +386,4 @@ public class ScheduleHandler extends BaseHandler {
         return 1;
     }
 }
-
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/schedule/test/ScheduleHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/schedule/test/ScheduleHandlerTest.java
@@ -241,7 +241,7 @@ public class ScheduleHandlerTest extends BaseHandlerTestCase {
         apiActions = handler.listAllArchivedActions(admin);
         assertTrue(apiActions.length > numActions);
 
-	int oldLimit = ConfigDefaults.get().getActionsDisplayLimit();
+        int oldLimit = ConfigDefaults.get().getActionsDisplayLimit();
         Config.get().setString(ConfigDefaults.ACTIONS_DISPLAY_LIMIT, "1");
         Object[] apiActionsLimitted = handler.listArchivedActions(admin);
         Config.get().setString(ConfigDefaults.ACTIONS_DISPLAY_LIMIT, String.valueOf(oldLimit));

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/schedule/test/ScheduleHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/schedule/test/ScheduleHandlerTest.java
@@ -14,6 +14,8 @@
  */
 package com.redhat.rhn.frontend.xmlrpc.schedule.test;
 
+import com.redhat.rhn.common.conf.Config;
+import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.db.datasource.DataResult;
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionFactory;
@@ -210,6 +212,42 @@ public class ScheduleHandlerTest extends BaseHandlerTestCase {
         apiActions = handler.listArchivedActions(admin);
 
         assertTrue(apiActions.length > numActions);
+    }
+
+    public void testListAllArchivedActions() throws Exception {
+        //obtain number of actions from action manager
+        DataResult actions = ActionManager.allArchivedActions(admin, null);
+        int numActions = actions.size();
+
+        //compare against number retrieved from api... should be the same
+        Object[] apiActions = handler.listAllArchivedActions(admin);
+        assertEquals(numActions, apiActions.length);
+
+        //add a new action and verify that the value returned by the api
+        //has increased
+        Server server = ServerFactoryTest.createTestServer(admin, true);
+        Action a = ActionFactoryTest.createAction(admin,
+                ActionFactory.TYPE_PACKAGES_UPDATE);
+        a.setArchived(1L);
+        ServerAction saction = ServerActionTest.createServerAction(server, a);
+        saction.setStatus(ActionFactory.STATUS_QUEUED);
+
+        Action a2 = ActionFactoryTest.createAction(admin,
+                ActionFactory.TYPE_PACKAGES_UPDATE);
+        a2.setArchived(1L);
+        ServerAction saction2 = ServerActionTest.createServerAction(server, a2);
+        saction2.setStatus(ActionFactory.STATUS_QUEUED);
+
+        apiActions = handler.listAllArchivedActions(admin);
+        assertTrue(apiActions.length > numActions);
+
+	int oldLimit = ConfigDefaults.get().getActionsDisplayLimit();
+        Config.get().setString(ConfigDefaults.ACTIONS_DISPLAY_LIMIT, "1");
+        Object[] apiActionsLimitted = handler.listArchivedActions(admin);
+        Config.get().setString(ConfigDefaults.ACTIONS_DISPLAY_LIMIT, String.valueOf(oldLimit));
+
+        assertEquals(apiActionsLimitted.length, 1);
+        assertTrue(apiActions.length > apiActionsLimitted.length);
     }
 
     public void testListCompletedSystems() throws Exception {

--- a/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
+++ b/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
@@ -936,12 +936,12 @@ public class ActionManager extends BaseManager {
         if (pc != null) {
             return makeDataResult(params, params, pc, m);
         }
-	if (!noLimit) {
+        if (!noLimit) {
             int limit = ConfigDefaults.get().getActionsDisplayLimit();
             if (limit > 0) {
                 m.setMaxRows(limit);
             }
-	}
+        }
         DataResult dr = m.execute(params);
         dr.setTotalSize(dr.size());
         dr.setElaborationParams(params);

--- a/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
+++ b/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
@@ -958,7 +958,7 @@ public class ActionManager extends BaseManager {
      */
     private static DataResult getActions(User user, PageControl pc, String mode,
             String setLabel) {
-        return getActions(user, pc, mode, null, false);
+        return getActions(user, pc, mode, setLabel, false);
     }
 
     /**

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Allow getting all archived actions via XMLRPC without display limit (bsc#1181223)
 - Link to CLM filter creation from system details page
 - Delete ActionChains when the last action is a Reboot and it completes (bsc#1188163)
 - XMLRPC: Add call for listing application monitoring endpoints

--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,4 @@
+- Make schedule_deletearchived to get all actions without display limit
 - Allow passing a date limit for schedule_deletearchived on spacecmd (bsc#1181223)
 - Remove whoami from the list of unauthenticated commands (bsc#1188977)
 

--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,4 @@
+- Allow passing a date limit for schedule_deletearchived on spacecmd (bsc#1181223)
 - Remove whoami from the list of unauthenticated commands (bsc#1188977)
 
 -------------------------------------------------------------------

--- a/spacecmd/src/spacecmd/schedule.py
+++ b/spacecmd/src/spacecmd/schedule.py
@@ -474,7 +474,6 @@ def do_schedule_deletearchived(self, args):
     else:
         date_limit = None
 
-    # Needs to happen in a loop, since we can only fetch in batches. 10k is the default.
     actions = self.client.schedule.listAllArchivedActions(self.session)
 
     # Filter out actions by date if limit is set

--- a/spacecmd/tests/test_schedule.py
+++ b/spacecmd/tests/test_schedule.py
@@ -14,6 +14,8 @@ class TestSCSchedule:
     Test suite for "schedule" module.
     """
 
+    @patch('spacecmd.utils.input', create=True, new=MagicMock(return_value='y'))
+    @patch('spacecmd.utils.raw_input', create=True, new=MagicMock(return_value='y'))
     def test_schedule_deletearchived_without_archived(self, shell):
         """
         Test do_schedule_deletearchived with no archived actions.
@@ -23,13 +25,13 @@ class TestSCSchedule:
         """
 
         shell.help_schedule_deletearchived = MagicMock()
-        shell.client.schedule.listArchivedActions = MagicMock(return_value=[])
+        shell.client.schedule.listAllArchivedActions = MagicMock(return_value=[])
         shell.client.schedule.deleteActions = MagicMock()
         logger = MagicMock()
 
         spacecmd.schedule.do_schedule_deletearchived(shell, "")
 
-        assert shell.client.schedule.listArchivedActions.called
+        assert shell.client.schedule.listAllArchivedActions.called
         assert not shell.client.schedule.deleteActions.called
 
     @patch('spacecmd.utils.input', create=True, new=MagicMock(return_value='y'))
@@ -44,8 +46,8 @@ class TestSCSchedule:
         archived_dummy_actions = [{'id': 1}, {'id': 2}, {'id': 3}]
 
         shell.help_schedule_deletearchived = MagicMock()
-        shell.client.schedule.listArchivedActions = MagicMock()
-        shell.client.schedule.listArchivedActions.side_effect = [archived_dummy_actions] + [[]]
+        shell.client.schedule.listAllArchivedActions = MagicMock()
+        shell.client.schedule.listAllArchivedActions.side_effect = [archived_dummy_actions] + [[]]
         shell.client.schedule.deleteActions = MagicMock()
         logger = MagicMock()
 
@@ -67,8 +69,8 @@ class TestSCSchedule:
         archived_dummy_actions = [{'id': 1}, {'id': 2}, {'id': 3}]
 
         shell.help_schedule_deletearchived = MagicMock()
-        shell.client.schedule.listArchivedActions = MagicMock()
-        shell.client.schedule.listArchivedActions.side_effect = [archived_dummy_actions] + [[]]
+        shell.client.schedule.listAllArchivedActions = MagicMock()
+        shell.client.schedule.listAllArchivedActions.side_effect = [archived_dummy_actions] + [[]]
         shell.client.schedule.deleteActions = MagicMock()
         logger = MagicMock()
 
@@ -89,38 +91,14 @@ class TestSCSchedule:
         archived_dummy_actions = [{'id': 1}, {'id': 2}, {'id': 3}]
 
         shell.help_schedule_deletearchived = MagicMock()
-        shell.client.schedule.listArchivedActions = MagicMock()
-        shell.client.schedule.listArchivedActions.side_effect = [archived_dummy_actions] + [[]]
+        shell.client.schedule.listAllArchivedActions = MagicMock()
+        shell.client.schedule.listAllArchivedActions.side_effect = [archived_dummy_actions] + [[]]
         shell.client.schedule.deleteActions = MagicMock()
         logger = MagicMock()
 
         spacecmd.schedule.do_schedule_deletearchived(shell, "")
 
         assert shell.client.schedule.deleteActions.call_count == 0
-
-    @patch('spacecmd.utils.input', create=True, new=MagicMock(return_value='y'))
-    @patch('spacecmd.utils.raw_input', create=True, new=MagicMock(return_value='y'))
-    def test_schedule_deletearchived_with_archived_batched(self, shell):
-        """
-        Test do_schedule_deletearchived with archived actions
-        and in a batched way.
-
-        :param shell:
-        :return:
-        """
-        archived_dummy_actions = [{'id': 1}, {'id': 2}, {'id': 3}]
-
-        shell.help_schedule_deletearchived = MagicMock()
-        shell.client.schedule.listArchivedActions = MagicMock()
-        shell.client.schedule.listArchivedActions.side_effect = [archived_dummy_actions] + [archived_dummy_actions] + [[]]
-        shell.client.schedule.deleteActions = MagicMock()
-        logger = MagicMock()
-
-        spacecmd.schedule.do_schedule_deletearchived(shell, "")
-
-        assert shell.client.schedule.listArchivedActions.called
-        assert shell.client.schedule.deleteActions.call_count == 2
-        assert shell.client.schedule.deleteActions.call_args[0][1] == [1, 2, 3]
 
     def test_schedule_cancel_noargs(self, shell):
         """


### PR DESCRIPTION
## What does this PR change?

This PR enhance the current `schedule_deletearchived` function to allow passing a date limit for the archived actions to remove.

Besides of the changes on `spacecmd`, a new XMLRPC endpoint has been created to allow listing all archived actions via API without the limitting the results to 10K (due the display limit configuration)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/14196

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
