### PR TITLE
Add python-mako, python-gnupg and gnupg1 to Debian9 bootstrap repo (bsc#1191898)

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -682,6 +682,9 @@ PKGLISTDEBIAN9 = [
     "python2.7-minimal",
     "salt-common",
     "salt-minion",
+    "dmidecode",
+    "gnupg",
+    "gnupg1",
 ]
 
 

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,5 @@
+- Add python-mako, python-gnupg and gnupg1 to the Debian 9 bootstrap repository
+  so bootstrapping without any enabled repositories is possible (bsc#1191898)
 - Strictly require tftp for the Proxy
 - Fix syntax error on migration script (bsc#1191551)
 - Add aarch64 bootstrap repositories for CentOS 7/8, Oracle Linux 7/8,


### PR DESCRIPTION
## What does this PR change?

Backport of https://github.com/SUSE/spacewalk/pull/16209
Tracks https://github.com/SUSE/spacewalk/issues/16206