### PR TITLE
Fix non-unique scenario name

### DIFF
--- a/testsuite/features/build_validation/smoke_tests/smoke_tests.template
+++ b/testsuite/features/build_validation/smoke_tests/smoke_tests.template
@@ -112,7 +112,7 @@ Feature: Smoke tests for <client>
     And I click on "Update Channel Rankings"
     Then I should see a "Channel Subscriptions successfully changed for" text
 
-  Scenario: Deploy the file to all subscribed systems
+  Scenario: Deploy the configuration file to <client>
     And I follow the left menu "Configuration > Channels"
     And I follow "Mixed Channel"
     And I follow "Deploy all configuration files to selected subscribed systems"


### PR DESCRIPTION
## What does this PR change?

A command like `cucumber -r features -n "Deploy the file to all subscribed systems"` would run the scenario on all minions.

This PR makes it possible to run `cucumber -r features -n "Deploy the configuration file to sle15sp3_minion"` for example.


## Links

Ports:
* 4.1: SUSE/spacewalk#15715
* 4.2: SUSE/spacewalk#15714


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
