### PR TITLE
CI: parallelize bootstrap clients

### DIFF
--- a/testsuite/features/init_clients/buildhost_bootstrap_end.feature
+++ b/testsuite/features/init_clients/buildhost_bootstrap_end.feature
@@ -2,21 +2,10 @@
 # Licensed under the terms of the MIT license.
 
 @buildhost
-Feature: Bootstrap a Salt build host via the GUI
+Feature: Bootstrap a Salt build host via the GUI end
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
-
-  Scenario: Bootstrap a SLES build host
-     When I follow the left menu "Systems > Bootstrapping"
-     Then I should see a "Bootstrap Minions" text
-     When I enter the hostname of "build_host" as "hostname"
-     And I enter "22" as "port"
-     And I enter "root" as "user"
-     And I enter "linux" as "password"
-     And I select the hostname of "proxy" from "proxies"
-     And I click on "Bootstrap"
-     And I wait until I see "Successfully bootstrapped host!" text
 
   Scenario: Check the new bootstrapped build host in System Overview page
     When I follow the left menu "Salt > Keys"

--- a/testsuite/features/init_clients/buildhost_bootstrap_start.feature
+++ b/testsuite/features/init_clients/buildhost_bootstrap_start.feature
@@ -1,0 +1,18 @@
+# Copyright (c) 2016-2021 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+@buildhost
+Feature: Bootstrap a Salt build host via the GUI start
+
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
+  Scenario: Bootstrap a SLES build host
+     When I follow the left menu "Systems > Bootstrapping"
+     Then I should see a "Bootstrap Minions" text
+     When I enter the hostname of "build_host" as "hostname"
+     And I enter "22" as "port"
+     And I enter "root" as "user"
+     And I enter "linux" as "password"
+     And I select the hostname of "proxy" from "proxies"
+     And I click on "Bootstrap"

--- a/testsuite/features/init_clients/min_centos_salt_end.feature
+++ b/testsuite/features/init_clients/min_centos_salt_end.feature
@@ -5,23 +5,13 @@
 #  2) subscribe it to a base channel for testing
 
 @centos_minion
-Feature: Bootstrap a CentOS minion and do some basic operations on it
+Feature: Bootstrap a CentOS minion and do some basic operations on it end
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
-  Scenario: Bootstrap a CentOS minion
-    When I follow the left menu "Systems > Bootstrapping"
-    Then I should see a "Bootstrap Minions" text
-    When I enter the hostname of "ceos_minion" as "hostname"
-    And I enter "22" as "port"
-    And I enter "root" as "user"
-    And I enter "linux" as "password"
-    And I select "1-SUSE-KEY-x86_64" from "activationKeys"
-    And I select the hostname of "proxy" from "proxies"
-    And I click on "Bootstrap"
-    And I wait until I see "Successfully bootstrapped host!" text
-    And I follow the left menu "Systems > Overview"
+  Scenario: Bootstrap a CentOS minion has ended
+    When I follow the left menu "Systems > Overview"
     And I wait until I see the name of "ceos_minion", refreshing the page
     And I wait until onboarding is completed for "ceos_minion"
 

--- a/testsuite/features/init_clients/min_centos_salt_start.feature
+++ b/testsuite/features/init_clients/min_centos_salt_start.feature
@@ -1,0 +1,22 @@
+# Copyright (c) 2016-2021 SUSE LLC
+# Licensed under the terms of the MIT license.
+#
+#  1) bootstrap a new CentOS minion via salt
+#  2) subscribe it to a base channel for testing
+
+@centos_minion
+Feature: Bootstrap a CentOS minion and do some basic operations on it start
+
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
+  Scenario: Bootstrap a CentOS minion
+    When I follow the left menu "Systems > Bootstrapping"
+    Then I should see a "Bootstrap Minions" text
+    When I enter the hostname of "ceos_minion" as "hostname"
+    And I enter "22" as "port"
+    And I enter "root" as "user"
+    And I enter "linux" as "password"
+    And I select "1-SUSE-KEY-x86_64" from "activationKeys"
+    And I select the hostname of "proxy" from "proxies"
+    And I click on "Bootstrap"

--- a/testsuite/features/init_clients/min_ubuntu_salt_end.feature
+++ b/testsuite/features/init_clients/min_ubuntu_salt_end.feature
@@ -5,23 +5,13 @@
 #  2) subscribe it to a base channel for testing
 
 @ubuntu_minion
-Feature: Bootstrap an Ubuntu minion and do some basic operations on it
+Feature: Bootstrap an Ubuntu minion and do some basic operations on it end
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
-  Scenario: Bootstrap an Ubuntu minion
-    When I follow the left menu "Systems > Bootstrapping"
-    Then I should see a "Bootstrap Minions" text
-    When I enter the hostname of "ubuntu_minion" as "hostname"
-    And I enter "22" as "port"
-    And I enter "root" as "user"
-    And I enter "linux" as "password"
-    And I select "1-UBUNTU-KEY" from "activationKeys"
-    And I select the hostname of "proxy" from "proxies"
-    And I click on "Bootstrap"
-    And I wait until I see "Successfully bootstrapped host!" text
-    And I follow the left menu "Systems > Overview"
+  Scenario: Bootstrap an Ubuntu minion ends
+    When I follow the left menu "Systems > Overview"
     And I wait until I see the name of "ubuntu_minion", refreshing the page
     And I wait until onboarding is completed for "ubuntu_minion"
     And I query latest Salt changes on ubuntu system "ubuntu_minion"

--- a/testsuite/features/init_clients/min_ubuntu_salt_start.feature
+++ b/testsuite/features/init_clients/min_ubuntu_salt_start.feature
@@ -1,0 +1,22 @@
+# Copyright (c) 2016-2021 SUSE LLC
+# Licensed under the terms of the MIT license.
+#
+#  1) bootstrap a new Ubuntu minion
+#  2) subscribe it to a base channel for testing
+
+@ubuntu_minion
+Feature: Bootstrap an Ubuntu minion and do some basic operations on it start
+
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
+  Scenario: Bootstrap an Ubuntu minion
+    When I follow the left menu "Systems > Bootstrapping"
+    Then I should see a "Bootstrap Minions" text
+    When I enter the hostname of "ubuntu_minion" as "hostname"
+    And I enter "22" as "port"
+    And I enter "root" as "user"
+    And I enter "linux" as "password"
+    And I select "1-UBUNTU-KEY" from "activationKeys"
+    And I select the hostname of "proxy" from "proxies"
+    And I click on "Bootstrap"

--- a/testsuite/features/init_clients/sle_client_end.feature
+++ b/testsuite/features/init_clients/sle_client_end.feature
@@ -1,16 +1,15 @@
 # Copyright (c) 2015-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-Feature: Register a traditional client
+Feature: Register a traditional client end
   In order to register a traditional client to the Uyuni server
   I want to create, parametrize and run boostrap script from proxy
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
-  Scenario: Register a traditional client
-    When I bootstrap traditional client "sle_client" using bootstrap script with activation key "1-SUSE-KEY-x86_64" from the proxy
-    And I wait until onboarding is completed for "sle_client"
+  Scenario: Register a traditional client end
+    When I wait until onboarding is completed for "sle_client"
     Then I should see "sle_client" via spacecmd
 
   Scenario: Check registration values

--- a/testsuite/features/init_clients/sle_client_start.feature
+++ b/testsuite/features/init_clients/sle_client_start.feature
@@ -1,0 +1,12 @@
+# Copyright (c) 2015-2021 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+Feature: Register a traditional client start
+  In order to register a traditional client to the Uyuni server
+  I want to create, parametrize and run boostrap script from proxy
+
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
+  Scenario: Register a traditional client
+    When I bootstrap traditional client "sle_client" using bootstrap script with activation key "1-SUSE-KEY-x86_64" from the proxy

--- a/testsuite/features/init_clients/sle_minion_end.feature
+++ b/testsuite/features/init_clients/sle_minion_end.feature
@@ -1,21 +1,10 @@
 # Copyright (c) 2016-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
-Feature: Bootstrap a Salt minion via the GUI
+Feature: Bootstrap a Salt minion via the GUI end
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
-
-  Scenario: Bootstrap a SLES minion
-    When I follow the left menu "Systems > Bootstrapping"
-    Then I should see a "Bootstrap Minions" text
-    When I enter the hostname of "sle_minion" as "hostname"
-    And I enter "22" as "port"
-    And I enter "root" as "user"
-    And I enter "linux" as "password"
-    And I select the hostname of "proxy" from "proxies"
-    And I click on "Bootstrap"
-    And I wait until I see "Successfully bootstrapped host!" text
 
   Scenario: Check the new bootstrapped minion in System Overview page
     When I follow the left menu "Salt > Keys"

--- a/testsuite/features/init_clients/sle_minion_start.feature
+++ b/testsuite/features/init_clients/sle_minion_start.feature
@@ -1,0 +1,17 @@
+# Copyright (c) 2016-2021 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+Feature: Bootstrap a Salt minion via the GUI start
+
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
+  Scenario: Bootstrap a SLES minion
+    When I follow the left menu "Systems > Bootstrapping"
+    Then I should see a "Bootstrap Minions" text
+    When I enter the hostname of "sle_minion" as "hostname"
+    And I enter "22" as "port"
+    And I enter "root" as "user"
+    And I enter "linux" as "password"
+    And I select the hostname of "proxy" from "proxies"
+    And I click on "Bootstrap"

--- a/testsuite/features/init_clients/sle_ssh_minion_end.feature
+++ b/testsuite/features/init_clients/sle_ssh_minion_end.feature
@@ -2,21 +2,13 @@
 # Licensed under the terms of the MIT license.
 
 @ssh_minion
-Feature: Bootstrap a Salt host managed via salt-ssh
+Feature: Bootstrap a Salt host managed via salt-ssh end
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
-  Scenario: Register this SSH minion for service pack migration
-    When I follow the left menu "Systems > Bootstrapping"
-    Then I should see a "Bootstrap Minions" text
-    When I check "manageWithSSH"
-    And I enter the hostname of "ssh_minion" as "hostname"
-    And I enter "linux" as "password"
-    And I select the hostname of "proxy" from "proxies"
-    And I click on "Bootstrap"
-    And I wait until I see "Successfully bootstrapped host!" text
-    And I follow the left menu "Systems > Overview"
+  Scenario: Register this SSH minion for service pack migration end
+    When I follow the left menu "Systems > Overview"
     And I wait until I see the name of "ssh_minion", refreshing the page
     And I wait until onboarding is completed for "ssh_minion"
 

--- a/testsuite/features/init_clients/sle_ssh_minion_start.feature
+++ b/testsuite/features/init_clients/sle_ssh_minion_start.feature
@@ -1,0 +1,17 @@
+# Copyright (c) 2016-2021 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+@ssh_minion
+Feature: Bootstrap a Salt host managed via salt-ssh start
+
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
+  Scenario: Register this SSH minion for service pack migration
+    When I follow the left menu "Systems > Bootstrapping"
+    Then I should see a "Bootstrap Minions" text
+    When I check "manageWithSSH"
+    And I enter the hostname of "ssh_minion" as "hostname"
+    And I enter "linux" as "password"
+    And I select the hostname of "proxy" from "proxies"
+    And I click on "Bootstrap"

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -60,7 +60,7 @@ Capybara.register_driver(:headless_chrome) do |app|
         'download.default_directory': '/tmp/downloads'
       }
     },
-    unexpectedAlertBehaviour: 'accept',
+    unexpectedAlertBehaviour: 'ignore',
     unhandledPromptBehavior: 'accept'
   )
 

--- a/testsuite/run_sets/init_clients.yml
+++ b/testsuite/run_sets/init_clients.yml
@@ -6,11 +6,17 @@
 
 ## Core - Initialize clients BEGIN ##
 
-- features/init_clients/sle_client.feature
-- features/init_clients/sle_minion.feature
-- features/init_clients/sle_ssh_minion.feature
-- features/init_clients/min_centos_salt.feature
-- features/init_clients/min_ubuntu_salt.feature
-- features/init_clients/buildhost_bootstrap.feature
+- features/init_clients/sle_client_start.feature
+- features/init_clients/sle_minion_start.feature
+- features/init_clients/sle_ssh_minion_start.feature
+- features/init_clients/min_centos_salt_start.feature
+- features/init_clients/min_ubuntu_salt_start.feature
+- features/init_clients/buildhost_bootstrap_start.feature
+- features/init_clients/sle_client_end.feature
+- features/init_clients/sle_minion_end.feature
+- features/init_clients/sle_ssh_minion_end.feature
+- features/init_clients/min_centos_salt_end.feature
+- features/init_clients/min_ubuntu_salt_end.feature
+- features/init_clients/buildhost_bootstrap_end.feature
 
 ## Post run Core - Initialize clients END ##


### PR DESCRIPTION
## What does this PR change?

Instead of bootstrapping each client and waiting for it, let's first
bootstrap all of them and then wait for them to appear in the system
list.

This way, we are parallelizing the bootstrap process. Thus, the total
time should be smaller, meaning faster.


## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed
- [X] **DONE**

## Test coverage
- No tests

- [X] **DONE**

## Links

N/A

- [X] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
