### PR TITLE
return value for enabled can be boolean or string depening on the OS

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/channels/disablelocalbrokenrepos.sls
+++ b/susemanager-utils/susemanager-sls/salt/channels/disablelocalbrokenrepos.sls
@@ -18,7 +18,7 @@ disable_repo_{{ repos_disabled.count }}:
 {% endif %}
 {% endfor %}
 {% else %}
-{% if data.get('enabled', '1') == '1' %}
+{% if data.get('enabled', True) in [True, '1'] %}
 {% set url = data.get('baseurl', 'file://').replace('$basearch', grains['osarch']).replace('$releasever', grains['osmajorrelease']|string) -%}
 {%- set repo_exists = (0 < salt['http.query'](url + '/repodata/repomd.xml', status=True, verify_ssl=True).get('status', 0) < 300) %}
 {% if not repo_exists %}

--- a/susemanager-utils/susemanager-sls/salt/channels/disablelocalrepos.sls
+++ b/susemanager-utils/susemanager-sls/salt/channels/disablelocalrepos.sls
@@ -21,7 +21,7 @@ disable_repo_{{ repos_disabled.count }}:
 {% endif %}
 {% endfor %}
 {% else %}
-{% if (repos_disabled.match_str in alias)|string == repos_disabled.matching|string and data.get('enabled', '1') == '1' %}
+{% if (repos_disabled.match_str in alias)|string == repos_disabled.matching|string and data.get('enabled', True) in [True, '1'] %}
 disable_repo_{{ alias }}:
   mgrcompat.module_run:
     - name: pkg.mod_repo


### PR DESCRIPTION
## What does this PR change?

On SUSE `pkg.list_repos()` return objects with enabled = boolean, while on RedHat enabled return a string which is "1" or "0".
In our states we need to handle both.

We cannot check:

```
data.get('enabled', True) in [True, '1']
```
as when "enabled" return the string '0', it would match the boolean True.
So we better do the negative test

```
data.get('enabled', True) not in [False, '0']
```


## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Additional fix for https://github.com/uyuni-project/uyuni/pull/4247
Tracks https://github.com/SUSE/spacewalk/pull/15962

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
