### PR TITLE
Master backport testsuite fix

### DIFF
--- a/testsuite/features/step_definitions/common_steps.rb
+++ b/testsuite/features/step_definitions/common_steps.rb
@@ -64,7 +64,14 @@ When(/^I wait at most (\d+) seconds until event "([^"]*)" is completed$/) do |fi
   steps %(
     When I follow "Events"
     And I follow "Pending"
-    And I wait at most #{final_timeout} seconds until I do not see "#{event}" text, refreshing the page
+  )
+  # WORKAROUND against https://bugzilla.suse.com/show_bug.cgi?id=1191444
+  #                    (events stuck in "pending")
+  # Please remove "at most 600 seconds" clause as soon as the bug is fixed,
+  # or better, change it into "at most 60 seconds", because the default
+  # timeout of 250 seconds is way too long from an usability point of view.
+  step %(I wait at most 600 seconds until I do not see "#{event}" text, refreshing the page)
+  steps %(
     And I follow "History"
     And I wait until I see "System History" text
     And I wait until I see "#{event}" text, refreshing the page


### PR DESCRIPTION
## What does this PR change?

Backport of https://github.com/SUSE/spacewalk/pull/16188 and https://github.com/SUSE/spacewalk/pull/16197/files


## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
