### PR TITLE
Introduce a banner in the login page when the available disk space reported by diskcheck is low

### DIFF
--- a/backend/satellite_tools/spacewalk-diskcheck
+++ b/backend/satellite_tools/spacewalk-diskcheck
@@ -1,66 +1,108 @@
 #!/bin/bash
 
-systemctl status spacewalk.target > /dev/null 2>&1
-if [ $? != 0 ]; then
-    logger  "SPACECHECK: spacewalk services are not running - skipping disk check."
-    exit 0
-fi
+function usage {
+    cat << EOF
+usage: $0 options
 
-EMAIL_ADDRESS=`grep ^[[:blank:]]*traceback_mail /etc/rhn/rhn.conf | sed -e "s/.*=[[:blank:]]*//"`
-SPACECHECKDIRS=`grep ^[[:blank:]]*spacecheck_dirs /etc/rhn/rhn.conf | sed -e "s/.*=[[:blank:]]*//"`
-SPACECHECKALERT=`grep ^[[:blank:]]*spacecheck_free_alert /etc/rhn/rhn.conf | sed -e "s/.*=[[:blank:]]*//"`
-SPACECHECKCRIT=`grep ^[[:blank:]]*spacecheck_free_critical /etc/rhn/rhn.conf | sed -e "s/.*=[[:blank:]]*//"`
-SPACECHECKSHUTDOWN=`grep ^[[:blank:]]*spacecheck_shutdown /etc/rhn/rhn.conf | sed -e "s/.*=[[:blank:]]*//"`
+    Check the disk space available for the configured directories
 
-if [ "x$EMAIL_ADDRESS" = "x" ]; then
-    EMAIL_ADDRESS="root@localhost"
-fi
-if [ "x$SPACECHECKDIRS" = "x" ]; then
-    SPACECHECKDIRS="/var/lib/pgsql /var/spacewalk /var/cache /srv"
-fi
-if [ "x$SPACECHECKALERT" = "x" ] || [ "$SPACECHECKALERT" -gt 90 ]; then
-    SPACECHECKALERT=10
-fi
-if [ "x$SPACECHECKCRIT" = "x" ] || [ "$SPACECHECKCRIT" -ge "$SPACECHECKALERT" ]; then
-    SPACECHECKCRIT=$(($SPACECHECKALERT / 2))
-fi
-if [ "x$SPACECHECKSHUTDOWN" = "x" ]; then
-    SPACECHECKSHUTDOWN="true"
-fi
+OPTIONS:
+    -c              Check only and do not send any emails
+    -h              Show this message
+EOF
+}
 
-STOPCHECK=0
+function parseArguments {
+    while getopts "h?c" opt; do
+        case "$opt" in
+            h|\?)
+                usage
+                exit 0
+                ;;
+            c)
+                CHECKONLY=true
+                ;;
+        esac
+    done
+}
 
-for DIR in $SPACECHECKDIRS
-do
-    if [ ! -d $DIR ]; then
-        logger "SPACECHECK: Directory $DIR does not exist!"
-        echo "SPACECHECK: Directory $DIR does not exist!" | mail -Ssendwait -s "SPACECHECK: Directory $DIR does not exist!" $EMAIL_ADDRESS
-        continue
+function parseConfiguration {
+    if [ -f $1 ]; then
+        EMAIL_ADDRESS=`grep ^[[:blank:]]*traceback_mail $1 | sed -e "s/.*=[[:blank:]]*//"`
+        SPACECHECKDIRS=`grep ^[[:blank:]]*spacecheck_dirs $1 | sed -e "s/.*=[[:blank:]]*//"`
+        SPACECHECKALERT=`grep ^[[:blank:]]*spacecheck_free_alert $1 | sed -e "s/.*=[[:blank:]]*//"`
+        SPACECHECKCRIT=`grep ^[[:blank:]]*spacecheck_free_critical $1 | sed -e "s/.*=[[:blank:]]*//"`
+        SPACECHECKSHUTDOWN=`grep ^[[:blank:]]*spacecheck_shutdown $1 | sed -e "s/.*=[[:blank:]]*//"`
     fi
-    USEDSPACE=`df -PH $DIR | tail -1 | awk '{print $5}' | sed -e"s/\%//"`
-    FREESPACE=$((100 - $USEDSPACE))
-    if [ $FREESPACE -lt $SPACECHECKCRIT ] && [ "$STOPCHECK" = "0" ]; then
-        if [ "$SPACECHECKSHUTDOWN" = "true" ]; then
-            logger "SPACECHECK CRITICAL: Less than $SPACECHECKCRIT% of space available on $DIR - shutting down!"
-            cat << EOF | mail -Ssendwait -s "SPACECHECK CRITICAL: Less than $SPACECHECKCRIT% of space available on $DIR" $EMAIL_ADDRESS
+
+    if [ "$EMAIL_ADDRESS" = "" ]; then
+        EMAIL_ADDRESS="root@localhost"
+    fi
+    if [ "$SPACECHECKDIRS" = "" ]; then
+        SPACECHECKDIRS="/var/lib/pgsql /var/spacewalk /var/cache /srv"
+    fi
+    if [ "$SPACECHECKALERT" = "" ] || [ "$SPACECHECKALERT" -gt 90 ]; then
+        SPACECHECKALERT=10
+    fi
+    if [ "$SPACECHECKCRIT" = "" ] || [ "$SPACECHECKCRIT" -ge "$SPACECHECKALERT" ]; then
+        SPACECHECKCRIT=$(($SPACECHECKALERT / 2))
+    fi
+    if [ "$SPACECHECKSHUTDOWN" = "" ]; then
+        SPACECHECKSHUTDOWN=true
+    fi
+}
+
+function ensureSpacewalkRunning {
+    systemctl status spacewalk.target > /dev/null 2>&1
+    if [ $? != 0 ]; then
+        logger  "SPACECHECK: spacewalk services are not running - skipping disk check."
+        exit 0
+    fi
+}
+
+function sendDirectoryMissing {
+    if [ "$CHECKONLY" = true ]; then
+        return
+    fi
+
+    logger "SPACECHECK: Directory $DIR does not exist!"
+    echo "SPACECHECK: Directory $DIR does not exist!" | mail -Ssendwait -s "SPACECHECK: Directory $DIR does not exist!" $EMAIL_ADDRESS
+}
+
+function sendCriticalShutdown {
+    if [ "$CHECKONLY" = true ]; then
+        return
+    fi
+
+    logger "SPACECHECK CRITICAL: Less than $SPACECHECKCRIT% of space available on $DIR - shutting down!"
+    cat << EOF | mail -Ssendwait -s "SPACECHECK CRITICAL: Less than $SPACECHECKCRIT% of space available on $DIR" $EMAIL_ADDRESS
 WARNING!
 Available space on $DIR is less than $SPACECHECKCRIT%.
 Some services have been shut down to avoid running out of disk space.
 EOF
-        else
-            logger "SPACECHECK CRITICAL: Less than $SPACECHECKCRIT% of space available on $DIR - NOT shutting down!"
-            cat << EOF | mail -Ssendwait -s "SPACECHECK CRITICAL: Less than $SPACECHECKCRIT% of space available on $DIR" $EMAIL_ADDRESS
+}
+
+function sendCritical {
+    if [ "$CHECKONLY" = true ]; then
+        return
+    fi
+
+    logger "SPACECHECK CRITICAL: Less than $SPACECHECKCRIT% of space available on $DIR - NOT shutting down!"
+    cat << EOF | mail -Ssendwait -s "SPACECHECK CRITICAL: Less than $SPACECHECKCRIT% of space available on $DIR" $EMAIL_ADDRESS
 WARNING!
 Available space on $DIR is less than $SPACECHECKCRIT%.
 Automatic shutdown of services is disabled.
 You must shut down services to avoid running out of disk space.
 EOF
-        fi
-        STOPCHECK=1
-        break
-    elif [ $FREESPACE -lt $SPACECHECKALERT ] && [ "$STOPCHECK" = "0" ]; then
-        logger "SPACECHECK ALERT: Less than $SPACECHECKALERT% of space available on $DIR"
-        cat << EOF | mail -Ssendwait -s "SPACECHECK ALERT: Less than $SPACECHECKALERT% of space available on $DIR" $EMAIL_ADDRESS
+}
+
+function sendAlert {
+    if [ "$CHECKONLY" = true ]; then
+        return
+    fi
+
+    logger "SPACECHECK ALERT: Less than $SPACECHECKALERT% of space available on $DIR"
+    cat << EOF | mail -Ssendwait -s "SPACECHECK ALERT: Less than $SPACECHECKALERT% of space available on $DIR" $EMAIL_ADDRESS
 IMPORTANT
 
 If you run out of disk space, SUSE Manager will stop running, and this could lead to a loss of data.
@@ -84,9 +126,54 @@ spacecheck_free_critical = $SPACECHECKCRIT
 spacecheck_shutdown = $SPACECHECKSHUTDOWN
 ==========================================================================================================
 EOF
+}
+
+function updateSeverity {
+    if [ $1 -gt $CHECKSEVERITY ]; then
+        CHECKSEVERITY=$1
+    fi
+}
+
+# Main script
+
+CHECKONLY=false
+STOPCHECK=0
+CHECKSEVERITY=0
+
+ensureSpacewalkRunning
+
+parseArguments "$@"
+parseConfiguration /etc/rhn/rhn.conf
+
+for DIR in $SPACECHECKDIRS
+do
+    if [ ! -d $DIR ]; then
+        sendDirectoryMissing
+        updateSeverity 1
+        continue
+    fi
+
+    USEDSPACE=`df -PH $DIR | tail -1 | awk '{print $5}' | sed -e"s/\%//"`
+    FREESPACE=$((100 - $USEDSPACE))
+    if [ $FREESPACE -lt $SPACECHECKCRIT ] && [ "$STOPCHECK" = "0" ]; then
+        if [ "$SPACECHECKSHUTDOWN" = true ]; then
+            sendCriticalShutdown
+            updateSeverity 3
+        else
+            sendCritical
+            updateSeverity 3
+        fi
+
+        STOPCHECK=1
+        break
+    elif [ $FREESPACE -lt $SPACECHECKALERT ] && [ "$STOPCHECK" = "0" ]; then
+        sendAlert
+        updateSeverity 2
     fi
 done
 
-if [ "$STOPCHECK" = "1" ] && [ "$SPACECHECKSHUTDOWN" = "true" ]; then
+if [ "$CHECKONLY" = false ] && [ "$STOPCHECK" = "1" ] && [ "$SPACECHECKSHUTDOWN" = true ]; then
     spacewalk-service stop ; systemctl stop postgresql.service
 fi
+
+exit $CHECKSEVERITY

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,5 @@
+- Improved the diskcheck script to return an exit value and to
+  allow performing the check without sending notification
 - handle download of metadata filesnames with checksums (bsc#1188315)
 - Sanitize cached filename for custom SSL certs used by reposync (bsc#1190751)
 

--- a/java/code/src/com/suse/manager/utils/DiskCheckHelper.java
+++ b/java/code/src/com/suse/manager/utils/DiskCheckHelper.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.suse.manager.utils;
+
+import org.apache.log4j.Logger;
+
+import java.io.IOException;
+
+/**
+ * Class to execute a check of the available disk space with an external bash script.
+ */
+public class DiskCheckHelper {
+
+    private static final Logger LOG = Logger.getLogger(DiskCheckHelper.class);
+
+    /**
+     * Default path of the bash script to check the available space.
+     */
+    public static final String DISKCHECK_SCRIPT = "/usr/bin/spacewalk-diskcheck";
+
+    /**
+     * Invoke the external script and execute the check.
+     *
+     * @return the {@link DiskCheckSeverity} reported by the script or {@link DiskCheckSeverity#UNDEFINED} if it was
+     * not possible to evaluate the available disk space.
+     */
+    public DiskCheckSeverity executeDiskCheck() {
+        try {
+            final int result = invokeExternalScript();
+            return DiskCheckSeverity.valueOf(result);
+        }
+        catch (IOException | InterruptedException ex) {
+            LOG.warn("Unable to execute disk space check", ex);
+            return DiskCheckSeverity.UNDEFINED;
+        }
+        catch (RuntimeException ex) {
+            LOG.warn("Unable to evaluate disk check severity", ex);
+            return DiskCheckSeverity.UNDEFINED;
+        }
+    }
+
+    /**
+     * Executes the external script and returns the exit code. This method can be overridden during unit test to mock a
+     * specific result.
+     * @return the exit value as returned from the execution of the script.
+     * @throws IOException          when an I/O error occurs during the execution of the script.
+     * @throws InterruptedException when the process is interrupted while waiting for a result from the script.
+     */
+    protected int invokeExternalScript() throws IOException, InterruptedException {
+        final Process process = Runtime.getRuntime().exec(new String[]{DISKCHECK_SCRIPT, "-c"});
+        return process.waitFor();
+    }
+}

--- a/java/code/src/com/suse/manager/utils/DiskCheckSeverity.java
+++ b/java/code/src/com/suse/manager/utils/DiskCheckSeverity.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.utils;
+
+public enum DiskCheckSeverity {
+    /**
+     * Due to an error it was not possible to define a disk check severity level
+     */
+    UNDEFINED,
+
+    /**
+     * All the required space is available, no problems detected.
+     */
+    OK,
+
+    /**
+     * The configuration is not correct. It must be reviewed in order to obtain a sensible result.
+     */
+    MISCONFIGURATION,
+
+    /**
+     * The services are running out of disk space.
+     */
+    ALERT,
+
+    /**
+     * The disk space is almost exhausted. An immediate action is needed in order to keep the system running.
+     */
+    CRITICAL;
+
+    /**
+     * Returns the enum constant corresponding to the exit value of the bash script.
+     * @param exitValue the exit value reported by the bash script.
+     * @return the enum constant equivalent to the specified exit value.
+     * @throws IllegalArgumentException if the exit value is invalid.
+     */
+    public static DiskCheckSeverity valueOf(int exitValue) {
+        switch (exitValue) {
+            case 0:
+                return OK;
+            case 1:
+                return MISCONFIGURATION;
+            case 2:
+                return ALERT;
+            case 3:
+                return CRITICAL;
+            default:
+                throw new IllegalArgumentException("Exit value " + exitValue + " is not valid");
+        }
+
+    }
+}

--- a/java/code/src/com/suse/manager/utils/test/DiskCheckHelperTest.java
+++ b/java/code/src/com/suse/manager/utils/test/DiskCheckHelperTest.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.utils.test;
+
+import com.suse.manager.utils.DiskCheckHelper;
+import com.suse.manager.utils.DiskCheckSeverity;
+
+import java.io.IOException;
+
+import junit.framework.TestCase;
+
+/**
+ * Test for {@link DiskCheckHelper}
+ */
+public class DiskCheckHelperTest extends TestCase {
+
+    /**
+     * Enforces the handling of any exception inside the execution of the script.
+     */
+    public void testReturnsUndefinedWhenAnExceptionIsThrown() {
+        final DiskCheckHelper diskCheckHelper = new DiskCheckHelper() {
+            @Override
+            protected int invokeExternalScript() throws IOException {
+                throw new IOException("Fake unexpected exception during the execution of the script");
+            }
+        };
+
+        assertEquals(DiskCheckSeverity.UNDEFINED, diskCheckHelper.executeDiskCheck());
+    }
+
+    /**
+     * Enforce behaviour for wrong exit value parsing
+     */
+    public void testThrowsIllegalArgumentWhenExitCodeIsNotValid() {
+        assertEquals(DiskCheckSeverity.UNDEFINED, new FixedResultDiskCheckHelper(256).executeDiskCheck());
+    }
+
+    /**
+     * Ensures that the script return values are converted correctly.
+     */
+    public void testConvertExitValueToSeverity() {
+        assertEquals(DiskCheckSeverity.OK, new FixedResultDiskCheckHelper(0).executeDiskCheck());
+        assertEquals(DiskCheckSeverity.MISCONFIGURATION, new FixedResultDiskCheckHelper(1).executeDiskCheck());
+        assertEquals(DiskCheckSeverity.ALERT, new FixedResultDiskCheckHelper(2).executeDiskCheck());
+        assertEquals(DiskCheckSeverity.CRITICAL, new FixedResultDiskCheckHelper(3).executeDiskCheck());
+    }
+
+    /**
+     * DiskCheckHelper that mocks the execution of the script and always returns the same exit value.
+     */
+    private static class FixedResultDiskCheckHelper extends DiskCheckHelper {
+
+        private final int scriptResult;
+
+        private FixedResultDiskCheckHelper(int scriptResultIn) {
+            this.scriptResult = scriptResultIn;
+        }
+
+        @Override
+        protected int invokeExternalScript() throws IOException, InterruptedException {
+            return scriptResult;
+        }
+    }
+
+
+}

--- a/java/code/src/com/suse/manager/webui/controllers/login/LoginController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/login/LoginController.java
@@ -123,6 +123,7 @@ public class LoginController {
         model.put("preferredLocale", ConfigDefaults.get().getDefaultLocale());
         model.put("docsLocale", ConfigDefaults.get().getDefaultDocsLocale());
         model.put("webTheme", ConfigDefaults.get().getDefaultWebTheme());
+        model.put("diskspaceSeverity", LoginHelper.validateDiskSpaceAvailability());
 
         return new ModelAndView(model, "controllers/login/templates/login.jade");
     }

--- a/java/code/src/com/suse/manager/webui/controllers/login/templates/login.jade
+++ b/java/code/src/com/suse/manager/webui/controllers/login/templates/login.jade
@@ -64,6 +64,7 @@ html(lang=window.preferredLocale.replace("_", "-"))
                           legalNote: '!{legalNote}',
                           loginLength: '!{loginLength}',
                           passwordLength: '!{passwordLength}',
+                          diskspaceSeverity: '#{diskspaceSeverity}',
                       }
                     )
                 });

--- a/java/code/src/com/suse/manager/webui/utils/LoginHelper.java
+++ b/java/code/src/com/suse/manager/webui/utils/LoginHelper.java
@@ -42,6 +42,9 @@ import com.redhat.rhn.manager.user.CreateUserCommand;
 import com.redhat.rhn.manager.user.UpdateUserCommand;
 import com.redhat.rhn.manager.user.UserManager;
 
+import com.suse.manager.utils.DiskCheckHelper;
+import com.suse.manager.utils.DiskCheckSeverity;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.time.StopWatch;
 import org.apache.log4j.Logger;
@@ -452,5 +455,16 @@ public class LoginHelper {
             errors.add(e.getMessage());
         }
         return user;
+    }
+
+    /**
+     * Validate the available disk space using an external script.
+     * @return a string representing the severity level.
+     */
+    public static String validateDiskSpaceAvailability() {
+        final DiskCheckHelper diskCheck = new DiskCheckHelper();
+
+        final DiskCheckSeverity diskCheckSeverity = diskCheck.executeDiskCheck();
+        return diskCheckSeverity.name().toLowerCase();
     }
 }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Execute the diskcheck script at login to validate the available space
 - Add checksums to repository metadata filenames (bsc#1188315)
 - Fix ISE in product migration if base product is missing (bsc#1190151)
 - Add 'Flush cache' option to Ansible playbook execution

--- a/web/html/src/manager/login/login.renderer.tsx
+++ b/web/html/src/manager/login/login.renderer.tsx
@@ -16,6 +16,7 @@ export const renderer = (
     legalNote,
     loginLength,
     passwordLength,
+    diskspaceSeverity,
   }
 ) => {
   const elementToRender = document.getElementById(id);
@@ -33,6 +34,7 @@ export const renderer = (
         legalNote={legalNote}
         loginLength={loginLength}
         passwordLength={passwordLength}
+        diskspaceSeverity={diskspaceSeverity}
       />,
       elementToRender
     );

--- a/web/html/src/manager/login/login.tsx
+++ b/web/html/src/manager/login/login.tsx
@@ -40,7 +40,7 @@ const products = {
   },
 };
 
-const getGlobalMessages = (validationErrors, schemaUpgradeRequired) => {
+const getGlobalMessages = (validationErrors, schemaUpgradeRequired, diskspaceSeverity) => {
   let messages: MessageType[] = [];
 
   if (validationErrors && validationErrors.length > 0) {
@@ -52,6 +52,22 @@ const getGlobalMessages = (validationErrors, schemaUpgradeRequired) => {
       "A schema upgrade is required. Please upgrade your schema at your earliest convenience to receive latest bug fixes and avoid potential problems."
     );
     messages = messages.concat({ severity: "error", text: schemaUpgradeError });
+  }
+
+  if (diskspaceSeverity !== "ok") {
+    const severity_messages = {
+      "undefined": Messages.info(t("Unable to validate the disk space availability. Please contact your system admistrator if this problem persists.")),
+      "misconfiguration": Messages.warning(t("Some important directories are missing. Please contact your system administrator to review the configuration.")),
+      "alert": Messages.warning(t("The available disk space on the server is running low. Please contact your system administrator to add more disk space.")),
+      "critical": Messages.error(t("The available disk space on the server is critically low. Please contact your system administrator to add more disk space.")),
+    }
+
+    if (diskspaceSeverity in severity_messages) {
+      messages = messages.concat(severity_messages[diskspaceSeverity]);
+    } else {
+      console.warn("Unknown disk space severity level: " + diskspaceSeverity)
+      messages = messages.concat(severity_messages["undefined"]);
+    }
   }
 
   return messages;
@@ -81,6 +97,7 @@ type Props = {
   legalNote: string;
   loginLength: string;
   passwordLength: string;
+  diskspaceSeverity: string;
 };
 
 const Login = (props: Props) => {
@@ -98,7 +115,7 @@ const Login = (props: Props) => {
         <section id="spacewalk-content">
           <div className="wrap">
             <div className="container">
-              <Messages items={getGlobalMessages(props.validationErrors, props.schemaUpgradeRequired)} />
+              <Messages items={getGlobalMessages(props.validationErrors, props.schemaUpgradeRequired, props.diskspaceSeverity)} />
               <React.Fragment>
                 <div className="col-sm-6">
                   <h1>{product.bodyTitle}</h1>

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,5 @@
+- Display a warning in the login page if the available disk space
+  on the server is running out
 - Add 'Flush cache' checkbox to Ansible playbook execution page
   (bsc#1190405)
 - Fix 'Type' input in CLM source edit form (bsc#1190820)


### PR DESCRIPTION
## What does this PR change?

When the space is running low on the server a warning banner is displayed at the top of the login page. If the space level is critical and the server has not been shut down the banner is displayed as an error. The diskcheck script was changed to allow executing the check without sending a mail notification.

## GUI diff

After:
A banner is shown when the server is running out of space in the directories monitored by the diskcheck script
- [X] **DONE**

## Documentation
- [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pull/1189)

- [X] **DONE**

## Test coverage

- Unit tests were added

- [X] **DONE**

## Links

Fixes SUSE/spacewalk/issues/14259

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
