### PR TITLE
API call to accept Salt keys 

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/saltkey/SaltKeyHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/saltkey/SaltKeyHandler.java
@@ -50,12 +50,7 @@ public class SaltKeyHandler extends BaseHandler {
      * @xmlrpc.returntype #array_single("string", "Accepted salt key list")
      */
     public List<String> acceptedList(User loggedInUser) {
-        try {
-            ensureOrgAdmin(loggedInUser);
-        }
-        catch (PermissionException e) {
-            throw new PermissionCheckFailureException(e);
-        }
+        ensureOrgAdmin(loggedInUser);
         return saltKeyUtils.acceptedSaltKeyList(loggedInUser);
 
     }
@@ -71,12 +66,7 @@ public class SaltKeyHandler extends BaseHandler {
      * @xmlrpc.returntype #array_single("string", "Pending salt key list")
      */
     public List<String> pendingList(User loggedInUser) {
-        try {
-            ensureOrgAdmin(loggedInUser);
-        }
-        catch (PermissionException e) {
-            throw new PermissionCheckFailureException(e);
-        }
+        ensureOrgAdmin(loggedInUser);
         return saltKeyUtils.unacceptedSaltKeyList(loggedInUser);
     }
 
@@ -92,8 +82,8 @@ public class SaltKeyHandler extends BaseHandler {
      * @xmlrpc.returntype #return_int_success()
      */
     public int accept(User loggedInUser, String minionId) {
+        ensureOrgAdmin(loggedInUser);
         try {
-            ensureOrgAdmin(loggedInUser);
             saltKeyUtils.acceptSaltKey(loggedInUser, minionId);
         }
         catch (PermissionException e) {
@@ -118,8 +108,8 @@ public class SaltKeyHandler extends BaseHandler {
      * @xmlrpc.returntype #return_int_success()
      */
     public int genAccept(User loggedInUser, String minionId) {
+        ensureOrgAdmin(loggedInUser);
         try {
-            ensureOrgAdmin(loggedInUser);
             saltKeyUtils.genAcceptSaltKey(loggedInUser, minionId);
         }
         catch (PermissionException e) {
@@ -143,8 +133,8 @@ public class SaltKeyHandler extends BaseHandler {
      * @xmlrpc.returntype #return_int_success()
      */
     public int delete(User loggedInUser, String minionId) {
+        ensureOrgAdmin(loggedInUser);
         try {
-            ensureOrgAdmin(loggedInUser);
             saltKeyUtils.deleteSaltKey(loggedInUser, minionId);
         }
         catch (PermissionException e) {

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/saltkey/SaltKeyHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/saltkey/SaltKeyHandler.java
@@ -47,7 +47,6 @@ public class SaltKeyHandler extends BaseHandler {
      *
      * @xmlrpc.doc List accepted salt keys
      * @xmlrpc.param #param("string", "loggedInUser")
-     * @xmlrpc.param #param("string", "minionId")
      * @xmlrpc.returntype #array_single("string", "Accepted salt key list")
      */
     public List<String> acceptedList(User loggedInUser) {

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/saltkey/SaltKeyHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/saltkey/SaltKeyHandler.java
@@ -84,6 +84,20 @@ public class SaltKeyHandler extends BaseHandler {
     }
 
     /**
+     * API endpoint to list denied salt keys
+     * @param loggedInUser the user
+     * @return 1 on success
+     *
+     * @xmlrpc.doc List of denied salt keys
+     * @xmlrpc.param #param("string", "loggedInUser")
+     * @xmlrpc.returntype #array_single("string", "Denied salt key list")
+     */
+    public List<String> deniedList(User loggedInUser) {
+        ensureOrgAdmin(loggedInUser);
+        return saltKeyUtils.deniedSaltKeyList(loggedInUser);
+    }
+    
+    /**
      * API endpoint to accept minion keys
      * @param loggedInUser the user
      * @param minionId the key identifier (minionId)
@@ -133,7 +147,6 @@ public class SaltKeyHandler extends BaseHandler {
         return 1;
     }
 
-
     /**
      * API endpoint to delete minion keys
      * @param loggedInUser the user
@@ -147,14 +160,15 @@ public class SaltKeyHandler extends BaseHandler {
      */
     public int delete(User loggedInUser, String minionId) {
         ensureOrgAdmin(loggedInUser);
+        boolean success = false;
         try {
-            saltKeyUtils.deleteSaltKey(loggedInUser, minionId);
+            success = saltKeyUtils.deleteSaltKey(loggedInUser, minionId);
         }
         catch (PermissionException e) {
             throw new PermissionCheckFailureException(e);
         }
-        catch (IllegalArgumentException e) {
-            throw new UnsupportedOperationException(e.getMessage());
+        if (!success) {
+            throw new UnsupportedOperationException("No key found for minionID [" + minionId + "]");
         }
         return 1;
     }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/saltkey/SaltKeyHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/saltkey/SaltKeyHandler.java
@@ -55,7 +55,6 @@ public class SaltKeyHandler extends BaseHandler {
 
     }
 
-
     /**
      * API endpoint to list pending salt keys
      * @param loggedInUser the user
@@ -68,6 +67,20 @@ public class SaltKeyHandler extends BaseHandler {
     public List<String> pendingList(User loggedInUser) {
         ensureOrgAdmin(loggedInUser);
         return saltKeyUtils.unacceptedSaltKeyList(loggedInUser);
+    }
+
+    /**
+     * API endpoint to list rejected salt keys
+     * @param loggedInUser the user
+     * @return 1 on success
+     *
+     * @xmlrpc.doc List of rejected salt keys
+     * @xmlrpc.param #param("string", "loggedInUser")
+     * @xmlrpc.returntype #array_single("string", "Rejected salt key list")
+     */
+    public List<String> rejectedList(User loggedInUser) {
+        ensureOrgAdmin(loggedInUser);
+        return saltKeyUtils.rejectedSaltKeyList(loggedInUser);
     }
 
     /**
@@ -94,6 +107,32 @@ public class SaltKeyHandler extends BaseHandler {
         }
         return 1;
     }
+
+    /**
+     * API endpoint to reject minion keys
+     * @param loggedInUser the user
+     * @param minionId the key identifier (minionId)
+     * @return 1 on success
+     *
+     * @xmlrpc.doc Reject a minion key
+     * @xmlrpc.param #param("string", "loggedInUser")
+     * @xmlrpc.param #param("string", "minionId")
+     * @xmlrpc.returntype #return_int_success()
+     */
+    public int reject(User loggedInUser, String minionId) {
+        ensureOrgAdmin(loggedInUser);
+        try {
+            saltKeyUtils.rejectSaltKey(loggedInUser, minionId);
+        }
+        catch (PermissionException e) {
+            throw new PermissionCheckFailureException(e);
+        }
+        catch (IllegalArgumentException e) {
+            throw new UnsupportedOperationException(e.getMessage());
+        }
+        return 1;
+    }
+
 
     /**
      * API endpoint to delete minion keys

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/saltkey/SaltKeyHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/saltkey/SaltKeyHandler.java
@@ -18,8 +18,11 @@ import com.redhat.rhn.common.security.PermissionException;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.xmlrpc.BaseHandler;
 import com.redhat.rhn.frontend.xmlrpc.PermissionCheckFailureException;
+import com.redhat.rhn.frontend.xmlrpc.UnsupportedOperationException;
 
 import com.suse.manager.utils.SaltKeyUtils;
+
+import java.util.List;
 
 /**
  * SaltKeyHandler
@@ -38,23 +41,118 @@ public class SaltKeyHandler extends BaseHandler {
     }
 
     /**
+     * API endpoint to list accepted salt keys
+     * @param loggedInUser the user
+     * @return 1 on success
+     *
+     * @xmlrpc.doc List accepted salt keys
+     * @xmlrpc.param #param("string", "loggedInUser")
+     * @xmlrpc.param #param("string", "minionId")
+     * @xmlrpc.returntype #array_single("string", "Accepted salt key list")
+     */
+    public List<String> acceptedList(User loggedInUser) {
+        try {
+            ensureOrgAdmin(loggedInUser);
+        }
+        catch (PermissionException e) {
+            throw new PermissionCheckFailureException(e);
+        }
+        return saltKeyUtils.acceptedSaltKeyList(loggedInUser);
+
+    }
+
+
+    /**
+     * API endpoint to list pending salt keys
+     * @param loggedInUser the user
+     * @return 1 on success
+     *
+     * @xmlrpc.doc List pending salt keys
+     * @xmlrpc.param #param("string", "loggedInUser")
+     * @xmlrpc.returntype #array_single("string", "Pending salt key list")
+     */
+    public List<String> pendingList(User loggedInUser) {
+        try {
+            ensureOrgAdmin(loggedInUser);
+        }
+        catch (PermissionException e) {
+            throw new PermissionCheckFailureException(e);
+        }
+        return saltKeyUtils.unacceptedSaltKeyList(loggedInUser);
+    }
+
+    /**
+     * API endpoint to accept minion keys
+     * @param loggedInUser the user
+     * @param minionId the key identifier (minionId)
+     * @return 1 on success
+     *
+     * @xmlrpc.doc Accept a minion key
+     * @xmlrpc.param #param("string", "loggedInUser")
+     * @xmlrpc.param #param("string", "minionId")
+     * @xmlrpc.returntype #return_int_success()
+     */
+    public int accept(User loggedInUser, String minionId) {
+        try {
+            ensureOrgAdmin(loggedInUser);
+            saltKeyUtils.acceptSaltKey(loggedInUser, minionId);
+        }
+        catch (PermissionException e) {
+            throw new PermissionCheckFailureException(e);
+        }
+        catch (IllegalArgumentException e) {
+            throw new UnsupportedOperationException(e.getMessage());
+        }
+        return 1;
+    }
+
+
+    /**
+     * API endpoint to generate and accept minion keys
+     * @param loggedInUser the user
+     * @param minionId the key identifier (minionId)
+     * @return 1 on success
+     *
+     * @xmlrpc.doc Generate and accept a minion key
+     * @xmlrpc.param #param("string", "loggedInUser")
+     * @xmlrpc.param #param("string", "minionId")
+     * @xmlrpc.returntype #return_int_success()
+     */
+    public int genAccept(User loggedInUser, String minionId) {
+        try {
+            ensureOrgAdmin(loggedInUser);
+            saltKeyUtils.genAcceptSaltKey(loggedInUser, minionId);
+        }
+        catch (PermissionException e) {
+            throw new PermissionCheckFailureException(e);
+        }
+        catch (IllegalArgumentException e) {
+            throw new UnsupportedOperationException(e.getMessage());
+        }
+        return 1;
+    }
+
+    /**
      * API endpoint to delete minion keys
      * @param loggedInUser the user
      * @param minionId the key identifier (minionId)
      * @return 1 on success
      *
      * @xmlrpc.doc Delete a minion key
-     * @xmlrpc.param #param("string", "sessionKey")
+     * @xmlrpc.param #param("string", "loggedInUser")
      * @xmlrpc.param #param("string", "minionId")
      * @xmlrpc.returntype #return_int_success()
      */
     public int delete(User loggedInUser, String minionId) {
-        ensureOrgAdmin(loggedInUser);
         try {
+            ensureOrgAdmin(loggedInUser);
             saltKeyUtils.deleteSaltKey(loggedInUser, minionId);
         }
         catch (PermissionException e) {
             throw new PermissionCheckFailureException(e);
+        }
+        catch (IllegalArgumentException e) {
+            throw new UnsupportedOperationException(e.getMessage());
         }
         return 1;
     }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/saltkey/SaltKeyHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/saltkey/SaltKeyHandler.java
@@ -46,13 +46,12 @@ public class SaltKeyHandler extends BaseHandler {
      * @return 1 on success
      *
      * @xmlrpc.doc List accepted salt keys
-     * @xmlrpc.param #param("string", "loggedInUser")
-     * @xmlrpc.returntype #array_single("string", "Accepted salt key list")
+     * @xmlrpc.param #param(" string ", " loggedInUser ")
+     * @xmlrpc.returntype #array_single(" string ", " Accepted salt key list ")
      */
     public List<String> acceptedList(User loggedInUser) {
         ensureOrgAdmin(loggedInUser);
         return saltKeyUtils.acceptedSaltKeyList(loggedInUser);
-
     }
 
     /**
@@ -61,8 +60,8 @@ public class SaltKeyHandler extends BaseHandler {
      * @return 1 on success
      *
      * @xmlrpc.doc List pending salt keys
-     * @xmlrpc.param #param("string", "loggedInUser")
-     * @xmlrpc.returntype #array_single("string", "Pending salt key list")
+     * @xmlrpc.param #param(" string ", " loggedInUser ")
+     * @xmlrpc.returntype #array_single(" string ", " Pending salt key list ")
      */
     public List<String> pendingList(User loggedInUser) {
         ensureOrgAdmin(loggedInUser);
@@ -75,8 +74,8 @@ public class SaltKeyHandler extends BaseHandler {
      * @return 1 on success
      *
      * @xmlrpc.doc List of rejected salt keys
-     * @xmlrpc.param #param("string", "loggedInUser")
-     * @xmlrpc.returntype #array_single("string", "Rejected salt key list")
+     * @xmlrpc.param #param(" string ", " loggedInUser ")
+     * @xmlrpc.returntype #array_single(" string ", " Rejected salt key list ")
      */
     public List<String> rejectedList(User loggedInUser) {
         ensureOrgAdmin(loggedInUser);
@@ -89,14 +88,14 @@ public class SaltKeyHandler extends BaseHandler {
      * @return 1 on success
      *
      * @xmlrpc.doc List of denied salt keys
-     * @xmlrpc.param #param("string", "loggedInUser")
-     * @xmlrpc.returntype #array_single("string", "Denied salt key list")
+     * @xmlrpc.param #param(" string ", " loggedInUser ")
+     * @xmlrpc.returntype #array_single(" string ", " Denied salt key list ")
      */
     public List<String> deniedList(User loggedInUser) {
         ensureOrgAdmin(loggedInUser);
         return saltKeyUtils.deniedSaltKeyList(loggedInUser);
     }
-    
+
     /**
      * API endpoint to accept minion keys
      * @param loggedInUser the user
@@ -104,8 +103,8 @@ public class SaltKeyHandler extends BaseHandler {
      * @return 1 on success
      *
      * @xmlrpc.doc Accept a minion key
-     * @xmlrpc.param #param("string", "loggedInUser")
-     * @xmlrpc.param #param("string", "minionId")
+     * @xmlrpc.param #param(" string ", " loggedInUser ")
+     * @xmlrpc.param #param(" string ", " minionId ")
      * @xmlrpc.returntype #return_int_success()
      */
     public int accept(User loggedInUser, String minionId) {
@@ -129,8 +128,8 @@ public class SaltKeyHandler extends BaseHandler {
      * @return 1 on success
      *
      * @xmlrpc.doc Reject a minion key
-     * @xmlrpc.param #param("string", "loggedInUser")
-     * @xmlrpc.param #param("string", "minionId")
+     * @xmlrpc.param #param(" string ", " loggedInUser ")
+     * @xmlrpc.param #param(" string ", " minionId ")
      * @xmlrpc.returntype #return_int_success()
      */
     public int reject(User loggedInUser, String minionId) {
@@ -154,8 +153,8 @@ public class SaltKeyHandler extends BaseHandler {
      * @return 1 on success
      *
      * @xmlrpc.doc Delete a minion key
-     * @xmlrpc.param #param("string", "loggedInUser")
-     * @xmlrpc.param #param("string", "minionId")
+     * @xmlrpc.param #param(" string ", " loggedInUser ")
+     * @xmlrpc.param #param(" string ", " minionId ")
      * @xmlrpc.returntype #return_int_success()
      */
     public int delete(User loggedInUser, String minionId) {

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/saltkey/SaltKeyHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/saltkey/SaltKeyHandler.java
@@ -95,32 +95,6 @@ public class SaltKeyHandler extends BaseHandler {
         return 1;
     }
 
-
-    /**
-     * API endpoint to generate and accept minion keys
-     * @param loggedInUser the user
-     * @param minionId the key identifier (minionId)
-     * @return 1 on success
-     *
-     * @xmlrpc.doc Generate and accept a minion key
-     * @xmlrpc.param #param("string", "loggedInUser")
-     * @xmlrpc.param #param("string", "minionId")
-     * @xmlrpc.returntype #return_int_success()
-     */
-    public int genAccept(User loggedInUser, String minionId) {
-        ensureOrgAdmin(loggedInUser);
-        try {
-            saltKeyUtils.genAcceptSaltKey(loggedInUser, minionId);
-        }
-        catch (PermissionException e) {
-            throw new PermissionCheckFailureException(e);
-        }
-        catch (IllegalArgumentException e) {
-            throw new UnsupportedOperationException(e.getMessage());
-        }
-        return 1;
-    }
-
     /**
      * API endpoint to delete minion keys
      * @param loggedInUser the user

--- a/java/code/src/com/suse/manager/utils/SaltKeyUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltKeyUtils.java
@@ -25,6 +25,7 @@ import com.suse.salt.netapi.calls.wheel.Key;
 import org.apache.log4j.Logger;
 
 import java.util.stream.Stream;
+import java.util.List;
 
 /**
  * SaltKeyUtils
@@ -42,6 +43,104 @@ public class SaltKeyUtils {
     }
 
     /**
+     * List of accepted salt keys
+     * @param user the user
+     * @return List of accepted salt keys
+     * @throws PermissionException requires org admin privileges
+     * or management privileges for the server
+     */
+    public List<String> acceptedSaltKeyList(User user) {
+
+        return saltApi.getKeys().getMinions();
+    }
+
+
+    /**
+     * List of pending salt keys
+     * @param user the user
+     * @return List of pending salt keys
+     * @throws PermissionException requires org admin privileges
+     * or management privileges for the server
+     */
+    public List<String> unacceptedSaltKeyList(User user) {
+
+        return saltApi.getKeys().getUnacceptedMinions();
+    }
+
+    /**
+     * Accept a salt key
+     * @param user the user
+     * @param minionId the key identifier (minion id)
+     * @return true on success otherwise false
+     * @throws PermissionException requires org admin privileges
+     * or management privileges for the server
+     */
+    public boolean acceptSaltKey(User user, String minionId) throws PermissionException {
+
+        //Note: since salt only allows globs we have to do our own strict matching
+        Key.Names keys = saltApi.getKeys();
+
+        boolean unaccepted = keys.getUnacceptedMinions().stream().anyMatch(minionId::equals);
+
+        if (!unaccepted) {
+            throw new IllegalArgumentException("Key for minionID [" + minionId + "] is not pending");
+        }
+
+        return MinionServerFactory.findByMinionId(minionId).map(minionServer -> {
+            if (user.getServers().contains(minionServer)) {
+                saltApi.acceptKey(minionId);
+                return true;
+            }
+            else {
+                throw new PermissionException("You do not have permissions to " +
+                        "perform this action for system id[" + minionServer.getId() + "]");
+            }
+        }).orElseGet(() -> {
+            if (!user.hasRole(RoleFactory.ORG_ADMIN)) {
+                throw new PermissionException(RoleFactory.ORG_ADMIN);
+            }
+            saltApi.acceptKey(minionId);
+            return true;
+        });
+    }
+
+    /**
+     * Generate and accept a salt key
+     * @param user the user
+     * @param minionId the key identifier (minion id)
+     * @return true on success otherwise false
+     * @throws PermissionException requires org admin privileges
+     * or management privileges for the server
+     */
+    public boolean genAcceptSaltKey(User user, String minionId) throws PermissionException {
+
+        //Note: since salt only allows globs we have to do our own strict matching
+        Key.Names keys = saltApi.getKeys();
+        boolean exists = keys.getMinions().stream().anyMatch(minionId::equals);
+
+        if (exists) {
+            throw new IllegalArgumentException("Key for minionID [" + minionId + "] already exists");
+        }
+
+        return MinionServerFactory.findByMinionId(minionId).map(minionServer -> {
+            if (user.getServers().contains(minionServer)) {
+                saltApi.generateKeysAndAccept(minionId, false);
+                return true;
+            }
+            else {
+                throw new PermissionException("You do not have permissions to " +
+                        "perform this action for system id[" + minionServer.getId() + "]");
+            }
+        }).orElseGet(() -> {
+            if (!user.hasRole(RoleFactory.ORG_ADMIN)) {
+                throw new PermissionException(RoleFactory.ORG_ADMIN);
+            }
+            saltApi.generateKeysAndAccept(minionId, false);
+            return true;
+        });
+    }
+
+    /**
      * Delete a salt key
      * @param user the user
      * @param minionId the key identifier (minion id)
@@ -49,7 +148,7 @@ public class SaltKeyUtils {
      * @throws PermissionException requires org admin privileges
      * or management privileges for the server
      */
-    public boolean deleteSaltKey(User user, String minionId) throws PermissionException {
+    public boolean deleteSaltKey(User user, String minionId) throws PermissionException, IllegalArgumentException {
 
         //Note: since salt only allows globs we have to do our own strict matching
         Key.Names keys = saltApi.getKeys();
@@ -81,8 +180,7 @@ public class SaltKeyUtils {
             });
         }
         else {
-            LOG.info(String.format("No key found for minionID [%s]", minionId));
-            return false;
+            throw new IllegalArgumentException("No key found for minionID [" + minionId + "]");
         }
     }
 }

--- a/java/code/src/com/suse/manager/utils/SaltKeyUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltKeyUtils.java
@@ -105,42 +105,6 @@ public class SaltKeyUtils {
     }
 
     /**
-     * Generate and accept a salt key
-     * @param user the user
-     * @param minionId the key identifier (minion id)
-     * @return true on success otherwise false
-     * @throws PermissionException requires org admin privileges
-     * or management privileges for the server
-     */
-    public boolean genAcceptSaltKey(User user, String minionId) throws PermissionException {
-
-        //Note: since salt only allows globs we have to do our own strict matching
-        Key.Names keys = saltApi.getKeys();
-        boolean exists = keys.getMinions().stream().anyMatch(minionId::equals);
-
-        if (exists) {
-            throw new IllegalArgumentException("Key for minionID [" + minionId + "] already exists");
-        }
-
-        return MinionServerFactory.findByMinionId(minionId).map(minionServer -> {
-            if (user.getServers().contains(minionServer)) {
-                saltApi.generateKeysAndAccept(minionId, false);
-                return true;
-            }
-            else {
-                throw new PermissionException("You do not have permissions to " +
-                        "perform this action for system id[" + minionServer.getId() + "]");
-            }
-        }).orElseGet(() -> {
-            if (!user.hasRole(RoleFactory.ORG_ADMIN)) {
-                throw new PermissionException(RoleFactory.ORG_ADMIN);
-            }
-            saltApi.generateKeysAndAccept(minionId, false);
-            return true;
-        });
-    }
-
-    /**
      * Delete a salt key
      * @param user the user
      * @param minionId the key identifier (minion id)

--- a/java/code/src/com/suse/manager/utils/SaltKeyUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltKeyUtils.java
@@ -135,7 +135,7 @@ public class SaltKeyUtils {
         if (!unaccepted) {
             throw new IllegalArgumentException("Key for minionID [" + minionId + "] is not pending");
         }
-        
+
         if (!user.hasRole(RoleFactory.ORG_ADMIN)) {
             throw new PermissionException(RoleFactory.ORG_ADMIN);
         }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Add endpoints to saltkeys API
+
 -------------------------------------------------------------------
 Fri Sep 17 12:18:34 CEST 2021 - jgonzalez@suse.com
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,4 +1,4 @@
-- Add endpoints to saltkeys API
+- Add new endpoints to saltkeys API: acceptedList, pendingList, rejectedList, deniedList, accept and reject
 
 -------------------------------------------------------------------
 Fri Sep 17 12:18:34 CEST 2021 - jgonzalez@suse.com


### PR DESCRIPTION
## What does this PR change?

Added some endpoint for salt key API:
- `accept` : API endpoint to accept minion keys
-  `reject` : API endpoint to reject minion keys
- `pendingList` :  API endpoint to list pending salt keys
- `acceptedList` : API endpoint to list accepted salt keys
- `rejectedList` : API endpoint to list rejected salt keys


Resolve minor issue in `delete` API
## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- API documentation generated correctly

- [ ] **DONE**

## Test coverage
- No tests: Not Appilicable

- [ ] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/14189

- [ ] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
