### PR TITLE
NPE fix: action can be null in handleImageBuildData bsc#1185951

### DIFF
--- a/java/code/src/com/redhat/rhn/common/hibernate/HibernateFactory.java
+++ b/java/code/src/com/redhat/rhn/common/hibernate/HibernateFactory.java
@@ -30,7 +30,6 @@ import org.hibernate.MappingException;
 import org.hibernate.Session;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.metadata.ClassMetadata;
-import org.hibernate.proxy.HibernateProxy;
 import org.hibernate.query.Query;
 
 import java.io.ByteArrayOutputStream;
@@ -772,26 +771,6 @@ public abstract class HibernateFactory {
     protected static void executeCallableMode(String name, String mode, Map params) {
         CallableMode m = ModeFactory.getCallableMode(name, mode);
         m.execute(params, new HashMap());
-    }
-
-    /**
-     * Makes sure the specified entity, presumably loaded via Hibernate's {@link Session#get(Class, Serializable)},
-     * is not a proxy.
-     *
-     * Impelmentation is copied from Hibernate 5.2.10 and this method should be removed after that release.
-     *
-     * @param entity an entity
-     * @param <T> type of entity
-     * @return the entity and not a proxy
-     */
-    @SuppressWarnings("unchecked")
-    public static <T> T unproxy(T entity) {
-        Hibernate.initialize(entity);
-        if (entity instanceof HibernateProxy) {
-            entity = (T) ((HibernateProxy) entity).getHibernateLazyInitializer()
-                    .getImplementation();
-        }
-        return entity;
     }
 
     /**

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -535,7 +535,7 @@ public class SaltUtils {
             serverAction.setStatus(ActionFactory.STATUS_COMPLETED);
         }
 
-        Action action = HibernateFactory.unproxy(serverAction.getParentAction());
+        Action action = serverAction.getParentAction();
 
         if (action.getActionType().equals(ActionFactory.TYPE_APPLY_STATES)) {
             ApplyStatesAction applyStatesAction = (ApplyStatesAction) action;

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -1165,7 +1165,8 @@ public class SaltUtils {
                         if (collectResult.getReturnCode() != 0) {
                             serverAction.setStatus(ActionFactory.STATUS_FAILED);
                             serverAction.setResultMsg(StringUtils
-                                    .left(printStdMessages(collectResult.getStderr(), collectResult.getStdout()), 1024));
+                                    .left(printStdMessages(collectResult.getStderr(), collectResult.getStdout()),
+                                            1024));
                         }
                     });
                 }));

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -1134,8 +1134,8 @@ public class SaltUtils {
 
     private void handleImageBuildData(ServerAction serverAction, JsonElement jsonResult) {
         Action action = serverAction.getParentAction();
-        ImageBuildAction ba = (ImageBuildAction)action;
-        ImageBuildActionDetails details = ba.getDetails();
+        ImageBuildAction ba = (ImageBuildAction) action;
+        Optional<ImageBuildActionDetails> details = Optional.ofNullable(ba.getDetails());
         Optional<ImageInfo> infoOpt = ImageInfoFactory.lookupByBuildAction(ba);
 
         // Pretty-print the whole return map (or whatever fits into 1024 characters)
@@ -1145,53 +1145,55 @@ public class SaltUtils {
         serverAction.setResultMsg(json);
 
         if (serverAction.getStatus().equals(ActionFactory.STATUS_COMPLETED)) {
-            Optional<ImageProfile> profileOpt =
-                    ImageProfileFactory.lookupById(details.getImageProfileId());
+            details.ifPresent(det -> {
+                Optional<ImageProfile> profileOpt =
+                        ImageProfileFactory.lookupById(det.getImageProfileId());
 
-            profileOpt.ifPresent(p -> p.asKiwiProfile().ifPresent(kiwiProfile -> {
-                serverAction.getServer().asMinionServer().ifPresent(minionServer -> {
-                    // Download the built Kiwi image to SUSE Manager server
-                    OSImageInspectSlsResult.Bundle bundleInfo =
-                            Json.GSON.fromJson(jsonResult, OSImageBuildSlsResult.class)
-                                    .getKiwiBuildInfo().getChanges().getRet().getBundle();
-                    infoOpt.ifPresent(info -> info.setChecksum(
-                            ImageInfoFactory.convertChecksum(bundleInfo.getChecksum())));
-                    MgrUtilRunner.ExecResult collectResult = systemQuery
-                            .collectKiwiImage(minionServer, bundleInfo.getFilepath(),
-                                    OSImageStoreUtils.getOsImageStorePath() + kiwiProfile.getTargetStore().getUri())
-                            .orElseThrow(() -> new RuntimeException("Failed to download image."));
+                profileOpt.ifPresent(p -> p.asKiwiProfile().ifPresent(kiwiProfile -> {
+                    serverAction.getServer().asMinionServer().ifPresent(minionServer -> {
+                        // Download the built Kiwi image to SUSE Manager server
+                        OSImageInspectSlsResult.Bundle bundleInfo =
+                                Json.GSON.fromJson(jsonResult, OSImageBuildSlsResult.class)
+                                        .getKiwiBuildInfo().getChanges().getRet().getBundle();
+                        infoOpt.ifPresent(info -> info.setChecksum(
+                                ImageInfoFactory.convertChecksum(bundleInfo.getChecksum())));
+                        MgrUtilRunner.ExecResult collectResult = systemQuery
+                                .collectKiwiImage(minionServer, bundleInfo.getFilepath(),
+                                        OSImageStoreUtils.getOsImageStorePath() + kiwiProfile.getTargetStore().getUri())
+                                .orElseThrow(() -> new RuntimeException("Failed to download image."));
 
-                    if (collectResult.getReturnCode() != 0) {
-                        serverAction.setStatus(ActionFactory.STATUS_FAILED);
-                        serverAction.setResultMsg(StringUtils
-                                .left(printStdMessages(collectResult.getStderr(), collectResult.getStdout()), 1024));
-                    }
+                        if (collectResult.getReturnCode() != 0) {
+                            serverAction.setStatus(ActionFactory.STATUS_FAILED);
+                            serverAction.setResultMsg(StringUtils
+                                    .left(printStdMessages(collectResult.getStderr(), collectResult.getStdout()), 1024));
+                        }
+                    });
+                }));
+                ImageInspectAction iAction = ActionManager.scheduleImageInspect(
+                        action.getSchedulerUser(),
+                        action.getServerActions()
+                                .stream()
+                                .map(ServerAction::getServerId)
+                                .collect(Collectors.toList()),
+                        Optional.of(action.getId()),
+                        det.getVersion(),
+                        profileOpt.map(ImageProfile::getLabel).orElse(null),
+                        profileOpt.map(ImageProfile::getTargetStore).orElse(null),
+                        Date.from(Instant.now())
+                );
+                try {
+                    TASKOMATIC_API.scheduleActionExecution(iAction);
+                }
+                catch (TaskomaticApiException e) {
+                    LOG.error("Could not schedule image inspection");
+                    LOG.error(e);
+                }
+
+                infoOpt.ifPresent(info -> {
+                    info.setRevisionNumber(info.getRevisionNumber() + 1);
+                    info.setInspectAction(iAction);
+                    ImageInfoFactory.save(info);
                 });
-            }));
-            ImageInspectAction iAction = ActionManager.scheduleImageInspect(
-                    action.getSchedulerUser(),
-                    action.getServerActions()
-                            .stream()
-                            .map(ServerAction::getServerId)
-                            .collect(Collectors.toList()),
-                    Optional.of(action.getId()),
-                    details.getVersion(),
-                    profileOpt.map(ImageProfile::getLabel).orElse(null),
-                    profileOpt.map(ImageProfile::getTargetStore).orElse(null),
-                    Date.from(Instant.now())
-            );
-            try {
-                TASKOMATIC_API.scheduleActionExecution(iAction);
-            }
-            catch (TaskomaticApiException e) {
-                LOG.error("Could not schedule image inspection");
-                LOG.error(e);
-            }
-
-            infoOpt.ifPresent(info -> {
-                info.setRevisionNumber(info.getRevisionNumber() + 1);
-                info.setInspectAction(iAction);
-                ImageInfoFactory.save(info);
             });
         }
     }

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -1145,7 +1145,7 @@ public class SaltUtils {
         serverAction.setResultMsg(json);
 
         if (serverAction.getStatus().equals(ActionFactory.STATUS_COMPLETED)) {
-            details.ifPresent(det -> {
+            details.ifPresentOrElse(det -> {
                 Optional<ImageProfile> profileOpt =
                         ImageProfileFactory.lookupById(det.getImageProfileId());
 
@@ -1195,6 +1195,12 @@ public class SaltUtils {
                     info.setInspectAction(iAction);
                     ImageInfoFactory.save(info);
                 });
+            }, () -> {
+                LOG.error("Details not found in ImageBuildAction");
+                LOG.error("Name is: " + action.getName());
+                LOG.error("Action ID is: " + action.getId());
+                LOG.error("Earliest action was: " + action.getEarliestAction());
+                LOG.error("Scheduler User is: " + action.getSchedulerUser());
             });
         }
     }

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -177,8 +177,6 @@ import org.cobbler.CobblerConnection;
 import org.cobbler.Distro;
 import org.cobbler.Profile;
 import org.cobbler.SystemRecord;
-import org.hibernate.Hibernate;
-import org.hibernate.proxy.HibernateProxy;
 import org.jose4j.lang.JoseException;
 
 import java.io.File;

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -277,15 +277,6 @@ public class SaltServerActionService {
         this.saltKeyUtils = saltKeyUtilsIn;
     }
 
-    private Action unproxy(Action entity) {
-        Hibernate.initialize(entity);
-        if (entity instanceof HibernateProxy) {
-            entity = (Action) ((HibernateProxy) entity).getHibernateLazyInitializer()
-                    .getImplementation();
-        }
-        return entity;
-    }
-
     /**
      * For a given action return the salt call(s) that need to be executed for the minions involved.
      *
@@ -310,7 +301,6 @@ public class SaltServerActionService {
         }
 
         ActionType actionType = actionIn.getActionType();
-        actionIn = unproxy(actionIn);
         if (ActionFactory.TYPE_ERRATA.equals(actionType)) {
             ErrataAction errataAction = (ErrataAction) actionIn;
             Set<Long> errataIds = errataAction.getErrata().stream()


### PR DESCRIPTION
## What does this PR change?
NPE is:
```
java.lang.NullPointerException
	at com.suse.manager.utils.SaltUtils.handleImageBuildData(SaltUtils.java:1149)
	at com.suse.manager.utils.SaltUtils.updateServerAction(SaltUtils.java:622)
	at com.suse.manager.webui.services.SaltServerActionService.lambda$handleAction$159(SaltServerActionService.java:2722)
```
Since the NPE happens also when everything is working fine, let' s put the root cause NPE variable as optional (but let's create a  warning if it's null).

Moreover, unproxy function is removed as suggested in the comment:
```
Impelmentation is copied from Hibernate 5.2.10 and this method should be removed after that release.
```
## GUI diff

No difference.

- [ ] **DONE**

## Documentation
- No documentation needed

- [ ] **DONE**

## Test coverage

- [ ] **DONE**

## Links

https://bugzilla.suse.com/show_bug.cgi?id=1185951
https://github.com/SUSE/spacewalk/issues/14927

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql" (Test skipped, there are no changes to test)
- [ ] Re-run test "java_pgsql_tests" 
- [x] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql" (Test skipped, there are no changes to test)
- [ ] Re-run test "susemanager_unittests" (Test skipped, there are no changes to test)
- [x] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests" (Test skipped, there are no changes to test)
