### PR TITLE
Avoid being stuck by confirmation question

### DIFF
--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -676,7 +676,7 @@ When(/^I perform a full salt minion cleanup on "([^"]*)"$/) do |host|
   if host.include? 'ceos'
     node.run('yum -y remove --setopt=clean_requirements_on_remove=1 salt salt-minion', false)
   elsif (host.include? 'ubuntu') || (host.include? 'debian')
-    node.run('apt-get --assume-yes remove salt-common salt-minion && apt-get purge salt-common salt-minion && apt-get autoremove', false)
+    node.run('apt-get --assume-yes remove salt-common salt-minion && apt-get --assume-yes purge salt-common salt-minion && apt-get --assume-yes autoremove', false)
   else
     node.run('zypper --non-interactive remove --clean-deps -y salt salt-minion spacewalk-proxy-salt', false)
   end


### PR DESCRIPTION
## What does this PR change?

This PR adds `--assume-yes` to two calls to `apt-get` to avoid being stuck by questions like:
```
Do you want to continue? [Y/n] 
```


## Links

Ports:
* 4.1: SUSE/spacewalk#15655
* 4.2: SUSE/spacewalk#15656


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
