### PR TITLE
Fix Cucumber tests for self-monitoring

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/srvmonitoring/status.sls
+++ b/susemanager-utils/susemanager-sls/salt/srvmonitoring/status.sls
@@ -22,7 +22,7 @@ jmx_taskomatic_java_config:
 
 mgr_is_prometheus_self_monitoring_enabled:
   cmd.run:
-    - name: grep -q 'prometheus_monitoring_enabled\s*=\s*1\s*$' /etc/rhn/rhn.conf
+    - name: grep -q -E 'prometheus_monitoring_enabled\s*=\s*(1|y|true|yes|on)\s*$' /etc/rhn/rhn.conf
 
 include:
   - util.syncstates

--- a/testsuite/features/secondary/srv_monitoring.feature
+++ b/testsuite/features/secondary/srv_monitoring.feature
@@ -22,12 +22,14 @@ Feature: Disable and re-enable monitoring of the server
     And I should see a list item with text "System" and a failing bullet
     And I should see a list item with text "PostgreSQL database" and a failing bullet
     And I should see a list item with text "Server self monitoring" and a warning bullet
-    And I should see a list item with text "Taskomatic (Java JMX)" and a warning bullet
-    And I should see a list item with text "Tomcat (Java JMX)" and a warning bullet
+    And I should see a list item with text "Taskomatic (Java JMX)" and a failing bullet
+    And I should see a list item with text "Tomcat (Java JMX)" and a failing bullet
     And I should see a "Restarting Tomcat and Taskomatic is needed for the configuration changes to take effect." text
     And file "/etc/rhn/rhn.conf" should contain "prometheus_monitoring_enabled = 0" on server
     And file "/etc/sysconfig/tomcat" should not contain "Dcom.sun.management.jmxremote.port=3333 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname=" on server
     And file "/etc/rhn/taskomatic.conf" should not contain "Dcom.sun.management.jmxremote.port=3334 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname=" on server
+    And file "/usr/lib/systemd/system/tomcat.service.d/jmx.conf" should not exist on server
+    And file "/usr/lib/systemd/system/taskomatic.service.d/jmx.conf" should not exist on server
 
   Scenario: Restart spacewalk services to apply config changes after disabling monitoring
     When I restart the spacewalk service
@@ -58,8 +60,10 @@ Feature: Disable and re-enable monitoring of the server
     And I should see a list item with text "Tomcat (Java JMX)" and a pending bullet
     And I should see a "Restarting Tomcat and Taskomatic is needed for the configuration changes to take effect." text
     And file "/etc/rhn/rhn.conf" should contain "prometheus_monitoring_enabled = 1" on server
-    And file "/etc/sysconfig/tomcat" should contain "Dcom.sun.management.jmxremote.port=3333 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname=" on server
-    And file "/etc/rhn/taskomatic.conf" should contain "Dcom.sun.management.jmxremote.port=3334 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname=" on server
+    And file "/etc/sysconfig/tomcat" should not contain "Dcom.sun.management.jmxremote.port=3333 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname=" on server
+    And file "/etc/rhn/taskomatic.conf" should not contain "Dcom.sun.management.jmxremote.port=3334 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Djava.rmi.server.hostname=" on server
+    And file "/usr/lib/systemd/system/tomcat.service.d/jmx.conf" should contain "jmx_prometheus_javaagent.jar=5556"
+    And file "/usr/lib/systemd/system/taskomatic.service.d/jmx.conf" should contain "jmx_prometheus_javaagent.jar=5557"
 
   Scenario: Restart spacewalk services to apply config changes after enabling monitoring
     When I restart the spacewalk service


### PR DESCRIPTION
## What does this PR change?

Update the configuration files paths and strings to examine.
This reflects the changes implemented in #4268

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Cucumber tests were updated

- [x] **DONE**

## Links

Related to #4268

- [x] **DONE**

## Changelogs

- [x] No changelog needed

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
