### PR TITLE
Fix custom "mgrcompat" state module to work with Salt 3003 and 3004

### DIFF
--- a/susemanager-utils/susemanager-sls/src/states/mgrcompat.py
+++ b/susemanager-utils/susemanager-sls/src/states/mgrcompat.py
@@ -60,14 +60,14 @@ def module_run(**kwargs):
     # The new syntax will be used as the default
     use_new_syntax = True
 
-    if __grains__['saltversioninfo'][0] > 3002:
+    if __grains__['saltversioninfo'][0] > 3004:
         # Only new syntax - default behavior for Phosphorus and future releases
         pass
     elif __grains__['saltversioninfo'][0] > 2016 and 'module.run' in __opts__.get('use_superseded', []):
-        # New syntax - explicitely enabled via 'use_superseded' configuration on 2018.3, 2019.2, 3000.x and 3002.x
+        # New syntax - explicitely enabled via 'use_superseded' configuration on 2018.3, 2019.2, 3000.x, 3002.x, 3003.x and 3004.x
         pass
     elif __grains__['saltversioninfo'][0] > 2016 and not 'module.run' in __opts__.get('use_superseded', []):
-        # Old syntax - default behavior for 2018.3, 2019.2, 3000.x and 3002.x
+        # Old syntax - default behavior for 2018.3, 2019.2, 3000.x, 3002.x, 3003.x and 3004.x
         use_new_syntax = False
     elif __grains__['saltversioninfo'][0] <= 2016:
         # Only old syntax - the new syntax is not available for 2016.11 and 2015.8

--- a/susemanager-utils/susemanager-sls/src/tests/test_state_mgrcompat.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_state_mgrcompat.py
@@ -23,9 +23,39 @@ mgrcompat.__grains__ = {}
 def test_module_run_on_phosphorous():
     mock = MagicMock(return_value={'changes': {'service.running': 'foobar'}})
     mgrcompat.module.run = mock
-    with patch.dict(mgrcompat.__grains__, {'saltversioninfo': [3003, None, None, None]}):
+    with patch.dict(mgrcompat.__grains__, {'saltversioninfo': [3005, None, None, None]}):
         mgrcompat.module_run(**MGRCOMPAT_MODULE_RUN_KWARGS)
         mock.assert_called_once_with(**TAILORED_MODULE_RUN_KWARGS)
+
+def test_module_run_on_silicon():
+    mock = MagicMock(return_value={'changes': {'service.running': 'foobar'}})
+    mgrcompat.module.run = mock
+    with patch.dict(mgrcompat.__grains__, {'saltversioninfo': [3004, None, None, None]}):
+        mgrcompat.module_run(**MGRCOMPAT_MODULE_RUN_KWARGS)
+        mock.assert_called_once_with(**MGRCOMPAT_MODULE_RUN_KWARGS)
+
+def test_module_run_on_silicon_use_superseded():
+    mock = MagicMock(return_value={'changes': {'service.running': 'foobar'}})
+    mgrcompat.module.run = mock
+    with patch.dict(mgrcompat.__grains__, {'saltversioninfo': [3004, None, None, None]}):
+        with patch.dict(mgrcompat.__opts__, {'use_superseded': ['module.run']}):
+            mgrcompat.module_run(**MGRCOMPAT_MODULE_RUN_KWARGS)
+            mock.assert_called_once_with(**TAILORED_MODULE_RUN_KWARGS)
+
+def test_module_run_on_aluminum():
+    mock = MagicMock(return_value={'changes': {'service.running': 'foobar'}})
+    mgrcompat.module.run = mock
+    with patch.dict(mgrcompat.__grains__, {'saltversioninfo': [3003, None, None, None]}):
+        mgrcompat.module_run(**MGRCOMPAT_MODULE_RUN_KWARGS)
+        mock.assert_called_once_with(**MGRCOMPAT_MODULE_RUN_KWARGS)
+
+def test_module_run_on_aluminum_use_superseded():
+    mock = MagicMock(return_value={'changes': {'service.running': 'foobar'}})
+    mgrcompat.module.run = mock
+    with patch.dict(mgrcompat.__grains__, {'saltversioninfo': [3003, None, None, None]}):
+        with patch.dict(mgrcompat.__opts__, {'use_superseded': ['module.run']}):
+            mgrcompat.module_run(**MGRCOMPAT_MODULE_RUN_KWARGS)
+            mock.assert_called_once_with(**TAILORED_MODULE_RUN_KWARGS)
 
 def test_module_run_on_magnesium():
     mock = MagicMock(return_value={'changes': {'service.running': 'foobar'}})

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,5 @@
+- Fix mgrcompat state module to work with Salt 3003 and 3004
+
 -------------------------------------------------------------------
 Fri Sep 17 12:17:49 CEST 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

This PR fixes custom `mgrcompat` state module to work properly on Salt 3003 version and future Silicon release (3004).

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/15371

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
