### PR TITLE
Skip tomcat users assignments in unit tests

### DIFF
--- a/java/code/src/com/redhat/rhn/testing/JMockBaseTestCaseWithUser.java
+++ b/java/code/src/com/redhat/rhn/testing/JMockBaseTestCaseWithUser.java
@@ -42,6 +42,7 @@ public abstract class JMockBaseTestCaseWithUser extends RhnJmockBaseTestCase {
     @Override
     public void setUp() throws Exception {
         super.setUp();
+        SaltStateGeneratorService.INSTANCE.setSkipSetOwner(true);
         user = UserTestUtils.findNewUser("testUser", "testOrg" +
                 this.getClass().getSimpleName());
         KickstartDataTest.setupTestConfiguration(user);

--- a/java/code/src/com/redhat/rhn/testing/RhnBaseTestCase.java
+++ b/java/code/src/com/redhat/rhn/testing/RhnBaseTestCase.java
@@ -19,6 +19,7 @@ import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.common.messaging.MessageQueue;
 import com.redhat.rhn.common.util.Asserts;
 
+import com.suse.manager.webui.services.SaltStateGeneratorService;
 import com.suse.manager.webui.services.test.TestSaltApi;
 import com.suse.manager.webui.services.test.TestSystemQuery;
 
@@ -68,6 +69,7 @@ public abstract class RhnBaseTestCase extends TestCase {
      */
     protected void setUp() throws Exception {
         super.setUp();
+        SaltStateGeneratorService.INSTANCE.setSkipSetOwner(true);
     }
 
     /**


### PR DESCRIPTION
## What does this PR change?

Don't let the junit tests require the tomcat user!

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible change.

- [X] **DONE**

## Test coverage
- Unit tests were changed

- [X] **DONE**

## Links

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
