### PR TITLE
Remove tito.props for spacewalk, so we can build the package again

### DIFF
--- a/spacewalk/package/tito.props
+++ b/spacewalk/package/tito.props
@@ -1,2 +1,0 @@
-[buildconfig]
-builder = spacewalk.releng.builder.NoTgzBuilder


### PR DESCRIPTION
## What does this PR change?

Remove tito.props for spacewalk, so we can build the package again, https://github.com/uyuni-project/uyuni/pull/4265

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Bugfix

- [x] **DONE**

## Test coverage
- No tests: Detected by the Jenkins jobs, but after merging the previous PR

- [x] **DONE**

## Links

None

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
