### PR TITLE
Fix internal server error on DuplicateSystemsCompare (bsc#1191643)

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
@@ -6,7 +6,7 @@ select * from (
   SELECT  DISTINCT S.id,
                    S.name,
                    SI.server_id AS IS_RHN_SATELLITE,
-                   PI.server_id AS IS_RHN_PROXY,
+                   PI.server_id AS IS_PROXY,
                    TO_CHAR(Sinfo.checkin, 'YYYY-MM-DD HH24:MI:SS') AS LAST_CHECKIN
     FROM rhnServerInfo SInfo, rhnUserServerPerms USP, rhnServer S
     LEFT OUTER JOIN rhnSatelliteInfo SI ON S.id = SI.server_id
@@ -1286,7 +1286,7 @@ SELECT  DISTINCT ST.element AS ID
   SELECT  DISTINCT S.id,
                    S.name,
                    SI.server_id AS IS_RHN_SATELLITE,
-                   PI.server_id AS IS_RHN_PROXY,
+                   PI.server_id AS IS_PROXY,
                    TO_CHAR(Sinfo.checkin, 'YYYY-MM-DD HH24:MI:SS') AS LAST_CHECKIN,
                    SO.SECURITY_ERRATA, SO.BUG_ERRATA, SO.ENHANCEMENT_ERRATA, SO.LOCKED,
                    SO.OUTDATED_PACKAGES, SO.SERVER_NAME, SO.SERVER_ADMINS, SO.GROUP_COUNT,
@@ -1347,7 +1347,7 @@ ORDER BY S.ID
   SELECT SERVER_ID AS ID, OUTDATED_PACKAGES, SERVER_NAME, security_errata, bug_errata, enhancement_errata,
           SERVER_ADMINS, GROUP_COUNT, MODIFIED, CHANNEL_LABELS, CHANNEL_ID, HISTORY_COUNT,
           LAST_CHECKIN_DAYS_AGO, PENDING_UPDATES, OS, RELEASE,
-          SERVER_ARCH_NAME, LAST_CHECKIN, LOCKED, PROXY_ID AS IS_RHN_PROXY
+          SERVER_ARCH_NAME, LAST_CHECKIN, LOCKED, PROXY_ID AS IS_PROXY
   FROM  rhnServerOverview
   WHERE  server_id IN (%s)
 ORDER BY  UPPER(COALESCE(SERVER_NAME, '(none)')), SERVER_ID

--- a/java/code/src/com/redhat/rhn/frontend/dto/SystemOverview.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/SystemOverview.java
@@ -65,7 +65,7 @@ public class SystemOverview extends BaseDto implements Serializable  {
     private List status;
     private List actionId;
     private boolean rhnSatellite;
-    private boolean rhnProxy;
+    private boolean proxy;
     private List entitlement;
     private List serverGroupTypeId;
     private List entitlementPermanent;
@@ -154,14 +154,14 @@ public class SystemOverview extends BaseDto implements Serializable  {
     /**
      * @return Returns the isRhnProxy.
      */
-    public boolean isRhnProxy() {
-        return rhnProxy;
+    public boolean isProxy() {
+        return proxy;
     }
     /**
      * @param serverId The server id, null if not a proxy
      */
-    public void setIsRhnProxy(Long serverId) {
-        this.rhnProxy = (serverId != null);
+    public void setIsProxy(Long serverId) {
+        this.proxy = (serverId != null);
     }
     /**
      * @return Returns the isRhnSatellite.

--- a/java/code/webapp/WEB-INF/pages/common/fragments/systems/system_list_fragment.jspf
+++ b/java/code/webapp/WEB-INF/pages/common/fragments/systems/system_list_fragment.jspf
@@ -15,7 +15,7 @@
   </c:otherwise>
 </c:choose>
 
-<c:if test="${current.rhnProxy}">
+<c:if test="${current.proxy}">
   <rhn:icon type="header-proxy" title="systemlist.jsp.isproxy" />
 </c:if>
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Fix internal server error on DuplicateSystemsCompare (bsc#1191643)
 - Fix Service Package migration with pillar in database
 - Run Prometheus JMX exporter as Java agent (bsc#1184617)
 - Allow usage of jinja template in Salt config channels


### PR DESCRIPTION
Signed-off-by: Ricardo Mateus <rmateus@suse.com>

## What does this PR change?

There is one inconsistency between the property name on Server class and SystemOverview.
Server -> isProxy
SystemOverview -> isRhnProxy

This PR changes it and always uses Isproxy.
This is needed because those two different objects were used in: https://github.com/uyuni-project/uyuni/blob/master/java/code/webapp/WEB-INF/pages/common/fragments/systems/system_list_fragment.jspf#L18

## GUI diff

No difference.

Before:

After:

- [ ] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes: https://github.com/SUSE/spacewalk/issues/16130

Tracks :
Manager 4.2: 
Manager 4.1: 

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
