### PR TITLE
Backend for 'AppStreams with defaults' filter template

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -8913,6 +8913,9 @@ Alternatively, you will want to download &lt;strong&gt;Incremental Channel Conte
       <trans-unit id="contentmanagement.environment_name_too_long" xml:space="preserve">
         <source>Name must not exceed 128 characters</source>
       </trans-unit>
+      <trans-unit id="contentmanagement.invalid_template" xml:space="preserve">
+        <source>Invalid filter template</source>
+      </trans-unit>
       <trans-unit id="contentmanagement.filter_exists" xml:space="preserve">
         <source>Filter name already exists</source>
       </trans-unit>

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/request/FilterRequest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/request/FilterRequest.java
@@ -27,10 +27,13 @@ public class FilterRequest {
     private String criteriaValue;
     private String rule;
 
-    // Live patching template params
+    // Filter template params
     private String template;
     private String prefix;
+    // Live patching
     private Long kernelEvrId;
+    // AppStreams
+    private Long channelId;
 
     public String getProjectLabel() {
         return projectLabel;
@@ -70,5 +73,9 @@ public class FilterRequest {
 
     public Long getKernelEvrId() {
         return kernelEvrId;
+    }
+
+    public Long getChannelId() {
+        return channelId;
     }
 }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- 'AppStreams with defaults' filter template in CLM
 - Delete ActionChains when the last action is a Reboot and it completes (bsc#1188163)
 - XMLRPC: Add call for listing application monitoring endpoints
 - Bring back Beta product tag


### PR DESCRIPTION
Backend implementation for 'AppStreams with defaults' CLM filter template

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
