### PR TITLE
Enhance base channel help message

### DIFF
--- a/web/html/src/manager/systems/activation-key/activation-key-channels.tsx
+++ b/web/html/src/manager/systems/activation-key/activation-key-channels.tsx
@@ -2,6 +2,8 @@ import ChildChannels from "./child-channels";
 import ActivationKeyChannelsApi from "./activation-key-channels-api";
 import * as React from "react";
 import { Loading } from "components/utils/Loading";
+import { Messages } from "components/messages";
+import { Utils as MessagesUtils } from 'components/messages';
 import MandatoryChannelsApi from "core/channels/api/mandatory-channels-api";
 import { availableChannelsType, ChannelDto } from "./activation-key-channels-api";
 
@@ -79,6 +81,7 @@ class ActivationKeyChannels extends React.Component<ActivationKeyChannelsProps, 
   };
 
   render() {
+    const defaultChannelName = this.getDefaultBase().name;
     return (
       <ActivationKeyChannelsApi
         onNewBaseChannel={this.onNewBaseChannel}
@@ -117,12 +120,17 @@ class ActivationKeyChannels extends React.Component<ActivationKeyChannelsProps, 
                   </select>
                   <span className="help-block">
                     {t(
-                      'Choose "SUSE Manager Default" to allow systems to register to the default SUSE Manager ' +
-                        "provided channel that corresponds to the installed SUSE Linux version. Instead of the default, " +
-                        "you may choose a particular SUSE provided channel or a custom base channel, but if a system using " +
-                        "this key is not compatible with the selected channel, it will fall back to its SUSE Manager Default channel."
+                      `Selecting the "${defaultChannelName}" base channel enables a system to register to the ` +
+                      'correct channel that corresponds to the installed operating system. You can also select ' +
+                      'SUSE provided channels, or use custom base channels but if a system using such a channel ' +
+                      `is not compatible then the fall back will be the "${defaultChannelName}" channel.`
                     )}
                   </span>
+                  <Messages items={
+                      MessagesUtils.warning(t(`When "${this.getDefaultBase().name}" is selected and the installed ` +
+                                              'product is not detected, no channel will be added even if children ' +
+                                              'channels are selected.'))
+                  }/>
                 </div>
               </div>
               <div className="form-group">

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Enhance the default base channel help message (bsc#1171520)
 - Don't capitalize acronyms
 - 'AppStreams with defaults' filter template in CLM
 - Add a link to OS image store dir in image list page


### PR DESCRIPTION
## What does this PR change?

Change the explanation and warning about the default base channel in the activation key dialog.

## GUI diff

Before:
![Screenshot_2021-09-03 SUSE Manager - Systems - Activation Keys](https://user-images.githubusercontent.com/397931/132004053-8d80baaf-4035-44d0-9d31-d4799ca61072.png)

After:
![Screenshot_2021-09-03 SUSE Manager - Systems - Activation Keys(1)](https://user-images.githubusercontent.com/397931/132004062-c373ad4a-7d9e-427e-bc6f-82de4170c051.png)

- [X] **DONE**

## Documentation
- No documentation needed: enhanced UI message

- [X] **DONE**

## Test coverage
- No tests: only messages rewording

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/11457

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
