### PR TITLE
Fix python2.6 compatibility in virt_utils module

### DIFF
--- a/susemanager-utils/susemanager-sls/src/modules/virt_utils.py
+++ b/susemanager-utils/susemanager-sls/src/modules/virt_utils.py
@@ -75,12 +75,11 @@ def vm_info(name=None):
     """
     try:
         infos = __salt__["virt.vm_info"](name)
-        all_vms = {
-            vm_name: {
+        all_vms = {}
+        for vm_name in infos.keys():
+            all_vms[vm_name] = {
                 "graphics_type": infos[vm_name].get("graphics", {}).get("type", None),
             }
-            for vm_name in infos.keys()
-        }
     except CommandExecutionError as err:
         all_vms = {}
 
@@ -92,11 +91,9 @@ def vm_info(name=None):
                 stdout=subprocess.PIPE,
             ).communicate()[0]
         )
-        resource_states = {
-            resource.get('id'): resource.get('active') == "true"
-            for resource
-            in crm_status.findall(".//resources/resource[@resource_agent='ocf::heartbeat:VirtualDomain']")
-        }
+        resource_states = {}
+        for resource in crm_status.findall(".//resources/resource[@resource_agent='ocf::heartbeat:VirtualDomain']"):
+            resource_states[resource.get('id')] = resource.get('active') == "true"
         crm_conf = ElementTree.fromstring(
             subprocess.Popen(
                 ["crm", "configure", "show", "xml", "type:primitive"],

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Fix virt_utils module python 2.6 compatibility (bsc#1191123)
 - Update proxy path on minion connection
 - deploy certificate on SLE Micro 5.1
 - Fix cpuinfo grain and virt_utils state python2 compatibility


### PR DESCRIPTION
## What does this PR change?

Fixes the following error on python2.6 minions:

```
2021-10-07 15:51:35,278 [salt.loader                                            ][ERROR   ][3975] Failed to import module virt_utils, this is due most likely to a syntax error:
Traceback (most recent call last):
  File "/usr/lib64/python2.6/site-packages/salt/loader.py", line 1334, in _load_module
    mod = imp.load_module(mod_namespace, fn_, fpath, desc)
  File "/var/cache/salt/minion/extmods/modules/virt_utils.py", line 82
     for vm_name in infos.keys()
       ^
 SyntaxError: invalid syntax
```

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: SLE 11 SP4 only
- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
