### PR TITLE
Add openSUSE 15.3 ARM minion to BV test suite

### DIFF
--- a/testsuite/features/build_validation/add_custom_repositories/srv_common_channels.feature
+++ b/testsuite/features/build_validation/add_custom_repositories/srv_common_channels.feature
@@ -8,7 +8,7 @@ Feature: Add common channels and schedule their synchronization
     Given I am authorized for the "Admin" section
 
   Scenario: Add common channels for Ubuntu 18.04 main
-    When I use spacewalk-common-channel to add Debian channel "ubuntu-1804-amd64-main"
+    When I use spacewalk-common-channel to add channel "ubuntu-1804-amd64-main" with arch "amd64-deb"
     And I follow the left menu "Software > Manage > Channels"
     And I follow "Ubuntu 18.04 LTS AMD64 Main"
     And I follow "Repositories" in the content area
@@ -20,7 +20,7 @@ Feature: Add common channels and schedule their synchronization
     Then I should see a "Repository sync scheduled for Ubuntu 18.04 LTS AMD64 Main." text
 
   Scenario: Add common channels for Ubuntu 18.04 updates
-    When I use spacewalk-common-channel to add Debian channel "ubuntu-1804-amd64-main-updates"
+    When I use spacewalk-common-channel to add channel "ubuntu-1804-amd64-main-updates" with arch "amd64-deb"
     And I follow the left menu "Software > Manage > Channels"
     And I follow "Ubuntu 18.04 LTS AMD64 Main Updates"
     And I follow "Repositories" in the content area
@@ -32,7 +32,7 @@ Feature: Add common channels and schedule their synchronization
     Then I should see a "Repository sync scheduled for Ubuntu 18.04 LTS AMD64 Main Updates." text
 
   Scenario: Add common channels for Ubuntu 18.04 security
-    When I use spacewalk-common-channel to add Debian channel "ubuntu-1804-amd64-main-security"
+    When I use spacewalk-common-channel to add channel "ubuntu-1804-amd64-main-security" with arch "amd64-deb"
     And I follow the left menu "Software > Manage > Channels"
     And I follow "Ubuntu 18.04 LTS AMD64 Main Security"
     And I follow "Repositories" in the content area
@@ -44,3 +44,15 @@ Feature: Add common channels and schedule their synchronization
     Then I should see a "Repository sync scheduled for Ubuntu 18.04 LTS AMD64 Main Security." text
 
   # No common channels for Ubuntu 20.04
+
+  Scenario: Add common channels for openSUSE 15.3 ARM
+    When I use spacewalk-common-channel to add channel "repo-15.3-oss-aarch64" with arch "aarch64"
+    And I follow the left menu "Software > Manage > Channels"
+    And I follow "openSUSE Leap 15.3 (aarch64)"
+    And I follow "Repositories" in the content area
+    And I select the "External - openSUSE Leap 15.3 (aarch64)" repo
+    And I click on "Save Repositories"
+    Then I should see a "repository information was successfully updated" text
+    When I follow "Sync"
+    And I click on "Sync Now"
+    Then I should see a "Repository sync scheduled for openSUSE Leap 15.3 (aarch64)" text

--- a/testsuite/features/build_validation/core/allcli_sanity.feature
+++ b/testsuite/features/build_validation/core/allcli_sanity.feature
@@ -274,3 +274,31 @@ Feature: Sanity checks
     And reverse resolution should work for "debian10_ssh_minion"
     And "debian10_ssh_minion" should communicate with the server
     And the clock from "debian10_ssh_minion" should be exact
+
+@sle11sp4_buildhost
+  Scenario: The SLES 11 SP4 build host is healthy
+    Then "sle11sp4_buildhost" should have a FQDN
+    And reverse resolution should work for "sle11sp4_buildhost"
+    And "sle11sp4_buildhost" should communicate with the server
+    And the clock from "sle11sp4_buildhost" should be exact
+
+@sle12sp5_buildhost
+  Scenario: The SLES 12 SP5 build host is healthy
+    Then "sle12sp5_buildhost" should have a FQDN
+    And reverse resolution should work for "sle12sp5_buildhost"
+    And "sle12sp5_buildhost" should communicate with the server
+    And the clock from "sle12sp5_buildhost" should be exact
+
+@sle15sp3_buildhost
+  Scenario: The SLES 15 SP3 build host is healthy
+    Then "sle15sp3_buildhost" should have a FQDN
+    And reverse resolution should work for "sle15sp3_buildhost"
+    And "sle15sp3_buildhost" should communicate with the server
+    And the clock from "sle15sp3_buildhost" should be exact
+
+@opensuse153arm_minion
+  Scenario: The openSUSE 15.3 ARM minion is healthy
+    Then "opensuse153arm_minion" should have a FQDN
+    And reverse resolution should work for "opensuse153arm_minion"
+    And "opensuse153arm_minion" should communicate with the server
+    And the clock from "opensuse153arm_minion" should be exact

--- a/testsuite/features/build_validation/create_bootstrap_repositories/srv_create_bootstrap_repositories.feature
+++ b/testsuite/features/build_validation/create_bootstrap_repositories/srv_create_bootstrap_repositories.feature
@@ -149,3 +149,7 @@ Feature: Create bootstrap repositories
 @debian10_ssh_minion
   Scenario: Create the bootstrap repository for a Debian 10 Salt SSH minion
     When I create the bootstrap repository for "debian10_ssh_minion" on the server
+
+@opensuse153arm_minion
+  Scenario: Create the bootstrap repository for a OpenSUSE 15.3 ARM minion
+    When I create the bootstrap repository for "opensuse 15.3arm_minion" on the server

--- a/testsuite/features/build_validation/init_clients/opensuse153arm_minion.feature
+++ b/testsuite/features/build_validation/init_clients/opensuse153arm_minion.feature
@@ -1,0 +1,47 @@
+# Copyright (c) 2021 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+@opensuse153arm_minion
+Feature: Bootstrap a openSUSE 15.3 ARM Salt minion
+
+  Scenario: Clean up sumaform leftovers on a openSUSE 15.3 ARM Salt minion
+    When I perform a full salt minion cleanup on "opensuse153arm_minion"
+
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
+  Scenario: Bootstrap a openSUSE 15.3 ARM minion
+    When I follow the left menu "Systems > Bootstrapping"
+    Then I should see a "Bootstrap Minions" text
+    When I enter the hostname of "opensuse153arm_minion" as "hostname"
+    And I enter "22" as "port"
+    And I enter "root" as "user"
+    And I enter "linux" as "password"
+    And I select "1-opensuse153arm_minion_key" from "activationKeys"
+    And I select the hostname of "proxy" from "proxies"
+    And I click on "Bootstrap"
+    And I wait until I see "Successfully bootstrapped host!" text
+    And I wait until onboarding is completed for "opensuse153arm_minion"
+
+  Scenario: Check the new bootstrapped openSUSE 15.3 ARM minion in System Overview page
+    When I follow the left menu "Salt > Keys"
+    Then I should see a "accepted" text
+    And the Salt master can reach "opensuse153arm_minion"
+
+@proxy
+  Scenario: Check connection from openSUSE 15.3 ARM minion to proxy
+    Given I am on the Systems overview page of this "opensuse153arm_minion"
+    When I follow "Details" in the content area
+    And I follow "Connection" in the content area
+    Then I should see "proxy" short hostname
+
+@proxy
+  Scenario: Check registration on proxy of openSUSE 15.3 ARM minion
+    Given I am on the Systems overview page of this "proxy"
+    When I follow "Details" in the content area
+    And I follow "Proxy" in the content area
+    Then I should see "opensuse153arm_minion" hostname
+
+  Scenario: Check events history for failures on openSUSE 15.3 ARM minion
+    Given I am on the Systems overview page of this "opensuse153arm_minion"
+    Then I check for failed events on history event page

--- a/testsuite/features/build_validation/retail/build_sle11_kiwi_image.feature
+++ b/testsuite/features/build_validation/retail/build_sle11_kiwi_image.feature
@@ -1,6 +1,7 @@
 # Copyright (c) 2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
+@sle11sp4_buildhost
 Feature: Prepare buildhost and build OS image for SLES 11 SP3
 
   Scenario: Log in as admin user

--- a/testsuite/features/build_validation/retail/build_sle12_kiwi_image.feature
+++ b/testsuite/features/build_validation/retail/build_sle12_kiwi_image.feature
@@ -1,6 +1,7 @@
 # Copyright (c) 2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
+@sle12sp5_buildhost
 Feature: Prepare buildhost and build OS image for SLES 12 SP5
 
   Scenario: Log in as admin user

--- a/testsuite/features/build_validation/retail/build_sle15_kiwi_image.feature
+++ b/testsuite/features/build_validation/retail/build_sle15_kiwi_image.feature
@@ -1,6 +1,7 @@
 # Copyright (c) 2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
+@sle15sp3_buildhost
 Feature: Prepare buildhost and build OS image for SLES 15 SP3
 
   Scenario: Log in as admin user

--- a/testsuite/features/build_validation/retail/deploy_sle11_terminal.feature
+++ b/testsuite/features/build_validation/retail/deploy_sle11_terminal.feature
@@ -1,6 +1,9 @@
 # Copyright (c) 2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
+@proxy
+@private_net
+@sle11sp3_terminal
 Feature: PXE boot a SLES 11 SP3 retail terminal
   In order to use SUSE Manager for Retail solution
   As the system administrator

--- a/testsuite/features/build_validation/retail/deploy_sle12_terminal.feature
+++ b/testsuite/features/build_validation/retail/deploy_sle12_terminal.feature
@@ -3,6 +3,7 @@
 
 @proxy
 @private_net
+@sle12sp5_terminal
 Feature: PXE boot a SLES 12 SP5 retail terminal
   In order to use SUSE Manager for Retail solution
   As the system administrator

--- a/testsuite/features/build_validation/retail/deploy_sle15_terminal.feature
+++ b/testsuite/features/build_validation/retail/deploy_sle15_terminal.feature
@@ -1,6 +1,9 @@
 # Copyright (c) 2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
+@proxy
+@private_net
+@sle15sp3_terminal
 Feature: PXE boot a SLES 15 SP3 retail terminal
   In order to use SUSE Manager for Retail solution
   As the system administrator

--- a/testsuite/features/build_validation/retail/sle11_deployment_preparation.feature
+++ b/testsuite/features/build_validation/retail/sle11_deployment_preparation.feature
@@ -1,6 +1,8 @@
 # Copyright (c) 2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
+@sle11sp3_terminal
+@sle11sp4_buildhost
 Feature: Prepare prerequisities for SLE11 SP3 terminal deployment
 
   Scenario: Prepare activation keys for SLE11 retail systems

--- a/testsuite/features/build_validation/retail/sle12_deployment_preparation.feature
+++ b/testsuite/features/build_validation/retail/sle12_deployment_preparation.feature
@@ -1,6 +1,8 @@
 # Copyright (c) 2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
+@sle12sp5_terminal
+@sle12sp5_buildhost
 Feature: Prepare prerequisities for SLE12 SP5 terminal deployment
 
   Scenario: Prepare activation keys for SLE12 SP5 retail systems

--- a/testsuite/features/build_validation/retail/sle15_deployment_preparation.feature
+++ b/testsuite/features/build_validation/retail/sle15_deployment_preparation.feature
@@ -1,6 +1,8 @@
 # Copyright (c) 2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
+@sle15sp3_terminal
+@sle15sp3_buildhost
 Feature: Prepare prerequisities for SLE15 SP3 terminal deployment
 
   Scenario: Prepare activation keys for SLE15 SP3 retail systems

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -123,8 +123,8 @@ When(/^I use spacewalk\-channel to list available channels$/) do
   $command_output, _code = $client.run(command)
 end
 
-When(/^I use spacewalk\-common\-channel to add Debian channel "([^"]*)"$/) do |child_channel|
-  command = "spacewalk-common-channels -u admin -p admin -a amd64-deb #{child_channel}"
+When(/^I use spacewalk\-common\-channel to add channel "([^"]*)" with arch "([^"]*)"$/) do |child_channel, arch|
+  command = "spacewalk-common-channels -u admin -p admin -a #{arch} #{child_channel}"
   $command_output, _code = $server.run(command)
 end
 

--- a/testsuite/features/support/constants.rb
+++ b/testsuite/features/support/constants.rb
@@ -141,7 +141,8 @@ PACKAGE_BY_CLIENT = { 'sle_client' => 'bison',
                       'debian9_minion' => 'bison',
                       'debian9_ssh_minion' => 'bison',
                       'debian10_minion' => 'bison',
-                      'debian10_ssh_minion' => 'bison' }.freeze
+                      'debian10_ssh_minion' => 'bison',
+                      'opensuse153arm_minion' => 'bison' }.freeze
 
 BASE_CHANNEL_BY_CLIENT = { 'proxy' => 'SLE-Product-SUSE-Manager-Proxy-4.2-Pool',
                            'sle_client' => 'SLES12-SP4-Pool',
@@ -188,7 +189,8 @@ BASE_CHANNEL_BY_CLIENT = { 'proxy' => 'SLE-Product-SUSE-Manager-Proxy-4.2-Pool',
                            'debian9_minion' => 'debian-9-pool',
                            'debian9_ssh_minion' => 'debian-9-pool',
                            'debian10_minion' => 'debian-10-pool',
-                           'debian10_ssh_minion' => 'debian-10-pool' }.freeze
+                           'debian10_ssh_minion' => 'debian-10-pool',
+                           'opensuse15sp3arm_minion' => 'repo-15.3-oss' }.freeze
 
 LABEL_BY_BASE_CHANNEL = { 'SLE-Product-SUSE-Manager-Proxy-4.2-Pool' => 'sle-product-suse-manager-proxy-4.2-pool-x86_64',
                           'SLES11-SP3-Pool' => 'sles11-sp3-pool-i586',
@@ -204,7 +206,8 @@ LABEL_BY_BASE_CHANNEL = { 'SLE-Product-SUSE-Manager-Proxy-4.2-Pool' => 'sle-prod
                           'ubuntu-18.04-pool' => 'ubuntu-18.04-pool-amd64',
                           'ubuntu-2004-amd64-main' => 'ubuntu-2004-amd64-main-amd64',
                           'debian-9-pool' => 'debian-9-pool-amd64',
-                          'debian-10-pool' => 'debian-10-pool-amd64' }.freeze
+                          'debian-10-pool' => 'debian-10-pool-amd64',
+                          'repo-15.3-oss' => 'repo-15.3-oss-aarch64' }.freeze
 
 CHANNEL_TO_SYNC_BY_BASE_CHANNEL = { 'SLE-Product-SUSE-Manager-Proxy-4.2-Pool' => 'SUMA-42-PROXY-x86_64',
                                     'SLES11-SP3-Pool' => 'SLE-11-SP3-i586',
@@ -220,7 +223,8 @@ CHANNEL_TO_SYNC_BY_BASE_CHANNEL = { 'SLE-Product-SUSE-Manager-Proxy-4.2-Pool' =>
                                     'ubuntu-18.04-pool' => 'ubuntu-18.04-amd64',
                                     'ubuntu-2004-amd64-main' => 'ubuntu-20.04-amd64',
                                     'debian-9-pool' => 'debian9-amd64',
-                                    'debian-10-pool' => 'debian10-amd64' }.freeze
+                                    'debian-10-pool' => 'debian10-amd64',
+                                    'repo-15.3-oss' => 'repo-15.3-oss-aarch64' }.freeze
 
 PARENT_CHANNEL_TO_SYNC_BY_BASE_CHANNEL = { 'SLE-Product-SUSE-Manager-Proxy-4.2-Pool' => 'sle-product-suse-manager-proxy-4.2-pool-x86_64',
                                            'SLES11-SP3-Pool' => nil,
@@ -236,7 +240,8 @@ PARENT_CHANNEL_TO_SYNC_BY_BASE_CHANNEL = { 'SLE-Product-SUSE-Manager-Proxy-4.2-P
                                            'ubuntu-18.04-pool' => nil,
                                            'ubuntu-2004-amd64-main' => nil,
                                            'debian-9-pool' => 'debian-9-pool-amd64',
-                                           'debian-10-pool' => 'debian-10-pool-amd64' }.freeze
+                                           'debian-10-pool' => 'debian-10-pool-amd64',
+                                           'repo-15.3-oss' => nil }.freeze
 
 PKGARCH_BY_CLIENT = { 'proxy' => 'x86_64',
                       'sle_client' => 'x86_64',
@@ -277,7 +282,8 @@ PKGARCH_BY_CLIENT = { 'proxy' => 'x86_64',
                       'debian9_minion' => 'amd64',
                       'debian9_ssh_minion' => 'amd64',
                       'debian10_minion' => 'amd64',
-                      'debian10_ssh_minion' => 'amd64' }.freeze
+                      'debian10_ssh_minion' => 'amd64',
+                      'opensuse15sp3arm_minion' => 'aarch64' }.freeze
 
 CHANNEL_TO_SYNCH_BY_OS_VERSION = {
   # 'default' is required for auto-installation tests.

--- a/testsuite/features/support/env.rb
+++ b/testsuite/features/support/env.rb
@@ -291,6 +291,34 @@ Before('@sle15sp3_client') do
   skip_this_scenario unless $sle15sp3_client
 end
 
+Before('@sle11sp4_buildhost') do
+  skip_this_scenario unless $sle11sp4_buildhost
+end
+
+Before('@sle11sp3_terminal') do
+  skip_this_scenario unless $sle11sp3_terminal
+end
+
+Before('@sle12sp5_buildhost') do
+  skip_this_scenario unless $sle12sp5_buildhost
+end
+
+Before('@sle12sp5_terminal') do
+  skip_this_scenario unless $sle12sp5_terminal
+end
+
+Before('@sle15sp3_buildhost') do
+  skip_this_scenario unless $sle15sp3_buildhost
+end
+
+Before('@sle15sp3_terminal') do
+  skip_this_scenario unless $sle15sp3_terminal
+end
+
+Before('@opensuse153arm_minion') do
+  skip_this_scenario unless $opensuse153arm_minion
+end
+
 Before('@skip_for_debianlike') do |scenario|
   filename = scenario.feature.location.file
   skip_this_scenario if (filename.include? 'ubuntu') || (filename.include? 'debian')

--- a/testsuite/features/support/twopence_init.rb
+++ b/testsuite/features/support/twopence_init.rb
@@ -75,6 +75,7 @@ if $build_validation
   $sle12sp5_terminal = twopence_init("ssh:#{ENV['SLE12SP5_TERMINAL']}") if ENV['SLE12SP5_TERMINAL']
   $sle15sp3_buildhost = twopence_init("ssh:#{ENV['SLE15SP3_BUILDHOST']}") if ENV['SLE15SP3_BUILDHOST']
   $sle15sp3_terminal = twopence_init("ssh:#{ENV['SLE15SP3_TERMINAL']}") if ENV['SLE15SP3_TERMINAL']
+  $opensuse153arm_minion = twopence_init("ssh:#{ENV['OPENSUSE153ARM_MINION']}") if ENV['OPENSUSE153ARM_MINION']
   $nodes += [$sle11sp4_client, $sle11sp4_minion, $sle11sp4_ssh_minion,
              $sle12sp4_client, $sle12sp4_minion, $sle12sp4_ssh_minion,
              $sle12sp5_client, $sle12sp5_minion, $sle12sp5_ssh_minion,
@@ -90,7 +91,8 @@ if $build_validation
              $debian10_minion, $debian10_ssh_minion,
              $sle11sp4_buildhost, $sle11sp3_terminal,
              $sle12sp5_buildhost, $sle12sp5_terminal,
-             $sle15sp3_buildhost, $sle15sp3_terminal]
+             $sle15sp3_buildhost, $sle15sp3_terminal,
+             $opensuse153arm_minion]
 else
   # Define twopence objects for QA environment
   $client = twopence_init("ssh:#{ENV['CLIENT']}") if ENV['CLIENT']
@@ -278,7 +280,8 @@ $node_by_host = { 'localhost'                 => $localhost,
                   'sle12sp4_buildhost'        => $sle12sp4_buildhost,
                   'sle12sp4_terminal'         => $sle12sp4_terminal,
                   'sle15sp3_buildhost'        => $sle15sp3_buildhost,
-                  'sle15sp3_terminal'         => $sle15sp3_terminal }
+                  'sle15sp3_terminal'         => $sle15sp3_terminal,
+                  'opensuse153arm_minion'     => $opensuse153arm_minion }
 
 # This is the inverse of `node_by_host`.
 $host_by_node = {}

--- a/testsuite/run_sets/build_validation_init_clients.yml
+++ b/testsuite/run_sets/build_validation_init_clients.yml
@@ -40,4 +40,6 @@
 - features/build_validation/init_clients/debian10_minion.feature
 - features/build_validation/init_clients/debian10_ssh_minion.feature
 
+- features/build_validation/init_clients/opensuse153arm_minion.feature
+
 ## Init clients END ###


### PR DESCRIPTION
## What does this PR change?

**add description**

Add openSUSE Leap 15.3 aarch64 testing to Build Validation test suite.

## Links

Ports:
4.1: SUSE/spacewalk#16139
4.2: SUSE/spacewalk#16138


## Changelogs

- [x] No changelog needed
