### PR TITLE
download metadata files with checksums for the traditional stack

### DIFF
--- a/backend/server/rhnRepository.py
+++ b/backend/server/rhnRepository.py
@@ -235,22 +235,20 @@ class Repository(rhnRepository.Repository):
 
         content_type = "application/x-gzip"
 
-        if file_name in ["repomd.xml", "comps.xml", "products.xml"]:
+        if file_name.endswith(".xml"):
             content_type = "text/xml"
         elif file_name in ["repomd.xml.asc", "repomd.xml.key"]:
             content_type = "text/plain"
-        elif file_name not in ["primary.xml.gz", "other.xml.gz",
-                               "filelists.xml.gz", "updateinfo.xml.gz", "Packages.gz", "modules.yaml",
-                               "InRelease", "Release", "Release.gpg",
-                               "susedata.xml.gz"]:
+        elif file_name.endswith(".yaml"):
+             content_type = "text/yaml"
+        file_path = "%s/%s/%s" % (CFG.REPOMD_PATH_PREFIX, self.channelName, file_name)
+        if file_name in ["comps.xml", "modules.yaml"]:
+            # without checksum in the filename, they are only available in the old style
+            return self._repodata_python(file_name)
+        elif not os.path.exists(CFG.REPOMD_CACHE_MOUNT_POINT + "/" + file_path):
             log_debug(2, "Unknown repomd file requested: %s" % file_name)
             raise rhnFault(6)
 
-        # XXX this won't be repconned or CDNd
-        if file_name in ["comps.xml", "modules.yaml"]:
-            return self._repodata_python(file_name)
-
-        file_path = "%s/%s/%s" % (CFG.REPOMD_PATH_PREFIX, self.channelName, file_name)
         rhnFlags.set('Content-Type', content_type)
         try:
             rhnFlags.set('Download-Accelerator-Path', file_path)
@@ -258,7 +256,7 @@ class Repository(rhnRepository.Repository):
         except IOError:
             e = sys.exc_info()[1]
             # For file not found, queue up a regen, and return 404
-            if e.errno == 2 and file_name not in ["comps.xml", "modules.yaml"]:
+            if e.errno == 2:
                 if file_name not in ["repomd.xml.key", "repomd.xml.asc"]:
                     taskomatic.add_to_repodata_queue(self.channelName, "repodata request",
                                                      file_name, bypass_filters=True)

--- a/backend/server/rhnRepository.py
+++ b/backend/server/rhnRepository.py
@@ -245,7 +245,7 @@ class Repository(rhnRepository.Repository):
         if file_name in ["comps.xml", "modules.yaml"]:
             # without checksum in the filename, they are only available in the old style
             return self._repodata_python(file_name)
-        elif not os.path.exists(CFG.REPOMD_CACHE_MOUNT_POINT + "/" + file_path):
+        elif not os.path.exists(os.path.join(CFG.REPOMD_CACHE_MOUNT_POINT, file_path)):
             log_debug(2, "Unknown repomd file requested: %s" % file_name)
             raise rhnFault(6)
 

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- handle download of metadata filesnames with checksums (bsc#1188315)
 - Sanitize cached filename for custom SSL certs used by reposync (bsc#1190751)
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Follow up on https://github.com/uyuni-project/uyuni/pull/4263

This PR adapt the download code for the traditional stack when downloading metadata files.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
