### PR TITLE
More python2 compatibility fixed in grains and states

### DIFF
--- a/susemanager-utils/susemanager-sls/src/grains/cpuinfo.py
+++ b/susemanager-utils/susemanager-sls/src/grains/cpuinfo.py
@@ -138,7 +138,10 @@ def cpu_data():
                     "Stepping": "cpu_stepping",
                     "Core(s) per socket": "cpu_cores",
                 }
-                values = {name_map[entry["field"][:-1]]: entry["data"] for entry in data.get("lscpu") if entry["field"][:-1] in name_map.keys()}
+                values = {}
+                for entry in data.get("lscpu"):
+                    if entry["field"][:-1] in name_map.keys():
+                        values[name_map[entry["field"][:-1]]] = entry["data"]
                 log.debug(values)
                 return values
             else:

--- a/susemanager-utils/susemanager-sls/src/states/virt_utils.py
+++ b/susemanager-utils/susemanager-sls/src/states/virt_utils.py
@@ -9,7 +9,7 @@ import re
 from salt.exceptions import CommandExecutionError
 try:
     import libvirt
-except ModuleNotFoundError:
+except ImportError:
     pass
 
 log = logging.getLogger(__name__)

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,5 @@
+- Fix cpuinfo grain and virt_utils state python2 compatibility
+  (bsc#1191139, bsc#1191123)
 - Fix pkgset beacon to work with salt-minion 2016.11.10 (bsc#1189260)
 - Add 'flush_cache' flag to 'ansible.playbooks' call (bsc#1190405)
 - Update kernel live patch version on minion startup (bsc#1190276)


### PR DESCRIPTION
## What does this PR change?

Fix python2.6 compatibility for cpuinfo grain and virt_utils state.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: python 2.6 only
- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/15982 and https://bugzilla.suse.com/show_bug.cgi?id=1191123

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
