### PR TITLE
fix mgr-sync refresh (bsc#1191222)

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -1953,7 +1953,8 @@ public class ContentSyncManager {
 
         Opt.consume(suseProductSCCRepositories.stream().findFirst(),
                 () -> {
-                    throw new ContentSyncException("No product tree entry found for label: '" + label + "'");
+                    log.warn("Cannot update channel with label " + label + ". Please run: ");
+                    log.warn("spacewalk-remove-channel -c " + label);
                 },
                 productrepo -> {
                     SUSEProduct product = productrepo.getProduct();

--- a/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -1953,7 +1953,7 @@ public class ContentSyncManager {
 
         Opt.consume(suseProductSCCRepositories.stream().findFirst(),
                 () -> {
-                    log.warn("Cannot update channel with label " + label + ". Please run: ");
+                    log.warn("Expired Vendor Channel with label '" + label + "' found. To remove it please run: ");
                     log.warn("spacewalk-remove-channel -c " + label);
                 },
                 productrepo -> {

--- a/java/code/src/com/redhat/rhn/manager/content/test/ContentSyncManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/content/test/ContentSyncManagerTest.java
@@ -23,7 +23,6 @@ import com.redhat.rhn.domain.channel.ChannelFactory;
 import com.redhat.rhn.domain.channel.ChannelFamily;
 import com.redhat.rhn.domain.channel.ChannelFamilyFactory;
 import com.redhat.rhn.domain.channel.ContentSource;
-import com.redhat.rhn.domain.channel.test.ChannelFactoryTest;
 import com.redhat.rhn.domain.channel.test.ChannelFamilyFactoryTest;
 import com.redhat.rhn.domain.common.ManagerInfoFactory;
 import com.redhat.rhn.domain.credentials.Credentials;
@@ -596,17 +595,6 @@ public class ContentSyncManagerTest extends BaseTestCaseWithUser {
                 inReaderTree, new TypeToken<List<ProductTreeEntry>>() { }.getType());
 
         ContentSyncManager csm = new ContentSyncManager();
-
-        try {
-            Channel channelWithWrongLabel = ChannelFactoryTest.createTestChannel(user.getOrg());
-            //force use an non-existing label (mgr-sync from CLI can cause it)
-            channelWithWrongLabel.setLabel("non-existing-label");
-            ContentSyncManager.updateChannel(channelWithWrongLabel);
-            fail("update non-existing-channel should fail");
-        }
-        catch (ContentSyncException e) {
-            assertContains(e.getMessage(), "No product tree entry found for label:");
-        }
 
         csm.updateSUSEProducts(productsChanged, upgradePaths, staticTreeChanged, Collections.emptyList());
         HibernateFactory.getSession().flush();


### PR DESCRIPTION
## What does this PR change?

**add description**

`mgr-sync refresh` goes in error because of an exception in  `updateChannel` . The exception happens just when a channel is removed from SCC Repositories. Changed the exception in a more clear log error.

## GUI diff

- [ ] **DONE**

## Documentation
- No documentation needed

## Test coverage

- [ ] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/16016
https://bugzilla.suse.com/show_bug.cgi?id=1191222

- [ ] **DONE**

## Changelogs

- [x] No changelog needed

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
