### PR TITLE
Fix autoupdate with maintenance windows

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Task_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Task_queries.xml
@@ -26,8 +26,12 @@ select distinct s.id as server_id, s.org_id, snc.errata_id
                   select c.label
                     from rhnChannel c
                     join rhnChannelErrata ce ON c.id = ce.channel_id
-                   where ce.errata_id = snc.errata_id)
-        )
+                   where ce.errata_id = snc.errata_id))
+   and not exists ( -- no CLM build in process where this errata exists
+        select 1
+         from susecontentenvironmenttarget cet
+        where cet.channel_id = snc.channel_id
+          and (cet.status = 'BUILDING' or cet.status = 'GENERATING_REPODATA'))
    and not exists ( -- haven't already scheduled action
        select 1
          from rhnServerAction sa,

--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Task_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Task_queries.xml
@@ -1,15 +1,23 @@
 <datasource_modes>
 
-<mode name="auto_errata_candidates">
+<mode name="auto_errata_systems">
   <query>
+select s.id
+ from rhnServer s
+ join rhnServerFeaturesView sfv
+ on s.id = sfv.server_id
+ where upper(s.auto_update) = 'Y'
+   and sfv.label = 'ftr_auto_errata_updates'
+   </query>
+ </mode>
+
+ <mode name="auto_errata_candidates">
+   <query>
 select distinct s.id as server_id, s.org_id, snc.errata_id
   from rhnServer s,
-       rhnServerFeaturesView sfv,
        rhnServerNeededCache snc
- where upper(s.auto_update) = 'Y'
-   and s.id = sfv.server_id
-   and sfv.label = 'ftr_auto_errata_updates'
-   and s.id = snc.server_id
+   where s.id = snc.server_id
+   and s.id in (%s)
    and snc.errata_id IS NOT NULL
    and not exists ( -- not regenerating channel metadata where this errata exists
        select 1

--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemDetailsEditAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemDetailsEditAction.java
@@ -31,17 +31,14 @@ import com.redhat.rhn.frontend.struts.RequestContext;
 import com.redhat.rhn.frontend.struts.RhnAction;
 import com.redhat.rhn.frontend.struts.RhnHelper;
 import com.redhat.rhn.frontend.struts.RhnValidationHelper;
-import com.redhat.rhn.manager.action.ActionManager;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
 import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 import com.redhat.rhn.manager.user.UserManager;
-import com.redhat.rhn.taskomatic.TaskomaticApiException;
 
 import com.suse.manager.maintenance.MaintenanceManager;
 import com.suse.manager.model.maintenance.MaintenanceSchedule;
 import com.suse.manager.webui.services.pillar.MinionPillarManager;
-
 import org.apache.log4j.Logger;
 import org.apache.struts.action.ActionErrors;
 import org.apache.struts.action.ActionForm;
@@ -52,7 +49,6 @@ import org.apache.struts.util.LabelValueBean;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Date;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -189,18 +185,6 @@ public class SystemDetailsEditAction extends RhnAction {
                 s.getAutoUpdate().equals("N")) {
                 // only set it if it has changed
                 s.setAutoUpdate("Y");
-
-                try {
-                    ActionManager.scheduleAllErrataUpdate(user, s, new Date());
-                    createSuccessMessage(request,
-                            "sdc.details.edit.propertieschangedupdate", s.getName());
-                }
-                catch (TaskomaticApiException e) {
-                    log.error("Could not schedule errata update:");
-                    log.error(e);
-                    getStrutsDelegate().addError("taskscheduler.down", errors);
-                    success = false;
-                }
             }
             else if (daForm.get(AUTO_UPDATE) == null) {
                 s.setAutoUpdate("N");

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -4833,16 +4833,6 @@ public class SystemHandler extends BaseHandler {
             Boolean autoUpdate = (Boolean)details.get("auto_errata_update");
 
             if (autoUpdate.booleanValue()) {
-                if (server.getAutoUpdate().equals("N")) {
-                    // schedule errata update only it if the value has changed
-                    try {
-                        ActionManager.scheduleAllErrataUpdate(loggedInUser, server,
-                                new Date());
-                    }
-                    catch (com.redhat.rhn.taskomatic.TaskomaticApiException e) {
-                        throw new TaskomaticApiException(e.getMessage());
-                    }
-                }
                 server.setAutoUpdate("Y");
             }
             else {

--- a/java/code/src/com/redhat/rhn/taskomatic/task/AutoErrataTask.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/AutoErrataTask.java
@@ -22,15 +22,20 @@ import com.redhat.rhn.domain.errata.Errata;
 import com.redhat.rhn.domain.errata.ErrataFactory;
 import com.redhat.rhn.domain.org.Org;
 import com.redhat.rhn.domain.org.OrgFactory;
+import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.manager.action.ActionManager;
 
+import com.suse.manager.maintenance.MaintenanceManager;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
+import java.util.stream.Collectors;
 
 /**
  * This is what automatically schedules automatic errata update actions.
@@ -57,17 +62,19 @@ public class AutoErrataTask extends RhnJavaJob {
     public void execute(JobExecutionContext context)
         throws JobExecutionException {
 
-        List<Map<String, Long>> results = getErrataToProcess();
-        if (results == null || results.size() == 0) {
-            if (log.isDebugEnabled()) {
-                log.debug("No unapplied auto errata found... exiting");
-            }
+        List<Long> systems = getAutoErrataSystems();
+        if (systems == null || systems.size() == 0) {
+            log.debug("No systems with auto errata enabled");
             return;
         }
 
-        if (log.isDebugEnabled()) {
-            log.debug("=== Scheduling " + results.size() + " auto errata updates");
+        List<Map<String, Long>> results = getErrataToProcess(filterSystemsInMaintenanceMode(systems));
+        if (results == null || results.size() == 0) {
+            log.debug("No unapplied auto errata found. Skipping systems not in maintenance mode... exiting");
+            return;
         }
+
+        log.debug("=== Scheduling " + results.size() + " auto errata updates");
 
         for (Map<String, Long> result : results) {
             Long errataId = result.get("errata_id");
@@ -87,11 +94,35 @@ public class AutoErrataTask extends RhnJavaJob {
                         serverId, e);
                 throw new JobExecutionException(e);
             }
-            if (log.isDebugEnabled()) {
-                log.debug("Scheduling auto update actions for server " + serverId +
-                        " and erratum " + errataId);
-            }
+            log.debug("Scheduling auto update actions for server " + serverId + " and erratum " + errataId);
         }
+    }
+
+    /**
+     * Return the list of systems that have the auto errata update function enabled
+     *
+     * @return list of systems with auto errata update enabled
+     */
+    protected List<Long> getAutoErrataSystems() {
+        SelectMode select = ModeFactory.getMode(TaskConstants.MODE_NAME,
+                TaskConstants.TASK_QUERY_AUTO_ERRATA_SYSTEMS);
+        @SuppressWarnings("unchecked")
+        List<Map<String, Long>> results = select.execute();
+        return results.stream().map(system -> system.get("id")).collect(Collectors.toList());
+    }
+
+    /**
+     * Return list of systems that are in maintenance mode
+     *
+     * @param systems systems with auto errata enabled
+     * @return list of systems in maintenance mode
+     */
+    protected List<Long> filterSystemsInMaintenanceMode(List<Long> systems) {
+        MaintenanceManager mm = new MaintenanceManager();
+        return ServerFactory.lookupByIds(systems).stream()
+                .filter(mm::isSystemInMaintenanceMode)
+                .map(Server::getId)
+                .collect(Collectors.toList());
     }
 
     /**
@@ -109,7 +140,7 @@ public class AutoErrataTask extends RhnJavaJob {
      *
      * @return maps of errata_id, server_id, and org_id that need actions
      */
-    protected List<Map<String, Long>> getErrataToProcess() {
+    protected List<Map<String, Long>> getErrataToProcess(List<Long> sids) {
         /*
          * Additional check might be needed. Do not schedule anything
          * if a task with bunch name "repo-sync-bunch" is ready or running.
@@ -121,10 +152,14 @@ public class AutoErrataTask extends RhnJavaJob {
          * where rtb.name = 'repo-sync-bunch'
          *   and rtr.status in ('RUNNING','READY')
          */
+        if (sids == null || sids.size() == 0) {
+            return new ArrayList<>();
+        }
+
         SelectMode select = ModeFactory.getMode(TaskConstants.MODE_NAME,
                 TaskConstants.TASK_QUERY_AUTO_ERRATA_CANDIDATES);
         @SuppressWarnings("unchecked")
-        List<Map<String, Long>> results = select.execute();
+        List<Map<String, Long>> results = select.execute(sids);
         return results;
     }
 

--- a/java/code/src/com/redhat/rhn/taskomatic/task/AutoErrataTask.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/AutoErrataTask.java
@@ -143,7 +143,8 @@ public class AutoErrataTask extends RhnJavaJob {
     protected List<Map<String, Long>> getErrataToProcess(List<Long> sids) {
         /*
          * Additional check might be needed. Do not schedule anything
-         * if a task with bunch name "repo-sync-bunch" is ready or running.
+         * if a task with bunch name "repo-sync-bunch" is ready or running
+         * or a CLM build is in process.
          *
          * select 1
          *  from rhnTaskoSchedule rts

--- a/java/code/src/com/redhat/rhn/taskomatic/task/TaskConstants.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/TaskConstants.java
@@ -50,6 +50,9 @@ public class TaskConstants {
     public static final String TASK_QUERY_ERRATA_QUEUE_FIND_CANDIDATES =
         "errataqueue_find_candidates";
 
+    public static final String TASK_QUERY_AUTO_ERRATA_SYSTEMS =
+        "auto_errata_systems";
+
     public static final String TASK_QUERY_AUTO_ERRATA_CANDIDATES =
         "auto_errata_candidates";
 

--- a/java/code/src/com/suse/manager/maintenance/MaintenanceManager.java
+++ b/java/code/src/com/suse/manager/maintenance/MaintenanceManager.java
@@ -825,7 +825,7 @@ public class MaintenanceManager {
      * @param server the server to check
      * @return true when the action is inside of a maintenance window, otherwise falsegg
      */
-    public boolean isSystemInMaintenanceMode(MinionServer server) {
+    public boolean isSystemInMaintenanceMode(Server server) {
         return server.getMaintenanceScheduleOpt()
                 .map(schedule -> !getCalendarForNow(schedule).isEmpty())
                 .orElse(true);

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Adapt auto errata update to respect maintenance windows
 - fix ISE in SSM when scheduling patches on multiple systems (bsc#1190396, bsc#1190275)
 - Add new endpoints to saltkeys API: acceptedList, pendingList, rejectedList, deniedList, accept and reject
 - add centos 7/8 aarch64

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Adapt auto errata update to skip during CLM build (bsc#1189609)
 - Adapt auto errata update to respect maintenance windows
 - fix ISE in SSM when scheduling patches on multiple systems (bsc#1190396, bsc#1190275)
 - Add new endpoints to saltkeys API: acceptedList, pendingList, rejectedList, deniedList, accept and reject


### PR DESCRIPTION
## What does this PR change?

Make the auto errata update respect maintenance windows
Fix a bug related to auto errata update when a CLM build of affected channel is in progress.

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: **Bugfix**

- [x] **DONE**

## Test coverage

- No tests: **Bugfix**

- [x] **DONE**

## Links


Tracks https://github.com/SUSE/spacewalk/issues/15720

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
