### PR TITLE
Fix API doc for system.monitoring.listEndpoints

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/monitoring/SystemMonitoringHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/monitoring/SystemMonitoringHandler.java
@@ -48,11 +48,12 @@ public class SystemMonitoringHandler extends BaseHandler {
      * @param systemIDs The system IDs
      * @return a list containing endpoint details for all Prometheus exporters on the passed system IDs.
      *
+     * @xmlrpc.doc Get the list of monitoring endpoint details.
      * @xmlrpc.param #session_key()
      * @xmlrpc.param #array_single("int", "systemID")
      * @xmlrpc.returntype
      *   #array_begin()
-     *     $EndpointInfo
+     *     $EndpointInfoSerializer
      *   #array_end()
      */
     public List<EndpointInfo> listEndpoints(User loggedInUser, List<Long> systemIDs) {


### PR DESCRIPTION
## What does this PR change?

Fix API documentation strings for the call `system.monitoring.listEndpoints`.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: No new functionality.

- [x] **DONE**

## Test coverage
- No tests: Just syntax fix.

- [x] **DONE**

## Links

- [ ] **DONE**

## Changelogs

- [x] No changelog needed

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
