### PR TITLE
Sanitize cached filename for custom SSL certs used by reposync (bsc#1190751)

### DIFF
--- a/backend/satellite_tools/reposync.py
+++ b/backend/satellite_tools/reposync.py
@@ -352,7 +352,7 @@ def write_ssl_set_cache(ca_cert, client_cert, client_key):
             else:
                 org = str(org)
             ssldir = os.path.join(CACHE_DIR, '.ssl-certs', org)
-            cert_file = os.path.join(ssldir, "%s.pem" % name)
+            cert_file = os.path.join(ssldir, "%s.pem" % re.sub(r'[^a-zA-Z0-9_-]', '_', name))
             if not os.path.exists(cert_file):
                 create_dir_tree(ssldir)
                 f = open(cert_file, "wb")

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,5 @@
+- Sanitize cached filename for custom SSL certs used by reposync (bsc#1190751)
+
 -------------------------------------------------------------------
 Fri Sep 17 12:02:04 CEST 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue in `spacewalk-repo-sync` when trying to sync a repository which is using custom SSL client certificates, added via webUI, that contains whitespaces or weird characters as part of the "Description" attribute when creating it.

When "description" contains whitespaces, the cached files generated by SUMA to be consumed by reposync are stored like:

```console
# ls -l /var/cache/rhn/reposync/.ssl-certs/1/
adb700c5.0 -> Example SSL.pem
Example SSL.pem
Example SSL key.pem
```
And this makes reposync to fail as it is not properly handling the whitespaces:

```
2021/09/24 17:38:03 +02:00 Command: ['/usr/bin/spacewalk-repo-sync', '--channel', 'testchannel', '--type', 'yum', '--non-interactive']
2021/09/24 17:38:03 +02:00 Sync of channel started.
Preparing custom SSL CAPATH at /var/cache/rhn/reposync/.ssl-certs/1
2021/09/24 17:38:05 +02:00 RepoMDError: Cannot access repository.
Repository 'testchannel' is invalid.
[testchannel|https://xxxxxxxxxxxxxxxxx/?ssl_capath=/var/cache/rhn/reposync/.ssl-certs/1&ssl_clientcert=/var/cache/rhn/reposync/.ssl-certs/1/Example+SSL.pem&ssl_clientkey=/var/cache/rhn/reposync/.ssl-certs/1/Example+SSL+key.pem] Valid metadata not found at specified URL
History:
 - [|] Error trying to read from 'https://xxxxxxxxxxxxxxxxx/?ssl_capath=/var/cache/rhn/reposync/.ssl-certs/1&ssl_clientcert=/var/cache/rhn/reposync/.ssl-certs/1/Example+SSL.pem&ssl_clientkey=/var/cache/rhn/reposync/.ssl-certs/1/Example+SSL+key.pem'
 - Download (curl) error for 'https://xxxxxxxxxxxxxxxxx/content?ssl_capath=/var/cache/rhn/reposync/.ssl-certs/1&ssl_clientcert=/var/cache/rhn/reposync/.ssl-certs/1/Example+SSL.pem&ssl_clientkey=/var/cache/rhn/reposync/.ssl-certs/1/Example+SSL+key.pem':
Error code: Curl error 58
Error message: could not load PEM client certificate, OpenSSL error error:0909006C:PEM routines:get_name:no start line, (no key found, wrong pass phrase, or wrong file format?)

Please check if the URIs defined for this repository are pointing to a valid repository.
Skipping repository 'testchannel' because of the above error.
Could not refresh the repositories because of errors.
```

After this PR, any "whitespace" or special character will be excluded from the generated cached filename to avoid "reposync" and "Zypper" to mess up with the paths to the SSL certificates.  

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **bugfix**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/15924

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
