### PR TITLE
Fix Build image with authenticated registry (bsc#1185951) 

### DIFF
--- a/testsuite/features/secondary/buildhost_docker_auth_registry.feature
+++ b/testsuite/features/secondary/buildhost_docker_auth_registry.feature
@@ -34,7 +34,7 @@ Feature: Build image with authenticated registry
     And I click on "submit-btn"
     Then I wait until I see "portus_profile" text
     # Verify the status of images in the authenticated image store
-    When I wait at most 600 seconds until container "portus_profile" is built successfully
+    When I wait at most 900 seconds until container "portus_profile" is built successfully
     And I refresh the page
     Then table row for "portus_profile" should contain "1"
 


### PR DESCRIPTION
## What does this PR change?

The error in CI "Build image with authenticated registry.Build an image in the authenticated image store" seems to be cause by a short timeout.
The NPE seems to be not the root cause of the issue, considering that it happens also when the test are successfull (so apparently it does not have side effect).

## GUI diff

No difference.

- [ ] **DONE**

## Documentation

- [ ] **DONE**

## Test coverage


- [ ] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/14927
[bsc#1185951](https://bugzilla.suse.com/show_bug.cgi?id=1185951)


- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
