### PR TITLE
CI fix ownership when building packages

### DIFF
--- a/susemanager-utils/testing/automation/chown-objects.sh
+++ b/susemanager-utils/testing/automation/chown-objects.sh
@@ -15,3 +15,9 @@ find /manager | sort > /tmp/objects-end.txt
 for LINE in $(diff /tmp/objects-init.txt /tmp/objects-end.txt|grep '^> .*$'|sed -e 's/^> //'); do
   chown ${NEWUID}:${NEWGID} ${LINE}
 done
+
+# Some files are not new but are owned by root. This happens when using yarn to install some sources
+for f in $(find /manager -user root);do
+  chown ${NEWUID}:${NEWGID} $f
+done
+


### PR DESCRIPTION
## What does this PR change?

When using yarn to build the packages, some files are owned by root.
These are not new files, but files that have changed their permissions
when running yarn.

Since they are not new files, their ownership was not changed by the
automation scripts, and the next run would fail to remove them.

This commit finds those files and changes the ownership to jenkins user,
so next run will be able to remove them.


## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed

- [X] **DONE**

## Test coverage
- No tests

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
