### PR TITLE
Change registry label for tests

### DIFF
--- a/testsuite/features/secondary/buildhost_docker_auth_registry.feature
+++ b/testsuite/features/secondary/buildhost_docker_auth_registry.feature
@@ -10,7 +10,7 @@ Feature: Build image with authenticated registry
     Given I am authorized as "docker" with password "docker"
     When I follow the left menu "Images > Stores"
     And I follow "Create"
-    And I enter "registry" as "label"
+    And I enter "galaxy-registry" as "label"
     And I check "useCredentials"
     And I enter URI, username and password for registry
     And I click on "create-btn"
@@ -20,7 +20,7 @@ Feature: Build image with authenticated registry
     When I follow the left menu "Images > Profiles"
     And I follow "Create"
     And I enter "registry_profile" as "label"
-    And I select "registry" from "imageStore"
+    And I select "galaxy-registry" from "imageStore"
     And I select "1-DOCKER-TEST" from "activationKey"
     And I enter "Docker/authprofile" relative to profiles as "path"
     And I click on "create-btn"
@@ -47,7 +47,7 @@ Feature: Build image with authenticated registry
 
   Scenario: Cleanup: remove authenticated image store
     When I follow the left menu "Images > Stores"
-    And I check the row with the "registry" text
+    And I check the row with the "galaxy-registry" text
     And I click on "Delete"
     And I click on the red confirmation button
     And I should see a "Image store has been deleted." text


### PR DESCRIPTION
## What does this PR change?

Change registry label for tests to match

## GUI diff

No difference.


- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
