### PR TITLE
Send suma id in http requests

### DIFF
--- a/java/buildconf/test/rhn.conf.postgresql-example
+++ b/java/buildconf/test/rhn.conf.postgresql-example
@@ -74,7 +74,7 @@ web.config_delim_end = |}
 web.maximum_config_file_size = 131072
 
 # Versions
-web.version = 2.4
+web.version = 4.3.999
 java.apiversion = 16
 
 # Satellite Installer settings

--- a/java/code/src/com/suse/scc/client/SCCRequestFactory.java
+++ b/java/code/src/com/suse/scc/client/SCCRequestFactory.java
@@ -14,6 +14,9 @@
  */
 package com.suse.scc.client;
 
+import com.redhat.rhn.common.conf.Config;
+import com.redhat.rhn.common.conf.ConfigDefaults;
+
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpRequestBase;
 
@@ -65,6 +68,10 @@ public class SCCRequestFactory {
         // Send the UUID for debugging if available
         String uuid = config.getUUID();
         request.addHeader("SMS", uuid != null ? uuid : "undefined");
+
+        // overwrite the default
+        request.addHeader("User-Agent", Config.get().getString(ConfigDefaults.PRODUCT_NAME) + "/" +
+                ConfigDefaults.get().getProductVersion());
 
         return request;
     }

--- a/java/code/src/com/suse/scc/client/SCCWebClient.java
+++ b/java/code/src/com/suse/scc/client/SCCWebClient.java
@@ -14,6 +14,7 @@
  */
 package com.suse.scc.client;
 
+import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.conf.ConfigDefaults;
 import com.redhat.rhn.common.util.http.HttpClientAdapter;
 import com.redhat.rhn.manager.content.ProductTreeEntry;
@@ -202,6 +203,10 @@ public class SCCWebClient implements SCCClient {
         // Send the UUID for debugging if available
         String uuid = config.getUUID();
         request.addHeader("SMS", uuid != null ? uuid : "undefined");
+
+        // overwrite the default
+        request.addHeader("User-Agent", Config.get().getString(ConfigDefaults.PRODUCT_NAME) + "/" +
+                ConfigDefaults.get().getProductVersion());
     }
 
     @Override

--- a/java/code/src/com/suse/scc/client/test/SCCRequestFactoryTest.java
+++ b/java/code/src/com/suse/scc/client/test/SCCRequestFactoryTest.java
@@ -56,5 +56,6 @@ public class SCCRequestFactoryTest extends TestCase {
                 request.getFirstHeader("Accept-Encoding").getValue());
         assertEquals(TEST_UUID,
                 request.getFirstHeader("SMS").getValue());
+        assertEquals("SUSE Manager/4.3.999", request.getFirstHeader("User-Agent").getValue());
     }
 }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Set product name and version in the User-Agent header when connecting to SCC
 - On salt-ssh minions, enforce package list refresh after state apply
 - Improve the API to query system events and history
 - Fix internal server error on DuplicateSystemsCompare (bsc#1191643)


### PR DESCRIPTION
## What does this PR change?

When connecting to SCC, set the product name and version as User-Agent header for better bug tracking
in case of invalid requests.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added
- manual test show for Uyuni:
```
2021-10-28 08:30:01,602 [DefaultQuartzScheduler_Worker-8] DEBUG org.apache.http.headers - http-outgoing-0 >> POST /connect/organizations/systems HTTP/1.1
2021-10-28 08:30:01,602 [DefaultQuartzScheduler_Worker-8] DEBUG org.apache.http.headers - http-outgoing-0 >> Accept: application/vnd.scc.suse.com.v4+json
2021-10-28 08:30:01,602 [DefaultQuartzScheduler_Worker-8] DEBUG org.apache.http.headers - http-outgoing-0 >> Accept-Encoding: gzip, deflate
2021-10-28 08:30:01,602 [DefaultQuartzScheduler_Worker-8] DEBUG org.apache.http.headers - http-outgoing-0 >> SMS: 2aa79f39-c9b6-4af0-9e6b-5619ae3183af
2021-10-28 08:30:01,602 [DefaultQuartzScheduler_Worker-8] DEBUG org.apache.http.headers - http-outgoing-0 >> User-Agent: Uyuni/2021.09

2021-10-28 08:33:00,182 [DefaultQuartzScheduler_Worker-7] DEBUG org.apache.http.headers - http-outgoing-36 >> GET /connect/organizations/repositories HTTP/1.1
2021-10-28 08:33:00,182 [DefaultQuartzScheduler_Worker-7] DEBUG org.apache.http.headers - http-outgoing-36 >> Accept: application/vnd.scc.suse.com.v4+json
2021-10-28 08:33:00,182 [DefaultQuartzScheduler_Worker-7] DEBUG org.apache.http.headers - http-outgoing-36 >> Accept-Encoding: gzip, deflate
2021-10-28 08:33:00,182 [DefaultQuartzScheduler_Worker-7] DEBUG org.apache.http.headers - http-outgoing-36 >> SMS: 2aa79f39-c9b6-4af0-9e6b-5619ae3183af
2021-10-28 08:33:00,182 [DefaultQuartzScheduler_Worker-7] DEBUG org.apache.http.headers - http-outgoing-36 >> User-Agent: Uyuni/2021.09
```
And for SUSE Manager:
```
2021-10-28 08:35:23,145 [pool-10-thread-39] DEBUG org.apache.http.headers - http-outgoing-81 >> GET /connect/organizations/repositories?page=40 HTTP/1.1
2021-10-28 08:35:23,145 [pool-10-thread-39] DEBUG org.apache.http.headers - http-outgoing-81 >> Accept: application/vnd.scc.suse.com.v4+json
2021-10-28 08:35:23,145 [pool-10-thread-39] DEBUG org.apache.http.headers - http-outgoing-81 >> Accept-Encoding: gzip, deflate
2021-10-28 08:35:23,145 [pool-10-thread-39] DEBUG org.apache.http.headers - http-outgoing-81 >> SMS: 2aa79f39-c9b6-4af0-9e6b-5619ae3183af
2021-10-28 08:35:23,145 [pool-10-thread-39] DEBUG org.apache.http.headers - http-outgoing-81 >> User-Agent: SUSE Manager/4.3.0 Alpha1

2021-10-28 08:38:10,628 [DefaultQuartzScheduler_Worker-6] DEBUG org.apache.http.headers - http-outgoing-182 >> POST /connect/organizations/systems HTTP/1.1
2021-10-28 08:38:10,628 [DefaultQuartzScheduler_Worker-6] DEBUG org.apache.http.headers - http-outgoing-182 >> Accept: application/vnd.scc.suse.com.v4+json
2021-10-28 08:38:10,628 [DefaultQuartzScheduler_Worker-6] DEBUG org.apache.http.headers - http-outgoing-182 >> Accept-Encoding: gzip, deflate
2021-10-28 08:38:10,628 [DefaultQuartzScheduler_Worker-6] DEBUG org.apache.http.headers - http-outgoing-182 >> SMS: 2aa79f39-c9b6-4af0-9e6b-5619ae3183af
2021-10-28 08:38:10,628 [DefaultQuartzScheduler_Worker-6] DEBUG org.apache.http.headers - http-outgoing-182 >> User-Agent: SUSE Manager/4.3.0 Alpha1
```
- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/16144
Tracks https://github.com/SUSE/spacewalk/pull/16258 https://github.com/SUSE/spacewalk/pull/16259

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
