### PR TITLE
Add missing string on XCCDF scan results (bsc#1190164)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -12763,6 +12763,12 @@ the &lt;strong&gt;@@ENTERPRISE_LINUX_NAME@@ System Administration Guide.&lt;/str
           <context context-type="sourcefile">Detailed view of SCAP XCCDF scan</context>
         </context-group>
         </trans-unit>
+        <trans-unit id="system.audit.xccdfdetails.jsp.ovalfiles">
+          <source>Optional OVAL Files</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">Detailed view of SCAP XCCDF scan</context>
+        </context-group>
+        </trans-unit>
         <trans-unit id="system.audit.xccdfdetails.jsp.title">
           <source>Profile Title</source>
         <context-group name="ctx">

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add missing string on XCCDF scan results (bsc#1190164)
 - Support syncing patches with advisory status 'pending'
 - Updated Enterprise Linux servlet requirement.
 - Ignore duplicates in 'pkg.installed' result when applying patches (bsc#1187572)


### PR DESCRIPTION
## What does this PR change?

This PR simply adds a missing string definition shown in the XCCDF scan results page.

## GUI diff

Now the missing string is visible

- [x] **DONE**

## Documentation
- No documentation needed: **bugfix**
- 
- [x] **DONE**

## Test coverage
- No tests: **cosmetic change**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/15824

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
