### PR TITLE
QA: Missing change in run parameters

### DIFF
--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -878,7 +878,7 @@ When(/^I (enable|disable) (the repositories|repository) "([^"]*)" on this "([^"]
                      end
           cmd_list.reduce(:+)
         end
-  node.run(cmd, error_control.empty?)
+  node.run(cmd, check_errors: error_control.empty?)
 end
 
 When(/^I enable source package syncing$/) do


### PR DESCRIPTION
## What does this PR change?

Missing change in run parameters

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were fixed

- [x] **DONE**

## Links

Needs ports

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
