### PR TITLE
require and link hibernate-types

### DIFF
--- a/java/buildconf/build-props.xml
+++ b/java/buildconf/build-props.xml
@@ -106,7 +106,7 @@
 
   <property name="hibernate3.6deps" value="hibernate3/hibernate-ehcache-3 hibernate3/hibernate-c3p0-3 hibernate3/hibernate-core-3 ${hibernate-commons-annotations} slf4j/api jboss-logging javassist slf4j/log4j12 ${ehcache} hibernate-jpa-2.0-api"/>
 
-  <property name="hibernate5deps" value="hibernate-ehcache-5 hibernate-c3p0-5 hibernate-core-5 ${hibernate-commons-annotations} slf4j/api jakarta-persistence-api byte-buddy jboss-logging javassist slf4j/log4j12 ${ehcache} classmate statistics hibernate-types-52-2.12.1"/>
+  <property name="hibernate5deps" value="hibernate-ehcache-5 hibernate-c3p0-5 hibernate-core-5 ${hibernate-commons-annotations} slf4j/api jakarta-persistence-api byte-buddy jboss-logging javassist slf4j/log4j12 ${ehcache} classmate statistics hibernate-types-52-2.12.1 jackson-databind jackson-core jackson-annotations"/>
 
   <available file="${java.lib.dir}/hibernate3.jar" type="file" property="hibernate" value="${hibernate3.2deps}" />
   <available file="${java.lib.dir}/hibernate3/hibernate-core-3.jar" type="file" property="hibernate" value="${hibernate3.6deps}" />

--- a/java/spacewalk-java.spec
+++ b/java/spacewalk-java.spec
@@ -798,6 +798,9 @@ chown tomcat:%{apache_group} /var/log/rhn/gatherer.log
 %{jardir}/javassist.jar
 %{jardir}/jboss-logging.jar
 %{jardir}/statistics.jar
+%{jardir}/jackson-databind.jar
+%{jardir}/jackson-core.jar
+%{jardir}/jackson-annotations.jar
 
 %{jardir}/jaf.jar
 %if 0%{?sle_version} >= 150200


### PR DESCRIPTION
## What does this PR change?

spacewalk-java package is not building as hibernate-types is not linked during compile time.
It is also not installed and linked during runtime.

Maybe more dependencies are missing.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Follow up on https://github.com/uyuni-project/uyuni/pull/4231

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
