### PR TITLE
Fix problem installing/removing packages using action chains in transactional systems

### DIFF
--- a/susemanager-utils/susemanager-sls/src/modules/mgractionchains.py
+++ b/susemanager-utils/susemanager-sls/src/modules/mgractionchains.py
@@ -26,38 +26,6 @@ __virtualname__ = 'mgractionchains'
 
 SALT_ACTIONCHAIN_BASE = 'actionchains'
 
-EXTRA_FILEREFS = ",".join(
-    map(
-        lambda x: "salt://" + x,
-        [
-            "certs",
-            "channels",
-            "cleanup_ssh_minion",
-            "configuration",
-            "distupgrade",
-            "hardware",
-            "images",
-            "packages/init.sls",
-            "packages/patchdownload.sls",
-            "packages/patchinstall.sls",
-            "packages/pkgdownload.sls",
-            "packages/pkginstall.sls",
-            "packages/pkgremove.sls",
-            "packages/profileupdate.sls",
-            "packages/redhatproductinfo.sls",
-            "remotecommands",
-            "scap",
-            "services",
-            "custom",
-            "custom_groups",
-            "custom_org",
-            "util",
-            "bootstrap",
-            "formulas.sls",
-        ],
-    )
-)
-
 
 def __virtual__():
     '''
@@ -162,7 +130,7 @@ def start(actionchain_id):
 
     inside_transaction = os.environ.get("TRANSACTIONAL_UPDATE")
     if __grains__.get("transactional") and not inside_transaction:
-        ret = __salt__['transactional_update.sls'](target_sls, queue=True, extra_filerefs=EXTRA_FILEREFS)
+        ret = __salt__['transactional_update.sls'](target_sls, queue=True)
     else:
         ret = __salt__['state.sls'](target_sls, queue=True)
 
@@ -224,7 +192,7 @@ def resume():
 
     inside_transaction = os.environ.get("TRANSACTIONAL_UPDATE")
     if __grains__.get("transactional") and not inside_transaction:
-        return __salt__['transactional_update.sls'](next_chunk, queue=True, extra_filerefs=EXTRA_FILEREFS)
+        return __salt__['transactional_update.sls'](next_chunk, queue=True)
     else:
         return __salt__['state.sls'](next_chunk, queue=True)
 

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,5 @@
+- Fix problem installing/removing packages using action chains
+  in transactional systems
 - Add state for changing proxy
 - Enable basic support for Debian 11
 


### PR DESCRIPTION
## What does this PR change?

This PR fixes an issue in transactional systems (SLE Micro / MicroOS) when using action chains to install/remove packages using action chains.

Before this PR, the actions are failing with the error like the following:

![image](https://user-images.githubusercontent.com/7229203/139029294-a360870e-f41b-4cf6-8106-cafd2d2ff3ed.png)

After this PR, the actions are successfully executed.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **bugfix**
- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/14572

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
