### PR TITLE
Used pgrep in place of pidof

### DIFF
--- a/spacewalk/admin/spacewalk-admin.changes
+++ b/spacewalk/admin/spacewalk-admin.changes
@@ -1,3 +1,5 @@
+- replaced pidof with pgrep and removed sysvinit-tools dependency
+
 -------------------------------------------------------------------
 Mon Aug 09 10:57:26 CEST 2021 - jgonzalez@suse.com
 

--- a/spacewalk/admin/spacewalk-admin.spec
+++ b/spacewalk/admin/spacewalk-admin.spec
@@ -36,11 +36,7 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 Requires:       %{pythonX}
 Requires:       lsof
 Requires:       spacewalk-base
-%if 0%{?suse_version}
-Requires:       sysvinit-tools
-%else
-Requires:       procps-ng
-%endif
+Requires:       procps
 Requires:       perl(MIME::Base64)
 BuildRequires:  /usr/bin/pod2man
 %if 0%{?rhel} >= 7 || 0%{?fedora} || 0%{?suse_version} >= 1210

--- a/spacewalk/admin/spacewalk-startup-helper
+++ b/spacewalk/admin/spacewalk-startup-helper
@@ -115,7 +115,7 @@ ensure_httpd_down() {
     COUNT=0
     LIMIT=10
 
-    while [ "$(pidof -c httpd | wc -w)" -gt 0 ] && [ "$COUNT" -lt "$LIMIT" ]
+    while [ "$(pgrep -c httpd)" -gt 0 ] && [ "$COUNT" -lt "$LIMIT" ]
     do
        sleep 1
        ((COUNT++))


### PR DESCRIPTION
## What does this PR change?

This PR removes the usage of pid and replace it with pgrep. It also removes the dependency on the `sysvinit-tools` on SUSE requiring the standard `procps`.

## GUI diff

No difference.


- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Fixes #
SUSE/spacewalk/issues/14901

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
