### PR TITLE
Disable the SPA engine for download links (bsc#1190964)

### DIFF
--- a/web/html/src/manager/audit/cveaudit/cveaudit.tsx
+++ b/web/html/src/manager/audit/cveaudit/cveaudit.tsx
@@ -364,6 +364,7 @@ class CVEAudit extends React.Component<Props, State> {
               "&statuses=" +
               this.state.statuses
             }
+            data-senna-off="true"
           >
             Download CSV
           </a>

--- a/web/html/src/manager/audit/subscription-matching/subscription-matching-util.tsx
+++ b/web/html/src/manager/audit/subscription-matching/subscription-matching-util.tsx
@@ -4,7 +4,7 @@ const ToolTip = (props) => <span title={props.title}>{props.content}</span>;
 
 const CsvLink = (props) => (
   <div className="spacewalk-csv-download">
-    <a className="btn btn-link" href={"/rhn/manager/subscription-matching/" + props.name}>
+    <a className="btn btn-link" href={"/rhn/manager/subscription-matching/" + props.name} data-senna-off="true">
       <i className="fa spacewalk-icon-download-csv"></i>
       {t("Download CSV")}
     </a>

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Disable the SPA engine for download links (bsc#1190964)
 - Fix datetime format parsing with moment (bsc#1191348)
 - add Content Lifecycle Management filter for package provides
 - Fix CLM filter edit modal opening (bsc#1190867)


### PR DESCRIPTION
- the CVE audit CSV download link
- the subscription matching CSV download links

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: fix

- [x] **DONE**

## Test coverage
- No tests: there are no tests here

- [x] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/15965

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
