### PR TITLE
Fix a library dependency issue with repeat_until_timeout

### DIFF
--- a/testsuite/features/support/client_stack.rb
+++ b/testsuite/features/support/client_stack.rb
@@ -4,10 +4,12 @@
 require 'nokogiri'
 require 'timeout'
 require_relative 'lavanda'
+require_relative 'timeout_lib'
 
 # Client stack module interacts with the default client
 module ClientStack
   extend LavandaBasic
+  extend TimeoutLib
   extend self
 
   # Returns the path for the repodata of a channel

--- a/testsuite/features/support/common_lib.rb
+++ b/testsuite/features/support/common_lib.rb
@@ -118,38 +118,6 @@ module CommonLib
     server_id
   end
 
-  # Repeatedly executes a block raising an exception in case it is not finished within timeout seconds
-  # or retries attempts, whichever comes first.
-  # Exception will optionally contain the specified message and the result from the last block execution, if any,
-  # in case report_result is set to true
-  #
-  # Implementation works around https://bugs.ruby-lang.org/issues/15886
-  def repeat_until_timeout(timeout: DEFAULT_TIMEOUT, retries: nil, message: nil, report_result: false)
-    last_result = nil
-    Timeout.timeout(timeout) do
-      # HACK: Timeout.timeout might not raise Timeout::Error depending on the yielded code block
-      # Pitfalls with this method have been long known according to the following articles:
-      # https://rnubel.svbtle.com/ruby-timeouts
-      # https://vaneyckt.io/posts/the_disaster_that_is_rubys_timeout_method
-      # At the time of writing some of the problems described have been addressed.
-      # However, at least https://bugs.ruby-lang.org/issues/15886 remains reproducible and code below
-      # works around it by adding an additional check between loops
-      start = Time.new
-      attempts = 0
-      while (Time.new - start <= timeout) && (retries.nil? || attempts < retries)
-        last_result = yield
-        attempts += 1
-      end
-
-      detail = format_detail(message, last_result, report_result)
-      raise(Timeout::Error, "Giving up after #{attempts} attempts#{detail}") if attempts == retries
-
-      raise(Timeout::Error, "Timeout after #{timeout} seconds (repeat_until_timeout)#{detail}")
-    end
-  rescue Timeout::Error
-    raise(Timeout::Error, "Timeout after #{timeout} seconds (Timeout.timeout)#{format_detail(message, last_result, report_result)}")
-  end
-
   # Returns a formatted message
   def format_detail(message, last_result, report_result)
     formatted_message = "#{': ' unless message.nil?}#{message}"

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -19,6 +19,7 @@ require_relative 'twopence_init'
 require_relative 'navigation_lib'
 require_relative 'client_stack'
 require_relative 'retail_lib'
+require_relative 'timeout_lib'
 require_relative 'xmlrpc/xmlrpc_test'
 require_relative 'xmlrpc/xmlrpc_image'
 require_relative 'custom_formatter'
@@ -59,7 +60,7 @@ end
 # Fix a problem with minitest and cucumber options passed through rake
 MultiTest.disable_autorun
 
-World(MiniTest::Assertions, CommonLib, LavandaBasic, TwoPenceLib, NavigationLib, ClientStack, RetailLib)
+World(MiniTest::Assertions, TimeoutLib, CommonLib, LavandaBasic, TwoPenceLib, NavigationLib, ClientStack, RetailLib)
 World(CustomFormatter, PrettyFormatterExtended)
 
 # Initialize Twopence Nodes

--- a/testsuite/features/support/lavanda.rb
+++ b/testsuite/features/support/lavanda.rb
@@ -2,11 +2,13 @@
 # Licensed under the terms of the MIT license.
 require 'twopence'
 require 'timeout'
+require_relative 'timeout_lib'
 
 # Extend the objects node VMs with useful methods needed for testsuite.
 # All function added here will be available like $server.run
 #  or $minion.run_until_ok etc.
 module LavandaBasic
+  extend TimeoutLib
   extend self
 
   # Hostname

--- a/testsuite/features/support/timeout_lib.rb
+++ b/testsuite/features/support/timeout_lib.rb
@@ -1,0 +1,43 @@
+# Copyright (c) 2013-2021 SUSE LLC.
+# Licensed under the terms of the MIT license.
+
+require 'tempfile'
+require 'yaml'
+require 'date'
+
+# Timeout Lib module includes methods to handle timeouts
+module TimeoutLib
+  extend self
+
+  # Repeatedly executes a block raising an exception in case it is not finished within timeout seconds
+  # or retries attempts, whichever comes first.
+  # Exception will optionally contain the specified message and the result from the last block execution, if any,
+  # in case report_result is set to true
+  #
+  # Implementation works around https://bugs.ruby-lang.org/issues/15886
+  def repeat_until_timeout(timeout: DEFAULT_TIMEOUT, retries: nil, message: nil, report_result: false)
+    last_result = nil
+    Timeout.timeout(timeout) do
+      # HACK: Timeout.timeout might not raise Timeout::Error depending on the yielded code block
+      # Pitfalls with this method have been long known according to the following articles:
+      # https://rnubel.svbtle.com/ruby-timeouts
+      # https://vaneyckt.io/posts/the_disaster_that_is_rubys_timeout_method
+      # At the time of writing some of the problems described have been addressed.
+      # However, at least https://bugs.ruby-lang.org/issues/15886 remains reproducible and code below
+      # works around it by adding an additional check between loops
+      start = Time.new
+      attempts = 0
+      while (Time.new - start <= timeout) && (retries.nil? || attempts < retries)
+        last_result = yield
+        attempts += 1
+      end
+
+      detail = format_detail(message, last_result, report_result)
+      raise(Timeout::Error, "Giving up after #{attempts} attempts#{detail}") if attempts == retries
+
+      raise(Timeout::Error, "Timeout after #{timeout} seconds (repeat_until_timeout)#{detail}")
+    end
+  rescue Timeout::Error
+    raise(Timeout::Error, "Timeout after #{timeout} seconds (Timeout.timeout)#{format_detail(message, last_result, report_result)}")
+  end
+end


### PR DESCRIPTION
## What does this PR change?

Fix a library dependency issue with repeat_until_timeout

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.2

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
