### PR TITLE
Automatically normalize labels in tests

### DIFF
--- a/web/html/src/components/input/Select.test.tsx
+++ b/web/html/src/components/input/Select.test.tsx
@@ -26,7 +26,7 @@ describe("Select", () => {
     expect(() => {
       renderWithForm(<Select name="level" label="Level" options={["beginner", "normal", "expert"]} />);
     }).not.toThrow();
-    openMenu(screen.getByLabelText(/^Level/));
+    openMenu(screen.getByLabelText("Level"));
     expect(screen.getByText("beginner")).toBeDefined();
   });
 
@@ -42,9 +42,9 @@ describe("Select", () => {
         ]}
       />
     );
-    await select(screen.getByLabelText(/^Level/), "Expert");
+    await select(screen.getByLabelText("Level"), "Expert");
     expect(getFieldValuesByName("test form", "level")).toStrictEqual(["expert"]);
-    openMenu(screen.getByLabelText(/^Level/));
+    openMenu(screen.getByLabelText("Level"));
     expect(screen.getByText("Beginner")).toBeDefined();
   });
 
@@ -66,16 +66,16 @@ describe("Select", () => {
       />
     );
     expect(getFieldValuesByName("test form", "flavor")).toStrictEqual(["vanilla", "strawberry"]);
-    await clearFirst(screen.getByLabelText(/^Flavor/));
+    await clearFirst(screen.getByLabelText("Flavor"));
     expect(getFieldValuesByName("test form", "flavor")).toStrictEqual(["strawberry"]);
-    await select(screen.getByLabelText(/^Flavor/), "Chocolate");
+    await select(screen.getByLabelText("Flavor"), "Chocolate");
     expect(screen.getByText("Chocolate").style.color).toEqual("rgb(123, 63, 0)");
     expect(getFieldValuesByName("test form", "flavor")).toStrictEqual(["strawberry", "chocolate"]);
-    await clearFirst(screen.getByLabelText(/^Flavor/));
-    await clearFirst(screen.getByLabelText(/^Flavor/));
+    await clearFirst(screen.getByLabelText("Flavor"));
+    await clearFirst(screen.getByLabelText("Flavor"));
     expect(getFieldValuesByName("test form", "flavor")).toStrictEqual([""]);
     expect(screen.getByText("Start typing...")).toBeDefined();
-    await type(screen.getByLabelText(/^Flavor/), "Mint");
+    await type(screen.getByLabelText("Flavor"), "Mint");
     expect(screen.getByText("No flavor")).toBeDefined();
   });
 

--- a/web/html/src/manager/virtualization/nets/network-properties.test.tsx
+++ b/web/html/src/manager/virtualization/nets/network-properties.test.tsx
@@ -73,8 +73,8 @@ describe("Rendering", () => {
 
     await renderWithNetwork();
     expect(fieldValuesByName("type")).toStrictEqual(["bridge"]);
-    await type(screen.getByLabelText(/^Name/), "bridge0");
-    await type(screen.getByLabelText(/^Bridge/), "br0");
+    await type(screen.getByLabelText("Name"), "bridge0");
+    await type(screen.getByLabelText("Bridge"), "br0");
     click(screen.getByLabelText("Start during virtual host boot"));
     expect(screen.getByText<HTMLButtonElement>("Submit").disabled).toBeFalsy();
     click(screen.getByText("Submit"));
@@ -99,9 +99,9 @@ describe("Rendering", () => {
     };
 
     await renderWithNetwork();
-    await select(screen.getByLabelText(/^Network type/), "nat");
-    await type(screen.getByLabelText(/^Name/), "nat0");
-    await type(screen.getByLabelText(/^Maximum Transmission Unit/), "7000");
+    await select(screen.getByLabelText("Network type"), "nat");
+    await type(screen.getByLabelText("Name"), "nat0");
+    await type(screen.getByLabelText("Maximum Transmission Unit (MTU)"), "7000");
     const ipv4_address = await screen.findByTitle("IPv4 Network address");
     await type(ipv4_address, "192.168.10.0");
     await type(screen.getByTitle("IPv4 Network address prefix"), "24");
@@ -173,10 +173,10 @@ describe("Rendering", () => {
     };
 
     await renderWithNetwork();
-    await select(screen.getByLabelText(/^Network type/), "open");
-    await type(screen.getByLabelText(/^Name/), "open0");
-    await type(screen.getByLabelText(/^Bridge/), "virbr2");
-    await type(screen.getByLabelText(/^Domain name/), "tf.local");
+    await select(screen.getByLabelText("Network type"), "open");
+    await type(screen.getByLabelText("Name"), "open0");
+    await type(screen.getByLabelText("Bridge"), "virbr2");
+    await type(screen.getByLabelText("Domain name"), "tf.local");
 
     // IPv4 fields setting
     const ipv4_address = await screen.findByTitle("IPv4 Network address");
@@ -200,9 +200,9 @@ describe("Rendering", () => {
     const dhcp1_host = await screen.findByTitle("DHCP host 1 address");
     await type(dhcp1_host, "192.168.10.3");
     await type(screen.getByTitle("DHCP host 1 MAC address"), "2A:C3:A7:A6:01:01");
-    await type(screen.getByLabelText(/^BOOTP image file/), "pxelinux.0");
-    await type(screen.getByLabelText(/^BOOTP server/), "192.168.10.2");
-    await type(screen.getByLabelText(/^TFTP root path/), "/path/to/tftproot");
+    await type(screen.getByLabelText("BOOTP image file"), "pxelinux.0");
+    await type(screen.getByLabelText("BOOTP server"), "192.168.10.2");
+    await type(screen.getByLabelText("TFTP root path"), "/path/to/tftproot");
 
     // IPv6 fields checks
     click(screen.getByText("Enable IPv6"));
@@ -276,11 +276,11 @@ describe("Rendering", () => {
 
     await renderWithNetwork();
     expect(fieldValuesByName("type")).toStrictEqual(["bridge"]);
-    fireEvent.change(screen.getByLabelText(/^Name/), { target: { value: "ovs0" } });
-    fireEvent.change(screen.getByLabelText(/^Bridge/), { target: { value: "ovsbr0" } });
+    fireEvent.change(screen.getByLabelText("Name"), { target: { value: "ovs0" } });
+    fireEvent.change(screen.getByLabelText("Bridge"), { target: { value: "ovsbr0" } });
     click(screen.getByLabelText("Start during virtual host boot"));
 
-    await select(screen.getByLabelText(/^Virtual Port Type/), "open vSwitch");
+    await select(screen.getByLabelText("Virtual Port Type"), "open vSwitch");
     const iface_id = await screen.findByLabelText(/^Interface id/);
     await type(iface_id, "09b11c53-8b5c-4eeb-8f00-d84eaa0aaa4f");
     click(screen.getByTitle("Add VLANs"));
@@ -308,18 +308,18 @@ describe("Rendering", () => {
     };
 
     await renderWithNetwork();
-    await select(screen.getByLabelText(/^Network type/), "macvtap");
+    await select(screen.getByLabelText("Network type"), "macvtap");
     const macvtap_mode = await screen.findByLabelText(/^Macvtap mode/);
     await select(macvtap_mode, "passthrough");
-    await type(screen.getByLabelText(/^Name/), "passthrough0");
+    await type(screen.getByLabelText("Name"), "passthrough0");
 
-    await select(screen.getByLabelText(/^Virtual Port Type/), "802.1Qbh");
+    await select(screen.getByLabelText("Virtual Port Type"), "802.1Qbh");
     const profile_id = await screen.findByLabelText(/^Profile id/);
     expect(screen.getByLabelText<HTMLInputElement>("By profile id").checked).toBeTruthy();
     await type(profile_id, "testprofile");
     expect(screen.getByLabelText<HTMLInputElement>("By interfaces").checked).toBeTruthy();
-    await select(screen.getByLabelText(/^Interfaces/), "eth7");
-    await select(screen.getByLabelText(/^Interfaces/), "eth8");
+    await select(screen.getByLabelText("Interfaces"), "eth7");
+    await select(screen.getByLabelText("Interfaces"), "eth8");
 
     expect(screen.getByText<HTMLButtonElement>("Submit").disabled).toBeFalsy();
     click(screen.getByText("Submit"));
@@ -344,21 +344,21 @@ describe("Rendering", () => {
     };
 
     await renderWithNetwork();
-    await type(screen.getByLabelText(/^Name/), "private0");
-    await select(screen.getByLabelText(/^Network type/), "macvtap");
+    await type(screen.getByLabelText("Name"), "private0");
+    await select(screen.getByLabelText("Network type"), "macvtap");
     const macvtap_mode = await screen.findByLabelText(/^Macvtap mode/);
     await select(macvtap_mode, "private");
 
-    await select(screen.getByLabelText(/^Virtual Port Type/), "802.1Qbh");
+    await select(screen.getByLabelText("Virtual Port Type"), "802.1Qbh");
     const by_vsi = await screen.findByLabelText("Virtual Station Interface (VSI) parameters");
     click(by_vsi);
     const mgr_id = await screen.findByLabelText(/^VSI manager id/);
     await type(mgr_id, "mgrid");
-    await type(screen.getByLabelText(/^VSI type id:/), "testtype");
-    await type(screen.getByLabelText(/^VSI type id version/), "testversion");
-    await type(screen.getByLabelText(/^VSI instance id/), "09b11c53-8b5c-4eeb-8f00-d84eaa0aaa4f");
+    await type(screen.getByLabelText("VSI type id"), "testtype");
+    await type(screen.getByLabelText("VSI type id version"), "testversion");
+    await type(screen.getByLabelText("VSI instance id"), "09b11c53-8b5c-4eeb-8f00-d84eaa0aaa4f");
     click(screen.getByLabelText("By physical function"));
-    const pf = await screen.getByLabelText(/^Physical Function/);
+    const pf = await screen.getByLabelText("Physical Function");
     await select(pf, "eth0");
 
     expect(screen.getByText<HTMLButtonElement>("Submit").disabled).toBeFalsy();
@@ -377,14 +377,14 @@ describe("Rendering", () => {
     };
 
     await renderWithNetwork();
-    await select(screen.getByLabelText(/^Network type/), "SR-IOV pool");
-    await type(screen.getByLabelText(/^Name/), "host0");
+    await select(screen.getByLabelText("Network type"), "SR-IOV pool");
+    await type(screen.getByLabelText("Name"), "host0");
 
     const by_vf = await screen.findByLabelText<HTMLInputElement>("By virtual functions");
     expect(by_vf.checked).toBeTruthy();
-    await select(screen.getByLabelText(/^Virtual Functions/), "eth7");
-    await select(screen.getByLabelText(/^Virtual Functions/), "eth8");
-    await type(screen.getByLabelText(/^VLAN tag/), "24");
+    await select(screen.getByLabelText("Virtual Functions"), "eth7");
+    await select(screen.getByLabelText("Virtual Functions"), "eth8");
+    await type(screen.getByLabelText("VLAN tag"), "24");
 
     expect(screen.getByText<HTMLButtonElement>("Submit").disabled).toBeFalsy();
     click(screen.getByText("Submit"));
@@ -436,8 +436,8 @@ describe("Network properties loading", () => {
     await renderWithNetwork(makeNetworkData(net));
     expect(fieldValuesByName("type")).toStrictEqual(["nat"]);
     expect(screen.getByLabelText<HTMLInputElement>("Start during virtual host boot").checked).toBeTruthy();
-    expect(screen.getByLabelText<HTMLInputElement>(/^Bridge/).value).toStrictEqual("virbr2");
-    expect(screen.getByLabelText<HTMLInputElement>(/^Maximum Transmission Unit/).value).toStrictEqual("7000");
+    expect(screen.getByLabelText<HTMLInputElement>("Bridge").value).toStrictEqual("virbr2");
+    expect(screen.getByLabelText<HTMLInputElement>("Maximum Transmission Unit (MTU)").value).toStrictEqual("7000");
     expect(screen.getByRole<HTMLInputElement>("textbox", { name: "IPv4 Network address" }).value).toStrictEqual("192.168.10.0");
     expect(screen.getByRole<HTMLInputElement>("textbox", { name: "IPv4 Network address prefix" }).value).toStrictEqual("24");
     expect(screen.getByLabelText<HTMLInputElement>("Enable IPv6").checked).toBeFalsy();
@@ -507,9 +507,9 @@ describe("Network properties loading", () => {
     await renderWithNetwork(makeNetworkData(net));
     expect(fieldValuesByName("type")).toStrictEqual(["open"]);
     expect(screen.getByLabelText<HTMLInputElement>("Start during virtual host boot").checked).toBeFalsy();
-    expect(screen.getByLabelText<HTMLInputElement>(/^Bridge/).value).toStrictEqual("virbr2");
-    expect(screen.getByLabelText<HTMLInputElement>(/^Maximum Transmission Unit/).value).toStrictEqual("");
-    expect(screen.getByLabelText<HTMLInputElement>(/^Domain name/).value).toStrictEqual("tf.local");
+    expect(screen.getByLabelText<HTMLInputElement>("Bridge").value).toStrictEqual("virbr2");
+    expect(screen.getByLabelText<HTMLInputElement>("Maximum Transmission Unit (MTU)").value).toStrictEqual("");
+    expect(screen.getByLabelText<HTMLInputElement>("Domain name").value).toStrictEqual("tf.local");
 
     // IPv4 fields checks
     expect(screen.getByRole<HTMLInputElement>("textbox", { name: "IPv4 Network address" }).value).toStrictEqual("192.168.10.0");
@@ -523,9 +523,9 @@ describe("Network properties loading", () => {
     expect(screen.getByTitle<HTMLInputElement>("DHCP host 0 name").value).toStrictEqual("dev-srv");
     expect(screen.getByTitle<HTMLInputElement>("DHCP host 1 address").value).toStrictEqual("192.168.10.3");
     expect(screen.getByTitle<HTMLInputElement>("DHCP host 1 MAC address").value).toStrictEqual("2A:C3:A7:A6:01:01");
-    expect(screen.getByLabelText<HTMLInputElement>(/^BOOTP image file/).value).toStrictEqual("pxelinux.0");
-    expect(screen.getByLabelText<HTMLInputElement>(/^BOOTP server/).value).toStrictEqual("192.168.10.2");
-    expect(screen.getByLabelText<HTMLInputElement>(/^TFTP root path/).value).toStrictEqual("/path/to/tftproot");
+    expect(screen.getByLabelText<HTMLInputElement>("BOOTP image file").value).toStrictEqual("pxelinux.0");
+    expect(screen.getByLabelText<HTMLInputElement>("BOOTP server").value).toStrictEqual("192.168.10.2");
+    expect(screen.getByLabelText<HTMLInputElement>("TFTP root path").value).toStrictEqual("/path/to/tftproot");
 
     // IPv6 fields checks
     expect(screen.getByLabelText<HTMLInputElement>("Enable IPv6").checked).toBeTruthy();
@@ -582,9 +582,9 @@ describe("Network properties loading", () => {
     };
     await renderWithNetwork(makeNetworkData(net));
     expect(fieldValuesByName("type")).toStrictEqual(["bridge"]);
-    expect(screen.getByLabelText<HTMLInputElement>(/^Bridge/).value).toStrictEqual("ovsbr0");
+    expect(screen.getByLabelText<HTMLInputElement>("Bridge").value).toStrictEqual("ovsbr0");
     expect(fieldValuesByName("virtualport_type")).toStrictEqual(["openvswitch"]);
-    expect(screen.getByLabelText<HTMLInputElement>(/^Interface id/).value).toStrictEqual("09b11c53-8b5c-4eeb-8f00-d84eaa0aaa4f");
+    expect(screen.getByLabelText<HTMLInputElement>("Interface id").value).toStrictEqual("09b11c53-8b5c-4eeb-8f00-d84eaa0aaa4f");
     expect(screen.getByLabelText<HTMLInputElement>("VLAN tags trunking").checked).toBeTruthy();
     expect(screen.getByTitle<HTMLInputElement>("VLAN 0 tag").value).toStrictEqual("42");
     expect(fieldValuesByName("vlans0_native")).toStrictEqual(["untagged"]);
@@ -615,7 +615,7 @@ describe("Network properties loading", () => {
     expect(fieldValuesByName("macvtapmode")).toStrictEqual(["passthrough"]);
     expect(fieldValuesByName("virtualport_type")).toStrictEqual(["802.1qbh"]);
     expect(screen.getByLabelText<HTMLInputElement>("By profile id").checked).toBeTruthy();
-    expect(screen.getByLabelText<HTMLInputElement>(/^Profile id/).value).toStrictEqual("testprofile");
+    expect(screen.getByLabelText<HTMLInputElement>("Profile id").value).toStrictEqual("testprofile");
     expect(screen.getByLabelText<HTMLInputElement>("By interfaces").checked).toBeTruthy();
     expect(fieldValuesByName("interfaces")).toStrictEqual(["eth7", "eth8"]);
 
@@ -648,10 +648,10 @@ describe("Network properties loading", () => {
     expect(fieldValuesByName("macvtapmode")).toStrictEqual(["private"]);
     expect(fieldValuesByName("virtualport_type")).toStrictEqual(["802.1qbh"]);
     expect(screen.getByLabelText<HTMLInputElement>("Virtual Station Interface (VSI) parameters").checked).toBeTruthy();
-    expect(screen.getByLabelText<HTMLInputElement>(/^VSI manager id/).value).toStrictEqual("mgrid");
-    expect(screen.getByLabelText<HTMLInputElement>(/^VSI type id:/).value).toStrictEqual("testtype");
-    expect(screen.getByLabelText<HTMLInputElement>(/^VSI type id version:/).value).toStrictEqual("testversion");
-    expect(screen.getByLabelText<HTMLInputElement>(/^VSI instance id/).value).toStrictEqual("09b11c53-8b5c-4eeb-8f00-d84eaa0aaa4f");
+    expect(screen.getByLabelText<HTMLInputElement>("VSI manager id").value).toStrictEqual("mgrid");
+    expect(screen.getByLabelText<HTMLInputElement>("VSI type id").value).toStrictEqual("testtype");
+    expect(screen.getByLabelText<HTMLInputElement>("VSI type id version").value).toStrictEqual("testversion");
+    expect(screen.getByLabelText<HTMLInputElement>("VSI instance id").value).toStrictEqual("09b11c53-8b5c-4eeb-8f00-d84eaa0aaa4f");
     expect(screen.getByLabelText<HTMLInputElement>("By physical function").checked).toBeTruthy();
     expect(fieldValuesByName("pf")).toStrictEqual(["eth0"]);
 
@@ -677,7 +677,7 @@ describe("Network properties loading", () => {
     expect(fieldValuesByName("type")).toStrictEqual(["hostdev"]);
     expect(screen.getByLabelText<HTMLInputElement>("By virtual functions").checked).toBeTruthy();
     expect(fieldValuesByName("vf")).toStrictEqual(["0000:3d:02.3", "0000:3d:02.2"]);
-    expect(screen.getByLabelText<HTMLInputElement>(/^VLAN tag/).value).toStrictEqual("24");
+    expect(screen.getByLabelText<HTMLInputElement>("VLAN tag").value).toStrictEqual("24");
 
     // Check that the form is valid
     expect(screen.getByText<HTMLButtonElement>("Submit").disabled).toBeFalsy();

--- a/web/html/src/utils/test-utils/screen.ts
+++ b/web/html/src/utils/test-utils/screen.ts
@@ -1,4 +1,4 @@
-import { screen as rawScreen, Screen } from "@testing-library/react";
+import { screen as rawScreen, Screen, getDefaultNormalizer } from "@testing-library/react";
 
 // Utility type, if a function TargetFunction returns a Promise, return an intersection with Promise<T>, otherwise with T
 type ReturnFromWith<TargetFunction extends (...args: any[]) => any, T> = ReturnType<TargetFunction> extends Promise<unknown>
@@ -15,6 +15,28 @@ type GenericScreen = {
         ? <T extends unknown>(...args: Parameters<Screen[Key]>) => ReturnFromWith<Screen[Key], T>
         : Screen[Key];
 };
+
+/**
+ * Labels (as in `components/input/Label.tsx`) often have a required suffix "*" and a generic display suffix ":".
+ * Instead of cluttering the DOM there, we account for it in the tests by using a normalizer here.
+ * See: https://testing-library.com/docs/queries/about/#normalization
+ */
+const defaultNormalizer = getDefaultNormalizer();
+const labelNormalizer = (input: string) => {
+    return defaultNormalizer(input)
+    .replace(/:$/, "") // Remove trailing ":"
+    .replace(/ \*$/, ""); // Remove trailing " *"
+};
+
+const getByLabelText = rawScreen.getByLabelText;
+type GetByLabelTextArgs = Parameters<typeof rawScreen.getByLabelText>;
+Object.assign(rawScreen, {
+    getByLabelText: (...[text, options, waitForElementOptions]: GetByLabelTextArgs) => {
+        options ??= {};
+        options.normalizer ??= labelNormalizer;
+        return getByLabelText(text, options, waitForElementOptions);
+    },
+} as Partial<Screen>);
 
 const screen = rawScreen as GenericScreen;
 


### PR DESCRIPTION
## What does this PR change?

As part of looking into https://github.com/SUSE/spacewalk/issues/15387 this removes the need to write regexes to match labels (which often have "*", ":" and other similar annotations).

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Part of https://github.com/SUSE/spacewalk/issues/15387

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
