### PR TITLE
Add aarch64 bootstrap repos for CentOS clones and openSUSE Leap 15.3 for SUSE Manager

### DIFF
--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -2,11 +2,11 @@
 - Adapt auto errata update to respect maintenance windows
 - fix ISE in SSM when scheduling patches on multiple systems (bsc#1190396, bsc#1190275)
 - Add new endpoints to saltkeys API: acceptedList, pendingList, rejectedList, deniedList, accept and reject
-- add centos 7/8 aarch64
-- add oraclelinux 7/8 aarch64
-- add rockylinux 8 aarch64
-- add almalinux 8 aarch64
-- add amazonlinux 2 aarch64
+- add CentOS 7/8 aarch64
+- add Oracle Linux 7/8 aarch64
+- add Rocky Linux 8 aarch64
+- add AlmaLinux 8 aarch64
+- add Amazon Linux 2 aarch64
 
 -------------------------------------------------------------------
 Fri Sep 17 12:18:34 CEST 2021 - jgonzalez@suse.com

--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -1227,6 +1227,10 @@ DATA = {
         'PDID' : [2236], 'PKGLIST' : PKGLIST15_SALT + PKGLIST15_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/opensuse/15/3/bootstrap/'
     },
+    'openSUSE-Leap-15.3-aarch64' : {
+        'PDID' : [2233], 'PKGLIST' : PKGLIST15_SALT + PKGLIST15_X86_ARM,
+        'DEST' : '/srv/www/htdocs/pub/repositories/opensuse/15/3/bootstrap/'
+    },
     'openSUSE-Leap-15.3-x86_64-uyuni' : {
         'BASECHANNEL' : 'opensuse_leap15_3-x86_64', 'PKGLIST' : PKGLIST15_TRAD + PKGLIST15_SALT + PKGLIST15SP0SP1_SALT + PKGLIST15_X86_ARM,
         'DEST' : '/srv/www/htdocs/pub/repositories/opensuse/15/3/bootstrap/'
@@ -1243,8 +1247,16 @@ DATA = {
         'PDID' : [-12, 1683], 'BETAPDID' : [2065], 'PKGLIST' : RES7 + RES7_X86,
         'DEST' : '/srv/www/htdocs/pub/repositories/centos/7/bootstrap/'
     },
+    'centos-7-aarch64' : {
+        'PDID' : [-31, 2361], 'BETAPDID' : [2363], 'PKGLIST' : RES7,
+        'DEST' : '/srv/www/htdocs/pub/repositories/centos/7/bootstrap/'
+    },
     'centos-8-x86_64' : {
         'PDID' : [-13, 2007], 'BETAPDID' : [2066], 'PKGLIST' : RES8 + RES8_X86,
+        'DEST' : '/srv/www/htdocs/pub/repositories/centos/8/bootstrap/'
+    },
+    'centos-8-aarch64' : {
+        'PDID' : [-30, 2362], 'BETAPDID' : [2364], 'PKGLIST' : RES8,
         'DEST' : '/srv/www/htdocs/pub/repositories/centos/8/bootstrap/'
     },
     'centos-6-x86_64-uyuni' : {
@@ -1283,8 +1295,16 @@ DATA = {
         'PDID' : [-14, 1683], 'BETAPDID' : [2065], 'PKGLIST' : RES7 + RES7_X86,
         'DEST' : '/srv/www/htdocs/pub/repositories/oracle/7/bootstrap/'
     },
+    'oracle-7-aarch64' : {
+        'PDID' : [-28, 2361], 'BETAPDID' : [2363], 'PKGLIST' : RES7,
+        'DEST' : '/srv/www/htdocs/pub/repositories/oracle/7/bootstrap/'
+    },
     'oracle-8-x86_64' : {
         'PDID' : [-17, 2007], 'BETAPDID' : [2066], 'PKGLIST' : RES8 + RES8_X86,
+        'DEST' : '/srv/www/htdocs/pub/repositories/oracle/8/bootstrap/'
+    },
+    'oracle-8-aarch64' : {
+        'PDID' : [-29, 2362], 'BETAPDID' : [2364], 'PKGLIST' : RES8,
         'DEST' : '/srv/www/htdocs/pub/repositories/oracle/8/bootstrap/'
     },
     'oracle-6-x86_64-uyuni' : {
@@ -1309,6 +1329,10 @@ DATA = {
     },
     'amazonlinux-2-x86_64' : {
         'PDID' : [-22, 1683], 'BETAPDID' : [2065], 'PKGLIST' : RES7 + RES7_X86 + AMAZONLINUX2,
+        'DEST' : '/srv/www/htdocs/pub/repositories/amzn/2/bootstrap/'
+    },
+    'amazonlinux-2-aarch64' : {
+        'PDID' : [-28, 2361], 'BETAPDID' : [2363], 'PKGLIST' : RES7 + AMAZONLINUX2,
         'DEST' : '/srv/www/htdocs/pub/repositories/amzn/2/bootstrap/'
     },
     'amazonlinux-2-x86_64-uyuni' : {
@@ -1351,12 +1375,20 @@ DATA = {
         'PDID' : [-23, 2007], 'BETAPDID' : [2066], 'PKGLIST' : RES8 + RES8_X86,
         'DEST' : '/srv/www/htdocs/pub/repositories/almalinux/8/bootstrap/'
     },
+    'almalinux-8-aarch64' : {
+        'PDID' : [-26, 2362], 'BETAPDID' : [2364], 'PKGLIST' : RES8,
+        'DEST' : '/srv/www/htdocs/pub/repositories/almalinux/8/bootstrap/'
+    },    
     'almalinux-8-x86_64-uyuni' : {
         'BASECHANNEL' : 'almalinux8-x86_64', 'PKGLIST' : RES8 + RES8_X86,
         'DEST' : '/srv/www/htdocs/pub/repositories/almalinux/8/bootstrap/'
     },    
     'rockylinux-8-x86_64' : {
         'PDID' : [-24, 2007], 'BETAPDID' : [2066], 'PKGLIST' : RES8 + RES8_X86,
+        'DEST' : '/srv/www/htdocs/pub/repositories/rockylinux/8/bootstrap/'
+    },
+    'rockylinux-8-aarch64' : {
+        'PDID' : [-27, 2362], 'BETAPDID' : [2364], 'PKGLIST' : RES8,
         'DEST' : '/srv/www/htdocs/pub/repositories/rockylinux/8/bootstrap/'
     },
     'rockylinux-8-x86_64-uyuni' : {

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,5 @@
+- Add aarch64 bootstrap repositories for CentOS 7/8, Oracle Linux 7/8,
+  Rocky Linux8, AlmaLinux8, Amazon Linux 2 and openSUSE Leap 15.3
 - Add the gnupg package for ubuntu which is then needed by apt-key (bsc#1187998)
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Add aarch64 bootstrap repositories for CentOS 7/8, Oracle Linux 7/8, Rocky Linux8, AlmaLinux8, Amazon Linux 2 and openSUSE Leap 15.3

Fix the changelog for `spacewalk-java`

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- Documentation issue was created: https://github.com/SUSE/spacewalk/issues/14440

- [x] **DONE**

## Test coverage
- Cucumber being added by QA, for the build validation

- [x] **DONE**

## Links

Tracks: https://github.com/SUSE/spacewalk/issues/15413

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
