### PR TITLE
Remove FileNotFoundError by OSError in grains and modules

### DIFF
--- a/susemanager-utils/susemanager-sls/src/grains/virt.py
+++ b/susemanager-utils/susemanager-sls/src/grains/virt.py
@@ -43,7 +43,7 @@ def features():
             libvirt_version = 0
             for idx in range(len(matcher.groups())):
                 libvirt_version += int(matcher.group(idx + 1)) * 1000 ** (len(matcher.groups()) - idx - 1)
-    except FileNotFoundError:
+    except OSError:
         log.error("libvirtd is not installed or is not in the PATH")
 
     return {

--- a/susemanager-utils/susemanager-sls/src/modules/virt_utils.py
+++ b/susemanager-utils/susemanager-sls/src/modules/virt_utils.py
@@ -63,7 +63,7 @@ def get_cluster_filesystem(path):
                         == directory_value
                     ):
                         return resource.get("id")
-    except FileNotFoundError as err:
+    except OSError as err:
         log.debug("Failed to get cluster resource name for path, %s: %s", path, err)
 
     return None
@@ -135,7 +135,7 @@ def vm_info(name=None):
             # No need to parse more XML files if we already had the ones we're looking for
             if name is not None and name_node == name:
                 break
-    except FileNotFoundError as err:
+    except OSError as err:
         log.debug("Failed to get cluster configuration: %s", err)
 
     return all_vms
@@ -159,7 +159,7 @@ def host_info():
             for node in crm_conf.findall(".//node")
             if node.get("uname") != node_name
         ]
-    except FileNotFoundError as err:
+    except OSError as err:
         log.debug("Failed to get cluster configuration: %s", err)
 
     return {
@@ -212,7 +212,7 @@ def vm_definition(uuid):
                         uuid_node = desc.find("./uuid")
                         if uuid_node is not None and uuid_node.text == uuid:
                             return {"definition": desc_content}
-        except FileNotFoundError:
+        except OSError:
             # May be this is not a cluster node
             pass
         finally:

--- a/susemanager-utils/susemanager-sls/src/tests/test_grains_virt.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_grains_virt.py
@@ -35,8 +35,8 @@ def test_features_cluster(cluster, start_resources):
   </parameters>
 </resource-agent>
 """.format(param)
-    popen_mock = MagicMock(side_effect=FileNotFoundError())
-    check_call_mock = MagicMock(side_effect=FileNotFoundError())
+    popen_mock = MagicMock(side_effect=OSError())
+    check_call_mock = MagicMock(side_effect=OSError())
     if cluster:
         popen_mock = MagicMock()
         popen_mock.return_value.communicate.side_effect = [(crm_resources, None), (b"libvirtd (libvirt) 5.1.0\n", None)]

--- a/susemanager-utils/susemanager-sls/src/tests/test_module_virt_utils.py
+++ b/susemanager-utils/susemanager-sls/src/tests/test_module_virt_utils.py
@@ -99,7 +99,7 @@ def test_get_cluster_filesystem_nocrm():
     with patch.object(virt_utils, "Path", MagicMock(wraps=virt_utils.Path)) as path_mock:
         path_mock.return_value.resolve.return_value = virt_utils.Path("/srv/clusterfs/xml")
         with patch.object(virt_utils.subprocess, "Popen", MagicMock()) as popen_mock:
-            popen_mock.return_value.communicate.side_effect = FileNotFoundError("No such file or directory: 'crm'")
+            popen_mock.return_value.communicate.side_effect = OSError("No such file or directory: 'crm'")
             assert virt_utils.get_cluster_filesystem("/srv/clusterfs/xml") == None
 
 

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Replace FileNotFoundError by python2-compatible OSError (bsc#1191139)
 - Run Prometheus JMX exporter as Java agent (bsc#1184617)
 - Fix virt_utils module python 2.6 compatibility (bsc#1191123)
 - Update proxy path on minion connection


### PR DESCRIPTION
## What does this PR change?

It's all in the title... `FileNotFoundError` doesn't exist in python 2 and `subprocess.Popen()` raises `OSError` in python2. Since that one if the base class of the `FileNotFoundError` use it in our grains and modules.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- Unit tests were changed

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
