### PR TITLE
Fix build-packages-local-obs.sh: Avoid multiple obscpio files

### DIFF
--- a/rel-eng/build-packages-local-obs.sh
+++ b/rel-eng/build-packages-local-obs.sh
@@ -142,6 +142,8 @@ for PACKAGE in ${PACKAGES}; do
     echo "ERROR: ${OSC_PROJECT_WC}/${PACKAGE} does not exist! Do you need to checkout the package?"
     exit 1
   fi
+  # Remove the package content, not the metadata
+  rm ${OSC_PROJECT_WC}/${PACKAGE}/*
   cp /tmp/push-packages-to-obs/SRPMS/${PACKAGE}/* ${OSC_PROJECT_WC}/${PACKAGE}
   cd ${OSC_PROJECT_WC}/${PACKAGE}
   set +e
@@ -174,7 +176,7 @@ else
   for PACKAGE in ${PACKAGES}; do
     echo "Reverting ${PACKAGE}..."
     cd ${OSC_PROJECT_WC}/${PACKAGE}
-    ${OSC} revert * || true # Tolerate errors, in case there are untracked files
+    ${OSC} revert . || true # Tolerate errors, in case there are untracked files
   done
 fi
 exit 0 


### PR DESCRIPTION
## What does this PR change?

Fix build-packages-local-obs.sh: Avoid multiple obscpio files.

The script was copying all the files generated by `build-packages-for-obs.sh` to the target working copy, so the original `.obscpio` file was kept.

Since the `_service` file handles all the `.obscpio` files, in some situations the `.obscpio` from the working copy had a "higher" filename, which means the one from `build-packages-for-obs.sh` was unpacked first, the one from the working copy in the second place. As a result new files were kept, but existing packages lost the changes from `build-packages-for-obs.sh`

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Bugfix

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/16142, requires backport to the SUSE Manager branches.

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
