### PR TITLE
Fix JSon null comparison when parsing virtual network infos

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/virtualization/gson/VirtualNetworkInfoJson.java
+++ b/java/code/src/com/suse/manager/webui/controllers/virtualization/gson/VirtualNetworkInfoJson.java
@@ -38,7 +38,7 @@ public class VirtualNetworkInfoJson {
     public VirtualNetworkInfoJson(String nameIn, JsonObject values) {
         setName(nameIn);
         setUuid(values.get("uuid").getAsString());
-        if (values.get("bridge") != null) {
+        if (!values.get("bridge").isJsonNull()) {
             setBridge(values.get("bridge").getAsString());
         }
         setActive(values.get("active").getAsInt() == 1);

--- a/java/code/src/com/suse/manager/webui/controllers/virtualization/test/VirtualNetsControllerTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/virtualization/test/VirtualNetsControllerTest.java
@@ -126,6 +126,9 @@ public class VirtualNetsControllerTest extends BaseControllerTestCase {
         assertFalse(net1.isAutostart());
         assertTrue(net1.isPersistent());
         assertEquals("860e49a3-d227-4105-95ca-d19dc8f0c8b6", net1.getUuid());
+
+        VirtualNetworkInfoJson net0 = nets.stream().filter(net -> net.getName().equals("net0")).findFirst().get();
+        assertNull(net0.getBridge());
     }
 
     public void testDevices() throws Exception {

--- a/java/code/src/com/suse/manager/webui/controllers/virtualization/test/virt.net.info.json
+++ b/java/code/src/com/suse/manager/webui/controllers/virtualization/test/virt.net.info.json
@@ -2,7 +2,7 @@
     "net0": {
         "active": 1,
         "autostart": 1,
-        "bridge": "br0",
+        "bridge": null,
         "leases": [],
         "persistent": 1,
         "uuid": "6682ddbc-e02d-4a13-9c03-f4d4a4924f09"

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix Json null comparison in virtual network info parsing (bsc#1189167)
 - 'AppStreams with defaults' filter template in CLM
 - Add a link to OS image store dir in image list page
 - Do not log XMLRPC fault exceptions as errors (bsc#1188853)


### PR DESCRIPTION
## What does this PR change?

The JSon None value is not mapped to `null`, but to `JSonNull`. Fix the
comparison hen parsing virtual networks that have no bridge.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- Unit tests were added

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
