### PR TITLE
Increase Jest timeouts

### DIFF
--- a/web/html/src/jest.config.js
+++ b/web/html/src/jest.config.js
@@ -6,6 +6,8 @@ module.exports = {
   preset: "ts-jest/presets/js-with-babel",
   // Required for in-memory rendering with @testing-library/react
   testEnvironment: "jsdom",
+  // We sometimes get slow runs in our internal infra when the load is high on tests that otherwise pass
+  testTimeout: 30000,
   verbose: true,
   moduleFileExtensions: [...defaults.moduleFileExtensions, "ts", "tsx"],
   moduleNameMapper: {

--- a/web/html/src/manager/virtualization/nets/network-properties.test.tsx
+++ b/web/html/src/manager/virtualization/nets/network-properties.test.tsx
@@ -258,7 +258,7 @@ describe("Rendering", () => {
 
     expect(screen.getByText<HTMLButtonElement>("Submit").disabled).toBeFalsy();
     click(screen.getByText("Submit"));
-  }, 10000);
+  });
 
   test("Create openVSwitch bridge network", async done => {
     onSubmit = ({ definition }) => {


### PR DESCRIPTION
## What does this PR change?

I couldn't identify the problem nor a fix for https://github.com/SUSE/spacewalk/issues/15387 so I raised Jest's timeouts so we don't get false positives in our internal test runs a-la https://ci.suse.de/view/Manager/view/Manager-4.2/job/manager-4.2-dev-javascript-lint/259/console.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

A workaround for https://github.com/uyuni-project/uyuni/pull/4218

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
