### PR TITLE
Include link to vendor security advisory

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/action/errata/ErrataDetailsSetupAction.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/errata/ErrataDetailsSetupAction.java
@@ -21,18 +21,25 @@ import com.redhat.rhn.domain.errata.Errata;
 import com.redhat.rhn.domain.errata.ErrataFactory;
 import com.redhat.rhn.domain.errata.ErrataFile;
 import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.frontend.html.HtmlTag;
 import com.redhat.rhn.frontend.struts.RequestContext;
 import com.redhat.rhn.frontend.struts.RhnAction;
 import com.redhat.rhn.frontend.struts.RhnHelper;
 import com.redhat.rhn.manager.errata.ErrataManager;
 
+import com.suse.manager.errata.ErrataParserFactory;
+import com.suse.manager.errata.ErrataParsingException;
+import com.suse.manager.errata.VendorSpecificErrataParser;
+
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.IteratorUtils;
 import org.apache.commons.collections.Transformer;
+import org.apache.log4j.Logger;
 import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionForward;
 import org.apache.struts.action.ActionMapping;
 
+import java.net.URI;
 import java.util.List;
 
 import javax.servlet.http.HttpServletRequest;
@@ -42,6 +49,9 @@ import javax.servlet.http.HttpServletResponse;
  * DetailsSetupAction
  */
 public class ErrataDetailsSetupAction extends RhnAction {
+
+    private static final Logger LOGGER = Logger.getLogger(ErrataManager.class);
+
     /** {@inheritDoc} */
     public ActionForward execute(ActionMapping mapping,
                                  ActionForm formIn,
@@ -59,6 +69,7 @@ public class ErrataDetailsSetupAction extends RhnAction {
         DataResult fixed = ErrataManager.bugsFixed(eid);
         DataResult cve = ErrataManager.errataCVEs(eid);
         DataResult keywords = ErrataManager.keywords(eid);
+        final String vendorAdvisoryLink = buildVendorAdvisoryLink(errata);
 
         //create the display for keywords
         //example: "/var/tmp, current, directory, expect"
@@ -93,6 +104,7 @@ public class ErrataDetailsSetupAction extends RhnAction {
         request.setAttribute("errataFrom", errata.getErrataFrom());
         request.setAttribute("advisoryStatus", LocalizationService.getInstance()
                 .getMessage("details.jsp.advisorystatus." + errata.getAdvisoryStatus().getMetadataValue()));
+        request.setAttribute("vendorAdvisory", vendorAdvisoryLink);
 
         return getStrutsDelegate().forwardParams(
                 mapping.findForward(RhnHelper.DEFAULT_FORWARD),
@@ -115,5 +127,29 @@ public class ErrataDetailsSetupAction extends RhnAction {
         buf.append("</a>");
         retval = buf.toString();
         return retval;
+    }
+
+    private String buildVendorAdvisoryLink(Errata errata) {
+
+        final URI advisoryUri;
+        final String id;
+
+        try {
+            final VendorSpecificErrataParser parser = ErrataParserFactory.getParser(errata);
+
+            advisoryUri = parser.getAdvisoryUri(errata);
+            id = parser.getAnnouncementId(errata);
+        }
+        catch (ErrataParsingException ex) {
+            LOGGER.info("Unable to parse errata metadata", ex);
+            return null;
+        }
+
+        final HtmlTag link = new HtmlTag("a");
+        link.setAttribute("target", "_blank");
+        link.setAttribute("href", advisoryUri.toString());
+        link.setBody(id);
+
+        return link.render();
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/action/errata/test/ErrataDetailsSetupActionTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/action/errata/test/ErrataDetailsSetupActionTest.java
@@ -14,11 +14,16 @@
  */
 package com.redhat.rhn.frontend.action.errata.test;
 
+import com.redhat.rhn.domain.errata.AdvisoryStatus;
 import com.redhat.rhn.domain.errata.Errata;
+import com.redhat.rhn.domain.errata.ErrataFactory;
 import com.redhat.rhn.domain.errata.test.ErrataFactoryTest;
 import com.redhat.rhn.frontend.action.errata.ErrataDetailsSetupAction;
 import com.redhat.rhn.testing.ActionHelper;
 import com.redhat.rhn.testing.RhnBaseTestCase;
+
+import java.util.Calendar;
+import java.util.GregorianCalendar;
 
 /**
  * ErrataDetailsSetupActionTest
@@ -30,26 +35,48 @@ public class ErrataDetailsSetupActionTest extends RhnBaseTestCase {
         ActionHelper sah = new ActionHelper();
         sah.setUpAction(action);
 
-        Errata e = ErrataFactoryTest.createTestErrata(
-                sah.getUser().getOrg().getId());
-        e.addKeyword("test");
+        Errata errata = ErrataFactoryTest.createTestErrata(sah.getUser().getOrg().getId());
 
-        sah.getRequest().setupAddParameter("eid", e.getId().toString());
+        errata.setAdvisory("SUSE-15-SP3-2021-3413");
+        errata.setAdvisoryName("SUSE-15-SP3-2021-3413");
+        errata.setAdvisoryRel(1L);
+        errata.setAdvisoryType(ErrataFactory.ERRATA_TYPE_BUG);
+        errata.setAdvisoryStatus(AdvisoryStatus.STABLE);
+        errata.setProduct("SUSE Updates SLE-Module-Basesystem 15-SP3 x86 64");
+        errata.setDescription("This update for suse-module-tools fixes bugs.");
+        errata.setSynopsis("Recommended update for suse-module-tools");
+        errata.setIssueDate(new GregorianCalendar(2021, Calendar.OCTOBER, 13).getTime());
+        errata.setUpdateDate(new GregorianCalendar(2021, Calendar.OCTOBER, 13).getTime());
+        errata.setErrataFrom("maint-coord@suse.de");
+        errata.addKeyword("test");
+
+        ErrataFactory.save(errata);
+
+        sah.getRequest().setupAddParameter("eid", errata.getId().toString());
 
         sah.executeAction();
 
-        assertNotNull(sah.getRequest().getAttribute("errata"));
-        assertNotNull(sah.getRequest().getAttribute("issued"));
-        assertNotNull(sah.getRequest().getAttribute("updated"));
-        assertNotNull(sah.getRequest().getAttribute("topic"));
-        assertNotNull(sah.getRequest().getAttribute("description"));
-        assertNotNull(sah.getRequest().getAttribute("solution"));
-        assertNotNull(sah.getRequest().getAttribute("notes"));
-        assertNotNull(sah.getRequest().getAttribute("references"));
+        assertEquals(errata, sah.getRequest().getAttribute("errata"));
+        assertEquals("10/13/21", sah.getRequest().getAttribute("issued"));
+        assertEquals("10/13/21", sah.getRequest().getAttribute("updated"));
+        assertEquals("This update for suse-module-tools fixes bugs.", sah.getRequest().getAttribute("description"));
+        assertEquals("Stable", sah.getRequest().getAttribute("advisoryStatus"));
+
+
+        String advisoryLink = "<a target=\"_blank\" " +
+                "href=\"https://www.suse.com/support/update/announcement/2021/suse-ru-20213413-1/\">" +
+                "SUSE-RU-2021:3413-1</a>";
+        assertEquals(advisoryLink, sah.getRequest().getAttribute("vendorAdvisory"));
+
+        assertEquals("test topic", sah.getRequest().getAttribute("topic"));
+        assertEquals("Test solution", sah.getRequest().getAttribute("solution"));
+        assertEquals("Test notes for test errata", sah.getRequest().getAttribute("notes"));
+        assertEquals("rhn unit tests", sah.getRequest().getAttribute("references"));
+
         assertNotNull(sah.getRequest().getAttribute("channels"));
         assertNotNull(sah.getRequest().getAttribute("fixed"));
         assertNotNull(sah.getRequest().getAttribute("cve"));
-        assertNotNull(sah.getRequest().getAttribute("keywords"));
-        assertNotNull(sah.getRequest().getAttribute("advisoryStatus"));
+
+        assertEquals("keyword, test", sah.getRequest().getAttribute("keywords"));
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
+++ b/java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource_en_US.xml
@@ -4348,6 +4348,12 @@ organization. You may grant or remove the organization administrator role in the
           <context context-type="sourcefile">/rhn/errata/details/Details</context>
         </context-group>
       </trans-unit>
+      <trans-unit id="details.jsp.vendoradvisory" xml:space="preserve">
+        <source>Vendor Advisory</source>
+            <context-group name="ctx">
+          <context context-type="sourcefile">/rhn/errata/details/Details</context>
+        </context-group>
+      </trans-unit>
       <trans-unit id="details.jsp.none" xml:space="preserve">
         <source>&lt;span class="no-details"&gt;(none)&lt;/span&gt;</source>
         <context-group name="ctx">

--- a/java/code/src/com/suse/manager/errata/AbstractSimpleErrataParser.java
+++ b/java/code/src/com/suse/manager/errata/AbstractSimpleErrataParser.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.errata;
+
+import com.redhat.rhn.domain.errata.Errata;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.text.MessageFormat;
+
+/**
+ * Base errata parser that uses a simple format where only the advisory code is substituted in the url.
+ */
+abstract class AbstractSimpleErrataParser implements VendorSpecificErrataParser {
+
+    private final String urlFormat;
+
+    /**
+     * Constructor to specify the url format. The string must be valid for {@link MessageFormat#format(Object)}. Only
+     * the string parameter {0} will be substituted.
+     *
+     * @param urlFormatIn The url of the advisory containing a single text parameter for substitution.
+     */
+    protected AbstractSimpleErrataParser(String urlFormatIn) {
+        this.urlFormat = urlFormatIn;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final URI getAdvisoryUri(Errata errata) throws ErrataParsingException {
+        if (StringUtils.isEmpty(errata.getAdvisory())) {
+            throw new ErrataParsingException("No advisory id found for errata");
+        }
+
+        try {
+            return new URI(MessageFormat.format(urlFormat, getAdvisoryCode(errata.getAdvisory())));
+        }
+        catch (URISyntaxException ex) {
+            throw new ErrataParsingException("Unable generate vendor link for errata", ex);
+        }
+    }
+
+    /**
+     * Extract the advisory code from the errata. The advisory code returned by this method is used as {0} parameter in
+     * the url format string.
+     *
+     * @param errataAdvisory The errata object. Guaranteed to be not null and not empty.
+     *
+     * @return the string to be used as the {0} parameter for building the url.
+     */
+    protected String getAdvisoryCode(String errataAdvisory) {
+        return errataAdvisory;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getAnnouncementId(Errata errata) throws ErrataParsingException {
+        if (StringUtils.isEmpty(errata.getAdvisory())) {
+            throw new ErrataParsingException("No advisory id found for errata");
+        }
+
+        // Default implementation returns the internal advisory id after checking it
+        return errata.getAdvisory();
+    }
+}

--- a/java/code/src/com/suse/manager/errata/AlibabaErrataParser.java
+++ b/java/code/src/com/suse/manager/errata/AlibabaErrataParser.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.errata;
+
+/**
+ * Parser specific for Alibaba cloud linux errata.
+ */
+public class AlibabaErrataParser extends AbstractSimpleErrataParser {
+
+    private static final String URL_FORMAT = "http://mirrors.aliyun.com/alinux/cve/{0}.xml";
+
+    /**
+     * Default constructor.
+     */
+    public AlibabaErrataParser() {
+        super(URL_FORMAT);
+    }
+
+    // Alibaba does not use ':' in the url and uses lower case
+    @Override
+    protected String getAdvisoryCode(String errataAdvisory) {
+        return errataAdvisory.toLowerCase().replaceAll(":", "");
+    }
+}

--- a/java/code/src/com/suse/manager/errata/AlmaLinuxErrataParser.java
+++ b/java/code/src/com/suse/manager/errata/AlmaLinuxErrataParser.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.errata;
+
+/**
+ * Parser specific for AlmaLinux errata.
+ */
+public class AlmaLinuxErrataParser extends AbstractSimpleErrataParser {
+
+    /*
+        TODO For now version 8 is hardcoded since it's not possible to figure out the distribution version.
+         The errata currently does not contain any information about that. When a new version of AlmaLinux is
+         released we need to review how they handle it and how we can detect the version of the distribution.
+     */
+    private static final String URL_FORMAT = "https://errata.almalinux.org/8/{0}.html";
+
+    /**
+     * Default constructor.
+     */
+    public AlmaLinuxErrataParser() {
+        super(URL_FORMAT);
+    }
+
+    // AlmaLinux is using '-' in place of ':' in the url
+    @Override
+    protected String getAdvisoryCode(String errataAdvisory) {
+        return errataAdvisory.replaceAll(":", "-");
+    }
+}

--- a/java/code/src/com/suse/manager/errata/AmazonErrataParser.java
+++ b/java/code/src/com/suse/manager/errata/AmazonErrataParser.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.errata;
+
+import com.redhat.rhn.domain.errata.Errata;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.text.MessageFormat;
+
+/**
+ * Parser specific for Amazon linux errata.
+ */
+public class AmazonErrataParser implements VendorSpecificErrataParser {
+
+    private static final String ID_PREFIX = "ALAS";
+
+    private static final String ANNOUNCEMENT_FORMAT = ID_PREFIX + "-{0}-{1}";
+
+    private static final String URL_FORMAT = "https://alas.aws.amazon.com{0}/" + ID_PREFIX + "-{1}-{2}.html";
+
+    private static final String VERSION_CODE = "AL";
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public URI getAdvisoryUri(Errata errata) throws ErrataParsingException {
+        final ErrataParameters data = parse(errata.getAdvisory());
+
+        try {
+            return new URI(MessageFormat.format(URL_FORMAT, data.getVersionUriPrefix(), data.getYear(), data.getId()));
+        }
+        catch (URISyntaxException e) {
+            throw new ErrataParsingException("Unable generate vendor link for errata", e);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getAnnouncementId(Errata errata) throws ErrataParsingException {
+        final ErrataParameters data = parse(errata.getAdvisory());
+
+        return MessageFormat.format(ANNOUNCEMENT_FORMAT, data.getYear(), data.getId());
+    }
+
+
+    private static ErrataParameters parse(String advisoryId) throws ErrataParsingException {
+        if (StringUtils.isEmpty(advisoryId)) {
+            throw new ErrataParsingException("No advisory id found for errata");
+        }
+
+        final String[] parts = advisoryId.split("-");
+
+        if (parts.length != 3) {
+            throw new ErrataParsingException("Unsupported advisory format " + advisoryId);
+        }
+
+        final String versionUriPrefix;
+        if (ID_PREFIX.equals(parts[0])) {
+            versionUriPrefix = StringUtils.EMPTY;
+        }
+        else if (parts[0].startsWith(ID_PREFIX)) {
+            versionUriPrefix = "/" + VERSION_CODE + parts[0].substring(4);
+        }
+        else {
+            throw new ErrataParsingException("Unsupported advisory prefix " + parts[0]);
+        }
+
+        return new ErrataParameters(versionUriPrefix, parts[1], parts[2]);
+    }
+
+    /**
+     * POJO to describe the parameters of the advisory id
+     */
+    private static class ErrataParameters {
+        private final String versionUriPrefix;
+
+        private final String year;
+
+        private final String id;
+
+        ErrataParameters(String versionUriPrefixIn, String yearIn, String idIn) {
+            this.versionUriPrefix = versionUriPrefixIn;
+            this.year = yearIn;
+            this.id = idIn;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public String getYear() {
+            return year;
+        }
+
+        public String getVersionUriPrefix() {
+            return versionUriPrefix;
+        }
+    }
+}

--- a/java/code/src/com/suse/manager/errata/ErrataParserFactory.java
+++ b/java/code/src/com/suse/manager/errata/ErrataParserFactory.java
@@ -30,6 +30,13 @@ public final class ErrataParserFactory {
      * All supported vendors
      */
     private enum SupportedVendor {
+        ALIBABA("alicloud-linux-os@service.aliyun.com", AlibabaErrataParser::new),
+        ALMALINUX("packager@almalinux.org", AlmaLinuxErrataParser::new),
+        AMAZON("linux-security@amazon.com", AmazonErrataParser::new),
+        ORACLE("el-errata@oss.oracle.com", OracleErrataParser::new),
+        REDHAT("release-engineering@redhat.com", RedhatErrataParser::new),
+        ROCKYLINUX("releng@rockylinux.org", RockyLinuxErrataParser::new),
+        SUSE_RES("res-maintenance@suse.de", SUSERESErrataParser::new),
         SUSE("maint-coord@suse.de", SUSEErrataParser::new);
 
         /** Email used in the errata */

--- a/java/code/src/com/suse/manager/errata/ErrataParserFactory.java
+++ b/java/code/src/com/suse/manager/errata/ErrataParserFactory.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.errata;
+
+import com.redhat.rhn.domain.errata.Errata;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+/**
+ * Factory to create concrete instances of {@link VendorSpecificErrataParser}.
+ */
+public final class ErrataParserFactory {
+
+    /**
+     * All supported vendors
+     */
+    private enum SupportedVendor {
+        SUSE("maint-coord@suse.de", SUSEErrataParser::new);
+
+        /** Email used in the errata */
+        private final String vendorEmail;
+
+        /** Supplier that builds the parser instance */
+        private final Supplier<VendorSpecificErrataParser> parserSupplier;
+
+        SupportedVendor(String vendorEmailIn, Supplier<VendorSpecificErrataParser> parserSupplierIn) {
+            this.vendorEmail = vendorEmailIn;
+            this.parserSupplier = parserSupplierIn;
+        }
+
+        /**
+         * The vendor email used in the errata.
+         *
+         * @return the vendor email.
+         */
+        public String getVendorEmail() {
+            return vendorEmail;
+        }
+
+        /**
+         * Builds an instance of the parser specific for this vendor
+         *
+         * @return a concrete instance of {@link VendorSpecificErrataParser}.
+         */
+        public VendorSpecificErrataParser getParser() {
+            return parserSupplier.get();
+        }
+    }
+
+    private ErrataParserFactory() {
+        // Prevent instantiation
+    }
+
+    /**
+     * Returns a parser that is specific for the given errata, depending on the vendor.
+     *
+     * @param errata the errata
+     * @return a parse for extracting vendor specific information
+     *
+     * @throws ErrataParsingException when it's not possible to build a parse for the errata.
+     */
+    public static VendorSpecificErrataParser getParser(Errata errata) throws ErrataParsingException {
+        final String errataEmail = Optional.ofNullable(errata)
+                                           .map(Errata::getErrataFrom)
+                                           .map(StringUtils::trimToNull)
+                                           .orElseThrow(() -> new ErrataParsingException(
+                                                   "Unable identify the vendor to parse the errata"));
+
+        for (SupportedVendor vendor : SupportedVendor.values()) {
+            if (errataEmail.equals(vendor.getVendorEmail())) {
+                return vendor.getParser();
+            }
+        }
+
+        throw new ErrataParsingException("Unable identify the vendor to parse the errata");
+    }
+}

--- a/java/code/src/com/suse/manager/errata/ErrataParsingException.java
+++ b/java/code/src/com/suse/manager/errata/ErrataParsingException.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.errata;
+
+/**
+ * Exception describing an error during the execution of a {@link VendorSpecificErrataParser}.
+ */
+public class ErrataParsingException extends Exception {
+
+    /**
+     * Default constructor.
+     */
+    public ErrataParsingException() {
+    }
+
+    /**
+     * @param message An error message
+     */
+    public ErrataParsingException(String message) {
+        super(message);
+    }
+
+    /**
+     * @param message An error message
+     * @param cause The Throwable to wrap
+     */
+    public ErrataParsingException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    /**
+     * @param cause The Throwable to wrap
+     */
+    public ErrataParsingException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/java/code/src/com/suse/manager/errata/OracleErrataParser.java
+++ b/java/code/src/com/suse/manager/errata/OracleErrataParser.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.errata;
+
+/**
+ * Parser specific for Oracle Linux errata.
+ */
+public class OracleErrataParser extends AbstractSimpleErrataParser {
+
+    private static final String URL_FORMAT = "https://linux.oracle.com/errata/{0}.html";
+
+    /**
+     * Default constructor.
+     */
+    public OracleErrataParser() {
+        super(URL_FORMAT);
+    }
+
+}

--- a/java/code/src/com/suse/manager/errata/RedhatErrataParser.java
+++ b/java/code/src/com/suse/manager/errata/RedhatErrataParser.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.errata;
+
+public class RedhatErrataParser extends AbstractSimpleErrataParser {
+
+    public static final String URL_FORMAT = "https://access.redhat.com/errata/{0}";
+
+    /**
+     * Default constructor.
+     */
+    public RedhatErrataParser() {
+        super(URL_FORMAT);
+    }
+
+}

--- a/java/code/src/com/suse/manager/errata/RockyLinuxErrataParser.java
+++ b/java/code/src/com/suse/manager/errata/RockyLinuxErrataParser.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.errata;
+
+/**
+ * Parser specific for Rocky Linux errata.
+ */
+public class RockyLinuxErrataParser extends AbstractSimpleErrataParser {
+
+    private static final String URL_FORMAT = "https://errata.rockylinux.org/{0}";
+
+    /**
+     * Default constructor.
+     */
+    public RockyLinuxErrataParser() {
+        super(URL_FORMAT);
+    }
+
+}

--- a/java/code/src/com/suse/manager/errata/SUSEErrataParser.java
+++ b/java/code/src/com/suse/manager/errata/SUSEErrataParser.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.errata;
+
+import com.redhat.rhn.domain.errata.Errata;
+import com.redhat.rhn.domain.errata.ErrataFactory;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.text.MessageFormat;
+import java.time.Year;
+import java.time.ZoneOffset;
+import java.util.Date;
+
+/**
+ * Parser specific for SUSE errata.
+ */
+public class SUSEErrataParser implements VendorSpecificErrataParser {
+
+    private static final String ANNOUNCEMENT_FORMAT = "SUSE-{0}-{1,number,0000}:{2,number,0000}-{3,number,0}";
+
+    private static final String URL_FORMAT = "https://www.suse.com/support/update/announcement/" +
+                    "{0,number,0000}/suse-{1}-{0,number,0000}{2,number,0000}-{3,number,0}/";
+
+    private static final String ADVISORY_CODE_SECURITY = "su";
+
+    private static final String ADVISORY_CODE_RECOMMENDED = "ru";
+
+    private static final int MINIMUM_PARSABLE_YEAR = 2019;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public URI getAdvisoryUri(Errata errata) throws ErrataParsingException {
+        final int year = extractYear(errata.getIssueDate());
+        final int advisoryId = extractId(errata.getAdvisory());
+        final String advisoryCode = extractCode(errata.getAdvisoryType());
+        final long version = extractVersion(errata.getAdvisoryRel());
+
+        try {
+            return new URI(MessageFormat.format(URL_FORMAT, year, advisoryCode, advisoryId, version));
+        }
+        catch (URISyntaxException ex) {
+            throw new ErrataParsingException("Unable generate vendor link for errata", ex);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getAnnouncementId(Errata errata) throws ErrataParsingException {
+        final int year = extractYear(errata.getIssueDate());
+        final int advisoryId = extractId(errata.getAdvisory());
+        final String advisoryCode = extractCode(errata.getAdvisoryType()).toUpperCase();
+        final long version = extractVersion(errata.getAdvisoryRel());
+
+        return MessageFormat.format(ANNOUNCEMENT_FORMAT, advisoryCode, year, advisoryId, version);
+    }
+
+    private long extractVersion(Long advisoryRelease) throws ErrataParsingException {
+        // Extract the release number of the errata
+        if (advisoryRelease == null || advisoryRelease <= 0L) {
+            throw new ErrataParsingException("Invalid advisory release number " + advisoryRelease);
+        }
+
+        return advisoryRelease;
+    }
+
+    private String extractCode(String advisoryType) throws ErrataParsingException {
+        if (StringUtils.isEmpty(advisoryType)) {
+            throw new ErrataParsingException("Advisory type is null");
+        }
+
+        // Extract the code used in the url from advisory type.
+        switch (advisoryType) {
+            case ErrataFactory.ERRATA_TYPE_SECURITY:
+                return ADVISORY_CODE_SECURITY;
+            case ErrataFactory.ERRATA_TYPE_BUG:
+                return ADVISORY_CODE_RECOMMENDED;
+
+            // TODO Optional and Feature codes are currently not supported since we have "Enhancement" for both
+            default:
+                throw new ErrataParsingException("Unsupported advisory type " + advisoryType);
+        }
+
+    }
+
+    private int extractId(String advisory) throws ErrataParsingException {
+        // The id is the last part of the advisoryId i.e. SUSE-15-SP3-2021-3411 or avahi-13947
+        final int lastDash = advisory.lastIndexOf('-');
+        if (lastDash == -1) {
+            throw new ErrataParsingException("Unable to parse advisory id from " + advisory);
+        }
+
+        try {
+            return Integer.parseInt(advisory.substring(lastDash + 1));
+        }
+        catch (NumberFormatException ex) {
+            throw new ErrataParsingException("Unable to parse the advisory id number from " + advisory);
+        }
+    }
+
+    private int extractYear(Date issueDate) throws ErrataParsingException {
+        if (issueDate == null) {
+            throw new ErrataParsingException("Issue date is null");
+        }
+
+        // Extract the year from the issue date and not from the advisory id because old ids do not include
+        // the date
+        final int year = Year.from(issueDate.toInstant().atZone(ZoneOffset.systemDefault())).getValue();
+
+        // Do not parse advisory issued before 2019 because the number in the id we have in the database does not
+        // match with the advisory id used in the url thus all urls we generate for those advisories do not exist.
+        if (year < MINIMUM_PARSABLE_YEAR) {
+            throw new ErrataParsingException("Unable to parse an advisory issued before " + MINIMUM_PARSABLE_YEAR);
+        }
+
+        return year;
+    }
+}

--- a/java/code/src/com/suse/manager/errata/SUSERESErrataParser.java
+++ b/java/code/src/com/suse/manager/errata/SUSERESErrataParser.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.errata;
+
+import com.redhat.rhn.domain.errata.Errata;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.text.MessageFormat;
+
+/**
+ * Errata parser for SUSE Expanded Support.
+ */
+public class SUSERESErrataParser implements VendorSpecificErrataParser {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public URI getAdvisoryUri(Errata errata) throws ErrataParsingException {
+        if (StringUtils.isEmpty(errata.getAdvisory())) {
+            throw new ErrataParsingException("No advisory id found for errata");
+        }
+
+        if (errata.getAdvisory().startsWith("RH")) {
+            try {
+                return new URI(MessageFormat.format(RedhatErrataParser.URL_FORMAT, errata.getAdvisory()));
+            }
+            catch (URISyntaxException ex) {
+                throw new ErrataParsingException("Unable generate vendor link for errata", ex);
+            }
+        }
+
+        throw new ErrataParsingException("Unsupported advisory " + errata.getAdvisory());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getAnnouncementId(Errata errata) throws ErrataParsingException {
+        if (StringUtils.isEmpty(errata.getAdvisory())) {
+            throw new IllegalArgumentException("No advisory id found for errata");
+        }
+
+        return errata.getAdvisory();
+    }
+}

--- a/java/code/src/com/suse/manager/errata/VendorSpecificErrataParser.java
+++ b/java/code/src/com/suse/manager/errata/VendorSpecificErrataParser.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.errata;
+
+import com.redhat.rhn.domain.errata.Errata;
+
+import java.net.URI;
+
+/**
+ * Class to parse the fields of the errata and extract vendor specific information.
+ */
+public interface VendorSpecificErrataParser {
+
+    /**
+     * Retrieve the URI of the original vendor advisory represented by the given errata.
+     *
+     * @param errata the errata.
+     * @return a URI representing the http address of the advisory.
+     *
+     * @throws ErrataParsingException if the required pieces of information are missing in the errata object.
+     */
+    URI getAdvisoryUri(Errata errata) throws ErrataParsingException;
+
+    /**
+     * Retrieve the vendor announcement id which can differ from the id used internally.
+     *
+     * @param errata the errata.
+     * @return a string defining the id of the advisory announcement for the vendor.
+
+     * @throws ErrataParsingException if the required pieces of information are missing in the errata object.
+     */
+    String getAnnouncementId(Errata errata) throws ErrataParsingException;
+}

--- a/java/code/src/com/suse/manager/errata/test/AlibabaErrataParserTest.java
+++ b/java/code/src/com/suse/manager/errata/test/AlibabaErrataParserTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.errata.test;
+
+import com.redhat.rhn.domain.errata.Errata;
+import com.redhat.rhn.domain.errata.ErrataFactory;
+
+import com.suse.manager.errata.AlibabaErrataParser;
+import com.suse.manager.errata.ErrataParsingException;
+
+import java.net.URI;
+import java.time.LocalDate;
+import java.time.Month;
+
+/**
+ * Tests For {@link AlibabaErrataParser}
+ */
+public class AlibabaErrataParserTest extends BaseErrataTestCase {
+
+    /**
+     * Test to ensure correct parsing of the url and the id in a valid case.
+     */
+    public void testCanBuildValidLinkAndId() throws ErrataParsingException {
+
+        final AlibabaErrataParser parser = new AlibabaErrataParser();
+        final Errata errata = createErrata("ALINUX2-SA-2019:0019", ErrataFactory.ERRATA_TYPE_SECURITY,
+                LocalDate.of(2019, Month.FEBRUARY, 8), 1L);
+
+        final String id = parser.getAnnouncementId(errata);
+        final URI uri = parser.getAdvisoryUri(errata);
+
+        assertEquals("ALINUX2-SA-2019:0019", id);
+        assertEquals("http://mirrors.aliyun.com/alinux/cve/alinux2-sa-20190019.xml", uri.toString());
+    }
+
+    /**
+     * Test the behaviour when the advisory code is null.
+     */
+    public void testThrowsExceptionWhenAdvisoryIsNotAvailable() {
+        final AlibabaErrataParser parser = new AlibabaErrataParser();
+        final Errata errata = createErrata(null, ErrataFactory.ERRATA_TYPE_SECURITY,
+                LocalDate.of(2019, Month.FEBRUARY, 8), 1L);
+
+        try {
+            parser.getAdvisoryUri(errata);
+            fail("Expected ErrataParsingException was not thrown");
+        }
+        catch (ErrataParsingException e) {
+            assertEquals("No advisory id found for errata", e.getMessage());
+        }
+    }
+}

--- a/java/code/src/com/suse/manager/errata/test/AlmaLinuxErrataParserTest.java
+++ b/java/code/src/com/suse/manager/errata/test/AlmaLinuxErrataParserTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.errata.test;
+
+import com.redhat.rhn.domain.errata.Errata;
+import com.redhat.rhn.domain.errata.ErrataFactory;
+
+import com.suse.manager.errata.AlmaLinuxErrataParser;
+import com.suse.manager.errata.ErrataParsingException;
+
+import java.net.URI;
+import java.time.LocalDate;
+import java.time.Month;
+
+/**
+ * Tests for {@link AlmaLinuxErrataParser}
+ */
+public class AlmaLinuxErrataParserTest extends BaseErrataTestCase {
+
+    /**
+     * Test to ensure correct parsing of the url and the id in a valid case.
+     */
+    public void testCanBuildValidLinkAndId() throws ErrataParsingException {
+
+        final AlmaLinuxErrataParser parser = new AlmaLinuxErrataParser();
+        final Errata errata = createErrata("ALSA-2021:3893", ErrataFactory.ERRATA_TYPE_SECURITY,
+                LocalDate.of(2021, Month.OCTOBER, 21), 1L);
+
+        final String id = parser.getAnnouncementId(errata);
+        final URI uri = parser.getAdvisoryUri(errata);
+
+        assertEquals("ALSA-2021:3893", id);
+        assertEquals("https://errata.almalinux.org/8/ALSA-2021-3893.html", uri.toString());
+    }
+
+    /**
+     * Test the behaviour when the advisory code is null.
+     */
+    public void testThrowsExceptionWhenAdvisoryIsNotAvailable() {
+        final AlmaLinuxErrataParser parser = new AlmaLinuxErrataParser();
+        final Errata errata = createErrata(null, ErrataFactory.ERRATA_TYPE_SECURITY,
+                LocalDate.of(2021, Month.OCTOBER, 21), 1L);
+
+        try {
+            parser.getAdvisoryUri(errata);
+            fail("Expected ErrataParsingException was not thrown");
+        }
+        catch (ErrataParsingException e) {
+            assertEquals("No advisory id found for errata", e.getMessage());
+        }
+    }
+}

--- a/java/code/src/com/suse/manager/errata/test/AmazonErrataParserTest.java
+++ b/java/code/src/com/suse/manager/errata/test/AmazonErrataParserTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.errata.test;
+
+import com.redhat.rhn.domain.errata.Errata;
+import com.redhat.rhn.domain.errata.ErrataFactory;
+
+import com.suse.manager.errata.AmazonErrataParser;
+import com.suse.manager.errata.ErrataParsingException;
+
+import java.net.URI;
+import java.time.LocalDate;
+import java.time.Month;
+
+/**
+ * Tests for {@link AmazonErrataParser}
+ */
+public class AmazonErrataParserTest extends BaseErrataTestCase {
+
+    /**
+     * Test to ensure correct parsing of the url and the id for Amazon Linux 2.
+     */
+    public void testCanBuildValidLinkAndIdForAL2() throws ErrataParsingException {
+
+        final AmazonErrataParser parser = new AmazonErrataParser();
+        final Errata errata = createErrata("ALAS2-2021-1710", ErrataFactory.ERRATA_TYPE_SECURITY,
+                LocalDate.of(2021, Month.SEPTEMBER, 30), 1L);
+
+        final String id = parser.getAnnouncementId(errata);
+        final URI uri = parser.getAdvisoryUri(errata);
+
+        assertEquals("ALAS-2021-1710", id);
+        assertEquals("https://alas.aws.amazon.com/AL2/ALAS-2021-1710.html", uri.toString());
+    }
+
+    /**
+     * Test to ensure correct parsing of the url and the id for Amazon Linux 1.
+     */
+    public void testCanBuildValidLinkAndIdForAL1() throws ErrataParsingException {
+
+        final AmazonErrataParser parser = new AmazonErrataParser();
+        final Errata errata = createErrata("ALAS-2021-1538", ErrataFactory.ERRATA_TYPE_SECURITY,
+                LocalDate.of(2021, Month.SEPTEMBER, 30), 1L);
+
+        final String id = parser.getAnnouncementId(errata);
+        final URI uri = parser.getAdvisoryUri(errata);
+
+        assertEquals("ALAS-2021-1538", id);
+        assertEquals("https://alas.aws.amazon.com/ALAS-2021-1538.html", uri.toString());
+    }
+
+    /**
+     * Test the behaviour when the advisory code is null.
+     */
+    public void testThrowsExceptionWhenAdvisoryIsNull() {
+
+        final AmazonErrataParser parser = new AmazonErrataParser();
+        final Errata errata = createErrata("WRONGFORMAT123", ErrataFactory.ERRATA_TYPE_SECURITY,
+                LocalDate.of(2012, Month.OCTOBER, 21), 1L);
+
+        try {
+            parser.getAdvisoryUri(errata);
+            fail("Expected ErrataParsingException was not thrown");
+        }
+        catch (ErrataParsingException e) {
+            assertEquals("Unsupported advisory format WRONGFORMAT123", e.getMessage());
+        }
+    }
+
+    /**
+     * Test the behaviour when the advisory code contains an invalid prefix
+     */
+    public void testThrowsExceptionWhenPrefixIsUnknown() {
+
+        final AmazonErrataParser parser = new AmazonErrataParser();
+        final Errata errata = createErrata("WRONG-2012-1567", ErrataFactory.ERRATA_TYPE_SECURITY,
+                LocalDate.of(2012, Month.OCTOBER, 21), 1L);
+
+        try {
+            parser.getAdvisoryUri(errata);
+            fail("Expected ErrataParsingException was not thrown");
+        }
+        catch (ErrataParsingException e) {
+            assertEquals("Unsupported advisory prefix WRONG", e.getMessage());
+        }
+    }
+
+    /**
+     * Test the behaviour when the advisory code format is wrong
+     */
+    public void testThrowsExceptionWhenFormatIsUnknown() {
+
+        final AmazonErrataParser parser = new AmazonErrataParser();
+        final Errata errata = createErrata(null, ErrataFactory.ERRATA_TYPE_SECURITY,
+                LocalDate.of(2012, Month.OCTOBER, 21), 1L);
+
+        try {
+            parser.getAdvisoryUri(errata);
+            fail("Expected ErrataParsingException was not thrown");
+        }
+        catch (ErrataParsingException e) {
+            assertEquals("No advisory id found for errata", e.getMessage());
+        }
+    }
+}

--- a/java/code/src/com/suse/manager/errata/test/BaseErrataTestCase.java
+++ b/java/code/src/com/suse/manager/errata/test/BaseErrataTestCase.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.errata.test;
+
+import com.redhat.rhn.domain.errata.Errata;
+import com.redhat.rhn.testing.RhnBaseTestCase;
+
+import java.sql.Date;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+
+/**
+ * Base class for testing implementations of {@link com.suse.manager.errata.VendorSpecificErrataParser}
+ */
+abstract class BaseErrataTestCase extends RhnBaseTestCase {
+
+    /**
+     * Builds a test errata object
+     */
+    protected Errata createErrata(String advisory, String type, LocalDate issedDate, Long release) {
+        final Errata errata = new Errata();
+
+        if (issedDate != null) {
+            errata.setIssueDate(Date.from(issedDate.atStartOfDay(ZoneOffset.systemDefault()).toInstant()));
+        }
+
+        errata.setAdvisory(advisory);
+        errata.setAdvisoryRel(release);
+        errata.setAdvisoryType(type);
+        return errata;
+    }
+
+
+}

--- a/java/code/src/com/suse/manager/errata/test/OracleErrataParserTest.java
+++ b/java/code/src/com/suse/manager/errata/test/OracleErrataParserTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.errata.test;
+
+import com.redhat.rhn.domain.errata.Errata;
+import com.redhat.rhn.domain.errata.ErrataFactory;
+
+import com.suse.manager.errata.ErrataParsingException;
+import com.suse.manager.errata.OracleErrataParser;
+
+import java.net.URI;
+import java.time.LocalDate;
+import java.time.Month;
+
+/**
+ * Test for {@link OracleErrataParser}
+ */
+public class OracleErrataParserTest extends BaseErrataTestCase {
+
+    /**
+     * Test to ensure correct parsing of the url and the id in a valid case.
+     */
+    public void testCanBuildValidLinkAndId() throws ErrataParsingException {
+
+        final OracleErrataParser parser = new OracleErrataParser();
+        final Errata errata = createErrata("ELSA-2021-3791", ErrataFactory.ERRATA_TYPE_SECURITY,
+                LocalDate.of(2021, Month.OCTOBER, 22), 1L);
+
+        final String id = parser.getAnnouncementId(errata);
+        final URI uri = parser.getAdvisoryUri(errata);
+
+        assertEquals("ELSA-2021-3791", id);
+        assertEquals("https://linux.oracle.com/errata/ELSA-2021-3791.html", uri.toString());
+    }
+
+    /**
+     * Test the behaviour when the advisory code is null.
+     */
+    public void testThrowsExceptionWhenAdvisoryIsNotAvailable() {
+        final OracleErrataParser parser = new OracleErrataParser();
+        final Errata errata = createErrata(null, ErrataFactory.ERRATA_TYPE_SECURITY,
+                LocalDate.of(2019, Month.FEBRUARY, 8), 1L);
+
+        try {
+            parser.getAdvisoryUri(errata);
+            fail("Expected ErrataParsingException was not thrown");
+        }
+        catch (ErrataParsingException e) {
+            assertEquals("No advisory id found for errata", e.getMessage());
+        }
+    }
+}

--- a/java/code/src/com/suse/manager/errata/test/RedhatErrataParserTest.java
+++ b/java/code/src/com/suse/manager/errata/test/RedhatErrataParserTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.errata.test;
+
+import com.redhat.rhn.domain.errata.Errata;
+import com.redhat.rhn.domain.errata.ErrataFactory;
+
+import com.suse.manager.errata.ErrataParsingException;
+import com.suse.manager.errata.RedhatErrataParser;
+
+import java.net.URI;
+import java.time.LocalDate;
+import java.time.Month;
+
+/**
+ * Tests for {@link RedhatErrataParser}
+ */
+public class RedhatErrataParserTest extends BaseErrataTestCase {
+
+    /**
+     * Test to ensure correct parsing of the url and the id in a valid case.
+     */
+    public void testCanBuildValidLinkAndId() throws ErrataParsingException {
+
+        final RedhatErrataParser parser = new RedhatErrataParser();
+        final Errata errata = createErrata("RHBA-2021:3831", ErrataFactory.ERRATA_TYPE_BUG,
+                LocalDate.of(2021, Month.OCTOBER, 20), 1L);
+
+        final String id = parser.getAnnouncementId(errata);
+        final URI uri = parser.getAdvisoryUri(errata);
+
+        assertEquals("RHBA-2021:3831", id);
+        assertEquals("https://access.redhat.com/errata/RHBA-2021:3831", uri.toString());
+    }
+
+    /**
+     * Test the behaviour when the advisory code is null.
+     */
+    public void testThrowsExceptionWhenAdvisoryIsNotAvailable() {
+        final RedhatErrataParser parser = new RedhatErrataParser();
+        final Errata errata = createErrata(null, ErrataFactory.ERRATA_TYPE_SECURITY,
+                LocalDate.of(2019, Month.FEBRUARY, 8), 1L);
+
+        try {
+            parser.getAdvisoryUri(errata);
+            fail("Expected ErrataParsingException was not thrown");
+        }
+        catch (ErrataParsingException e) {
+            assertEquals("No advisory id found for errata", e.getMessage());
+        }
+    }
+}

--- a/java/code/src/com/suse/manager/errata/test/RockyLinuxErrataParserTest.java
+++ b/java/code/src/com/suse/manager/errata/test/RockyLinuxErrataParserTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.errata.test;
+
+import com.redhat.rhn.domain.errata.Errata;
+import com.redhat.rhn.domain.errata.ErrataFactory;
+
+import com.suse.manager.errata.ErrataParsingException;
+import com.suse.manager.errata.RockyLinuxErrataParser;
+
+import java.net.URI;
+import java.time.LocalDate;
+import java.time.Month;
+
+/**
+ * Tests for {@link RockyLinuxErrataParser}
+ */
+public class RockyLinuxErrataParserTest extends BaseErrataTestCase {
+
+    /**
+     * Test to ensure correct parsing of the url and the id in a valid case.
+     */
+    public void testCanBuildValidLinkAndId() throws ErrataParsingException {
+
+        final RockyLinuxErrataParser parser = new RockyLinuxErrataParser();
+        final Errata errata = createErrata("RLSA-2021:3893", ErrataFactory.ERRATA_TYPE_BUG,
+                LocalDate.of(2021, Month.OCTOBER, 21), 1L);
+
+        final String id = parser.getAnnouncementId(errata);
+        final URI uri = parser.getAdvisoryUri(errata);
+
+        assertEquals("RLSA-2021:3893", id);
+        assertEquals("https://errata.rockylinux.org/RLSA-2021:3893", uri.toString());
+    }
+
+    /**
+     * Test the behaviour when the advisory code is null.
+     */
+    public void testThrowsExceptionWhenAdvisoryIsNotAvailable() {
+        final RockyLinuxErrataParser parser = new RockyLinuxErrataParser();
+        final Errata errata = createErrata(null, ErrataFactory.ERRATA_TYPE_SECURITY,
+                LocalDate.of(2019, Month.FEBRUARY, 8), 1L);
+
+        try {
+            parser.getAdvisoryUri(errata);
+            fail("Expected ErrataParsingException was not thrown");
+        }
+        catch (ErrataParsingException e) {
+            assertEquals("No advisory id found for errata", e.getMessage());
+        }
+    }
+
+}

--- a/java/code/src/com/suse/manager/errata/test/SUSEErrataParserTest.java
+++ b/java/code/src/com/suse/manager/errata/test/SUSEErrataParserTest.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.errata.test;
+
+import com.redhat.rhn.domain.errata.Errata;
+import com.redhat.rhn.domain.errata.ErrataFactory;
+import com.redhat.rhn.testing.RhnBaseTestCase;
+
+import com.suse.manager.errata.ErrataParsingException;
+import com.suse.manager.errata.SUSEErrataParser;
+
+import java.net.URI;
+import java.sql.Date;
+import java.time.LocalDate;
+import java.time.Month;
+import java.time.ZoneOffset;
+
+/**
+ * Tests class for {@link SUSEErrataParser}
+ */
+public class SUSEErrataParserTest extends RhnBaseTestCase {
+
+    /**
+     * Test to ensure correct parsing of the url and the id in a valid case.
+     */
+    public void testCanBuildValidLinkAndId() throws ErrataParsingException {
+
+        final SUSEErrataParser parser = new SUSEErrataParser();
+        final Errata errata = createErrata("avahi-13947", ErrataFactory.ERRATA_TYPE_SECURITY,
+                LocalDate.of(2019, Month.FEBRUARY, 8), 1L);
+
+        final String id = parser.getAnnouncementId(errata);
+        final URI uri = parser.getAdvisoryUri(errata);
+
+        assertEquals("SUSE-SU-2019:13947-1", id);
+        assertEquals("https://www.suse.com/support/update/announcement/2019/suse-su-201913947-1/", uri.toString());
+    }
+
+    /**
+     * Test to verify the required leading zeros are added
+     */
+    public void testAddsLeadingZeroWhenIdIsLessThanFourDigits() throws ErrataParsingException {
+
+        final SUSEErrataParser parser = new SUSEErrataParser();
+        final Errata errata = createErrata("SUSE-15-2020-683", ErrataFactory.ERRATA_TYPE_BUG,
+                LocalDate.of(2020, Month.MARCH, 13), 1L);
+
+        final String id = parser.getAnnouncementId(errata);
+        final URI uri = parser.getAdvisoryUri(errata);
+
+        assertEquals("SUSE-RU-2020:0683-1", id);
+        assertEquals("https://www.suse.com/support/update/announcement/2020/suse-ru-20200683-1/", uri.toString());
+    }
+
+    /**
+     * Test the behaviour when the issue date is null.
+     */
+    public void testThrowsExceptionWhenIssueDateIsNull() {
+
+        final SUSEErrataParser parser = new SUSEErrataParser();
+        final Errata errata = createErrata("SUSE-15-2020-683", ErrataFactory.ERRATA_TYPE_BUG, null, 1L);
+
+        try {
+            parser.getAdvisoryUri(errata);
+            fail("Expected ErrataParsingException was not thrown");
+        }
+        catch (ErrataParsingException e) {
+            assertEquals("Issue date is null", e.getMessage());
+        }
+    }
+
+    /**
+     * Test the behaviour when the advisory id is not a valid number
+     */
+    public void testThrowsExceptionWhenUnableToParseAdvisoryId() {
+
+        final SUSEErrataParser parser = new SUSEErrataParser();
+        final Errata errata = createErrata("wrong-advisory-format", ErrataFactory.ERRATA_TYPE_BUG,
+                LocalDate.of(2020, Month.MARCH, 13), 1L);
+
+        try {
+            parser.getAdvisoryUri(errata);
+            fail("Expected ErrataParsingException was not thrown");
+        }
+        catch (ErrataParsingException e) {
+            assertEquals("Unable to parse the advisory id number from wrong-advisory-format", e.getMessage());
+        }
+    }
+
+    /**
+     * Test the behaviour when the format of the advisory code is not expected.
+     */
+    public void testThrowsExceptionWhenAdvisoryIsNotInTheExpectedFormat() {
+
+        final SUSEErrataParser parser = new SUSEErrataParser();
+        final Errata errata = createErrata("invalid", ErrataFactory.ERRATA_TYPE_BUG,
+                LocalDate.of(2020, Month.MARCH, 13), 1L);
+
+        try {
+            parser.getAdvisoryUri(errata);
+            fail("Expected ErrataParsingException was not thrown");
+        }
+        catch (ErrataParsingException e) {
+            assertEquals("Unable to parse advisory id from invalid", e.getMessage());
+        }
+    }
+
+    /**
+     * Test the behaviour when the release number is not valid
+     */
+    public void testThrowsExceptionWhenReleaseIsInvalid() {
+
+        final SUSEErrataParser parser = new SUSEErrataParser();
+        final Errata errata = createErrata("SUSE-15-2020-683", ErrataFactory.ERRATA_TYPE_BUG,
+                LocalDate.of(2020, Month.MARCH, 13), 0L);
+
+        try {
+            parser.getAdvisoryUri(errata);
+            fail("Expected ErrataParsingException was not thrown");
+        }
+        catch (ErrataParsingException e) {
+            assertEquals("Invalid advisory release number 0", e.getMessage());
+        }
+    }
+
+    /**
+     * Test the behaviour when the type of advisory is not valid.
+     */
+    public void testThrowsExceptionWhenTypeIsInvalid() {
+
+        final SUSEErrataParser parser = new SUSEErrataParser();
+        final Errata errata = createErrata("SUSE-15-2020-683", "invalidType",
+                LocalDate.of(2020, Month.MARCH, 13), 1L);
+
+        try {
+            parser.getAdvisoryUri(errata);
+            fail("Expected ErrataParsingException was not thrown");
+        }
+        catch (ErrataParsingException e) {
+            assertEquals("Unsupported advisory type invalidType", e.getMessage());
+        }
+    }
+
+    /**
+     * Test the behaviour when the type of advisory is null.
+     */
+    public void testThrowsExceptionWhenTypeIsNull() {
+
+        final SUSEErrataParser parser = new SUSEErrataParser();
+        final Errata errata = createErrata("SUSE-15-2020-683", null,
+                LocalDate.of(2020, Month.MARCH, 13), 1L);
+
+        try {
+            parser.getAdvisoryUri(errata);
+            fail("Expected ErrataParsingException was not thrown");
+        }
+        catch (ErrataParsingException e) {
+            assertEquals("Advisory type is null", e.getMessage());
+        }
+    }
+
+    /**
+     * Test the behaviour when the advisory is too old to correctly generate a link
+     */
+    public void testCanParseFirstValidIssueDate() throws ErrataParsingException {
+
+        final SUSEErrataParser parser = new SUSEErrataParser();
+        final Errata errata = createErrata("SUSE-2019-0002", ErrataFactory.ERRATA_TYPE_SECURITY,
+                LocalDate.of(2019, Month.JANUARY, 1), 1L);
+
+        final String id = parser.getAnnouncementId(errata);
+        final URI uri = parser.getAdvisoryUri(errata);
+
+        assertEquals("SUSE-SU-2019:0002-1", id);
+        assertEquals("https://www.suse.com/support/update/announcement/2019/suse-su-20190002-1/", uri.toString());
+
+    }
+
+    /**
+     * Test the behaviour when the advisory is too old to correctly generate a link
+     */
+    public void testThrowsExceptionWhenAdvisoryIsTooOld() {
+
+        final SUSEErrataParser parser = new SUSEErrataParser();
+        final Errata errata = createErrata("salt-201811-13898", ErrataFactory.ERRATA_TYPE_SECURITY,
+                LocalDate.of(2018, Month.NOVEMBER, 26), 1L);
+
+        try {
+            parser.getAdvisoryUri(errata);
+            fail("Expected ErrataParsingException was not thrown");
+        }
+        catch (ErrataParsingException e) {
+            assertEquals("Unable to parse an advisory issued before 2019", e.getMessage());
+        }
+    }
+
+    private Errata createErrata(String advisory, String type, LocalDate issedDate, Long release) {
+        final Errata errata = new Errata();
+
+        if (issedDate != null) {
+            errata.setIssueDate(Date.from(issedDate.atStartOfDay(ZoneOffset.systemDefault()).toInstant()));
+        }
+
+        errata.setAdvisory(advisory);
+        errata.setErrataFrom("maint-coord@suse.de");
+        errata.setAdvisoryRel(release);
+        errata.setAdvisoryType(type);
+        return errata;
+    }
+
+}

--- a/java/code/src/com/suse/manager/errata/test/SUSEErrataParserTest.java
+++ b/java/code/src/com/suse/manager/errata/test/SUSEErrataParserTest.java
@@ -16,21 +16,18 @@ package com.suse.manager.errata.test;
 
 import com.redhat.rhn.domain.errata.Errata;
 import com.redhat.rhn.domain.errata.ErrataFactory;
-import com.redhat.rhn.testing.RhnBaseTestCase;
 
 import com.suse.manager.errata.ErrataParsingException;
 import com.suse.manager.errata.SUSEErrataParser;
 
 import java.net.URI;
-import java.sql.Date;
 import java.time.LocalDate;
 import java.time.Month;
-import java.time.ZoneOffset;
 
 /**
  * Tests class for {@link SUSEErrataParser}
  */
-public class SUSEErrataParserTest extends RhnBaseTestCase {
+public class SUSEErrataParserTest extends BaseErrataTestCase {
 
     /**
      * Test to ensure correct parsing of the url and the id in a valid case.
@@ -204,20 +201,6 @@ public class SUSEErrataParserTest extends RhnBaseTestCase {
         catch (ErrataParsingException e) {
             assertEquals("Unable to parse an advisory issued before 2019", e.getMessage());
         }
-    }
-
-    private Errata createErrata(String advisory, String type, LocalDate issedDate, Long release) {
-        final Errata errata = new Errata();
-
-        if (issedDate != null) {
-            errata.setIssueDate(Date.from(issedDate.atStartOfDay(ZoneOffset.systemDefault()).toInstant()));
-        }
-
-        errata.setAdvisory(advisory);
-        errata.setErrataFrom("maint-coord@suse.de");
-        errata.setAdvisoryRel(release);
-        errata.setAdvisoryType(type);
-        return errata;
     }
 
 }

--- a/java/code/src/com/suse/manager/errata/test/SUSERESErrataParserTest.java
+++ b/java/code/src/com/suse/manager/errata/test/SUSERESErrataParserTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.suse.manager.errata.test;
+
+import com.redhat.rhn.domain.errata.Errata;
+import com.redhat.rhn.domain.errata.ErrataFactory;
+
+import com.suse.manager.errata.ErrataParsingException;
+import com.suse.manager.errata.SUSERESErrataParser;
+
+import java.net.URI;
+import java.time.LocalDate;
+import java.time.Month;
+
+/**
+ * Tests for {@link SUSERESErrataParser}
+ */
+public class SUSERESErrataParserTest extends BaseErrataTestCase {
+
+    /**
+     * Test to ensure correct parsing of the url and the id in a valid case.
+     */
+    public void testCanBuildValidLinkAndId() throws ErrataParsingException {
+
+        final SUSERESErrataParser parser = new SUSERESErrataParser();
+        final Errata errata = createErrata("RHSA-2021:3666", ErrataFactory.ERRATA_TYPE_BUG,
+                LocalDate.of(2021, Month.SEPTEMBER, 27), 1L);
+
+        final String id = parser.getAnnouncementId(errata);
+        final URI uri = parser.getAdvisoryUri(errata);
+
+        assertEquals("RHSA-2021:3666", id);
+        assertEquals("https://access.redhat.com/errata/RHSA-2021:3666", uri.toString());
+    }
+
+    /**
+     * Test the behaviour when the advisory code is null.
+     */
+    public void testThrowsExceptionWhenAdvisoryIsNotAvailable() {
+        final SUSERESErrataParser parser = new SUSERESErrataParser();
+        final Errata errata = createErrata(null, ErrataFactory.ERRATA_TYPE_SECURITY,
+                LocalDate.of(2019, Month.FEBRUARY, 8), 1L);
+
+        try {
+            parser.getAdvisoryUri(errata);
+            fail("Expected ErrataParsingException was not thrown");
+        }
+        catch (ErrataParsingException e) {
+            assertEquals("No advisory id found for errata", e.getMessage());
+        }
+    }
+
+    /**
+     * Test the behaviour when the advisory code is not valid.
+     */
+    public void testThrowsExceptionWhenAdvisoryPrefixIsInvalid() {
+        final SUSERESErrataParser parser = new SUSERESErrataParser();
+        final Errata errata = createErrata("SUSE-2021:3666", ErrataFactory.ERRATA_TYPE_SECURITY,
+                LocalDate.of(2019, Month.FEBRUARY, 8), 1L);
+
+        try {
+            parser.getAdvisoryUri(errata);
+            fail("Expected ErrataParsingException was not thrown");
+        }
+        catch (ErrataParsingException e) {
+            assertEquals("Unsupported advisory SUSE-2021:3666", e.getMessage());
+        }
+    }
+}

--- a/java/code/webapp/WEB-INF/pages/errata/details.jsp
+++ b/java/code/webapp/WEB-INF/pages/errata/details.jsp
@@ -229,6 +229,25 @@
 
     <div class="panel panel-default">
         <div class="panel-heading">
+            <h2><bean:message key="details.jsp.vendoradvisory"/></h2>
+        </div>
+        <div class="panel-body">
+            <div class="page-summary">
+                ${vendorAdvisory}
+                <c:if test="${empty vendorAdvisory}">
+                    <bean:message key="details.jsp.none"/>
+                </c:if>
+                <c:if test="${not empty vendorAdvisory}">
+                    <c:if test="${empty fn:trim(vendorAdvisory)}">
+                        <bean:message key="details.jsp.none"/>
+                    </c:if>
+                </c:if>
+            </div>
+        </div>
+    </div>
+
+    <div class="panel panel-default">
+        <div class="panel-heading">
             <h2><bean:message key="details.jsp.references"/></h2>
         </div>
         <div class="panel-body">

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Add link to the original vendor advisory in the patch details page
 - fix issue with empty action chains getting deleted too early (bsc#1191377)
 - Move pickedup actions to history as soon as they are pickedup (bsc#1191444)
 - Add additional matchers to package (nevra) filter


### PR DESCRIPTION
## What does this PR change?

This PR adds a link in the patch details page to the original vendor advisory. At the moment only SUSE is supported. More vendor will be added.

## GUI diff

After: 
  * A new section in the patch details page that show the vendor advisory link

![Patch Detail - 0 - top](https://user-images.githubusercontent.com/2292684/138723374-dcdf6abf-3aea-48db-9b2d-7aaea14365a3.png)
![Patch Detail - 1 - bottom](https://user-images.githubusercontent.com/2292684/138723420-ae98014a-b76f-4f30-9b0a-3e7c85462f45.png)

- [X] **DONE**

## Documentation
- [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pull/1251)


- [X] **DONE**

## Test coverage
- Unit tests were added
- Cucumber tests were added

- [X] **DONE**

## Links

Fixes SUSE/spacewalk/issues/14409

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [X] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
