### PR TITLE
Fix ISE in product migration if base product is missing

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/product/SUSEProductSet.java
+++ b/java/code/src/com/redhat/rhn/domain/product/SUSEProductSet.java
@@ -253,7 +253,9 @@ public class SUSEProductSet {
     public String toString() {
         StringBuilder builder = new StringBuilder();
         builder.append("[base: ");
-        builder.append(baseProduct.getFriendlyName());
+        if (baseProduct != null) {
+            builder.append(baseProduct.getFriendlyName());
+        }
         if (!addonProducts.isEmpty()) {
             builder.append(", addon: ");
             int i = 0;

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix ISE in product migration if base product is missing (bsc#1190151)
 - Add 'Flush cache' option to Ansible playbook execution
   (bsc#1190405)
 - Update kernel live patch version on minion startup (bsc#1190276)


### PR DESCRIPTION
## What does this PR change?

Prevent ISE if there is no base product when trying to schedule a product migration

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: **Bugfix**

- [x] **DONE**

## Test coverage

- No tests: **Bugfix**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/15799

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
