### PR TITLE
Fix Cucumber selectors for datetime pickers

### DIFF
--- a/testsuite/features/step_definitions/datepicker_steps.rb
+++ b/testsuite/features/step_definitions/datepicker_steps.rb
@@ -24,7 +24,7 @@ end
 
 Given(/^I pick "([^"]*)" as date$/) do |desired_date|
   value = Date.parse(desired_date)
-  date_input = find('input[data-provide="date-picker"]')
+  date_input = find('input[data-testid="date-picker"]')
   date_input.click
   picker = find(:xpath, '//body').find('.datepicker')
   picker_years = picker.find('.datepicker-years', visible: false)
@@ -62,7 +62,7 @@ Then(/^the date field is set to "([^"]*)"$/) do |arg1|
 end
 
 Given(/^I open the date picker$/) do
-  find('input[data-provide="date-picker"]').click
+  find('input[data-testid="date-picker"]').click
 end
 
 Then(/^the date picker is closed$/) do

--- a/web/html/src/components/datetime/DateTimePicker.tsx
+++ b/web/html/src/components/datetime/DateTimePicker.tsx
@@ -128,7 +128,7 @@ class DatePicker extends React.PureComponent<DatePickerProps> {
         data-date-format="yyyy-mm-dd"
         data-date-week-start="0"
         // This is used by Cucumber to interact with the component
-        data-provide="date-picker"
+        data-testid="date-picker"
         className="form-control"
         size={15}
         ref={c => (this._input = jQuery(c!))}
@@ -225,7 +225,7 @@ class TimePicker extends React.PureComponent<TimePickerProps> {
         id={this.props.id}
         data-time-format="H:i"
         // This is used by Cucumber to interact with the component
-        data-provide="time-picker"
+        data-testid="time-picker"
         className="form-control"
         size={10}
         ref={c => (this._input = jQuery(c!))}

--- a/web/html/src/components/datetime/DateTimePicker.tsx
+++ b/web/html/src/components/datetime/DateTimePicker.tsx
@@ -127,6 +127,8 @@ class DatePicker extends React.PureComponent<DatePickerProps> {
         data-date-language="en_US"
         data-date-format="yyyy-mm-dd"
         data-date-week-start="0"
+        // This is used by Cucumber to interact with the component
+        data-provide="date-picker"
         className="form-control"
         size={15}
         ref={c => (this._input = jQuery(c!))}
@@ -222,6 +224,8 @@ class TimePicker extends React.PureComponent<TimePickerProps> {
         type="text"
         id={this.props.id}
         data-time-format="H:i"
+        // This is used by Cucumber to interact with the component
+        data-provide="time-picker"
         className="form-control"
         size={10}
         ref={c => (this._input = jQuery(c!))}


### PR DESCRIPTION
## What does this PR change?

[`testsuite/features/step_definitions/datepicker_steps.rb`](https://github.com/uyuni-project/uyuni/blob/master/testsuite/features/step_definitions/datepicker_steps.rb#L27) relies on the `data-provide` field used by the old datetime pickers. This PR adds those fields back so Cucumber is happy.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
