### PR TITLE
Add additional matchers to package (nevra) filter

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/FilterCriteria.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/FilterCriteria.java
@@ -71,7 +71,9 @@ public class FilterCriteria {
     static {
         validCombinations.add(Triple.of(PACKAGE, CONTAINS, "name"));
         validCombinations.add(Triple.of(PACKAGE, EQUALS, "nevr"));
+        validCombinations.add(Triple.of(PACKAGE, GREATEREQ, "nevr"));
         validCombinations.add(Triple.of(PACKAGE, EQUALS, "nevra"));
+        validCombinations.add(Triple.of(PACKAGE, GREATEREQ, "nevra"));
         validCombinations.add(Triple.of(PACKAGE, MATCHES, "name"));
         validCombinations.add(Triple.of(ERRATUM, EQUALS, "advisory_name"));
         validCombinations.add(Triple.of(ERRATUM, EQUALS, "advisory_type"));

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/FilterCriteria.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/FilterCriteria.java
@@ -30,6 +30,8 @@ import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.EQUALS;
 import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.EXISTS;
 import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.GREATER;
 import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.GREATEREQ;
+import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.LOWER;
+import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.LOWEREQ;
 import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.MATCHES;
 import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.MATCHES_PKG_NAME;
 import static com.redhat.rhn.domain.contentmgmt.FilterCriteria.Matcher.PROVIDES_NAME;
@@ -70,10 +72,16 @@ public class FilterCriteria {
 
     static {
         validCombinations.add(Triple.of(PACKAGE, CONTAINS, "name"));
+        validCombinations.add(Triple.of(PACKAGE, LOWER, "nevr"));
+        validCombinations.add(Triple.of(PACKAGE, LOWEREQ, "nevr"));
         validCombinations.add(Triple.of(PACKAGE, EQUALS, "nevr"));
         validCombinations.add(Triple.of(PACKAGE, GREATEREQ, "nevr"));
+        validCombinations.add(Triple.of(PACKAGE, GREATER, "nevr"));
+        validCombinations.add(Triple.of(PACKAGE, LOWER, "nevra"));
+        validCombinations.add(Triple.of(PACKAGE, LOWEREQ, "nevra"));
         validCombinations.add(Triple.of(PACKAGE, EQUALS, "nevra"));
         validCombinations.add(Triple.of(PACKAGE, GREATEREQ, "nevra"));
+        validCombinations.add(Triple.of(PACKAGE, GREATER, "nevra"));
         validCombinations.add(Triple.of(PACKAGE, MATCHES, "name"));
         validCombinations.add(Triple.of(ERRATUM, EQUALS, "advisory_name"));
         validCombinations.add(Triple.of(ERRATUM, EQUALS, "advisory_type"));
@@ -109,6 +117,8 @@ public class FilterCriteria {
         CONTAINS_PKG_EQ_EVR("contains_pkg_eq_evr"), // ==
         CONTAINS_PKG_GE_EVR("contains_pkg_ge_evr"), // >=
         CONTAINS_PKG_GT_EVR("contains_pkg_gt_evr"), // >
+        LOWER("lower"),
+        LOWEREQ("lowereq"),
         EQUALS("equals"),
         GREATER("greater"),
         GREATEREQ("greatereq"),

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/PackageFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/PackageFilter.java
@@ -16,6 +16,7 @@
 package com.redhat.rhn.domain.contentmgmt;
 
 import com.redhat.rhn.domain.rhnpackage.Package;
+import com.redhat.rhn.domain.rhnpackage.PackageEvr;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -46,6 +47,9 @@ public class PackageFilter extends ContentFilter<Package> {
                 return getField(pack, field, String.class).contains(value);
             case EQUALS:
                 return getField(pack, field, String.class).equals(value);
+            case GREATEREQ:
+                return pack.getPackageEvr().compareTo(
+                        PackageEvr.parsePackageEvr(pack.getPackageType(), getEvr(field, value))) >= 0;
             case MATCHES:
                 if (pattern == null) {
                     pattern = Pattern.compile(value);
@@ -76,6 +80,18 @@ public class PackageFilter extends ContentFilter<Package> {
                 return type.cast(pack.getExtraTag("modularitylabel"));
             default:
                 throw new UnsupportedOperationException("Field " + field + " not supported");
+        }
+    }
+
+    private static String getEvr(String field, String value) {
+        if (field.equals("nevr")) {
+            return value.replaceAll("(.*)-(.*:)?(.*)-(.*)", "$2$3-$4");
+        }
+        else if (field.equals("nevra")) {
+            return value.replaceAll("(.*)-(.*:)?(.*)-(.*)\\.(.*)", "$2$3-$4");
+        }
+        else {
+            throw new UnsupportedOperationException("Field " + field + " not supported for filter Package (NEVRA)");
         }
     }
 

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/PackageFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/PackageFilter.java
@@ -46,18 +46,18 @@ public class PackageFilter extends ContentFilter<Package> {
             case CONTAINS:
                 return getField(pack, field, String.class).contains(value);
             case LOWER:
-                return pack.getPackageEvr().compareTo(
+                return checkNameAndArch(field, value, pack) && pack.getPackageEvr().compareTo(
                         PackageEvr.parsePackageEvr(pack.getPackageType(), getEvr(field, value))) < 0;
             case LOWEREQ:
-                return pack.getPackageEvr().compareTo(
+                return checkNameAndArch(field, value, pack) && pack.getPackageEvr().compareTo(
                         PackageEvr.parsePackageEvr(pack.getPackageType(), getEvr(field, value))) <= 0;
             case EQUALS:
                 return getField(pack, field, String.class).equals(value);
             case GREATEREQ:
-                return pack.getPackageEvr().compareTo(
+                return checkNameAndArch(field, value, pack) && pack.getPackageEvr().compareTo(
                         PackageEvr.parsePackageEvr(pack.getPackageType(), getEvr(field, value))) >= 0;
             case GREATER:
-                return pack.getPackageEvr().compareTo(
+                return checkNameAndArch(field, value, pack) && pack.getPackageEvr().compareTo(
                         PackageEvr.parsePackageEvr(pack.getPackageType(), getEvr(field, value))) > 0;
             case MATCHES:
                 if (pattern == null) {
@@ -89,6 +89,19 @@ public class PackageFilter extends ContentFilter<Package> {
                 return type.cast(pack.getExtraTag("modularitylabel"));
             default:
                 throw new UnsupportedOperationException("Field " + field + " not supported");
+        }
+    }
+
+    private static boolean checkNameAndArch(String field, String value, Package pack) {
+        if (field.equals("nevr")) {
+            return value.replaceAll("(.*)-(.*:)?(.*)-(.*)", "$1").equals(pack.getPackageName().getName());
+        }
+        else if (field.equals("nevra")) {
+            return value.replaceAll("(.*)-(.*:)?(.*)-(.*)\\.(.*)", "$1$5")
+                    .equals(pack.getPackageName().getName() + pack.getPackageArch().getLabel());
+        }
+        else {
+            throw new UnsupportedOperationException("Field " + field + " not supported for filter Package (NEVRA)");
         }
     }
 

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/PackageFilter.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/PackageFilter.java
@@ -45,11 +45,20 @@ public class PackageFilter extends ContentFilter<Package> {
         switch (matcher) {
             case CONTAINS:
                 return getField(pack, field, String.class).contains(value);
+            case LOWER:
+                return pack.getPackageEvr().compareTo(
+                        PackageEvr.parsePackageEvr(pack.getPackageType(), getEvr(field, value))) < 0;
+            case LOWEREQ:
+                return pack.getPackageEvr().compareTo(
+                        PackageEvr.parsePackageEvr(pack.getPackageType(), getEvr(field, value))) <= 0;
             case EQUALS:
                 return getField(pack, field, String.class).equals(value);
             case GREATEREQ:
                 return pack.getPackageEvr().compareTo(
                         PackageEvr.parsePackageEvr(pack.getPackageType(), getEvr(field, value))) >= 0;
+            case GREATER:
+                return pack.getPackageEvr().compareTo(
+                        PackageEvr.parsePackageEvr(pack.getPackageType(), getEvr(field, value))) > 0;
             case MATCHES:
                 if (pattern == null) {
                     pattern = Pattern.compile(value);

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentFilterTest.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentFilterTest.java
@@ -100,7 +100,7 @@ public class ContentFilterTest extends JMockBaseTestCaseWithUser {
         assertFalse(filter.test(pack));
     }
 
-    public void testPackageNevraFilter() throws Exception {
+    public void testPackageNevraFilterRPM() throws Exception {
         Package pack = PackageTest.createTestPackage(user.getOrg());
         PackageEvr evr = PackageEvrFactoryTest.createTestPackageEvr(
                 "1", "1.0.0", "3", PackageType.RPM);
@@ -110,6 +110,98 @@ public class ContentFilterTest extends JMockBaseTestCaseWithUser {
         String evrLower = "-1:0.9.9-5";
         String evrEquals = "-1:1.0.0-3";
         String evrGreater = "-1:1.1.0-1";
+
+        // LOWER
+        FilterCriteria criteria = new FilterCriteria(FilterCriteria.Matcher.LOWER, "nevr", "should-fail" + evrGreater);
+        ContentFilter filter = contentManager.createFilter(packageName + "nevra-lower-filter1",
+                DENY, PACKAGE, criteria, user);
+        assertFalse(filter.test(pack));
+
+        criteria = new FilterCriteria(FilterCriteria.Matcher.LOWER, "nevra",
+                packageName + evrGreater + ".x86_64");
+        filter = contentManager.createFilter(packageName + "nevra-lower-filter2", DENY, PACKAGE, criteria, user);
+        assertFalse(filter.test(pack));
+
+        criteria = new FilterCriteria(FilterCriteria.Matcher.LOWER, "nevra",
+                packageName + evrGreater + "." + pack.getPackageArch().getLabel());
+        filter = contentManager.createFilter(packageName + "nevra-lower-filter3", DENY, PACKAGE, criteria, user);
+        assertTrue(filter.test(pack));
+
+        criteria = new FilterCriteria(FilterCriteria.Matcher.LOWER, "nevr", packageName + evrLower);
+        filter = contentManager.createFilter(packageName + "nevra-lower-filter4", DENY, PACKAGE, criteria, user);
+        assertFalse(filter.test(pack));
+
+        criteria = new FilterCriteria(FilterCriteria.Matcher.LOWER, "nevr", packageName + evrEquals);
+        filter = contentManager.createFilter(packageName + "nevra-lower-filter5", DENY, PACKAGE, criteria, user);
+        assertFalse(filter.test(pack));
+
+        criteria = new FilterCriteria(FilterCriteria.Matcher.LOWER, "nevr", packageName + evrGreater);
+        filter = contentManager.createFilter(packageName + "nevra-lower-filter6", DENY, PACKAGE, criteria, user);
+        assertTrue(filter.test(pack));
+
+        // LOWEREQ
+        criteria = new FilterCriteria(FilterCriteria.Matcher.LOWEREQ, "nevr", packageName + evrLower);
+        filter = contentManager.createFilter(packageName + "nevra-lowereq-filter1", DENY, PACKAGE, criteria, user);
+        assertFalse(filter.test(pack));
+
+        criteria = new FilterCriteria(FilterCriteria.Matcher.LOWEREQ, "nevr", packageName + evrEquals);
+        filter = contentManager.createFilter(packageName + "nevra-lowereq-filter2", DENY, PACKAGE, criteria, user);
+        assertTrue(filter.test(pack));
+
+        criteria = new FilterCriteria(FilterCriteria.Matcher.LOWEREQ, "nevr", packageName + evrGreater);
+        filter = contentManager.createFilter(packageName + "nevra-lowereq-filter3", DENY, PACKAGE, criteria, user);
+        assertTrue(filter.test(pack));
+
+        // EQUALS
+        criteria = new FilterCriteria(FilterCriteria.Matcher.EQUALS, "nevra", pack.getNameEvra());
+        filter = contentManager.createFilter(packageName + "-nevra-equals-filter1", DENY, PACKAGE, criteria, user);
+        assertTrue(filter.test(pack));
+
+        criteria = new FilterCriteria(FilterCriteria.Matcher.EQUALS, "nevra", pack.getNameEvr());
+        filter = contentManager.createFilter(packageName + "nevra-equals-filter2", DENY, PACKAGE, criteria, user);
+        assertFalse(filter.test(pack));
+
+        criteria = new FilterCriteria(FilterCriteria.Matcher.EQUALS, "nevra", packageName);
+        filter = contentManager.createFilter(packageName + "nevra-equals-filter3", DENY, PACKAGE, criteria, user);
+        assertFalse(filter.test(pack));
+
+        // GREATEREQ
+        criteria = new FilterCriteria(FilterCriteria.Matcher.GREATEREQ, "nevr", packageName + evrLower);
+        filter = contentManager.createFilter(packageName + "nevra-greatereq-filter1", DENY, PACKAGE, criteria, user);
+        assertTrue(filter.test(pack));
+
+        criteria = new FilterCriteria(FilterCriteria.Matcher.GREATEREQ, "nevr", packageName + evrEquals);
+        filter = contentManager.createFilter(packageName + "nevra-greatereq-filter2", DENY, PACKAGE, criteria, user);
+        assertTrue(filter.test(pack));
+
+        criteria = new FilterCriteria(FilterCriteria.Matcher.GREATEREQ, "nevr", packageName + evrGreater);
+        filter = contentManager.createFilter(packageName + "nevra-greatereq-filter3", DENY, PACKAGE, criteria, user);
+        assertFalse(filter.test(pack));
+
+        // GREATER
+        criteria = new FilterCriteria(FilterCriteria.Matcher.GREATER, "nevr", packageName + evrLower);
+        filter = contentManager.createFilter(packageName + "nevra-greater-filter1", DENY, PACKAGE, criteria, user);
+        assertTrue(filter.test(pack));
+
+        criteria = new FilterCriteria(FilterCriteria.Matcher.GREATER, "nevr", packageName + evrEquals);
+        filter = contentManager.createFilter(packageName + "nevra-greater-filter2", DENY, PACKAGE, criteria, user);
+        assertFalse(filter.test(pack));
+
+        criteria = new FilterCriteria(FilterCriteria.Matcher.GREATER, "nevr", packageName + evrGreater);
+        filter = contentManager.createFilter(packageName + "nevra-greater-filter3", DENY, PACKAGE, criteria, user);
+        assertFalse(filter.test(pack));
+    }
+
+    public void testPackageNevraFilterDeb() throws Exception {
+        Package pack = PackageTest.createTestPackage(user.getOrg());
+        PackageEvr evr = PackageEvrFactoryTest.createTestPackageEvr(
+                "1", "2.3~.4a+b", "5+abc.6~", PackageType.DEB);
+        pack.setPackageEvr(evr);
+        String packageName = pack.getPackageName().getName();
+
+        String evrLower = "-1:2.2~.4a+b-4+abc.6~";
+        String evrEquals = "-1:2.3~.4a+b-5+abc.6~";
+        String evrGreater = "-1:2.4~.4a+b-6+abc.6~";
 
         // LOWER
         FilterCriteria criteria = new FilterCriteria(FilterCriteria.Matcher.LOWER, "nevr", "should-fail" + evrGreater);

--- a/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentFilterTest.java
+++ b/java/code/src/com/redhat/rhn/domain/contentmgmt/test/ContentFilterTest.java
@@ -29,7 +29,10 @@ import com.redhat.rhn.domain.errata.Errata;
 import com.redhat.rhn.domain.errata.ErrataFactory;
 import com.redhat.rhn.domain.rhnpackage.Package;
 import com.redhat.rhn.domain.rhnpackage.PackageCapability;
+import com.redhat.rhn.domain.rhnpackage.PackageEvr;
 import com.redhat.rhn.domain.rhnpackage.PackageProvides;
+import com.redhat.rhn.domain.rhnpackage.PackageType;
+import com.redhat.rhn.domain.rhnpackage.test.PackageEvrFactoryTest;
 import com.redhat.rhn.domain.rhnpackage.test.PackageTest;
 import com.redhat.rhn.manager.contentmgmt.ContentManager;
 import com.redhat.rhn.testing.ErrataTestUtils;
@@ -99,19 +102,93 @@ public class ContentFilterTest extends JMockBaseTestCaseWithUser {
 
     public void testPackageNevraFilter() throws Exception {
         Package pack = PackageTest.createTestPackage(user.getOrg());
+        PackageEvr evr = PackageEvrFactoryTest.createTestPackageEvr(
+                "1", "1.0.0", "3", PackageType.RPM);
+        pack.setPackageEvr(evr);
         String packageName = pack.getPackageName().getName();
 
-        FilterCriteria criteria = new FilterCriteria(FilterCriteria.Matcher.EQUALS, "nevra", pack.getNameEvra());
-        ContentFilter filter = contentManager.createFilter(packageName + "-nevra-filter",
+        String evrLower = "-1:0.9.9-5";
+        String evrEquals = "-1:1.0.0-3";
+        String evrGreater = "-1:1.1.0-1";
+
+        // LOWER
+        FilterCriteria criteria = new FilterCriteria(FilterCriteria.Matcher.LOWER, "nevr", "should-fail" + evrGreater);
+        ContentFilter filter = contentManager.createFilter(packageName + "nevra-lower-filter1",
                 DENY, PACKAGE, criteria, user);
+        assertFalse(filter.test(pack));
+
+        criteria = new FilterCriteria(FilterCriteria.Matcher.LOWER, "nevra",
+                packageName + evrGreater + ".x86_64");
+        filter = contentManager.createFilter(packageName + "nevra-lower-filter2", DENY, PACKAGE, criteria, user);
+        assertFalse(filter.test(pack));
+
+        criteria = new FilterCriteria(FilterCriteria.Matcher.LOWER, "nevra",
+                packageName + evrGreater + "." + pack.getPackageArch().getLabel());
+        filter = contentManager.createFilter(packageName + "nevra-lower-filter3", DENY, PACKAGE, criteria, user);
+        assertTrue(filter.test(pack));
+
+        criteria = new FilterCriteria(FilterCriteria.Matcher.LOWER, "nevr", packageName + evrLower);
+        filter = contentManager.createFilter(packageName + "nevra-lower-filter4", DENY, PACKAGE, criteria, user);
+        assertFalse(filter.test(pack));
+
+        criteria = new FilterCriteria(FilterCriteria.Matcher.LOWER, "nevr", packageName + evrEquals);
+        filter = contentManager.createFilter(packageName + "nevra-lower-filter5", DENY, PACKAGE, criteria, user);
+        assertFalse(filter.test(pack));
+
+        criteria = new FilterCriteria(FilterCriteria.Matcher.LOWER, "nevr", packageName + evrGreater);
+        filter = contentManager.createFilter(packageName + "nevra-lower-filter6", DENY, PACKAGE, criteria, user);
+        assertTrue(filter.test(pack));
+
+        // LOWEREQ
+        criteria = new FilterCriteria(FilterCriteria.Matcher.LOWEREQ, "nevr", packageName + evrLower);
+        filter = contentManager.createFilter(packageName + "nevra-lowereq-filter1", DENY, PACKAGE, criteria, user);
+        assertFalse(filter.test(pack));
+
+        criteria = new FilterCriteria(FilterCriteria.Matcher.LOWEREQ, "nevr", packageName + evrEquals);
+        filter = contentManager.createFilter(packageName + "nevra-lowereq-filter2", DENY, PACKAGE, criteria, user);
+        assertTrue(filter.test(pack));
+
+        criteria = new FilterCriteria(FilterCriteria.Matcher.LOWEREQ, "nevr", packageName + evrGreater);
+        filter = contentManager.createFilter(packageName + "nevra-lowereq-filter3", DENY, PACKAGE, criteria, user);
+        assertTrue(filter.test(pack));
+
+        // EQUALS
+        criteria = new FilterCriteria(FilterCriteria.Matcher.EQUALS, "nevra", pack.getNameEvra());
+        filter = contentManager.createFilter(packageName + "-nevra-equals-filter1", DENY, PACKAGE, criteria, user);
         assertTrue(filter.test(pack));
 
         criteria = new FilterCriteria(FilterCriteria.Matcher.EQUALS, "nevra", pack.getNameEvr());
-        filter = contentManager.createFilter(packageName + "nevra2-filter", DENY, PACKAGE, criteria, user);
+        filter = contentManager.createFilter(packageName + "nevra-equals-filter2", DENY, PACKAGE, criteria, user);
         assertFalse(filter.test(pack));
 
         criteria = new FilterCriteria(FilterCriteria.Matcher.EQUALS, "nevra", packageName);
-        filter = contentManager.createFilter(packageName + "nevra3-filter", DENY, PACKAGE, criteria, user);
+        filter = contentManager.createFilter(packageName + "nevra-equals-filter3", DENY, PACKAGE, criteria, user);
+        assertFalse(filter.test(pack));
+
+        // GREATEREQ
+        criteria = new FilterCriteria(FilterCriteria.Matcher.GREATEREQ, "nevr", packageName + evrLower);
+        filter = contentManager.createFilter(packageName + "nevra-greatereq-filter1", DENY, PACKAGE, criteria, user);
+        assertTrue(filter.test(pack));
+
+        criteria = new FilterCriteria(FilterCriteria.Matcher.GREATEREQ, "nevr", packageName + evrEquals);
+        filter = contentManager.createFilter(packageName + "nevra-greatereq-filter2", DENY, PACKAGE, criteria, user);
+        assertTrue(filter.test(pack));
+
+        criteria = new FilterCriteria(FilterCriteria.Matcher.GREATEREQ, "nevr", packageName + evrGreater);
+        filter = contentManager.createFilter(packageName + "nevra-greatereq-filter3", DENY, PACKAGE, criteria, user);
+        assertFalse(filter.test(pack));
+
+        // GREATER
+        criteria = new FilterCriteria(FilterCriteria.Matcher.GREATER, "nevr", packageName + evrLower);
+        filter = contentManager.createFilter(packageName + "nevra-greater-filter1", DENY, PACKAGE, criteria, user);
+        assertTrue(filter.test(pack));
+
+        criteria = new FilterCriteria(FilterCriteria.Matcher.GREATER, "nevr", packageName + evrEquals);
+        filter = contentManager.createFilter(packageName + "nevra-greater-filter2", DENY, PACKAGE, criteria, user);
+        assertFalse(filter.test(pack));
+
+        criteria = new FilterCriteria(FilterCriteria.Matcher.GREATER, "nevr", packageName + evrGreater);
+        filter = contentManager.createFilter(packageName + "nevra-greater-filter3", DENY, PACKAGE, criteria, user);
         assertFalse(filter.test(pack));
     }
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add additional matchers to package (nevra) filter
 - Add greater equals matcher to package (nevra) filter
 - UI and API call for changing proxy
 - Use an 'allow' filter for the kernel packages with live patching

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add greater equals matcher to package (nevra) filter
 - UI and API call for changing proxy
 - Use an 'allow' filter for the kernel packages with live patching
   filter templates (bsc#1191460)

--- a/web/html/src/manager/content-management/shared/business/filters.enum.test.ts
+++ b/web/html/src/manager/content-management/shared/business/filters.enum.test.ts
@@ -33,6 +33,24 @@ describe("Testing filters enum and descriptions", () => {
     filter.criteriaValue = "asd-123-123";
     filter.rule = "deny";
     expect(getClmFilterDescription(filter)).toEqual("filter by nevra name: deny package equal asd-123-123 (nevr)");
+
+    filter.matcher = "lower";
+    expect(getClmFilterDescription(filter)).toEqual("filter by nevra name: deny package lower than asd-123-123 (nevr)");
+
+    filter.matcher = "lowereq";
+    expect(getClmFilterDescription(filter)).toEqual(
+      "filter by nevra name: deny package lower or equal than asd-123-123 (nevr)"
+    );
+
+    filter.matcher = "greater";
+    expect(getClmFilterDescription(filter)).toEqual(
+      "filter by nevra name: deny package greater than asd-123-123 (nevr)"
+    );
+
+    filter.matcher = "greatereq";
+    expect(getClmFilterDescription(filter)).toEqual(
+      "filter by nevra name: deny package greater or equal than asd-123-123 (nevr)"
+    );
   });
 
   test("test filter package provides description", () => {
@@ -123,7 +141,7 @@ describe("Testing filters enum and descriptions", () => {
     };
 
     expect(getClmFilterDescription(filter)).toEqual(
-      "filter by date: deny patch later or equal than 2018-09-10T00:00+01:00 (issue_date)"
+      "filter by date: deny patch greater or equal than 2018-09-10T00:00+01:00 (issue_date)"
     );
   });
 

--- a/web/html/src/manager/content-management/shared/business/filters.enum.ts
+++ b/web/html/src/manager/content-management/shared/business/filters.enum.ts
@@ -81,6 +81,16 @@ const filterMatchers: FilterMatcherEnumType = {
     text: "provides name",
     longDescription: t("contains package which provides name equal"),
   },
+  LOWER: {
+    key: "lower",
+    text: t("lower"),
+    longDescription: t("lower than"),
+  },
+  LOWEREQ: {
+    key: "lowereq",
+    text: t("lower or equal"),
+    longDescription: t("lower or equal than"),
+  },
   EQUALS: {
     key: "equals",
     text: t("equals"),
@@ -88,8 +98,13 @@ const filterMatchers: FilterMatcherEnumType = {
   },
   GREATEREQ: {
     key: "greatereq",
-    text: t("later or equal"),
-    longDescription: t("later or equal than"),
+    text: t("greater or equal"),
+    longDescription: t("greater or equal than"),
+  },
+  GREATER: {
+    key: "greater",
+    text: t("greater"),
+    longDescription: t("greater than"),
   },
   MATCHES: {
     key: "matches",
@@ -114,7 +129,13 @@ export const clmFilterOptions: ClmFilterOptionsEnumType = {
     key: "nevra",
     text: t("NEVRA"),
     entityType: filterEntity.PACKAGE,
-    matchers: [filterMatchers.EQUALS, filterMatchers.GREATEREQ],
+    matchers: [
+      filterMatchers.LOWER,
+      filterMatchers.LOWEREQ,
+      filterMatchers.EQUALS,
+      filterMatchers.GREATER,
+      filterMatchers.GREATEREQ
+    ],
   },
   PROVIDES_NAME: {
     key: "provides_name",

--- a/web/html/src/manager/content-management/shared/business/filters.enum.ts
+++ b/web/html/src/manager/content-management/shared/business/filters.enum.ts
@@ -114,7 +114,7 @@ export const clmFilterOptions: ClmFilterOptionsEnumType = {
     key: "nevra",
     text: t("NEVRA"),
     entityType: filterEntity.PACKAGE,
-    matchers: [filterMatchers.EQUALS],
+    matchers: [filterMatchers.EQUALS, filterMatchers.GREATEREQ],
   },
   PROVIDES_NAME: {
     key: "provides_name",

--- a/web/html/src/manager/content-management/shared/business/filters.enum.ts
+++ b/web/html/src/manager/content-management/shared/business/filters.enum.ts
@@ -134,7 +134,7 @@ export const clmFilterOptions: ClmFilterOptionsEnumType = {
       filterMatchers.LOWEREQ,
       filterMatchers.EQUALS,
       filterMatchers.GREATER,
-      filterMatchers.GREATEREQ
+      filterMatchers.GREATEREQ,
     ],
   },
   PROVIDES_NAME: {


### PR DESCRIPTION
## What does this PR change?

Add additional matchers (lower, lowereq, greater, greatereq) to CLM package (NEVRA) filter

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: **TODO: Check docs if there are mentions about the package (NEVRA) matchers**

- [x] **DONE**

## Test coverage

- Unit tests were added

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/13617
Tracks https://github.com/uyuni-project/uyuni/issues/3406

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
