### PR TITLE
Abort db migration if data_directory is set in postgresql configuration

### DIFF
--- a/susemanager/bin/pg-migrate-x-to-y.sh
+++ b/susemanager/bin/pg-migrate-x-to-y.sh
@@ -76,6 +76,12 @@ fi
 
 DIR=/var/lib/pgsql
 
+if [ $(grep data_directory ${DIR}/data/postgresql.conf) ]; then
+    echo "$(timestamp) data_directory is configured in ${DIR}/data/postgresql.conf"
+    echo "$(timestamp) For the migration to work, data_directory should not be defined explicetely"
+    exit 1
+fi
+
 if [ "$FAST_UPGRADE" !=  "" ]; then
     echo "$(timestamp)   Performing fast upgrade..."
 else

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,4 +1,5 @@
-
+- Abort migration if data_directory is defined at the PostgreSQL
+  configuration file
 - Package 'snapper' is now optional.
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

The migration script assumes data_directory is not set. Otherwise, it
would give an error.

This commit prevents the error by checking and aborting it.

## GUI diff

Before: If data_directory had a value in /var/lib/pgsql/data/postgresql.conf, you would see an error when trying to start the database after migration.

After: You will see an error before attempting the migration

- [X] **DONE**

## Documentation
- No documentation needed

- [X] **DONE**

## Test coverage
- No tests

- [X] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/15556

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
