### PR TITLE
spacewalk-java: Updated jakarta-activation reference (jaf).

### DIFF
--- a/java/buildconf/build-props.xml
+++ b/java/buildconf/build-props.xml
@@ -160,7 +160,7 @@
        concurrent xalan-j2" />
 
   <property name="run.jar.dependencies"
-	  value="antlr objectweb-asm/asm ${cglib-jar} c3p0 commons-discovery dom4j ${jaf} ${jta11-jars} ojdbc14 sitemesh
+      value="antlr objectweb-asm/asm ${cglib-jar} c3p0 commons-discovery dom4j ${jaf} ${jta11-jars} ojdbc14 sitemesh
              taglibs-standard-impl taglibs-standard-jstlel taglibs-standard-spec
              xalan-j2 xalan-j2-serializer xerces-j2 ${common.jar.dependencies}" />
 
@@ -182,7 +182,7 @@
       ${install.common.jar.dependencies} xalan-j2" />
 
   <property name="install.run.jar.dependencies"
-	  value="antlr objectweb-asm/asm ${cglib-jar} c3p0 commons-discovery dom4j dwr ${jaf} ${jta11-jars} sitemesh
+      value="antlr objectweb-asm/asm ${cglib-jar} c3p0 commons-discovery dom4j dwr ${jaf} ${jta11-jars} sitemesh
              taglibs-standard-impl taglibs-standard-jstlel taglibs-standard-spec
              xalan-j2 xalan-j2-serializer xerces-j2 ${install.common.jar.dependencies}" />
 
@@ -203,7 +203,7 @@
              commons-digester commons-discovery commons-el commons-fileupload commons-io
              ${commons-lang} commons-logging
              ${commons-validator} concurrent dom4j ${hibernate} ${jta11-jars}
-	     ${jaf} ${jasper-jars} ${javamail} ${jaxb} jcommon jdom ${other-jars}
+             ${jaf} ${jasper-jars} ${javamail} ${jaxb} jcommon jdom ${other-jars}
              ${tomcat-jars} ${log4j-jars} redstone-xmlrpc-client redstone-xmlrpc
              oro quartz stringtree-json sitemesh ${struts-jars}
              taglibs-standard-impl taglibs-standard-jstlel taglibs-standard-spec

--- a/java/buildconf/build-props.xml
+++ b/java/buildconf/build-props.xml
@@ -83,6 +83,10 @@
   <available file="${java.lib.dir}/ehcache.jar" type="file" property="ehcache" value="ehcache" />
   <available file="${java.lib.dir}/ehcache-core.jar" type="file" property="ehcache" value="ehcache-core" />
 
+  <condition property="jaf" value="jaf" else="jakarta-activation">
+    <available file="${java.lib.dir}/jaf/jakarta.activation.jar"/>
+  </condition>
+
   <!-- com.sun.xml.bind replacement (jaxb) -->
   <condition property="jaxb-api" value="jaxb-api" else="">
     <available file="${java.lib.dir}/jaxb-api.jar" />
@@ -156,7 +160,7 @@
        concurrent xalan-j2" />
 
   <property name="run.jar.dependencies"
-      value="antlr objectweb-asm/asm ${cglib-jar} c3p0 commons-discovery dom4j jaf ${jta11-jars} ojdbc14 sitemesh
+	  value="antlr objectweb-asm/asm ${cglib-jar} c3p0 commons-discovery dom4j ${jaf} ${jta11-jars} ojdbc14 sitemesh
              taglibs-standard-impl taglibs-standard-jstlel taglibs-standard-spec
              xalan-j2 xalan-j2-serializer xerces-j2 ${common.jar.dependencies}" />
 
@@ -178,7 +182,7 @@
       ${install.common.jar.dependencies} xalan-j2" />
 
   <property name="install.run.jar.dependencies"
-      value="antlr objectweb-asm/asm ${cglib-jar} c3p0 commons-discovery dom4j dwr jaf ${jta11-jars} sitemesh
+	  value="antlr objectweb-asm/asm ${cglib-jar} c3p0 commons-discovery dom4j dwr ${jaf} ${jta11-jars} sitemesh
              taglibs-standard-impl taglibs-standard-jstlel taglibs-standard-spec
              xalan-j2 xalan-j2-serializer xerces-j2 ${install.common.jar.dependencies}" />
 
@@ -199,7 +203,7 @@
              commons-digester commons-discovery commons-el commons-fileupload commons-io
              ${commons-lang} commons-logging
              ${commons-validator} concurrent dom4j ${hibernate} ${jta11-jars}
-             jaf ${jasper-jars} ${javamail} ${jaxb} jcommon jdom ${other-jars}
+	     ${jaf} ${jasper-jars} ${javamail} ${jaxb} jcommon jdom ${other-jars}
              ${tomcat-jars} ${log4j-jars} redstone-xmlrpc-client redstone-xmlrpc
              oro quartz stringtree-json sitemesh ${struts-jars}
              taglibs-standard-impl taglibs-standard-jstlel taglibs-standard-spec

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Updated jakarta-activation reference (jaf).
 - fix logging of the spark framework and map requests to media.1
   directory in the download controller (bsc#1189933)
 - Add 'Last build date' column to CLM project list (jsc#PM-2644)

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -107,7 +107,7 @@ BuildRequires:  httpcomponents-asyncclient
 BuildRequires:  httpcomponents-client
 BuildRequires:  ical4j
 BuildRequires:  jade4j
-BuildRequires:  jaf
+BuildRequires:  (jaf or jakarta-activation)
 %if 0%{?rhel} >= 8 || 0%{?fedora}
 BuildRequires:  glassfish-jaxb-core
 BuildRequires:  glassfish-jaxb-runtime
@@ -185,7 +185,7 @@ Requires:       %{ehcache}
 Requires:       cobbler >= 3.0.0
 Requires:       concurrent
 Requires:       dwr >= 3
-Requires:       (jaf or gnu-jaf)
+Requires:       (jaf or jakarta-activation)
 %if 0%{?rhel} || 0%{?fedora}
 Requires:       glassfish-jaxb-core
 Requires:       glassfish-jaxb-runtime
@@ -636,11 +636,11 @@ mv $RPM_BUILD_ROOT%{jardir}/jboss-loggingjboss-logging.jar $RPM_BUILD_ROOT%{jard
 
 # Prettifying symlinks for RHEL
 %if 0%{?rhel}
-mv $RPM_BUILD_ROOT%{jardir}/jafjakarta.activation.jar $RPM_BUILD_ROOT%{jardir}/jaf.jar
+mv $RPM_BUILD_ROOT%{jardir}/jakarta-activationjakarta.activation.jar $RPM_BUILD_ROOT%{jardir}/jaf.jar
 mv $RPM_BUILD_ROOT%{jardir}/javamailjavax.mail.jar $RPM_BUILD_ROOT%{jardir}/javamail.jar
 mv $RPM_BUILD_ROOT%{jardir}/jta.jar $RPM_BUILD_ROOT%{jardir}/geronimo-jta-1.1-api.jar
 # Removing unused symlinks.
-rm -rf $RPM_BUILD_ROOT%{jardir}/jafjakarta.activation-api.jar
+rm -rf $RPM_BUILD_ROOT%{jardir}/jakarta-activationjakarta.activation-api.jar
 rm -rf $RPM_BUILD_ROOT%{jardir}/javamaildsn.jar
 rm -rf $RPM_BUILD_ROOT%{jardir}/javamailgimap.jar
 rm -rf $RPM_BUILD_ROOT%{jardir}/javamailimap.jar


### PR DESCRIPTION
## What does this PR change?

- Updated jaf references. EPEL repo will contain the updated name jakarta-activation.
- Removed gnu-jaf reference.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered
Manually build and tested on AlmaLinux 8.
Leap not specifically tested.

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
