### PR TITLE
Fix incorrect identifier in recurring states

### DIFF
--- a/web/html/src/components/table/Table.tsx
+++ b/web/html/src/components/table/Table.tsx
@@ -134,7 +134,7 @@ export function Table(props: TableProps) {
           const rowClass = props.cssClassFunction ? props.cssClassFunction(datum, index) : "";
           const evenOddClass = index % 2 === 0 ? "list-row-odd" : "list-row-even";
           let key = props.identifier(datum);
-          if (!key) {
+          if (typeof key === 'undefined') {
             Loggerhead.error(`Could not identify table row with identifier: ${props.identifier}`);
             key = index;
           }

--- a/web/html/src/manager/state/highstate-summary.tsx
+++ b/web/html/src/manager/state/highstate-summary.tsx
@@ -7,7 +7,7 @@ import { AsyncButton } from "components/buttons";
 import { Utils } from "utils/functions";
 
 interface StateSource {
-  id: number;
+  id?: number;
   name: string;
   type: "STATE" | "CONFIG" | "FORMULA" | "INTERNAL";
   typeName: string; //Filled in on-the-fly via typeMap
@@ -52,10 +52,17 @@ export default function HighstateSummary({ minionId }) {
     );
   }
 
+  const identifier = (state: StateSource) => {
+    if (Object.prototype.hasOwnProperty.call(state, 'id')) {
+      return state.id;
+    }
+    // Internal states have no id
+    return `${state.type}_${state.name}`;
+  }
+
   return (
-    // TODO: This identifier seems wrong, what's the correct identifier here?
     <>
-      <Table identifier={state => state.state} data={summary} initialItemsPerPage={0}>
+      <Table identifier={identifier} data={summary} initialItemsPerPage={0}>
         <Column header={t("State Source")} comparator={Utils.sortByText} columnKey="name" cell={source => <State minionId={minionId} state={source} />} />
         <Column header={t("Type")} comparator={Utils.sortByText} columnKey="typeName" cell={source => source.typeName} />
         <Column header={t("Inherited From")} comparator={Utils.sortByText} sortable columnKey="sourceName" cell={source => <Source source={source} />} />


### PR DESCRIPTION
## What does this PR change?

In highstate overview in creating a recurring state we currently try to key table items by a field which doesn't exist. This seems like a reasonable alternative, please feel free to propose a better field if `id` isn't sufficiently unique.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: bugfix.

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/15856

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
