### PR TITLE
Wait until dialog box to create new CLM filter is fully loaded

### DIFF
--- a/testsuite/features/build_validation/add_custom_repositories/add_ceos8_repositories.feature
+++ b/testsuite/features/build_validation/add_custom_repositories/add_ceos8_repositories.feature
@@ -65,14 +65,16 @@ Feature: Adding the CentOS 8 distribution custom repositories
     Given I am authorized for the "Admin" section
     When I follow the left menu "Content Lifecycle > Filters"
     And I click on "Create Filter"
-    And I enter "ruby-2.7" as "filter_name"
+    Then I should see a "Create a new filter" text
+    When I enter "ruby-2.7" as "filter_name"
     And I select "Module (Stream)" from "type"
     And I enter "ruby" as "moduleName"
     And I enter "2.7" as "moduleStream"
     And I click on "Save"
     Then I should see a "ruby-2.7" text
     When I click on "Create Filter"
-    And I enter "python-3.6" as "filter_name"
+    Then I should see a "Create a new filter" text
+    When I enter "python-3.6" as "filter_name"
     And I select "Module (Stream)" from "type"
     And I enter "python36" as "moduleName"
     And I enter "3.6" as "moduleStream"


### PR DESCRIPTION
## What does this PR change?

This PR waits until title "Create a new filter" appears before filling in the fields of the CLM filter dialog box.


## Links

Ports:
* 4.1: SUSE/spacewalk#15707
* 4.2: SUSE/spacewalk#15706


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
