### PR TITLE
Add extra parameter for publishing packages

### DIFF
--- a/susemanager-utils/testing/automation/publish-rpms.sh
+++ b/susemanager-utils/testing/automation/publish-rpms.sh
@@ -40,6 +40,11 @@ fi
 repo_dir=$repo_dir/$obs_project/$obs_repo/$obs_arch
 
 osc getbinaries $obs_project $obs_repo $obs_arch -d $repo_dir
+
+# Checkout specific packages. For example, multibuild packages won't
+# be downloaded by using "osc getbinaries PROJECT", so we need to
+# be explicit. For example 000product:Uyuni-Server-release
+
 for i in ${packages};do
     osc getbinaries $obs_project $i $obs_repo $obs_arch -d $repo_dir
 done

--- a/susemanager-utils/testing/automation/publish-rpms.sh
+++ b/susemanager-utils/testing/automation/publish-rpms.sh
@@ -8,17 +8,21 @@ usage()
     echo "  -r repo is the repo in the build service"
     echo "  -a arch is the arch in the build service"
     echo "  -d dir is the directory where to create the repo"
+    echo "  -q pkg is a specific package"
     echo "Example:"
-    echo "$0 -p systemsmanagement:Uyuni:Master:PR:123 -r openSUSE_Leap_15.2 -a x86_64 -d /home/jenkins/jenkins-build/workspace/"
+    echo "$0 -p systemsmanagement:Uyuni:Master:PR:123 -r openSUSE_Leap_15.2 -a x86_64 -d /home/jenkins/jenkins-build/workspace/ -q 000product:Uyuni-Server-release -q 000product:Uyuni-Proxy-release"
     echo "This will create a repo in /home/jenkins/jenkins-build/workspace/systemsmanagement:Uyuni:Master:PR:123/openSUSE_Leap_15.2/x86_64"
 }
 
-while getopts ":p:r:a:d:" opts;do
+packages=""
+
+while getopts ":p:r:a:d:q:" opts;do
     case "${opts}" in
         p) echo "PPPP";obs_project=${OPTARG};;
         r) echo "RRRR";obs_repo=${OPTARG};;
         a) echo "AAA";obs_arch=${OPTARG};;
         d) echo "DDDD";repo_dir=${OPTARG};;
+        q) packages="${packages} ${OPTARG}";;
         \?) usage;exit -1;;
     esac
 done
@@ -36,4 +40,8 @@ fi
 repo_dir=$repo_dir/$obs_project/$obs_repo/$obs_arch
 
 osc getbinaries $obs_project $obs_repo $obs_arch -d $repo_dir
+for i in ${packages};do
+    osc getbinaries $obs_project $i $obs_repo $obs_arch -d $repo_dir
+done
+
 cd $repo_dir && createrepo .


### PR DESCRIPTION
## What does this PR change?

The release packages are not being published. The reason is that these
packages are "sub-packages" and `osc getbinaries` is not downloading them.

However, we can specify the subpackage when calling `osc getbinaries`.

Thus, let's add an extra parameter so we can specify the subpackage
names.


## GUI diff

No difference.


- [X] **DONE**

## Documentation
- No documentation needed
- [X] **DONE**

## Test coverage
- No tests
- [X] **DONE**

## Links

related to https://github.com/SUSE/spacewalk/issues/15846

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
