### PR TITLE
Fix package update action with shared channels

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/errata/Errata.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/errata/Errata.hbm.xml
@@ -189,6 +189,22 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         <return-scalar column="pid" type="long" />
         <return-scalar column="sid" type="long" />
     </sql-query>
+
+    <sql-query name="Errata.retractedPackagesByNevra">
+        <![CDATA[
+            SELECT pid, sid
+            FROM suseServerChannelsRetractedPackagesView
+                JOIN rhnpackage p on p.id = pid
+                JOIN rhnpackagename pn on pn.id = p.name_id
+                JOIN rhnpackageevr pevr on pevr.id = p.evr_id
+                JOIN rhnpackagearch parch on parch.id = p.package_arch_id
+            WHERE (pn.name || '-' || COALESCE(pevr.epoch || ':', '') || pevr.version || '-' || pevr.release || '.' || parch.label) in (:nevras)
+                AND sid in (:sids)
+        ]]>
+        <return-scalar column="pid" type="long" />
+        <return-scalar column="sid" type="long" />
+    </sql-query>
+
     <sql-query name="Errata.searchById">
         <![CDATA[select distinct e.id, e.advisory, e.advisory_name as advisoryName,
                     e.advisory_type as advisoryType, e.synopsis as advisorySynopsis,

--- a/java/code/src/com/redhat/rhn/domain/errata/ErrataFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/errata/ErrataFactory.java
@@ -810,6 +810,23 @@ public class ErrataFactory extends HibernateFactory {
     }
 
     /**
+     * Takes a set of packages that should be installed on a set of systems and checks whether there are
+     * and packages that are retracted. A packages counts as retracted for a server if it is contained
+     * in any retracted errata of a channel assigned to the system.
+     *
+     * @param nevras package nevras as formatted string
+     * @param sids server ids
+     * @return pairs of package and server ids of packages that are retracted for a given server.
+     */
+    public static List<Tuple2<Long, Long>> retractedPackagesByNevra(List<String> nevras, List<Long> sids) {
+        Map<String, Object> params = new HashMap<>();
+        params.put("nevras", nevras);
+        params.put("sids", sids);
+        List<Object[]> results = singleton.listObjectsByNamedQuery("Errata.retractedPackagesByNevra", params);
+        return results.stream().map(r -> new Tuple2<>((long)r[0], (long)r[1])).collect(Collectors.toList());
+    }
+
+    /**
      * Returns a list of ErrataOverview that match the given errata ids.
      * @param eids Errata ids.
      * @param org Organization to match results with

--- a/java/code/src/com/redhat/rhn/domain/errata/test/ErrataFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/errata/test/ErrataFactoryTest.java
@@ -32,13 +32,19 @@ import com.redhat.rhn.domain.errata.ErrataFile;
 import com.redhat.rhn.domain.errata.Severity;
 import com.redhat.rhn.domain.org.Org;
 import com.redhat.rhn.domain.org.OrgFactory;
+import com.redhat.rhn.domain.product.Tuple2;
 import com.redhat.rhn.domain.rhnpackage.Package;
 import com.redhat.rhn.domain.rhnpackage.PackageEvr;
 import com.redhat.rhn.domain.rhnpackage.PackageEvrFactory;
+import com.redhat.rhn.domain.rhnpackage.PackageFactory;
+import com.redhat.rhn.domain.rhnpackage.PackageType;
+import com.redhat.rhn.domain.rhnpackage.test.PackageEvrFactoryTest;
 import com.redhat.rhn.domain.rhnpackage.test.PackageTest;
 import com.redhat.rhn.domain.server.InstalledPackage;
+import com.redhat.rhn.domain.server.MinionServer;
 import com.redhat.rhn.domain.server.Server;
 import com.redhat.rhn.domain.server.ServerFactory;
+import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
 import com.redhat.rhn.domain.server.test.ServerFactoryTest;
 import com.redhat.rhn.frontend.action.channel.manage.ErrataHelper;
 import com.redhat.rhn.frontend.dto.ErrataCacheDto;
@@ -469,6 +475,59 @@ public class ErrataFactoryTest extends BaseTestCaseWithUser {
         assertFalse(ErrataFactory.listErrata(
                 Set.of(original.getId()), user.getOrg().getId()).iterator().next().isCloned());
         assertTrue(ErrataFactory.listErrata(Set.of(clone.getId()), user.getOrg().getId()).iterator().next().isCloned());
+    }
+
+    /**
+     * Tests that retrieving reatracted packages for systems by nevra works correctly
+     *
+     * @throws Exception if anything goes wrong
+     */
+    public void testRetractedPackagesByNevra() throws Exception {
+        MinionServer testMinionServer = MinionServerFactoryTest.createTestMinionServer(user);
+        Channel channel = ChannelFactoryTest.createTestChannel(user);
+        SystemManager.subscribeServerToChannel(user, testMinionServer, channel);
+
+        Errata retracted = ErrataFactoryTest.createTestErrata(user.getOrg().getId());
+        Errata notRetracted = ErrataFactoryTest.createTestErrata(user.getOrg().getId());
+        retracted.setAdvisoryStatus(AdvisoryStatus.RETRACTED);
+        retracted.addChannel(channel);
+        notRetracted.addChannel(channel);
+
+        List<Package> packages = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            Package retractedPack = ErrataTestUtils.createTestPackage(user, retracted, channel, "x86_64");
+            Package notRetractedPack = ErrataTestUtils.createTestPackage(user, notRetracted, channel, "x86_64");
+            if (i % 2 == 0) {
+                // Set EVR without epoch
+                PackageEvr evr = PackageEvrFactoryTest.createTestPackageEvr(
+                        null,
+                        i + "." + (i + 1) + "." + (i + 2),
+                        String.valueOf(i * 10),
+                        PackageType.RPM
+                );
+                retractedPack.setPackageEvr(evr);
+                notRetractedPack.setPackageEvr(evr);
+            }
+            packages.add(retractedPack);
+            packages.add(notRetractedPack);
+        }
+
+        List<Tuple2<Long, Long>> retractedPackages = ErrataFactory.retractedPackagesByNevra(
+                packages.stream().map(p ->
+                        p.getPackageName().getName() + "-" +
+                                p.getPackageEvr().toUniversalEvrString() + "." +
+                                p.getPackageArch().getLabel()
+                ).collect(Collectors.toList()),
+                List.of(testMinionServer.getId())
+        );
+
+        assertNotNull(retractedPackages);
+        assertEquals(10, retractedPackages.size());
+        assertEquals(
+                retractedPackages.stream().map(t -> PackageFactory.lookupByIdAndUser(t.getA(), user))
+                        .collect(Collectors.toSet()),
+                packages.stream().filter(Package::isPartOfRetractedPatch).collect(Collectors.toSet())
+        );
     }
 }
 

--- a/java/code/src/com/redhat/rhn/testing/ErrataTestUtils.java
+++ b/java/code/src/com/redhat/rhn/testing/ErrataTestUtils.java
@@ -352,7 +352,8 @@ public class ErrataTestUtils {
 
         if (errata != null) {
             errata.addPackage(result);
-            TestUtils.saveAndFlush(errata);
+            result.setErrata(Set.of(errata));
+            HibernateFactory.getSession().refresh(errata);
         }
 
         return result;

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix package update action with shared channels (bsc#1191313)
 - Implement using re-activation keys when bootstrapping with the Web UI
   or XMLRPC API
 - Show salt ssh error message in failed action details


### PR DESCRIPTION
## What does this PR change?

Fix a potential problem when updating packages if subscribed channels are shared to other organizations

**Note**: Still need to check if this also affects the traditional stack
**Update:** The tradiational stack is not affected by this issue

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: **Bugfix**

- [x] **DONE**

## Test coverage

- Unit tests added

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/16049

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"  
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
