### PR TITLE
QA: Refactor run command to use keyword parameters

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -16,7 +16,7 @@ end
 When(/^I mount as "([^"]+)" the ISO from "([^"]+)" in the server$/) do |name, url|
   iso_path = "/tmp/#{name}.iso"
   mount_point = "/srv/www/htdocs/#{name}"
-  $server.run("wget --no-check-certificate -O #{iso_path} #{url}", true, 500, 'root')
+  $server.run("wget --no-check-certificate -O #{iso_path} #{url}", timeout: 500)
   $server.run("mkdir -p #{mount_point}")
   $server.run("grep #{iso_path} /etc/fstab || echo '#{iso_path}  #{mount_point}  iso9660  loop,ro  0 0' >> /etc/fstab")
   $server.run("umount #{iso_path}; mount #{iso_path}")
@@ -156,7 +156,7 @@ end
 
 Then(/^I should see the power is "([^"]*)"$/) do |status|
   within(:xpath, "//*[@for='powerStatus']/..") do
-    repeat_until_timeout(timeout: DEFAULT_TIMEOUT, message: "power is not #{status}") do
+    repeat_until_timeout(message: "power is not #{status}") do
       break if has_content?(status)
       find(:xpath, '//button[@value="Get status"]').click
     end
@@ -257,7 +257,7 @@ When(/^I refresh the metadata for "([^"]*)"$/) do |host|
   if os_family =~ /^opensuse/ || os_family =~ /^sles/
     node.run_until_ok('zypper --non-interactive refresh -s')
   elsif os_family =~ /^centos/
-    node.run('yum clean all && yum makecache', true, 600, 'root')
+    node.run('yum clean all && yum makecache', timeout: 600)
   elsif os_family =~ /^ubuntu/
     node.run('apt-get update')
   else
@@ -272,7 +272,7 @@ end
 
 Then(/^channel "([^"]*)" should not be enabled on "([^"]*)"$/) do |channel, host|
   node = get_target(host)
-  _out, code = node.run("zypper lr -E | grep '#{channel}'", false)
+  _out, code = node.run("zypper lr -E | grep '#{channel}'", check_errors: false)
   raise "'#{channel}' was not expected but was found." if code.to_i.zero?
 end
 
@@ -296,7 +296,7 @@ Then(/^I should have '([^']*)' in the metadata for "([^"]*)"$/) do |text, host|
   arch, _code = target.run('uname -m')
   arch.chomp!
   cmd = "zgrep '#{text}' #{client_raw_repodata_dir("test-channel-#{arch}")}/primary.xml.gz"
-  target.run(cmd, true, 500, 'root')
+  target.run(cmd, timeout: 500)
 end
 
 Then(/^I should not have '([^']*)' in the metadata for "([^"]*)"$/) do |text, host|
@@ -305,7 +305,7 @@ Then(/^I should not have '([^']*)' in the metadata for "([^"]*)"$/) do |text, ho
   arch, _code = target.run('uname -m')
   arch.chomp!
   cmd = "zgrep '#{text}' #{client_raw_repodata_dir("test-channel-#{arch}")}/primary.xml.gz"
-  target.run(cmd, true, 500, 'root')
+  target.run(cmd, timeout: 500)
 end
 
 Then(/^"([^"]*)" should exist in the metadata for "([^"]*)"$/) do |file, host|
@@ -321,7 +321,7 @@ Then(/^I should have '([^']*)' in the patch metadata$/) do |text|
   arch, _code = $client.run('uname -m')
   arch.chomp!
   cmd = "zgrep '#{text}' #{client_raw_repodata_dir("test-channel-#{arch}")}/updateinfo.xml.gz"
-  $client.run(cmd, true, 500, 'root')
+  $client.run(cmd, timeout: 500)
 end
 
 # package steps
@@ -336,8 +336,8 @@ end
 And(/^I push package "([^"]*)" into "([^"]*)" channel$/) do |arg1, arg2|
   srvurl = "http://#{ENV['SERVER']}/APP"
   command = "rhnpush --server=#{srvurl} -u admin -p admin --nosig -c #{arg2} #{arg1} "
-  $server.run(command, true, 500, 'root')
-  $server.run('ls -lR /var/spacewalk/packages', true, 500, 'root')
+  $server.run(command, timeout: 500)
+  $server.run('ls -lR /var/spacewalk/packages', timeout: 500)
 end
 
 Then(/^I should see package "([^"]*)" in channel "([^"]*)"$/) do |pkg, channel|
@@ -511,7 +511,7 @@ When(/^I click the Add Product button$/) do
 end
 
 Then(/^the SLE12 SP5 product should be added$/) do
-  output, _code = $server.run('echo -e "admin\nadmin\n" | mgr-sync list channels', fatal = false, buffer_size = 1_000_000)
+  output, _code = $server.run('echo -e "admin\nadmin\n" | mgr-sync list channels', check_errors: false, buffer_size: 1_000_000)
   raise unless output.include? '[I] SLES12-SP5-Pool for x86_64 SUSE Linux Enterprise Server 12 SP5 x86_64 [sles12-sp5-pool-x86_64]'
   if $product != 'Uyuni'
     raise unless output.include? '[I] SLE-Manager-Tools12-Pool for x86_64 SP5 SUSE Linux Enterprise Server 12 SP5 x86_64 [sle-manager-tools12-pool-x86_64-sp5]'
@@ -520,7 +520,7 @@ Then(/^the SLE12 SP5 product should be added$/) do
 end
 
 Then(/^the SLE15 (SP2|SP3) product should be added$/) do |sp_version|
-  output, _code = $server.run('echo -e "admin\nadmin\n" | mgr-sync list channels', fatal = false, buffer_size = 1_000_000)
+  output, _code = $server.run('echo -e "admin\nadmin\n" | mgr-sync list channels', check_errors: false, buffer_size: 1_000_000)
   raise unless output.include? "[I] SLE-Product-SLES15-#{sp_version}-Pool for x86_64 SUSE Linux Enterprise Server 15 #{sp_version} x86_64 [sle-product-sles15-#{sp_version.downcase}-pool-x86_64]"
   raise unless output.include? "[I] SLE-Module-Basesystem15-#{sp_version}-Updates for x86_64 Basesystem Module 15 #{sp_version} x86_64 [sle-module-basesystem15-#{sp_version.downcase}-updates-x86_64]"
   raise unless output.include? "[I] SLE-Module-Server-Applications15-#{sp_version}-Pool for x86_64 Server Applications Module 15 #{sp_version} x86_64 [sle-module-server-applications15-#{sp_version.downcase}-pool-x86_64]"
@@ -575,12 +575,12 @@ end
 
 Then(/^file "([^"]*)" should exist on "([^"]*)"$/) do |filename, host|
   node = get_target(host)
-  node.run("test -f #{filename}", true)
+  node.run("test -f #{filename}")
 end
 
 Then(/^file "([^"]*)" should have ([0-9]+) permissions on "([^"]*)"$/) do |filename, permissions, host|
   node = get_target(host)
-  node.run("test \"`stat -c '%a' #{filename}`\" = \"#{permissions}\"", true)
+  node.run("test \"`stat -c '%a' #{filename}`\" = \"#{permissions}\"")
 end
 
 Then(/^file "([^"]*)" should not exist on server$/) do |filename|
@@ -594,7 +594,7 @@ end
 
 When(/^I store "([^"]*)" into file "([^"]*)" on "([^"]*)"$/) do |content, filename, host|
   node = get_target(host)
-  node.run("echo \"#{content}\" > #{filename}", true, 600, 'root')
+  node.run("echo \"#{content}\" > #{filename}", timeout: 600)
 end
 
 When(/^I set the activation key "([^"]*)" in the bootstrap script on the server$/) do |key|
@@ -834,7 +834,7 @@ end
 
 Given(/^I update the profile of "([^"]*)"$/) do |client|
   node = get_target(client)
-  node.run('rhn-profile-sync', true, 500, 'root')
+  node.run('rhn-profile-sync', timeout: 500)
 end
 
 When(/^I register using "([^"]*)" key$/) do |key|
@@ -848,15 +848,15 @@ end
 And(/^I register "([^*]*)" as traditional client with activation key "([^*]*)"$/) do |client, key|
   node = get_target(client)
   if client.include? 'sle'
-    node.run('zypper --non-interactive install wget', true, 500, 'root')
+    node.run('zypper --non-interactive install wget', timeout: 500)
   else # As Ubuntu has no support, must be CentOS/SLES_ES
-    node.run('yum install wget', true, 600, 'root')
+    node.run('yum install wget', timeout: 600)
   end
   command1 = "wget --no-check-certificate -O /usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT http://#{$server.ip}/pub/RHN-ORG-TRUSTED-SSL-CERT"
   # Replace unicode chars \xHH with ? in the output (otherwise, they might break Cucumber formatters).
-  puts node.run(command1, true, 500, 'root').to_s.gsub(/(\\x\h+){1,}/, '?')
+  puts node.run(command1, timeout: 500).to_s.gsub(/(\\x\h+){1,}/, '?')
   command2 = "rhnreg_ks --force --serverUrl=#{registration_url} --sslCACert=/usr/share/rhn/RHN-ORG-TRUSTED-SSL-CERT --activationkey=#{key}"
-  puts node.run(command2, true, 500, 'root').to_s.gsub(/(\\x\h+){1,}/, '?')
+  puts node.run(command2, timeout: 500).to_s.gsub(/(\\x\h+){1,}/, '?')
 end
 
 When(/^I wait until onboarding is completed for "([^"]*)"$/) do |host|
@@ -879,9 +879,9 @@ end
 Then(/^I should see "([^"]*)" via spacecmd$/) do |host|
   command = "spacecmd -u admin -p admin system_list"
   system_name = get_system_name(host)
-  repeat_until_timeout(timeout: DEFAULT_TIMEOUT, message: "system #{system_name} is not in the list yet") do
+  repeat_until_timeout(message: "system #{system_name} is not in the list yet") do
     $server.run("spacecmd -u admin -p admin clear_caches")
-    result, code = $server.run(command, false)
+    result, code = $server.run(command, check_errors: false)
     break if result.include? system_name
     sleep 1
   end
@@ -1250,7 +1250,7 @@ And(/^I add pre\-generated SSH public key to authorized_keys of host "([^"]*)"$/
     File.dirname(__FILE__) + '/../upload_files/ssh_keypair/' + key_filename,
     '/tmp/' + key_filename
   )
-  target.run("cat /tmp/#{key_filename} >> /root/.ssh/authorized_keys", true, 500, 'root')
+  target.run("cat /tmp/#{key_filename} >> /root/.ssh/authorized_keys", timeout: 500)
   raise 'Error copying ssh pubkey to host' if ret_code.nonzero?
 end
 

--- a/testsuite/features/step_definitions/lock_packages_on_client.rb
+++ b/testsuite/features/step_definitions/lock_packages_on_client.rb
@@ -5,7 +5,7 @@ Then(/^"(.*?)" is locked on this client$/) do |pkg|
   zypp_lock_file = '/etc/zypp/locks'
   raise "File already exist: #{zypp_lock_file}" unless file_exists?($client, zypp_lock_file)
   command = "zypper locks  --solvables | grep #{pkg}"
-  $client.run(command, true, 600, 'root')
+  $client.run(command, timeout: 600)
 end
 
 Then(/^package "(.*?)" is reported as locked$/) do |pkg|
@@ -20,7 +20,7 @@ Then(/^"(.*?)" is unlocked on this client$/) do |pkg|
   raise "File #{zypp_lock_file} not found" unless file_exists?($client, zypp_lock_file)
 
   command = "zypper locks  --solvables | grep #{pkg}"
-  $client.run(command, false, 600, 'root')
+  $client.run(command, timeout: 600)
 end
 
 Then(/^package "(.*?)" is reported as unlocked$/) do |pkg|

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -28,20 +28,20 @@ end
 
 When(/^I stop salt-minion on "(.*?)"$/) do |minion|
   node = get_target(minion)
-  node.run('rcsalt-minion stop', false) if minion == 'sle_minion'
-  node.run('systemctl stop salt-minion', false) if %w[ceos_minion ubuntu_minion kvm_server xen_server].include?(minion)
+  node.run('rcsalt-minion stop', check_errors: false) if minion == 'sle_minion'
+  node.run('systemctl stop salt-minion', check_errors: false) if %w[ceos_minion ubuntu_minion kvm_server xen_server].include?(minion)
 end
 
 When(/^I start salt-minion on "(.*?)"$/) do |minion|
   node = get_target(minion)
-  node.run('rcsalt-minion restart', false) if minion == 'sle_minion'
-  node.run('systemctl restart salt-minion', false) if %w[ceos_minion ubuntu_minion kvm_server xen_server].include?(minion)
+  node.run('rcsalt-minion restart', check_errors: false) if minion == 'sle_minion'
+  node.run('systemctl restart salt-minion', check_errors: false) if %w[ceos_minion ubuntu_minion kvm_server xen_server].include?(minion)
 end
 
 When(/^I restart salt-minion on "(.*?)"$/) do |minion|
   node = get_target(minion)
-  node.run('rcsalt-minion restart', false) if minion == 'sle_minion'
-  node.run('systemctl restart salt-minion', false) if %w[ceos_minion ubuntu_minion kvm_server xen_server].include?(minion)
+  node.run('rcsalt-minion restart', check_errors: false) if minion == 'sle_minion'
+  node.run('systemctl restart salt-minion', check_errors: false) if %w[ceos_minion ubuntu_minion kvm_server xen_server].include?(minion)
 end
 
 When(/^I wait at most (\d+) seconds until Salt master sees "([^"]*)" as "([^"]*)"$/) do |key_timeout, minion, key_type|
@@ -49,7 +49,7 @@ When(/^I wait at most (\d+) seconds until Salt master sees "([^"]*)" as "([^"]*)
   repeat_until_timeout(timeout: key_timeout.to_i, message: "Minion '#{minion}' is not listed among #{key_type} keys on Salt master") do
     system_name = get_system_name(minion)
     unless system_name.empty?
-      output, return_code = $server.run(cmd, false)
+      output, return_code = $server.run(cmd, check_errors: false)
       break if return_code.zero? && output.include?(system_name)
     end
     sleep 1
@@ -67,7 +67,7 @@ end
 
 When(/^I delete "([^"]*)" key in the Salt master$/) do |host|
   system_name = get_system_name(host)
-  $output, _code = $server.run("salt-key -y -d #{system_name}", false)
+  $output, _code = $server.run("salt-key -y -d #{system_name}", check_errors: false)
 end
 
 When(/^I accept "([^"]*)" key in the Salt master$/) do |host|
@@ -631,22 +631,22 @@ end
 When(/^I uninstall Salt packages from "(.*?)"$/) do |host|
   target = get_target(host)
   if %w[sle_minion ssh_minion sle_client].include?(host)
-    target.run("test -e /usr/bin/zypper && zypper --non-interactive remove -y salt salt-minion", false)
+    target.run("test -e /usr/bin/zypper && zypper --non-interactive remove -y salt salt-minion", check_errors: false)
   elsif %w[ceos_minion].include?(host)
-    target.run("test -e /usr/bin/yum && yum -y remove salt salt-minion", false)
+    target.run("test -e /usr/bin/yum && yum -y remove salt salt-minion", check_errors: false)
   elsif %w[ubuntu_minion].include?(host)
-    target.run("test -e /usr/bin/apt && apt -y remove salt-common salt-minion", false)
+    target.run("test -e /usr/bin/apt && apt -y remove salt-common salt-minion", check_errors: false)
   end
 end
 
 When(/^I install Salt packages from "(.*?)"$/) do |host|
   target = get_target(host)
   if %w[sle_minion ssh_minion sle_client].include?(host)
-    target.run("test -e /usr/bin/zypper && zypper --non-interactive install -y salt salt-minion", false)
+    target.run("test -e /usr/bin/zypper && zypper --non-interactive install -y salt salt-minion", check_errors: false)
   elsif %w[ceos_minion].include?(host)
-    target.run("test -e /usr/bin/yum && yum -y install salt salt-minion", false)
+    target.run("test -e /usr/bin/yum && yum -y install salt salt-minion", check_errors: false)
   elsif %w[ubuntu_minion].include?(host)
-    target.run("test -e /usr/bin/apt && apt -y install salt-common salt-minion", false)
+    target.run("test -e /usr/bin/apt && apt -y install salt-common salt-minion", check_errors: false)
   end
 end
 
@@ -674,13 +674,13 @@ end
 When(/^I perform a full salt minion cleanup on "([^"]*)"$/) do |host|
   node = get_target(host)
   if host.include? 'ceos'
-    node.run('yum -y remove --setopt=clean_requirements_on_remove=1 salt salt-minion', false)
+    node.run('yum -y remove --setopt=clean_requirements_on_remove=1 salt salt-minion', check_errors: false)
   elsif (host.include? 'ubuntu') || (host.include? 'debian')
-    node.run('apt-get --assume-yes remove salt-common salt-minion && apt-get --assume-yes purge salt-common salt-minion && apt-get --assume-yes autoremove', false)
+    node.run('apt-get --assume-yes remove salt-common salt-minion && apt-get --assume-yes purge salt-common salt-minion && apt-get --assume-yes autoremove', check_errors: false)
   else
-    node.run('zypper --non-interactive remove --clean-deps -y salt salt-minion spacewalk-proxy-salt', false)
+    node.run('zypper --non-interactive remove --clean-deps -y salt salt-minion spacewalk-proxy-salt', check_errors: false)
   end
-  node.run('rm -Rf /root/salt /var/cache/salt/minion /var/run/salt /var/log/salt /etc/salt /var/tmp/.root*', false)
+  node.run('rm -Rf /root/salt /var/cache/salt/minion /var/run/salt /var/log/salt /etc/salt /var/tmp/.root*', check_errors: false)
   step %(I disable the repositories "tools_update_repo tools_pool_repo" on this "#{host}" without error control)
 end
 

--- a/testsuite/features/support/client_stack.rb
+++ b/testsuite/features/support/client_stack.rb
@@ -37,7 +37,7 @@ def check_restart(host, node, time_out)
     sleep 1
   end
   repeat_until_timeout(timeout: time_out, message: "machine didn't come up") do
-    _out, code = node.run('ls', false, 10)
+    _out, code = node.run('ls', check_errors: false, timeout: 10)
     if code.zero?
       puts "machine: #{host} ssh is up"
       break
@@ -50,12 +50,12 @@ end
 # We get these data decoding the values in '/etc/os-release'
 # rubocop:disable Metrics/AbcSize
 def get_os_version(node)
-  os_family_raw, code = node.run('grep "^ID=" /etc/os-release', false)
+  os_family_raw, code = node.run('grep "^ID=" /etc/os-release', check_errors: false)
   return nil, nil unless code.zero?
   os_family = os_family_raw.strip.split('=')[1]
   return nil, nil if os_family.nil?
   os_family.delete! '"'
-  os_version_raw, code = node.run('grep "^VERSION_ID=" /etc/os-release', false)
+  os_version_raw, code = node.run('grep "^VERSION_ID=" /etc/os-release', check_errors: false)
   return nil, nil unless code.zero?
   os_version = os_version_raw.strip.split('=')[1]
   return nil, nil if os_version.nil?
@@ -73,17 +73,17 @@ def get_gpg_keys(node, target = $server)
     os_version = 12 if os_version =~ /^15/
     # SLE11 and SLE12 gpg keys don't contain service pack strings
     os_version = os_version.split('-')[0] if os_version =~ /^1[12]/
-    gpg_keys, _code = target.run("cd /srv/www/htdocs/pub/ && ls -1 sle#{os_version}*", false)
+    gpg_keys, _code = target.run("cd /srv/www/htdocs/pub/ && ls -1 sle#{os_version}*", check_errors: false)
   elsif os_family =~ /^centos/
-    gpg_keys, _code = target.run("cd /srv/www/htdocs/pub/ && ls -1 #{os_family}#{os_version}* res*", false)
+    gpg_keys, _code = target.run("cd /srv/www/htdocs/pub/ && ls -1 #{os_family}#{os_version}* res*", check_errors: false)
   else
-    gpg_keys, _code = target.run("cd /srv/www/htdocs/pub/ && ls -1 #{os_family}*", false)
+    gpg_keys, _code = target.run("cd /srv/www/htdocs/pub/ && ls -1 #{os_family}*", check_errors: false)
   end
   gpg_keys.lines.map(&:strip)
 end
 # rubocop:enable Metrics/AbcSize
 
 def sle11family?(node)
-  _out, code = node.run('pidof systemd', false)
+  _out, code = node.run('pidof systemd', check_errors: false)
   code.nonzero?
 end

--- a/testsuite/features/support/cobbler_test.rb
+++ b/testsuite/features/support/cobbler_test.rb
@@ -53,8 +53,8 @@ class CobblerTest
       raise 'creating profile failed.' + $ERROR_INFO.to_s
     end
     begin
-      @server.call('modify_profile', profile_id, 'name',      name,     @token)
-      @server.call('modify_profile', profile_id, 'distro',    distro,   @token)
+      @server.call('modify_profile', profile_id, 'name', name, @token)
+      @server.call('modify_profile', profile_id, 'distro', distro, @token)
       @server.call('modify_profile', profile_id, 'kickstart', location, @token)
     rescue
       raise 'modify profile failed.' + $ERROR_INFO.to_s
@@ -82,11 +82,11 @@ class CobblerTest
   def distro_create(name, kernel, initrd, breed = 'suse')
     begin
       distro_id = @server.call('new_distro', @token)
-      @server.call('modify_distro', distro_id, 'name',   name,   @token)
+      @server.call('modify_distro', distro_id, 'name', name, @token)
       @server.call('modify_distro', distro_id, 'kernel', kernel, @token)
       @server.call('modify_distro', distro_id, 'initrd', initrd, @token)
-      @server.call('modify_distro', distro_id, 'breed',  breed,  @token)
-      @server.call('save_distro', distro_id,                     @token)
+      @server.call('modify_distro', distro_id, 'breed', breed, @token)
+      @server.call('save_distro', distro_id, @token)
     rescue
       raise 'creating distribution failed.' + $ERROR_INFO.to_s
     end

--- a/testsuite/features/support/commonlib.rb
+++ b/testsuite/features/support/commonlib.rb
@@ -107,9 +107,9 @@ def count_table_items
 end
 
 def product
-  _product_raw, code = $server.run('rpm -q patterns-uyuni_server', false)
+  _product_raw, code = $server.run('rpm -q patterns-uyuni_server', check_errors: false)
   return 'Uyuni' if code.zero?
-  _product_raw, code = $server.run('rpm -q patterns-suma_server', false)
+  _product_raw, code = $server.run('rpm -q patterns-suma_server', check_errors: false)
   return 'SUSE Manager' if code.zero?
   raise 'Could not determine product'
 end
@@ -241,7 +241,7 @@ def extract_logs_from_node(node)
     node.run('zypper --non-interactive install tar')
     node.run('zypper mr --disable os_pool_repo os_update_repo') unless $build_validation
   end
-  node.run('journalctl > /var/log/messages', false) # Some clients might not support systemd
+  node.run('journalctl > /var/log/messages', check_errors: false) # Some clients might not support systemd
   node.run("tar cfvJP /tmp/#{node.full_hostname}-logs.tar.xz /var/log/ || [[ $? -eq 1 ]]")
   `mkdir logs` unless Dir.exist?('logs')
   code = file_extract(node, "/tmp/#{node.full_hostname}-logs.tar.xz", "logs/#{node.full_hostname}-logs.tar.xz")

--- a/testsuite/features/support/lavanda.rb
+++ b/testsuite/features/support/lavanda.rb
@@ -47,9 +47,9 @@ module LavandaBasic
   end
 
   # run functions
-  def run(cmd, fatal = true, timeout = DEFAULT_TIMEOUT, user = 'root', successcodes = [0], buffer_size = 65536)
+  def run(cmd, check_errors: true, timeout: DEFAULT_TIMEOUT, user: 'root', successcodes: [0], buffer_size: 65536)
     out, _lo, _rem, code = test_and_store_results_together(cmd, user, timeout, buffer_size)
-    if fatal
+    if check_errors
       raise "FAIL: #{cmd} returned #{code}. output : #{out}" unless successcodes.include?(code)
     end
     [out, code]
@@ -58,7 +58,7 @@ module LavandaBasic
   def run_until_ok(cmd)
     result = nil
     repeat_until_timeout(report_result: true) do
-      result, code = run(cmd, false)
+      result, code = run(cmd, check_errors: false)
       break if code.zero?
       sleep 2
       result
@@ -68,7 +68,7 @@ module LavandaBasic
   def run_until_fail(cmd)
     result = nil
     repeat_until_timeout(report_result: true) do
-      result, code = run(cmd, false)
+      result, code = run(cmd, check_errors: false)
       break if code.nonzero?
       sleep 2
       result
@@ -78,7 +78,7 @@ module LavandaBasic
   def wait_while_process_running(process)
     result = nil
     repeat_until_timeout(report_result: true) do
-      result, code = run("pgrep -x #{process} >/dev/null", false)
+      result, code = run("pgrep -x #{process} >/dev/null", check_errors: false)
       break if code.nonzero?
       sleep 2
       result

--- a/testsuite/features/upload_files/Redfish-Mockup-Server/rfSsdpServer.py
+++ b/testsuite/features/upload_files/Redfish-Mockup-Server/rfSsdpServer.py
@@ -99,7 +99,7 @@ class RfSSDPServer():
         logger.info('SSDP Packet received from {}'.format(addr))
         decoded = data.decode().replace('\r', '').split('\n')
         msgtype, decoded = decoded[0], decoded[1:]
-        decodeddict = {x.split(':',  1)[0].upper(): x.split(':', 1)[1].strip(' ') for x in decoded if x != ''}
+        decodeddict = {x.split(':', 1)[0].upper(): x.split(':', 1)[1].strip(' ') for x in decoded if x != ''}
 
         if 'M-SEARCH' in msgtype:
             st = decodeddict.get('ST')


### PR DESCRIPTION
## What does this PR change?

Refactor run command to use keyword parameters

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were refactored

- [x] **DONE**

## Links

Ports:
- Manager-4.1
- Manager-4.2

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
