### PR TITLE
Bootstrap UI for reactivation

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -21372,7 +21372,7 @@ The Tree Path, Base Channel, and Installer Generation should always match. This 
         </context-group>
       </trans-unit>
       <trans-unit id="sdc.details.activation.header" xml:space="preserve">
-        <source>System Activation Key</source>
+        <source>System Reactivation Key</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/systems/details/Activation.do</context>
         </context-group>

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -7747,6 +7747,7 @@ public class SystemHandler extends BaseHandler {
         List<String> activationKeys = maybeActivationKeys(activationKey);
         BootstrapParameters params = new BootstrapParameters(host, of(sshPort), sshUser, maybePassword, activationKeys,
                 empty(), true, empty());
+        log.debug("bootstrap called: " + params);
         return xmlRpcSystemHelper.bootstrap(user, params, saltSSH);
     }
 
@@ -7784,6 +7785,7 @@ public class SystemHandler extends BaseHandler {
         List<String> activationKeys = maybeActivationKeys(activationKey);
         BootstrapParameters params = new BootstrapParameters(host, of(sshPort), sshUser, sshPrivKey,
                 maybeString(sshPrivKeyPass), activationKeys, empty(), true, empty());
+        log.debug("bootstrapWithPrivateSshKey called: " + params);
         return xmlRpcSystemHelper.bootstrap(user, params, saltSSH);
     }
 
@@ -7819,6 +7821,7 @@ public class SystemHandler extends BaseHandler {
         List<String> activationKeys = maybeActivationKeys(activationKey);
         BootstrapParameters params = new BootstrapParameters(host, of(sshPort), sshUser, maybePassword, activationKeys,
                 empty(), true, of(proxyId.longValue()));
+        log.debug("bootstrap called with proxyId: " + params);
         return xmlRpcSystemHelper.bootstrap(user, params, saltSSH);
     }
 
@@ -7858,6 +7861,7 @@ public class SystemHandler extends BaseHandler {
         List<String> activationKeys = maybeActivationKeys(activationKey);
         BootstrapParameters params = new BootstrapParameters(host, of(sshPort), sshUser, sshPrivKey,
                 maybeString(sshPrivKeyPass), activationKeys, empty(), true, of(proxyId.longValue()));
+        log.debug("bootstrapWithPrivateSshKey called with proxyId: " + params);
         return xmlRpcSystemHelper.bootstrap(user, params, saltSSH);
     }
 
@@ -7893,6 +7897,7 @@ public class SystemHandler extends BaseHandler {
         List<String> activationKeys = maybeActivationKeys(activationKey);
         BootstrapParameters params = new BootstrapParameters(host, of(sshPort), sshUser, maybePassword, activationKeys,
                 maybeString(reactivationKey), true, empty());
+        log.debug("bootstrap called with re-activation key: " + params);
         return xmlRpcSystemHelper.bootstrap(user, params, saltSSH);
     }
 
@@ -7933,6 +7938,7 @@ public class SystemHandler extends BaseHandler {
         List<String> activationKeys = maybeActivationKeys(activationKey);
         BootstrapParameters params = new BootstrapParameters(host, of(sshPort), sshUser, sshPrivKey,
                 maybeString(sshPrivKeyPass), activationKeys, maybeString(reactivationKey), true, empty());
+        log.debug("bootstrapWithPrivateSshKey called with reactivationKey: " + params);
         return xmlRpcSystemHelper.bootstrap(user, params, saltSSH);
     }
 
@@ -7971,6 +7977,7 @@ public class SystemHandler extends BaseHandler {
         List<String> activationKeys = maybeActivationKeys(activationKey);
         BootstrapParameters params = new BootstrapParameters(host, of(sshPort), sshUser, maybePassword, activationKeys,
                 maybeString(reactivationKey), true, of(proxyId.longValue()));
+        log.debug("bootstrap called with re-activation key and proxyId: " + params);
         return xmlRpcSystemHelper.bootstrap(user, params, saltSSH);
     }
 
@@ -8014,6 +8021,7 @@ public class SystemHandler extends BaseHandler {
         BootstrapParameters params = new BootstrapParameters(host, of(sshPort), sshUser, sshPrivKey,
                 maybeString(sshPrivKeyPass), activationKeys, maybeString(reactivationKey), true,
                 of(proxyId.longValue()));
+        log.debug("bootstrapWithPrivateSshKey called with reactivation key and proxyId: " + params);
         return xmlRpcSystemHelper.bootstrap(user, params, saltSSH);
     }
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -7746,7 +7746,7 @@ public class SystemHandler extends BaseHandler {
         Optional<String> maybePassword = maybeString(sshPassword);
         List<String> activationKeys = maybeActivationKeys(activationKey);
         BootstrapParameters params = new BootstrapParameters(host, of(sshPort), sshUser, maybePassword, activationKeys,
-                true, empty());
+                empty(), true, empty());
         return xmlRpcSystemHelper.bootstrap(user, params, saltSSH);
     }
 
@@ -7783,7 +7783,7 @@ public class SystemHandler extends BaseHandler {
             String sshPrivKey, String sshPrivKeyPass, String activationKey, boolean saltSSH) {
         List<String> activationKeys = maybeActivationKeys(activationKey);
         BootstrapParameters params = new BootstrapParameters(host, of(sshPort), sshUser, sshPrivKey,
-                maybeString(sshPrivKeyPass), activationKeys, true, empty());
+                maybeString(sshPrivKeyPass), activationKeys, empty(), true, empty());
         return xmlRpcSystemHelper.bootstrap(user, params, saltSSH);
     }
 
@@ -7818,7 +7818,7 @@ public class SystemHandler extends BaseHandler {
         Optional<String> maybePassword = maybeString(sshPassword);
         List<String> activationKeys = maybeActivationKeys(activationKey);
         BootstrapParameters params = new BootstrapParameters(host, of(sshPort), sshUser, maybePassword, activationKeys,
-                true, of(proxyId.longValue()));
+                empty(), true, of(proxyId.longValue()));
         return xmlRpcSystemHelper.bootstrap(user, params, saltSSH);
     }
 
@@ -7857,7 +7857,163 @@ public class SystemHandler extends BaseHandler {
             String sshPrivKey, String sshPrivKeyPass, String activationKey, Integer proxyId, boolean saltSSH) {
         List<String> activationKeys = maybeActivationKeys(activationKey);
         BootstrapParameters params = new BootstrapParameters(host, of(sshPort), sshUser, sshPrivKey,
-                maybeString(sshPrivKeyPass), activationKeys, true, of(proxyId.longValue()));
+                maybeString(sshPrivKeyPass), activationKeys, empty(), true, of(proxyId.longValue()));
+        return xmlRpcSystemHelper.bootstrap(user, params, saltSSH);
+    }
+
+    /**
+     * Bootstrap a system for management via either Salt (minion/master) or Salt SSH.
+     *
+     * NOTE: Arguments contain sensitive data, which is hidden from logging in {@link LoggingInvocationProcessor}
+     *
+     * @param user the current user
+     * @param host hostname or IP address of the target machine
+     * @param sshPort SSH port to be used on the target machine
+     * @param sshUser SSH user to be used on the target machine
+     * @param sshPassword SSH password of given user
+     * @param activationKey activation key to be used for registration
+     * @param reactivationKey reactivation key to be used for registration
+     * @param saltSSH manage system with Salt SSH
+     * @return 1 on success, 0 on failure
+     *
+     * @xmlrpc.doc Bootstrap a system for management via either Salt or Salt SSH.
+     * @xmlrpc.param #session_key()
+     * @xmlrpc.param #param_desc("string", "host", "Hostname or IP address of target")
+     * @xmlrpc.param #param_desc("int", "sshPort", "SSH port on target machine")
+     * @xmlrpc.param #param_desc("string", "sshUser", "SSH user on target machine")
+     * @xmlrpc.param #param_desc("string", "sshPassword", "SSH password of given user")
+     * @xmlrpc.param #param_desc("string", "activationKey", "Activation key")
+     * @xmlrpc.param #param_desc("string", "reactivationKey", "Reactivation key")
+     * @xmlrpc.param #param_desc("boolean", "saltSSH", "Manage system with Salt SSH")
+     * @xmlrpc.returntype #return_int_success()
+     */
+    public int bootstrap(User user, String host, Integer sshPort, String sshUser,
+            String sshPassword, String activationKey, String reactivationKey, boolean saltSSH) {
+        Optional<String> maybePassword = maybeString(sshPassword);
+        List<String> activationKeys = maybeActivationKeys(activationKey);
+        BootstrapParameters params = new BootstrapParameters(host, of(sshPort), sshUser, maybePassword, activationKeys,
+                maybeString(reactivationKey), true, empty());
+        return xmlRpcSystemHelper.bootstrap(user, params, saltSSH);
+    }
+
+    /**
+     * Bootstrap a system for management via either Salt (minion/master) or Salt SSH.
+     * Use SSH private key for authentication.
+     *
+     * NOTE: Arguments contain sensitive data, which is hidden from logging in {@link LoggingInvocationProcessor}
+     *
+     * @param user the current user
+     * @param host hostname or IP address of the target machine
+     * @param sshPort SSH port to be used on the target machine
+     * @param sshUser SSH user to be used on the target machine
+     * @param sshPrivKey SSH private key as a string in PEM format
+     * @param sshPrivKeyPass SSH passphrase for the key (use empty string for no passphrase)
+     * @param activationKey activation key to be used for registration
+     * @param reactivationKey reactivation key to be used for registration
+     * @param saltSSH manage system with Salt SSH
+     * @return 1 on success, 0 on failure
+     *
+     * @xmlrpc.doc Bootstrap a system for management via either Salt or Salt SSH.
+     * Use SSH private key for authentication.
+     * @xmlrpc.param #session_key()
+     * @xmlrpc.param #param_desc("string", "host", "Hostname or IP address of target")
+     * @xmlrpc.param #param_desc("int", "sshPort", "SSH port on target machine")
+     * @xmlrpc.param #param_desc("string", "sshUser", "SSH user on target machine")
+     * @xmlrpc.param #param_desc("string", "sshPrivKey", "SSH private key as a string in PEM format")
+     * @xmlrpc.param #param_desc("string", "sshPrivKeyPass",
+     * "SSH passphrase for the key (use empty string for no passphrase)")
+     * @xmlrpc.param #param_desc("string", "activationKey", "Activation key")
+     * @xmlrpc.param #param_desc("string", "reactivationKey", "Reactivation key")
+     * @xmlrpc.param #param_desc("boolean", "saltSSH", "Manage system with Salt SSH")
+     * @xmlrpc.returntype #return_int_success()
+     */
+    public int bootstrapWithPrivateSshKey(User user, String host, Integer sshPort, String sshUser,
+            String sshPrivKey, String sshPrivKeyPass, String activationKey, String reactivationKey,
+            boolean saltSSH) {
+        List<String> activationKeys = maybeActivationKeys(activationKey);
+        BootstrapParameters params = new BootstrapParameters(host, of(sshPort), sshUser, sshPrivKey,
+                maybeString(sshPrivKeyPass), activationKeys, maybeString(reactivationKey), true, empty());
+        return xmlRpcSystemHelper.bootstrap(user, params, saltSSH);
+    }
+
+    /**
+     * Bootstrap a system for management via either Salt (minion/master) or Salt SSH.
+     *
+     * NOTE: Arguments contain sensitive data, which is hidden from logging in {@link LoggingInvocationProcessor}
+     *
+     * @param user the current user
+     * @param host hostname or IP address of the target machine
+     * @param sshPort SSH port to be used on the target machine
+     * @param sshUser SSH user to be used on the target machine
+     * @param sshPassword SSH password of given user
+     * @param activationKey activation key to be used for registration
+     * @param reactivationKey reactivation key to be used for registration
+     * @param proxyId system ID of proxy to use
+     * @param saltSSH manage system with Salt SSH
+     * @return 1 on success, 0 on failure
+     *
+     * @xmlrpc.doc Bootstrap a system for management via either Salt or Salt SSH.
+     * @xmlrpc.param #session_key()
+     * @xmlrpc.param #param_desc("string", "host", "Hostname or IP address of target")
+     * @xmlrpc.param #param_desc("int", "sshPort", "SSH port on target machine")
+     * @xmlrpc.param #param_desc("string", "sshUser", "SSH user on target machine")
+     * @xmlrpc.param #param_desc("string", "sshPassword", "SSH password of given user")
+     * @xmlrpc.param #param_desc("string", "activationKey", "Activation key")
+     * @xmlrpc.param #param_desc("string", "reactivationKey", "Reactivation key")
+     * @xmlrpc.param #param_desc("int", "proxyId", "System ID of proxy to use")
+     * @xmlrpc.param #param_desc("boolean", "saltSSH", "Manage system with Salt SSH")
+     * @xmlrpc.returntype #return_int_success()
+     */
+    public int bootstrap(User user, String host, Integer sshPort, String sshUser,
+            String sshPassword, String activationKey, String reactivationKey, Integer proxyId,
+            boolean saltSSH) {
+        Optional<String> maybePassword = maybeString(sshPassword);
+        List<String> activationKeys = maybeActivationKeys(activationKey);
+        BootstrapParameters params = new BootstrapParameters(host, of(sshPort), sshUser, maybePassword, activationKeys,
+                maybeString(reactivationKey), true, of(proxyId.longValue()));
+        return xmlRpcSystemHelper.bootstrap(user, params, saltSSH);
+    }
+
+    /**
+     * Bootstrap a system for management via either Salt (minion/master) or Salt SSH.
+     * Use SSH private key for authentication.
+     *
+     * NOTE: Arguments contain sensitive data, which is hidden from logging in {@link LoggingInvocationProcessor}
+     *
+     * @param user the current user
+     * @param host hostname or IP address of the target machine
+     * @param sshPort SSH port to be used on the target machine
+     * @param sshUser SSH user to be used on the target machine
+     * @param sshPrivKey SSH private key as a string in PEM format
+     * @param sshPrivKeyPass SSH passphrase for the key (use empty string for no passphrase)
+     * @param activationKey activation key to be used for registration
+     * @param reactivationKey reactivation key to be used for registration
+     * @param proxyId system ID of proxy to use
+     * @param saltSSH manage system with Salt SSH
+     * @return 1 on success, 0 on failure
+     *
+     * @xmlrpc.doc Bootstrap a system for management via either Salt or Salt SSH.
+     * Use SSH private key for authentication.
+     * @xmlrpc.param #session_key()
+     * @xmlrpc.param #param_desc("string", "host", "Hostname or IP address of target")
+     * @xmlrpc.param #param_desc("int", "sshPort", "SSH port on target machine")
+     * @xmlrpc.param #param_desc("string", "sshUser", "SSH user on target machine")
+     * @xmlrpc.param #param_desc("string", "sshPrivKey", "SSH private key as a string in PEM format")
+     * @xmlrpc.param #param_desc("string", "sshPrivKeyPass",
+     * "SSH passphrase for the key (use empty string for no passphrase)")
+     * @xmlrpc.param #param_desc("string", "activationKey", "Activation key")
+     * @xmlrpc.param #param_desc("string", "reactivationKey", "Reactivation key")
+     * @xmlrpc.param #param_desc("int", "proxyId", "System ID of proxy to use")
+     * @xmlrpc.param #param_desc("boolean", "saltSSH", "Manage system with Salt SSH")
+     * @xmlrpc.returntype #return_int_success()
+     */
+    public int bootstrapWithPrivateSshKey(User user, String host, Integer sshPort, String sshUser,
+            String sshPrivKey, String sshPrivKeyPass, String activationKey, String reactivationKey,
+            Integer proxyId, boolean saltSSH) {
+        List<String> activationKeys = maybeActivationKeys(activationKey);
+        BootstrapParameters params = new BootstrapParameters(host, of(sshPort), sshUser, sshPrivKey,
+                maybeString(sshPrivKeyPass), activationKeys, maybeString(reactivationKey), true,
+                of(proxyId.longValue()));
         return xmlRpcSystemHelper.bootstrap(user, params, saltSSH);
     }
 

--- a/java/code/src/com/suse/manager/webui/controllers/utils/AbstractMinionBootstrapper.java
+++ b/java/code/src/com/suse/manager/webui/controllers/utils/AbstractMinionBootstrapper.java
@@ -352,17 +352,18 @@ public abstract class AbstractMinionBootstrapper {
      * @return Optional with error message or empty if validation succeeds
      */
     private Optional<String> validateReactivationKey(Optional<String> reactivationKeyLabel) {
-        if (!reactivationKeyLabel.isPresent()) {
+        if (reactivationKeyLabel.isEmpty()) {
             return Optional.empty();
         }
-
-        ActivationKey reactivationKey = ActivationKeyFactory.lookupByKey(reactivationKeyLabel.get());
+        String rLabel = reactivationKeyLabel.get();
+        ActivationKey reactivationKey = ActivationKeyFactory.lookupByKey(rLabel);
 
         if (reactivationKey == null) {
-            return Optional.of("Selected reactivation key not found.");
+            return Optional.of(String.format("Selected reactivation '%s' key not found.", rLabel));
         }
         if (reactivationKey.getServer() == null) {
-            return Optional.of("Selected reactivation key has no server set for reactivation.");
+            return Optional.of(String.format("Selected reactivation key '%s' has no server set for reactivation.",
+                    rLabel));
         }
         return Optional.empty();
     }

--- a/java/code/src/com/suse/manager/webui/controllers/utils/AbstractMinionBootstrapper.java
+++ b/java/code/src/com/suse/manager/webui/controllers/utils/AbstractMinionBootstrapper.java
@@ -252,6 +252,7 @@ public abstract class AbstractMinionBootstrapper {
         pillarData.put("minion_id", input.getHost());
         pillarData.put("contact_method", contactMethod);
         pillarData.put("mgr_sudo_user", SaltSSHService.getSSHUser());
+        input.getReactivationKey().ifPresent(r -> pillarData.put("management_key", r));
         ActivationKeyManager.getInstance().findAll(user)
                 .stream()
                 .filter(ak -> input.getActivationKeys().contains(ak.getKey()))
@@ -304,10 +305,19 @@ public abstract class AbstractMinionBootstrapper {
             return Collections.singletonList(activationKeyErrorMessage.get());
         }
 
+        Optional<String> reactivationKeyError = validateReactivationKey(params.getReactivationKey());
+        if (reactivationKeyError.isPresent()) {
+            return Collections.singletonList(reactivationKeyError.get());
+        }
+
         if (saltApi.keyExists(params.getHost(), KeyStatus.ACCEPTED, KeyStatus.DENIED, KeyStatus.REJECTED)) {
             return Collections.singletonList("A salt key for this" +
                     " host (" + params.getHost() +
                     ") seems to already exist, please check!");
+        }
+
+        if (params.getReactivationKey().isPresent()) {
+            return Collections.emptyList();
         }
 
         return MinionServerFactory.findByMinionId(params.getHost())
@@ -333,6 +343,28 @@ public abstract class AbstractMinionBootstrapper {
         }
 
         return validateContactMethod(activationKey.getContactMethod());
+    }
+
+    /**
+     * Checks whether the reactivation key exists
+     *
+     * @param reactivationKeyLabel desired reactivation key label
+     * @return Optional with error message or empty if validation succeeds
+     */
+    private Optional<String> validateReactivationKey(Optional<String> reactivationKeyLabel) {
+        if (!reactivationKeyLabel.isPresent()) {
+            return Optional.empty();
+        }
+
+        ActivationKey reactivationKey = ActivationKeyFactory.lookupByKey(reactivationKeyLabel.get());
+
+        if (reactivationKey == null) {
+            return Optional.of("Selected reactivation key not found.");
+        }
+        if (reactivationKey.getServer() == null) {
+            return Optional.of("Selected reactivation key has no server set for reactivation.");
+        }
+        return Optional.empty();
     }
 
     protected abstract Optional<String> validateContactMethod(ContactMethod desiredContactMethod);

--- a/java/code/src/com/suse/manager/webui/controllers/utils/test/AbstractMinionBootstrapperTestBase.java
+++ b/java/code/src/com/suse/manager/webui/controllers/utils/test/AbstractMinionBootstrapperTestBase.java
@@ -114,6 +114,8 @@ public abstract class AbstractMinionBootstrapperTestBase extends JMockBaseTestCa
             will(returnValue(empty()));
             allowing(mock).getProxy();
             will(returnValue(null));
+            allowing(mock).maybeGetReactivationKey();
+            will(returnValue(empty()));
         }});
     }
 
@@ -158,7 +160,7 @@ public abstract class AbstractMinionBootstrapperTestBase extends JMockBaseTestCa
             will(returnValue(keyPair));
 
             List<String> bootstrapMods = bootstrapMods();
-            Map<String, Object> pillarData = createPillarData(Optional.empty());
+            Map<String, Object> pillarData = createPillarData(Optional.empty(), Optional.empty());
             // return success when calling low-level bootstrap
             allowing(saltServiceMock).bootstrapMinion(with(any(BootstrapParameters.class)),
                     with(bootstrapMods), with(pillarData));
@@ -189,6 +191,8 @@ public abstract class AbstractMinionBootstrapperTestBase extends JMockBaseTestCa
             will(returnValue(of(key.getKey())));
             allowing(input).getActivationKeys();
             will(returnValue(List.of(key.getKey())));
+            allowing(input).maybeGetReactivationKey();
+            will(returnValue(null));
         }});
 
         BootstrapParameters params = bootstrapper.createBootstrapParams(input);
@@ -208,6 +212,8 @@ public abstract class AbstractMinionBootstrapperTestBase extends JMockBaseTestCa
             will(returnValue(Collections.singletonList(key.getKey())));
             allowing(input).getFirstActivationKey();
             will(returnValue(of(key.getKey())));
+            allowing(input).maybeGetReactivationKey();
+            will(returnValue(empty()));
 
             allowing(saltServiceMock).keyExists("myhost", KeyStatus.ACCEPTED, KeyStatus.DENIED, KeyStatus.REJECTED);
             will(returnValue(false));
@@ -219,7 +225,7 @@ public abstract class AbstractMinionBootstrapperTestBase extends JMockBaseTestCa
             will(returnValue(keyPair));
 
             List<String> bootstrapMods = bootstrapMods();
-            Map<String, Object> pillarData = createPillarData(Optional.of(key));
+            Map<String, Object> pillarData = createPillarData(Optional.of(key), Optional.empty());
             allowing(saltServiceMock).bootstrapMinion(with(any(BootstrapParameters.class)),
                     with(bootstrapMods), with(pillarData));
             Object sshResult = createSuccessResult();
@@ -230,7 +236,48 @@ public abstract class AbstractMinionBootstrapperTestBase extends JMockBaseTestCa
         assertTrue(bootstrapper.bootstrap(params, user, getDefaultContactMethod()).isSuccess());
     }
 
-    protected abstract Map<String, Object> createPillarData(Optional<ActivationKey> key);
+    /**
+     * Base for tests that check that bootstrap SUCCEEDS with on current bootstrapper (set
+     * in implementations of this base class) and given activation key.
+     * @param key activation key
+     * @param reactKey an reactivation key
+     * @throws Exception if anything goes wrong
+     */
+    protected void testCompatibleActivationKeysBase(ActivationKey key, ActivationKey reactKey) throws Exception {
+        BootstrapHostsJson input = mockStandardInput();
+        context().checking(new Expectations() {{
+            allowing(input).getActivationKeys();
+            will(returnValue(Collections.singletonList(key.getKey())));
+            allowing(input).getFirstActivationKey();
+            will(returnValue(of(key.getKey())));
+            allowing(input).maybeGetReactivationKey();
+            will(returnValue(Optional.of(reactKey.getKey())));
+
+            allowing(saltServiceMock).keyExists("myhost", KeyStatus.ACCEPTED, KeyStatus.DENIED, KeyStatus.REJECTED);
+            will(returnValue(false));
+            allowing(saltServiceMock).keyExists("myhost", KeyStatus.UNACCEPTED);
+            will(returnValue(false));
+
+            Key.Pair keyPair = mockKeyPair();
+            allowing(saltServiceMock).generateKeysAndAccept("myhost", false);
+            will(returnValue(keyPair));
+
+            List<String> bootstrapMods = bootstrapMods();
+            Map<String, Object> pillarData = createPillarData(Optional.of(key), Optional.of(reactKey));
+            allowing(saltServiceMock).bootstrapMinion(with(any(BootstrapParameters.class)),
+                    with(bootstrapMods), with(pillarData));
+            Object sshResult = createSuccessResult();
+            will(returnValue(new Result<>(Xor.right(sshResult))));
+        }});
+
+        BootstrapParameters params = bootstrapper.createBootstrapParams(input);
+        assertTrue(params.getReactivationKey().isPresent());
+        assertEquals(params.getReactivationKey().get(), reactKey.getKey());
+        assertTrue(bootstrapper.bootstrap(params, user, getDefaultContactMethod()).isSuccess());
+    }
+
+    protected abstract Map<String, Object> createPillarData(Optional<ActivationKey> key,
+            Optional<ActivationKey> reactKey);
 
     protected abstract List<String> bootstrapMods();
 

--- a/java/code/src/com/suse/manager/webui/controllers/utils/test/RegularMinionBootstrapperTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/utils/test/RegularMinionBootstrapperTest.java
@@ -16,9 +16,13 @@
 package com.suse.manager.webui.controllers.utils.test;
 
 import com.redhat.rhn.common.conf.ConfigDefaults;
+import com.redhat.rhn.domain.role.RoleFactory;
+import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.ServerFactory;
+import com.redhat.rhn.domain.server.test.ServerFactoryTest;
 import com.redhat.rhn.domain.token.ActivationKey;
 import com.redhat.rhn.domain.token.test.ActivationKeyTest;
+import com.redhat.rhn.manager.token.ActivationKeyManager;
 
 import com.suse.manager.webui.controllers.utils.AbstractMinionBootstrapper.BootstrapResult;
 import com.suse.manager.webui.controllers.utils.ContactMethodUtil;
@@ -75,7 +79,7 @@ public class RegularMinionBootstrapperTest extends AbstractMinionBootstrapperTes
             will(returnValue(keyPair));
 
             List<String> bootstrapMods = bootstrapMods();
-            Map<String, Object> pillarData = createPillarData(Optional.empty());
+            Map<String, Object> pillarData = createPillarData(Optional.empty(), Optional.empty());
 
             // return failure when calling low-level bootstrap
             allowing(saltServiceMock).bootstrapMinion(with(any(BootstrapParameters.class)),
@@ -109,6 +113,16 @@ public class RegularMinionBootstrapperTest extends AbstractMinionBootstrapperTes
         super.testCompatibleActivationKeysBase(key);
     }
 
+    public void testCompatibleActivationKeysAndReactivation() throws Exception {
+        user.addPermanentRole(RoleFactory.ORG_ADMIN);
+        Server testServer = ServerFactoryTest.createTestServer(user);
+        ActivationKey key = ActivationKeyManager.getInstance().createNewActivationKey(user, "");
+        ActivationKey reactkey = ActivationKeyTest.createTestActivationKey(user);
+
+        key.setContactMethod(ServerFactory.findContactMethodByLabel("default"));
+        super.testCompatibleActivationKeysBase(key, reactkey);
+    }
+
     @Override
     protected List<String> bootstrapMods() {
         return Arrays.asList("certs", "bootstrap");
@@ -120,8 +134,15 @@ public class RegularMinionBootstrapperTest extends AbstractMinionBootstrapperTes
     }
 
     @Override
-    protected Map<String, Object> createPillarData(Optional<ActivationKey> key) {
+    protected Map<String, Object> createPillarData(Optional<ActivationKey> key, Optional<ActivationKey> reactKey) {
         Map<String, Object> pillarData = new HashMap<>();
+        key.ifPresent(k -> {
+            ActivationKeyManager.getInstance().findAll(user)
+            .stream()
+            .filter(ak -> k.getKey().equals(ak.getKey()))
+            .findFirst()
+            .ifPresent(ak -> pillarData.put("activation_key", ak.getKey()));
+        });
         pillarData.put("mgr_server", ConfigDefaults.get().getCobblerHost());
         pillarData.put("mgr_origin_server", ConfigDefaults.get().getCobblerHost());
         pillarData.put("contact_method", key
@@ -131,6 +152,7 @@ public class RegularMinionBootstrapperTest extends AbstractMinionBootstrapperTes
         pillarData.put("minion_pub", "pubKey");
         pillarData.put("minion_pem", "privKey");
         pillarData.put("mgr_sudo_user", "root");
+        reactKey.ifPresent(k -> pillarData.put("management_key", k.getKey()));
         return pillarData;
     }
 

--- a/java/code/src/com/suse/manager/webui/controllers/utils/test/SSHMinionBootstrapperTest.java
+++ b/java/code/src/com/suse/manager/webui/controllers/utils/test/SSHMinionBootstrapperTest.java
@@ -19,6 +19,7 @@ import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.token.ActivationKey;
 import com.redhat.rhn.domain.token.test.ActivationKeyTest;
+import com.redhat.rhn.manager.token.ActivationKeyManager;
 
 import com.suse.manager.reactor.messaging.RegisterMinionEventMessageAction;
 import com.suse.manager.webui.controllers.utils.ContactMethodUtil;
@@ -96,9 +97,16 @@ public class SSHMinionBootstrapperTest extends AbstractMinionBootstrapperTestBas
     }
 
     @Override
-    protected Map<String, Object> createPillarData(Optional<ActivationKey> key) {
+    protected Map<String, Object> createPillarData(Optional<ActivationKey> key, Optional<ActivationKey> reactKey) {
         String contactMethod = key.map(k -> k.getContactMethod().getLabel()).orElse(getDefaultContactMethod());
         Map<String, Object> pillarData = new HashMap<>();
+        key.ifPresent(k -> {
+            ActivationKeyManager.getInstance().findAll(user)
+            .stream()
+            .filter(ak -> k.getKey().equals(ak.getKey()))
+            .findFirst()
+            .ifPresent(ak -> pillarData.put("activation_key", ak.getKey()));
+        });
         pillarData.put("mgr_server", ConfigDefaults.get().getCobblerHost());
         if (contactMethod.equals("ssh-push-tunnel")) {
             pillarData.put("mgr_server_https_port", Config.get().getInt("ssh_push_port_https"));
@@ -107,6 +115,7 @@ public class SSHMinionBootstrapperTest extends AbstractMinionBootstrapperTestBas
         pillarData.put("minion_id", "myhost");
         pillarData.put("contact_method", contactMethod);
         pillarData.put("mgr_sudo_user", "root");
+        reactKey.ifPresent(k -> pillarData.put("management_key", k.getKey()));
         return pillarData;
     }
 }

--- a/java/code/src/com/suse/manager/webui/utils/gson/BootstrapHostsJson.java
+++ b/java/code/src/com/suse/manager/webui/utils/gson/BootstrapHostsJson.java
@@ -37,6 +37,7 @@ public class BootstrapHostsJson {
     private String privKey;
     private String privKeyPwd;
     private List<String> activationKeys;
+    private String reactivationKey;
     private boolean ignoreHostKeys;
     private Long proxy;
 
@@ -140,6 +141,13 @@ public class BootstrapHostsJson {
     }
 
     /**
+     * @return value of reactivationKey
+     */
+    public String getReactivationKey() {
+        return reactivationKey;
+    }
+
+    /**
      * @return the id of the proxy
      */
     public Long getProxy() {
@@ -202,6 +210,15 @@ public class BootstrapHostsJson {
      */
     public Optional<String> maybeGetPrivKeyPwd() {
         return maybeGetString(getPrivKeyPwd());
+    }
+
+    /**
+     * Helper method to return the reactivation key as as an Optional&lt;String&gt;.
+     *
+     * @return reactivation key wrapped as Optional, or empty if no reactivation key is provided
+     */
+    public Optional<String> maybeGetReactivationKey() {
+        return maybeGetString(getReactivationKey());
     }
 
     private static Optional<String> maybeGetString(String str) {

--- a/java/code/src/com/suse/manager/webui/utils/gson/BootstrapParameters.java
+++ b/java/code/src/com/suse/manager/webui/utils/gson/BootstrapParameters.java
@@ -16,6 +16,8 @@ package com.suse.manager.webui.utils.gson;
 
 import com.suse.manager.webui.utils.gson.BootstrapHostsJson.AuthMethod;
 
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -287,5 +289,16 @@ public class BootstrapParameters {
      */
     public Optional<Long> getProxyId() {
         return proxyId;
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .append("host", host)
+                .append("port", port)
+                .append("activationKeys", activationKeys)
+                .append("proxyId", proxyId)
+                .append("reactivationKey", reactivationKey)
+                .toString();
     }
 }

--- a/java/code/src/com/suse/manager/webui/utils/gson/BootstrapParameters.java
+++ b/java/code/src/com/suse/manager/webui/utils/gson/BootstrapParameters.java
@@ -14,7 +14,7 @@
  */
 package com.suse.manager.webui.utils.gson;
 
-import static com.suse.manager.webui.utils.gson.BootstrapHostsJson.AuthMethod;
+import com.suse.manager.webui.utils.gson.BootstrapHostsJson.AuthMethod;
 
 import java.util.List;
 import java.util.Optional;
@@ -32,6 +32,7 @@ public class BootstrapParameters {
     private Optional<String> privateKey;
     private Optional<String> privateKeyPassphrase;
     private List<String> activationKeys;
+    private Optional<String> reactivationKey;
     private boolean ignoreHostKeys;
     private Optional<Long> proxyId;
 
@@ -43,11 +44,13 @@ public class BootstrapParameters {
      * @param userIn user
      * @param passwordIn password
      * @param activationKeysIn activation keys
+     * @param reactivationKeyIn reactivation key
      * @param ignoreHostKeysIn ignore hostIn keys?
      * @param proxyIdIn proxy id
      */
     public BootstrapParameters(String hostIn, Optional<Integer> portIn, String userIn, Optional<String> passwordIn,
-            List<String> activationKeysIn, boolean ignoreHostKeysIn, Optional<Long> proxyIdIn) {
+            List<String> activationKeysIn, Optional<String> reactivationKeyIn, boolean ignoreHostKeysIn,
+            Optional<Long> proxyIdIn) {
         this.host = hostIn;
         this.port = portIn;
         this.user = userIn;
@@ -55,6 +58,7 @@ public class BootstrapParameters {
         this.privateKey = Optional.empty();
         this.privateKeyPassphrase = Optional.empty();
         this.activationKeys = activationKeysIn;
+        this.reactivationKey = reactivationKeyIn;
         this.ignoreHostKeys = ignoreHostKeysIn;
         this.proxyId = proxyIdIn;
     }
@@ -68,12 +72,13 @@ public class BootstrapParameters {
      * @param privateKeyIn SSH private key as string in PEM format
      * @param privateKeyPwdIn SSH private key passphrase
      * @param activationKeysIn activation keys
+     * @param reactivationKeyIn reactivation key
      * @param ignoreHostKeysIn ignore hostIn keys?
      * @param proxyIdIn proxy id
      */
     public BootstrapParameters(String hostIn, Optional<Integer> portIn, String userIn, String privateKeyIn,
-            Optional<String> privateKeyPwdIn, List<String> activationKeysIn, boolean ignoreHostKeysIn,
-            Optional<Long> proxyIdIn) {
+            Optional<String> privateKeyPwdIn, List<String> activationKeysIn, Optional<String> reactivationKeyIn,
+            boolean ignoreHostKeysIn, Optional<Long> proxyIdIn) {
         this.host = hostIn;
         this.port = portIn;
         this.user = userIn;
@@ -81,6 +86,7 @@ public class BootstrapParameters {
         this.privateKey = Optional.of(privateKeyIn);
         this.privateKeyPassphrase = privateKeyPwdIn;
         this.activationKeys = activationKeysIn;
+        this.reactivationKey = reactivationKeyIn;
         this.ignoreHostKeys = ignoreHostKeysIn;
         this.proxyId = proxyIdIn;
     }
@@ -96,12 +102,13 @@ public class BootstrapParameters {
         switch (authMethod) {
             case PASSWORD:
                 return new BootstrapParameters(json.getHost(), json.getPortInteger(), json.getUser(),
-                        json.maybeGetPassword(), json.getActivationKeys(), json.getIgnoreHostKeys(),
-                        Optional.ofNullable(json.getProxy()));
+                        json.maybeGetPassword(), json.getActivationKeys(), json.maybeGetReactivationKey(),
+                        json.getIgnoreHostKeys(), Optional.ofNullable(json.getProxy()));
             case SSH_KEY:
                 return new BootstrapParameters(json.getHost(), json.getPortInteger(), json.getUser(),
                         json.getPrivKey(), json.maybeGetPrivKeyPwd(), json.getActivationKeys(),
-                        json.getIgnoreHostKeys(), Optional.ofNullable(json.getProxy()));
+                        json.maybeGetReactivationKey(), json.getIgnoreHostKeys(),
+                        Optional.ofNullable(json.getProxy()));
             default:
                 throw new UnsupportedOperationException("Unsupported auth method " + authMethod);
         }
@@ -240,6 +247,20 @@ public class BootstrapParameters {
      */
     public void setActivationKeys(List<String> activationKeysIn) {
         activationKeys = activationKeysIn;
+    }
+
+    /**
+     * @return Returns the reactivationKey.
+     */
+    public Optional<String> getReactivationKey() {
+        return reactivationKey;
+    }
+
+    /**
+     * @param reactivationKeyIn The reactivationKey to set.
+     */
+    public void setReactivationKey(Optional<String> reactivationKeyIn) {
+        reactivationKey = reactivationKeyIn;
     }
 
     /**

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Implement using re-activation keys when bootstrapping with the Web UI
+  or XMLRPC API
 - Show salt ssh error message in failed action details
 - switch to best repo auth item for contentsources (bsc#1191442)
 - Add compressed flag to image pillars when kiwi image is compressed (bsc#1191702)

--- a/susemanager-utils/susemanager-sls/salt/bootstrap/susemanager.conf
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/susemanager.conf
@@ -3,10 +3,15 @@ master: {{ pillar['mgr_server'] }}
 server_id_use_crc: adler32
 enable_legacy_startup_events: False
 enable_fqdns_grains: False
-{% if pillar['activation_key'] is defined %}
+{% if pillar['activation_key'] is defined or pillar['management_key'] is defined %}
 grains:
   susemanager:
+{%- if pillar['activation_key'] is defined %}
     activation_key: {{ pillar['activation_key'] }}
+{%- endif %}
+{%- if pillar['management_key'] is defined %}
+    management_key: {{ pillar['management_key'] }}
+{%- endif %}
 {% endif %}
 start_event_grains:
   - machine_id

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Implement using re-activation keys when bootstrapping
 - Add missing compressed_hash value from Kiwi inspect (bsc#1191702)
 
 -------------------------------------------------------------------

--- a/testsuite/features/secondary/min_bootstrap_reactivation.feature
+++ b/testsuite/features/secondary/min_bootstrap_reactivation.feature
@@ -1,0 +1,89 @@
+# Copyright (c) 2021 SUSE LLC
+# Licensed under the terms of the MIT license.
+
+@sle_minion
+@scope_onboarding
+Feature: bootstrapping with reactivation key
+  In order to re-register valid minions
+  As an authorized user
+  I want to avoid re-registration with invalid input parameters
+
+  Scenario: Log in as admin user
+    Given I am authorized for the "Admin" section
+
+  Scenario: generate a re-activation key
+     Given I am on the Systems overview page of this "sle_minion"
+     When I follow "Reactivation"
+     And I click on "Generate New Key"
+     Then I should see a "Key:" text
+
+  Scenario: Bootstrap should fail when minion already exists
+     And I follow the left menu "Systems > Bootstrapping"
+     Then I should see a "Bootstrap Minions" text
+     When I enter the hostname of "sle_minion" as "hostname"
+     And I enter "22" as "port"
+     And I enter "root" as "user"
+     And I enter "linux" as "password"
+     And I click on "Bootstrap"
+     And I wait until I see "A salt key for this host" text
+     Then I should not see a "GenericSaltError" text
+     And I should see a "seems to already exist, please check!" text
+
+  Scenario: Bootstrap should fail when system already exists in the server
+     Given I delete "sle_minion" key in the Salt master
+     And I follow the left menu "Systems > Bootstrapping"
+     Then I should see a "Bootstrap Minions" text
+     When I enter the hostname of "sle_minion" as "hostname"
+     And I enter "22" as "port"
+     And I enter "root" as "user"
+     And I enter "linux" as "password"
+     And I click on "Bootstrap"
+     And I wait until I see "seems to already exist, please check!" text
+     Then I should not see a "GenericSaltError" text
+     And I should see a "with minion id" text
+
+  Scenario: Bootstrap a SLES minion with reactivation key
+     And I follow the left menu "Systems > Bootstrapping"
+     Then I should see a "Bootstrap Minions" text
+     When I enter the hostname of "sle_minion" as "hostname"
+     And I enter "22" as "port"
+     And I enter "root" as "user"
+     And I enter "linux" as "password"
+     And I enter the reactivation key of "sle_minion"
+     And I click on "Bootstrap"
+     And I wait until I see "Successfully bootstrapped host!" text
+     And I follow the left menu "Systems > Overview"
+     And I wait until I see the name of "sle_minion", refreshing the page
+      
+  Scenario: Check that events history for the reactivation
+     Given I am on the Systems overview page of this "sle_minion"
+     When I follow "Events" in the content area
+     And I follow "History" in the content area
+     Then I wait until I see "Server reactivated as Salt minion" text, refreshing the page
+
+
+  Scenario: Cleanup: bootstrap a SLES minion after reactivation tests
+     When I follow the left menu "Systems > Bootstrapping"
+     Then I should see a "Bootstrap Minions" text
+     When I enter the hostname of "sle_minion" as "hostname"
+     And I enter "22" as "port"
+     And I enter "root" as "user"
+     And I enter "linux" as "password"
+     And I select the hostname of "proxy" from "proxies"
+     And I click on "Bootstrap"
+     And I wait until I see "Successfully bootstrapped host!" text
+     And I follow the left menu "Systems > Overview"
+     And I wait until I see the name of "sle_minion", refreshing the page
+
+  Scenario: Cleanup: subscribe again to base channel after reactivation tests
+    Given I am on the Systems overview page of this "sle_minion"
+    When I follow "Software" in the content area
+    And I follow "Software Channels" in the content area
+    And I wait until I do not see "Loading..." text
+    And I check radio button "Test-Channel-x86_64"
+    And I wait until I do not see "Loading..." text
+    And I click on "Next"
+    Then I should see a "Confirm Software Channel Change" text
+    When I click on "Confirm"
+    Then I should see a "Changing the channels has been scheduled." text
+    And I wait until event "Subscribe channels scheduled by admin" is completed

--- a/testsuite/features/secondary/min_bootstrap_reactivation.feature
+++ b/testsuite/features/secondary/min_bootstrap_reactivation.feature
@@ -61,6 +61,13 @@ Feature: bootstrapping with reactivation key
      And I follow "History" in the content area
      Then I wait until I see "Server reactivated as Salt minion" text, refreshing the page
 
+  Scenario: Cleanup: delete SLES minion system profile
+    Given I am on the Systems overview page of this "sle_minion"
+    When I follow "Delete System"
+    Then I should see a "Confirm System Profile Deletion" text
+    When I click on "Delete Profile"
+    And I wait until I see "has been deleted" text
+    Then "sle_minion" should not be registered
 
   Scenario: Cleanup: bootstrap a SLES minion after reactivation tests
      When I follow the left menu "Systems > Bootstrapping"

--- a/testsuite/features/secondary/trad_check_registration.feature
+++ b/testsuite/features/secondary/trad_check_registration.feature
@@ -151,7 +151,7 @@ Feature: Client display after registration
   Scenario: Show Details => Reactivation page
     Given I am on the Systems overview page of this "sle_client"
     When I follow "Reactivation" in the content area
-    Then I should see a "System Activation Key" text
+    Then I should see a "System Reactivation Key" text
      And I should see a "Generate New Key" button
 
   Scenario: Show Details => Hardware page

--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -1304,3 +1304,13 @@ When(/^I remove testing playbooks and inventory files from "([^"]*)"$/) do |host
   dest = "/srv/playbooks/"
   target.run("rm -rf #{dest}")
 end
+
+When(/^I enter the reactivation key of "([^"]*)"$/) do |host|
+  system_name = get_system_name(host)
+  node_id = retrieve_server_id(system_name)
+  @system_api = XMLRPCSystemTest.new(ENV['SERVER'])
+  @system_api.login('admin', 'admin')
+  react_key = @system_api.obtain_reactivation_key(node_id)
+  puts "Reactivation Key: #{react_key}"
+  step %(I enter "#{react_key}" as "reactivationKey")
+end

--- a/testsuite/features/support/xmlrpc_system.rb
+++ b/testsuite/features/support/xmlrpc_system.rb
@@ -92,4 +92,9 @@ class XMLRPCSystemTest < XMLRPCBaseTest
   def list_empty_system_profiles
     @connection.call('system.listEmptySystemProfiles', @sid)
   end
+
+  # Obtain Reactivation Key
+  def obtain_reactivation_key(server)
+    @connection.call('system.obtainReactivationKey', @sid, server)
+  end
 end

--- a/testsuite/run_sets/secondary_parallelizable.yml
+++ b/testsuite/run_sets/secondary_parallelizable.yml
@@ -50,6 +50,7 @@
 - features/secondary/min_ubuntu_salt_install_package.feature
 - features/secondary/min_bootstrap_xmlrpc.feature
 - features/secondary/min_bootstrap_negative.feature
+- features/secondary/min_bootstrap_reactivation.feature
 - features/secondary/min_salt_software_states.feature
 - features/secondary/min_salt_install_with_staging.feature
 - features/secondary/min_salt_formulas.feature

--- a/web/html/src/manager/systems/bootstrap/bootstrap-minions.tsx
+++ b/web/html/src/manager/systems/bootstrap/bootstrap-minions.tsx
@@ -298,7 +298,7 @@ class BootstrapMinions extends React.Component<Props, State> {
     const authenticationData =
       this.state.authMethod === "password" ? (
         <div className="form-group">
-          <label className="col-md-3 control-label">Password:</label>
+          <label className="col-md-3 control-label">{t("Password")}:</label>
           <div className="col-md-6">
             <input
               name="password"
@@ -353,7 +353,7 @@ class BootstrapMinions extends React.Component<Props, State> {
         {messages}
         <div className="form-horizontal">
           <div className="form-group">
-            <label className="col-md-3 control-label">Host:</label>
+            <label className="col-md-3 control-label">{t("Host")}:</label>
             <div className="col-md-6">
               <input
                 name="hostname"
@@ -366,7 +366,7 @@ class BootstrapMinions extends React.Component<Props, State> {
             </div>
           </div>
           <div className="form-group">
-            <label className="col-md-3 control-label">SSH Port:</label>
+            <label className="col-md-3 control-label">{t("SSH Port")}:</label>
             <div className="col-md-6">
               <input
                 name="port"
@@ -383,7 +383,7 @@ class BootstrapMinions extends React.Component<Props, State> {
             </div>
           </div>
           <div className="form-group">
-            <label className="col-md-3 control-label">User:</label>
+            <label className="col-md-3 control-label">{t("User")}:</label>
             <div className="col-md-6">
               <input
                 name="user"
@@ -405,7 +405,7 @@ class BootstrapMinions extends React.Component<Props, State> {
             </div>
           </div>
           <div className="form-group">
-            <label className="col-md-3 control-label">Authentication Method:</label>
+            <label className="col-md-3 control-label">{t("Authentication Method")}:</label>
 
             <div className="col-md-6">
               <div className="radio col-md-3">
@@ -436,7 +436,7 @@ class BootstrapMinions extends React.Component<Props, State> {
           </div>
           {authenticationData}
           <div className="form-group">
-            <label className="col-md-3 control-label">Activation Key:</label>
+            <label className="col-md-3 control-label">{t("Activation Key")}:</label>
             <div className="col-md-6">
               <select
                 value={this.state.activationKey}
@@ -511,7 +511,7 @@ class BootstrapMinions extends React.Component<Props, State> {
                     checked={this.state.ignoreHostKeys}
                     onChange={this.ignoreHostKeysChanged}
                   />
-                  <span>Disable SSH strict host key checking during bootstrap process</span>
+                  <span>{t("Disable SSH strict host key checking during bootstrap process")}</span>
                 </label>
               </div>
             </div>
@@ -527,7 +527,7 @@ class BootstrapMinions extends React.Component<Props, State> {
                     checked={this.state.manageWithSSH}
                     onChange={this.manageWithSSHChanged}
                   />
-                  <span>Manage system completely via SSH (will not install an agent)</span>
+                  <span>{t("Manage system completely via SSH (will not install an agent)")}</span>
                 </label>
               </div>
             </div>
@@ -543,7 +543,7 @@ class BootstrapMinions extends React.Component<Props, State> {
   componentDidMount() {
     window.addEventListener("beforeunload", (e) => {
       if (this.state.loading) {
-        var confirmationMessage = "Are you sure you want to close this page while bootstrapping is in progress ?";
+        var confirmationMessage = t("Are you sure you want to close this page while bootstrapping is in progress ?");
         (e || window.event).returnValue = confirmationMessage;
         return confirmationMessage;
       }

--- a/web/html/src/manager/systems/bootstrap/bootstrap-minions.tsx
+++ b/web/html/src/manager/systems/bootstrap/bootstrap-minions.tsx
@@ -28,6 +28,7 @@ type State = {
   privKey: string;
   privKeyPwd: string;
   activationKey: string;
+  reactivationKey: string;
   ignoreHostKeys: boolean;
   manageWithSSH: boolean;
   messages: any[];
@@ -53,6 +54,7 @@ class BootstrapMinions extends React.Component<Props, State> {
       privKey: "",
       privKeyPwd: "",
       activationKey: "",
+      reactivationKey: "",
       ignoreHostKeys: true,
       manageWithSSH: false,
       messages: [],
@@ -76,6 +78,7 @@ class BootstrapMinions extends React.Component<Props, State> {
       "ignoreHostKeysChanged",
       "manageWithSSHChanged",
       "activationKeyChanged",
+      "reactivationKeyChanged",
       "clearFields",
       "proxyChanged",
     ].forEach((method) => (this[method] = this[method].bind(this)));
@@ -153,6 +156,12 @@ class BootstrapMinions extends React.Component<Props, State> {
     });
   }
 
+  reactivationKeyChanged(event) {
+    this.setState({
+      reactivationKey: event.target.value,
+    });
+  }
+
   proxyChanged(event) {
     var proxyId = event.target.value;
     var proxy = this.props.proxies.find((p) => DEPRECATED_unsafeEquals(p.id, proxyId));
@@ -170,6 +179,8 @@ class BootstrapMinions extends React.Component<Props, State> {
     formData["port"] = this.state.port.trim() === "" ? undefined : this.state.port.trim();
     formData["user"] = this.state.user.trim() === "" ? undefined : this.state.user.trim();
     formData["activationKeys"] = this.state.activationKey === "" ? [] : [this.state.activationKey];
+    formData["reactivationKey"] =
+      this.state.reactivationKey.trim() === "" ? undefined : this.state.reactivationKey.trim();
     formData["ignoreHostKeys"] = this.state.ignoreHostKeys;
 
     const authMethod = this.state.authMethod;
@@ -444,6 +455,19 @@ class BootstrapMinions extends React.Component<Props, State> {
                     </option>
                   ))}
               </select>
+            </div>
+          </div>
+          <div className="form-group">
+            <label className="col-md-3 control-label">{t("Reactivation Key")}:</label>
+            <div className="col-md-6">
+              <input
+                name="reactivationKey"
+                className="form-control"
+                type="text"
+                placeholder={t("Leave empty when no reactivation is wanted")}
+                value={this.state.reactivationKey}
+                onChange={this.reactivationKeyChanged}
+              />
             </div>
           </div>
           <div className="form-group">

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,5 @@
+- Implement using re-activation keys when bootstrapping with the Web UI
+
 -------------------------------------------------------------------
 Fri Nov 05 14:04:09 CET 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Enance the Bootstrap UI and API to allow reactivations using a reactivation key.

## GUI diff

No difference.

After:

![image](https://user-images.githubusercontent.com/1038917/136565067-29628ff8-6e0f-4b71-93cb-fc99aef8407e.png)

- [x] **DONE**

## Documentation
- Documentation PR was created: https://github.com/uyuni-project/uyuni-docs/pull/1232

- [x] **DONE**

## Test coverage
- Unit tests were added
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/14703
Tracks https://github.com/SUSE/spacewalk/pull/16260

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [x] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
