### PR TITLE
Remove mgr_bootstrap_data's code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -41,6 +41,9 @@ java/conf/cobbler/snippets/ @SchoolGuy
 
 # Python
 *.py @uyuni-project/python
+# This file only holds data, no Python code
+mgr_bootstrap_data.py
+
 
 # Frontend
 web/ @uyuni-project/frontend


### PR DESCRIPTION
## What does this PR change?

While this file ends with ".py", it's not a Python code file. It "only" contains Python lists and dicts with data needed for bootstrapping.

Is there anyone who'd like to own `mgr_bootstrap_data.py`?

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
