### PR TITLE
Do not fail if there is no custom repo for a given client

### DIFF
--- a/testsuite/features/build_validation/add_custom_repositories/add_maintenance_update_repository.template
+++ b/testsuite/features/build_validation/add_custom_repositories/add_maintenance_update_repository.template
@@ -38,4 +38,4 @@ Feature: Adding a Maintenance Update custom channel and the custom repositories 
     And I follow "Repositories" in the content area
     And I follow "Sync"
     And I click on "Sync Now"
-    Then I should see a "Repository sync scheduled" text
+    Then I should see a "Repository sync scheduled" text or "No repositories are currently associated with this channel" text


### PR DESCRIPTION
## What does this PR change?

In the build validation test suite, when there is no MI for the client tools on some client, then there are no custom repositories for that client. This PR ensures that we don't fail when we try to synchronize these non-existing repositories.


## Links

Ports:
* 4.1:
* 4.2:


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
