### PR TITLE
Add GitHub CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,53 @@
+# CODEOWNERS info & syntax
+# Lines starting with "#" are comments.
+#
+# Each line is a file pattern followed by one or more owners.
+#
+# Order is important; the last matching pattern takes the most
+# precedence.
+#
+# Owners can be specified by email address or GitHub username
+#
+# Teams can be specified as code owners as well. Teams should
+# be identified in the format @org/team-name. Teams must have
+# explicit write access to the repository.
+#
+# Patterns
+#
+# Whole repository
+# * @global-owner
+#
+# Directory (without subdirectories)
+# docs/* @tech_writer
+#
+# Directory (including subdirectories)
+# apps/ @app_developer
+#
+# Adding a leading "/" to a pattern means the directory must
+# be in the root of the repository.
+#
+# Empty Pattern -> no owner (@app_developer owns all of apps/ except apps/github)
+# apps/ @app_developer
+# apps/github
+
+# Uyuni Code Owners
+
+# Release Engineering
+rel-eng/ @release-engineering
+tito.props @release-engineering
+
+# Cobbler
+java/conf/cobbler/snippets/ @SchoolGuy
+
+# Python
+*.py @uyuni-project/python
+backend/satellite_exporter/ @uyuni-project/python @lucidd
+
+# Frontend
+web/ @uyuni-project/frontend
+branding/ @uyuni-project/frontend
+susemanager-frontend/ @uyuni-project/frontend
+*.jsp @uyuni-project/frontend
+
+# Testsuite
+testsuite/ @uyuni-project/qe


### PR DESCRIPTION
Add GitHub CODEOWNERS file

This file maps path globs to uyuni-project org teams



## Documentation
- No documentation needed: Only touches .github

- [x] **DONE**

## Test coverage
- No tests: Only touches .github

- [x] **DONE**


## Changelogs


- [x] No changelog needed


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
