### PR TITLE
Ignore duplicates in 'pkg.installed' result when applying patches (bsc#1187572)

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
@@ -293,6 +293,24 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         assertEquals(0, minion.getPackages().size());
     }
 
+    public void testApplyPackageDeltaWithDuplicates() throws Exception {
+        MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
+
+        Map<String, Change<Xor<String, List<Pkg.Info>>>> install = Json.GSON.fromJson(new InputStreamReader(getClass()
+                        .getResourceAsStream("/com/suse/manager/reactor/messaging/test/pkg_install.duplicates.json")),
+                new TypeToken<Map<String, Change<Xor<String, List<Pkg.Info>>>>>(){}.getType());
+
+        SaltUtils.applyChangesFromStateModule(install, minion);
+
+        // The duplicate should be ignored (bsc#1187572)
+        assertEquals(1, minion.getPackages().size());
+        List<InstalledPackage> packages = new ArrayList<>(minion.getPackages());
+        assertEquals("vim", packages.get(0).getName().getName());
+        assertEquals("x86_64", packages.get(0).getArch().getLabel());
+        assertEquals("1.42.11", packages.get(0).getEvr().getVersion());
+        assertEquals("7.1", packages.get(0).getEvr().getRelease());
+    }
+
     public void testsPackageDeltaFromStateApply() throws Exception {
         MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
         assertEquals(0, minion.getPackages().size());

--- a/java/code/src/com/suse/manager/reactor/messaging/test/pkg_install.duplicates.json
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/pkg_install.duplicates.json
@@ -1,0 +1,19 @@
+{
+  "vim": {
+    "old": "",
+    "new": [
+      {
+        "install_date_time_t": 1498636531,
+        "version": "1.42.11",
+        "release": "7.1",
+        "arch": "x86_64"
+      },
+      {
+        "install_date_time_t": 1498640000,
+        "version": "1.42.11",
+        "release": "7.1",
+        "arch": "x86_64"
+      }
+    ]
+  }
+}

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Ignore duplicates in 'pkg.installed' result when applying patches (bsc#1187572)
 - Improved timezone support
 - implement package locking for salt minions
 - Show AppStreams tab just for modular channels


### PR DESCRIPTION
Sometimes Salt lists the same NEVRA twice in a `pkg.installed` result, only with different install timestamps. Use a merge function is to ignore these duplicate entries.

https://bugzilla.suse.com/1187572

Port of: https://github.com/SUSE/spacewalk/pull/15818

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
