### PR TITLE
Adjust CLM filter that became a modal

### DIFF
--- a/testsuite/features/build_validation/add_custom_repositories/add_ceos8_repositories.feature
+++ b/testsuite/features/build_validation/add_custom_repositories/add_ceos8_repositories.feature
@@ -64,21 +64,22 @@ Feature: Adding the CentOS 8 distribution custom repositories
   Scenario: Create CLM filters to remove AppStream metadata
     Given I am authorized for the "Admin" section
     When I follow the left menu "Content Lifecycle > Filters"
-    And I click on "Create Filter"
+    Then I wait at most 10 seconds until I see modal containing "Create a new filter" text
     Then I should see a "Create a new filter" text
-    When I enter "ruby-2.7" as "filter_name"
+    And I enter "ruby-2.7" as "filter_name"
     And I select "Module (Stream)" from "type"
     And I enter "ruby" as "moduleName"
     And I enter "2.7" as "moduleStream"
-    And I click on "Save"
+    And I click on "Save" in "Create a new filter" modal
     Then I should see a "ruby-2.7" text
     When I click on "Create Filter"
+    Then I wait at most 10 seconds until I see modal containing "Create a new filter" text
     Then I should see a "Create a new filter" text
     When I enter "python-3.6" as "filter_name"
     And I select "Module (Stream)" from "type"
     And I enter "python36" as "moduleName"
     And I enter "3.6" as "moduleStream"
-    And I click on "Save"
+    And I click on "Save" in "Create a new filter" modal
     Then I should see a "python-3.6" text
 
   Scenario: Create a CLM project to remove AppStream metadata

--- a/testsuite/features/step_definitions/navigation_steps.rb
+++ b/testsuite/features/step_definitions/navigation_steps.rb
@@ -958,7 +958,7 @@ end
 
 # Wait until a modal window with a specific content is shown
 When(/^I wait at most (\d+) seconds until I see modal containing "([^"]*)" text$/) do |timeout, title|
-  path = "//*[contains(@class, \"modal-body\") and contains(., \"#{title}\")]" \
+  path = "//*[contains(@class, \"modal-content\") and contains(., \"#{title}\")]" \
     '/ancestor::div[contains(@class, "modal-dialog")]'
 
   dialog = find(:xpath, path, wait: timeout.to_i)


### PR DESCRIPTION
## What does this PR change?

Adjust CLM filter that became a modal

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes no issue, directly from BV review
Tracks 4.2: https://github.com/SUSE/spacewalk/pull/15821
4.1: Not needed because it didn't change in that version

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
