### PR TITLE
Ansible 'flush_cache' flag for Playbook execution (bsc#1190405)

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/action/salt/PlaybookActionDetails.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/salt/PlaybookActionDetails.hbm.xml
@@ -14,6 +14,7 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         <property name="playbookPath" column="playbook_path" type="string" />
         <property name="inventoryPath" column="inventory_path" type="string" />
         <property name="testMode" column="test_mode" type="yes_no"/>
+        <property name="flushCache" column="flush_cache" type="yes_no"/>
         <property name="created" type="timestamp" insert="false" update="false" />
         <property name="modified" type="timestamp" insert="false" update="false" />
         <many-to-one name="parentAction" column="action_id" class="com.redhat.rhn.domain.action.Action"

--- a/java/code/src/com/redhat/rhn/domain/action/salt/PlaybookActionDetails.java
+++ b/java/code/src/com/redhat/rhn/domain/action/salt/PlaybookActionDetails.java
@@ -26,6 +26,7 @@ public class PlaybookActionDetails extends ActionChild {
     private String playbookPath;
     private String inventoryPath;
     private boolean testMode;
+    private boolean flushCache;
 
     /**
      * @return the id
@@ -77,5 +78,13 @@ public class PlaybookActionDetails extends ActionChild {
 
     public void setTestMode(boolean testModeIn) {
         this.testMode = testModeIn;
+    }
+
+    public boolean isFlushCache() {
+        return flushCache;
+    }
+
+    public void setFlushCache(boolean flushCacheIn) {
+        this.flushCache = flushCacheIn;
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/ansible/AnsibleHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/ansible/AnsibleHandler.java
@@ -30,10 +30,13 @@ import com.redhat.rhn.manager.system.AnsibleManager;
 
 import com.suse.manager.webui.utils.salt.custom.AnsiblePlaybookSlsResult;
 
+import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Ansible XMLRPC handler
@@ -41,6 +44,9 @@ import java.util.Optional;
  * @xmlrpc.doc Provides methods to manage Ansible systems
  */
 public class AnsibleHandler extends BaseHandler {
+
+    // Keys to pass to schedulePlaybook endpoint as additional args for Ansible
+    public static final String ANSIBLE_FLUSH_CACHE = "flushCache";
 
     /**
      * Schedule a playbook execution
@@ -70,7 +76,7 @@ public class AnsibleHandler extends BaseHandler {
     }
 
     /**
-     * Schedule a playbook execution with test mode option
+     * Schedule a playbook execution
      *
      * @param loggedInUser the current user
      * @param playbookPath the path to the playbook file
@@ -92,16 +98,90 @@ public class AnsibleHandler extends BaseHandler {
      * @xmlrpc.param #param_desc("boolean", "testMode", "'true' if the playbook shall be executed in test mode")
      * @xmlrpc.returntype #param_desc("int", "id", "ID of the playbook execution action created")
      */
+    public Long schedulePlaybook(User loggedInUser, String playbookPath, String inventoryPath, Integer controlNodeId,
+            Date earliestOccurrence, String actionChainLabel, boolean testMode) {
+        return schedulePlaybook(loggedInUser, playbookPath, inventoryPath, controlNodeId, earliestOccurrence,
+                actionChainLabel, testMode, Collections.emptyMap());
+    }
+
+    /**
+     * Schedule a playbook execution with test mode option
+     *
+     * @param loggedInUser the current user
+     * @param playbookPath the path to the playbook file
+     * @param inventoryPath the path to the inventory file
+     * @param controlNodeId the system ID of the control node
+     * @param earliestOccurrence earliest occurrence of the execution command
+     * @param actionChainLabel label af action chain to use
+     * @param ansibleArgs the dictionary of additional arguments to pass to ansiblegate
+     * @return the execute playbook action id
+     *
+     * @xmlrpc.doc Schedule a playbook execution
+     * @xmlrpc.param #param("string", "sessionKey")
+     * @xmlrpc.param #param("string", "playbookPath", "path to the playbook file in the control node")
+     * @xmlrpc.param #param_desc("string", "inventoryPath", "path to Ansible inventory or empty")
+     * @xmlrpc.param #param_desc("int", "controlNodeId", "system ID of the control node")
+     * @xmlrpc.param #param_desc("dateTime.iso8601", "earliestOccurrence",
+     * "earliest the execution command can be sent to the control node. ignored when actionChainLabel is used")
+     * @xmlrpc.param #param_desc("string", "actionChainLabel", "label of an action chain to use, or None")
+     * @xmlrpc.param
+     *     #struct_begin("ansibleArgs")
+     *         #prop("boolean", "flushCache", "clear the fact cache for every host in inventory")
+     *     #struct_end()
+     * @xmlrpc.returntype #param_desc("int", "id", "ID of the playbook execution action created")
+     */
+    public Long schedulePlaybook(User loggedInUser, String playbookPath, String inventoryPath, Integer controlNodeId,
+            Date earliestOccurrence, String actionChainLabel, Map<String, Object> ansibleArgs) {
+        return schedulePlaybook(loggedInUser, playbookPath, inventoryPath, controlNodeId, earliestOccurrence,
+                actionChainLabel, false, ansibleArgs);
+    }
+
+    /**
+     * Schedule a playbook execution with test mode option
+     *
+     * @param loggedInUser the current user
+     * @param playbookPath the path to the playbook file
+     * @param inventoryPath the path to the inventory file
+     * @param controlNodeId the system ID of the control node
+     * @param earliestOccurrence earliest occurrence of the execution command
+     * @param actionChainLabel label af action chain to use
+     * @param testMode true if the playbook shall be executed in test mode
+     * @param ansibleArgs the dictionary of additional arguments to pass to ansiblegate
+     * @return the execute playbook action id
+     *
+     * @xmlrpc.doc Schedule a playbook execution
+     * @xmlrpc.param #param("string", "sessionKey")
+     * @xmlrpc.param #param("string", "playbookPath", "path to the playbook file in the control node")
+     * @xmlrpc.param #param_desc("string", "inventoryPath", "path to Ansible inventory or empty")
+     * @xmlrpc.param #param_desc("int", "controlNodeId", "system ID of the control node")
+     * @xmlrpc.param #param_desc("dateTime.iso8601", "earliestOccurrence",
+     * "earliest the execution command can be sent to the control node. ignored when actionChainLabel is used")
+     * @xmlrpc.param #param_desc("string", "actionChainLabel", "label of an action chain to use, or None")
+     * @xmlrpc.param #param_desc("boolean", "testMode", "'true' if the playbook shall be executed in test mode")
+     * @xmlrpc.param
+     *     #struct_begin("ansibleArgs")
+     *         #prop("boolean", "flushCache", "clear the fact cache for every host in inventory")
+     *     #struct_end()
+     * @xmlrpc.returntype #param_desc("int", "id", "ID of the playbook execution action created")
+     */
     public Long schedulePlaybook(User loggedInUser, String playbookPath, String inventoryPath,
-            Integer controlNodeId, Date earliestOccurrence, String actionChainLabel, boolean testMode) {
+            Integer controlNodeId, Date earliestOccurrence, String actionChainLabel, boolean testMode,
+            Map<String, Object> ansibleArgs) {
+
+        // Validate the args map and set defaults
+        Map<String, Object> argMap = new HashMap<>(ansibleArgs);
+        validateMap(Set.of(ANSIBLE_FLUSH_CACHE), argMap);
+        argMap.putIfAbsent(ANSIBLE_FLUSH_CACHE, false);
+
         try {
             return AnsibleManager.schedulePlaybook(playbookPath, inventoryPath, controlNodeId, testMode,
-                    earliestOccurrence, Optional.ofNullable(actionChainLabel), loggedInUser);
+                    (Boolean) argMap.get(ANSIBLE_FLUSH_CACHE), earliestOccurrence,
+                    Optional.ofNullable(actionChainLabel), loggedInUser);
         }
         catch (com.redhat.rhn.taskomatic.TaskomaticApiException e) {
             throw new TaskomaticApiException(e.getMessage());
         }
-        catch (IllegalArgumentException e) {
+        catch (IllegalArgumentException | ClassCastException e) {
             throw new InvalidParameterException("Invalid parameter", e);
         }
     }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/ansible/test/AnsibleHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/ansible/test/AnsibleHandlerTest.java
@@ -52,6 +52,7 @@ import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.jmock.integration.junit3.JUnit3Mockery;
 import org.jmock.lib.concurrent.Synchroniser;
 
+import java.util.Collections;
 import java.util.Date;
 import java.util.Map;
 import java.util.Optional;
@@ -88,7 +89,7 @@ public class AnsibleHandlerTest extends BaseHandlerTestCase {
         Date scheduleDate = new Date();
 
         Long actionId = handler.schedulePlaybook(admin, "/path/to/myplaybook.yml", "/path/to/hosts",
-                controlNode.getId().intValue(), scheduleDate, null);
+                controlNode.getId().intValue(), scheduleDate, null, false);
         assertNotNull(actionId);
 
         DataResult schedule = ActionManager.recentlyScheduledActions(admin, null, 30);
@@ -114,7 +115,7 @@ public class AnsibleHandlerTest extends BaseHandlerTestCase {
         Date scheduleDate = new Date();
 
         Long actionId = handler.schedulePlaybook(admin, "/path/to/myplaybook.yml", null, controlNode.getId().intValue(),
-                scheduleDate, null, true);
+                scheduleDate, null, true, Collections.singletonMap(AnsibleHandler.ANSIBLE_FLUSH_CACHE, true));
         assertNotNull(actionId);
 
         DataResult schedule = ActionManager.recentlyScheduledActions(admin, null, 30);
@@ -132,6 +133,7 @@ public class AnsibleHandlerTest extends BaseHandlerTestCase {
         assertEquals("/path/to/myplaybook.yml", details.getPlaybookPath());
         assertNull(details.getInventoryPath());
         assertTrue(details.isTestMode());
+        assertTrue(details.isFlushCache());
     }
 
     public void testCreateAndGetAnsiblePath() throws Exception {

--- a/java/code/src/com/redhat/rhn/manager/action/ActionChainManager.java
+++ b/java/code/src/com/redhat/rhn/manager/action/ActionChainManager.java
@@ -794,10 +794,11 @@ public class ActionChainManager {
      * @param actionChain the action chain to add to or null
      * @param earliest action will not be executed before this date
      * @param testMode true if the playbook shall be executed in test mode
+     * @param flushCache true if --flush-cache flag is to be set
      * @return the action object
      */
     public static PlaybookAction scheduleExecutePlaybook(User scheduler, Long controlNodeId, String playbookPath,
-            String inventoryPath, ActionChain actionChain, Date earliest, boolean testMode)
+            String inventoryPath, ActionChain actionChain, Date earliest, boolean testMode, boolean flushCache)
             throws TaskomaticApiException {
         String playbookName = FileUtils.getFile(playbookPath).getName();
 
@@ -810,6 +811,7 @@ public class ActionChainManager {
         details.setPlaybookPath(playbookPath);
         details.setInventoryPath(inventoryPath);
         details.setTestMode(testMode);
+        details.setFlushCache(flushCache);
         action.setDetails(details);
         ActionFactory.save(action);
 

--- a/java/code/src/com/redhat/rhn/manager/action/test/ActionChainManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/action/test/ActionChainManagerTest.java
@@ -122,7 +122,7 @@ public class ActionChainManagerTest extends JMockBaseTestCaseWithUser {
         Server server = ServerFactoryTest.createTestServer(user);
         Date earliestAction = new Date();
         PlaybookAction action = ActionChainManager.scheduleExecutePlaybook(user, server.getId(),
-                "/path/to/myplaybook.yml", "/path/to/hosts", null, earliestAction, false);
+                "/path/to/myplaybook.yml", "/path/to/hosts", null, earliestAction, false, false);
 
         // Look it up and verify
         PlaybookAction savedAction = (PlaybookAction) ActionFactory.lookupByUserAndId(user, action.getId());
@@ -136,6 +136,8 @@ public class ActionChainManagerTest extends JMockBaseTestCaseWithUser {
         assertNotNull(details);
         assertEquals("/path/to/myplaybook.yml", details.getPlaybookPath());
         assertEquals("/path/to/hosts", details.getInventoryPath());
+        assertFalse(details.isTestMode());
+        assertFalse(details.isFlushCache());
     }
 
     /**
@@ -147,7 +149,7 @@ public class ActionChainManagerTest extends JMockBaseTestCaseWithUser {
         Server server = ServerFactoryTest.createTestServer(user);
         Date earliestAction = new Date();
         PlaybookAction action = ActionChainManager.scheduleExecutePlaybook(user, server.getId(),
-                "/path/to/myplaybook.yml", null, null, earliestAction, true);
+                "/path/to/myplaybook.yml", null, null, earliestAction, true, true);
 
         // Look it up and verify
         PlaybookAction savedAction = (PlaybookAction) ActionFactory.lookupByUserAndId(user, action.getId());
@@ -162,5 +164,6 @@ public class ActionChainManagerTest extends JMockBaseTestCaseWithUser {
         assertEquals("/path/to/myplaybook.yml", details.getPlaybookPath());
         assertNull(details.getInventoryPath());
         assertTrue(details.isTestMode());
+        assertTrue(details.isFlushCache());
     }
 }

--- a/java/code/src/com/redhat/rhn/manager/system/AnsibleManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/AnsibleManager.java
@@ -270,6 +270,7 @@ public class AnsibleManager extends BaseManager {
      * @param inventoryPath inventory path
      * @param controlNodeId control node id
      * @param testMode true if the playbook should be executed as test mode
+     * @param flushCache true if --flush-cache flag is to be set
      * @param earliestOccurrence earliestOccurrence
      * @param actionChainLabel the action chain label
      * @param user the user
@@ -278,7 +279,8 @@ public class AnsibleManager extends BaseManager {
      * @throws IllegalArgumentException if playbook path is empty
      */
     public static Long schedulePlaybook(String playbookPath, String inventoryPath, long controlNodeId, boolean testMode,
-            Date earliestOccurrence, Optional<String> actionChainLabel, User user) throws TaskomaticApiException {
+            boolean flushCache, Date earliestOccurrence, Optional<String> actionChainLabel, User user)
+            throws TaskomaticApiException {
         if (StringUtils.isBlank(playbookPath)) {
             throw new IllegalArgumentException("Playbook path cannot be empty.");
         }
@@ -290,7 +292,7 @@ public class AnsibleManager extends BaseManager {
                 .orElse(null);
 
         return ActionChainManager.scheduleExecutePlaybook(user, controlNode.getId(), playbookPath,
-                inventoryPath, actionChain, earliestOccurrence, testMode).getId();
+                inventoryPath, actionChain, earliestOccurrence, testMode, flushCache).getId();
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/system/test/AnsibleManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/system/test/AnsibleManagerTest.java
@@ -262,7 +262,7 @@ public class AnsibleManagerTest extends BaseTestCaseWithUser {
     public void testSchedulePlaybookBlankPath() throws Exception {
         MinionServer minion = createAnsibleControlNode(user);
         try {
-            AnsibleManager.schedulePlaybook("   ", "/etc/ansible/hosts", minion.getId(), false, new Date(),
+            AnsibleManager.schedulePlaybook("   ", "/etc/ansible/hosts", minion.getId(), false, false, new Date(),
                     Optional.empty(), user);
             fail("An exception should have been thrown.");
         }
@@ -278,7 +278,7 @@ public class AnsibleManagerTest extends BaseTestCaseWithUser {
      */
     public void testSchedulePlaybookNonexistingMinion() throws Exception {
         try {
-            AnsibleManager.schedulePlaybook("/test/site.yml", "/etc/ansible/hosts", -1234, false, new Date(),
+            AnsibleManager.schedulePlaybook("/test/site.yml", "/etc/ansible/hosts", -1234, false, false, new Date(),
                     Optional.empty(), user);
             fail("An exception should have been thrown.");
         }

--- a/java/code/src/com/suse/manager/webui/controllers/AnsibleController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/AnsibleController.java
@@ -303,6 +303,7 @@ public class AnsibleController {
                     params.getInventoryPath().orElse(null),
                     params.getControlNodeId(),
                     params.isTestMode(),
+                    params.isFlushCache(),
                     params.getEarliest().map(AnsibleController::getScheduleDate).orElse(new Date()),
                     params.getActionChainLabel(),
                     user);

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -2373,6 +2373,7 @@ public class SaltServerActionService {
         pillarData.put("playbook_path", playbookPath);
         pillarData.put("inventory_path", inventoryPath);
         pillarData.put("rundir", rundir);
+        pillarData.put("flush_cache", details.isFlushCache());
         return State.apply(singletonList(ANSIBLE_RUNPLAYBOOK), Optional.of(pillarData), Optional.of(true),
                 Optional.of(details.isTestMode()));
     }

--- a/java/code/src/com/suse/manager/webui/utils/gson/AnsiblePlaybookExecutionJson.java
+++ b/java/code/src/com/suse/manager/webui/utils/gson/AnsiblePlaybookExecutionJson.java
@@ -29,6 +29,7 @@ public class AnsiblePlaybookExecutionJson {
     private Optional<String> inventoryPath = Optional.empty();
     private long controlNodeId;
     private boolean testMode;
+    private boolean flushCache;
     private Optional<LocalDateTime> earliest = Optional.empty();
     private Optional<String> actionChainLabel = Optional.empty();
 
@@ -66,6 +67,15 @@ public class AnsiblePlaybookExecutionJson {
      */
     public boolean isTestMode() {
         return testMode;
+    }
+
+    /**
+     * True if Ansible's --flush-cache flag is to be set
+     *
+     * @return the --flush-cache flag
+     */
+    public boolean isFlushCache() {
+        return flushCache;
     }
 
     /**

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Add 'Flush cache' option to Ansible playbook execution
+  (bsc#1190405)
 - Update kernel live patch version on minion startup (bsc#1190276)
 - use TLSv1.3 if it is a supported Protocol
 - Adapt auto errata update to skip during CLM build (bsc#1189609)

--- a/schema/spacewalk/common/tables/rhnActionPlaybook.sql
+++ b/schema/spacewalk/common/tables/rhnActionPlaybook.sql
@@ -27,6 +27,9 @@ CREATE TABLE rhnActionPlaybook
     test_mode           CHAR(1) DEFAULT ('N') NOT NULL
                             CONSTRAINT rhn_action_playbook_testmode_ck
                                 CHECK (test_mode IN ('Y', 'N')),
+    flush_cache         CHAR(1) DEFAULT ('N') NOT NULL
+                            CONSTRAINT rhn_action_playbook_flushcache_ck
+                                CHECK (flush_cache IN ('Y', 'N')),
     created             TIMESTAMPTZ
                             DEFAULT (current_timestamp) NOT NULL,
     modified            TIMESTAMPTZ

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,5 @@
+- Add 'flush_cache' flag to Ansible playbook execution action
+  (bsc#1190405)
 - create unique index on package details action id (bsc#1190396, bsc#1190275)
 
 -------------------------------------------------------------------

--- a/schema/spacewalk/upgrade/susemanager-schema-4.3.2-to-susemanager-schema-4.3.3/100-playbook-action-flushcache-flag.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.3.2-to-susemanager-schema-4.3.3/100-playbook-action-flushcache-flag.sql
@@ -1,0 +1,4 @@
+ALTER TABLE rhnActionPlaybook ADD COLUMN IF NOT EXISTS
+    flush_cache CHAR(1) DEFAULT ('N') NOT NULL
+        CONSTRAINT rhn_action_playbook_flushcache_ck
+            CHECK (flush_cache IN ('Y', 'N'));

--- a/susemanager-utils/susemanager-sls/salt/ansible/runplaybook.sls
+++ b/susemanager-utils/susemanager-sls/salt/ansible/runplaybook.sls
@@ -16,7 +16,8 @@ run_ansible_playbook:
   ansible.playbooks:
     - name: {{ pillar["playbook_path"] }}
     - rundir: {{ pillar["rundir"] }}
-{%- if "inventory_path" in pillar %}
     - ansible_kwargs:
+        flush_cache: {{ pillar["flush_cache"] }}
+{%- if "inventory_path" in pillar %}
         inventory: {{ pillar["inventory_path"] }}
 {% endif %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Add 'flush_cache' flag to 'ansible.playbooks' call (bsc#1190405)
 - Update kernel live patch version on minion startup (bsc#1190276)
 - Fix virt grain python2 compatibility
 - disable unaccessible local repos before bootstrapping (bsc#1186405)

--- a/web/html/src/manager/minion/ansible/schedule-playbook.tsx
+++ b/web/html/src/manager/minion/ansible/schedule-playbook.tsx
@@ -13,10 +13,15 @@ import { ActionChainLink, ActionLink } from "components/links";
 import { Toggler } from "components/toggler";
 import { Loading } from "components/utils/Loading";
 import { localizedMoment } from "utils";
+import { Check, Form } from "components/input";
 
 interface SchedulePlaybookProps {
   playbook: PlaybookDetails;
   onBack: () => void;
+}
+
+interface PlaybookArgs {
+  flushCache: Boolean
 }
 
 export default function SchedulePlaybook({ playbook, onBack }: SchedulePlaybookProps) {
@@ -26,6 +31,7 @@ export default function SchedulePlaybook({ playbook, onBack }: SchedulePlaybookP
   const [messages, setMessages] = useState<MessageType[]>([]);
   const [inventoryPath, setInventoryPath] = useState<ComboboxItem | null>(null);
   const [inventories, setInventories] = useState<string[]>([]);
+  const [playbookArgs, setPlaybookArgs] = useState<PlaybookArgs>({ flushCache: false });
   const [actionChain, setActionChain] = useState<ActionChain | null>(null);
   const [datetime, setDatetime] = useState(localizedMoment());
 
@@ -60,6 +66,7 @@ export default function SchedulePlaybook({ playbook, onBack }: SchedulePlaybookP
       inventoryPath: inventoryPath?.text,
       controlNodeId: playbook.path.minionServerId,
       testMode: isTestMode,
+      flushCache: playbookArgs.flushCache,
       actionChainLabel: actionChain?.text || null,
       earliest: datetime,
     })
@@ -110,7 +117,11 @@ export default function SchedulePlaybook({ playbook, onBack }: SchedulePlaybookP
               systemIds={[playbook.path.minionServerId]}
               actionType="ansible.playbook"
             />
-            <div className="form-horizontal">
+            <Form
+              model={playbookArgs}
+              onChange={setPlaybookArgs}
+              formDirection="form-horizontal"
+            >
               <div className="form-group">
                 <div className="col-sm-3 control-label">
                   <label>{t("Inventory Path")}:</label>
@@ -125,7 +136,10 @@ export default function SchedulePlaybook({ playbook, onBack }: SchedulePlaybookP
                   />
                 </div>
               </div>
-            </div>
+              <div className="col-sm-offset-3 col-sm-6">
+                <Check name="flushCache" label={t("Flush Ansible fact cache")} title={t("Clear the fact cache for every host in inventory")}/>
+              </div>
+            </Form>
           </div>
         </div>
 

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,5 @@
+- Add 'Flush cache' checkbox to Ansible playbook execution page
+  (bsc#1190405)
 - Fix 'Type' input in CLM source edit form (bsc#1190820)
 
 -------------------------------------------------------------------


### PR DESCRIPTION
In some cases, Ansible users need to use `--flush-cache` flag when executing playbooks. This PR adds the flag as a checkbox on the schedule playbook page and passes it to Salt during action execution.

See: https://bugzilla.suse.com/show_bug.cgi?id=1190405

Port of: https://github.com/SUSE/spacewalk/pull/15933

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
