### PR TITLE
use a different counter name

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/channels/disablelocalbrokenrepos.sls
+++ b/susemanager-utils/susemanager-sls/salt/channels/disablelocalbrokenrepos.sls
@@ -1,4 +1,4 @@
-{% do repos_disabled.update({'count': 0}) %}
+{% do broken_repos_disabled.update({'count': 0}) %}
 {% set repos = salt['pkg.list_repos']() %}
 {% for alias, data in repos.items() %}
 {% if grains['os_family'] == 'Debian' %}
@@ -7,13 +7,13 @@
 {% set url = entry.get('uri') %}
 {%- set repo_exists = (0 < salt['http.query'](url + '/Release', status=True, verify_ssl=True).get('status', 0) < 300) %}
 {% if not repo_exists %} 
-disable_broken_repo_{{ repos_disabled.count }}:
+disable_broken_repo_{{ broken_repos_disabled.count }}:
   mgrcompat.module_run:
     - name: pkg.mod_repo
     - repo: {{ "'" ~ entry.line ~ "'" }}
     - kwargs:
         disabled: True
-{% do repos_disabled.update({'count': repos_disabled.count + 1}) %}
+{% do broken_repos_disabled.update({'count': broken_repos_disabled.count + 1}) %}
 {% endif %}
 {% endif %}
 {% endfor %}
@@ -34,7 +34,7 @@ disable_broken_repo_{{ alias }}:
 {%- else %}
       - mgrcompat: sync_states
 {%- endif %}
-{% do repos_disabled.update({'count': repos_disabled.count + 1}) %}
+{% do broken_repos_disabled.update({'count': broken_repos_disabled.count + 1}) %}
 {% endif %}
 {% endif %}
 {% endif %}


### PR DESCRIPTION
## What does this PR change?

Use a different counter name to not interfer with the normal `repos_disabled` from the standard disable state.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
