### PR TITLE
Fix changelog checker

### DIFF
--- a/.github/scripts/changelog.rb
+++ b/.github/scripts/changelog.rb
@@ -1,16 +1,19 @@
 #! /usr/bin/ruby
+# Check if a .changes file is added/modified in a pull request *or* the "No
+# changelog needed" box in the pull request description is ticked. If neither of
+# these are true, exit 1 to fail the check.
+#
+# List of added/modified in the pull request is stored in ARGV
 require 'json'
 
-# if true we exit with 0, so the test is sucessefull. otherwise the test fail.
-def check_changelog?(pr_body, files)
-  return true if pr_body.match(/\[x\]\s+No\s+changelog\s+needed/i)
-  
-  puts 'Looking for a .changes file...'
-  files.any? { |f| f.include? '.changes' } 
+def not_needed?(pr_body)
+  pr_body.match(/\[x\]\s+No\s+changelog\s+needed/i)
 end
 
 github_event = JSON.parse(File.read(ENV['GITHUB_EVENT_PATH']))
-files = ARGV[0].split(' ')
-puts "-" * 20, "PR Description: #{github_event['pull_request']['body']}"
-puts "-" * 20, "Files modified: #{files}"
-check_changelog?(github_event['pull_request']['body'], files) ?  exit(0) : exit(1)
+pr_body = github_event['pull_request']['body']
+puts '-' * 20, "PR Description: #{github_event['pull_request']['body']}"
+puts '-' * 20, "Added or modified .changes files: #{ARGV}"
+
+exit(0) unless ARGV.empty?
+not_needed?(pr_body) ? exit(0) : exit(1)

--- a/.github/workflows/changelog_checker.yml
+++ b/.github/workflows/changelog_checker.yml
@@ -1,7 +1,7 @@
 name: changelog_test
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, synchronize, reopened, closed]
 
 jobs:

--- a/.github/workflows/changelog_checker.yml
+++ b/.github/workflows/changelog_checker.yml
@@ -14,10 +14,13 @@ jobs:
       with:
         fetch-depth: 1
     - uses: actions/setup-ruby@v1
-    - name: Run a changelog checker
+    - id: files
+      uses: Ana06/get-changed-files@v2.0.0
+      with:
+        filter: '*.changes'
+    - name: Run changelog checker
       run: |
-        files_modified=`git diff --name-only "origin/$GITHUB_BASE_REF..HEAD" | xargs`
-        ruby .github/scripts/changelog.rb "$files_modified"
+        ruby .github/scripts/changelog.rb ${{ steps.files.outputs.added_modified }}
         
   changelog_approved:
     if: github.event.action != 'closed'


### PR DESCRIPTION
## What does this PR change?
Use get-changed-files action, it also works on merged pull requests. Before, $files_modified was empty on merged pull requests and the workflow failed. Also simplified the ruby script while I was at it.

## GUI diff

No diff.

- [x] **DONE**

## Documentation
- No documentation needed: github actions only

- [x] **DONE**

## Test coverage
- No tests: github actions only

GitHub is a bit slow for me today, I want to do another manual test in my fork before ticking "done".

- [ ] **DONE**

## Links

Couldn't find any issue.

- [x] **DONE**

## Changelogs



If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
