### PR TITLE
prevent conflicting IDs when disabling repos

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/channels/disablelocalbrokenrepos.sls
+++ b/susemanager-utils/susemanager-sls/salt/channels/disablelocalbrokenrepos.sls
@@ -7,7 +7,7 @@
 {% set url = entry.get('uri') %}
 {%- set repo_exists = (0 < salt['http.query'](url + '/Release', status=True, verify_ssl=True).get('status', 0) < 300) %}
 {% if not repo_exists %} 
-disable_repo_{{ repos_disabled.count }}:
+disable_broken_repo_{{ repos_disabled.count }}:
   mgrcompat.module_run:
     - name: pkg.mod_repo
     - repo: {{ "'" ~ entry.line ~ "'" }}
@@ -22,7 +22,7 @@ disable_repo_{{ repos_disabled.count }}:
 {% set url = data.get('baseurl', 'file://').replace('$basearch', grains['osarch']).replace('$releasever', grains['osmajorrelease']|string) -%}
 {%- set repo_exists = (0 < salt['http.query'](url + '/repodata/repomd.xml', status=True, verify_ssl=True).get('status', 0) < 300) %}
 {% if not repo_exists %}
-disable_repo_{{ alias }}:
+disable_broken_repo_{{ alias }}:
   mgrcompat.module_run:
     - name: pkg.mod_repo
     - repo: {{ alias }}


### PR DESCRIPTION
## What does this PR change?

New disable broken repos state can result in conflicting IDs. This PR make them unique.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Additional fix for #4247 
Tracks https://github.com/SUSE/spacewalk/pull/16000

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
