### PR TITLE
Ansible ent for all archs

### DIFF
--- a/schema/spacewalk/common/data/rhnServerServerGroupArchCompat.sql
+++ b/schema/spacewalk/common/data/rhnServerServerGroupArchCompat.sql
@@ -914,6 +914,18 @@ insert into rhnServerServerGroupArchCompat ( server_arch_id, server_group_type )
             lookup_sg_type('ansible_control_node'));
 
 insert into rhnServerServerGroupArchCompat ( server_arch_id, server_group_type )
+	values (lookup_server_arch('ppc64le-redhat-linux'),
+            lookup_sg_type('ansible_control_node'));
+
+insert into rhnServerServerGroupArchCompat ( server_arch_id, server_group_type )
+	values (lookup_server_arch('aarch64-redhat-linux'),
+            lookup_sg_type('ansible_control_node'));
+
+insert into rhnServerServerGroupArchCompat ( server_arch_id, server_group_type )
+	values (lookup_server_arch('s390x-redhat-linux'),
+            lookup_sg_type('ansible_control_node'));
+
+insert into rhnServerServerGroupArchCompat ( server_arch_id, server_group_type )
 	values (lookup_server_arch('amd64-debian-linux'),
             lookup_sg_type('ansible_control_node'));
 

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- allow Ansible Control Node entitlement for aarch64, ppc64le and s390x(bsc#1189799)
 - implement package locking for salt minions
 
 -------------------------------------------------------------------

--- a/schema/spacewalk/upgrade/susemanager-schema-4.3.1-to-susemanager-schema-4.3.2/002-ansible-entitlement-for-all-archs.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.3.1-to-susemanager-schema-4.3.2/002-ansible-entitlement-for-all-archs.sql
@@ -1,0 +1,33 @@
+INSERT INTO rhnServerServerGroupArchCompat ( server_arch_id, server_group_type )
+SELECT
+    lookup_server_arch('aarch64-redhat-linux'),
+    lookup_sg_type('ansible_control_node')
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM rhnServerServerGroupArchCompat
+    WHERE server_arch_id = lookup_server_arch('aarch64-redhat-linux')
+        AND server_group_type = lookup_sg_type('ansible_control_node')
+);
+
+INSERT INTO rhnServerServerGroupArchCompat ( server_arch_id, server_group_type )
+SELECT
+    lookup_server_arch('ppc64le-redhat-linux'),
+    lookup_sg_type('ansible_control_node')
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM rhnServerServerGroupArchCompat
+    WHERE server_arch_id = lookup_server_arch('ppc64le-redhat-linux')
+        AND server_group_type = lookup_sg_type('ansible_control_node')
+);
+
+INSERT INTO rhnServerServerGroupArchCompat ( server_arch_id, server_group_type )
+SELECT
+    lookup_server_arch('s390x-redhat-linux'),
+    lookup_sg_type('ansible_control_node')
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM rhnServerServerGroupArchCompat
+    WHERE server_arch_id = lookup_server_arch('s390x-redhat-linux')
+        AND server_group_type = lookup_sg_type('ansible_control_node')
+);
+


### PR DESCRIPTION
## What does this PR change?

We ship the ansible package for all architectures in our SUSE Manager Tools Channel, but allow to set the entitlement only for x86_64 and amd64.
A customer want to use it on POWER (ppc64le) and run into errors.

As we ship the packages for this arch we should also allow to use it.

Port of https://github.com/SUSE/spacewalk/pull/15793

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **such a militation was never documented**

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
