### PR TITLE
spacewalk-setup: Only write config if options are available

### DIFF
--- a/spacewalk/setup/bin/spacewalk-setup
+++ b/spacewalk/setup/bin/spacewalk-setup
@@ -1011,8 +1011,10 @@ sub populate_initial_configs {
           chmod 0640, Spacewalk::Setup::SCC_CREDENTIAL_FILE;
       }
   }
-  Spacewalk::Setup::write_config( \%rhnopt,
+  if(keys %rhnopt) {
+      Spacewalk::Setup::write_config( \%rhnopt,
                 '/var/lib/rhn/rhn-satellite-prep/etc/rhn/rhn.conf' );
+  }
 
     foreach my $opt_name (qw/session_swap_secret session_secret/) {
         foreach my $i (1 .. 4) {


### PR DESCRIPTION
## What does this PR change?

Fixes #4332 

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: Manually tested fix. No build test.

- [X] **DONE**

## Links

Fixes #4332 

- [X] **DONE**

## Changelogs

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
