### PR TITLE
Fix pkgset beacon to work with salt-minion 2016.11.10 (bsc#1189260)

### DIFF
--- a/susemanager-utils/susemanager-sls/src/beacons/pkgset.py
+++ b/susemanager-utils/susemanager-sls/src/beacons/pkgset.py
@@ -27,24 +27,14 @@ COOKIE_PATH = None
 
 
 def __virtual__():
-    return any(
-               os.path.exists(plug) for plug in PKG_PLUGINS
-           ) and __virtualname__ or False
-
-
-def validate(config):
-    '''
-    Validate the beacon configuration. A "cookie" file path is mandatory.
-    '''
-
     global COOKIE_PATH
 
-    for plug in PKG_PLUGINS:
+    for plug, cookie in PKG_PLUGINS.items():
         if os.path.exists(plug):
-            COOKIE_PATH = PKG_PLUGINS.get(plug)
-            return True, 'Configuration validated'
+            COOKIE_PATH = cookie
+            break
 
-    return False, 'Cookie path has not been set.'
+    return COOKIE_PATH and __virtualname__ or False
 
 
 def beacon(config):

--- a/susemanager-utils/susemanager-sls/src/tests/test_beacon_pkgset.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_beacon_pkgset.py
@@ -12,24 +12,10 @@ def test_virtual():
     '''
     Test virtual function.
     '''
-    with patch.object(pkgset.os.path, "exists", MagicMock(return_value=True)):
-        assert pkgset.__virtual__() == pkgset.__virtualname__
-    with patch.object(pkgset.os.path, "exists", MagicMock(return_value=False)):
+    with patch('os.path.exists', MagicMock(return_value=False)):
         assert pkgset.__virtual__() != pkgset.__virtualname__
-
-
-def test_validate():
-    '''
-    Test validate() function
-    '''
-    with patch.object(pkgset.os.path, "exists", MagicMock(return_value=True)):
-        res, msg = pkgset.validate({})
-        assert res is True
-        assert msg == 'Configuration validated'
-    with patch.object(pkgset.os.path, "exists", MagicMock(return_value=False)):
-        res, msg = pkgset.validate({})
-        assert res is False
-        assert msg == 'Cookie path has not been set.'
+    with patch('os.path.exists', MagicMock(return_value=True)):
+        assert pkgset.__virtual__() == pkgset.__virtualname__
 
 
 @patch.object(pkgset.os.path, 'exists', MagicMock(return_value=True))

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Fix pkgset beacon to work with salt-minion 2016.11.10 (bsc#1189260)
 - Add 'flush_cache' flag to 'ansible.playbooks' call (bsc#1190405)
 - Update kernel live patch version on minion startup (bsc#1190276)
 - Fix virt grain python2 compatibility


### PR DESCRIPTION
## What does this PR change?

Fixes the traceback on salt-minion 2016.11.10.
```
2021-08-10 09:06:20,578 [salt.minion][CRITICAL][11722] The beacon errored: 
Traceback (most recent call last):
  File "/usr/lib64/python2.6/site-packages/salt/minion.py", line 2250, in handle_beacons
    beacons = self.process_beacons(self.functions)
  File "/usr/lib64/python2.6/site-packages/salt/minion.py", line 421, in process_beacons
    return self.beacons.process(b_conf, self.opts['grains'])  # pylint: disable=no-member
  File "/usr/lib64/python2.6/site-packages/salt/beacons/__init__.py", line 96, in process
    raw = self.beacons[fun_str](b_config[mod])
  File "/var/cache/salt/minion/extmods/beacons/pkgset.py", line 67, in beacon
    if os.path.exists(COOKIE_PATH):
  File "/usr/lib64/python2.6/genericpath.py", line 18, in exists
    st = os.stat(path)
TypeError: coercing to Unicode: need string or buffer, NoneType found
```
salt-minion 2016 is not calling `validate`

## GUI diff

No difference.

## Documentation
- No documentation needed: only internal and user invisible changes

## Test coverage
- Unit tests were realigned

## Changelogs

- Fix pkgset beacon to work with salt-minion 2016.11.10 (bsc#1189260)