### PR TITLE
Make hostname renaming a smoother experience

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
@@ -438,6 +438,18 @@ ORDER BY  UPPER(COALESCE(S.NAME, '(none)')), S.ID
   <elaborator name="system_overview" />
 </mode>
 
+<mode name="systems_with_entitlement" class="com.redhat.rhn.frontend.dto.SystemOverview">
+  <query params="user_id, entitlement_label">
+SELECT  S.id, S.name
+  FROM  rhnServer S, rhnServerEntitlementView E
+ WHERE  S.id = E.server_id
+   AND  E.label = :entitlement_label
+   AND  EXISTS (SELECT 1 FROM rhnUserServerPerms USP WHERE USP.user_id = :user_id AND USP.server_id = S.id)
+ORDER BY  UPPER(COALESCE(S.NAME, '(none)')), S.ID
+  </query>
+  <elaborator name="system_overview" />
+</mode>
+
 <mode name="target_systems_for_channel" class="com.redhat.rhn.frontend.dto.SystemOverview">
   <query params="org_id, cid, user_id">
 SELECT ES.id, S.name, 1 as selectable

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -5622,6 +5622,29 @@ public class SystemHandler extends BaseHandler {
     }
 
     /**
+     * Method to list systems having a given entitlement
+     *
+     * @param loggedInUser the current user
+     * @param entitlementName the entitlement name to look for
+     * @return an array of systemOverview objects
+     *
+     * @xmlrpc.doc Lists the systems that have the given entitlement
+     * @xmlrpc.param #param("string", "sessionKey")
+     * @xmlrpc.param #param_desc("string", "entitlementName", "the entitlement name")
+     * @xmlrpc.returntype
+     *              #array_begin()
+     *                  $SystemOverviewSerializer
+     *              #array_end()
+     */
+    public List<SystemOverview> listSystemsWithEntitlement(User loggedInUser, String entitlementName) {
+        Entitlement entitlement = EntitlementManager.getByName(entitlementName);
+        if (entitlement == null) {
+            throw new InvalidEntitlementException(entitlementName);
+        }
+        return SystemManager.listSystemsWithEntitlement(loggedInUser, entitlement);
+    }
+
+    /**
      * Gets a list of all Physical systems visible to user
      * @param loggedInUser The current user
      * @return Returns an array of maps representing all systems visible to user

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
@@ -3032,6 +3032,22 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
         assertTrue(VersionConstraints.LATEST.id() == packageStates.iterator().next().getVersionConstraintId());
     }
 
+    /**
+     * Test the SystemHandler.refreshPillar method
+     * @throws Exception if anything failed
+     */
+    public void testRefreshPillar() throws Exception {
+        MinionServer server1 = MinionServerFactoryTest.createTestMinionServer(admin);
+        MinionServer server2 = MinionServerFactoryTest.createTestMinionServer(admin);
+        Server server3 = ServerFactoryTest.createTestServer(admin);
+
+        SystemHandler systemHandler = getMockedHandler();
+        List<Integer> skipped = systemHandler.refreshPillar(admin, "General",
+                List.of(server1.getId().intValue(), server2.getId().intValue(), server3.getId().intValue()));
+        assertEquals(1, skipped.size());
+        assertEquals(Integer.valueOf(server3.getId().intValue()), skipped.get(0));
+    }
+
     private SystemHandler getMockedHandler() throws Exception {
         TaskomaticApi taskomaticMock = MOCK_CONTEXT.mock(TaskomaticApi.class);
         SystemHandler systemHandler = new SystemHandler(taskomaticMock, xmlRpcSystemHelper, systemEntitlementManager,

--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -2606,6 +2606,24 @@ public class SystemManager extends BaseManager {
     }
 
     /**
+     * List all systems with the given entitlement
+     *
+     * @param user the user doing the search
+     * @param entitlement the entitlement to match
+     * @return list of SystemOverview objects
+     */
+    public static List<SystemOverview> listSystemsWithEntitlement(User user, Entitlement entitlement) {
+        SelectMode m = ModeFactory.getMode("System_queries",
+                "systems_with_entitlement");
+        Map<String, Object> params = new HashMap<String, Object>();
+        params.put("user_id", user.getId());
+        params.put("entitlement_label", entitlement.getLabel());
+        DataResult<SystemOverview> toReturn = m.execute(params);
+        toReturn.elaborate();
+        return toReturn;
+    }
+
+    /**
      * Returns the number of systems subscribed to the channel that are
      * <strong>not</strong> in the given org.
      *

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add XMLRPC API to force refreshing pillar data (bsc#1190123)
 - Add missing string on XCCDF scan results (bsc#1190164)
 - Support syncing patches with advisory status 'pending'
 - Updated Enterprise Linux servlet requirement.

--- a/utils/spacewalk-hostname-rename
+++ b/utils/spacewalk-hostname-rename
@@ -73,7 +73,7 @@ IPADDR_REGEX="($IPV4ADDR_REGEX)|($IPV6ADDR_REGEX)"
 
 function echo_usage {
     echo "Usage:"
-    echo "   $(basename $0) <IP_ADDRESS> [ --ssl-country=<SSL_COUNTRY> --ssl-state=<SSL_STATE> --ssl-city=<SSL_CITY> --ssl-org=<SSL_ORG> --ssl-orgunit=<SSL_ORGUNIT> --ssl-email=<SSL_EMAIL> --ssl-ca-password=<SSL_CA_PASSWORD>]"
+    echo "   $(basename $0) <IP_ADDRESS> [ --ssl-country=<SSL_COUNTRY> --ssl-state=<SSL_STATE> --ssl-city=<SSL_CITY> --ssl-org=<SSL_ORG> --ssl-orgunit=<SSL_ORGUNIT> --ssl-email=<SSL_EMAIL> --ssl-ca-password=<SSL_CA_PASSWORD> --ssl-ca-cert=<PATH> --ssl-server-key=<PATH> --ssl-server-cert=<PATH>]"
     echo "   $(basename $0) { -h | --help }"
     exit 1
 }
@@ -227,8 +227,8 @@ function re-generate_server_ssl_certificate {
 
         if [ ! -n "$CML_NEW_SSL_CERT_REQUEST" ]
         then
-            # Common Name is prefilled by actuall HOSTNAME
-            HOSTNAME_CERT=`awk "/Subject:/ && /, CN=$HOSTNAME\//" $CERT_FILE`
+            # Common Name is prefilled by actual HOSTNAME
+            HOSTNAME_CERT=`awk "/Subject:/ && /, CN=$HOSTNAME(\/|$)/" $CERT_FILE`
             if [ -n "$HOSTNAME_CERT" ]
             then
                 echo " No need to re-generate SSL certificate." | tee -a $LOG
@@ -237,123 +237,157 @@ function re-generate_server_ssl_certificate {
         fi
     fi
 
-    # is there a need to re-generate SSL certificate?
-    if [ -n "$CML_NEW_SSL_CERT_REQUEST" -o "$GEN_NEW_SSL" == "y" ]
+    if [ -n "$CML_NEW_SSL_CERT_REQUEST" -o "$GEN_NEW_SSL" == "y" -o -n "$CML_THIRD_PARTY_CERT" ]
     then
-        if [ -n "$SUBJECT" ]
-        then
-            SUBJECT_PATTERN='[[:space:]]*Subject: C=\(..*\), ST=\(..*\), O=\(..*\), OU=\(..*\), CN=\(..*\)\/emailAddress=\(..*\)'
-            SSL_COUNTRY_OLD=`echo $SUBJECT | sed "s/$SUBJECT_PATTERN/\1/"`
-            SSL_STATE_OLD=`echo $SUBJECT | sed "s/$SUBJECT_PATTERN/\2/"`
-            SSL_CITY_OLD=`echo $SUBJECT | sed "s/$SUBJECT_PATTERN/\2/"`
-            SSL_ORG_OLD=`echo $SUBJECT | sed "s/$SUBJECT_PATTERN/\3/"`
-            SSL_ORGUNIT_OLD=`echo $SUBJECT | sed "s/$SUBJECT_PATTERN/\4/"`
-            SSL_EMAIL_OLD=`echo $SUBJECT | sed "s/$SUBJECT_PATTERN/\6/"`
-        fi
 
-        echo "Starting generation of new SSL certificate:"
-        # COUNTRY
-        if [ -n "${CML_SSL_COUNTRY+x}" ]
+        # is there a need to re-generate SSL certificate?
+        if [ -n "$CML_THIRD_PARTY_CERT" ]
         then
-            SSL_COUNTRY=${CML_SSL_COUNTRY}
+            echo "Generating SSL packages:"
+            echo "rhn-ssl-tool --gen-ca --rpm-only \
+                --dir="$SSL_BUILD_DIR" \
+                --from-ca-cert="${CML_SSL_CA_CERT}" \
+            " >> $LOG
+            rhn-ssl-tool --gen-ca --rpm-only \
+                --dir="$SSL_BUILD_DIR" \
+                --from-ca-cert="${CML_SSL_CA_CERT}" \
+                2>>$LOG
+            echo "rhn-ssl-tool --gen-server --rpm-only \
+                --dir="$SSL_BUILD_DIR" \
+                --from-server-key="${CML_SSL_SERVER_KEY}" \
+                --from-server-cert="${CML_SSL_SERVER_CERT}" \
+            " >> $LOG
+            SSL_KEY_PAIR_RPM=`rhn-ssl-tool --gen-server --rpm-only \
+                --dir="$SSL_BUILD_DIR" \
+                --from-server-key="${CML_SSL_SERVER_KEY}" \
+                --from-server-cert="${CML_SSL_SERVER_CERT}" \
+                2>>$LOG | grep noarch.rpm`
+            GEN_NEW_CA="y"
         else
-            read -e -p " Enter Country [$SSL_COUNTRY_OLD] : "
-            SSL_COUNTRY=${REPLY:-$SSL_COUNTRY_OLD}
-        fi
-        # STATE
-        if [ -n "${CML_SSL_STATE+x}" ]
-        then
-            SSL_STATE=${CML_SSL_STATE}
-        else
-            read -e -p " Enter State [$SSL_STATE_OLD] : "
-            SSL_STATE=${REPLY:-$SSL_STATE_OLD}
-        fi
-        # CITY
-        if [ -n "${CML_SSL_CITY+x}" ]
-        then
-            SSL_CITY=${CML_SSL_CITY}
-        else
-            read -e -p " Enter City [$SSL_CITY_OLD] : "
-            SSL_CITY=${REPLY:-$SSL_CITY_OLD}
-        fi
-        # ORGANIZATION
-        if [ -n "${CML_SSL_ORG+x}" ]
-        then
-            SSL_ORG=${CML_SSL_ORG}
-        else
-            read -e -p " Enter Organization [$SSL_ORG_OLD] : "
-            SSL_ORG=${REPLY:-$SSL_ORG_OLD}
-        fi
-        # ORGANIZATION UNIT
-        if [ -n "${CML_SSL_ORGUNIT+x}" ]
-        then
-            SSL_ORGUNIT=${CML_SSL_ORGUNIT}
-        else
-            # offer hostname as ORG UNIT everytime
-            read -e -p " Enter Organization Unit [$HOSTNAME] : "
-            SSL_ORGUNIT=${REPLY:-$HOSTNAME}
-        fi
-        # EMAIL ADDRESS
-        if [ -n "${CML_SSL_EMAIL+x}" ]
-        then
-            SSL_EMAIL=${CML_SSL_EMAIL}
-        else
-            read -e -p " Enter Email Address [$SSL_EMAIL_OLD] : "
-            SSL_EMAIL=${REPLY:-$SSL_EMAIL_OLD}
-        fi
-        # CA PASSWORD
-        # ask explicitelly (different behaviour on sat and spw)
-        if [ -n "${CML_SSL_CA_PASSWORD+x}" ]
-        then
-            SSL_CA_PASSWORD=${CML_SSL_CA_PASSWORD}
-        else
-            read -e -p " Enter CA password : " -s
-            echo
-            SSL_CA_PASSWORD=${REPLY}
-        fi
+            if [ -n "$SUBJECT" ]
+            then
+                SUBJECT_PATTERN='[[:space:]]*Subject: C=\(..*\), ST=\(..*\), O=\(..*\), OU=\(..*\), CN=\(..*\)\/emailAddress=\(..*\)'
+                SSL_COUNTRY_OLD=`echo $SUBJECT | sed "s/$SUBJECT_PATTERN/\1/"`
+                SSL_STATE_OLD=`echo $SUBJECT | sed "s/$SUBJECT_PATTERN/\2/"`
+                SSL_CITY_OLD=`echo $SUBJECT | sed "s/$SUBJECT_PATTERN/\2/"`
+                SSL_ORG_OLD=`echo $SUBJECT | sed "s/$SUBJECT_PATTERN/\3/"`
+                SSL_ORGUNIT_OLD=`echo $SUBJECT | sed "s/$SUBJECT_PATTERN/\4/"`
+                SSL_EMAIL_OLD=`echo $SUBJECT | sed "s/$SUBJECT_PATTERN/\6/"`
+            fi
 
-        echo " Generating SSL certificates:" | tee -a $LOG
-        # just log the SSL info ...
-        echo "rhn-ssl-tool --gen-ca --force \
-            --dir="$SSL_BUILD_DIR" \
-            --set-country="$SSL_COUNTRY" \
-            --set-state="$SSL_STATE" \
-            --set-city="$SSL_CITY" \
-            --set-org="$SSL_ORG" \
-            --set-org-unit="$SSL_ORGUNIT" \
-            --set-common-name="${HOSTNAME}" \
-        " >> $LOG
-        rhn-ssl-tool --gen-ca --force \
-            --dir="$SSL_BUILD_DIR" \
-            --set-country="$SSL_COUNTRY" \
-            --set-state="$SSL_STATE" \
-            --set-city="$SSL_CITY" \
-            --set-org="$SSL_ORG" \
-            --set-org-unit="$SSL_ORGUNIT" \
-            --set-common-name="${HOSTNAME}" \
-            --password="$SSL_CA_PASSWORD" \
-            2>>$LOG
-        echo "rhn-ssl-tool --gen-server \
-            --dir="$SSL_BUILD_DIR" \
-            --set-country="$SSL_COUNTRY" \
-            --set-state="$SSL_STATE" \
-            --set-city="$SSL_CITY" \
-            --set-org="$SSL_ORG" \
-            --set-org-unit="$SSL_ORGUNIT" \
-            --set-email="$SSL_EMAIL" \
-            --set-hostname="${HOSTNAME}" \
-        " >> $LOG
-        SSL_KEY_PAIR_RPM=`rhn-ssl-tool --gen-server \
-            --dir="$SSL_BUILD_DIR" \
-            --set-country="$SSL_COUNTRY" \
-            --set-state="$SSL_STATE" \
-            --set-city="$SSL_CITY" \
-            --set-org="$SSL_ORG" \
-            --set-org-unit="$SSL_ORGUNIT" \
-            --set-email="$SSL_EMAIL" \
-            --set-hostname="${HOSTNAME}" \
-            --password="$SSL_CA_PASSWORD" \
-            2>>$LOG | grep noarch.rpm`
+            echo "Starting generation of new SSL certificate:"
+            # COUNTRY
+            if [ -n "${CML_SSL_COUNTRY+x}" ]
+            then
+                SSL_COUNTRY=${CML_SSL_COUNTRY}
+            else
+                read -e -p " Enter Country [$SSL_COUNTRY_OLD] : "
+                SSL_COUNTRY=${REPLY:-$SSL_COUNTRY_OLD}
+            fi
+            # STATE
+            if [ -n "${CML_SSL_STATE+x}" ]
+            then
+                SSL_STATE=${CML_SSL_STATE}
+            else
+                read -e -p " Enter State [$SSL_STATE_OLD] : "
+                SSL_STATE=${REPLY:-$SSL_STATE_OLD}
+            fi
+            # CITY
+            if [ -n "${CML_SSL_CITY+x}" ]
+            then
+                SSL_CITY=${CML_SSL_CITY}
+            else
+                read -e -p " Enter City [$SSL_CITY_OLD] : "
+                SSL_CITY=${REPLY:-$SSL_CITY_OLD}
+            fi
+            # ORGANIZATION
+            if [ -n "${CML_SSL_ORG+x}" ]
+            then
+                SSL_ORG=${CML_SSL_ORG}
+            else
+                read -e -p " Enter Organization [$SSL_ORG_OLD] : "
+                SSL_ORG=${REPLY:-$SSL_ORG_OLD}
+            fi
+            # ORGANIZATION UNIT
+            if [ -n "${CML_SSL_ORGUNIT+x}" ]
+            then
+                SSL_ORGUNIT=${CML_SSL_ORGUNIT}
+            else
+                # offer hostname as ORG UNIT everytime
+                read -e -p " Enter Organization Unit [$HOSTNAME] : "
+                SSL_ORGUNIT=${REPLY:-$HOSTNAME}
+            fi
+            # EMAIL ADDRESS
+            if [ -n "${CML_SSL_EMAIL+x}" ]
+            then
+                SSL_EMAIL=${CML_SSL_EMAIL}
+            else
+                read -e -p " Enter Email Address [$SSL_EMAIL_OLD] : "
+                SSL_EMAIL=${REPLY:-$SSL_EMAIL_OLD}
+            fi
+            # CA PASSWORD
+            # ask explicitelly (different behaviour on sat and spw)
+            if [ -n "${CML_SSL_CA_PASSWORD+x}" ]
+            then
+                SSL_CA_PASSWORD=${CML_SSL_CA_PASSWORD}
+            else
+                read -e -p " Enter CA password : " -s
+                echo
+                SSL_CA_PASSWORD=${REPLY}
+            fi
+
+            echo " Generating SSL certificates:" | tee -a $LOG
+            CA_RPM=$(grep noarch.rpm $SSL_BUILD_DIR/latest.txt)
+            GEN_NEW_CA="n"
+            if [ -z "$CA_RPM" -o ! -f $SSL_BUILD_DIR/$CA_RPM ]; then
+                GEN_NEW_CA="y"
+                # We don't have the CA in SSL build dir: generate a new one
+                echo " Generating SSL CA Certificate:" | tee -a $LOG
+                # just log the SSL info ...
+                echo "rhn-ssl-tool --gen-ca --force \
+                    --dir="$SSL_BUILD_DIR" \
+                    --set-country="$SSL_COUNTRY" \
+                    --set-state="$SSL_STATE" \
+                    --set-city="$SSL_CITY" \
+                    --set-org="$SSL_ORG" \
+                    --set-org-unit="$SSL_ORGUNIT" \
+                    --set-common-name="${HOSTNAME}" \
+                " >> $LOG
+                rhn-ssl-tool --gen-ca --force \
+                    --dir="$SSL_BUILD_DIR" \
+                    --set-country="$SSL_COUNTRY" \
+                    --set-state="$SSL_STATE" \
+                    --set-city="$SSL_CITY" \
+                    --set-org="$SSL_ORG" \
+                    --set-org-unit="$SSL_ORGUNIT" \
+                    --set-common-name="${HOSTNAME}" \
+                    --password="$SSL_CA_PASSWORD" \
+                    2>>$LOG
+            else
+                echo " No need to generate a new SSL CA Certificate" | tee -a $LOG
+            fi
+            echo "rhn-ssl-tool --gen-server \
+                --dir="$SSL_BUILD_DIR" \
+                --set-country="$SSL_COUNTRY" \
+                --set-state="$SSL_STATE" \
+                --set-city="$SSL_CITY" \
+                --set-org="$SSL_ORG" \
+                --set-org-unit="$SSL_ORGUNIT" \
+                --set-email="$SSL_EMAIL" \
+                --set-hostname="${HOSTNAME}" \
+            " >> $LOG
+            SSL_KEY_PAIR_RPM=`rhn-ssl-tool --gen-server \
+                --dir="$SSL_BUILD_DIR" \
+                --set-country="$SSL_COUNTRY" \
+                --set-state="$SSL_STATE" \
+                --set-city="$SSL_CITY" \
+                --set-org="$SSL_ORG" \
+                --set-org-unit="$SSL_ORGUNIT" \
+                --set-email="$SSL_EMAIL" \
+                --set-hostname="${HOSTNAME}" \
+                --password="$SSL_CA_PASSWORD" \
+                2>>$LOG | grep noarch.rpm`
+        fi
 
         if [ ! -n "$SSL_KEY_PAIR_RPM" ]
         then
@@ -372,9 +406,11 @@ function re-generate_server_ssl_certificate {
         rpm -Uh $SSL_KEY_PAIR_RPM >>$LOG
         print_status $?
 
-        echo -n "Making new SSL certificate publicly available ... " | tee -a $LOG
-        /usr/bin/rhn-deploy-ca-cert.pl --source-dir=$SSL_BUILD_DIR --target-dir=$HTTP_PUB_DIR --trust-dir=$CA_CERT_TRUST_DIR
-        print_status $?
+        if [ $GEN_NEW_CA == "y" ]; then
+            echo -n "Making new SSL certificate publicly available ... " | tee -a $LOG
+            /usr/bin/rhn-deploy-ca-cert.pl --source-dir=$SSL_BUILD_DIR --target-dir=$HTTP_PUB_DIR --trust-dir=$CA_CERT_TRUST_DIR
+            print_status $?
+        fi
 
         # copy jabberd certificate, too
         echo -n "Deploying jabberd certificate ... " | tee -a $LOG
@@ -390,6 +426,25 @@ function re-generate_server_ssl_certificate {
     fi
 }
 
+function refresh_pillar {
+    echo -n "Refreshing Salt minion pillar data, may take a while ... " | tee -a $LOG
+    for ID in `spacecmd -q api system.listSystemsWithEntitlement -- -A "salt_entitled" -F "%(id)s"`
+    do
+        if [ -n "$SIDS" ]
+        then
+            SIDS="$SIDS,$ID"
+        else
+            SIDS="$SID"
+        fi
+    done
+    SKIPPED=`spacecmd -q api system.refreshPillar -- -A "[\\\\\"general\\\\\",[$SIDS]]"`
+    if [ "$SKIPPED" != "[]" ]
+    then
+        echo "Some minions pillar have not been refreshed: $SKIPPED" | tee -a $LOG
+        print_status 1
+    fi
+    print_status 0
+}
 ###############################################################################
 
 echo "[$(date)]: $0 $*" >> $LOG
@@ -412,6 +467,10 @@ while [ $# -ge 1 ]; do
             --ssl-email=*) CML_SSL_EMAIL=$(echo $1 | cut -d= -f2-);;
 
             --ssl-ca-password=*) CML_SSL_CA_PASSWORD=$(echo $1 | cut -d= -f2-);;
+
+            --ssl-ca-cert=*) CML_SSL_CA_CERT=$(echo $1 | cut -d= -f2-);;
+            --ssl-server-cert=*) CML_SSL_SERVER_CERT=$(echo $1 | cut -d= -f2-);;
+            --ssl-server-key=*) CML_SSL_SERVER_KEY=$(echo $1 | cut -d= -f2-);;
             *) echo_err "Error: Invalid option $1"
                echo_usage;;
     esac
@@ -434,6 +493,17 @@ for ssl_var in ${CML_SSL_COUNTRY} ${CML_SSL_STATE} ${CML_SSL_CITY} ${CML_SSL_ORG
 do
     [ -n "${ssl_var}" ] && CML_NEW_SSL_CERT_REQUEST=1
 done
+
+if [ -n "${CML_SSL_CA_CERT}" -a -n "${CML_SSL_SERVER_KEY}" -a -n "${CML_SSL_SERVER_CERT}" ]
+then
+    CML_THIRD_PARTY_CERT=1
+else
+    if [ -n "${CML_SSL_CA_CERT}" -o -n "${CML_SSL_SERVER_CERT}" -o -n "${CML_SSL_SERVER_KEY}" ]
+    then
+        echo_err "Either all or none of --ssl-ca-cert, --ssl-server-key and --ssl-server-cert must be provided"
+        echo_usage
+    fi
+fi
 
 OLD_HOSTNAME=$(grep ^redhat_management_server /etc/cobbler/settings | awk '{print $2}')
 
@@ -593,5 +663,8 @@ then
 fi
 /usr/sbin/spacewalk-service start >> $LOG 2>&1
 print_status 0  # just simulate end
+
+# Refresh the minion pillar data since they contain the repos URLs with the old hostname
+refresh_pillar
 
 echo "[$(date)]: $(basename $0) finished successfully." >> $LOG

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,6 @@
+- When renaming: don't regenerate CA, allow using third-party
+  certificate and trigger pillar refresh (bsc#1190123)
+
 -------------------------------------------------------------------
 Mon Aug 09 11:07:38 CEST 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Fix the `spacewalk-hostname-rename` script to:
 * Avoid generating a new SSL CA if not needed
 * Allow using third-party SSL certificate
 * Refresh the minion pillar data since they also contain the server hostname in the repositories URLs

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- PR submitted: https://github.com/uyuni-project/uyuni-docs/pull/1158

- [X] **DONE**

## Test coverage
- Unit tests were added
- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/15801

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
