### PR TITLE
Do not log XMLRPC FaultExceptions as errors (bsc#1188853)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/BaseHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/BaseHandler.java
@@ -50,6 +50,7 @@ import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.session.WebSession;
 import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.FaultException;
 import com.redhat.rhn.manager.session.SessionManager;
 import com.redhat.rhn.manager.system.SystemManager;
 
@@ -147,8 +148,17 @@ public class BaseHandler implements XmlRpcInvocationHandler {
         }
         catch (InvocationTargetException e) {
             Throwable cause = e.getCause();
-            log.error("Error calling method: ", e);
-            log.error("Caused by: ", cause);
+
+            if (cause instanceof FaultException) {
+                // FaultExceptions are "bad request" type of exceptions
+                // Normally they should be thrown as response to the client but there's no need to log them as errors.
+                FaultException fault = (FaultException) cause;
+                log.debug("'" + methodCalled + "' returned: [" + fault.getErrorCode() + "] " + fault.getMessage());
+            }
+            else {
+                log.error("Error calling method: ", e);
+                log.error("Caused by: ", cause);
+            }
 
             /*
              * HACK: this should really be handled by SessionFilter.doFilter,
@@ -158,7 +168,7 @@ public class BaseHandler implements XmlRpcInvocationHandler {
              * committing changes after an Exception, roll back here.
              */
             try {
-                log.error("Rolling back transaction");
+                log.debug("Rolling back transaction");
                 HibernateFactory.rollbackTransaction();
             }
             catch (HibernateException he) {

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/LoggingInvocationProcessor.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/LoggingInvocationProcessor.java
@@ -102,7 +102,7 @@ public class LoggingInvocationProcessor implements XmlRpcInvocationInterceptor {
             buf.append(getStopWatch().getTime() / 1000.00);
             buf.append(" seconds");
 
-            log.info(buf.toString());
+            log.info(buf);
         }
         catch (RuntimeException e) {
             log.error("postProcess error CALL: " + invocation.getHandlerName() +
@@ -136,7 +136,10 @@ public class LoggingInvocationProcessor implements XmlRpcInvocationInterceptor {
             buf.append(getStopWatch().getTime() / 1000.00);
             buf.append(" seconds");
 
-            log.error(buf.toString(), exception);
+            buf.append(System.lineSeparator());
+            buf.append(exception);
+
+            log.info(buf);
         }
         catch (RuntimeException e) {
             log.error("postProcess error CALL: " + invocation.getHandlerName() +

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Do not log XMLRPC fault exceptions as errors (bsc#1188853)
 - AppStreams tab for modular channels
 - Allow getting all archived actions via XMLRPC without display limit (bsc#1181223)
 - Link to CLM filter creation from system details page


### PR DESCRIPTION
`FaultException`s are expected outcomes and shouldn't be treated as errors in the logs. This PR reduces their log level to `DEBUG` and suppresses their stack traces in `rhn_web_ui.log`. The full exception will be still in the client response.

Also, in `rhn_web_api.log` even with **any kind of** exception, all the calls will be logged as `INFO`, without stack traces.
When any unexpected exception occurs, the stack traces will be still logged in `rhn_web_ui.log` anyway.

See: https://bugzilla.suse.com/1188853

Port of: https://github.com/SUSE/spacewalk/pull/15703

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
