### PR TITLE
Build susemanager-branding-oss only for SLE

### DIFF
--- a/susemanager-branding-oss/susemanager-branding-oss.changes
+++ b/susemanager-branding-oss/susemanager-branding-oss.changes
@@ -1,3 +1,5 @@
+- Build the package only for SUSE Linux Enterprise
+
 -------------------------------------------------------------------
 Mon Aug 09 10:44:25 CEST 2021 - jgonzalez@suse.com
 

--- a/susemanager-branding-oss/susemanager-branding-oss.spec
+++ b/susemanager-branding-oss/susemanager-branding-oss.spec
@@ -26,12 +26,12 @@ URL:            https://github.com/uyuni-project/uyuni
 Source0:        %{name}-%{version}.tar.gz
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
-%if 0%{?is_opensuse}
-ExcludeArch:    i586 x86_64 ppc64le s390x aarch64
-%else
+%if 0%{?sle_version} && !0%{?is_opensuse}
 # SUSE Manager does not support aarch64 for the server
 ExcludeArch:    aarch64
 BuildRequires:  SUSE-Manager-Server-release
+%else
+ExcludeArch:    i586 x86_64 ppc64le s390x aarch64
 %endif
 Provides:       susemanager-branding = %{version}
 Conflicts:      otherproviders(susemanager-branding)


### PR DESCRIPTION
## What does this PR change?

Build susemanager-branding-oss only for SLE

Tested at:
https://build.opensuse.org/package/show/home:juliogonzalezgil:branches:systemsmanagement:Uyuni:Master/susemanager-branding-oss
https://build.suse.de/package/show/home:juliogonzalezgil:branches:Devel:Galaxy:Manager:Head/susemanager-branding-oss

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: This package is not mentioned anywhere at the doc

- [x] **DONE**

## Test coverage
- No tests: Covered by cucumber

- [x] **DONE**

## Links

None

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
