### PR TITLE
Set key format to PEM for traditional clients push ssh

### DIFF
--- a/spacewalk/certs-tools/spacewalk-certs-tools.changes
+++ b/spacewalk/certs-tools/spacewalk-certs-tools.changes
@@ -1,3 +1,5 @@
+- set key format to PEM when generating key for traditional
+  clients push ssh (bsc#1189643)
 - add GPG keys using apt-key on debian machines (bsc#1187998)
 
 -------------------------------------------------------------------

--- a/spacewalk/certs-tools/spacewalk-ssh-push-init
+++ b/spacewalk/certs-tools/spacewalk-ssh-push-init
@@ -197,7 +197,7 @@ exec > >(sudo tee -a $LOGFILE) 2>&1
 # Run key generation if key doesn't exist
 if [ ! -f "${SSH_IDENTITY}" ]; then
   echo "* SUSE Manager key not found, generating it (${SSH_IDENTITY})"
-  ssh-keygen -q -N '' -C ${SSH_KEY_COMMENT} -f ${SSH_IDENTITY}
+  ssh-keygen -q -m PEM -N '' -C ${SSH_KEY_COMMENT} -f ${SSH_IDENTITY}
 else
   echo "* SUSE Manager key found: ${SSH_IDENTITY}"
 fi


### PR DESCRIPTION
Signed-off-by: Ricardo Mateus <rmateus@suse.com>

## What does this PR change?

Follow up PR after solving the issue: https://bugzilla.suse.com/show_bug.cgi?id=1189643

key is generated using open ssh format, but library JSCH only supports PEM format. This PR set the flag to generate key on PEM format when no key is found.

This change was tested at the reference server.


## GUI diff

No difference.


- [X] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes #
Tracks:
Backport to:
Head:
4.2:
4.1:

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
