### PR TITLE
Add context manager for rhnConfig

### DIFF
--- a/backend/satellite_tools/download.py
+++ b/backend/satellite_tools/download.py
@@ -31,7 +31,7 @@ except ImportError:
 import pycurl
 from urlgrabber.grabber import URLGrabberOptions, PyCurlFileObject, URLGrabError
 from uyuni.common.checksum import getFileChecksum
-from spacewalk.common.rhnConfig import CFG, initCFG
+from uyuni.common.context_managers import cfg_component
 from spacewalk.satellite_tools.syncLib import log, log2
 
 
@@ -281,9 +281,7 @@ class DownloadThread(Thread):
 class ThreadedDownloader:
     def __init__(self, retries=3, log_obj=None, force=False):
         self.queues = {}
-        comp = CFG.getComponent()
-        initCFG("server.satellite")
-        try:
+        with cfg_component("server.satellite") as CFG:
             try:
                 self.threads = int(CFG.REPOSYNC_DOWNLOAD_THREADS)
             except ValueError:
@@ -303,10 +301,6 @@ class ThreadedDownloader:
                     "Minimal transfer rate in bytes pre second expected, found: '%s'"
                     % CFG.REPOSYNC_MINRATE
                 )
-        except Exception as e:
-            raise e from None
-        finally:
-            initCFG(comp)
 
         if self.threads < 1:
             raise ValueError("Invalid number of threads: %d" % self.threads)

--- a/backend/satellite_tools/repo_plugins/deb_src.py
+++ b/backend/satellite_tools/repo_plugins/deb_src.py
@@ -24,12 +24,12 @@ import requests
 from functools import cmp_to_key
 from salt.utils.versions import LooseVersion
 from uyuni.common import fileutils
+from uyuni.common.context_managers import cfg_component
 from spacewalk.common.suseLib import get_proxy
 from spacewalk.satellite_tools.download import get_proxies
 from spacewalk.satellite_tools.repo_plugins import ContentPackage, CACHE_DIR
 from spacewalk.satellite_tools.syncLib import log2
 from spacewalk.server import rhnSQL
-from spacewalk.common.rhnConfig import CFG, initCFG
 from spacewalk.common import repo
 
 try:
@@ -319,12 +319,8 @@ class ContentSource:
         else:
             self.org = "NULL"
 
-        comp = CFG.getComponent()
         # read the proxy configuration in /etc/rhn/rhn.conf
-        initCFG('server.satellite')
-
-        # ensure the config namespace will be switched back in any case
-        try:
+        with cfg_component('server.satellite') as CFG:
             self.proxy_addr, self.proxy_user, self.proxy_pass = get_proxy(self.url)
             self.authtoken = None
 
@@ -360,9 +356,6 @@ class ContentSource:
                 self.timeout = int(CFG.REPOSYNC_TIMEOUT)
             except ValueError:
                 self.timeout = 300
-        finally:
-            # set config component back to original
-            initCFG(comp)
 
     def get_md_checksum_type(self):
         pass

--- a/backend/satellite_tools/reposync.py
+++ b/backend/satellite_tools/reposync.py
@@ -23,13 +23,8 @@ import socket
 import subprocess
 import sys
 import tempfile
-import time
 import traceback
 from datetime import datetime
-try:
-    from html.parser import HTMLParser
-except ImportError:
-    from HTMLParser import HTMLParser
 from dateutil.parser import parse as parse_date
 from xml.dom import minidom
 import gzip
@@ -44,7 +39,7 @@ from uyuni.common.usix import raise_with_tb
 
 from spacewalk.server import rhnPackage, rhnSQL, rhnChannel, suseEula
 from uyuni.common import fileutils
-from spacewalk.common import rhnLog, rhnCache, rhnMail, suseLib
+from spacewalk.common import rhnLog, rhnMail, suseLib
 from spacewalk.common.rhnTB import fetchTraceback
 from spacewalk.common import repo
 from uyuni.common.rhnLib import isSUSE, utc

--- a/backend/satellite_tools/test/unit/test_download.py
+++ b/backend/satellite_tools/test/unit/test_download.py
@@ -22,7 +22,7 @@ class NoKeyErrorsDict(dict):
 
 
 # this initCFG also operates on spacewalk.common.rhnConfig.CFG
-@patch("spacewalk.satellite_tools.download.initCFG", Mock())
+@patch("uyuni.common.context_managers.initCFG", Mock())
 @patch("spacewalk.satellite_tools.download.log", Mock())  # no logging
 @patch("urlgrabber.grabber.PyCurlFileObject._do_grab", Mock())  # no downloads
 @patch("urlgrabber.grabber.PyCurlFileObject.close", Mock())  # no need to close files
@@ -40,7 +40,7 @@ def test_reposync_timeout_minrate_are_passed_to_curl():
 
     with patch(
         "spacewalk.satellite_tools.download.pycurl.Curl", Mock(return_value=curl_spy)
-    ), patch("spacewalk.satellite_tools.download.CFG", CFG):
+    ), patch("uyuni.common.context_managers.CFG", CFG):
 
         td = ThreadedDownloader(force=True)
         td.add(params)

--- a/backend/satellite_tools/test/unit/test_reposync.py
+++ b/backend/satellite_tools/test/unit/test_reposync.py
@@ -318,13 +318,16 @@ class RepoSyncTest(unittest.TestCase):
         self.assertEqual(self.reposync.RepoSync._update_keywords(notice),
                          [])
 
+    @patch("uyuni.common.context_managers.initCFG", Mock())
     def test_send_error_mail(self):
         rs = self._create_mocked_reposync()
         self.reposync.rhnMail.send = Mock()
-        self.reposync.CFG.TRACEBACK_MAIL = 'recipient'
         self.reposync.hostname = 'testhost'
+        CFG = Mock()
+        CFG.TRACEBACK_MAIL = 'recipient'
 
-        rs.sendErrorMail('email body')
+        with patch("uyuni.common.context_managers.CFG", CFG):
+            rs.sendErrorMail('email body')
 
         self.assertEqual(self.reposync.rhnMail.send.call_args, (
                 ({'To': 'recipient',

--- a/backend/satellite_tools/test/unit/test_yum_src.py
+++ b/backend/satellite_tools/test/unit/test_yum_src.py
@@ -147,7 +147,7 @@ class YumSrcTest(unittest.TestCase):
         self.assertEqual(len(patches[1]), 2)
 
 
-    @patch("spacewalk.satellite_tools.repo_plugins.yum_src.initCFG", Mock())
+    @patch("uyuni.common.context_managers.initCFG", Mock())
     @patch("spacewalk.satellite_tools.repo_plugins.yum_src.os.unlink", Mock())
     @patch("urlgrabber.grabber.PyCurlFileObject", Mock())
     @patch("spacewalk.common.rhnLog", Mock())
@@ -165,7 +165,7 @@ class YumSrcTest(unittest.TestCase):
 
         with patch(
             "spacewalk.satellite_tools.repo_plugins.yum_src.urlgrabber.urlread", grabber_spy
-        ), patch("spacewalk.satellite_tools.repo_plugins.yum_src.CFG", CFG), patch(
+        ), patch("uyuni.common.context_managers.CFG", CFG), patch(
             "spacewalk.satellite_tools.repo_plugins.yum_src.os.path.isfile",
             Mock(return_value=False),
         ):

--- a/uyuni/common-libs/common/Makefile
+++ b/uyuni/common-libs/common/Makefile
@@ -7,18 +7,19 @@ TOP     = ..
 # Specific stuff
 SUBDIR  = common
 SPACEWALK_FILES	=   __init__ \
-            rhnLib \
-	    checksum \
-	    cli \
-	    fileutils \
-	    rhn_deb \
-	    rhn_mpm \
-	    rhn_pkg \
-	    rhn_rpm \
-	    stringutils \
-	    timezone_utils \
-	    usix \
-	    notificationUtils
+		checksum \
+		cli \
+		context_managers \
+		fileutils \
+		notificationUtils \
+		rhnLib \
+		rhn_deb \
+		rhn_mpm \
+		rhn_pkg \
+		rhn_rpm \
+		stringutils \
+		timezone_utils \
+		usix
 
 SCRIPTS =
 

--- a/uyuni/common-libs/common/context_managers.py
+++ b/uyuni/common-libs/common/context_managers.py
@@ -1,0 +1,29 @@
+"""Collection of context managers for Uyuni."""
+from contextlib import contextmanager
+from spacewalk.common.rhnConfig import CFG, initCFG
+
+@contextmanager
+def cfg_component(component, root=None, filename=None):
+    """Context manager for rhnConfig.
+
+    :param comp: The configuration component to use in this context
+    :param root: Root directory location of configuration files, optional
+    :param filename: Configuration file, optional
+
+    There is a common pattern when using rhnConfig that consists of the following steps:
+    1. save current component: old = CFG.getComponent()
+    2. set CFG to another component: initCFG('my_component')
+    3. Read / Set configuration values
+    4. set CFG back to the previous component
+
+    This pattern can now be expressed using the ``with`` statement:
+
+    with cfg_component('my_component') as CFG:
+        print(CFG.my_value)
+    """
+    previous = CFG.getComponent()
+    initCFG(component=component, root=root, filename=filename)
+    try:
+        yield CFG
+    finally:
+        initCFG(previous)


### PR DESCRIPTION
## What does this PR change?

There is a common pattern when using rhnConfig that, when forgetting a step, can cause issues in unrelated parts later on. This pattern is

1) save current component
2) switch to another component
3) read config from this component
4) switch back to the old component

There can be unforeseen bugs when the last step is forgotten.

Luckily, we now have a one-line solution that makes it impossible to forget a step -- there is only one:

    with cfg_component("my_component") as CFG:
        print(CFG.my_value)

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only changes implementation

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

I think it's a better idea to test this in uyuni before we think about backporting.

- [ ] **DONE**

## Changelogs

No user impacting change -> no changelog entry needed

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
