### PR TITLE
Update kernel live patch version on minion startup (bsc#1190276)

### DIFF
--- a/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/JobReturnEventMessageActionTest.java
@@ -509,7 +509,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         messageAction.execute(message);
 
         // Verify live patching version
-        assertEquals("kgraft_patch_2_2_1", minion.getKernelLiveVersion());
+        assertEquals("livepatch_2_2_1", minion.getKernelLiveVersion());
 
         //Switch back from live patching
         message = new JobReturnEventMessage(JobReturnEvent
@@ -2216,6 +2216,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
     public void testMinionStartupResponse() throws Exception {
         MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
         String runningKernel = minion.getRunningKernel();
+        assertNull(minion.getKernelLiveVersion());
         Long lastBoot = minion.getLastBoot();
         String name = minion.getName();
         Map<String, String> placeholders = new HashMap<>();
@@ -2230,6 +2231,7 @@ public class JobReturnEventMessageActionTest extends JMockBaseTestCaseWithUser {
         messageAction.execute(message);
         assertEquals(name, minion.getName());
         assertNotSame(runningKernel, minion.getRunningKernel());
+        assertEquals("livepatch_2_2_3", minion.getKernelLiveVersion());
         assertNotSame(lastBoot, minion.getLastBoot());
     }
 

--- a/java/code/src/com/suse/manager/reactor/messaging/test/minion.startup.applied.state.response.json
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/minion.startup.applied.state.response.json
@@ -35,6 +35,21 @@
         },
         "__id__": "grains_update"
       },
+      "mgrcompat_|-kernel_live_version_|-sumautil.get_kernel_live_version_|-module_run": {
+        "comment": "Module function sumautil.get_kernel_live_version executed",
+        "name": "sumautil.get_kernel_live_version",
+        "start_time": "15:10:28.950000",
+        "result": true,
+        "duration": 10,
+        "__run_num__": 4,
+        "__sls__": "util.systeminfo",
+        "changes": {
+          "ret": {
+            "mgr_kernel_live_version": "livepatch_2_2_3"
+          }
+        },
+        "__id__": "grains_update"
+      },
       "mgrcompat_|-status_uptime_|-status.uptime_|-module_run": {
         "__id__": "status_uptime",
         "__run_num__": 3,

--- a/java/code/src/com/suse/manager/reactor/messaging/test/packages.profileupdate.livepatching.json
+++ b/java/code/src/com/suse/manager/reactor/messaging/test/packages.profileupdate.livepatching.json
@@ -258,7 +258,7 @@
         "__run_num__": 5,
         "changes": {
           "ret": {
-            "mgr_kernel_live_version": "kgraft_patch_2_2_1"
+            "mgr_kernel_live_version": "livepatch_2_2_1"
           }
         },
         "comment": "Module function sumautil.get_kernel_live_version executed",

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -1958,10 +1958,10 @@ public class SaltUtils {
      * @param minion  minion for which information should be updated
      */
     public void updateSystemInfo(SystemInfo systemInfo, MinionServer minion) {
-        systemInfo.getKerneRelese().ifPresent(kerneRelese -> {
-            minion.setRunningKernel(kerneRelese);
-            ServerFactory.save(minion);
-        });
+        systemInfo.getKerneRelese().ifPresent(minion::setRunningKernel);
+        systemInfo.getKernelLiveVersion().ifPresent(minion::setKernelLiveVersion);
+        ServerFactory.save(minion);
+
         //Update the uptime
         systemInfo.getUptimeSeconds().ifPresent(us-> handleUptimeUpdate(minion, us.longValue()));
     }

--- a/java/code/src/com/suse/manager/webui/utils/salt/custom/SystemInfo.java
+++ b/java/code/src/com/suse/manager/webui/utils/salt/custom/SystemInfo.java
@@ -34,6 +34,8 @@ public class SystemInfo {
     private StateApplyResult<Ret<Map<String, Object>>> upTime;
     @SerializedName("mgrcompat_|-grains_update_|-grains.item_|-module_run")
     private StateApplyResult<Ret<Map<String, Object>>> grains;
+    @SerializedName("mgrcompat_|-kernel_live_version_|-sumautil.get_kernel_live_version_|-module_run")
+    private StateApplyResult<Ret<KernelLiveVersionInfo>> kernelLiveVersion;
 
     /**
      * Gets grains in key/value pair.
@@ -59,5 +61,18 @@ public class SystemInfo {
      */
     public Optional<String> getKerneRelese() {
        return getGrains().getOptionalAsString("kernelrelease");
+    }
+
+    /**
+     * Get the kernel live patch version, if exists
+     *
+     * @return the kernel live patch version
+     */
+    public Optional<String> getKernelLiveVersion() {
+        if (kernelLiveVersion == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(kernelLiveVersion.getChanges().getRet())
+                .map(KernelLiveVersionInfo::getKernelLiveVersion);
     }
 }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Update kernel live patch version on minion startup (bsc#1190276)
 - use TLSv1.3 if it is a supported Protocol
 - Adapt auto errata update to skip during CLM build (bsc#1189609)
 - Adapt auto errata update to respect maintenance windows

--- a/susemanager-utils/susemanager-sls/salt/util/systeminfo.sls
+++ b/susemanager-utils/susemanager-sls/salt/util/systeminfo.sls
@@ -11,3 +11,6 @@ grains_update:
     - name: grains.item
     - args:
       - kernelrelease
+kernel_live_version:
+  mgrcompat.module_run:
+    - name: sumautil.get_kernel_live_version

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Update kernel live patch version on minion startup (bsc#1190276)
 - Fix virt grain python2 compatibility
 - disable unaccessible local repos before bootstrapping (bsc#1186405)
 - Fix mgrcompat state module to work with Salt 3003 and 3004


### PR DESCRIPTION
When the running kernel is changed on a system after a reboot, the corresponding live patch version also changes. At minion startup, we always check and update the running kernel but not the live patch info, so system details show outdated information for the live patch.

This PR adds a `sumautil.get_kernel_live_version` call to `util.systeminfo` state which is run in response to a minion startup, ensuring we update the live patch version properly.

See: https://bugzilla.suse.com/show_bug.cgi?id=1190276

Port of: https://github.com/SUSE/spacewalk/pull/15916

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
