### PR TITLE
CI: Fix ownership on package building

### DIFF
--- a/susemanager-utils/testing/automation/push-to-obs.sh
+++ b/susemanager-utils/testing/automation/push-to-obs.sh
@@ -63,6 +63,7 @@ if [ ! -f ${CREDENTIALS} ]; then
 fi
 
 INITIAL_CMD="/manager/susemanager-utils/testing/automation/initial-objects.sh"
+CHOWN_CMD="/manager/susemanager-utils/testing/automation/chown-objects.sh $(id -u) $(id -g)"
 docker pull $REGISTRY/$PUSH2OBS_CONTAINER
 
 test -n "$PACKAGES" || {

--- a/susemanager-utils/testing/automation/push-to-obs.sh
+++ b/susemanager-utils/testing/automation/push-to-obs.sh
@@ -73,7 +73,7 @@ date
 [ -d ${GITROOT}/logs ] || mkdir ${GITROOT}/logs
 for p in ${PACKAGES};do
     pkg_dir=$(cat rel-eng/packages/${p} | tr -s " " | cut -d" " -f 2)
-    CHOWN_CMD="chown -f -R $(id -u):$(id -g) /manager/$pkg_dir"
+    CHOWN_CMD_FULL="${CHOWN_CMD}; chown -f -R $(id -u):$(id -g) /manager/$pkg_dir"
     CMD="/manager/susemanager-utils/testing/docker/scripts/push-to-obs.sh -d '${DESTINATIONS}' -c /tmp/.oscrc -p '${p}' ${VERBOSE} ${TEST} ${OBS_TEST_PROJECT} ${EXTRA_OPTS}"
     if [ "$PARALLEL_BUILD" == "TRUE" ];then
         docker run --rm=true -v $GITROOT:/manager -v /srv/mirror:/srv/mirror --mount type=bind,source=${CREDENTIALS},target=/tmp/.oscrc $REGISTRY/$PUSH2OBS_CONTAINER /bin/bash -c "trap \"${CHOWN_CMD};exit -1\" SIGHUP SIGINT SIGTERM EXIT;${INITIAL_CMD}; ${CMD}; RET=\${?}; ${CHOWN_CMD} && exit \${RET}" | tee ${GITROOT}/logs/${p}.log &


### PR DESCRIPTION
## What does this PR change?

When building packages with yarn inside a container, the ownership of some files get
changed to root. Without this commit, the ownership is fixed **only**
for new files, not for old ones.

This commit fixes the ownership of **all** files.

Otherwise, next run in jenkins will fail because it can't clean up the
environment.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed

- [X] **DONE**

## Test coverage
- No tests

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
