### PR TITLE
Last build date column in CLM project list

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/ContentProjectSerializer.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/ContentProjectSerializer.java
@@ -16,10 +16,12 @@
 package com.redhat.rhn.frontend.xmlrpc.serializer;
 
 import com.redhat.rhn.domain.contentmgmt.ContentProject;
+import com.redhat.rhn.domain.contentmgmt.ContentProjectHistoryEntry;
 import com.redhat.rhn.frontend.xmlrpc.serializer.util.SerializerHelper;
 
 import java.io.IOException;
 import java.io.Writer;
+import java.util.Comparator;
 
 import redstone.xmlrpc.XmlRpcException;
 import redstone.xmlrpc.XmlRpcSerializer;
@@ -33,6 +35,7 @@ import redstone.xmlrpc.XmlRpcSerializer;
  *   #prop("string", "label")
  *   #prop("string", "name")
  *   #prop("string", "description")
+ *   #prop("dateTime.iso8601", "lastBuildDate")
  *   #prop("int", "orgId")
  *   #prop("string", "firstEnvironment label")
  * #struct_end()
@@ -59,6 +62,10 @@ public class ContentProjectSerializer extends RhnXmlRpcCustomSerializer {
         helper.add("label", contentProject.getLabel());
         helper.add("name", contentProject.getName());
         helper.add("description", contentProject.getDescription());
+        helper.add("lastBuildDate", contentProject.getHistoryEntries().stream()
+                .map(ContentProjectHistoryEntry::getCreated)
+                .max(Comparator.naturalOrder())
+                .orElse(null));
         helper.add("orgId", contentProject.getOrg().getId());
         helper.add("firstEnvironment", contentProject.getFirstEnvironmentOpt().map(e -> e.getLabel()).orElse(null));
         helper.writeTo(writer);

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/mappers/ResponseMappers.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/mappers/ResponseMappers.java
@@ -22,6 +22,7 @@ import com.redhat.rhn.domain.contentmgmt.ContentEnvironment;
 import com.redhat.rhn.domain.contentmgmt.ContentFilter;
 import com.redhat.rhn.domain.contentmgmt.ContentProject;
 import com.redhat.rhn.domain.contentmgmt.ContentProjectFilter;
+import com.redhat.rhn.domain.contentmgmt.ContentProjectHistoryEntry;
 import com.redhat.rhn.domain.contentmgmt.EnvironmentTarget;
 import com.redhat.rhn.domain.contentmgmt.ProjectSource;
 import com.redhat.rhn.domain.contentmgmt.SoftwareEnvironmentTarget;
@@ -46,6 +47,7 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
@@ -76,6 +78,10 @@ public class ResponseMappers {
         properties.setLabel(projectDB.getLabel());
         properties.setName(projectDB.getName());
         properties.setDescription(projectDB.getDescription());
+        properties.setLastBuildDate(projectDB.getHistoryEntries().stream()
+                .map(ContentProjectHistoryEntry::getCreated)
+                .max(Comparator.naturalOrder())
+                .orElse(null));
 
         List<ProjectHistoryEntryResponse> historyEntries = projectDB.getHistoryEntries().stream()
                 .map(entry -> {

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/mappers/ResponseMappersTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/mappers/ResponseMappersTest.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.webui.controllers.contentmanagement.mappers;
+
+import static com.redhat.rhn.domain.contentmgmt.ProjectSource.Type.SW_CHANNEL;
+import static java.util.Optional.empty;
+
+import com.redhat.rhn.domain.channel.Channel;
+import com.redhat.rhn.domain.channel.ChannelFactory;
+import com.redhat.rhn.domain.contentmgmt.ContentProject;
+import com.redhat.rhn.domain.contentmgmt.ContentProjectFactory;
+import com.redhat.rhn.domain.role.RoleFactory;
+import com.redhat.rhn.manager.contentmgmt.ContentManager;
+import com.redhat.rhn.testing.BaseTestCaseWithUser;
+import com.redhat.rhn.testing.ChannelTestUtils;
+
+import com.suse.manager.webui.controllers.contentmanagement.response.ProjectPropertiesResponse;
+
+import java.util.Date;
+
+public class ResponseMappersTest extends BaseTestCaseWithUser {
+
+    private ContentManager manager;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        manager = new ContentManager();
+        user.addPermanentRole(RoleFactory.ORG_ADMIN);
+    }
+
+    /**
+     * Test if a project's properties are properly mapped
+     */
+    public void testMapProjectPropertiesFromDB() throws Exception {
+        ContentProject cp = new ContentProject("myproject", "My Project", "My CLM project", user.getOrg());
+        ContentProjectFactory.save(cp);
+        manager.createEnvironment(cp.getLabel(), empty(), "dev", "Development", "Development environment", false, user);
+
+        // Initial project creation
+        ProjectPropertiesResponse props = ResponseMappers.mapProjectPropertiesFromDB(cp);
+        assertEquals("myproject", props.getLabel());
+        assertEquals("My Project", props.getName());
+        assertEquals("My CLM project", props.getDescription());
+        assertNull(props.getLastBuildDate());
+        assertTrue(props.getHistoryEntries().isEmpty());
+
+        // First build
+        Channel source = ChannelTestUtils.createTestChannel(user);
+        source.setChecksumType(ChannelFactory.findChecksumTypeByLabel("sha1"));
+        ChannelFactory.save(source);
+        manager.attachSource(cp.getLabel(), SW_CHANNEL, source.getLabel(), empty(), user);
+        manager.buildProject(cp, empty(), false, user);
+
+        props = ResponseMappers.mapProjectPropertiesFromDB(cp);
+        Date firstBuildDate = props.getLastBuildDate();
+        assertNotNull(firstBuildDate);
+        assertEquals(1, props.getHistoryEntries().size());
+
+        // Second build
+        manager.buildProject(cp, empty(), false, user);
+        props = ResponseMappers.mapProjectPropertiesFromDB(cp);
+        assertTrue(props.getLastBuildDate().after(firstBuildDate));
+        assertEquals(2, props.getHistoryEntries().size());
+    }
+}

--- a/java/code/src/com/suse/manager/webui/controllers/contentmanagement/response/ProjectPropertiesResponse.java
+++ b/java/code/src/com/suse/manager/webui/controllers/contentmanagement/response/ProjectPropertiesResponse.java
@@ -14,6 +14,7 @@
  */
 package com.suse.manager.webui.controllers.contentmanagement.response;
 
+import java.util.Date;
 import java.util.List;
 
 /**
@@ -24,7 +25,28 @@ public class ProjectPropertiesResponse {
     private String label;
     private String name;
     private String description;
+    private Date lastBuildDate;
     private List<ProjectHistoryEntryResponse> historyEntries;
+
+    public String getLabel() {
+        return label;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public Date getLastBuildDate() {
+        return lastBuildDate;
+    }
+
+    public List<ProjectHistoryEntryResponse> getHistoryEntries() {
+        return historyEntries;
+    }
 
     public void setLabel(String labelIn) {
         this.label = labelIn;
@@ -36,6 +58,10 @@ public class ProjectPropertiesResponse {
 
     public void setDescription(String descriptionIn) {
         this.description = descriptionIn;
+    }
+
+    public void setLastBuildDate(Date lastBuildDateIn) {
+        this.lastBuildDate = lastBuildDateIn;
     }
 
     public void setHistoryEntries(List<ProjectHistoryEntryResponse> historyEntriesIn) {

--- a/java/code/src/com/suse/manager/webui/utils/ViewHelper.java
+++ b/java/code/src/com/suse/manager/webui/utils/ViewHelper.java
@@ -108,17 +108,15 @@ public enum ViewHelper {
     }
 
     /**
-     * TODO -> DROP
-     * This is a buggy method, it does not return the "user" timezone but the timezone of the "Context" from where
-     * the request comes from, AKA the client/browser timezone. Uyuni/SUSE Manager user has a dedicated preference
-     * parameter to define it. See layout_head.jsp
-     *
-     *
      * Render the current user's configured timezone for being displayed (falling back to
      * the system default in case there is currently no user context).
      *
      * @return timezone to be displayed
+     * @deprecated this is a buggy method, it does not use the "user" timezone but the timezone of the "Context" from
+     * where the request comes from, AKA the client/browser timezone. Uyuni/SUSE Manager user has a dedicated preference
+     * parameter to define it. See layout_head.jsp
      */
+    @Deprecated
     public String renderTimezone() {
         Context ctx = Context.getCurrentContext();
         Locale locale = ctx != null ? ctx.getLocale() : Locale.getDefault();
@@ -129,32 +127,29 @@ public enum ViewHelper {
     }
 
     /**
-     * TODO -> DROP
-     * This is a buggy method, it does not use the "user" timezone but the timezone of the "Context" from where
-     * the request comes from, AKA the client/browser timezone. Uyuni/SUSE Manager user has a dedicated preference
-     * parameter to define it. See layout_head.jsp
-     *
-     *
      * Render the time in the current user's configured timezone (falling back to
      * the system default in case there is currently no user context).
      *
      * @return user's local time
+     * @deprecated this is a buggy method, it does not use the "user" timezone but the timezone of the "Context" from
+     * where the request comes from, AKA the client/browser timezone. Uyuni/SUSE Manager user has a dedicated preference
+     * parameter to define it. See layout_head.jsp
      */
+    @Deprecated
     public String renderLocalTime() {
         return renderDate(new Date());
     }
 
     /**
-     * TODO -> DROP
-     * This is a buggy method, it does not use the "user" timezone but the timezone of the "Context" from where
-     * the request comes from, AKA the client/browser timezone. Uyuni/SUSE Manager user has a dedicated preference
-     * parameter to define it. See layout_head.jsp
-     *
-     *
      * Render a given time in the current user's configured timezone
+     *
      * @param date the date
      * @return user's local time
+     * @deprecated this is a buggy method, it does not use the "user" timezone but the timezone of the "Context" from
+     * where the request comes from, AKA the client/browser timezone. Uyuni/SUSE Manager user has a dedicated preference
+     * parameter to define it. See layout_head.jsp
      */
+    @Deprecated
     public String renderDate(Date date) {
         Context ctx = Context.getCurrentContext();
         Locale locale = ctx != null ? ctx.getLocale() : Locale.getDefault();
@@ -168,7 +163,11 @@ public enum ViewHelper {
      * Render a given time in the current user's configured timezone
      * @param instant the instant
      * @return user's local time
+     * @deprecated this is a buggy method, it does not use the "user" timezone but the timezone of the "Context" from
+     * where the request comes from, AKA the client/browser timezone. Uyuni/SUSE Manager user has a dedicated preference
+     * parameter to define it. See layout_head.jsp
      */
+    @Deprecated
     public String renderDate(Instant instant) {
         return renderDate(new Date(instant.toEpochMilli()));
     }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Add 'Last build date' column to CLM project list (jsc#PM-2644)
+  (jsc#SUMA-61)
 - Improve exception handling and logging for mgr-libmod calls
 - Execute the diskcheck script at login to validate the available space
 - Add checksums to repository metadata filenames (bsc#1188315)

--- a/web/html/src/manager/content-management/list-projects/list-projects.tsx
+++ b/web/html/src/manager/content-management/list-projects/list-projects.tsx
@@ -14,12 +14,14 @@ import withPageWrapper from "components/general/with-page-wrapper";
 import useRoles from "core/auth/use-roles";
 import { isOrgAdmin } from "core/auth/auth.utils";
 import { ServerMessageType } from "components/messages";
+import { localizedMoment } from "utils/datetime";
 
 type ContentProjectOverviewType = {
   properties: {
     label: String;
     name: String;
     description: String;
+    lastBuildDate: Date | null;
   };
   environments: Array<String>;
   needRebuild: Boolean;
@@ -56,6 +58,7 @@ const ListProjects = (props: Props) => {
     label: project.properties.label,
     name: project.properties.name,
     description: project.properties.description,
+    lastBuildDate: project.properties.lastBuildDate,
     environmentLifecycle: project.environments.join(" > "),
   }));
 
@@ -73,6 +76,14 @@ const ListProjects = (props: Props) => {
       )}
     </div>
   );
+
+  const renderDate = (date: Date | null) => {
+    if (date === null) {
+      return <span>{t("never")}</span>
+    }
+    const lmDate = localizedMoment(date);
+    return <span title={lmDate.toUserDateTimeString()}>{lmDate.fromNow()}</span>
+  }
 
   return (
     <TopPanel
@@ -103,6 +114,12 @@ const ListProjects = (props: Props) => {
           comparator={Utils.sortByText}
           header={t("Description")}
           cell={row => _truncate(row.description, { length: 120 })}
+        />
+        <Column
+          columnKey="lastBuildDate"
+          comparator={Utils.sortByDate}
+          header={t("Last Build")}
+          cell={row => renderDate(row.lastBuildDate)}
         />
         <Column
           columnKey="environmentLifecycle"

--- a/web/html/src/utils/functions.ts
+++ b/web/html/src/utils/functions.ts
@@ -83,9 +83,9 @@ function sortByDate(aRaw: any, bRaw: any, columnKey: string, sortDirection: numb
    */
   const unparsableDateRegex = /(\d{2,4}.\d{2}.\d{2,4}.\d{1,2}.\d{2}.\d{2})( \w+)*/g;
 
-  const aDate =
+  const aDate = aRaw[columnKey] === null ? null :
     aRaw[columnKey] instanceof Date ? aRaw[columnKey] : new Date(aRaw[columnKey].replace(unparsableDateRegex, "$1"));
-  const bDate =
+  const bDate = bRaw[columnKey] === null ? null :
     bRaw[columnKey] instanceof Date ? bRaw[columnKey] : new Date(bRaw[columnKey].replace(unparsableDateRegex, "$1"));
 
   const result = aDate > bDate ? 1 : aDate < bDate ? -1 : 0;

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,5 @@
+- Add 'Last build date' column to CLM project list (jsc#PM-2644)
+  (jsc#SUMA-61)
 - Display a warning in the login page if the available disk space
   on the server is running out
 - Add 'Flush cache' checkbox to Ansible playbook execution page


### PR DESCRIPTION
Add a "Last build date" column to the CLM project list page

## GUI diff
![clm-project-lastbuild](https://user-images.githubusercontent.com/1103552/135299949-37b7a4ae-dcfe-48dd-ba5a-75a3d03ac50b.png)

## Documentation
- No documentation needed: minor UI enhancement

## Test coverage
- Unit tests were added

## Links

Fixes https://github.com/SUSE/spacewalk/issues/15632

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
