### PR TITLE
Bump immer to 9.0.6

### DIFF
--- a/susemanager-frontend/susemanager-nodejs-sdk-devel/package.json
+++ b/susemanager-frontend/susemanager-nodejs-sdk-devel/package.json
@@ -85,7 +85,7 @@
     "d3": "4.5.0",
     "gettext-parser": "^4.0.4",
     "html-react-parser": "^0.10.0",
-    "immer": "^8.0.1",
+    "immer": "^9.0.6",
     "ip-regex": "^4.3.0",
     "jexl": "2.2.2",
     "lodash": "4.17.21",

--- a/susemanager-frontend/yarn.lock
+++ b/susemanager-frontend/yarn.lock
@@ -9637,10 +9637,10 @@ immer@1.10.0:
   resolved "https://registry.yarnpkg.com/immer/-/immer-1.10.0.tgz#bad67605ba9c810275d91e1c2a47d4582e98286d"
   integrity sha512-O3sR1/opvCDGLEVcvrGTMtLac8GJ5IwZC4puPrLuRj3l7ICKvkmA0vGuU9OW8mV9WIBRnaxp5GJh9IEAaNOoYg==
 
-immer@^8.0.1:
-  version "8.0.1"
-  resolved "https://registry.yarnpkg.com/immer/-/immer-8.0.1.tgz#9c73db683e2b3975c424fb0572af5889877ae656"
-  integrity sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==
+immer@^9.0.6:
+  version "9.0.6"
+  resolved "https://registry.yarnpkg.com/immer/-/immer-9.0.6.tgz#7a96bf2674d06c8143e327cbf73539388ddf1a73"
+  integrity sha512-G95ivKpy+EvVAnAab4fVa4YGYn24J1SpEktnJX7JJ45Bd7xqME/SCplFzYFmTbrkwZbQ4xJK1xMTUYBkN6pWsQ==
 
 import-cwd@^2.0.0:
   version "2.1.0"

--- a/web/html/src/vendors/npm.licenses.structured.js
+++ b/web/html/src/vendors/npm.licenses.structured.js
@@ -33,7 +33,7 @@ const npmDependencies = [
   { name: "hoist-non-react-statics", license: "BSD-3-Clause",  version: "3.3.2" }, 
   { name: "html-dom-parser", license: "MIT",  version: "0.2.3" }, 
   { name: "html-react-parser", license: "MIT",  version: "0.10.0" }, 
-  { name: "immer", license: "MIT",  version: "8.0.1" }, 
+  { name: "immer", license: "MIT",  version: "9.0.6" }, 
   { name: "inline-style-parser", license: "MIT",  version: "0.1.1" }, 
   { name: "ip-regex", license: "MIT",  version: "4.3.0" }, 
   { name: "jexl", license: "MIT",  version: "2.2.2" }, 

--- a/web/html/src/vendors/npm.licenses.txt
+++ b/web/html/src/vendors/npm.licenses.txt
@@ -871,7 +871,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 --------------------------------------------------------------------------------
-immer v8.0.1 - Michel Weststrate
+immer v9.0.6 - Michel Weststrate
 https://github.com/immerjs/immer.git
 --------------------------------------------------------------------------------
 

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Upgrade immer to 9.0.6 to fix CVE-2021-23436
 - Improved timezone support
 - Enhance the default base channel help message (bsc#1171520)
 - Don't capitalize acronyms


### PR DESCRIPTION
## What does this PR change?

Bumps immer to 9.0.6 to fix CVE-2021-23436.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
