### PR TITLE
Update documentation and linting for datetimes usage

### DIFF
--- a/web/html/src/.eslintrc.js
+++ b/web/html/src/.eslintrc.js
@@ -32,7 +32,7 @@ module.exports = {
     "no-redeclare": "off",
     "@typescript-eslint/no-redeclare": ["error"],
     // TODO: Eventually this should be "error"
-    "local-rules/no-raw-date": "off",
+    "local-rules/no-raw-date": "warn",
     // TODO: Eventually we should enforce this as well
     // "no-eq-null": "error",
     // TODO: This needs to be reworked with Typescript support in mind

--- a/web/html/src/components/datetime/DateTimePicker.stories.js
+++ b/web/html/src/components/datetime/DateTimePicker.stories.js
@@ -38,6 +38,7 @@ storiesOf("DateTimePicker", module).add("basic timezone support", () => {
           .toISOString(true)}
       </p>
       <p>iso time: {value.toISOString()}</p>
+      {/* eslint-disable-next-line local-rules/no-raw-date */}
       <p>browser time: {moment().toISOString(true)}</p>
       <DateTimePicker value={value} onChange={newValue => setValue(newValue)} />
     </div>

--- a/web/html/src/components/datetime/DateTimePicker.tsx
+++ b/web/html/src/components/datetime/DateTimePicker.tsx
@@ -101,6 +101,7 @@ class DatePicker extends React.PureComponent<DatePickerProps> {
 
   // The jQuery date picker always uses browser time (not user or server time), so we can only use it to get specific numeric values, not a coherent object
   toFauxBrowserDate(props: DatePickerProps) {
+    // eslint-disable-next-line local-rules/no-raw-date
     const date = new Date();
     date.setFullYear(props.year);
     date.setMonth(props.month);

--- a/web/html/src/eslint-local-rules/no-raw-date.js
+++ b/web/html/src/eslint-local-rules/no-raw-date.js
@@ -20,9 +20,25 @@ module.exports = {
             message: "Don't use raw Javascript Date instances",
             suggest: [
               {
-                desc: "Use `moment()` instead",
+                desc: "Use `localizedMoment()` instead",
                 fix: function(fixer) {
                   return fixer.replaceText(node.parent, `moment(${args.join(", ")})`);
+                },
+              },
+            ],
+          });
+        } else if (
+          node.name === "moment" &&
+          (node.parent.type === "CallExpression" || node.parent.type === "MemberExpression")
+        ) {
+          context.report({
+            node: node,
+            message: "Prefer `localizedMoment()` over `moment()`",
+            suggest: [
+              {
+                desc: "Use `localizedMoment()` instead",
+                fix: function(fixer) {
+                  return fixer.replaceText(node, "localizedMoment");
                 },
               },
             ],

--- a/web/html/src/manager/maintenance/calendar/web-calendar.test.tsx
+++ b/web/html/src/manager/maintenance/calendar/web-calendar.test.tsx
@@ -1,4 +1,6 @@
 import * as React from "react";
+// TODO: This should eventually be localizedMoment instead
+/* eslint-disable local-rules/no-raw-date */
 import moment from "moment";
 
 import {click, render, screen, server, waitFor} from "utils/test-utils";

--- a/web/html/src/manager/maintenance/calendar/web-calendar.tsx
+++ b/web/html/src/manager/maintenance/calendar/web-calendar.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 // TODO: This should eventually be localizedMoment instead
+/* eslint-disable local-rules/no-raw-date */
 import moment from "moment";
 import { useState, useEffect, useRef } from "react";
 

--- a/web/html/src/utils/datetime/README.md
+++ b/web/html/src/utils/datetime/README.md
@@ -1,3 +1,30 @@
-TODO: Write once the spec is finalized
+# Handling dates and times
 
-There is no need to manually handle timezones before passing `localizedMoment` instances to the API. The API internally stringifies the values with `JSON.stringify()` which results in ISO strings in UTC.  
+All dates and times on the frontend should be handled via `localizedMoment`. `localizedMoment` is a wrapper around [Moment](https://momentjs.com/docs/) and [Moment Timezone](https://momentjs.com/timezone/) and can be initialized the same way a regular moment can:  
+
+```ts
+const now = localizedMoment();
+```
+
+Internally, values are handled as UTC. There is no need to manually handle timezones before passing `localizedMoment` instances to the API. The API internally stringifies the values with `JSON.stringify()` which results in ISO strings in UTC.  
+
+```ts
+try {
+  const input = await Network.get("/foo");
+  const result = localizedMoment(input);
+  await Network.post("/bar", { result });
+} catch (error) {
+  // ...
+}
+```
+
+`localizedMoment` exposes a number of methods such as `toUserDateTimeString()`, `toUserDateString()` etc to correctly display values to the user. In general, all values should be shown in the user configured time zone, but if needed, values can also be shown in the server time zone with `toServerDateTimeString()` etc.  
+
+```tsx
+const now = localizedMoment();
+return (
+  <p>Latest render was at {now.toUserDateTimeString()}</p>
+);
+```
+
+Time zone configuration values are expected from the server and errors are logged when the values are missing or the server and the client can't agree on what the current date and time is (after accounting for time zones).  

--- a/web/html/src/utils/datetime/localizedMoment.ts
+++ b/web/html/src/utils/datetime/localizedMoment.ts
@@ -1,3 +1,4 @@
+/* eslint-disable local-rules/no-raw-date */
 import moment from "moment-timezone";
 
 declare global {


### PR DESCRIPTION
## What does this PR change?

Adds missing documentation, improves linter rule.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
Internal documentation was added.

- [x] **DONE**

## Test coverage
- Unit tests were improved

- [x] **DONE**

## Links

Documentation for https://github.com/SUSE/spacewalk/issues/9049

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
