### PR TITLE
Fix python2 compatibility of virt grain

### DIFF
--- a/susemanager-utils/susemanager-sls/src/grains/virt.py
+++ b/susemanager-utils/susemanager-sls/src/grains/virt.py
@@ -38,7 +38,7 @@ def features():
     libvirt_version = -1
     try:
         version_out = subprocess.Popen(["libvirtd", "-V"], stdout=subprocess.PIPE).communicate()[0]
-        matcher = re.search(rb'(\d+)\.(\d+)\.(\d+)', version_out)
+        matcher = re.search(b'(\d+)\.(\d+)\.(\d+)', version_out)
         if matcher:
             libvirt_version = 0
             for idx in range(len(matcher.groups())):

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Fix virt grain python2 compatibility
 - disable unaccessible local repos before bootstrapping (bsc#1186405)
 - Fix mgrcompat state module to work with Salt 3003 and 3004
 


### PR DESCRIPTION
## What does this PR change?

r-strings are not supported in python2.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: python2-related change

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
