### PR TITLE
The registry name was matching in a regex with galaxy-registry image store

### DIFF
--- a/testsuite/features/secondary/buildhost_docker_auth_registry.feature
+++ b/testsuite/features/secondary/buildhost_docker_auth_registry.feature
@@ -10,7 +10,7 @@ Feature: Build image with authenticated registry
     Given I am authorized as "docker" with password "docker"
     When I follow the left menu "Images > Stores"
     And I follow "Create"
-    And I enter "registry" as "label"
+    And I enter "auth_registry" as "label"
     And I check "useCredentials"
     And I enter URI, username and password for registry
     And I click on "create-btn"
@@ -19,39 +19,39 @@ Feature: Build image with authenticated registry
   Scenario: Create a profile for the authenticated image store as Docker admin
     When I follow the left menu "Images > Profiles"
     And I follow "Create"
-    And I enter "registry_profile" as "label"
-    And I select "registry" from "imageStore"
+    And I enter "auth_registry_profile" as "label"
+    And I select "auth_registry" from "imageStore"
     And I select "1-DOCKER-TEST" from "activationKey"
     And I enter "Docker/authprofile" relative to profiles as "path"
     And I click on "create-btn"
-    Then I wait until I see "registry_profile" text
+    Then I wait until I see "auth_registry_profile" text
 
   Scenario: Build an image in the authenticated image store
     When I follow the left menu "Images > Build"
-    And I select "registry_profile" from "profileId"
+    And I select "auth_registry_profile" from "profileId"
     And I enter "latest" as "version"
     And I select the hostname of "build_host" from "buildHostId"
     And I click on "submit-btn"
-    Then I wait until I see "registry_profile" text
+    Then I wait until I see "auth_registry_profile" text
     # Verify the status of images in the authenticated image store
-    When I wait at most 600 seconds until container "registry_profile" is built successfully
+    When I wait at most 600 seconds until container "auth_registry_profile" is built successfully
     And I refresh the page
-    Then table row for "registry_profile" should contain "1"
+    Then table row for "auth_registry_profile" should contain "1"
 
   Scenario: Cleanup: remove Docker profile for the authenticated image store
     When I follow the left menu "Images > Profiles"
-    And I check the row with the "registry_profile" text
+    And I check the row with the "auth_registry_profile" text
     And I click on "Delete"
     And I click on the red confirmation button
     And I should see a "Image profile has been deleted." text
 
   Scenario: Cleanup: remove authenticated image store
     When I follow the left menu "Images > Stores"
-    And I check the row with the "registry" text
+    And I check the row with the "auth_registry" text
     And I click on "Delete"
     And I click on the red confirmation button
     And I should see a "Image store has been deleted." text
 
   Scenario: Cleanup: delete registry image
     Given I am authorized as "admin" with password "admin"
-    When I delete the image "registry_profile" with version "latest" via XML-RPC calls
+    When I delete the image "auth_registry_profile" with version "latest" via XML-RPC calls

--- a/testsuite/features/step_definitions/docker_steps.rb
+++ b/testsuite/features/step_definitions/docker_steps.rb
@@ -141,6 +141,7 @@ When(/^I list image store types and image stores via XML-RPC$/) do
   raise "imagestore label type should be 'os_image' but is #{store_typ[1]['label']}" unless store_typ[1]['label'] == 'os_image'
 
   registry_list = cont_op.list_image_stores
+  puts "Image Stores: #{registry_list}"
   raise "Label #{registry_list[0]['label']} is different than 'galaxy-registry'" unless registry_list[0]['label'] == 'galaxy-registry'
   raise "URI #{registry_list[0]['uri']} is different than '#{$no_auth_registry}'" unless registry_list[0]['uri'] == $no_auth_registry.to_s
 end


### PR DESCRIPTION
## What does this PR change?

The registry name was matching in a regex with galaxy-registry image store

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- Cucumber tests were changed

- [x] **DONE**

## Links

Ports:
- Manager-4.1 https://github.com/SUSE/spacewalk/pull/16265
- Manager-4.2 https://github.com/SUSE/spacewalk/pull/16268

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
