### PR TITLE
Align the test to the datetime picker format

### DIFF
--- a/testsuite/features/secondary/srv_datepicker.feature
+++ b/testsuite/features/secondary/srv_datepicker.feature
@@ -21,7 +21,7 @@ Feature: Pick dates
     And I follow "Remote Command" in the content area
     And I enter "ls" as "Script"
     And I pick "2016-08-27" as date
-    And I pick "5:30 pm" as time
+    And I pick "17:30" as time
     Then the date field is set to "2016-08-27"
     And the time field is set to "17:30"
     And the date picker is closed


### PR DESCRIPTION
## What does this PR change?

Test fix to the new format

## GUI diff

No difference.

The following image shows the captured real UI during the test:
![image](https://user-images.githubusercontent.com/7080830/135868905-1213de04-dc19-4ba8-840f-84962777e152.png)


- [x] **DONE**

## Documentation
- No documentation needed: test fix

- [x] **DONE**

## Test coverage
- No tests: test fix

- [x] **DONE**

## Links

Fixes [internal/private link](https://ci.suse.de/view/Manager/view/Manager-4.2/job/manager-4.2-dev-acceptance-tests-PRV/546/testReport/junit/(root)/Pick%20dates/Picking_a_time_should_set_the_hidden_fields/)
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
