### PR TITLE
Add a link to OS image store dir in image list page

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/image/OSImageStoreUtils.java
+++ b/java/code/src/com/redhat/rhn/domain/image/OSImageStoreUtils.java
@@ -66,4 +66,14 @@ public class OSImageStoreUtils {
     public static String getOSImageStoreURIForOrg(Org org) {
         return getOSImageStoreURI() + org.getId() + "/";
     }
+
+    /**
+     * Returns a OS Image Store URI relative to the server's domain name for an Org
+     *
+     * @param org the org associated with the Image Store
+     * @return the relative URI for the Org
+     */
+    public static String getOSImageStoreRelativeURI(Org org) {
+        return "/" + osImageWWWDirectory + "/" + org.getId() + "/";
+    }
 }

--- a/java/code/src/com/suse/manager/webui/controllers/ImageBuildController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/ImageBuildController.java
@@ -33,6 +33,7 @@ import com.redhat.rhn.domain.image.ImageOverview;
 import com.redhat.rhn.domain.image.ImageProfile;
 import com.redhat.rhn.domain.image.ImageProfileFactory;
 import com.redhat.rhn.domain.image.ImageStoreFactory;
+import com.redhat.rhn.domain.image.OSImageStoreUtils;
 import com.redhat.rhn.domain.role.Role;
 import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.domain.server.ServerGroup;
@@ -71,6 +72,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
 import org.apache.log4j.Logger;
 
+import java.io.File;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Date;
@@ -270,6 +272,10 @@ public class ImageBuildController {
         }
         else {
             model.put("id", null);
+        }
+
+        if (new File(OSImageStoreUtils.getOSImageStorePathForOrg(user.getOrg())).exists()) {
+            model.put("osImageStoreUrl", OSImageStoreUtils.getOSImageStoreRelativeURI(user.getOrg()));
         }
 
         model.put("isAdmin", user.hasRole(ADMIN_ROLE));

--- a/java/code/src/com/suse/manager/webui/templates/content_management/view.jade
+++ b/java/code/src/com/suse/manager/webui/templates/content_management/view.jade
@@ -9,6 +9,7 @@ script(type='text/javascript').
     window.timezone = "#{h.renderTimezone()}";
     window.localTime = "#{h.renderLocalTime()}";
     window.isRuntimeInfoEnabled = #{isRuntimeInfoEnabled};
+    window.osImageStoreUrl = "#{osImageStoreUrl}";
 
 +userPreferences
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add a link to OS image store dir in image list page
 - Do not log XMLRPC fault exceptions as errors (bsc#1188853)
 - AppStreams tab for modular channels
 - Allow getting all archived actions via XMLRPC without display limit (bsc#1181223)

--- a/web/html/src/manager/images/image-view.tsx
+++ b/web/html/src/manager/images/image-view.tsx
@@ -28,6 +28,7 @@ declare global {
     timezone?: any;
     localTime?: any;
     isRuntimeInfoEnabled?: any;
+    osImageStoreUrl?: string;
   }
 }
 
@@ -693,6 +694,14 @@ class ImageViewList extends React.Component<ImageViewListProps, ImageViewListSta
             }}
           />
         </Table>
+        {window.osImageStoreUrl &&
+          <div>
+            <a href={window.osImageStoreUrl} target="_blank">
+              <i className="fa fa-folder-open"/>
+              Go to OS image directory listing
+            </a>
+          </div>
+        }
         <DeleteDialog
           id="delete-modal"
           title={t("Delete Image")}

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Add a link to OS image store dir in image list page
 - Link to CLM filter creation from system details page
 
 -------------------------------------------------------------------


### PR DESCRIPTION
Add a link to OS image store directory listing in image list page.

The link only displays if the directory exists for an org. The directory should not exist until at least one OS image is built.

## GUI diff

![os-image-link-after](https://user-images.githubusercontent.com/1103552/130114603-1e8c1004-7d29-45e9-90be-09d74b9fa445.png)

## Documentation
- No documentation needed: minor addition

## Test coverage
- Cucumber tests will be adapted

## Links

Fixes https://github.com/SUSE/spacewalk/issues/15256
Fixes https://github.com/SUSE/spacewalk/issues/12766

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
