### PR TITLE
Disable broken local repos before bootstrap

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
@@ -10,6 +10,9 @@ mgr_server_localhost_alias_absent:
 {% set repos_disabled = {'match_str': 'susemanager:', 'matching': true} %}
 {%- include 'channels/disablelocalrepos.sls' %}
 
+# disable all unaccessible local repos
+{%- include 'channels/disablelocalbrokenrepos.sls' %}
+
 {% set os_base = 'sle' %}
 # CentOS6 oscodename is bogus
 {%- if "centos" in grains['os']|lower %}

--- a/susemanager-utils/susemanager-sls/salt/channels/disablelocalbrokenrepos.sls
+++ b/susemanager-utils/susemanager-sls/salt/channels/disablelocalbrokenrepos.sls
@@ -1,0 +1,41 @@
+{% do repos_disabled.update({'count': 0}) %}
+{% set repos = salt['pkg.list_repos']() %}
+{% for alias, data in repos.items() %}
+{% if grains['os_family'] == 'Debian' %}
+{% for entry in data %}
+{% if entry.get('enabled', True) %}
+{% set url = entry.get('uri') %}
+{%- set repo_exists = (0 < salt['http.query'](url + '/Release', status=True, verify_ssl=True).get('status', 0) < 300) %}
+{% if not repo_exists %} 
+disable_repo_{{ repos_disabled.count }}:
+  mgrcompat.module_run:
+    - name: pkg.mod_repo
+    - repo: {{ "'" ~ entry.line ~ "'" }}
+    - kwargs:
+        disabled: True
+{% do repos_disabled.update({'count': repos_disabled.count + 1}) %}
+{% endif %}
+{% endif %}
+{% endfor %}
+{% else %}
+{% if data.get('enabled', True) %}
+{% set url = data.get('baseurl') %}
+{%- set repo_exists = (0 < salt['http.query'](url + '/repodata/repomd.xml', status=True, verify_ssl=True).get('status', 0) < 300) %}
+{% if not repo_exists %}
+disable_repo_{{ alias }}:
+  mgrcompat.module_run:
+    - name: pkg.mod_repo
+    - repo: {{ alias }}
+    - kwargs:
+        enabled: False
+    - require:
+{%- if grains.get('__suse_reserved_saltutil_states_support', False) %}
+      - saltutil: sync_states
+{%- else %}
+      - mgrcompat: sync_states
+{%- endif %}
+{% do repos_disabled.update({'count': repos_disabled.count + 1}) %}
+{% endif %}
+{% endif %}
+{% endif %}
+{% endfor %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- disable unaccessible local repos before bootstrapping (bsc#1186405)
 - Fix mgrcompat state module to work with Salt 3003 and 3004
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Some OS images include enabled repositories which are accessible only in special environments (e.g. inside of a specific cloud)
These images cannot be bootstrapped as they produce errors on refreshing the repositories.

This PR add a state which test the accessability of the local enabled repos and disable all, which cannot be used.
We keep the accessible once enabled until the bootstrapping is finished before we also disable them.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/15196
Fixes https://github.com/uyuni-project/uyuni/issues/3755
Tracks https://github.com/SUSE/spacewalk/pull/15938

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
