### PR TITLE
clarify where the reboot action is set to completed for salt ssh minions

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/task/sshpush/SSHPushWorkerSalt.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/sshpush/SSHPushWorkerSalt.java
@@ -89,8 +89,9 @@ public class SSHPushWorkerSalt implements QueueWorker {
     }
 
     /**
-     * Get pending actions for the given minion server and execute those where the schedule
-     * date and time has come.
+     * Looking for minions which either reached the checkin timeout and needs to be
+     * tested if they are still alive or are in "rebooting" state and needs to be checked
+     * if they are up again.
      */
     @Override
     public void run() {
@@ -112,6 +113,7 @@ public class SSHPushWorkerSalt implements QueueWorker {
                     performCheckin(m);
                 }
 
+                // update uptime, etc and set Reboot Actions to COMPLETED
                 updateSystemInfo(new MinionList(m.getMinionId()));
                 log.debug("Nothing left to do for " + m.getMinionId() + ", exiting worker");
             });

--- a/java/code/src/com/suse/manager/utils/SaltUtils.java
+++ b/java/code/src/com/suse/manager/utils/SaltUtils.java
@@ -2000,7 +2000,7 @@ public class SaltUtils {
     }
 
     /**
-     * Update the system info of the minion
+     * Update the system info of the minion and set Reboot Actions to completed
      * @param systemInfo response from salt master against util.systeminfo state
      * @param minion  minion for which information should be updated
      */


### PR DESCRIPTION
## What does this PR change?

Just update function docs to clarify where the reboot action is set to completed for salt ssh minions

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- [x] **DONE**

## Test coverage
- No tests: no code changed

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
