### PR TITLE
Show AppStream just for modular channel

### DIFF
--- a/java/code/src/com/redhat/rhn/common/security/acl/Access.java
+++ b/java/code/src/com/redhat/rhn/common/security/acl/Access.java
@@ -454,6 +454,21 @@ public class Access extends BaseHandler {
     }
 
     /**
+     * Returns true if it is a modular channel
+     * @param ctx acl context (includes the channel cid and the user name)
+     * @param params parameters for acl (ignored)
+     * @return true if the user is channel admin of the corresponding channel.
+     */
+    public boolean aclIsModularChannel(Object ctx, String[] params) {
+        Map map = (Map) ctx;
+        Long cid = getAsLong(map.get("cid"));
+        User user = (User) map.get("user");
+        Channel chan = ChannelManager.lookupByIdAndUser(cid, user);
+
+        return chan.isModular();
+    }
+
+    /**
      * Returns true if the user is channel admin of the corresponding channel.
      * If the channel is a vendor channel, the return value is false.
      * @param ctx acl context (includes the channel cid and the user name)

--- a/java/code/src/com/redhat/rhn/common/security/acl/test/AccessTest.java
+++ b/java/code/src/com/redhat/rhn/common/security/acl/test/AccessTest.java
@@ -18,6 +18,7 @@ import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.security.acl.Access;
 import com.redhat.rhn.common.security.acl.Acl;
 import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.domain.channel.Modules;
 import com.redhat.rhn.domain.channel.test.ChannelFactoryTest;
 import com.redhat.rhn.domain.role.Role;
 import com.redhat.rhn.domain.role.RoleFactory;
@@ -38,14 +39,15 @@ import com.redhat.rhn.testing.BaseTestCaseWithUser;
 import com.redhat.rhn.testing.ServerTestUtils;
 import com.redhat.rhn.testing.TestUtils;
 import com.redhat.rhn.testing.UserTestUtils;
+
 import com.suse.manager.clusters.ClusterManager;
 import com.suse.manager.virtualization.VirtManagerSalt;
 import com.suse.manager.webui.services.iface.MonitoringManager;
 import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.iface.SystemQuery;
+import com.suse.manager.webui.services.iface.VirtManager;
 import com.suse.manager.webui.services.test.TestSaltApi;
 import com.suse.manager.webui.services.test.TestSystemQuery;
-import com.suse.manager.webui.services.iface.VirtManager;
 
 import java.util.Date;
 import java.util.HashMap;
@@ -321,6 +323,34 @@ public class AccessTest extends BaseTestCaseWithUser {
         catch (Exception e) {
             fail("channel validation failed");
         }
+    }
+
+    public void testIsModularChannel() {
+        Map context = new HashMap();
+        User user = UserTestUtils.findNewUser("testUser", "testOrg" + this.getClass().getSimpleName());
+        context.put("user", user);
+
+        user.addPermanentRole(RoleFactory.CHANNEL_ADMIN);
+        Channel chan = null;
+
+        try {
+            chan = ChannelFactoryTest.createTestChannel(user);
+        }
+        catch (Exception e) {
+            fail("channel validation failed");
+        }
+
+        context.put("cid", chan.getId());
+
+        assertFalse(acl.evalAcl(context, "is_modular_channel()"));
+
+        Modules mod = new Modules();
+        mod.setRelativeFilename("filename");
+        chan.setModules(mod);
+        mod.setChannel(chan);
+
+        assertTrue(acl.evalAcl(context, "is_modular_channel()"));
+
     }
 
     public void testFormvarExists() {

--- a/java/code/webapp/WEB-INF/nav/channel_detail.xml
+++ b/java/code/webapp/WEB-INF/nav/channel_detail.xml
@@ -23,7 +23,7 @@
     <rhn-tab-url>/rhn/channels/TargetSystems.do</rhn-tab-url>
     <rhn-tab-url>/rhn/channels/TargetSystemsConfirm.do</rhn-tab-url>
   </rhn-tab>
-  <rhn-tab name="AppStreams">
+  <rhn-tab name="AppStreams" acl="is_modular_channel()">
     <rhn-tab-url>/rhn/channels/AppStreams.do</rhn-tab-url>
   </rhn-tab>
 </rhn-navi-tree>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Show AppStreams tab just for modular channels
 - 'AppStreams with defaults' filter template in CLM
 - Add a link to OS image store dir in image list page
 - Do not log XMLRPC fault exceptions as errors (bsc#1188853)


### PR DESCRIPTION
## What does this PR change?

Show AppStream tab just for modular channel
## GUI diff
N/A

- [ ] **DONE**

## Documentation
N/A

- [ ] **DONE**

## Test coverage
- Unit tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks # https://github.com/SUSE/spacewalk/issues/10098

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql" (Test skipped, there are no changes to test)
- [ ] Re-run test "java_pgsql_tests"         
- [x] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql" (Test skipped, there are no changes to test)
- [ ] Re-run test "susemanager_unittests" (Test skipped, there are no changes to test)
- [x] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests" (Test skipped, there are no changes to test)
