### PR TITLE
Increase timeout for cobbler to install SLE 15 SP2

### DIFF
--- a/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
+++ b/testsuite/features/secondary/proxy_cobbler_pxeboot.feature
@@ -99,7 +99,7 @@ Feature: PXE boot a terminal with Cobbler
     When I reboot the PXE boot minion
     And I wait for "60" seconds
     And I set the default PXE menu entry to the "local boot" on the "proxy"
-    And I wait at most 900 seconds until Salt master sees "pxeboot_minion" as "unaccepted"
+    And I wait at most 1200 seconds until Salt master sees "pxeboot_minion" as "unaccepted"
     And I accept "pxeboot_minion" key in the Salt master
     And I am on the Systems page
     And I wait until I see the name of "pxeboot_minion", refreshing the page


### PR DESCRIPTION
## What does this PR change?

When we prepare the PXE boot minion from cobbler in Provo, we see:
```
And I wait at most 900 seconds until Salt master sees "pxeboot_minion" as "unaccepted"
This scenario took: 887 seconds
```

13 seconds margin is too little, increasing the timeout to 1200 seconds for now.
I created a card to have less packages installed, in the hope we can reduce this timeout again.


## Links

Ports:
* 4.1: SUSE/spacewalk#16080
* 4.2: SUSE/spacewalk#16081

Spin-off card: SUSE/spacewalk#16079


## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed
