### PR TITLE
virt guests: formatting the earliest field breaks now

### DIFF
--- a/web/html/src/manager/virtualization/guests/create/guests-create.tsx
+++ b/web/html/src/manager/virtualization/guests/create/guests-create.tsx
@@ -8,7 +8,6 @@ import { GuestProperties } from "../GuestProperties";
 import { SimpleActionApi } from "../../SimpleActionApi";
 import * as GuestNicsPanel from "../properties/guest-nics-panel";
 import * as DiskUtils from "../properties/disk-utils";
-import { Formats } from "utils/functions";
 
 type Props = {
   host: any;
@@ -44,10 +43,10 @@ class GuestsCreate extends React.Component<Props, State> {
       {
         type: model.vmType,
         memory: model.memory,
+        earliest: model.earliest,
       },
       nics.length !== 0 ? { interfaces: nics } : undefined,
       disks.length !== 0 ? { disks } : undefined,
-      { earliest: Formats.LocalDateTime(model.earliest) }
     );
   }
 

--- a/web/html/src/manager/virtualization/guests/edit/guests-edit.tsx
+++ b/web/html/src/manager/virtualization/guests/edit/guests-edit.tsx
@@ -10,7 +10,6 @@ import * as GuestNicsPanel from "../properties/guest-nics-panel";
 import * as DiskUtils from "../properties/disk-utils";
 import { SimpleActionApi } from "../../SimpleActionApi";
 import { VirtualizationGuestDefinitionApi } from "../virtualization-guest-definition-api";
-import { Formats } from "utils/functions";
 
 type Props = {
   host: any;
@@ -70,10 +69,10 @@ class GuestsEdit extends React.Component<Props> {
       ),
       {
         memory: model.memory,
+        earliest: model.earliest,
       },
       nicsParams,
       disksParams,
-      { earliest: Formats.LocalDateTime(model.earliest) }
     );
   }
 

--- a/web/html/src/utils/functions.ts
+++ b/web/html/src/utils/functions.ts
@@ -35,34 +35,6 @@ function cancelable<T = any>(promise: Promise<T>, onCancel?: (arg0: Error | void
   return castRace;
 }
 
-function LocalDateTime(date: Date): string {
-  const padTo = v => {
-    v = v.toString();
-    if (v.length >= 2) return v;
-    else return padTo("0" + v);
-  };
-  const year = date.getFullYear();
-  const month = date.getMonth();
-  const days = date.getDate();
-  const hours = date.getHours();
-  const minutes = date.getMinutes();
-  const seconds = date.getSeconds();
-  return (
-    "" +
-    year +
-    "-" +
-    padTo(month + 1) +
-    "-" +
-    padTo(days) +
-    "T" +
-    padTo(hours) +
-    ":" +
-    padTo(minutes) +
-    ":" +
-    padTo(seconds)
-  );
-}
-
 function sortById(aRaw: any, bRaw: any): number {
   const aId = aRaw["id"];
   const bId = bRaw["id"];
@@ -202,13 +174,9 @@ const Utils = {
   getProductName,
 };
 
-const Formats = {
-  LocalDateTime,
-};
-
 const Formulas = {
   EditGroupSubtype,
   getEditGroupSubtype,
 };
 
-export { Utils, Formats, Formulas };
+export { Utils, Formulas };

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,5 @@
+- Fix the VM creation and editing submit button action (bsc#1190602)
+
 -------------------------------------------------------------------
 Fri Sep 17 12:12:54 CEST 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?



## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/15895

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
