### PR TITLE
Appstreams filter template

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -8913,6 +8913,9 @@ Alternatively, you will want to download &lt;strong&gt;Incremental Channel Conte
       <trans-unit id="contentmanagement.environment_name_too_long" xml:space="preserve">
         <source>Name must not exceed 128 characters</source>
       </trans-unit>
+      <trans-unit id="contentmanagement.invalid_template" xml:space="preserve">
+        <source>Invalid filter template</source>
+      </trans-unit>
       <trans-unit id="contentmanagement.filter_exists" xml:space="preserve">
         <source>Filter name already exists</source>
       </trans-unit>

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/request/FilterRequest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/request/FilterRequest.java
@@ -27,10 +27,13 @@ public class FilterRequest {
     private String criteriaValue;
     private String rule;
 
-    // Live patching template params
+    // Filter template params
     private String template;
     private String prefix;
+    // Live patching
     private Long kernelEvrId;
+    // AppStreams
+    private Long channelId;
 
     public String getProjectLabel() {
         return projectLabel;
@@ -70,5 +73,9 @@ public class FilterRequest {
 
     public Long getKernelEvrId() {
         return kernelEvrId;
+    }
+
+    public Long getChannelId() {
+        return channelId;
     }
 }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- 'AppStreams with defaults' filter template in CLM
 - Add a link to OS image store dir in image list page
 - Do not log XMLRPC fault exceptions as errors (bsc#1188853)
 - AppStreams tab for modular channels

--- a/web/html/src/manager/content-management/list-filters/filter.utils.ts
+++ b/web/html/src/manager/content-management/list-filters/filter.utils.ts
@@ -18,6 +18,7 @@ export function mapFilterFormToRequest(
   if (Object.prototype.hasOwnProperty.call(filterForm, "template")) {
     requestForm.prefix = filterForm.labelPrefix;
     requestForm.kernelEvrId = filterForm.kernelId;
+    requestForm.channelId = filterForm.channelId;
     requestForm.template = filterForm['template'];
   }
 

--- a/web/html/src/manager/content-management/list-filters/templates/app-streams.tsx
+++ b/web/html/src/manager/content-management/list-filters/templates/app-streams.tsx
@@ -1,0 +1,52 @@
+import * as React from "react";
+import { useEffect, useState } from "react";
+import { usePrevious } from "utils/hooks";
+import { Select, FormContext } from "components/input";
+import { Props as FilterFormProps } from "../filter-form";
+
+import { Template } from "./index";
+import Network, { JsonResult } from "utils/network";
+
+type Channel = {
+  id: number;
+  label: string;
+  name: string;
+};
+
+function getChannels() {
+  return Network.get<JsonResult<Channel[]>>("/rhn/manager/api/channels/modular").then(Network.unwrap);
+}
+
+export default (props: FilterFormProps & { template: Template }) => {
+  const template = props.template;
+  const prevTemplate = usePrevious(template);
+
+  const formContext = React.useContext(FormContext);
+  const setModelValue = formContext.setModelValue;
+  const [channels, setChannels] = useState<Channel[]>([]);
+
+  useEffect(() => {
+    getChannels()
+      .then(setChannels)
+      .catch(Network.showResponseErrorToastr);
+  }, []);
+
+  useEffect(() => {
+    if (prevTemplate) {
+      setModelValue?.("channelId", null);
+    }
+  }, [template]);
+
+  return (
+    <Select
+        name="channelId"
+        label={t("Channel")}
+        labelClass="col-md-3"
+        divClass="col-md-6"
+        required
+        options={channels}
+        getOptionValue={channel => channel.id}
+        getOptionLabel={channel => channel.name}
+      />
+  );
+};

--- a/web/html/src/manager/content-management/list-filters/templates/index.tsx
+++ b/web/html/src/manager/content-management/list-filters/templates/index.tsx
@@ -2,10 +2,12 @@ import { FormContext, Select } from "components/input";
 import * as React from "react";
 import { Props as FilterFormProps } from "../filter-form";
 import LivePatching from "./live-patching";
+import AppStreams from "./app-streams";
 
 export enum Template {
   LivePatchingSystem = "LivePatchingSystem",
   LivePatchingProduct = "LivePatchingProduct",
+  AppStreamsWithDefaults = "AppStreamsWithDefaults",
 }
 
 const TemplateForm = (props: FilterFormProps) => {
@@ -15,6 +17,8 @@ const TemplateForm = (props: FilterFormProps) => {
     case Template.LivePatchingSystem:
     case Template.LivePatchingProduct:
       return <LivePatching template={template} {...props} />;
+    case Template.AppStreamsWithDefaults:
+      return <AppStreams template={template} {...props} />;
     default:
       return null;
   }
@@ -30,6 +34,10 @@ export default (props: FilterFormProps) => {
       label: t("Live patching based on a SUSE product"),
       value: Template.LivePatchingProduct,
     },
+    {
+      label: t("AppStream modules with defaults"),
+      value: Template.AppStreamsWithDefaults,
+    }
   ];
   return (
     <>

--- a/web/html/src/manager/content-management/shared/api/use-lifecycle-actions-api.ts
+++ b/web/html/src/manager/content-management/shared/api/use-lifecycle-actions-api.ts
@@ -22,7 +22,6 @@ const networkAction = {
 };
 
 type NetworkActionKey = keyof typeof networkAction;
-type NetworkMethod = typeof networkAction[NetworkActionKey]
 
 const getApiUrl = (resource: string, nestedResource?: string, id?: string) => {
   if (!id) {
@@ -51,7 +50,7 @@ const useLifecycleActionsApi = (props: Props): returnUseProjectActionsApi => {
 
       const apiUrl = getApiUrl(props.resource, props.nestedResource, id);
 
-      let networkRequest: ReturnType<NetworkMethod>;
+      let networkRequest: Cancelable;
       if (action === "get" || !networkAction[action]) {
         networkRequest = networkAction.get(apiUrl);
       } else {

--- a/web/html/src/manager/content-management/shared/type/filter.type.ts
+++ b/web/html/src/manager/content-management/shared/type/filter.type.ts
@@ -41,4 +41,5 @@ export type FilterFormType = {
   systemName?: string;
   kernelId?: number;
   kernelName?: string;
+  channelId?: number;
 };

--- a/web/html/src/utils/hooks.test.tsx
+++ b/web/html/src/utils/hooks.test.tsx
@@ -9,15 +9,15 @@ describe("usePrevious", () => {
 
   test("yields undefined on first render", () => {
     render(<TestComponent value="1" />);
-    expect(screen.getByText("undefined"));
+    screen.getByText("undefined");
   });
 
   test("yields previous value on rerenders", () => {
     const { rerender } = render(<TestComponent value="1" />);
     rerender(<TestComponent value="2" />);
-    expect(screen.getByText("1"));
+    screen.getByText("1");
 
     rerender(<TestComponent value="3" />);
-    expect(screen.getByText("2"));
+    screen.getByText("2");
   });
 });

--- a/web/html/src/utils/hooks.test.tsx
+++ b/web/html/src/utils/hooks.test.tsx
@@ -1,0 +1,23 @@
+import { usePrevious } from "./hooks";
+import { render, screen } from "utils/test-utils";
+
+describe("usePrevious", () => {
+  const TestComponent = (props: { value: string }) => {
+    const prevValue = usePrevious(props.value);
+    return <p>{prevValue ?? typeof prevValue}</p>;
+  };
+
+  test("yields undefined on first render", () => {
+    render(<TestComponent value="1" />);
+    expect(screen.getByText("undefined"));
+  });
+
+  test("yields previous value on rerenders", () => {
+    const { rerender } = render(<TestComponent value="1" />);
+    rerender(<TestComponent value="2" />);
+    expect(screen.getByText("1"));
+
+    rerender(<TestComponent value="3" />);
+    expect(screen.getByText("2"));
+  });
+});

--- a/web/html/src/utils/hooks.ts
+++ b/web/html/src/utils/hooks.ts
@@ -1,0 +1,9 @@
+import { useEffect, useRef } from "react";
+
+export function usePrevious<T>(value: T) {
+  const ref = useRef<T>();
+  useEffect(() => {
+    ref.current = value;
+  });
+  return ref.current;
+}

--- a/web/html/src/utils/hooks.ts
+++ b/web/html/src/utils/hooks.ts
@@ -1,5 +1,9 @@
 import { useEffect, useRef } from "react";
 
+/**
+ * Get the value of a variable from the previous render of a functional component, initially returns undefined.
+ * Can be used for variables, props, state, or anything really.
+ */
 export function usePrevious<T>(value: T) {
   const ref = useRef<T>();
   useEffect(() => {

--- a/web/html/src/utils/network.ts
+++ b/web/html/src/utils/network.ts
@@ -58,15 +58,15 @@ function request<Returns>(
     return Utils.cancelable(Promise.resolve(a), () => a.abort());
 }
 
-function post<Payload, Returns = any>(url: string, data?: DataType<Payload>, contentType: string = "application/json", processData: boolean = true): Cancelable<Returns> {
+function post<Returns = any, Payload = any>(url: string, data?: DataType<Payload>, contentType: string = "application/json", processData: boolean = true): Cancelable<Returns> {
     return request<Returns>(url, "POST", {"X-CSRF-Token": csrfToken}, data, contentType, processData);
 }
 
-function del<Payload, Returns = any>(url: string, data?: DataType<Payload>, contentType: string = "application/json", processData: boolean = true): Cancelable<Returns> {
+function del<Returns = any, Payload = any>(url: string, data?: DataType<Payload>, contentType: string = "application/json", processData: boolean = true): Cancelable<Returns> {
     return request<Returns>(url, "DELETE", {"X-CSRF-Token": csrfToken}, data, contentType, processData);
 }
 
-function put<Payload, Returns = any>(url: string, data?: DataType<Payload>, contentType: string = "application/json", processData: boolean = true): Cancelable<Returns> {
+function put<Returns = any, Payload = any>(url: string, data?: DataType<Payload>, contentType: string = "application/json", processData: boolean = true): Cancelable<Returns> {
     return request<Returns>(url, "PUT", {"X-CSRF-Token": csrfToken}, data, contentType, processData);
 }
 

--- a/web/html/src/utils/network.ts
+++ b/web/html/src/utils/network.ts
@@ -1,4 +1,5 @@
 import {MessageType, Utils as MessagesUtils} from "components/messages";
+import { showErrorToastr } from "components/toastr";
 import {Utils} from "utils/functions";
 import {Cancelable} from "utils/functions";
 
@@ -26,14 +27,14 @@ export type JsonResult<T> = {
 type CommonMimeTypes = "application/json" | "application/xml" | "application/x-www-form-urlencoded";
 type DataType<T> = T & (T extends CommonMimeTypes ? never : T);
 
-function request(
+function request<Returns>(
     url: string,
     type: "GET" | "POST" | "DELETE" | "PUT",
     headers: Record<string, string>,
     data: any,
     contentType: string,
     processData: boolean = true
-): Cancelable {
+): Cancelable<Returns> {
     const isRegularObject = typeof data === "object" && !(data instanceof FormData);
     const isNumber = typeof data === 'number';
     if ((isRegularObject || isNumber) && processData === true) {
@@ -57,20 +58,20 @@ function request(
     return Utils.cancelable(Promise.resolve(a), () => a.abort());
 }
 
-function post<T>(url: string, data?: DataType<T>, contentType: string = "application/json", processData: boolean = true): Cancelable {
-    return request(url, "POST", {"X-CSRF-Token": csrfToken}, data, contentType, processData);
+function post<Payload, Returns = any>(url: string, data?: DataType<Payload>, contentType: string = "application/json", processData: boolean = true): Cancelable<Returns> {
+    return request<Returns>(url, "POST", {"X-CSRF-Token": csrfToken}, data, contentType, processData);
 }
 
-function del<T>(url: string, data?: DataType<T>, contentType: string = "application/json", processData: boolean = true): Cancelable {
-    return request(url, "DELETE", {"X-CSRF-Token": csrfToken}, data, contentType, processData);
+function del<Payload, Returns = any>(url: string, data?: DataType<Payload>, contentType: string = "application/json", processData: boolean = true): Cancelable<Returns> {
+    return request<Returns>(url, "DELETE", {"X-CSRF-Token": csrfToken}, data, contentType, processData);
 }
 
-function put<T>(url: string, data?: DataType<T>, contentType: string = "application/json", processData: boolean = true): Cancelable {
-    return request(url, "PUT", {"X-CSRF-Token": csrfToken}, data, contentType, processData);
+function put<Payload, Returns = any>(url: string, data?: DataType<Payload>, contentType: string = "application/json", processData: boolean = true): Cancelable<Returns> {
+    return request<Returns>(url, "PUT", {"X-CSRF-Token": csrfToken}, data, contentType, processData);
 }
 
-function get(url: string, contentType: string = "application/json"): Cancelable {
-    return request(url, "GET", {}, {}, contentType);
+function get<Returns = any>(url: string, contentType: string = "application/json"): Cancelable<Returns> {
+    return request<Returns>(url, "GET", {}, {}, contentType);
 }
 
 function errorMessageByStatus(status: number): Array<string> {
@@ -126,6 +127,24 @@ function responseErrorMessage(
     }
 }
 
+function hasMessages(input: any): input is JsonResult<never> {
+    return input && Object.prototype.hasOwnProperty.call(input, "messages") && Array.isArray(input.messages);
+}
+
+function showResponseErrorToastr(responseOrError: Error | JQueryXHR | JsonResult<never>) {
+    if (hasMessages(responseOrError)) {
+        responseOrError.messages.flatMap(msg => showErrorToastr(msg));
+    } else {
+        responseErrorMessage(responseOrError).map(msg => showErrorToastr(msg.text));
+    }
+}
+
+// TODO: Make this globally automatic and update relevant calls in a follow-up PR
+/** Unwrap the data from a `JsonResult` if the request is a success */
+function unwrap<T>(response: JsonResult<T>) {
+    return response.success ? response.data : Promise.reject(response);
+}
+
 export default {
     get,
     post,
@@ -133,4 +152,6 @@ export default {
     del,
     errorMessageByStatus,
     responseErrorMessage,
+    showResponseErrorToastr,
+    unwrap,
 };

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- 'AppStreams with defaults' filter template in CLM
 - Add a link to OS image store dir in image list page
 - Link to CLM filter creation from system details page
 


### PR DESCRIPTION
## What does this PR change?

Frontend part for the appstreams filter template along with some network updates. I also cherry-picked the backend branch onto this for easier testing. I couldn't figure out how to correctly configure modular channels to get them to show up though (slight facepalm).

## GUI diff

<img width="608" alt="Screenshot 2021-08-20 at 11 53 07" src="https://user-images.githubusercontent.com/3171718/130215823-25357e9c-3479-47f7-8ed4-01a83338ef78.png">

- [x] **DONE**

## Documentation
- Documentation issue was created: https://github.com/SUSE/spacewalk/issues/15727

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/14100

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
