### PR TITLE
Testsuite: Split a scenario in two

### DIFF
--- a/testsuite/features/secondary/minkvm_guests.feature
+++ b/testsuite/features/secondary/minkvm_guests.feature
@@ -378,6 +378,10 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I click on "Create"
     Then I should see a "Autoinstallation: 15-sp2-kvm" text
     And I should see a "Autoinstallation Details" text
+
+@long_test
+@scc_credentials
+  Scenario: Configure auto installation profile
     When I enter "self_update=0" as "kernel_options"
     And I click on "Update"
     And I follow "Variables"

--- a/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
+++ b/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
@@ -81,6 +81,8 @@ Feature: PXE boot a terminal with Cobbler
     And I click on "Create"
     Then I should see a "Autoinstallation: 15-sp2-cobbler" text
     And I should see a "Autoinstallation Details" text
+
+  Scenario: Configure auto installation profile
     When I enter "self_update=0" as "kernel_options"
     And I click on "Update"
     And I follow "Variables"


### PR DESCRIPTION
## What does this PR change?
Split a scenario in two

- testsuite/features/secondary/minkvm_guests.feature
- testsuite/features/secondary/proxy_cobbler_pxeboot.feature:
One scenario creates the profile, the other configures it.

## Links
https://github.com/SUSE/spacewalk/issues/15336

### Ports
- Manager-4.2: https://github.com/SUSE/spacewalk/pull/15833
- Manager-4.1: https://github.com/SUSE/spacewalk/pull/15834

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)
