### PR TITLE
Align tls protocols for proxy

### DIFF
--- a/java/code/src/com/redhat/rhn/common/util/http/HttpClientAdapter.java
+++ b/java/code/src/com/redhat/rhn/common/util/http/HttpClientAdapter.java
@@ -52,6 +52,8 @@ import java.util.Optional;
 
 import javax.net.ssl.SSLContext;
 
+import spark.route.HttpMethod;
+
 /**
  * Adapter class holding an {@link HttpClient} object and offering a simple API to execute
  * arbitrary HTTP requests while proxy settings are applied transparently.
@@ -101,9 +103,12 @@ public class HttpClientAdapter {
         Optional<SSLConnectionSocketFactory> sslSocketFactory = Optional.empty();
         try {
             SSLContext sslContext = SSLContext.getDefault();
+            List<String> supportedProtocols = Arrays.asList(sslContext.getSupportedSSLParameters().getProtocols());
+            List<String> wantedProtocols = Arrays.asList("TLSv1", "TLSv1.1", "TLSv1.2", "TLSv1.3");
+            wantedProtocols.retainAll(supportedProtocols);
             sslSocketFactory = Optional.of(new SSLConnectionSocketFactory(
                     sslContext,
-                    new String[]{"TLSv1", "TLSv1.1", "TLSv1.2"},
+                    wantedProtocols.toArray(new String[0]),
                     null,
                     SSLConnectionSocketFactory.getDefaultHostnameVerifier()));
         }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- use TLSv1.3 if it is a supported Protocol
 - Adapt auto errata update to skip during CLM build (bsc#1189609)
 - Adapt auto errata update to respect maintenance windows
 - fix ISE in SSM when scheduling patches on multiple systems (bsc#1190396, bsc#1190275)

--- a/proxy/installer/configure-proxy.sh
+++ b/proxy/installer/configure-proxy.sh
@@ -613,7 +613,7 @@ fi
 sed -e "s|^[\t ]*SSLCertificateFile.*$|SSLCertificateFile $HTTPDCONF_DIR/ssl.crt/server.crt|g" \
     -e "s|^[\t ]*SSLCertificateKeyFile.*$|SSLCertificateKeyFile $HTTPDCONF_DIR/ssl.key/server.key|g" \
     -e "s|^[\t ]*SSLCipherSuite.*$|SSLCipherSuite ALL:!aNULL:!eNULL:!SSLv2:!LOW:!EXP:!MD5:@STRENGTH|g" \
-    -e "s|</VirtualHost>|SSLProtocol all -SSLv2 -SSLv3\nRewriteEngine on\nRewriteOptions inherit\nSSLProxyEngine on\n</VirtualHost>|" \
+    -e "s|</VirtualHost>|RewriteEngine on\nRewriteOptions inherit\nSSLProxyEngine on\n</VirtualHost>|" \
     < $HTTPDCONF_DIR/vhosts.d/ssl.conf.bak  > $HTTPDCONF_DIR/vhosts.d/ssl.conf
 
 

--- a/proxy/installer/spacewalk-proxy-installer.changes
+++ b/proxy/installer/spacewalk-proxy-installer.changes
@@ -1,3 +1,5 @@
+- use system default for SSLProtocol
+
 -------------------------------------------------------------------
 Mon Aug 09 11:02:43 CEST 2021 - jgonzalez@suse.com
 

--- a/proxy/installer/spacewalk-proxy-installer.spec
+++ b/proxy/installer/spacewalk-proxy-installer.spec
@@ -134,6 +134,15 @@ install -m 755 fetch-certificate.py  $RPM_BUILD_ROOT/%{_usr}/sbin/fetch-certific
 spacewalk-python3-pylint .
 %endif
 
+%post
+if [ $1 -eq 2 ]
+then
+  if [ -e /etc/apache2/vhosts.d/ssl.conf ]
+  then
+    sed 's/^SSLProtocol all.*$//g' /etc/apache2/vhosts.d/ssl.conf
+  fi
+fi
+
 %files
 %defattr(-,root,root,-)
 %dir %{defaultdir}

--- a/proxy/proxy/httpd-conf/spacewalk-proxy.conf
+++ b/proxy/proxy/httpd-conf/spacewalk-proxy.conf
@@ -49,9 +49,4 @@
    RewriteRule ^/rhn/?$ https://%{SERVER_NAME}/rhn/manager/login  [R,L]
 </IfModule>
 
-
-
-#Disable SSL2, left only higher
-SSLProtocol all -SSLv2
 SSLProxyEngine on
-

--- a/proxy/proxy/spacewalk-proxy.changes
+++ b/proxy/proxy/spacewalk-proxy.changes
@@ -1,3 +1,6 @@
+- remove SSLProtocol configuration which should be done in the ssl
+  configuration file
+
 -------------------------------------------------------------------
 Mon Aug 09 11:02:14 CEST 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

configure-proxy.sh was configuring SSLProtocol with some outdated values.
The apache default is a better use for now. 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **the current docs say already to adapt the config**

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/uyuni-project/uyuni/issues/4105
Tracks https://github.com/SUSE/spacewalk/pull/15940 https://github.com/SUSE/spacewalk/pull/15941

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
