### PR TITLE
remove dropped option from test script

### DIFF
--- a/susemanager-utils/testing/docker/scripts/schema_migration_test_pgsql.sh
+++ b/susemanager-utils/testing/docker/scripts/schema_migration_test_pgsql.sh
@@ -37,7 +37,7 @@ cp /root/rhn.conf /etc/rhn/rhn.conf
 smdba system-check autotuning
 
 # this command will fail with certificate error. This is ok, so ignore the error
-spacewalk-setup --skip-system-version-test --skip-selinux-test --skip-fqdn-test --skip-gpg-key-import --skip-ssl-cert-generation --skip-ssl-vhost-setup --skip-services-check --clear-db --answer-file=clear-db-answers-pgsql.txt --external-postgresql --non-interactive ||:
+spacewalk-setup --skip-system-version-test --skip-selinux-test --skip-fqdn-test --skip-ssl-cert-generation --skip-ssl-vhost-setup --skip-services-check --clear-db --answer-file=clear-db-answers-pgsql.txt --external-postgresql --non-interactive ||:
 
 
 # this copy the latest schema from the git into the system


### PR DESCRIPTION
## What does this PR change?

--skip-gpg-key-import was dropped from spacewalk-setup scripts. Do not use it anymore when calling it to setup a test environment.

Follow up on https://github.com/uyuni-project/uyuni/pull/4301

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql" (Test skipped, there are no changes to test)
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
