### PR TITLE
Revert "TEST: new file" commit from PR #4382

### DIFF
--- a/susemanager-utils/susemanager-sls/modules/pillar/foobar.py
+++ b/susemanager-utils/susemanager-sls/modules/pillar/foobar.py
@@ -1,1 +1,0 @@
-# New file


### PR DESCRIPTION
This reverts commit 8c9c8565eeace82afe0baf8fa35154ec08458554. (this was simply a test commit expected to be reverted before #4382 was merged)

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
