### PR TITLE
Fix unwanted CLM filter edit modal opening (bsc#1190867)

### DIFF
--- a/web/html/src/manager/content-management/list-filters/filter-edit.tsx
+++ b/web/html/src/manager/content-management/list-filters/filter-edit.tsx
@@ -70,7 +70,9 @@ const FilterEdit = (props: FilterEditProps) => {
   const modalNameId = `${props.id}-modal`;
 
   useEffect(() => {
-    if (props.initialFilterForm.id === props.openFilterId || (props.openFilterId === -1 && !props.editing)) {
+    const openWithInitial = props.initialFilterForm.id && props.initialFilterForm.id === props.openFilterId;
+    const openCreateWithParams = props.openFilterId === -1 && !props.editing;
+    if (openWithInitial || openCreateWithParams) {
       showDialog(modalNameId);
       setOpen(true);
       setFormData(props.initialFilterForm);

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Fix CLM filter edit modal opening (bsc#1190867)
 - Add 'Last build date' column to CLM project list (jsc#PM-2644)
   (jsc#SUMA-61)
 - Display a warning in the login page if the available disk space


### PR DESCRIPTION
## What does this PR change?

Fix a regression that causes the CLM filter edit modal to open when navigating to the list view.  

https://bugzilla.suse.com/show_bug.cgi?id=1190867

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Bug fix.

- [x] **DONE**

## Test coverage
- No tests: Nothing to test.

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/15951

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
