### PR TITLE
Hide link to live patching filter template for unsupporeted systems in system details (bsc#1190866)

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemOverviewAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/systems/sdc/SystemOverviewAction.java
@@ -20,6 +20,8 @@ import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.ActionFactory;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.entitlement.Entitlement;
+import com.redhat.rhn.domain.product.SUSEProductFactory;
+import com.redhat.rhn.domain.server.InstalledProduct;
 import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.user.User;
@@ -43,6 +45,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import javax.servlet.http.HttpServletRequest;
@@ -155,6 +158,17 @@ public class SystemOverviewAction extends RhnAction {
                 !(s.getLocation() == null || s.getLocation().isEmpty()));
         request.setAttribute("kernelLiveVersion",
                 s.asMinionServer().map(MinionServer::getKernelLiveVersion).orElse(null));
+
+        // Is live patching available for the system?
+        // Check if the base product is a live patch supported one
+        request.setAttribute("isLivePatchingAvailable",
+                s.getInstalledProducts().stream()
+                        .filter(InstalledProduct::isBaseproduct)
+                        .map(InstalledProduct::getSUSEProduct)
+                        .filter(Objects::nonNull)
+                        .findFirst()
+                        .map(p -> SUSEProductFactory.getLivePatchSupportedProducts().anyMatch(p::equals))
+                        .orElse(false));
 
         return mapping.findForward(RhnHelper.DEFAULT_FORWARD);
     }

--- a/java/code/webapp/WEB-INF/pages/systems/sdc/overview.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/sdc/overview.jsp
@@ -146,7 +146,11 @@
                 </c:when>
                 <c:otherwise>
                   <c:out value="${system.runningKernel}" />
-                  <a href="/rhn/manager/contentmanagement/filters?openFilterId=-1&openTemplate=LivePatchingSystem&systemId=${system.id}&systemName=${system.name}&kernelName=${system.runningKernel}">(<bean:message key="sdc.details.overview.create_clm_filter"/>)</a>
+                  <c:if test="${isLivePatchingAvailable}">
+                    <a href="/rhn/manager/contentmanagement/filters?openFilterId=-1&openTemplate=LivePatchingSystem&systemId=${system.id}&systemName=${system.name}&kernelName=${system.runningKernel}">
+                      (<bean:message key="sdc.details.overview.create_clm_filter"/>)
+                    </a>
+                  </c:if>
                 </c:otherwise>
               </c:choose>
               <c:if test="${not empty kernelLiveVersion}">

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Hide link to CLM live patching template in system details for
+  products that don't support live patching (bsc#1190866)
 - fix logging of the spark framework and map requests to media.1
   directory in the download controller (bsc#1189933)
 - Add 'Last build date' column to CLM project list (jsc#PM-2644)


### PR DESCRIPTION
It doesn't make any sense to display a link to CLM live patching filter templates for systems that are of a product that doesn't have live patching. This PR hides the link for those systems.

Port of: https://github.com/SUSE/spacewalk/pull/16015

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
