### PR TITLE
Add support for formulas configuration in spacecmd group backup

### DIFF
--- a/spacecmd/spacecmd.changes
+++ b/spacecmd/spacecmd.changes
@@ -1,3 +1,6 @@
+- Include group formulas configuration in spacecmd group_backup and
+  spacecmd group_restore. This changes backup format to json,
+  previously used plain text is still supported for reading (bsc#1190462)
 - Fix interactive mode for "system_applyerrata" and "errata_apply" (bsc#1194363)
 
 -------------------------------------------------------------------

--- a/spacecmd/src/spacecmd/group.py
+++ b/spacecmd/src/spacecmd/group.py
@@ -277,11 +277,20 @@ def do_group_backup(self, args):
     for group in groups:
         print(_("Backup Group: %s") % group)
         details = self.client.systemgroup.getDetails(self.session, group)
+        formulas = self.client.formula.getFormulasByGroupId(self.session, details['id'])
+        formula_data = {}
+        for f in formulas:
+            formula_data[f] = self.client.formula.getGroupFormulaData(self.session, details['id'], f)
+
         outputpath = outputpath_base + "/" + group
         print(_("Output File: %s") % outputpath)
-        fh = open(outputpath, 'w')
-        fh.write(details['description'])
-        fh.close()
+
+        backup = {
+            'description': details['description'],
+            'formulas': formula_data
+        }
+
+        json_dump_to_file(backup, outputpath)
 
     return 0
 
@@ -355,36 +364,68 @@ def do_group_restore(self, args):
 
     for groupname in self.do_group_list('', True):
         details = self.client.systemgroup.getDetails(self.session, groupname)
-        current[groupname] = details['description']
-        current[groupname] = current[groupname].rstrip('\n')
+        formulas = self.client.formula.getFormulasByGroupId(self.session, details['id'])
+        formula_data = {}
+        for f in formulas:
+            formula_data[f] = self.client.formula.getGroupFormulaData(self.session, details['id'], f)
+
+        current[groupname] = {
+            'description': details['description'],
+            'id': details['id'],
+            'formulas': formula_data
+        }
 
     for groupname in files:
-        fh = open(files[groupname], 'r')
-        details = fh.read()
-        fh.close()
-        details = details.rstrip('\n')
-
-        if groupname in current and current[groupname] == details:
-            logging.error(_N("Group %s already restored") % groupname)
-            continue
+        backup = json_read_from_file(files[groupname])
+        if backup is None:
+            # assume old backup, not in json format. Read complete file as string
+            logging.info(_("Assuming group to be in old plain text format"))
+            with open(files[groupname], 'r') as fh:
+                details = fh.read()
+            backup = {
+                'description': details.rstrip('\n'),
+                'formulas': {}
+            }
 
         if groupname in current:
-            logging.debug("Already have %s but the description has changed" % groupname)
-
-            if is_interactive(options):
-                print(_("Changing description from:"))
-                print("\n\"%s\"\nto\n\"%s\"\n" % (current[groupname], details))
-                userinput = prompt_user(_('Continue [y/N]:'))
-
-                if re.match('y', userinput, re.I):
-                    logging.info(_N("Updating description for group: %s") % groupname)
-                    self.client.systemgroup.update(self.session, groupname, details)
+            # pass id to the backup structure, so that comparison works
+            backup['id'] = current[groupname]['id']
+            if current[groupname] == backup:
+                logging.error(_N("Group %s already restored") % groupname)
             else:
-                logging.info(_N("Updating description for group: %s") % groupname)
-                self.client.systemgroup.update(self.session, groupname, details)
+                logging.debug("Already have %s but the data have changed" % groupname)
+
+                if is_interactive(options):
+                    if current[groupname]['description'] != backup['description']:
+                        print(_("Changing description from:"))
+                        print("\n\"%s\"\nto\n\"%s\"\n" % (current[groupname]['description'], backup['description']))
+                        userinput = prompt_user(_('Continue [y/N]:'))
+
+                        if re.match('y', userinput, re.I):
+                            logging.info(_N("Updating description for group: %s") % groupname)
+                            self.client.systemgroup.update(self.session, groupname, backup['description'])
+                    if current[groupname]['formulas'] != backup['formulas']:
+                        userinput = prompt_user(_('Update formula data from backup? [y/N]:'))
+                        if re.match('y', userinput, re.I):
+                            formulas = list(backup['formulas'].keys())
+                            self.client.formula.setFormulasOfGroup(self.session, current[groupname]['id'], formulas)
+                            for f, v in backup['formulas'].items():
+                                self.client.formula.setGroupFormulaData(self.session, current[groupname]['id'], f, v)
+                else:
+                    logging.info(_N("Updating data for group: %s") % groupname)
+                    self.client.systemgroup.update(self.session, groupname, backup['description'])
+                    formulas = list(backup['formulas'].keys())
+                    self.client.formula.setFormulasOfGroup(self.session, current[groupname]['id'], formulas)
+                    for f, v in backup['formulas'].items():
+                        self.client.formula.setGroupFormulaData(self.session, current[groupname]['id'], f, v)
+
         else:
             logging.info(_N("Creating new group %s") % groupname)
-            self.client.systemgroup.create(self.session, groupname, details)
+            details = self.client.systemgroup.create(self.session, groupname, backup['description'])
+            formulas = list(backup['formulas'].keys())
+            self.client.formula.setFormulasOfGroup(self.session, details['id'], formulas)
+            for f, v in backup['formulas'].items():
+                self.client.formula.setGroupFormulaData(self.session, details['id'], f, v)
 
     return 0
 

--- a/spacecmd/src/spacecmd/group.py
+++ b/spacecmd/src/spacecmd/group.py
@@ -278,9 +278,10 @@ def do_group_backup(self, args):
         print(_("Backup Group: %s") % group)
         details = self.client.systemgroup.getDetails(self.session, group)
         formulas = self.client.formula.getFormulasByGroupId(self.session, details['id'])
-        formula_data = {}
-        for f in formulas:
-            formula_data[f] = self.client.formula.getGroupFormulaData(self.session, details['id'], f)
+        formula_data = {
+            f: self.client.formula.getGroupFormulaData(self.session, details['id'], f)
+            for f in formulas
+        }
 
         outputpath = outputpath_base + "/" + group
         print(_("Output File: %s") % outputpath)
@@ -398,15 +399,15 @@ def do_group_restore(self, args):
                 if is_interactive(options):
                     if current[groupname]['description'] != backup['description']:
                         print(_("Changing description from:"))
-                        print("\n\"%s\"\nto\n\"%s\"\n" % (current[groupname]['description'], backup['description']))
+                        print('\n"%s"\nto\n"%s"\n' % (current[groupname]['description'], backup['description']))
                         userinput = prompt_user(_('Continue [y/N]:'))
 
-                        if re.match('y', userinput, re.I):
+                        if userinput.lower() == 'y':
                             logging.info(_N("Updating description for group: %s") % groupname)
                             self.client.systemgroup.update(self.session, groupname, backup['description'])
                     if current[groupname]['formulas'] != backup['formulas']:
                         userinput = prompt_user(_('Update formula data from backup? [y/N]:'))
-                        if re.match('y', userinput, re.I):
+                        if userinput.lower() == 'y':
                             formulas = list(backup['formulas'].keys())
                             self.client.formula.setFormulasOfGroup(self.session, current[groupname]['id'], formulas)
                             for f, v in backup['formulas'].items():

--- a/spacecmd/tests/test_group.py
+++ b/spacecmd/tests/test_group.py
@@ -5,7 +5,7 @@ Test suite for group module of spacecmd
 
 import datetime
 import os
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, mock_open, call, ANY
 from helpers import shell, assert_expect, assert_list_args_expect, assert_args_expect
 import spacecmd.group
 from xmlrpc import client as xmlrpclib
@@ -414,14 +414,23 @@ class TestSCGroup:
         shell.do_group_list = MagicMock(return_value=["group-a", "group-b"])
         shell.client.systemgroup.getDetails = MagicMock(
             side_effect=[
-                {"description": "Group A description"},
-                {"description": "Group B description"},
+                {"description": "Group A description", "id": 1},
+                {"description": "Group B description", "id": 1},
             ]
         )
+        shell.client.formula.getFormulasByGroupId = MagicMock(
+            side_effect = [[], ['pxe']]
+            )
+        shell.client.formula.getGroupFormulaData = MagicMock(
+            side_effect = [{"pxe": {
+                "default_kernel_parameters": "panic=60 ramdisk_size=710000 ramdisk_blocksize=4096 vga=0x317 splash=silent kiwidebug=0",
+                "initrd_name": "initrd",
+                "kernel_name": "linux",
+                "pxe_root_directory": "/srv/saltboot"
+            }}])
         mprint = MagicMock()
         logger = MagicMock()
-        opener = MagicMock()
-        _open = MagicMock(return_value=opener)
+        dumper = MagicMock()
 
         _datetime = MagicMock()
         _datetime.now = MagicMock(return_value=datetime.datetime(2019, 1, 1))
@@ -429,7 +438,7 @@ class TestSCGroup:
         with patch("spacecmd.group.print", mprint) as prn, \
             patch("spacecmd.group.logging", logger) as lgr, \
             patch("spacecmd.group.os.path.expanduser", exp_user) as exu, \
-            patch("spacecmd.group.open", _open) as opr, \
+            patch("spacecmd.group.json_dump_to_file", dumper) as opr, \
             patch("spacecmd.group.datetime", _datetime) as dtm:
             spacecmd.group.do_group_backup(shell, "ALL")
 
@@ -438,8 +447,7 @@ class TestSCGroup:
         assert shell.do_group_list.called
         assert shell.client.systemgroup.getDetails.called
         assert mprint.called
-        assert opener.write.called
-        assert opener.close.called
+        assert dumper.called
 
         assert_list_args_expect(mprint.call_args_list,
                                 ['Backup Group: group-a',
@@ -447,12 +455,27 @@ class TestSCGroup:
                                  'Backup Group: group-b',
                                  'Output File: /opt/spacecmd/spacecmd-backup/group/2019-01-01/group-b'
                                  ])
-
-        assert_list_args_expect(opener.write.call_args_list,
-                                ["Group A description", "Group B description"])
-        assert_args_expect(_open.call_args_list,
-                           [(('/opt/spacecmd/spacecmd-backup/group/2019-01-01/group-a', 'w'), {}),
-                            (('/opt/spacecmd/spacecmd-backup/group/2019-01-01/group-b', 'w'), {}),])
+        calls = [call({
+                        "description": "Group A description",
+                        "formulas": {}
+                    },
+                    '/opt/spacecmd/spacecmd-backup/group/2019-01-01/group-a'),
+                call({
+                        "description": "Group B description",
+                        "formulas": {
+                            "pxe": {
+                                "pxe": {
+                                    "default_kernel_parameters": "panic=60 ramdisk_size=710000 ramdisk_blocksize=4096 vga=0x317 splash=silent kiwidebug=0",
+                                    "initrd_name": "initrd",
+                                    "kernel_name": "linux",
+                                    "pxe_root_directory": "/srv/saltboot"
+                                }
+                            }
+                        }
+                    },
+                    '/opt/spacecmd/spacecmd-backup/group/2019-01-01/group-b')
+                ]
+        dumper.assert_has_calls(calls)
 
     @patch("spacecmd.group.os.path.isdir", MagicMock(return_value=False))
     @patch("spacecmd.group.os.makedirs", MagicMock(side_effect=OSError))
@@ -529,8 +552,8 @@ class TestSCGroup:
         shell.do_group_list = MagicMock(return_value=["group-a", "group-b"])
         shell.client.systemgroup.getDetails = MagicMock(
             side_effect=[
-                {"description": "Group A description"},
-                {"description": "Group B description"},
+                {"description": "Group A description", "id": 1},
+                {"description": "Group B description", "id": 1},
             ]
         )
         mprint = MagicMock()
@@ -759,20 +782,40 @@ class TestSCGroup:
         shell.help_group_restore = MagicMock()
         shell.do_group_list = MagicMock(return_value=["group-a", "group-b"])
         shell.client.systemgroup.getDetails = MagicMock(side_effect=[
-            {"description": "Description of Group A"},
-            {"description": "Description of Group B"},
+            {"description": "Description of Group A", "id": 1},
+            {"description": "Description of Group B", "id": 1},
         ])
+        shell.client.formula.getFormulasByGroupId = MagicMock(
+            side_effect = [['pxe'], []]
+            )
+        shell.client.formula.getGroupFormulaData = MagicMock(
+            side_effect = [{"pxe": {
+                "default_kernel_parameters": "panic=60 ramdisk_size=710000 ramdisk_blocksize=4096 vga=0x317 splash=silent kiwidebug=0",
+                "initrd_name": "initrd",
+                "kernel_name": "linux",
+                "pxe_root_directory": "/srv/saltboot"
+            }}])
         shell.client.systemgroup.update = MagicMock()
         shell.client.systemgroup.create = MagicMock()
         logger = MagicMock()
         mprint = MagicMock()
-        opener = MagicMock()
-        opener.read = MagicMock(return_value="Description of Group A")
-        _open = MagicMock(return_value=opener)
+        json = MagicMock(return_value={
+                    "description": "Description of Group A",
+                    "formulas": {
+                        "pxe": {
+                            "pxe": {
+                                "default_kernel_parameters": "panic=60 ramdisk_size=710000 ramdisk_blocksize=4096 vga=0x317 splash=silent kiwidebug=0",
+                                "initrd_name": "initrd",
+                                "kernel_name": "linux",
+                                "pxe_root_directory": "/srv/saltboot"
+                            }
+                        }
+                    }
+                })
 
         with patch("spacecmd.group.print", mprint) as prn, \
             patch("spacecmd.group.logging", logger) as lgr, \
-            patch("spacecmd.group.open", _open) as opn, \
+            patch("spacecmd.group.json_read_from_file", json) as opr, \
             patch("spacecmd.group.os.path.abspath", _abspath) as abp:
             spacecmd.group.do_group_restore(shell, "/opt/backup group-a")
 
@@ -785,6 +828,8 @@ class TestSCGroup:
         assert shell.do_group_list.called
         assert shell.client.systemgroup.getDetails.called
         assert logger.debug.called
+
+        json.assert_called_once()
 
         assert_expect(logger.error.call_args_list,
                       "Group group-a already restored")
@@ -812,20 +857,24 @@ class TestSCGroup:
         shell.help_group_restore = MagicMock()
         shell.do_group_list = MagicMock(return_value=["group-a", "group-b"])
         shell.client.systemgroup.getDetails = MagicMock(side_effect=[
-            {"description": "Description of Group A newer"},
-            {"description": "Description of Group B"},
+            {"description": "Description of Group A", "id": 1},
+            {"description": "Description of Group B", "id": 1},
         ])
+        shell.client.formula.getFormulasByGroupId = MagicMock(
+            side_effect = [[], []]
+            )
         shell.client.systemgroup.update = MagicMock()
         shell.client.systemgroup.create = MagicMock()
         logger = MagicMock()
         mprint = MagicMock()
-        opener = MagicMock()
-        opener.read = MagicMock(return_value="Description of Group A")
-        _open = MagicMock(return_value=opener)
+        json = MagicMock(return_value={
+                    "description": "Group A description",
+                    "formulas": {}
+                })
 
         with patch("spacecmd.group.print", mprint) as prn, \
             patch("spacecmd.group.logging", logger) as lgr, \
-            patch("spacecmd.group.open", _open) as opn, \
+            patch("spacecmd.group.json_read_from_file", json) as opr, \
             patch("spacecmd.group.os.path.abspath", _abspath) as abp:
             spacecmd.group.do_group_restore(shell, "/opt/backup group-a")
 
@@ -839,8 +888,153 @@ class TestSCGroup:
         assert shell.client.systemgroup.getDetails.called
         assert logger.debug.called
 
+        json.assert_called_once()
+
         assert_expect(logger.info.call_args_list,
-                      'Updating description for group: group-a')
+                      'Updating data for group: group-a')
+
+    @patch("spacecmd.group.os.listdir", MagicMock(return_value=["group-a"]))
+    @patch("spacecmd.group.os.path.isdir", MagicMock(return_value=True))
+    @patch("spacecmd.group.os.path.isfile", MagicMock(return_value=True))
+    @patch("spacecmd.group.os.path.exists", MagicMock(return_value=True))
+    def test_group_restore_catch_existing_formulas_changed(self, shell):
+        """
+        Test do_group_restore indempotent recovery
+
+        :param shell:
+        :return:
+        """
+        def _abspath(path):
+            """
+            Fake os.path.abspath that expands to /tmp/test
+
+            :param path:
+            :return:
+            """
+            return os.path.join("/tmp/test", path.strip("/"))
+
+        shell.help_group_restore = MagicMock()
+        shell.do_group_list = MagicMock(return_value=["group-a", "group-b"])
+        shell.client.systemgroup.getDetails = MagicMock(side_effect=[
+            {"description": "Description of Group A", "id": 1},
+            {"description": "Description of Group B", "id": 1},
+        ])
+        shell.client.formula.getFormulasByGroupId = MagicMock(
+            side_effect = [['pxe'], []]
+            )
+        shell.client.formula.getGroupFormulaData = MagicMock(
+            side_effect = [{"pxe": {
+                "default_kernel_parameters": "panic=60 ramdisk_size=710000 ramdisk_blocksize=4096 vga=0x317 splash=silent kiwidebug=0",
+                "initrd_name": "initrd",
+                "kernel_name": "linux",
+                "pxe_root_directory": "/srv/saltboot"
+            }}])
+        shell.client.systemgroup.update = MagicMock()
+        shell.client.systemgroup.create = MagicMock()
+        shell.client.formula.setGroupFormulaData = MagicMock()
+
+        logger = MagicMock()
+        mprint = MagicMock()
+        json = MagicMock(return_value={
+                    "description": "Group A description",
+                    "formulas": {
+                    "pxe": {
+                        "pxe": {
+                            "initrd_name": "initrd",
+                            "kernel_name": "linux",
+                            "pxe_root_directory": "/srv/tftpboot"
+                        }
+                    }
+                }
+            })
+
+        with patch("spacecmd.group.print", mprint) as prn, \
+            patch("spacecmd.group.logging", logger) as lgr, \
+            patch("spacecmd.group.json_read_from_file", json) as opr, \
+            patch("spacecmd.group.os.path.abspath", _abspath) as abp:
+            spacecmd.group.do_group_restore(shell, "/opt/backup group-a")
+
+        assert not shell.client.systemgroup.create.called
+        assert not shell.help_group_restore.called
+        assert not mprint.called
+        assert not logger.error.called
+        assert shell.client.systemgroup.update.called
+        assert logger.info.called
+        assert shell.do_group_list.called
+        assert shell.client.systemgroup.getDetails.called
+        assert logger.debug.called
+
+        json.assert_called_once()
+
+        shell.client.formula.setGroupFormulaData.assert_called_with(
+                    ANY,
+                    1, 'pxe',
+                    { "pxe": {
+                        "initrd_name": "initrd",
+                        "kernel_name": "linux",
+                        "pxe_root_directory": "/srv/tftpboot"
+                    }})
+
+        assert_expect(logger.info.call_args_list,
+                      'Updating data for group: group-a')
+
+    @patch("spacecmd.group.os.listdir", MagicMock(return_value=["group-a"]))
+    @patch("spacecmd.group.os.path.isdir", MagicMock(return_value=True))
+    @patch("spacecmd.group.os.path.isfile", MagicMock(return_value=True))
+    @patch("spacecmd.group.os.path.exists", MagicMock(return_value=True))
+    def test_group_restore_accept_old_format_description_changed(self, shell):
+        """
+        Test do_group_restore indempotent recovery
+
+        :param shell:
+        :return:
+        """
+        def _abspath(path):
+            """
+            Fake os.path.abspath that expands to /tmp/test
+
+            :param path:
+            :return:
+            """
+            return os.path.join("/tmp/test", path.strip("/"))
+
+        shell.help_group_restore = MagicMock()
+        shell.do_group_list = MagicMock(return_value=["group-a", "group-b"])
+        shell.client.systemgroup.getDetails = MagicMock(side_effect=[
+            {"description": "Description of Group A", "id": 1},
+            {"description": "Description of Group B", "id": 1},
+        ])
+        shell.client.formula.getFormulasByGroupId = MagicMock(
+            side_effect = [[], []]
+            )
+        shell.client.systemgroup.update = MagicMock()
+        shell.client.systemgroup.create = MagicMock()
+        logger = MagicMock()
+        mprint = MagicMock()
+        json = MagicMock(return_value=None)
+        opener = mock_open(read_data = 'Group A description newer')
+
+        with patch("spacecmd.group.print", mprint) as prn, \
+            patch("spacecmd.group.logging", logger) as lgr, \
+            patch("spacecmd.group.json_read_from_file", json) as opr, \
+            patch("spacecmd.group.open", opener) as opn, \
+            patch("spacecmd.group.os.path.abspath", _abspath) as abp:
+            spacecmd.group.do_group_restore(shell, "/opt/backup group-a")
+
+        assert not shell.client.systemgroup.create.called
+        assert not shell.help_group_restore.called
+        assert not mprint.called
+        assert not logger.error.called
+        assert shell.client.systemgroup.update.called
+        assert logger.info.called
+        assert shell.do_group_list.called
+        assert shell.client.systemgroup.getDetails.called
+        assert logger.debug.called
+
+        assert_list_args_expect(logger.info.call_args_list,
+                      ['Assuming group to be in old plain text format',
+                       'Updating data for group: group-a'])
+
 
     def test_group_list_data(self, shell):
         """

--- a/spacecmd/tests/test_group.py
+++ b/spacecmd/tests/test_group.py
@@ -422,12 +422,12 @@ class TestSCGroup:
             side_effect = [[], ['pxe']]
             )
         shell.client.formula.getGroupFormulaData = MagicMock(
-            side_effect = [{"pxe": {
+            return_value = {"pxe": {
                 "default_kernel_parameters": "panic=60 ramdisk_size=710000 ramdisk_blocksize=4096 vga=0x317 splash=silent kiwidebug=0",
                 "initrd_name": "initrd",
                 "kernel_name": "linux",
                 "pxe_root_directory": "/srv/saltboot"
-            }}])
+            }})
         mprint = MagicMock()
         logger = MagicMock()
         dumper = MagicMock()


### PR DESCRIPTION
## What does this PR change?

`spacecmd group_backup` command backups system groups. This backup backups only name and description.  However since some time we allow formulas to be configured for groups as well. This PR enhanced backup (and restore via `spacecmd group_restore`) to include formulas configuration in the group backup.

Previously group backups were simple text files containing description string of the group. For formulas I changed that format to be in a JSON format having special field for description and formula configuration.
Restore procedure now tries to decode JSON to dics and if that fails it assumes that backup is in old format and loads it as a plain file.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: **add explanation. This can't be used if there is a GUI diff**
- No documentation needed: only internal and user invisible changes
- Documentation issue was created: [Link for SUSE Manager contributors](https://github.com/SUSE/spacewalk/issues/new?template=ISSUE_TEMPLATE_DOCUMENTATION.md&labels=documentation&projects=SUSE/spacewalk/31), [Link for community contributors](https://github.com/uyuni-project/uyuni-docs/issues/new).
- (OPTIONAL) [Documentation PR](https://github.com/uyuni-project/uyuni-docs/pulls)

- [ ] **DONE**

## Test coverage
- Unit tests were added

- [X] **DONE**

## Links

Fixes #https://github.com/SUSE/spacewalk/issues/15872

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
