### PR TITLE
Improve exception handling and logging for ModulemdApi

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/modulemd/ConflictingStreamsException.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/modulemd/ConflictingStreamsException.java
@@ -18,7 +18,7 @@ package com.redhat.rhn.domain.contentmgmt.modulemd;
 /**
  * Exception thrown when more then one stream is selected for a module
  */
-public class ConflictingStreamsException extends Exception {
+public class ConflictingStreamsException extends ModulemdApiException {
 
     private Module module;
     private Module other;

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/modulemd/ModuleDependencyException.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/modulemd/ModuleDependencyException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 SUSE LLC
+ * Copyright (c) 2021 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -15,22 +15,23 @@
 
 package com.redhat.rhn.domain.contentmgmt.modulemd;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Exception thrown when a selected module is not found
+ * Exception thrown when modular dependencies cannot be determined
  */
-public class ModuleNotFoundException extends ModulemdApiException {
+public class ModuleDependencyException extends ModulemdApiException {
 
     private List<Module> modules;
 
     /**
      * Initialize a new instance
      *
-     * @param modulesIn the missing modules
+     * @param modulesIn the modules with dependency errors
      */
-    public ModuleNotFoundException(List<Module> modulesIn) {
-        this.modules = modulesIn;
+    public ModuleDependencyException(List<Module> modulesIn) {
+        this.modules = modulesIn != null ? modulesIn : new ArrayList<>();
     }
 
     public List<Module> getModules() {

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/modulemd/ModulemdApi.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/modulemd/ModulemdApi.java
@@ -19,7 +19,6 @@ import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.channel.Modules;
-import com.redhat.rhn.manager.contentmgmt.DependencyResolutionException;
 
 import com.google.gson.FieldNamingPolicy;
 import com.google.gson.Gson;
@@ -52,7 +51,7 @@ public class ModulemdApi {
      * @param channel the modular channel
      * @return a map of module name to stream lists
      */
-    public Map<String, ModuleStreams> getAllModulesInChannel(Channel channel) {
+    public Map<String, ModuleStreams> getAllModulesInChannel(Channel channel) throws ModulemdApiException {
         ModulemdApiResponse res = callSync(ModulemdApiRequest.listModulesRequest(getMetadataPath(channel)));
         return res.getListModules().getModules();
     }
@@ -63,9 +62,8 @@ public class ModulemdApi {
      * @param sources the modular source channels
      * @return a list of modular packages in NEVRA format
      */
-    public List<String> getAllPackages(List<Channel> sources) {
+    public List<String> getAllPackages(List<Channel> sources) throws ModulemdApiException {
         List<String> metadataPaths = getMetadataPaths(sources);
-
         ModulemdApiResponse res = callSync(ModulemdApiRequest.listPackagesRequest(metadataPaths));
         return res.getListPackages().getPackages();
     }
@@ -80,7 +78,7 @@ public class ModulemdApi {
      * @throws ModuleNotFoundException if a selected module is not found
      */
     public ModulePackagesResponse getPackagesForModules(List<Channel> sources, List<Module> selectedModules)
-            throws ConflictingStreamsException, ModuleNotFoundException, DependencyResolutionException {
+            throws ModulemdApiException {
         List<String> mdPaths = getMetadataPaths(sources);
 
         Map<String, List<Module>> moduleMap = selectedModules.stream().collect(Collectors.groupingBy(Module::getName));
@@ -90,26 +88,7 @@ public class ModulemdApi {
             }
         }
 
-        ModulemdApiResponse res =
-                callSync(ModulemdApiRequest.modulePackagesRequest(mdPaths, selectedModules));
-
-        // Handle possible errors
-        if (res.isError()) {
-            switch (res.getErrorCode()) {
-                case ModulemdApiResponse.CONFLICTING_STREAMS:
-                    List<Module> conflictingModules = res.getData().getStreams();
-                    throw new ConflictingStreamsException(conflictingModules.get(0), conflictingModules.get(1));
-                case ModulemdApiResponse.MODULE_NOT_FOUND:
-                    throw new ModuleNotFoundException(res.getData().getStreams());
-                case ModulemdApiResponse.DEPENDENCY_RESOLUTION_ERROR:
-                    throw new DependencyResolutionException(res.getData().getStreams() != null ?
-                            res.getData().getStreams().get(0) : null);
-                    default:
-                        throw new RuntimeException(String.format("Cannot resolve modular dependencies. %s (%s)",
-                                res.getException(), res.getErrorCode()));
-            }
-        }
-
+        ModulemdApiResponse res = callSync(ModulemdApiRequest.modulePackagesRequest(mdPaths, selectedModules));
         return res.getModulePackages();
     }
 
@@ -145,7 +124,7 @@ public class ModulemdApi {
      * @param request the request data
      * @return the response object
      */
-    private ModulemdApiResponse callSync(ModulemdApiRequest request) {
+    private ModulemdApiResponse callSync(ModulemdApiRequest request) throws ModulemdApiException {
         ProcessBuilder pb = new ProcessBuilder(API_EXE).redirectErrorStream(true);
 
         try {
@@ -161,11 +140,27 @@ public class ModulemdApi {
             ModulemdApiResponse res = GSON.fromJson(procReader, new TypeToken<ModulemdApiResponse>() { }.getType());
 
             proc.waitFor();
+
+            // Handle possible errors
+            if (res.isError()) {
+                switch (res.getErrorCode()) {
+                    case ModulemdApiResponse.CONFLICTING_STREAMS:
+                        List<Module> conflictingModules = res.getData().getStreams();
+                        throw new ConflictingStreamsException(conflictingModules.get(0), conflictingModules.get(1));
+                    case ModulemdApiResponse.MODULE_NOT_FOUND:
+                        throw new ModuleNotFoundException(res.getData().getStreams());
+                    case ModulemdApiResponse.DEPENDENCY_RESOLUTION_ERROR:
+                        throw new ModuleDependencyException(res.getData().getStreams());
+                    default:
+                        throw new ModulemdApiException(String.format("%s (%s)", res.getException(),
+                                res.getErrorCode()));
+                }
+            }
             return res;
 
         }
         catch (IOException | InterruptedException e) {
-            throw new RuntimeException(e);
+            throw new ModulemdApiException(e);
         }
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/modulemd/ModulemdApiException.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/modulemd/ModulemdApiException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2020 SUSE LLC
+ * Copyright (c) 2021 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -15,25 +15,31 @@
 
 package com.redhat.rhn.domain.contentmgmt.modulemd;
 
-import java.util.List;
-
 /**
- * Exception thrown when a selected module is not found
+ * General exception class thrown when an unknown error occurs on a Modulemd API call
  */
-public class ModuleNotFoundException extends ModulemdApiException {
-
-    private List<Module> modules;
+public class ModulemdApiException extends Exception {
 
     /**
-     * Initialize a new instance
-     *
-     * @param modulesIn the missing modules
+     * Initialize a new exception
      */
-    public ModuleNotFoundException(List<Module> modulesIn) {
-        this.modules = modulesIn;
+    public ModulemdApiException() {
+        super();
     }
 
-    public List<Module> getModules() {
-        return modules;
+    /**
+     * Initialize a new exception
+     * @param message the exception message
+     */
+    public ModulemdApiException(String message) {
+        super(message);
+    }
+
+    /**
+     * Initialize a new exception
+     * @param cause the causing throwable
+     */
+    public ModulemdApiException(Throwable cause) {
+        super(cause);
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/action/channel/AppStreamsAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/channel/AppStreamsAction.java
@@ -19,6 +19,7 @@ import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.channel.ChannelFactory;
 import com.redhat.rhn.domain.contentmgmt.modulemd.ModuleStreams;
 import com.redhat.rhn.domain.contentmgmt.modulemd.ModulemdApi;
+import com.redhat.rhn.domain.contentmgmt.modulemd.ModulemdApiException;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.struts.RequestContext;
 import com.redhat.rhn.frontend.struts.RhnAction;
@@ -29,10 +30,10 @@ import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionForward;
 import org.apache.struts.action.ActionMapping;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -55,12 +56,15 @@ public class AppStreamsAction extends RhnAction {
 
         if (chan.isModular()) {
             ModulemdApi api = new ModulemdApi();
-            Map<String, ModuleStreams> result = api.getAllModulesInChannel(chan);
 
-            List<Entry<String, ModuleStreams>> resultList =
-                    result.entrySet().stream().collect(Collectors.toList());
-
-            request.setAttribute(RequestContext.PAGE_LIST, resultList);
+            try {
+                Map<String, ModuleStreams> result = api.getAllModulesInChannel(chan);
+                List<Entry<String, ModuleStreams>> resultList = new ArrayList<>(result.entrySet());
+                request.setAttribute(RequestContext.PAGE_LIST, resultList);
+            }
+            catch (ModulemdApiException e) {
+                throw new RuntimeException("Cannot get channel modules.", e);
+            }
         }
 
         request.setAttribute("cid", chan.getId());

--- a/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/java/StringResource_en_US.xml
@@ -8925,6 +8925,9 @@ Alternatively, you will want to download &lt;strong&gt;Incremental Channel Conte
       <trans-unit id="contentmanagement.filter_name_too_long" xml:space="preserve">
         <source>Name must not exceed 128 characters</source>
       </trans-unit>
+      <trans-unit id="contentmanagement.modules_error" xml:space="preserve">
+        <source>Cannot get channel modules. Please check the server logs for detailed information.</source>
+      </trans-unit>
       <trans-unit id="cveaudit.nav.title" xml:space="preserve">
         <source>CVE Audit</source>
       </trans-unit>

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/DependencyResolver.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/DependencyResolver.java
@@ -25,11 +25,10 @@ import com.redhat.rhn.domain.contentmgmt.FilterCriteria;
 import com.redhat.rhn.domain.contentmgmt.ModuleFilter;
 import com.redhat.rhn.domain.contentmgmt.PackageFilter;
 import com.redhat.rhn.domain.contentmgmt.ProjectSource;
-import com.redhat.rhn.domain.contentmgmt.modulemd.ConflictingStreamsException;
 import com.redhat.rhn.domain.contentmgmt.modulemd.Module;
-import com.redhat.rhn.domain.contentmgmt.modulemd.ModuleNotFoundException;
 import com.redhat.rhn.domain.contentmgmt.modulemd.ModulePackagesResponse;
 import com.redhat.rhn.domain.contentmgmt.modulemd.ModulemdApi;
+import com.redhat.rhn.domain.contentmgmt.modulemd.ModulemdApiException;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -130,7 +129,7 @@ public class DependencyResolver {
         try {
             modPkgList = modulemdApi.getPackagesForModules(sources, modules);
         }
-        catch (ConflictingStreamsException | ModuleNotFoundException e) {
+        catch (ModulemdApiException e) {
             throw new DependencyResolutionException("Failed to resolve modular dependencies.", e);
         }
 

--- a/java/code/src/com/redhat/rhn/manager/contentmgmt/FilterTemplateManager.java
+++ b/java/code/src/com/redhat/rhn/manager/contentmgmt/FilterTemplateManager.java
@@ -23,6 +23,7 @@ import com.redhat.rhn.domain.contentmgmt.ContentFilter;
 import com.redhat.rhn.domain.contentmgmt.ContentProjectFactory;
 import com.redhat.rhn.domain.contentmgmt.FilterCriteria;
 import com.redhat.rhn.domain.contentmgmt.modulemd.ModulemdApi;
+import com.redhat.rhn.domain.contentmgmt.modulemd.ModulemdApiException;
 import com.redhat.rhn.domain.rhnpackage.PackageEvr;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.EntityExistsException;
@@ -91,7 +92,8 @@ public class FilterTemplateManager {
      * @param user the user
      * @return the list of created filters
      */
-    public List<ContentFilter> createAppStreamFilters(String prefix, Channel channel, User user) {
+    public List<ContentFilter> createAppStreamFilters(String prefix, Channel channel, User user)
+            throws ModulemdApiException {
         ensureOrgAdmin(user);
 
         // Create an AppStream filter for every module that has a default stream

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/AppStreamsApiController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/AppStreamsApiController.java
@@ -18,14 +18,17 @@ import static com.suse.manager.webui.utils.SparkApplicationHelper.json;
 import static com.suse.manager.webui.utils.SparkApplicationHelper.withUser;
 import static spark.Spark.get;
 
+import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.contentmgmt.modulemd.ModulemdApi;
+import com.redhat.rhn.domain.contentmgmt.modulemd.ModulemdApiException;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.manager.channel.ChannelManager;
 
 import com.suse.manager.webui.utils.gson.ResultJson;
 
 import org.apache.http.HttpStatus;
+import org.apache.log4j.Logger;
 
 import spark.Request;
 import spark.Response;
@@ -36,7 +39,9 @@ import spark.Spark;
  */
 public class AppStreamsApiController {
 
-    private static ModulemdApi api = new ModulemdApi();
+    private static final Logger LOG = Logger.getLogger(AppStreamsApiController.class);
+    private static final ModulemdApi API = new ModulemdApi();
+    private static final LocalizationService LOC = LocalizationService.getInstance();
 
     private AppStreamsApiController() { }
 
@@ -57,10 +62,14 @@ public class AppStreamsApiController {
     public static String getModulesInChannel(Request req, Response res, User user) {
         try {
             Channel channel = ChannelManager.lookupByIdAndUser(Long.parseLong(req.params("channelId")), user);
-            return json(res, ResultJson.success(api.getAllModulesInChannel(channel)));
+            return json(res, ResultJson.success(API.getAllModulesInChannel(channel)));
         }
         catch (NumberFormatException e) {
             throw Spark.halt(HttpStatus.SC_BAD_REQUEST);
+        }
+        catch (ModulemdApiException e) {
+            LOG.error(e);
+            return json(res, ResultJson.error(LOC.getMessage("contentmanagement.modules_error")));
         }
     }
 

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/FilterApiController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/handlers/FilterApiController.java
@@ -28,6 +28,7 @@ import com.redhat.rhn.domain.contentmgmt.ContentFilter;
 import com.redhat.rhn.domain.contentmgmt.ContentManagementException;
 import com.redhat.rhn.domain.contentmgmt.ContentProject;
 import com.redhat.rhn.domain.contentmgmt.FilterCriteria;
+import com.redhat.rhn.domain.contentmgmt.modulemd.ModulemdApiException;
 import com.redhat.rhn.domain.rhnpackage.PackageEvr;
 import com.redhat.rhn.domain.rhnpackage.PackageEvrFactory;
 import com.redhat.rhn.domain.user.User;
@@ -45,6 +46,7 @@ import com.google.gson.Gson;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
+import org.apache.log4j.Logger;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -65,6 +67,7 @@ public class FilterApiController {
     private static final ContentManager CONTENT_MGR = ControllerApiUtils.CONTENT_MGR;
     private static final FilterTemplateManager TEMPLATE_MGR = ControllerApiUtils.TEMPLATE_MGR;
     private static final LocalizationService LOC = LocalizationService.getInstance();
+    private static final Logger LOG = Logger.getLogger(FilterApiController.class);
 
     private FilterApiController() {
     }
@@ -166,7 +169,13 @@ public class FilterApiController {
                 break;
             case "AppStreamsWithDefaults":
                 Channel channel = ChannelManager.lookupByIdAndUser(createFilterRequest.getChannelId(), user);
-                createdFilters = TEMPLATE_MGR.createAppStreamFilters(prefix, channel, user);
+                try {
+                    createdFilters = TEMPLATE_MGR.createAppStreamFilters(prefix, channel, user);
+                }
+                catch (ModulemdApiException e) {
+                    LOG.error(e);
+                    return json(GSON, res, ResultJson.error(LOC.getMessage("contentmanagement.modules_error")));
+                }
                 break;
             default:
                 return json(GSON, res, HttpStatus.SC_BAD_REQUEST, ResultJson.error(Collections.emptyList(),

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Improve exception handling and logging for mgr-libmod calls
 - Execute the diskcheck script at login to validate the available space
 - Add checksums to repository metadata filenames (bsc#1188315)
 - Fix ISE in product migration if base product is missing (bsc#1190151)


### PR DESCRIPTION
Improve exception handling and logging by adding checks to `getAllPackages` and `getAllModulesInChannel` API calls as well.

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
- No tests: already covered

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
