### PR TITLE
Update proxy path on minion connection

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/server/MinionServer.java
+++ b/java/code/src/com/redhat/rhn/domain/server/MinionServer.java
@@ -305,4 +305,52 @@ public class MinionServer extends Server implements SaltConfigurable {
     public Optional<MinionServer> asMinionServer() {
         return Optional.of(this);
     }
+
+    /**
+     * Updates Server Path according to Salt master/proxy hostname.
+     * @param hostname hostname of Salt master the minion is connected to
+     * @return <code>true</code> if the path has been changed
+     */
+    public boolean updateServerPaths(String hostname) {
+        Optional<Server> proxy = ServerFactory.lookupProxyServer(hostname);
+
+        return updateServerPaths(proxy, Optional.of(hostname));
+    }
+
+    /**
+     * Updates Server Path according to proxyId.
+     * @param proxyId Id of a proxy the minion is connected to
+     * @return <code>true</code> if the path has been changed
+     */
+    public boolean updateServerPaths(Optional<Long> proxyId) {
+        return updateServerPaths(proxyId.map(id -> ServerFactory.lookupById(id)), Optional.empty());
+    }
+
+    private boolean updateServerPaths(Optional<Server> proxy, Optional<String> hostname) {
+
+        boolean changed = false;
+
+        if (proxy.isPresent()) {
+                // the system is connected to a proxy
+                // check if serverPath already exists
+                if (!ServerFactory.findServerPath(this, proxy.get()).isPresent()) {
+                    // proxy path does not exist -> create it
+                    Set<ServerPath> proxyPaths = ServerFactory.createServerPaths(this, proxy.get(),
+                                                 hostname.orElse(proxy.get().getHostname()));
+                    getServerPaths().clear();
+                    getServerPaths().addAll(proxyPaths);
+
+                    changed = true;
+                }
+         }
+         else {
+                if (!getServerPaths().isEmpty()) {
+                    // reconnecting from proxy to master
+                    getServerPaths().clear();
+
+                    changed = true;
+                }
+        }
+        return changed;
+    }
 }

--- a/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
@@ -338,7 +338,13 @@ public class ServerFactory extends HibernateFactory {
         return paths;
     }
 
-    private static Optional<ServerPath> findServerPath(Server server, Server proxyServer) {
+    /**
+     * Finds a Server Path identified by proxyServer
+     * @param server the server
+     * @param proxyServer the proxy server to which <code>server</code> connects directly
+     * @return the ServerPath if found
+     */
+    public static Optional<ServerPath> findServerPath(Server server, Server proxyServer) {
         if (server.getId() == null) {
             // not yet persisted, return empty to avoid Hibernate error
             // on query with a transient object

--- a/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/RegisterMinionEventMessageAction.java
@@ -44,7 +44,6 @@ import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.server.ServerGroupFactory;
 import com.redhat.rhn.domain.server.ServerHistoryEvent;
-import com.redhat.rhn.domain.server.ServerPath;
 import com.redhat.rhn.domain.state.ServerStateRevision;
 import com.redhat.rhn.domain.state.StateFactory;
 import com.redhat.rhn.domain.token.ActivationKey;
@@ -481,7 +480,12 @@ public class RegisterMinionEventMessageAction implements MessageAction {
 
             mapHardwareGrains(minion, grains);
 
-            setServerPaths(minion, master, isSaltSSH, saltSSHProxyId);
+            if (isSaltSSH) {
+                minion.updateServerPaths(saltSSHProxyId);
+            }
+            else {
+                minion.updateServerPaths(master);
+            }
 
             ServerFactory.save(minion);
             giveCapabilities(minion, isSaltSSH);
@@ -734,23 +738,6 @@ public class RegisterMinionEventMessageAction implements MessageAction {
         }
         throw new IllegalStateException(matchingEmptyProfiles.size() + " matching empty profiles found when matching" +
                 " with " + hostname.map(n -> "hostname: " + n + " and ").orElse("") + " HW addresseses: " + hwAddrs);
-    }
-
-    private void setServerPaths(MinionServer server, String master,
-                                boolean isSaltSSH, Optional<Long> saltSSHProxyId) {
-        Optional<Set<ServerPath>> proxyPaths =
-                isSaltSSH ?
-                        saltSSHProxyId
-                                .map(proxyId -> ServerFactory.lookupById(proxyId))
-                                .map(proxy -> ServerFactory
-                                        .createServerPaths(server, proxy, proxy.getHostname())
-                                ) :
-                        ServerFactory.lookupProxyServer(master).map(proxy ->
-                            ServerFactory
-                                    .createServerPaths(server, proxy, master)
-                        );
-        server.getServerPaths().clear();
-        server.getServerPaths().addAll(proxyPaths.orElse(Collections.emptySet()));
     }
 
     private void giveCapabilities(MinionServer server, boolean isSaltSSH) {

--- a/java/code/src/com/suse/manager/webui/utils/salt/custom/SystemInfo.java
+++ b/java/code/src/com/suse/manager/webui/utils/salt/custom/SystemInfo.java
@@ -75,4 +75,12 @@ public class SystemInfo {
         return Optional.ofNullable(kernelLiveVersion.getChanges().getRet())
                 .map(KernelLiveVersionInfo::getKernelLiveVersion);
     }
+
+    /**
+     * Get the master grain
+     * @return master grain
+     */
+    public Optional<String> getMaster() {
+       return getGrains().getOptionalAsString("master");
+    }
 }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Update proxy path on minion connection
 - mgr-sync refresh logs when a vendor channel is expired and shows how to remove it (bsc#1191222)
 - Hide link to CLM live patching template in system details for
   products that don't support live patching (bsc#1190866)

--- a/susemanager-utils/susemanager-sls/salt/util/systeminfo.sls
+++ b/susemanager-utils/susemanager-sls/salt/util/systeminfo.sls
@@ -11,6 +11,8 @@ grains_update:
     - name: grains.item
     - args:
       - kernelrelease
+      - master
+
 kernel_live_version:
   mgrcompat.module_run:
     - name: sumautil.get_kernel_live_version

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Update proxy path on minion connection
 - deploy certificate on SLE Micro 5.1
 - Fix cpuinfo grain and virt_utils state python2 compatibility
   (bsc#1191139, bsc#1191123)


### PR DESCRIPTION
## What does this PR change?

This updates proxy path each time when the minion connects.
If the proxy is changed, it regenerates pillars and channels to point to the new proxy.

This is a part of implementation of https://github.com/SUSE/spacewalk/issues/15630

Open questions:
- it probably needs refactoring
- ssh minions might need special handling

## GUI diff

No difference.

- [x] **DONE**

## Documentation

WIP

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Partially fixes https://github.com/SUSE/spacewalk/issues/15630


- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
