### PR TITLE
Testsuite: Split a long scenario

### DIFF
--- a/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
+++ b/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
@@ -26,14 +26,11 @@ Feature: PXE boot a terminal with Cobbler
     And I click on "Save Formula"
     Then I should see a "Formula saved" text
 
-  Scenario: Configure PXE part of DNS on the proxy
+  # Note: Avahi does not cross networks, so we need to cheat by serving tf.local
+  Scenario: Configure avahi info for PXE part of DNS on the proxy
     When I follow first "Bind" in the content area
-    # general information:
-    #   (Avahi does not cross networks, so we need to cheat by serving tf.local)
     And I press "Add Item" in configured zones section
     And I enter "tf.local" in third configured zone name field
-    # direct zone tf.local:
-    #   (Avahi does not cross networks, so we need to cheat by serving tf.local)
     And I scroll to the top of the page
     And I press "Add Item" in available zones section
     And I enter "tf.local" in third available zone name field
@@ -48,7 +45,6 @@ Feature: PXE boot a terminal with Cobbler
     And I enter the IP address of "server" in sixth A address field
     And I press "Add Item" in third NS section
     And I enter the hostname of "proxy" in third NS field
-    # end
     And I scroll to the top of the page
     And I should see a "Bind" text
     And I click on "Save Formula"
@@ -150,7 +146,7 @@ Feature: PXE boot a terminal with Cobbler
     Then "pxeboot_minion" should not be registered
     And I stop salt-minion on the PXE boot minion
 
-  Scenario: Cleanup: remove DNS records added by mass import
+  Scenario: Cleanup: remove avahi info from DNS records
     Given I am on the Systems overview page of this "proxy"
     When I follow "Formulas" in the content area
     And I follow first "Bind" in the content area

--- a/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
+++ b/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
@@ -47,15 +47,10 @@ Feature: PXE boot a Retail terminal
     And the "vsftpd" formula should be checked
     And the "pxe" formula should be checked
 
-  Scenario: Configure PXE part of DNS on the branch server
+  Scenario: Configure general info for PXE part of DNS on the branch server
     Given I am on the Systems overview page of this "proxy"
     When I follow "Formulas" in the content area
     And I follow first "Bind" in the content area
-    # general information:
-    #   (Avahi does not cross networks, so we need to cheat by serving tf.local)
-    And I press "Add Item" in configured zones section
-    And I enter "tf.local" in third configured zone name field
-    # direct zone example.org:
     And I press "Add Item" in first CNAME section
     And I enter "ftp" in first CNAME alias field
     And I enter "proxy" in first CNAME name field
@@ -63,22 +58,24 @@ Feature: PXE boot a Retail terminal
     And I enter "tftp" in second CNAME alias field
     And I enter "proxy" in second CNAME name field
     And I press "Add Item" in first CNAME section
-    And I enter "salt" in third CNAME alias field
     And I enter the hostname of "proxy" in third CNAME name field
-    # direct zone tf.local:
-    #   (Avahi does not cross networks, so we need to cheat by serving tf.local)
+
+  # Note: Avahi does not cross networks, so we need to cheat by serving tf.local
+  Scenario: Configure avahi info for PXE part of DNS on the branch server
     And I scroll to the top of the page
+    And I press "Add Item" in configured zones section
+    And I enter "tf.local" in third configured zone name field
     And I press "Add Item" in available zones section
     And I enter "tf.local" in third available zone name field
     And I enter "master/db.tf.local" in third file name field
     And I enter the hostname of "proxy" in third name server field
     And I enter "admin@tf.local." in third contact field
+    And I enter "salt" in third CNAME alias field
     And I press "Add Item" in third A section
     And I enter the hostname of "proxy" in fifth A name field
     And I enter the IP address of "proxy" in fifth A address field
     And I press "Add Item" in third NS section
     And I enter the hostname of "proxy" in third NS field
-    # end
     And I scroll to the top of the page
     And I should see a "Bind" text
     And I click on "Save Formula"


### PR DESCRIPTION
## What does this PR change?

A minor refactor in a couple of tests:
split a long scenario in two and rewrite some scenario titles.

- proxy_retail_pxeboot_and_mass_import.feature
Split a long scenario in two.

- proxy_cobbler_pxeboot.feature: Rewrite two scenario titles.

## Links
https://github.com/SUSE/spacewalk/issues/15337
### Ports
- Manager-4.2: https://github.com/SUSE/spacewalk/pull/15794
- Manager-4.1: https://github.com/SUSE/spacewalk/pull/15795

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)
