### PR TITLE
UI and API call for changing proxy

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/action/salt/ApplyStatesActionDetails.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/salt/ApplyStatesActionDetails.hbm.xml
@@ -12,6 +12,7 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
             </generator>
         </id>
         <property name="states" column="states" type="string" />
+        <property name="pillars" column="pillars" type="string" />
         <property name="test" column="test" type="yes_no" />
         <property name="created" type="timestamp" insert="false" update="false" />
         <property name="modified" type="timestamp" insert="false" update="false" />

--- a/java/code/src/com/redhat/rhn/domain/action/salt/ApplyStatesActionDetails.java
+++ b/java/code/src/com/redhat/rhn/domain/action/salt/ApplyStatesActionDetails.java
@@ -16,11 +16,14 @@ package com.redhat.rhn.domain.action.salt;
 
 import com.redhat.rhn.domain.action.ActionChild;
 
+import com.suse.utils.Json;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -33,6 +36,7 @@ public class ApplyStatesActionDetails extends ActionChild {
     private long id;
     private long actionId;
     private String states;
+    private String pillars;
     private Set<ApplyStatesActionResult> results;
     private boolean test = false;
 
@@ -83,6 +87,24 @@ public class ApplyStatesActionDetails extends ActionChild {
     }
 
     /**
+     * Only for hibernate, please use getPillarsMap() instead.
+     *
+     * @return the pillars
+     */
+    public String getPillars() {
+        return pillars;
+    }
+
+    /**
+     * Only for hibernate, please use setPillarsMap() instead.
+     *
+     * @param pillarsIn the states to set
+     */
+    public void setPillars(String pillarsIn) {
+        this.pillars = pillarsIn;
+    }
+
+    /**
      * Return the state modules as a list.
      *
      * @return state modules as list of strings
@@ -106,6 +128,33 @@ public class ApplyStatesActionDetails extends ActionChild {
         else {
             states = null;
         }
+    }
+
+    /**
+     * Return the pillars as a Map.
+     *
+     * @return the pillars as a Optional Map
+     */
+    public Optional<Map<String, Object>> getPillarsMap() {
+        if (pillars != null) {
+            return Optional.of(Json.GSON.fromJson(pillars, Map.class));
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * Set the the pillars as a Map.
+     *
+     * @param op Optiona Map with pillars
+     */
+    public void setPillarsMap(Optional<Map<String, Object>> op) {
+        op.ifPresentOrElse(
+            p -> {
+                pillars = Json.GSON.toJson(p);
+            },
+            () -> {
+                pillars = null;
+            });
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/server/MinionServer.java
+++ b/java/code/src/com/redhat/rhn/domain/server/MinionServer.java
@@ -359,7 +359,8 @@ public class MinionServer extends Server implements SaltConfigurable {
         if (proxy.isPresent()) {
                 // the system is connected to a proxy
                 // check if serverPath already exists
-                if (!ServerFactory.findServerPath(this, proxy.get()).isPresent()) {
+                Optional<ServerPath> path = ServerFactory.findServerPath(this, proxy.get());
+                if (!path.isPresent() || path.get().getPosition() != 0) {
                     // proxy path does not exist -> create it
                     Set<ServerPath> proxyPaths = ServerFactory.createServerPaths(this, proxy.get(),
                                                  hostname.orElse(proxy.get().getHostname()));

--- a/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/server/ServerFactory.java
@@ -318,10 +318,10 @@ public class ServerFactory extends HibernateFactory {
             ServerPath path = findServerPath(server, parentPath.getId().getProxyServer()).orElseGet(() -> {
                 ServerPath newPath = new ServerPath();
                 newPath.setId(new ServerPathId(server, parentPath.getId().getProxyServer()));
-                newPath.setPosition(parentPath.getPosition() + 1);
                 newPath.setHostname(parentPath.getHostname());
                 return newPath;
             });
+            path.setPosition(parentPath.getPosition() + 1);
             paths.add(path);
 
         }
@@ -330,10 +330,10 @@ public class ServerFactory extends HibernateFactory {
             newPath.setId(new ServerPathId(server, proxyServer));
             // the first proxy is the one to which
             // the server connects directly
-            newPath.setPosition(0L);
             newPath.setHostname(proxyHostname);
             return newPath;
         });
+        path.setPosition(0L);
         paths.add(path);
         return paths;
     }

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -4942,6 +4942,12 @@ organization. You may grant or remove the organization administrator role in the
           <context context-type="sourcefile">/rhn/ssm/Index.do</context>
         </context-group>
         </trans-unit>
+        <trans-unit id="ssm.overview.misc.proxy">
+          <source>Connect minions to another &lt;a href="/rhn/manager/systems/ssm/proxy"&gt;proxy server&lt;/a&gt;</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/ssm/Index.do</context>
+        </context-group>
+        </trans-unit>
         <trans-unit id="ssm.overview.misc.lock">
           <source>&lt;a href="/rhn/systems/ssm/misc/LockUnlockSystem.do"&gt;Lock/unlock&lt;/a&gt; systems</source>
         <context-group name="ctx">
@@ -5117,6 +5123,12 @@ organization. You may grant or remove the organization administrator role in the
         </trans-unit>
         <trans-unit id="ssm.misc.index.tabs.custom">
           <source>Custom Values</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/systems/ssm/misc/Index.do</context>
+        </context-group>
+        </trans-unit>
+        <trans-unit id="ssm.misc.index.tabs.proxy">
+          <source>Proxy</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/rhn/systems/ssm/misc/Index.do</context>
         </context-group>
@@ -21315,6 +21327,12 @@ The Tree Path, Base Channel, and Installer Generation should always match. This 
         <source>Memory:</source>
         <context-group name="ctx">
           <context context-type="sourcefile">/systems/details/SystemHardware.do</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="sdc.details.connection.change" xml:space="preserve">
+        <source>Change</source>
+        <context-group name="ctx">
+          <context context-type="sourcefile">/systems/details/Connection.do</context>
         </context-group>
       </trans-unit>
       <trans-unit id="sdc.details.connection.header" xml:space="preserve">

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -178,7 +178,9 @@ import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 import com.redhat.rhn.manager.token.ActivationKeyManager;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 
+import com.suse.manager.reactor.messaging.ApplyStatesEventMessage;
 import com.suse.manager.virtualization.VirtualizationActionHelper;
+import com.suse.manager.webui.controllers.utils.ContactMethodUtil;
 import com.suse.manager.webui.controllers.virtualization.gson.VirtualGuestSetterActionJson;
 import com.suse.manager.webui.controllers.virtualization.gson.VirtualGuestsBaseActionJson;
 import com.suse.manager.webui.services.pillar.MinionPillarManager;
@@ -8313,6 +8315,37 @@ public class SystemHandler extends BaseHandler {
             }
         }
         return skipped;
+    }
+
+    /**
+     * Connect given systems to another proxy.
+     *
+     * @param loggedInUser The current user
+     * @param sids A list of systems ids
+     * @param proxyId Id of the proxy or 0 for direct connection to SUMA server
+     * @return Returns a list of scheduled action ids
+     *
+     * @xmlrpc.doc Connect given systems to another proxy.
+     * @xmlrpc.param #param("string", "sessionKey")
+     * @xmlrpc.param #array_single("int", "systemIds")
+     * @xmlrpc.param #param("int", "proxyId")
+     * @xmlrpc.returntype #array_single("int", "actionIds", "list of scheduled action ids")
+     */
+
+    public List<Long> changeProxy(User loggedInUser, List<Integer> sids, Integer proxyId) {
+        List<Long> sysids = sids.stream().map(Integer::longValue).collect(Collectors.toList());
+        try {
+            return ActionManager.changeProxy(loggedInUser, sysids, proxyId.longValue());
+        }
+        catch (LookupException e) {
+            throw new NoSuchSystemException(e);
+        }
+        catch (com.redhat.rhn.taskomatic.TaskomaticApiException e) {
+            throw new TaskomaticApiException(e.getMessage());
+        }
+        catch (java.lang.UnsupportedOperationException e) {
+            throw new UnsupportedOperationException(e.getMessage());
+        }
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -178,9 +178,7 @@ import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
 import com.redhat.rhn.manager.token.ActivationKeyManager;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 
-import com.suse.manager.reactor.messaging.ApplyStatesEventMessage;
 import com.suse.manager.virtualization.VirtualizationActionHelper;
-import com.suse.manager.webui.controllers.utils.ContactMethodUtil;
 import com.suse.manager.webui.controllers.virtualization.gson.VirtualGuestSetterActionJson;
 import com.suse.manager.webui.controllers.virtualization.gson.VirtualGuestsBaseActionJson;
 import com.suse.manager.webui.services.pillar.MinionPillarManager;

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/test/SystemHandlerTest.java
@@ -19,6 +19,7 @@ import static com.suse.manager.webui.services.SaltConstants.PILLAR_DATA_FILE_PRE
 
 import com.redhat.rhn.FaultException;
 import com.redhat.rhn.common.client.ClientCertificate;
+import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.db.datasource.DataResult;
 import com.redhat.rhn.common.db.datasource.ModeFactory;
 import com.redhat.rhn.common.db.datasource.WriteMode;
@@ -3132,6 +3133,121 @@ public class SystemHandlerTest extends BaseHandlerTestCase {
                 List.of(server1.getId().intValue(), server2.getId().intValue(), server3.getId().intValue()));
         assertEquals(1, skipped.size());
         assertEquals(Integer.valueOf(server3.getId().intValue()), skipped.get(0));
+    }
+
+    /**
+     * Test the SystemHandler.changeProxy method
+     * @throws Exception if anything failed
+     */
+    public void testChangeProxy() throws Exception {
+        SystemHandler systemHandler = getMockedHandler();
+        ActionManager.setTaskomaticApi(systemHandler.getTaskomaticApi());
+
+        MinionServer minion = MinionServerFactoryTest.createTestMinionServer(admin);
+        MinionServer minionSsh1 = MinionServerFactoryTest.createTestMinionServer(admin);
+        MinionServer minionSsh2 = MinionServerFactoryTest.createTestMinionServer(admin);
+        minionSsh1.setContactMethod(ServerFactory.findContactMethodByLabel("ssh-push"));
+        minionSsh2.setContactMethod(ServerFactory.findContactMethodByLabel("ssh-push-tunnel"));
+
+        Server proxy = ServerFactoryTest.createTestProxyServer(admin, true);
+        proxy.setHostname("testproxy");
+
+        List<Long> actions = systemHandler.changeProxy(admin,
+                                List.of(minion.getId().intValue()), proxy.getId().intValue());
+
+        assertEquals(1, actions.size());
+        ApplyStatesAction action = (ApplyStatesAction) ActionFactory.lookupByUserAndId(admin, actions.get(0));
+        assertNotNull(action);
+        assertEquals(ActionFactory.TYPE_APPLY_STATES, action.getActionType());
+
+        ApplyStatesActionDetails details = action.getDetails();
+        assertNotNull(details);
+        assertEquals(1, details.getMods().size());
+        assertEquals("bootstrap.set_proxy", details.getMods().get(0));
+        assertFalse(details.isTest());
+
+        // for normal minions the new proxy appears in the pillar of the scheduled state action
+        assertEquals(proxy.getHostname(), details.getPillarsMap().get().get("mgr_server"));
+
+        actions = systemHandler.changeProxy(admin,
+                        List.of(minionSsh1.getId().intValue(), minionSsh2.getId().intValue()),
+                        proxy.getId().intValue());
+
+        assertEquals(1, actions.size());
+        action = (ApplyStatesAction) ActionFactory.lookupByUserAndId(admin, actions.get(0));
+        assertNotNull(action);
+        assertEquals(ActionFactory.TYPE_APPLY_STATES, action.getActionType());
+        details = action.getDetails();
+        assertNotNull(details);
+        assertEquals(1, details.getMods().size());
+        assertEquals("channels", details.getMods().get(0));
+        assertFalse(details.isTest());
+
+        // for ssh minions the proxy is updated directly
+        assertEquals(proxy.getHostname(), minionSsh1.getFirstServerPath().get().getHostname());
+        assertEquals(proxy.getHostname(), minionSsh2.getFirstServerPath().get().getHostname());
+
+        // mix of normal and ssh minions creates 2 actions
+        actions = systemHandler.changeProxy(admin,
+                    List.of(minion.getId().intValue(), minionSsh1.getId().intValue(), minionSsh2.getId().intValue()),
+                    proxy.getId().intValue());
+
+        assertEquals(2, actions.size());
+
+        // back to direct connection to SUMA
+        actions = systemHandler.changeProxy(admin, List.of(minion.getId().intValue()), 0);
+
+        assertEquals(1, actions.size());
+        action = (ApplyStatesAction) ActionFactory.lookupByUserAndId(admin, actions.get(0));
+        assertNotNull(action);
+        assertEquals(ActionFactory.TYPE_APPLY_STATES, action.getActionType());
+
+        details = action.getDetails();
+        assertNotNull(details);
+        assertEquals(1, details.getMods().size());
+        assertEquals("bootstrap.set_proxy", details.getMods().get(0));
+        assertFalse(details.isTest());
+
+        // direct connection to SUMA
+        assertEquals(ConfigDefaults.get().getCobblerHost(), details.getPillarsMap().get().get("mgr_server"));
+
+        actions = systemHandler.changeProxy(admin,
+                             List.of(minionSsh1.getId().intValue(), minionSsh2.getId().intValue()),
+                             0);
+
+        assertEquals(1, actions.size());
+        action = (ApplyStatesAction) ActionFactory.lookupByUserAndId(admin, actions.get(0));
+        assertNotNull(action);
+        assertEquals(ActionFactory.TYPE_APPLY_STATES, action.getActionType());
+        details = action.getDetails();
+        assertNotNull(details);
+        assertEquals(1, details.getMods().size());
+        assertEquals("channels", details.getMods().get(0));
+        assertFalse(details.isTest());
+
+        // for ssh minions directly connected to SUMA the path should be empty
+        assertEquals(0, minionSsh1.getServerPaths().size());
+        assertEquals(0, minionSsh2.getServerPaths().size());
+
+        // only normal minions are supported, not proxies
+        try {
+            actions = systemHandler.changeProxy(admin, List.of(proxy.getId().intValue()), proxy.getId().intValue());
+            fail("Should throw UnsupportedOperationException");
+        }
+        catch (UnsupportedOperationException e) {
+            // success
+        }
+
+        // proxy is not a proxy
+        try {
+            actions = systemHandler.changeProxy(admin,
+                        List.of(minionSsh1.getId().intValue()),
+                        minion.getId().intValue());
+            fail("Should throw UnsupportedOperationException");
+        }
+        catch (UnsupportedOperationException e) {
+            // success
+        }
     }
 
     private SystemHandler getMockedHandler() throws Exception {

--- a/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
+++ b/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
@@ -74,7 +74,9 @@ import com.redhat.rhn.domain.rhnset.RhnSet;
 import com.redhat.rhn.domain.rhnset.RhnSetElement;
 import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.domain.server.MinionServer;
+import com.redhat.rhn.domain.server.MinionServerFactory;
 import com.redhat.rhn.domain.server.Server;
+import com.redhat.rhn.domain.server.ServerFactory;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.dto.PackageMetadata;
 import com.redhat.rhn.frontend.dto.ScheduledAction;
@@ -93,7 +95,10 @@ import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
 
+import com.suse.manager.reactor.messaging.ApplyStatesEventMessage;
 import com.suse.manager.maintenance.MaintenanceManager;
+import com.suse.manager.webui.controllers.utils.ContactMethodUtil;
+import com.suse.manager.webui.services.pillar.MinionPillarManager;
 import com.suse.utils.Opt;
 
 import org.apache.commons.codec.binary.Base64;
@@ -2265,6 +2270,23 @@ public class ActionManager extends BaseManager {
      */
     public static ApplyStatesAction scheduleApplyStates(User scheduler, List<Long> sids, List<String> mods,
             Date earliest, Optional<Boolean> test) {
+        return scheduleApplyStates(scheduler, sids, mods, Optional.empty(), earliest, test);
+    }
+
+    /**
+     * Schedule state application given a list of state modules. Salt will apply the
+     * highstate if an empty list of state modules is given.
+     *
+     * @param scheduler the user who is scheduling
+     * @param sids list of server ids
+     * @param mods list of state modules to be applied
+     * @param pillar optional pillar map
+     * @param earliest action will not be executed before this date
+     * @param test run states in test-only mode
+     * @return the action object
+     */
+    public static ApplyStatesAction scheduleApplyStates(User scheduler, List<Long> sids, List<String> mods,
+            Optional<Map<String, Object>> pillar, Date earliest, Optional<Boolean> test) {
         ApplyStatesAction action = (ApplyStatesAction) ActionFactory
                 .createAction(ActionFactory.TYPE_APPLY_STATES, earliest);
         String states = mods.isEmpty() ? "highstate" : "states " + mods.toString();
@@ -2275,6 +2297,7 @@ public class ActionManager extends BaseManager {
 
         ApplyStatesActionDetails actionDetails = new ApplyStatesActionDetails();
         actionDetails.setMods(mods);
+        actionDetails.setPillarsMap(pillar);
         test.ifPresent(t -> actionDetails.setTest(t));
         action.setDetails(actionDetails);
         ActionFactory.save(action);
@@ -2343,5 +2366,87 @@ public class ActionManager extends BaseManager {
 
         scheduleForExecution(action, new HashSet<>(sids));
         return action;
+    }
+
+    /**
+     * Connect given systems to another proxy.
+     *
+     * @param loggedInUser The current user
+     * @param sysids A list of systems ids
+     * @param proxyId Id of the proxy or 0 for direct connection to SUMA server
+     * @return Returns a list of scheduled action ids
+     *
+     */
+
+    public static List<Long> changeProxy(User loggedInUser, List<Long> sysids, Long proxyId) 
+        throws TaskomaticApiException {
+        List<Long> visible = MinionServerFactory.lookupVisibleToUser(loggedInUser)
+                    .map(m -> m.getId()).collect(toList());
+        if (!visible.containsAll(sysids)) {
+            sysids.removeAll(visible);
+            throw new UnsupportedOperationException("Some System not available or not managed with Salt: " + sysids);
+        }
+
+        List<MinionServer> minions = sysids.stream().map(
+            id -> SystemManager.lookupByIdAndUser(id, loggedInUser).asMinionServer().get()).collect(toList());
+
+        List<Long> proxies = minions.stream().filter(m -> m.isProxy()).map(m -> m.getId()).collect(toList());
+        if (!proxies.isEmpty()) {
+            throw new UnsupportedOperationException("Some of the minions are proxies: " + proxies);
+        }
+
+        Optional<Server> proxy = Optional.empty();
+
+        if (proxyId != 0) {
+            proxy = Optional.of(SystemManager.lookupByIdAndUser(proxyId, loggedInUser));
+            proxy.ifPresent(p -> {
+                if (!p.isProxy()) {
+                    throw new UnsupportedOperationException("The system is not a proxy: " + p.getId());
+                }
+            });
+        }
+        Optional<Long> proxyIdOpt = proxy.map(p -> p.getId());
+
+        List<Long> sshIds = minions.stream()
+                            .filter(minion -> ContactMethodUtil.isSSHPushContactMethod(minion.getContactMethod()))
+                            .map(minion -> {
+            // handle SSH minions
+            minion.updateServerPaths(proxyIdOpt);
+            ServerFactory.save(minion);
+
+            MinionPillarManager.INSTANCE.generatePillar(minion);
+            return minion.getId();
+        }).collect(toList());
+
+
+        List<Long> normalIds = minions.stream()
+                               .filter(minion -> !ContactMethodUtil.isSSHPushContactMethod(minion.getContactMethod()))
+                               .map(minion -> minion.getId())
+                               .collect(toList());
+
+        List<Long> ret = new ArrayList<Long>();
+        if (!sshIds.isEmpty()) {
+            // action for SSH minions - update channel configuration
+            Action a = scheduleApplyStates(loggedInUser, sshIds,
+                       Collections.singletonList(ApplyStatesEventMessage.CHANNELS),
+                       new Date());
+            a = ActionFactory.save(a);
+            taskomaticApi.scheduleActionExecution(a);
+            ret.add(a.getId());
+        }
+
+        if (!normalIds.isEmpty()) {
+            // action for normal minions - update salt master, the channels will be updated after minion restart
+            Map<String, Object> pillar = new HashMap<>();
+            pillar.put("mgr_server", proxy.map(p -> p.getHostname()).orElse(ConfigDefaults.get().getCobblerHost()));
+
+            Action a = scheduleApplyStates(loggedInUser, normalIds,
+                       Collections.singletonList(ApplyStatesEventMessage.SET_PROXY),
+                       Optional.of(pillar), new Date(), Optional.empty());
+            a = ActionFactory.save(a);
+            taskomaticApi.scheduleActionExecution(a);
+            ret.add(a.getId());
+        }
+        return ret;
     }
 }

--- a/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
+++ b/java/code/src/com/redhat/rhn/manager/action/ActionManager.java
@@ -95,8 +95,8 @@ import com.redhat.rhn.manager.system.SystemManager;
 import com.redhat.rhn.taskomatic.TaskomaticApi;
 import com.redhat.rhn.taskomatic.TaskomaticApiException;
 
-import com.suse.manager.reactor.messaging.ApplyStatesEventMessage;
 import com.suse.manager.maintenance.MaintenanceManager;
+import com.suse.manager.reactor.messaging.ApplyStatesEventMessage;
 import com.suse.manager.webui.controllers.utils.ContactMethodUtil;
 import com.suse.manager.webui.services.pillar.MinionPillarManager;
 import com.suse.utils.Opt;
@@ -2378,7 +2378,7 @@ public class ActionManager extends BaseManager {
      *
      */
 
-    public static List<Long> changeProxy(User loggedInUser, List<Long> sysids, Long proxyId) 
+    public static List<Long> changeProxy(User loggedInUser, List<Long> sysids, Long proxyId)
         throws TaskomaticApiException {
         List<Long> visible = MinionServerFactory.lookupVisibleToUser(loggedInUser)
                     .map(m -> m.getId()).collect(toList());

--- a/java/code/src/com/suse/manager/reactor/messaging/ApplyStatesEventMessage.java
+++ b/java/code/src/com/suse/manager/reactor/messaging/ApplyStatesEventMessage.java
@@ -41,6 +41,7 @@ public class ApplyStatesEventMessage implements EventDatabaseMessage {
     public static final String DISTUPGRADE = "distupgrade";
     public static final String SALTBOOT = "saltboot";
     public static final String SYSTEM_INFO = "util.systeminfo";
+    public static final String SET_PROXY = "bootstrap.set_proxy";
 
     private final long serverId;
     private final Long userId;

--- a/java/code/src/com/suse/manager/webui/controllers/MinionsAPI.java
+++ b/java/code/src/com/suse/manager/webui/controllers/MinionsAPI.java
@@ -25,6 +25,7 @@ import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.MinionServerFactory;
 import com.redhat.rhn.domain.user.User;
 import com.redhat.rhn.frontend.xmlrpc.PermissionCheckFailureException;
+import com.redhat.rhn.manager.action.ActionManager;
 
 import com.suse.manager.utils.SaltKeyUtils;
 import com.suse.manager.webui.controllers.utils.ContactMethodUtil;
@@ -34,7 +35,9 @@ import com.suse.manager.webui.services.iface.SaltApi;
 import com.suse.manager.webui.services.impl.MinionPendingRegistrationService;
 import com.suse.manager.webui.utils.gson.BootstrapHostsJson;
 import com.suse.manager.webui.utils.gson.BootstrapParameters;
+import com.suse.manager.webui.utils.gson.ResultJson;
 import com.suse.manager.webui.utils.gson.SaltMinionJson;
+import com.suse.manager.webui.utils.gson.ServerSetProxyJson;
 import com.suse.salt.netapi.calls.wheel.Key;
 
 import com.google.gson.Gson;
@@ -45,10 +48,12 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 
+import org.apache.http.HttpStatus;
 import org.apache.log4j.Logger;
 
 import java.io.IOException;
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -105,6 +110,7 @@ public class MinionsAPI {
         post("/manager/api/systems/keys/:target/accept", withOrgAdmin(this::accept));
         post("/manager/api/systems/keys/:target/reject", withOrgAdmin(this::reject));
         post("/manager/api/systems/keys/:target/delete", withOrgAdmin(this::delete));
+        post("/manager/api/systems/proxy", withOrgAdmin(this::setProxy));
     }
 
     /**
@@ -252,4 +258,26 @@ public class MinionsAPI {
             throw new UnsupportedOperationException();
         }
     }
+
+    public String setProxy(Request req, Response res, User user) {
+        res.type("application/json");
+        ServerSetProxyJson rq = GSON.fromJson(req.body(),
+                ServerSetProxyJson.class);
+
+        try {
+             Map<String, Object> data = new TreeMap<>();
+             List<Long> actions = ActionManager.changeProxy(user, rq.getIds(), rq.getProxy());
+             if (actions.isEmpty()) {
+                 throw new RuntimeException("No action in schedule result");
+             }
+             data.put("actions", actions);
+             return json(GSON, res, ResultJson.success(data));
+        }
+        catch (Exception e) {
+            LOG.error("Could not change proxy", e);
+            res.status(HttpStatus.SC_INTERNAL_SERVER_ERROR);
+            return "{}";
+        }
+    }
+
 }

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -333,7 +333,8 @@ public class SaltServerActionService {
         }
         else if (ActionFactory.TYPE_APPLY_STATES.equals(actionType)) {
             ApplyStatesActionDetails actionDetails = ((ApplyStatesAction) actionIn).getDetails();
-            return applyStatesAction(minions, actionDetails.getMods(), actionDetails.isTest());
+            return applyStatesAction(minions, actionDetails.getMods(),
+                                     actionDetails.getPillarsMap(), actionDetails.isTest());
         }
         else if (ActionFactory.TYPE_IMAGE_INSPECT.equals(actionType)) {
             ImageInspectAction iia = (ImageInspectAction) actionIn;
@@ -1343,9 +1344,10 @@ public class SaltServerActionService {
     }
 
     private Map<LocalCall<?>, List<MinionSummary>> applyStatesAction(
-            List<MinionSummary> minionSummaries, List<String> mods, boolean test) {
+            List<MinionSummary> minionSummaries, List<String> mods,
+            Optional<Map<String, Object>> pillar, boolean test) {
         Map<LocalCall<?>, List<MinionSummary>> ret = new HashMap<>();
-        ret.put(com.suse.salt.netapi.calls.modules.State.apply(mods, Optional.empty(), Optional.of(true),
+        ret.put(com.suse.salt.netapi.calls.modules.State.apply(mods, pillar, Optional.of(true),
                 test ? Optional.of(test) : Optional.empty()), minionSummaries);
         return ret;
     }

--- a/java/code/src/com/suse/manager/webui/templates/minion/proxy.jade
+++ b/java/code/src/com/suse/manager/webui/templates/minion/proxy.jade
@@ -1,0 +1,13 @@
+include ./minion-header.jade
+
+#proxy
+
+script(type="text/javascript").
+    window.csrfToken = "#{csrf_token}";
+    window.minions = [{id: #{server.id}, name: "#{server.name}"}];
+    window.proxies = !{proxies};
+    window.currentProxy = !{currentProxy};
+
+script(type='text/javascript').
+    spaImportReactPage('systems/proxy')
+        .then(function(module) { module.renderer('proxy') });

--- a/java/code/src/com/suse/manager/webui/templates/ssm/proxy.jade
+++ b/java/code/src/com/suse/manager/webui/templates/ssm/proxy.jade
@@ -1,0 +1,18 @@
+.spacewalk-toolbar-h1
+  h1
+    i.fa.spacewalk-icon-system-groups
+    | #{' System Set Manager Overview '}
+    a(href="/docs/#{docsLocale}/reference/systems/ssm-overview.html", target="_blank")
+      i.fa.fa-question-circle.spacewalk-help-link
+
+!{tabs}
+#proxy
+
+script(type="text/javascript").
+    window.csrfToken = "#{csrf_token}";
+    window.minions = !{minions};
+    window.proxies = !{proxies};
+
+script(type='text/javascript').
+    spaImportReactPage('systems/proxy')
+        .then(function(module) { module.renderer('proxy') });

--- a/java/code/src/com/suse/manager/webui/utils/gson/ServerSetProxyJson.java
+++ b/java/code/src/com/suse/manager/webui/utils/gson/ServerSetProxyJson.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.webui.utils.gson;
+
+import java.util.List;
+
+/**
+ * JSON representation of multiple server ids with a proxy.
+ */
+public class ServerSetProxyJson {
+
+    /** Server id */
+    private List<Long> ids;
+
+    /** The earliest execution date */
+    private Long proxy;
+
+    /**
+     * @return the server id
+     */
+    public List<Long> getIds() {
+        return ids;
+    }
+
+    /**
+     * @return the proxy
+     */
+    public Long getProxy() {
+        return proxy;
+    }
+
+}

--- a/java/code/webapp/WEB-INF/nav/ssm.xml
+++ b/java/code/webapp/WEB-INF/nav/ssm.xml
@@ -124,6 +124,7 @@
                 acl="all_systems_in_set_have_feature(ftr_system_lock)"/>
         <rhn-tab name="ssm.misc.index.tabs.reboot" url="/rhn/systems/ssm/misc/RebootSystem.do"
                 acl="all_systems_in_set_have_feature(ftr_reboot)"/>
+        <rhn-tab name="ssm.misc.index.tabs.proxy" url="/rhn/manager/systems/ssm/proxy"/>
         <rhn-tab name="ssm.misc.index.tabs.migrate" url="/rhn/systems/ssm/MigrateSystems.do"/>
         <rhn-tab name="ssm.misc.index.tabs.delete" url="/rhn/systems/ssm/DeleteConfirm.do"/>
         <rhn-tab-url>/rhn/systems/ssm/misc/ConfirmSystemPreferences.do</rhn-tab-url>

--- a/java/code/webapp/WEB-INF/pages/ssm/ssmindex.jsp
+++ b/java/code/webapp/WEB-INF/pages/ssm/ssmindex.jsp
@@ -189,6 +189,7 @@
                         <rhn:require acl="all_systems_in_set_have_feature(ftr_reboot)">
                             <li><bean:message key="ssm.overview.misc.reboot"/></li>
                         </rhn:require>
+                        <li><bean:message key="ssm.overview.misc.proxy"/></li>
                         <li><bean:message key="ssm.overview.misc.migrate"/></li>
                         <li><bean:message key="ssm.overview.misc.delete"/></li>
                     </ul>

--- a/java/code/webapp/WEB-INF/pages/systems/sdc/connection.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/sdc/connection.jsp
@@ -8,7 +8,14 @@
   <body>
     <%@ include file="/WEB-INF/pages/common/fragments/systems/system-header.jspf" %>
 
-    <h2><rhn:icon type="header-proxy" /><bean:message key="sdc.details.connection.header"/></h2>
+    <rhn:toolbar base="h2" icon="header-proxy"
+           aclMixins="com.redhat.rhn.common.security.acl.SystemAclHandler"
+           miscUrl="/rhn/manager/systems/details/proxy?sid=${system.id}"
+           miscText="sdc.details.connection.change"
+           miscIcon="header-proxy"
+           miscAcl="user_role(org_admin); not system_is_proxy(); system_has_salt_entitlement()">
+      <bean:message key="sdc.details.connection.header"/>
+    </rhn:toolbar>
 
     <p><bean:message key="sdc.details.connection.summary1"/></p>
     <p><bean:message key="sdc.details.connection.summary2"/></p>

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- UI and API call for changing proxy
 - require postgresql14 on SLE15 SP4
 
 -------------------------------------------------------------------

--- a/schema/spacewalk/common/tables/rhnActionApplyStates.sql
+++ b/schema/spacewalk/common/tables/rhnActionApplyStates.sql
@@ -22,6 +22,7 @@ CREATE TABLE rhnActionApplyStates
                              REFERENCES rhnAction (id)
                              ON DELETE CASCADE,
     states           VARCHAR(1024),
+    pillars          TEXT,
     test             CHAR(1)
                          DEFAULT ('N') NOT NULL
                          CONSTRAINT rhn_act_apply_states_test_ck

--- a/schema/spacewalk/common/tables/rhnServerPath.sql
+++ b/schema/spacewalk/common/tables/rhnServerPath.sql
@@ -27,14 +27,13 @@ CREATE TABLE rhnServerPath
     created          TIMESTAMPTZ
                          DEFAULT (current_timestamp) NOT NULL,
     modified         TIMESTAMPTZ
-                         DEFAULT (current_timestamp) NOT NULL
+                         DEFAULT (current_timestamp) NOT NULL,
+
+    CONSTRAINT rhn_serverpath_sid_pos UNIQUE
+        (server_id, position) DEFERRABLE INITIALLY DEFERRED
 )
 
 ;
-
-CREATE UNIQUE INDEX rhn_serverpath_sid_pos_uq
-    ON rhnServerPath (server_id, position)
-    ;
 
 CREATE UNIQUE INDEX rhn_serverpath_psid_sid_uq
     ON rhnServerPath (proxy_server_id, server_id)

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,5 @@
+- Fix changing of existing proxy path
+- Add pillars to Apply States action
 - require postgresql14 on SLE15 SP4
 
 -------------------------------------------------------------------

--- a/schema/spacewalk/upgrade/susemanager-schema-4.3.4-to-susemanager-schema-4.3.5/010-apply-states.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.3.4-to-susemanager-schema-4.3.5/010-apply-states.sql
@@ -1,0 +1,2 @@
+ALTER TABLE rhnActionApplyStates ADD COLUMN IF NOT EXISTS
+    pillars TEXT;

--- a/schema/spacewalk/upgrade/susemanager-schema-4.3.4-to-susemanager-schema-4.3.5/020-server-path-idx.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.3.4-to-susemanager-schema-4.3.5/020-server-path-idx.sql
@@ -1,0 +1,6 @@
+
+DROP INDEX IF EXISTS rhn_serverpath_sid_pos_uq;
+
+ALTER TABLE rhnServerPath DROP CONSTRAINT IF EXISTS rhn_serverpath_sid_pos;
+ALTER TABLE rhnServerPath ADD CONSTRAINT rhn_serverpath_sid_pos UNIQUE
+    (server_id, position) DEFERRABLE INITIALLY DEFERRED;

--- a/susemanager-utils/susemanager-sls/salt/bootstrap/set_proxy.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/set_proxy.sls
@@ -1,0 +1,11 @@
+/etc/salt/minion.d/susemanager.conf:
+  file.line:
+    - mode: replace
+    - match: "master:"
+    - content: "master: {{ pillar['mgr_server'] }}"
+
+restart:
+  mgrcompat.module_run:
+    - name: cmd.run_bg
+    - cmd: "sleep 2; service salt-minion restart"
+    - python_shell: true

--- a/susemanager-utils/susemanager-sls/salt/bootstrap/set_proxy.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/set_proxy.sls
@@ -1,7 +1,12 @@
-/etc/salt/minion.d/susemanager.conf:
+{%- set conf_file = '/etc/salt/minion.d/susemanager.conf' %}
+{%- set pattern = '^master:.*' %}
+
+{% if salt['file.search'](conf_file, pattern) -%}
+
+{{ conf_file }}:
   file.line:
     - mode: replace
-    - match: "master:"
+    - match: "{{ pattern }}"
     - content: "master: {{ pillar['mgr_server'] }}"
 
 restart:
@@ -9,3 +14,13 @@ restart:
     - name: cmd.run_bg
     - cmd: "sleep 2; service salt-minion restart"
     - python_shell: true
+
+{% else -%}
+
+non_standard_conf:
+  test.configurable_test_state:
+    - changes: False
+    - result: False
+    - comment: "Can't change proxy. Salt master is not configured in {{ conf_file }}"
+
+{% endif %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Add state for changing proxy
 - Enable basic support for Debian 11
 
 -------------------------------------------------------------------

--- a/web/html/src/manager/systems/index.ts
+++ b/web/html/src/manager/systems/index.ts
@@ -1,6 +1,7 @@
 export default {
   "systems/activation-key/activation-key-channels": () => import("./activation-key/activation-key-channels.renderer"),
   "systems/bootstrap/bootstrap-minions": () => import("./bootstrap/bootstrap-minions"),
+  "systems/proxy": () => import("./proxy.renderer"),
   "systems/ssm/ssm-subscribe-channels": () => import("./ssm/ssm-subscribe-channels"),
   "systems/subscribe-channels/subscribe-channels": () => import("./subscribe-channels/subscribe-channels.renderer"),
   "systems/virtualhostmanager/virtualhostmanager": () => import("./virtualhostmanager/virtualhostmanager"),

--- a/web/html/src/manager/systems/proxy.renderer.tsx
+++ b/web/html/src/manager/systems/proxy.renderer.tsx
@@ -1,0 +1,9 @@
+import * as React from "react";
+import { Proxy } from "./proxy";
+import SpaRenderer from "core/spa/spa-renderer";
+
+export const renderer = (id) =>
+  SpaRenderer.renderNavigationReact(
+    <Proxy proxies={window.proxies} currentProxy={window.currentProxy} />,
+    document.getElementById(id)
+  );

--- a/web/html/src/manager/systems/proxy.tsx
+++ b/web/html/src/manager/systems/proxy.tsx
@@ -1,0 +1,140 @@
+import * as React from "react";
+import { BootstrapPanel } from "components/panels/BootstrapPanel";
+import { Messages, MessageType } from "components/messages";
+import { Utils as MessagesUtils } from "components/messages";
+import Network from "utils/network";
+import { AsyncButton } from "components/buttons";
+import { ActionLink } from "components/links";
+
+type ProxyType = {
+  hostname: string;
+  id: number;
+  name: string;
+  path: string[];
+};
+
+// See java/code/src/com/suse/manager/webui/templates/minion/proxy.jade
+declare global {
+  interface Window {
+    proxies?: any;
+    minions?: any[];
+    currentProxy?: number;
+  }
+}
+
+type Props = {
+  proxies: ProxyType[];
+  currentProxy?: number;
+};
+
+type State = {
+  messages: MessageType[];
+  proxy: number;
+};
+
+class Proxy extends React.Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+
+    const msg = window.minions?.length
+      ? []
+      : MessagesUtils.warning(
+          <span>{t("Please select a list of minions (not proxies or traditional clients).")}</span>
+        );
+
+    this.state = {
+      messages: msg,
+      proxy: props.currentProxy || 0,
+    };
+  }
+
+  proxyChanged = (event) => {
+    var proxyId = event.target.value;
+    var proxy = this.props.proxies.find((p) => p.id === proxyId);
+    this.setState({
+      proxy: event.target.value,
+    });
+  };
+
+  onSet = () => {
+    const request = Network.post("/rhn/manager/api/systems/proxy", {
+      proxy: this.state.proxy ? this.state.proxy : 0,
+      ids: window.minions?.map((m) => m.id),
+    })
+      .then((data) => {
+        const msg = MessagesUtils.info(
+          <span>
+            {t("Change of proxy server has been ")}
+            {data.data.actions.length > 1 ? (
+              <>
+                <ActionLink id={data.data.actions[0]}>{t("scheduled")}(1)</ActionLink>
+                <ActionLink id={data.data.actions[1]}>(2).</ActionLink>
+              </>
+            ) : (
+              <ActionLink id={data.data.actions[0]}>{t("scheduled")}.</ActionLink>
+            )}
+          </span>
+        );
+
+        this.setState({
+          messages: msg,
+        });
+      })
+      .catch(this.handleResponseError);
+
+    return request;
+  };
+
+  handleResponseError = (jqXHR) => {
+    this.setState({
+      messages: Network.responseErrorMessage(jqXHR),
+    });
+  };
+
+  render() {
+    const messages = this.state.messages.length > 0 ? <Messages items={this.state.messages} /> : null;
+    const buttons = [
+      <AsyncButton
+        id="bootstrap-btn"
+        defaultType="btn-success"
+        icon="fa-plus"
+        text={t("Change Proxy")}
+        action={this.onSet}
+        disabled={!window.minions?.length}
+      />,
+    ];
+
+    const arrow = " \u2192 ";
+    const proxies = this.props.proxies.map((p) => (
+      <option key={p.id} value={p.id}>
+        {[p.name].concat(p.path).join(arrow)}
+      </option>
+    ));
+
+    return (
+      <div>
+        {messages}
+        <BootstrapPanel title={t("Change Proxy")} header={<p>{t("Connect minion(s) to another proxy server.")}</p>}>
+          <div className="form-horizontal">
+            <div className="form-group">
+              <label className="col-md-3 control-label">{t("New Proxy")}:</label>
+              <div className="col-md-6">
+                <select value={this.state.proxy} onChange={this.proxyChanged} className="form-control" name="proxies">
+                  <option key="none" value="0">
+                    {t("None")}
+                  </option>
+                  {proxies}
+                </select>
+              </div>
+            </div>
+            <div className="form-group">
+              <div className="col-md-offset-3 col-md-6">{buttons}</div>
+            </div>
+          </div>
+        </BootstrapPanel>
+      </div>
+    );
+  }
+}
+
+export { Proxy };

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,5 @@
+- UI for changing proxy
+
 -------------------------------------------------------------------
 Fri Dec 03 12:30:08 CET 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

This PR adds an API call for changing proxy.

It also extends ApplyStatesAction to handle local pillars in similar way as salt commandline.

## GUI diff

There is an new React page `Change Proxy` reachable from minion Connection or via SSM.

- [x] **DONE**

## Documentation
- Documentation issue was created: https://github.com/SUSE/spacewalk/issues/16513
- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

Together with https://github.com/uyuni-project/uyuni/pull/4191
fixes https://github.com/SUSE/spacewalk/issues/15630

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
