### PR TITLE
Fix slf4j log4j provider

### DIFF
--- a/java/code/src/com/suse/manager/webui/controllers/DownloadController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/DownloadController.java
@@ -25,6 +25,7 @@ import com.redhat.rhn.domain.channel.AccessTokenFactory;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.channel.ChannelFactory;
 import com.redhat.rhn.domain.channel.Comps;
+import com.redhat.rhn.domain.channel.MediaProducts;
 import com.redhat.rhn.domain.channel.Modules;
 import com.redhat.rhn.domain.rhnpackage.Package;
 import com.redhat.rhn.domain.rhnpackage.PackageEvr;
@@ -93,12 +94,16 @@ public class DownloadController {
                 DownloadController::downloadPackage);
         get("/manager/download/:channel/repodata/:file",
                 DownloadController::downloadMetadata);
+        get("/manager/download/:channel/media.1/:file",
+                DownloadController::downloadMediaFiles);
         head("/manager/download/:channel/getPackage/:file",
                 DownloadController::downloadPackage);
         head("/manager/download/:channel/getPackage/:org/:checksum/:file",
                 DownloadController::downloadPackage);
         head("/manager/download/:channel/repodata/:file",
                 DownloadController::downloadMetadata);
+        head("/manager/download/:channel/media.1/:file",
+                DownloadController::downloadMediaFiles);
     }
 
     /**
@@ -266,6 +271,31 @@ public class DownloadController {
     }
 
     /**
+     * Download media metadata taking the channel and filename from the request path.
+     *
+     * @param request the request object
+     * @param response the response object
+     * @return an object to make spark happy
+     */
+    public static Object downloadMediaFiles(Request request, Response response) {
+        String channelLabel = request.params(":channel");
+        String filename = request.params(":file");
+
+        if (checkTokens) {
+            String token = getTokenFromRequest(request);
+            validateToken(token, channelLabel, filename);
+        }
+        if (filename.equals("products")) {
+            File file = getMediaProductsFile(ChannelFactory.lookupByLabel(channelLabel));
+            if (file != null && file.exists()) {
+                return downloadFile(request, response, file);
+            }
+        }
+        halt(HttpStatus.SC_NOT_FOUND, String.format("%s not found", filename));
+        return null;
+    }
+
+    /**
      * Determines the comps file for a channel.
      * If the channel doesn't have comps file associated and it's a cloned one, try to
      * use the comps of the original channel.
@@ -303,6 +333,28 @@ public class DownloadController {
         }
         if (modules != null) {
             return new File(MOUNT_POINT_PATH, modules.getRelativeFilename()).getAbsoluteFile();
+        }
+
+        return null;
+    }
+
+    /**
+     * Determines the media products file for a channel.
+     * If the channel doesn't have products file associated and it's a cloned one, try to
+     * use the products file of the original channel.
+     *
+     * @param channel - the channel
+     * @return media products file to be used for this channel
+     */
+    private static File getMediaProductsFile(Channel channel) {
+        MediaProducts product = channel.getMediaProducts();
+
+        if (product == null && channel.isCloned()) {
+            product = channel.getOriginal().getMediaProducts();
+        }
+        if (product != null) {
+            return new File(MOUNT_POINT_PATH, product.getRelativeFilename())
+                    .getAbsoluteFile();
         }
 
         return null;

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- fix logging of the spark framework and map requests to media.1
+  directory in the download controller (bsc#1189933)
 - Add 'Last build date' column to CLM project list (jsc#PM-2644)
   (jsc#SUMA-61)
 - Improve exception handling and logging for mgr-libmod calls

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -138,6 +138,7 @@ BuildRequires:  libxml2-devel
 BuildRequires:  libxml2-tools
 %endif
 BuildRequires:  %{log4j}
+BuildRequires:  slf4j-log4j12
 BuildRequires:  netty
 BuildRequires:  objectweb-asm
 BuildRequires:  perl
@@ -235,6 +236,7 @@ Requires:       apache-commons-el
 Requires:       jcommon
 Requires:       jdom
 Requires:       jta
+Requires:       slf4j-log4j12
 Requires:       redstone-xmlrpc
 Requires:       simple-core
 Requires:       simple-xml


### PR DESCRIPTION
## What does this PR change?

* fix logging of spark framework
* map requests to media.1/ directory in the DownloadController and provide the "products" file when its available.

Port of https://github.com/SUSE/spacewalk/pull/15869

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
