### PR TITLE
Disable immediate errata update when enabling auto errata update via ssm

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
+++ b/java/code/src/com/redhat/rhn/manager/system/SystemManager.java
@@ -102,7 +102,6 @@ import com.redhat.rhn.frontend.xmlrpc.ProxySystemIsSatelliteException;
 import com.redhat.rhn.manager.BaseManager;
 import com.redhat.rhn.manager.channel.ChannelManager;
 import com.redhat.rhn.manager.entitlement.EntitlementManager;
-import com.redhat.rhn.manager.errata.ErrataManager;
 import com.redhat.rhn.manager.kickstart.cobbler.CobblerSystemRemoveCommand;
 import com.redhat.rhn.manager.rhnset.RhnSetDecl;
 import com.redhat.rhn.manager.system.entitling.SystemEntitlementManager;
@@ -3531,23 +3530,12 @@ public class SystemManager extends BaseManager {
     /**
      * Set auto_update for all systems in the system set
      * @param user The user
-     * @param value True if the servers should audo update
+     * @param value True if the servers should enable auto update
      * @throws TaskomaticApiException if there was a Taskomatic error
      * (typically: Taskomatic is down)
      */
     public static void setAutoUpdateBulk(User user, Boolean value)
         throws TaskomaticApiException {
-        if (value) {
-            // schedule all existing applicable errata
-            List<SystemOverview> systems = inSet(user, "system_list");
-            List<Long> sids = new ArrayList<Long>();
-            for (SystemOverview system : systems) {
-                sids.add(system.getId());
-            }
-            List<Long> eids = errataIdsReleventToSystemSet(user);
-            java.util.Date earliest = new java.util.Date();
-            ErrataManager.applyErrata(user, eids, earliest, sids);
-        }
         CallableMode mode = ModeFactory.getCallableMode("System_queries",
                 "set_auto_update_bulk");
         Map<String, Object> params = new HashMap<String, Object>();


### PR DESCRIPTION
## What does this PR change?

Disable immediate scheduling of errata update on enabling auto errata update via ssm.
This has already been disabled when enabling auto errata update via single systems properties and xmlrpc in https://github.com/uyuni-project/uyuni/pull/4158
Not disabling this for ssm was simply an oversight.

## GUI diff

- [x] **DONE**

## Documentation

- No documentation needed: 

- [x] **DONE**

## Test coverage

- No tests: 

- [x] **DONE**

## Links

Tracks 

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
