### PR TITLE
Removed wrong checkstyle suppressions and updated missing javadoc

### DIFF
--- a/java/buildconf/checkstyle-suppressions.xml
+++ b/java/buildconf/checkstyle-suppressions.xml
@@ -5,8 +5,4 @@
 
 <suppressions>
     <suppress checks="MissingJavadocMethod" files="[/\\]test[/\\]"/>
-  <suppress checks="MagicNumberCheck"
-    files="JavadocStyleCheck.java"
-    lines="221"/>
-  <suppress message="Missing a Javadoc comment"/>
 </suppressions>

--- a/java/code/src/com/suse/manager/webui/controllers/MinionController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/MinionController.java
@@ -433,6 +433,12 @@ public class MinionController {
         model.put("actionChains", ActionChainHelper.actionChainsJson(user));
     }
 
+    /**
+     * Add the proxies configured for  the use to the bootstrap object model
+     *
+     * @param user the user
+     * @param model the current bootstrap model
+     */
     public static void addProxies(User user, Map<String, Object> model) {
         List<Map<String, Object>> proxies = ServerFactory.lookupProxiesByOrg(user)
                 .stream()
@@ -471,6 +477,15 @@ public class MinionController {
     }
 
 
+    /**
+     * Handler for the proxy page
+     *
+     * @param request the request object
+     * @param response the response object
+     * @param user the current user
+     * @param server the current server
+     * @return the ModelAndView object to render the page
+     */
     public static ModelAndView proxy(Request request, Response response, User user, Server server) {
         Map<String, Object> data = new HashMap<>();
         data.put("entityType", "MINION");
@@ -482,6 +497,14 @@ public class MinionController {
         return new ModelAndView(data, "templates/minion/proxy.jade");
     }
 
+    /**
+     * Handler for the ssm proxy page
+     *
+     * @param request the request object
+     * @param response the response object
+     * @param user the current user
+     * @return the ModelAndView object to render the page
+     */
     public static ModelAndView ssmProxy(Request request, Response response, User user) {
         Map<String, Object> data = new HashMap<>();
         data.put("entityType", "SSM");

--- a/java/code/src/com/suse/manager/webui/controllers/MinionsAPI.java
+++ b/java/code/src/com/suse/manager/webui/controllers/MinionsAPI.java
@@ -88,7 +88,7 @@ public class MinionsAPI {
      * @param saltApiIn instance to use.
      * @param regularMinionBootstrapperIn regular bootstrapper
      * @param sshMinionBootstrapperIn ssh bootstrapper
-     * @param saltKeyUtilsIn
+     * @param saltKeyUtilsIn salt key utils instance
      */
     public MinionsAPI(SaltApi saltApiIn, SSHMinionBootstrapper sshMinionBootstrapperIn,
                       RegularMinionBootstrapper regularMinionBootstrapperIn,
@@ -257,6 +257,14 @@ public class MinionsAPI {
         }
     }
 
+    /**
+     * API endpoint to set a proxy
+     *
+     * @param req the request object
+     * @param res the response object
+     * @param user the current user
+     * @return json result of the API call
+     */
     public String setProxy(Request req, Response res, User user) {
         res.type("application/json");
         ServerSetProxyJson rq = GSON.fromJson(req.body(),

--- a/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
+++ b/java/code/src/com/suse/manager/webui/services/impl/SaltService.java
@@ -208,6 +208,15 @@ public class SaltService implements SystemQuery, SaltApi {
         }
     }
 
+    /**
+     * Synchronously executes a salt function on a single minion and returns the result.
+     *
+     * @param call the salt function
+     * @param minionId the minion server id
+     * @param <R> type of result
+     * @return an optional containing the result or empty if no result was retrieved from the minion
+     * @throws RuntimeException when a {@link SaltException} is thrown
+     */
     public <R> Optional<Result<R>> callSyncResult(LocalCall<R> call, String minionId) {
         try {
             Map<String, Result<R>> stringRMap = callSync(call, new MinionList(minionId));

--- a/java/code/src/com/suse/manager/xmlrpc/dto/SystemEventDetailsDto.java
+++ b/java/code/src/com/suse/manager/xmlrpc/dto/SystemEventDetailsDto.java
@@ -37,6 +37,9 @@ public class SystemEventDetailsDto extends SystemEventDto implements Serializabl
 
     private List<Map<String, String>> additionalInfo;
 
+    /**
+     * Default constructor.
+     */
     public SystemEventDetailsDto() {
         additionalInfo = new ArrayList<>();
     }
@@ -73,6 +76,12 @@ public class SystemEventDetailsDto extends SystemEventDto implements Serializabl
         this.additionalInfo = additionalInfoIn;
     }
 
+    /**
+     * Check if this event has the additional information specific for the event type.
+     *
+     * @return <code>true</code> when there are additional pieces of information thus {@link #getAdditionalInfo()} will
+     * return a collection with at least one valid entry.
+     */
     public boolean hasAdditionInfo() {
         return additionalInfo != null && !additionalInfo.isEmpty();
     }


### PR DESCRIPTION
## What does this PR change?

This PR fixes the `checkstyle-suppression.xml` file which contained wrong entries and fixes the javadoc of a class that was missing the documentation due to the suppressed warning.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: just a configuration fix

- [X] **DONE**

## Links

n/a

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
