### PR TITLE
BugFix: make sure pickup_time is not null when setting the status to picked up

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
@@ -951,18 +951,20 @@ public class ActionFactory extends HibernateFactory {
     }
 
     /**
-     * Update the status of several rhnServerAction rows identified by server and action IDs.
+     * Update the {@link ActionStatus} to "PickedUp" of several rhnServerAction rows identified
+     * by server and action IDs.
+     *
      * @param actionIn associated action of rhnServerAction records
      * @param serverIds server Ids for which action is scheduled
-     * @param status {@link ActionStatus} object that needs to be set
      */
-    public static void updateServerActionsPickedUp(Action actionIn, List<Long> serverIds, ActionStatus status) {
+    public static void updateServerActionsPickedUp(Action actionIn, List<Long> serverIds) {
         if (log.isDebugEnabled()) {
-            log.debug("Action status " + status.getName() + " is going to b set for these servers: " + serverIds);
+            log.debug("Action status " + ActionFactory.STATUS_PICKED_UP.getName() +
+                    " is going to b set for these servers: " + serverIds);
         }
         Map<String, Object>  parameters = new HashMap<String, Object>();
         parameters.put("action_id", actionIn.getId());
-        parameters.put("status", status.getId());
+        parameters.put("status", ActionFactory.STATUS_PICKED_UP.getId());
 
         udpateByIds(serverIds, "Action.updateServerActionsPickedUp", "server_ids", parameters);
     }

--- a/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/action/ActionFactory.java
@@ -956,6 +956,23 @@ public class ActionFactory extends HibernateFactory {
      * @param serverIds server Ids for which action is scheduled
      * @param status {@link ActionStatus} object that needs to be set
      */
+    public static void updateServerActionsPickedUp(Action actionIn, List<Long> serverIds, ActionStatus status) {
+        if (log.isDebugEnabled()) {
+            log.debug("Action status " + status.getName() + " is going to b set for these servers: " + serverIds);
+        }
+        Map<String, Object>  parameters = new HashMap<String, Object>();
+        parameters.put("action_id", actionIn.getId());
+        parameters.put("status", status.getId());
+
+        udpateByIds(serverIds, "Action.updateServerActionsPickedUp", "server_ids", parameters);
+    }
+
+    /**
+     * Update the status of several rhnServerAction rows identified by server and action IDs.
+     * @param actionIn associated action of rhnServerAction records
+     * @param serverIds server Ids for which action is scheduled
+     * @param status {@link ActionStatus} object that needs to be set
+     */
     public static void updateServerActions(Action actionIn, List<Long> serverIds, ActionStatus status) {
         if (log.isDebugEnabled()) {
             log.debug("Action status " + status.getName() + " is going to b set for these servers: " + serverIds);

--- a/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/action/Action_legacyUser.hbm.xml
@@ -796,6 +796,16 @@ select sa.server_id
         <return alias="ra" class="com.redhat.rhn.domain.action.Action"/>
     </sql-query>
 
+    <sql-query name="Action.updateServerActionsPickedUp">
+        <![CDATA[
+            UPDATE rhnServerAction
+                SET status = :status,
+                    pickup_time = current_timestamp
+            WHERE action_id  = :action_id
+                AND server_id  IN (:server_ids)
+                AND status NOT IN(2,3)
+        ]]>
+    </sql-query>
     <sql-query name="Action.updateServerActions">
         <![CDATA[
             UPDATE rhnServerAction

--- a/java/code/src/com/redhat/rhn/domain/action/test/ActionFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/action/test/ActionFactoryTest.java
@@ -364,7 +364,7 @@ public class ActionFactoryTest extends RhnBaseTestCase {
         list.add(sa1.getServerId());
 
         // Should NOT update if already in final state.
-        ActionFactory.updateServerActionsPickedUp(a1, list, ActionFactory.STATUS_PICKED_UP);
+        ActionFactory.updateServerActionsPickedUp(a1, list);
         HibernateFactory.reload(sa1);
         assertTrue(sa1.getStatus().equals(ActionFactory.STATUS_FAILED));
 

--- a/java/code/src/com/redhat/rhn/domain/action/test/ActionFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/action/test/ActionFactoryTest.java
@@ -364,7 +364,7 @@ public class ActionFactoryTest extends RhnBaseTestCase {
         list.add(sa1.getServerId());
 
         // Should NOT update if already in final state.
-        ActionFactory.updateServerActions(a1, list, ActionFactory.STATUS_PICKED_UP);
+        ActionFactory.updateServerActionsPickedUp(a1, list, ActionFactory.STATUS_PICKED_UP);
         HibernateFactory.reload(sa1);
         assertTrue(sa1.getStatus().equals(ActionFactory.STATUS_FAILED));
 

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -564,8 +564,7 @@ public class SaltServerActionService {
                 List<Long> succeededServerIds = results.get(true).stream()
                         .map(MinionSummary::getServerId).collect(toList());
                 if (!succeededServerIds.isEmpty()) {
-                    ActionFactory.updateServerActionsPickedUp(
-                            actionIn, succeededServerIds, ActionFactory.STATUS_PICKED_UP);
+                    ActionFactory.updateServerActionsPickedUp(actionIn, succeededServerIds);
                 }
                 List<Long> failedServerIds  = results.get(false).stream()
                         .map(MinionSummary::getServerId).collect(toList());

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -564,7 +564,8 @@ public class SaltServerActionService {
                 List<Long> succeededServerIds = results.get(true).stream()
                         .map(MinionSummary::getServerId).collect(toList());
                 if (!succeededServerIds.isEmpty()) {
-                    ActionFactory.updateServerActions(actionIn, succeededServerIds, ActionFactory.STATUS_PICKED_UP);
+                    ActionFactory.updateServerActionsPickedUp(
+                            actionIn, succeededServerIds, ActionFactory.STATUS_PICKED_UP);
                 }
                 List<Long> failedServerIds  = results.get(false).stream()
                         .map(MinionSummary::getServerId).collect(toList());

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Move pickedup actions to history as soon as they are pickedup (bsc#1191444)
 - UI and API call for changing proxy
 - Use an 'allow' filter for the kernel packages with live patching
   filter templates (bsc#1191460)


### PR DESCRIPTION
## What does this PR change?

BugFix: backport of https://github.com/SUSE/spacewalk/pull/16254

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
