### PR TITLE
Fix changelog automation hook

### DIFF
--- a/.github/workflows/changelog_checker.yml
+++ b/.github/workflows/changelog_checker.yml
@@ -1,7 +1,7 @@
 name: changelog_test
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, synchronize, reopened, closed]
 
 jobs:


### PR DESCRIPTION
## What does this PR change?

The changelog automation is bugged as [discussed in chat](https://suse.slack.com/archives/C02D78LLS04/p1634548428234100). As covered in [the documentation](https://github.com/peter-evans/create-or-update-comment#action-inputs), the automation to create comments doesn't work on the `pull_request` hook for forks due to permissions. According to the docs, the right hook to use is `pull_request_target` instead.  

I tested this out across forks and it seems to work fine: https://github.com/uyuni-project/uyuni/pull/4367#issuecomment-946219332

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: Github automation.

- [x] **DONE**

## Links

Fixes: my sanity.

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
