### PR TITLE
CI: add workflow to check if there are needed translations

### DIFF
--- a/.github/workflows/check_translations.yml
+++ b/.github/workflows/check_translations.yml
@@ -1,0 +1,51 @@
+name: Check if translation is required
+
+on:
+  pull_request:
+    paths:
+      - 'java/code/src/com/redhat/rhn/frontend/strings/**'
+      - 'backend/**'
+      - 'client/rhel/yum-rhn-plugin/**'
+      - 'client/rhel/mgr-daemon/**'
+      - 'client/rhel/spacewalk-client-tools/**'
+      - 'web/**'
+      - 'susemanager/**'
+      - 'spacecmd/**'
+
+jobs:
+  run:
+    name: Check by trying to locally update translation files 
+    if: github.repository == 'uyuni-project/uyuni'
+    runs-on: ubuntu-latest
+    steps:
+    - name: Cancel Previous Runs
+      uses: styfle/cancel-workflow-action@0.8.0
+      with:
+        access_token: ${{ github.token }}
+
+    - name: Checkout repo
+      uses: actions/checkout@v2
+
+    - name: Setup tooling
+      run: sudo apt-get install -y make git gettext intltool python3
+
+    - name: Setup git
+      run: |
+        git config --global user.name "Galaxy CI"
+        git config --global user.email "galaxy-ci@suse.de" 
+        git switch -c check_translations
+        git branch origin_check_translations
+
+    - name: Update all translations files
+      run: ADDITIONAL_SAFE_BRANCHNAME=check_translations scripts/translation/update-all-translation-strings.sh
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Check if there has been changes on translation files
+      run: |
+        if [ $(git diff origin_check_translations check_translations | wc -l) -ne 0 ];then
+          echo "Translations are needed"
+          git diff origin_check_translations check_translations
+          exit -1
+        fi
+


### PR DESCRIPTION
## What does this PR change?

CI: add workflow to check if there are needed translations

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed

- [X] **DONE**

## Test coverage
- No tests

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/15482

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
