### PR TITLE
Fix time zone mismatch in recurring events

### DIFF
--- a/web/html/src/components/datetime/DateTimePicker.tsx
+++ b/web/html/src/components/datetime/DateTimePicker.tsx
@@ -237,6 +237,8 @@ type DateTimePickerProps = {
   onChange: (value: moment.Moment) => void;
   hideDatePicker?: boolean;
   hideTimePicker?: boolean;
+  // By default date times are shown in the user's configured time zone. Setting this property will default to the server time zone instead.
+  serverTimeZone?: boolean;
 };
 
 type DateTimePickerState = {
@@ -255,8 +257,8 @@ export class DateTimePicker extends React.Component<DateTimePickerProps, DateTim
       timeOpen: false,
       hideDate: props.hideDatePicker || false,
       hideTime: props.hideTimePicker || false,
-      // Use the user's configured time zone by default
-      timeZone: localizedMoment.userTimeZone,
+      // Use the user's configured time zone by default, but allow overrides
+      timeZone: props.serverTimeZone ? localizedMoment.serverTimeZone : localizedMoment.userTimeZone,
     };
   }
 

--- a/web/html/src/components/datetime/DateTimePicker.tsx
+++ b/web/html/src/components/datetime/DateTimePicker.tsx
@@ -257,7 +257,6 @@ export class DateTimePicker extends React.Component<DateTimePickerProps, DateTim
       timeOpen: false,
       hideDate: props.hideDatePicker || false,
       hideTime: props.hideTimePicker || false,
-      // Use the user's configured time zone by default, but allow overrides
       timeZone: props.serverTimeZone ? localizedMoment.serverTimeZone : localizedMoment.userTimeZone,
     };
   }

--- a/web/html/src/components/panels/InnerPanel.tsx
+++ b/web/html/src/components/panels/InnerPanel.tsx
@@ -1,36 +1,40 @@
 import * as React from "react";
 
 import { SectionToolbar } from "components/section-toolbar/section-toolbar";
+import { cloneReactElement } from "components/utils";
 
 type Props = {
   title: string;
   icon: string;
-  buttons: React.ReactNode[];
+  buttons?: React.ReactNode[];
   buttonsLeft?: React.ReactNode[];
   children: React.ReactNode;
 };
 
 function InnerPanel(props: Props) {
-  let toolbar;
+  let toolbar: React.ReactNode = null;
 
-  if (props.buttons?.length > 0 || props.buttonsLeft?.length !== 0) {
-    toolbar =
+  if (props.buttons?.length || props.buttonsLeft?.length) {
+    toolbar = (
       <SectionToolbar>
-        {
-          props.buttonsLeft?.length !== 0 ?
-            <div className="selector-button-wrapper">
-              <div className="btn-group">{props.buttonsLeft}</div>
+        {props.buttonsLeft?.length ? (
+          <div className="selector-button-wrapper">
+            <div className="btn-group">
+              {React.Children.toArray(props.buttonsLeft).map((child, index) =>
+                cloneReactElement(child, { key: index })
+              )}
             </div>
-            : null
-        }
-        {
-          props.buttons?.length > 0 ?
-            <div className="action-button-wrapper">
-              <div className="btn-group">{props.buttons}</div>
+          </div>
+        ) : null}
+        {props.buttons?.length ? (
+          <div className="action-button-wrapper">
+            <div className="btn-group">
+              {React.Children.toArray(props.buttons).map((child, index) => cloneReactElement(child, { key: index }))}
             </div>
-            : null
-        }
-      </SectionToolbar>;
+          </div>
+        ) : null}
+      </SectionToolbar>
+    );
   }
 
   return (
@@ -39,7 +43,7 @@ function InnerPanel(props: Props) {
         <i className={`fa ${props.icon}`} />
         {props.title}
       </h2>
-      { toolbar }
+      {toolbar}
       <div className="row">
         <div className="panel panel-default">
           <div className="panel-body">{props.children}</div>

--- a/web/html/src/components/picker/recurring-event-picker.tsx
+++ b/web/html/src/components/picker/recurring-event-picker.tsx
@@ -97,7 +97,6 @@ class RecurringEventPicker extends React.Component<RecurringEventPickerProps, Re
   }
 
   initialize = () => {
-    // Select weekly schedule by default
     // TODO: This logic needs to be lifted up since this internally calls `setState()` which is not valid while mounting
     this.onSelectWeekly();
   };

--- a/web/html/src/components/picker/recurring-event-picker.tsx
+++ b/web/html/src/components/picker/recurring-event-picker.tsx
@@ -9,18 +9,23 @@ import styles from "./recurring-event-picker.css";
 import { localizedMoment } from "utils";
 
 type RecurringType = "hourly" | "daily" | "weekly" | "monthly" | "cron";
-// TODO: This should be `Record<string, string>` or `Record<string, number>`, but currently they're used mixed up
-type CronTimesType = Record<string, string | number>;
+type CronTimes = {
+  // TODO: These should be `string` or `number`, but currently they're used mixed up
+  minute: number | string;
+  hour: number | string;
+  dayOfMonth: string;
+  dayOfWeek: string;
+};
 
 type RecurringEventPickerProps = {
   timezone: string;
   scheduleName: string;
   type: RecurringType;
   cron: string;
-  cronTimes: CronTimesType;
+  cronTimes: CronTimes;
   onScheduleNameChanged: (scheduleName: string) => void;
   onTypeChanged: (type: string) => void;
-  onCronTimesChanged: (cronTimes: CronTimesType) => void;
+  onCronTimesChanged: (cronTimes: CronTimes) => void;
   onCronChanged: (cron: string) => void;
 };
 
@@ -32,20 +37,20 @@ type RecurringEventPickerState = {
   weekDay: ComboboxItem;
   monthDay: ComboboxItem;
   cron: string;
-  cronTimes: CronTimesType;
+  cronTimes: CronTimes;
 };
 
 class RecurringEventPicker extends React.Component<RecurringEventPickerProps, RecurringEventPickerState> {
   minutes = Array.from(Array(60).keys()).map(id => ({ id: Number(id), text: id.toString() }));
 
   weekDays = [
-    { id: Number(1), text: "Sunday" },
-    { id: Number(2), text: "Monday" },
-    { id: Number(3), text: "Tuesday" },
-    { id: Number(4), text: "Wednesday" },
-    { id: Number(5), text: "Thursday" },
-    { id: Number(6), text: "Friday" },
-    { id: Number(7), text: "Saturday" },
+    { id: Number(1), text: t("Sunday") },
+    { id: Number(2), text: t("Monday") },
+    { id: Number(3), text: t("Tuesday") },
+    { id: Number(4), text: t("Wednesday") },
+    { id: Number(5), text: t("Thursday") },
+    { id: Number(6), text: t("Friday") },
+    { id: Number(7), text: t("Saturday") },
   ];
 
   monthDays = Array.from(Array(28).keys()).map(id => ({ id: Number(id + 1), text: (id + 1).toString() }));
@@ -64,23 +69,43 @@ class RecurringEventPicker extends React.Component<RecurringEventPickerProps, Re
       monthDay: this.monthDays[0],
     };
 
-    this.props.cronTimes ? this.setTimeAndDays(this.state.time) : this.initialize();
+    this.props.cronTimes ? this.setInitialTimeAndDays(this.state.time) : this.initialize();
+  }
+
+  /**
+   * In this view, for legacy reasons, the user selects time values (without any date values) that are used as inputs to
+   * Quartz cron configuration without regarding time zones. To accommodate for this, we manually offset the values as
+   * needed. This is a very specific use case and should **NOT** be used elsewhere where dates and times are concerned.
+   */
+   private fromLegacyServerTime(value: moment.Moment, hour: number, minute: number): moment.Moment {
+    const serverTime = localizedMoment(value).tz(localizedMoment.serverTimeZone);
+    if (!isNaN(hour)) {
+      serverTime.hours(hour);
+    }
+    if (!isNaN(minute)) {
+      serverTime.minutes(minute);
+    }
+    return localizedMoment(serverTime);
+  }
+
+  private toLegacyServerTime(value: moment.Moment): { hour: number, minute: number } {
+    const serverTime = localizedMoment(value).tz(localizedMoment.serverTimeZone);
+    return {
+      hour: serverTime.hours(),
+      minute: serverTime.minutes(),
+    }
   }
 
   initialize = () => {
+    // Select weekly schedule by default
+    // TODO: This logic needs to be lifted up since this internally calls `setState()` which is not valid while mounting
     this.onSelectWeekly();
   };
 
-  setTimeAndDays = (value: moment.Moment) => {
-    const hours = Number(this.state.cronTimes.hour);
-    const minutes = Number(this.state.cronTimes.minute);
-    const time = localizedMoment(value);
-    if (!isNaN(hours)) {
-      time.hours(hours);
-    }
-    if (!isNaN(minutes)) {
-      time.minutes(minutes);
-    }
+  setInitialTimeAndDays = (value: moment.Moment) => {
+    const hour = Number(this.state.cronTimes.hour);
+    const minute = Number(this.state.cronTimes.minute);
+    const time = this.fromLegacyServerTime(value, hour, minute);
     Object.assign(this.state, {
       time: time,
       cron: this.state.cron,
@@ -146,8 +171,7 @@ class RecurringEventPicker extends React.Component<RecurringEventPickerProps, Re
 
   onSelectDaily = () => {
     this.props.onCronTimesChanged({
-      minute: this.state.time.minutes(),
-      hour: this.state.time.hours(),
+      ...this.toLegacyServerTime(this.state.time),
       dayOfMonth: "",
       dayOfWeek: "",
     });
@@ -159,8 +183,7 @@ class RecurringEventPicker extends React.Component<RecurringEventPickerProps, Re
       time: value,
     });
     this.props.onCronTimesChanged({
-      minute: value.minutes(),
-      hour: value.hours(),
+      ...this.toLegacyServerTime(value),
       dayOfMonth: "",
       dayOfWeek: "",
     });
@@ -169,8 +192,7 @@ class RecurringEventPicker extends React.Component<RecurringEventPickerProps, Re
 
   onSelectWeekly = () => {
     this.props.onCronTimesChanged({
-      minute: this.state.time.minutes(),
-      hour: this.state.time.hours(),
+      ...this.toLegacyServerTime(this.state.time),
       dayOfMonth: "",
       dayOfWeek: this.state.weekDay.id,
     });
@@ -200,8 +222,7 @@ class RecurringEventPicker extends React.Component<RecurringEventPickerProps, Re
       weekDay: newWeekDay,
     });
     this.props.onCronTimesChanged({
-      minute: this.state.time.minutes(),
-      hour: this.state.time.hours(),
+      ...this.toLegacyServerTime(this.state.time),
       dayOfMonth: "",
       dayOfWeek: selectedItem.id,
     });
@@ -213,8 +234,7 @@ class RecurringEventPicker extends React.Component<RecurringEventPickerProps, Re
       time: value,
     });
     this.props.onCronTimesChanged({
-      minute: value.minutes(),
-      hour: value.hours(),
+      ...this.toLegacyServerTime(value),
       dayOfMonth: "",
       dayOfWeek: this.state.weekDay.id,
     });
@@ -223,8 +243,7 @@ class RecurringEventPicker extends React.Component<RecurringEventPickerProps, Re
 
   onSelectMonthly = () => {
     this.props.onCronTimesChanged({
-      minute: this.state.time.minutes(),
-      hour: this.state.time.hours(),
+      ...this.toLegacyServerTime(this.state.time),
       dayOfMonth: this.state.monthDay.id,
       dayOfWeek: "",
     });
@@ -254,8 +273,7 @@ class RecurringEventPicker extends React.Component<RecurringEventPickerProps, Re
       monthDay: newMonthDay,
     });
     this.props.onCronTimesChanged({
-      minute: this.state.time.minutes(),
-      hour: this.state.time.hours(),
+      ...this.toLegacyServerTime(this.state.time),
       dayOfMonth: selectedItem.id,
       dayOfWeek: "",
     });
@@ -267,8 +285,7 @@ class RecurringEventPicker extends React.Component<RecurringEventPickerProps, Re
       time: value,
     });
     this.props.onCronTimesChanged({
-      minute: value.minutes(),
-      hour: value.hours(),
+      ...this.toLegacyServerTime(value),
       dayOfMonth: this.state.monthDay.id,
       dayOfWeek: "",
     });
@@ -365,7 +382,8 @@ class RecurringEventPicker extends React.Component<RecurringEventPickerProps, Re
                   <DateTimePicker
                     onChange={this.onDailyTimeChanged}
                     value={this.state.time}
-                    hideDatePicker={true}
+                    hideDatePicker
+                    serverTimeZone
                     id="time-daily"
                   />
                 </div>
@@ -398,7 +416,8 @@ class RecurringEventPicker extends React.Component<RecurringEventPickerProps, Re
                   <DateTimePicker
                     onChange={this.onWeeklyTimeChanged}
                     value={this.state.time}
-                    hideDatePicker={true}
+                    hideDatePicker
+                    serverTimeZone
                     id="time-weekly"
                   />
                 </div>
@@ -431,7 +450,8 @@ class RecurringEventPicker extends React.Component<RecurringEventPickerProps, Re
                   <DateTimePicker
                     onChange={this.onMonthlyTimeChanged}
                     value={this.state.time}
-                    hideDatePicker={true}
+                    hideDatePicker
+                    serverTimeZone
                     id="time-monthly"
                   />
                 </div>
@@ -457,15 +477,19 @@ class RecurringEventPicker extends React.Component<RecurringEventPickerProps, Re
                   </label>
                 </div>
                 <div className="col-sm-3">
-                  <input
-                    className="form-control"
-                    type="text"
-                    name="cron"
-                    value={this.state.cron}
-                    placeholder={t('e.g. "0 15 2 ? * 7"')}
-                    id="custom-cron"
-                    onChange={this.onCronChanged}
-                  />
+                  <div className="input-group">
+                    <input
+                      className="form-control"
+                      type="text"
+                      name="cron"
+                      value={this.state.cron}
+                      placeholder={t('e.g. "0 15 2 ? * 7"')}
+                      id="custom-cron"
+                      onChange={this.onCronChanged}
+                    />
+                    {/* This field is always in the server time zone, but just be explicit to the user */}
+                    <span className="input-group-addon">{localizedMoment.serverTimeZone}</span>
+                  </div>
                 </div>
               </div>
             </div>

--- a/web/html/src/components/table/Table.tsx
+++ b/web/html/src/components/table/Table.tsx
@@ -133,8 +133,13 @@ export function Table(props: TableProps) {
 
           const rowClass = props.cssClassFunction ? props.cssClassFunction(datum, index) : "";
           const evenOddClass = index % 2 === 0 ? "list-row-odd" : "list-row-even";
+          let key = props.identifier(datum);
+          if (!key) {
+            Loggerhead.error(`Could not identify table row with identifier: ${props.identifier}`);
+            key = index;
+          }
           return (
-            <tr className={rowClass + " " + evenOddClass} key={props.identifier(datum)}>
+            <tr className={rowClass + " " + evenOddClass} key={key}>
               {cells}
             </tr>
           );

--- a/web/html/src/manager/maintenance/list/schedule-list.tsx
+++ b/web/html/src/manager/maintenance/list/schedule-list.tsx
@@ -22,7 +22,7 @@ const MaintenanceScheduleList = (props: ScheduleListProps) => {
   const [scheduleToDelete, setScheduleToDelete] = useState({});
 
   return (
-    <div>
+    <>
       <Table
         data={props.data}
         identifier={row => row.id}
@@ -91,7 +91,7 @@ const MaintenanceScheduleList = (props: ScheduleListProps) => {
         onConfirm={() => props.onDelete(scheduleToDelete)}
         onClosePopUp={() => setScheduleToDelete({})}
       />
-    </div>
+    </>
   );
 };
 

--- a/web/html/src/manager/state/highstate-summary.tsx
+++ b/web/html/src/manager/state/highstate-summary.tsx
@@ -53,6 +53,7 @@ export default function HighstateSummary({ minionId }) {
   }
 
   return (
+    // TODO: This identifier seems wrong, what's the correct identifier here?
     <>
       <Table identifier={state => state.state} data={summary} initialItemsPerPage={0}>
         <Column header={t("State Source")} comparator={Utils.sortByText} columnKey="name" cell={source => <State minionId={minionId} state={source} />} />

--- a/web/html/src/manager/state/recurring-states-edit.tsx
+++ b/web/html/src/manager/state/recurring-states-edit.tsx
@@ -135,27 +135,25 @@ class RecurringStatesEdit extends React.Component<Props, State> {
     ];
 
     return (
-      <div>
-        <InnerPanel
-          title={t("Schedule Recurring Highstate")}
-          icon="spacewalk-icon-salt"
-          buttonsLeft={buttonsLeft}
-          buttons={buttons}
-        >
-          <RecurringEventPicker
-            timezone={window.timezone}
-            scheduleName={this.state.scheduleName}
-            type={this.state.type}
-            cron={this.state.cron}
-            cronTimes={this.state.cronTimes}
-            onScheduleNameChanged={this.onScheduleNameChanged}
-            onTypeChanged={this.onTypeChanged}
-            onCronTimesChanged={this.onCronTimesChanged}
-            onCronChanged={this.onCustomCronChanged}
-          />
-          {window.entityType === "NONE" ? null : <DisplayHighstate minions={this.state.minions} />}
-        </InnerPanel>
-      </div>
+      <InnerPanel
+        title={t("Schedule Recurring Highstate")}
+        icon="spacewalk-icon-salt"
+        buttonsLeft={buttonsLeft}
+        buttons={buttons}
+      >
+        <RecurringEventPicker
+          timezone={window.timezone}
+          scheduleName={this.state.scheduleName}
+          type={this.state.type}
+          cron={this.state.cron}
+          cronTimes={this.state.cronTimes}
+          onScheduleNameChanged={this.onScheduleNameChanged}
+          onTypeChanged={this.onTypeChanged}
+          onCronTimesChanged={this.onCronTimesChanged}
+          onCronChanged={this.onCustomCronChanged}
+        />
+        {window.entityType === "NONE" ? null : <DisplayHighstate minions={this.state.minions} />}
+      </InnerPanel>
     );
   }
 }

--- a/web/html/src/manager/state/recurring-states-list.tsx
+++ b/web/html/src/manager/state/recurring-states-list.tsx
@@ -52,7 +52,6 @@ class RecurringStatesList extends React.Component<Props, State> {
     ];
 
     return (
-      <div>
         <InnerPanel
           title={t("Recurring States")}
           icon="spacewalk-icon-salt"
@@ -146,7 +145,6 @@ class RecurringStatesList extends React.Component<Props, State> {
             </div>
           </div>
         </InnerPanel>
-      </div>
     );
   }
 }

--- a/web/html/src/manager/state/recurring-states.tsx
+++ b/web/html/src/manager/state/recurring-states.tsx
@@ -6,6 +6,7 @@ import { RecurringStatesList } from "./recurring-states-list";
 import { RecurringStatesEdit } from "./recurring-states-edit";
 import { Utils as MessagesUtils } from "components/messages";
 import SpaRenderer from "core/spa/spa-renderer";
+import { localizedMoment } from "utils";
 
 /**
  * See:
@@ -52,9 +53,7 @@ function inferEntityParams() {
   return "";
 }
 
-type Props = {
-
-};
+type Props = {};
 
 type State = {
   messages: any[];
@@ -80,7 +79,10 @@ class RecurringStates extends React.Component<Props, State> {
     this.state = {
       messages: [],
       schedules: [],
-      minionIds: (window.minions?.length ?? 0) > 0 && window.minions?.[0].id ? window.minions?.map(minion => minion.id) : undefined,
+      minionIds:
+        (window.minions?.length ?? 0) > 0 && window.minions?.[0].id
+          ? window.minions?.map(minion => minion.id)
+          : undefined,
     };
   }
 
@@ -204,17 +206,22 @@ class RecurringStates extends React.Component<Props, State> {
   };
 
   render() {
-    const messages = this.state.messages ? <Messages items={this.state.messages} /> : null;
-    const notification = (
-      <Messages
-        items={[
-          {
-            severity: "warning",
-            text: "The timezone displayed is the server timezone. The scheduled time will be the server time.",
-          },
-        ]}
-      />
-    );
+    const messages = this.state.messages ? <Messages key="state-messages" items={this.state.messages} /> : null;
+    const notification =
+      localizedMoment.userTimeZone !== localizedMoment.serverTimeZone ? (
+        <Messages
+          key="notification-messages"
+          items={[
+            {
+              severity: "warning",
+              text: t(
+                "The below times are displayed is the server time zone {0}. The scheduled time will be the server time.",
+                localizedMoment.serverTimeZone
+              ),
+            },
+          ]}
+        />
+      ) : null;
     return (
       <div>
         {messages}
@@ -227,14 +234,15 @@ class RecurringStates extends React.Component<Props, State> {
           />
         ) : (this.state.action === "edit" && this.state.selected) ||
           (this.state.action === "create" && this.isFilteredList()) ? (
-          [
-            notification,
+          <>
+            {notification}
             <RecurringStatesEdit
+              key="edit"
               schedule={this.state.selected}
               onEdit={this.updateSchedule}
               onActionChanged={this.handleForwardAction}
-            />,
-          ]
+            />
+          </>
         ) : (
           <RecurringStatesList
             data={this.state.schedules}

--- a/web/html/src/manager/state/recurring-states.tsx
+++ b/web/html/src/manager/state/recurring-states.tsx
@@ -215,7 +215,7 @@ class RecurringStates extends React.Component<Props, State> {
             {
               severity: "warning",
               text: t(
-                "The below times are displayed is the server time zone {0}. The scheduled time will be the server time.",
+                "The below times are displayed in the server time zone {0}. The scheduled time will be the server time.",
                 localizedMoment.serverTimeZone
               ),
             },


### PR DESCRIPTION
## What does this PR change?

Fixes time zone offset problems in recurring events views.  

Also fixes a number of missing key bugs and related issues I found when debugging the recurring events view.

## GUI diff

Minor cosmetic difference, nothing to document.

- [x] **DONE**

## Documentation
- No documentation needed: only very minor user invisible changes.

- [x] **DONE**

## Test coverage
- No tests: already covered by Cucumber which uncovered this problem.

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/15841

Part of https://github.com/SUSE/spacewalk/issues/9049

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
