### PR TITLE
QA: Fix server secret function

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -932,7 +932,7 @@ def token(secret, claims = {})
 end
 
 def server_secret
-  rhnconf = $server.run('cat /etc/rhn/rhn.conf', check_errors: false)
+  rhnconf, _code = $server.run('cat /etc/rhn/rhn.conf', check_errors: false)
   data = /server.secret_key\s*=\s*(\h+)$/.match(rhnconf)
   data[1].strip
 end

--- a/testsuite/features/step_definitions/smdba_steps.rb
+++ b/testsuite/features/step_definitions/smdba_steps.rb
@@ -94,7 +94,7 @@ When(/^I create backup directory "(.*?)" with UID "(.*?)" and GID "(.*?)"$/) do 
   $server.run("mkdir /#{bkp_dir};chown #{uid}:#{gid} /#{bkp_dir}")
   bkp_dir.sub!('/', '')
   puts 'Backup directory:'
-  puts $server.run("ls -la / | /usr/bin/grep #{bkp_dir}", check_errors: false)
+  puts $server.run("ls -la / | /usr/bin/grep #{bkp_dir}", check_errors: false)[0]
 end
 
 Then(/^I should see error message that asks "(.*?)" belong to the same UID\/GID as "(.*?)" directory$/) do |bkp_dir, data_dir|
@@ -115,7 +115,7 @@ When(/^I change Access Control List on "(.*?)" directory to "(.*?)"$/) do |bkp_d
   bkp_dir.sub!('/', '')
   $server.run("test -d /#{bkp_dir} && chmod #{acl_octal} /#{bkp_dir}")
   puts "Backup directory, ACL to \"#{acl_octal}\":"
-  puts $server.run("ls -la / | /usr/bin/grep #{bkp_dir}", check_errors: false)
+  puts $server.run("ls -la / | /usr/bin/grep #{bkp_dir}", check_errors: false)[0]
   puts "\n*** Taking backup, this might take a while ***\n"
 end
 
@@ -167,6 +167,6 @@ end
 
 Then(/^I disable backup in the directory "(.*?)"$/) do |_arg1|
   assert_includes(
-    $server.run('smdba backup-hot --enable=off', check_errors: false), 'Finished'
+    $server.run('smdba backup-hot --enable=off', check_errors: false)[0], 'Finished'
   )
 end


### PR DESCRIPTION
## What does this PR change?

Fix server secret function

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.1
- Manager-4.2

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
