### PR TITLE
Fix 'Type' input in CLM source edit form (bsc#1190820)

### DIFF
--- a/web/html/src/manager/content-management/shared/components/panels/sources/sources.tsx
+++ b/web/html/src/manager/content-management/shared/components/panels/sources/sources.tsx
@@ -29,6 +29,7 @@ const ModalSourceCreationContent = ({ isLoading, softwareSources, onChange }) =>
           label={t("Type")}
           labelClass="col-md-3"
           divClass="col-md-8"
+          defaultValue="software"
           options={[{ value: "software", label: t("Channel") }]}
         />
       </div>

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,5 @@
+- Fix 'Type' input in CLM source edit form (bsc#1190820)
+
 -------------------------------------------------------------------
 Fri Sep 17 14:58:41 CEST 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
Since the "Type" select input has only a single hardcoded option, it bypasses the form context model implementation, so the value cannot be changed at all. This PR fixes the input value so the single option is selected by default.

If we add more values in the future, we'll need to implement the form model properly, but it's not required for now.

https://bugzilla.suse.com/show_bug.cgi?id=1190820

Port of: https://github.com/SUSE/spacewalk/pull/15937

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
