### PR TITLE
Fix virt grains unit tests

### DIFF
--- a/susemanager-utils/susemanager-sls/src/tests/test_grains_virt.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_grains_virt.py
@@ -39,13 +39,14 @@ def test_features_cluster(cluster, start_resources):
     check_call_mock = MagicMock(side_effect=FileNotFoundError())
     if cluster:
         popen_mock = MagicMock()
-        popen_mock.return_value.communicate.return_value = (crm_resources, None)
+        popen_mock.return_value.communicate.side_effect = [(crm_resources, None), (b"libvirtd (libvirt) 5.1.0\n", None)]
         check_call_mock = MagicMock(return_value = 0)
 
     with patch.object(virt.subprocess, "check_call", check_call_mock):
         with patch.object(virt.subprocess, "Popen", popen_mock):
-            assert virt.features()["virt_features"]["cluster"] == cluster
-            assert virt.features()["virt_features"]["resource_agent_start_resources"] == start_resources
+            actual = virt.features()["virt_features"]
+            assert actual["cluster"] == cluster
+            assert actual["resource_agent_start_resources"] == start_resources
 
 
 @pytest.mark.parametrize("version, expected", [("5.1.0", False), ("7.3.0", True)])


### PR DESCRIPTION
## What does this PR change?

Fixes virt grains unit test. The introduction of another `Popen()`  requires to fix the test to use a `side_effect` rather than a `return_value`

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- Unit tests were fixed

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
