### PR TITLE
QA: Use a bigger buffer size when calling mgr-sync with twopence

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -94,7 +94,7 @@ When(/^I list channels with spacewalk\-remove\-channel$/) do
 end
 
 When(/^I add "([^"]*)" channel$/) do |channel|
-  $server.run("echo -e \"admin\nadmin\n\" | mgr-sync add channel #{channel}")
+  $server.run("echo -e \"admin\nadmin\n\" | mgr-sync add channel #{channel}", buffer_size = 1_000_000)
 end
 
 When(/^I use spacewalk\-channel to add "([^"]*)"$/) do |child_channel|
@@ -226,7 +226,7 @@ Then(/^I wait until "([^"]*)" service is active on "([^"]*)"$/) do |service, hos
 end
 
 When(/^I enable product "([^"]*)"$/) do |prd|
-  list_output, _code = $server.run("mgr-sync list products", false)
+  list_output, _code = $server.run("mgr-sync list products", fatal = false, buffer_size = 1_000_000)
   executed = false
   linenum = 0
   list_output.each_line do |line|
@@ -234,14 +234,14 @@ When(/^I enable product "([^"]*)"$/) do |prd|
     linenum += 1
     next unless line.include? prd
     executed = true
-    $command_output, _code = $server.run("echo '#{linenum}' | mgr-sync add product", false)
+    $command_output, _code = $server.run("echo '#{linenum}' | mgr-sync add product", fatal = false, buffer_size = 1_000_000)
     break
   end
   raise $command_output.to_s unless executed
 end
 
 When(/^I enable product "([^"]*)" without recommended$/) do |prd|
-  list_output, _code = $server.run("mgr-sync list products", false)
+  list_output, _code = $server.run("mgr-sync list products", fatal = false, buffer_size = 1_000_000)
   executed = false
   linenum = 0
   list_output.each_line do |line|
@@ -249,18 +249,18 @@ When(/^I enable product "([^"]*)" without recommended$/) do |prd|
     linenum += 1
     next unless line.include? prd
     executed = true
-    $command_output, _code = $server.run("echo '#{linenum}' | mgr-sync add product --no-recommends", false)
+    $command_output, _code = $server.run("echo '#{linenum}' | mgr-sync add product --no-recommends", fatal = false, buffer_size = 1_000_000)
     break
   end
   raise $command_output.to_s unless executed
 end
 
 When(/^I execute mgr\-sync "([^"]*)" with user "([^"]*)" and password "([^"]*)"$/) do |arg1, u, p|
-  $command_output, _code = $server.run("echo -e '#{u}\n#{p}\n' | mgr-sync #{arg1}", false)
+  $command_output, _code = $server.run("echo -e '#{u}\n#{p}\n' | mgr-sync #{arg1}", fatal = false, buffer_size = 1_000_000)
 end
 
 When(/^I execute mgr\-sync "([^"]*)"$/) do |arg1|
-  $command_output, _code = $server.run("mgr-sync #{arg1}")
+  $command_output, _code = $server.run("mgr-sync #{arg1}", buffer_size = 1_000_000)
 end
 
 When(/^I remove the mgr\-sync cache file$/) do

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -511,7 +511,7 @@ When(/^I click the Add Product button$/) do
 end
 
 Then(/^the SLE12 SP5 product should be added$/) do
-  output, _code = $server.run('echo -e "admin\nadmin\n" | mgr-sync list channels', false)
+  output, _code = $server.run('echo -e "admin\nadmin\n" | mgr-sync list channels', fatal = false, buffer_size = 1_000_000)
   raise unless output.include? '[I] SLES12-SP5-Pool for x86_64 SUSE Linux Enterprise Server 12 SP5 x86_64 [sles12-sp5-pool-x86_64]'
   if $product != 'Uyuni'
     raise unless output.include? '[I] SLE-Manager-Tools12-Pool for x86_64 SP5 SUSE Linux Enterprise Server 12 SP5 x86_64 [sle-manager-tools12-pool-x86_64-sp5]'
@@ -520,7 +520,7 @@ Then(/^the SLE12 SP5 product should be added$/) do
 end
 
 Then(/^the SLE15 (SP2|SP3) product should be added$/) do |sp_version|
-  output, _code = $server.run('echo -e "admin\nadmin\n" | mgr-sync list channels', false)
+  output, _code = $server.run('echo -e "admin\nadmin\n" | mgr-sync list channels', fatal = false, buffer_size = 1_000_000)
   raise unless output.include? "[I] SLE-Product-SLES15-#{sp_version}-Pool for x86_64 SUSE Linux Enterprise Server 15 #{sp_version} x86_64 [sle-product-sles15-#{sp_version.downcase}-pool-x86_64]"
   raise unless output.include? "[I] SLE-Module-Basesystem15-#{sp_version}-Updates for x86_64 Basesystem Module 15 #{sp_version} x86_64 [sle-module-basesystem15-#{sp_version.downcase}-updates-x86_64]"
   raise unless output.include? "[I] SLE-Module-Server-Applications15-#{sp_version}-Pool for x86_64 Server Applications Module 15 #{sp_version} x86_64 [sle-module-server-applications15-#{sp_version.downcase}-pool-x86_64]"

--- a/testsuite/features/support/lavanda.rb
+++ b/testsuite/features/support/lavanda.rb
@@ -47,8 +47,8 @@ module LavandaBasic
   end
 
   # run functions
-  def run(cmd, fatal = true, timeout = DEFAULT_TIMEOUT, user = 'root', successcodes = [0])
-    out, _lo, _rem, code = test_and_store_results_together(cmd, user, timeout)
+  def run(cmd, fatal = true, timeout = DEFAULT_TIMEOUT, user = 'root', successcodes = [0], buffer_size = 65536)
+    out, _lo, _rem, code = test_and_store_results_together(cmd, user, timeout, buffer_size)
     if fatal
       raise "FAIL: #{cmd} returned #{code}. output : #{out}" unless successcodes.include?(code)
     end


### PR DESCRIPTION
## What does this PR change?

Use a bigger buffer size when calling mgr-sync with twopence 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.1
- Manager-4.2

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
