### PR TITLE
Don't create skeleton /srv/salt/top.sls

### DIFF
--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- Don't create skeleton /srv/salt/top.sls
 - Replace FileNotFoundError by python2-compatible OSError (bsc#1191139)
 - Run Prometheus JMX exporter as Java agent (bsc#1184617)
 - Fix virt_utils module python 2.6 compatibility (bsc#1191123)

--- a/susemanager-utils/susemanager-sls/susemanager-sls.spec
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.spec
@@ -126,22 +126,6 @@ py.test%{?rhel:-3}
 # HACK! Create broken link when it will be replaces with the real file
 ln -sf %{wwwdocroot}/pub/RHN-ORG-TRUSTED-SSL-CERT \
    /usr/share/susemanager/salt/certs/RHN-ORG-TRUSTED-SSL-CERT 2>&1 ||:
-# Pre-create top.sls to suppress empty/absent top.sls warning/error (bsc#1017754)
-USERLAND="/srv/salt"
-TOP="$USERLAND/top.sls"
-if [ -d "$USERLAND" ]; then
-    if [ ! -f "$TOP" ]; then
-	cat <<EOF >> $TOP
-# This only calls no-op statement from
-# /usr/share/susemanager/salt/util/noop.sls state
-# Feel free to change it.
-
-base:
-  '*':
-    - util.noop
-EOF
-    fi
-fi
 
 %posttrans
 # Run JMX exporter as Java Agent (bsc#1184617)


### PR DESCRIPTION
## What does this PR change?

The skeleton top.sls file was working around salt-minion logging missing top.sls files as ERRORs. Even then, the top.sls file was optional when master_tops were used. salt-minion only logs on level DEBUG that a top.sls is missing, therefore this workaround is not needed anymore.

## GUI diff

No difference.

- [X] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes
- [x] **DONE**

## Test coverage
- No tests: Only a change in a `%post` scriplet, no code change

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/15970
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
