### PR TITLE
Add links to the changelog policies for the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -37,6 +37,8 @@ Tracks # **add downstream PR, if any**
 
 ## Changelogs
 
+Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository
+
 If you don't need a changelog check, please mark this checkbox:
 
 - [ ] No changelog needed


### PR DESCRIPTION
## What does this PR change?

Add a link to the changelog policies for the PR template.

Links:
https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs
https://github.com/uyuni-project/uyuni/wiki/Contributing#changelog-rules-for-packages-at-git

Feel free to improve the wiki.

NOTE: If approved, this will require a backport to the private repo.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- Irrelevant.

- [x] **DONE**

## Test coverage
- Irrelevant

- [x] **DONE**

## Links

- None

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
