### PR TITLE
Support syncing patches with advisory status 'pending'

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/errata/AdvisoryStatus.java
+++ b/java/code/src/com/redhat/rhn/domain/errata/AdvisoryStatus.java
@@ -24,6 +24,7 @@ public enum AdvisoryStatus {
     FINAL("final"),
     STABLE("stable"),
     TESTING("testing"),
+    PENDING("pending"),
     RETRACTED("retracted");
 
     private final String metadataValue;

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Support syncing patches with advisory status 'pending'
 - Updated Enterprise Linux servlet requirement.
 - Ignore duplicates in 'pkg.installed' result when applying patches (bsc#1187572)
 - Improved timezone support

--- a/schema/spacewalk/common/tables/rhnErrata.sql
+++ b/schema/spacewalk/common/tables/rhnErrata.sql
@@ -30,7 +30,7 @@ CREATE TABLE rhnErrata
     advisory_status   VARCHAR(32) NOT NULL DEFAULT('final')
                           CONSTRAINT rhn_errata_adv_status_ck
                               CHECK (advisory_status in ('final', 'stable', 'testing',
-                                                         'retracted')),
+                                                         'pending', 'retracted')),
     product           VARCHAR(64) NOT NULL,
     description       VARCHAR(4000),
     synopsis          VARCHAR(4000) NOT NULL,

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- Support syncing patches with advisory status 'pending'
 - allow Ansible Control Node entitlement for aarch64, ppc64le and s390x(bsc#1189799)
 - implement package locking for salt minions
 

--- a/schema/spacewalk/upgrade/susemanager-schema-4.3.1-to-susemanager-schema-4.3.2/310-add-pending-advisory-status.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.3.1-to-susemanager-schema-4.3.2/310-add-pending-advisory-status.sql
@@ -1,0 +1,5 @@
+ALTER TABLE rhnErrata DROP CONSTRAINT IF EXISTS rhn_errata_adv_status_ck;
+ALTER TABLE rhnErrata ADD
+    CONSTRAINT rhn_errata_adv_status_ck
+    CHECK (advisory_status in ('final', 'stable', 'testing', 'pending', 'retracted'));
+


### PR DESCRIPTION
$subj

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: bug

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links
https://github.com/uyuni-project/uyuni/issues/4011

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
