### PR TITLE
Uyuni tftp script multiple ip on server

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -633,9 +633,9 @@ When(/^I configure tftp on the "([^"]*)"$/) do |host|
   when 'server'
     $server.run("configure-tftpsync.sh #{ENV['PROXY']}")
   when 'proxy'
-    cmd = "configure-tftpsync.sh --tftpbootdir=/srv/tftpboot \
---server-fqdn=#{ENV['PROXY']} --server-ip=#{$server.public_ip} \
---proxy-fqdn=#{ENV['SERVER']} --proxy-ip=#{$proxy.public_ip}"
+    cmd = "configure-tftpsync.sh --non-interactive --tftpbootdir=/srv/tftpboot \
+--server-fqdn=#{ENV['SERVER']} \
+--proxy-fqdn=#{ENV['PROXY']}"
     $proxy.run(cmd)
   end
 end

--- a/tftpsync/susemanager-tftpsync-recv/configure-tftpsync.sh
+++ b/tftpsync/susemanager-tftpsync-recv/configure-tftpsync.sh
@@ -109,11 +109,11 @@ default_or_input "TFTP Boot directory" TFTPBOOT "/srv/tftpboot"
 
 default_or_input "SUSE Manager Proxy FQDN" SUMA_PROXY_FQDN $(hostname -f)
 
-default_or_input "SUSE Manager Proxy IP Address" SUMA_PROXY_IP $(host $SUMA_PROXY_FQDN | awk '{ print $4 }' || echo "")
+default_or_input "SUSE Manager Proxy IP Address" SUMA_PROXY_IP $(getent hosts $SUMA_PROXY_FQDN | awk '{ print $1 }' || echo "")
 
 default_or_input "SUSE Manager Server FQDN" SUMA_FQDN $PARENT_FQDN
 
-default_or_input "SUSE Manager Parent IP Address" SUMA_IP $( host $SUMA_FQDN | awk '{ print $4 }' || echo "" )
+default_or_input "SUSE Manager Parent IP Address" SUMA_IP $(getent hosts $SUMA_FQDN | awk '{ print $1 }' || echo "" )
 
 
 

--- a/tftpsync/susemanager-tftpsync-recv/susemanager-tftpsync-recv.changes
+++ b/tftpsync/susemanager-tftpsync-recv/susemanager-tftpsync-recv.changes
@@ -1,3 +1,5 @@
+- adapt configure-tftpsync.sh to work on machines with multiple IP's (bsc#1189263)
+
 -------------------------------------------------------------------
 Mon Aug 09 10:45:16 CEST 2021 - jgonzalez@suse.com
 

--- a/tftpsync/susemanager-tftpsync-recv/susemanager-tftpsync-recv.spec
+++ b/tftpsync/susemanager-tftpsync-recv/susemanager-tftpsync-recv.spec
@@ -83,7 +83,7 @@ if [ -f /etc/apache2/conf.d/susemanager-tftpsync-recv.conf.rpmnew ]; then
             exit 1;
     fi;
 
-    SUMA_IP=$( host $PARENT_FQDN | awk '{ print $4 }' )
+    SUMA_IP=$(getent hosts $PARENT_FQDN | awk '{ print $1 }' || echo "")
 
     sed -i "s/^[[:space:]]*Allow from[[:space:]].*$/        Allow from $SUMA_IP/" /etc/apache2/conf.d/susemanager-tftpsync-recv.conf.rpmnew
     sed -i "s/^[[:space:]#]*Require ip[[:space:]].*$/        Require ip $SUMA_IP/" /etc/apache2/conf.d/susemanager-tftpsync-recv.conf.rpmnew


### PR DESCRIPTION
## What does this PR change?

Solution for: https://github.com/SUSE/spacewalk/issues/15639

When a server has IPv4 and IPv6 configured installation script only allows IPv4. With this change, if no IP is passed, the default value will contain all the visible IPs (returned by host command) and will add them to apache configuration.

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
