### PR TITLE
wait after copying the CA to give systemd time to finish automations

### DIFF
--- a/spacewalk/admin/rhn-deploy-ca-cert.pl
+++ b/spacewalk/admin/rhn-deploy-ca-cert.pl
@@ -94,6 +94,8 @@ $ret = system('cp', $cert_target_file, $trust_dir);
 if ($ret) {
   die "Could not link $cert_target_file to $trust_dir";
 }
+# give systemd timer a bit time to finish
+sleep(3);
 if ( -e '/usr/sbin/update-ca-certificates' ) {
     $ret = system('/usr/sbin/update-ca-certificates');
 } else {


### PR DESCRIPTION
## What does this PR change?

Sometimes deployment faild with:

```
p11-kit: couldn't complete writing of file: /var/lib/ca-certificates/ca-bundle.pem.tmp: File exists
Could not update CA trusts. at /usr/bin/rhn-deploy-ca-cert.pl line 104.
```

This is caused by a systemd timer which does the deployment automatically on some OSes.
This PR workaround it by giving it a bit time to finish before we continue.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
