### PR TITLE
CI: improve error reporting when building packages

### DIFF
--- a/susemanager-utils/testing/automation/push-to-obs.sh
+++ b/susemanager-utils/testing/automation/push-to-obs.sh
@@ -117,7 +117,6 @@ if [ $PRET -ne 0 ];then
     echo "The following packages failed to build:"
     for p in ${PKG_FAILED}; do echo "- ${p}"; done
     echo "Please review the logs at ${GITROOT}/logs/"
-    echo "Review the logs."
     exit ${PRET}
 fi
 

--- a/susemanager-utils/testing/automation/push-to-obs.sh
+++ b/susemanager-utils/testing/automation/push-to-obs.sh
@@ -1,4 +1,6 @@
 #! /bin/sh -e
+# Set pipefail so the result of a pipe is different to zero if one of the commands fail.
+# This way, we can add tee but be sure the result would be non zero if the command before has failed.
 set -o pipefail
 
 HERE=`dirname $0`
@@ -78,8 +80,6 @@ for p in ${PACKAGES};do
     pkg_dir=$(cat rel-eng/packages/${p} | tr -s " " | cut -d" " -f 2)
     CHOWN_CMD="${CHOWN_CMD}; chown -f -R $(id -u):$(id -g) /manager/$pkg_dir"
     CMD="/manager/susemanager-utils/testing/docker/scripts/push-to-obs.sh -d '${DESTINATIONS}' -c /tmp/.oscrc -p '${p}' ${VERBOSE} ${TEST} ${OBS_TEST_PROJECT} ${EXTRA_OPTS}"
-    # Set pipefail so the result of a pipe is different to zero if one of the commands fail.
-    # This way, we can add tee at the end but be sure the result would be non zero if the command before has failed.
     if [ "$PARALLEL_BUILD" == "TRUE" ];then
         echo "Building ${p} in parallel"
         docker run --rm=true -v ${GITROOT}:/manager -v /srv/mirror:/srv/mirror --mount type=bind,source=${CREDENTIALS},target=/tmp/.oscrc ${REGISTRY}/${PUSH2OBS_CONTAINER} /bin/bash -c "${INITIAL_CMD};${CMD};RET=\${?};${CHOWN_CMD} && exit \${RET}" 2>&1 > ${GITROOT}/logs/${p}.log &
@@ -97,19 +97,24 @@ echo "End of task at ($(date). Logs for each package at ${GITROOT}/logs/"
 set +e
 
 PRET=0
+PKG_FAILED=""
 for i in $PIDS;do
-    echo "Waiting for pid $i"
+    package_name=$(basename $(readlink ${GITROOT}/logs/${i}.log) | cut -d"." -f1 )
+    echo "Waiting for process with pid $i, building package ${package_name}"
     wait $i
     result=$?
     echo "$i finished, result is $result"
-    cat ${GITROOT}/logs/${i}.log
     if [ $result -ne 0 ];then
-        echo "Seems there was an error with pid $i"
+        echo "Seems there was an error with process pid ${i}"
+        echo "When building package ${package_name}"
+        cat ${GITROOT}/logs/${i}.log
+        PKG_FAILED="${PKG_FAILED} ${package_name}"
         PRET=-1
     fi
 done
 
 if [ $PRET -ne 0 ];then
+    echo "$Fail to build packages ${PKG_FAILED}"
     echo "Review the logs."
     exit ${PRET}
 fi

--- a/susemanager-utils/testing/automation/push-to-obs.sh
+++ b/susemanager-utils/testing/automation/push-to-obs.sh
@@ -100,7 +100,7 @@ PRET=0
 PKG_FAILED=""
 for i in $PIDS;do
     package_name=$(basename $(readlink ${GITROOT}/logs/${i}.log) | cut -d"." -f1 )
-    echo "Waiting for process with pid $i, building package ${package_name}"
+    echo "Waiting for process with pid ${i}, building package ${package_name}"
     wait $i
     result=$?
     echo "$i finished, result is $result"

--- a/susemanager-utils/testing/automation/push-to-obs.sh
+++ b/susemanager-utils/testing/automation/push-to-obs.sh
@@ -114,7 +114,9 @@ for i in $PIDS;do
 done
 
 if [ $PRET -ne 0 ];then
-    echo "$Fail to build packages ${PKG_FAILED}"
+    echo "The following packages failed to build:"
+    for p in ${PKG_FAILED}; do echo "- ${p}"; done
+    echo "Please review the logs at ${GITROOT}/logs/"
     echo "Review the logs."
     exit ${PRET}
 fi


### PR DESCRIPTION
## What does this PR change?

Only show logs when there has been an error and show which package
failed to build, not only the pid of the process that failed.

This should make it easier to find errors.


## GUI diff

Before: A lot of output for packages that were successfully built, so finding the one that failed was like finding a needle in a haystack

After: Only the log of the failed package is shown, with a message stating which package is it.

- [X] **DONE**

## Documentation
- No documentation needed

- [X] **DONE**

## Test coverage
- No tests

- [X] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/15560

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
