### PR TITLE
Speedup: Improve performance of inventory report (bsc#1191495)

### DIFF
--- a/reporting/reports/data/inventory
+++ b/reporting/reports/data/inventory
@@ -53,21 +53,24 @@ sql:
 		entitlements, system_group, organization, virtual_host, architecture, is_virtualized, virt_type, osad_status, hardware,
 		minion_id, machine_id
 	from (
-	select rhnserver.id as server_id, rhnserver.name as profile_name,
-		rhnserver.hostname, suseminioninfo.minion_id, trim(ipaddr) as ip_address,
+	select servers_data.*,
+	rhnchannel.name as software_channel,
+	rhnchannel.parent_channel as parent_channel,
+	rhnchannel.id as channel_id,
+	COALESCE(update_data.packages_out_of_date, 0) as packages_out_of_date,
+	COALESCE(update_data.errata_out_of_date, 0) as errata_out_of_date
+	from
+	(select rhnserver.id as server_id,
+		rhnserver.name as profile_name,
+		rhnserver.hostname,
+		(select minion_id from suseMinionInfo where rhnserver.id = suseMinionInfo.server_id) as minion_id,
+		trim(ipaddr) as ip_address,
 		trim(ip6addr) as ipv6_address,
 		rhnserver.machine_id,
 		( select login from web_contact where rhnserver.creator_id = web_contact.id ) as registered_by,
 		to_char(rhnserver.created, 'YYYY-MM-DD HH24:MI:SS') as registration_time,
 		( select to_char(checkin, 'YYYY-MM-DD HH24:MI:SS') from rhnserverinfo where rhnserver.id = server_id ) as last_checkin_time,
 		running_kernel as kernel_version,
-		( select count(distinct rhnpackage.name_id) from rhnpackage, rhnServerNeededCache
-			where rhnserver.id = rhnServerNeededCache.server_id
-				and rhnServerNeededCache.package_id = rhnpackage.id ) as packages_out_of_date,
-		( select count(*) from rhnServerNeededCache where rhnserver.id = server_id and errata_id is not null) as errata_out_of_date,
-		rhnchannel.name as software_channel,
-		rhnchannel.parent_channel as parent_channel,
-		rhnchannel.id as channel_id,
 		rhnconfigchannel.name as configuration_channel,
 		rhnconfigchannel.id as configuration_channel_id,
 		entitlement_data.name as entitlements,
@@ -102,10 +105,6 @@ sql:
 			)
 		) netinfos
 		on rhnserver.id = netinfos.server_id
-		left outer join rhnserverchannel
-		on rhnserver.id = rhnserverchannel.server_id
-		left outer join rhnchannel
-		on rhnserverchannel.channel_id = rhnchannel.id
 		left outer join rhnserverconfigchannel
 		on rhnserver.id = rhnserverconfigchannel.server_id
 		left outer join rhnconfigchannel
@@ -133,8 +132,17 @@ sql:
 		where host_system_id is not null
 		) virtual_data
 		on rhnserver.id = virtual_data.virtual_system_id
-		left outer join suseMinionInfo
-		on rhnserver.id = suseMinionInfo.server_id
+		) servers_data
+		left outer join rhnserverchannel
+			on servers_data.server_id = rhnserverchannel.server_id
+		left outer join rhnchannel
+			on rhnserverchannel.channel_id = rhnchannel.id
+		left join (select rhnServerNeededCache.server_id,
+					count(distinct rhnpackage.name_id) as packages_out_of_date,
+					count(rhnServerNeededCache.errata_id) as errata_out_of_date
+				from rhnpackage, rhnServerNeededCache
+				where rhnServerNeededCache.package_id = rhnpackage.id
+				group by rhnServerNeededCache.server_id) update_data on update_data.server_id = servers_data.server_id
 	) X
 	-- where placeholder
 	order by server_id, parent_channel nulls first, channel_id,

--- a/reporting/spacewalk-reports.changes
+++ b/reporting/spacewalk-reports.changes
@@ -1,3 +1,5 @@
+- Improve performance of inventory report (bsc#1191495)
+
 -------------------------------------------------------------------
 Mon Aug 09 11:03:10 CEST 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
Signed-off-by: Ricardo Mateus <rmateus@suse.com>

## What does this PR change?

Improves performance in query that produces inventory report.

Execution plan from large deployment (17k minions):
- Original Query 
[explain_plan_original.txt](https://github.com/uyuni-project/uyuni/files/7347707/explain_plan_original.txt)

- Optimized one
[explain_plan_changed_2.txt](https://github.com/uyuni-project/uyuni/files/7347710/explain_plan_changed_2.txt)


I have also run it on a smaller environment, without to much activity, and the query result was equal.

Performance :
Original: 81058 seconds
Optimized: 47 seconds 

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes: https://github.com/SUSE/spacewalk/issues/16111


- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
