### PR TITLE
Fix incorrect changes location

### DIFF
--- a/susemanager-frontend/susemanager-nodejs-sdk-devel/susemanager-nodejs-sdk-devel.changes
+++ b/susemanager-frontend/susemanager-nodejs-sdk-devel/susemanager-nodejs-sdk-devel.changes
@@ -1,3 +1,4 @@
+- Upgrade immer to 9.0.6 to fix CVE-2021-23436
 - Add moment and moment-timezone
 - Upgrade react-select to 4.3.1
 

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,4 +1,3 @@
-- Upgrade immer to 9.0.6 to fix CVE-2021-23436
 - Improved timezone support
 - Enhance the default base channel help message (bsc#1171520)
 - Don't capitalize acronyms


### PR DESCRIPTION
## What does this PR change?

In https://github.com/uyuni-project/uyuni/pull/4207 I used the wrong changes file, this PR fixes the mistake.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Follow-up to https://github.com/uyuni-project/uyuni/pull/4207

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
