### PR TITLE
Fix ise package action details

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
+++ b/java/code/src/com/redhat/rhn/manager/errata/ErrataManager.java
@@ -219,7 +219,7 @@ public class ErrataManager extends BaseManager {
         log.debug("addChannelsToErrata - storing errata");
         ErrataFactory.save(errata);
 
-        errata = (Errata) HibernateFactory.reload(errata);
+        errata = HibernateFactory.reload(errata);
         log.debug("addChannelsToErrata - errata reloaded from DB");
         return errata;
     }
@@ -1838,7 +1838,9 @@ public class ErrataManager extends BaseManager {
             nonUpdateStackActions))
             .collect(toList());
         traditionalErrataActions.stream().forEach(ea-> {
-            ea.setDetails(new ActionPackageDetails(ea, allowVendorChange));
+            ActionPackageDetails details = ea.getDetails();
+            details.setAllowVendorChange(allowVendorChange);
+            ea.setDetails(details);
             Action action = ActionManager.storeAction(ea);
             actionIds.add(action.getId());
         });
@@ -1846,7 +1848,9 @@ public class ErrataManager extends BaseManager {
         List<ErrataAction> minionErrataActions = minionActions.collect(toList());
         List<Action> minionTaskoActions = new ArrayList<>();
         minionErrataActions.stream().forEach(ea-> {
-           ea.setDetails(new ActionPackageDetails(ea, allowVendorChange));
+           ActionPackageDetails details = ea.getDetails();
+           details.setAllowVendorChange(allowVendorChange);
+           ea.setDetails(details);
            Action action = ActionManager.storeAction(ea);
            minionTaskoActions.add(action);
            actionIds.add(action.getId());

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- fix ISE in SSM when scheduling patches on multiple systems (bsc#1190396, bsc#1190275)
 - Add new endpoints to saltkeys API: acceptedList, pendingList, rejectedList, deniedList, accept and reject
 
 -------------------------------------------------------------------

--- a/schema/spacewalk/common/tables/rhnActionPackageDetails.sql
+++ b/schema/spacewalk/common/tables/rhnActionPackageDetails.sql
@@ -32,7 +32,7 @@ CREATE TABLE rhnActionPackageDetails
 );
 
 
-CREATE INDEX rhn_act_eud_aid_idx
+CREATE UNIQUE INDEX rhn_act_eud_aid_uq
     ON rhnActionPackageDetails (action_id);
 
 CREATE SEQUENCE rhn_actiondpd_id_seq;

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,5 @@
+- create unique index on package details action id (bsc#1190396, bsc#1190275)
+
 -------------------------------------------------------------------
 Fri Sep 17 12:16:58 CEST 2021 - jgonzalez@suse.com
 

--- a/schema/spacewalk/upgrade/susemanager-schema-4.3.2-to-susemanager-schema-4.3.3/400-rhnactionpackagedetails-idx.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.3.2-to-susemanager-schema-4.3.3/400-rhnactionpackagedetails-idx.sql
@@ -1,0 +1,24 @@
+--
+-- Copyright (c) 2021 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+--
+
+DROP INDEX IF EXISTS rhn_act_eud_aid_idx;
+
+DELETE FROM rhnactionpackagedetails d1
+ where d1.id > any (SELECT d2.id
+                      FROM rhnactionpackagedetails d2
+	             WHERE d1.action_id = d2.action_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS rhn_act_eud_aid_uq
+    ON rhnActionPackageDetails (action_id);


### PR DESCRIPTION
## What does this PR change?

When scheduling a patch installation in SSM for multiple systems via Action Chain, the Package Details entry will be created 2 times and cause a ISE when selecting the chain.
This PR avoid to create multiple entries and set a unique index in DB to prevent storing wrong data in future.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/15881

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
