### PR TITLE
spacecmd: enhacements for mass delete/archive actions (bsc#181223)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/schedule/ScheduleHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/schedule/ScheduleHandler.java
@@ -263,6 +263,24 @@ public class ScheduleHandler extends BaseHandler {
     }
 
     /**
+     * List all the scheduled actions that have been completed.
+     * @param loggedInUser The current user
+     * @return Returns a list of actions with details
+     *
+     * @xmlrpc.doc Returns a list of actions that have been completed.
+     * @xmlrpc.param #session_key()
+     * @xmlrpc.returntype
+     * #array_begin()
+     *   $ScheduleActionSerializer
+     * #array_end()
+     */
+    public Object[] listAllCompletedActions(User loggedInUser) {
+        // the second argument is "PageControl". This is not needed for the api usage;
+        // therefore, null will be used.
+        return ActionManager.allCompletedActions(loggedInUser, null).toArray();
+    }
+
+    /**
      * List the systems that have a specific action in progress.
      * @param loggedInUser The current user
      * @param actionId The id of the action.

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/schedule/test/ScheduleHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/schedule/test/ScheduleHandlerTest.java
@@ -250,6 +250,40 @@ public class ScheduleHandlerTest extends BaseHandlerTestCase {
         assertTrue(apiActions.length > apiActionsLimitted.length);
     }
 
+    public void testListAllCompletedActions() throws Exception {
+        //obtain number of actions from action manager
+        DataResult actions = ActionManager.allCompletedActions(admin, null);
+        int numActions = actions.size();
+
+        //compare against number retrieved from api... should be the same
+        Object[] apiActions = handler.listAllCompletedActions(admin);
+        assertEquals(numActions, apiActions.length);
+
+        //add a new action and verify that the value returned by the api
+        //has increased
+        Server server = ServerFactoryTest.createTestServer(admin, true);
+        Action a = ActionFactoryTest.createAction(admin,
+                ActionFactory.TYPE_PACKAGES_UPDATE);
+        ServerAction saction = ServerActionTest.createServerAction(server, a);
+        saction.setStatus(ActionFactory.STATUS_COMPLETED);
+
+        Action a2 = ActionFactoryTest.createAction(admin,
+                ActionFactory.TYPE_PACKAGES_UPDATE);
+        ServerAction saction2 = ServerActionTest.createServerAction(server, a2);
+        saction2.setStatus(ActionFactory.STATUS_COMPLETED);
+
+        apiActions = handler.listAllCompletedActions(admin);
+        assertTrue(apiActions.length > numActions);
+
+        int oldLimit = ConfigDefaults.get().getActionsDisplayLimit();
+        Config.get().setString(ConfigDefaults.ACTIONS_DISPLAY_LIMIT, "1");
+        Object[] apiActionsLimitted = handler.listCompletedActions(admin);
+        Config.get().setString(ConfigDefaults.ACTIONS_DISPLAY_LIMIT, String.valueOf(oldLimit));
+
+        assertEquals(apiActionsLimitted.length, 1);
+        assertTrue(apiActions.length > apiActionsLimitted.length);
+    }
+
     public void testListCompletedSystems() throws Exception {
         //create a new action
         Server server = ServerFactoryTest.createTestServer(admin, true);

--- a/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
+++ b/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
@@ -895,6 +895,16 @@ public class ActionManager extends BaseManager {
     }
 
     /**
+     * Retrieve the list of all completed actions for a particular user
+     * @param user The user in question
+     * @param pc The details of which results to return
+     * @return A list containing the pending actions for the user
+     */
+    public static DataResult allCompletedActions(User user, PageControl pc) {
+        return getActions(user, pc, "completed_action_list", null, true);
+    }
+
+    /**
      * Retrieve the list of archived actions for a particular user
      * @param user The user in question
      * @param pc The details of which results to return

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Allow getting all completed actions via XMLRPC without display limit (bsc#1181223)
 - Add XMLRPC API to force refreshing pillar data (bsc#1190123)
 - Add missing string on XCCDF scan results (bsc#1190164)
 - Support syncing patches with advisory status 'pending' (bsc#1190455)

--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,4 @@
+- Add schedule_archivecompleted to mass archive actions (bsc#1181223)
 - Make schedule_deletearchived to get all actions without display limit
 - Allow passing a date limit for schedule_deletearchived on spacecmd (bsc#1181223)
 - Remove whoami from the list of unauthenticated commands (bsc#1188977)

--- a/spacecmd/src/spacecmd/schedule.py
+++ b/spacecmd/src/spacecmd/schedule.py
@@ -507,3 +507,59 @@ def do_schedule_deletearchived(self, args):
                 print("Deleted {} actions of {}".format(processed, len(action_ids)))
     else:
         print(_("No archived actions found."))
+
+####################
+
+
+def help_schedule_archivecompleted(self):
+    print(_('schedule_archivecompleted: Archive all completed actions older than given date.'))
+    print(_('usage: schedule_archivecompleted [yyyymmdd]'))
+    print('')
+    print(_('If no date is provided it will archive all completed actions'))
+
+def do_schedule_archivecompleted(self, args):
+    """
+    This method removes all of the completed actions older than provided date.
+    If no date is provided it will archive all completed actions.
+    """
+    arg_parser = get_argument_parser()
+    arg_parser.add_argument('-y', '--yes', default=False, action="store_true")
+
+    (args, _options) = parse_command_arguments(args, arg_parser)
+
+    if args:
+        date_limit = parse_time_input(args[0])
+        logging.debug('Date limit: %s' % date_limit)
+    else:
+        date_limit = None
+
+    actions = self.client.schedule.listAllCompletedActions(self.session)
+
+    # Filter out actions by date if limit is set
+    if date_limit:
+        actions = [action for action in actions if action.get('earliest') < date_limit]
+
+    logging.debug("actions: {}".format(actions))
+    if actions:
+        if not _options.yes:
+            user_answer = prompt_user(_("Do you want to archive ({}) completed actions? [y/N]").format(len(actions)))
+            if user_answer not in ("y", "Y", "yes", "Yes", "YES"):
+                return
+
+        # Collect IDs of actions that should be archived
+        action_ids = [action.get('id') for action in actions]
+
+        # Remove duplicates if any
+        # set needs to be cast to list, since set cannot be marshalled
+        action_ids = list(set(action_ids))
+
+        if action_ids:
+            # Process archiving in batches
+            BATCH_SIZE = 500
+            for i in range(0, len(action_ids), BATCH_SIZE):
+                # Pass list of actions that should be archived
+                self.client.schedule.archiveActions(self.session, action_ids[i:i + BATCH_SIZE])
+                processed = i + BATCH_SIZE if i + BATCH_SIZE <= len(action_ids) else len(action_ids)
+                print("Archived {} actions of {}".format(processed, len(action_ids)))
+    else:
+        print(_("No completed actions found."))

--- a/spacecmd/src/spacecmd/schedule.py
+++ b/spacecmd/src/spacecmd/schedule.py
@@ -457,7 +457,10 @@ def do_schedule_list(self, args):
 
 def help_schedule_deletearchived(self):
     print(_('schedule_deletearchived: Delete all archived actions older than given date.'))
-    print(_('usage: schedule_deletearchived [yyyymmdd]'))
+    print(_('usage: schedule_deletearchived [yyyymmdd] [options]'))
+    print(_('''
+options:
+  -y, --yes   Confirm without prompt'''))
     print('')
     print(_('If no date is provided it will delete all archived actions'))
 
@@ -513,7 +516,10 @@ def do_schedule_deletearchived(self, args):
 
 def help_schedule_archivecompleted(self):
     print(_('schedule_archivecompleted: Archive all completed actions older than given date.'))
-    print(_('usage: schedule_archivecompleted [yyyymmdd]'))
+    print(_('usage: schedule_archivecompleted [yyyymmdd] [options]'))
+    print(_('''
+options:
+  -y, --yes   Confirm without prompt'''))
     print('')
     print(_('If no date is provided it will archive all completed actions'))
 

--- a/spacecmd/src/spacecmd/schedule.py
+++ b/spacecmd/src/spacecmd/schedule.py
@@ -495,7 +495,7 @@ def do_schedule_deletearchived(self, args):
 
         if action_ids:
             # Process deletion in batches
-            BATCH_SIZE = 50
+            BATCH_SIZE = 500
             for i in range(0, len(action_ids), BATCH_SIZE):
                 # Pass list of actions that should be deleted
                 self.client.schedule.deleteActions(self.session, action_ids[i:i + BATCH_SIZE])

--- a/spacecmd/src/spacecmd/schedule.py
+++ b/spacecmd/src/spacecmd/schedule.py
@@ -466,7 +466,10 @@ def do_schedule_deletearchived(self, args):
     This method removes all of the archived actions older than provided date.
     If no date is provided it will delete all archived actions.
     """
-    args = args.split() or []
+    arg_parser = get_argument_parser()
+    arg_parser.add_argument('-y', '--yes', default=False, action="store_true")
+
+    (args, _options) = parse_command_arguments(args, arg_parser)
 
     if args:
         date_limit = parse_time_input(args[0])
@@ -482,9 +485,10 @@ def do_schedule_deletearchived(self, args):
 
     logging.debug("actions: {}".format(actions))
     if actions:
-        user_answer = prompt_user(_("Do you want to delete ({}) archived actions? [y/N]").format(len(actions)))
-        if user_answer not in ("y", "Y", "yes", "Yes", "YES"):
-            return
+        if not _options.yes:
+            user_answer = prompt_user(_("Do you want to delete ({}) archived actions? [y/N]").format(len(actions)))
+            if user_answer not in ("y", "Y", "yes", "Yes", "YES"):
+                return
 
         # Collect IDs of actions that should be deleted
         action_ids = [action.get('id') for action in actions]


### PR DESCRIPTION
## What does this PR change?

This is a follows-up PR from https://github.com/uyuni-project/uyuni/pull/4007

This new PR introduces some more enhacements to "spacecmd" in order to do operate massively with actions:

- Add new `schedule_archivecompleted` fuction to massively archive completed actions older than a given date.
- Allow "non-interactive" usage of `schedule_deletearchived` and `schedule_archivecompleted` by allowing `-y|--yes` argument.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **no documentation for spacecmd**

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/14196

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
