### PR TITLE
Supportconfig broken symlink check

### DIFF
--- a/susemanager-utils/supportutils-plugin-susemanager/supportutils-plugin-susemanager.changes
+++ b/susemanager-utils/supportutils-plugin-susemanager/supportutils-plugin-susemanager.changes
@@ -1,3 +1,5 @@
+- detect broken symlinks in tomcat, taskomatic and search daemon
+
 -------------------------------------------------------------------
 Mon Aug 09 10:42:54 CEST 2021 - jgonzalez@suse.com
 

--- a/susemanager-utils/supportutils-plugin-susemanager/susemanager
+++ b/susemanager-utils/supportutils-plugin-susemanager/susemanager
@@ -50,6 +50,10 @@ done
 plugin_command "/bin/ls -l --time-style=long-iso /usr/local/lib"
 plugin_command "/bin/ls -l --time-style=long-iso /usr/local/lib64"
 
+plugin_command "find /srv/tomcat/webapps/rhn/WEB-INF/lib/ | xargs file | grep broken"
+plugin_command "find /usr/share/spacewalk/taskomatic/ | xargs file | grep broken"
+plugin_command "find /usr/share/rhn/search/lib/ | xargs file | grep broken"
+
 section_header "SSL Configuration"
 
 pconf_files /srv/www/htdocs/pub/RHN-ORG-TRUSTED-SSL-CERT \


### PR DESCRIPTION
## What does this PR change?

Broken symlinks in tomcat, taskomatic or search daemon do not prevent them from starting but result in any kind of funny errors which are hard to detect. So actively search for them and report them.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **support tool changes**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/15861 https://github.com/SUSE/spacewalk/pull/15862

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
