### PR TITLE
Add ubuntu repos to publish script

### DIFF
--- a/susemanager-utils/testing/automation/publish-rpms.sh
+++ b/susemanager-utils/testing/automation/publish-rpms.sh
@@ -36,4 +36,13 @@ fi
 repo_dir=$repo_dir/$obs_project/$obs_repo/$obs_arch
 
 osc getbinaries $obs_project $obs_repo $obs_arch -d $repo_dir
-cd $repo_dir && createrepo .
+cd $repo_dir
+echo ${obs_repo} | grep "Ubuntu" -i
+if [  ${?} -eq 0 ];then
+    dpkg-scanpackages -m . /dev/null > Packages
+    gzip Packages
+else
+     createrepo .
+fi
+
+echo "Publishing done."


### PR DESCRIPTION
## What does this PR change?

We are using this script in the CI for downloading packages from obs, instead of from openSUSE mirrors.

However, the script was only working for yum/zypper repos.

This commit adds the ubuntu repos.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed
- [X] **DONE**

## Test coverage
- No tests

- [X] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/15846

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" (Test skipped, there are no changes to test)
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
