### PR TITLE
Fix: allow admins to modify only spacewalk config files with rhn-config-satellite.pl (bsc#1190040)

### DIFF
--- a/spacewalk/admin/rhn-config-satellite.pl
+++ b/spacewalk/admin/rhn-config-satellite.pl
@@ -29,7 +29,7 @@ my @options = ();
 my @removals = ();
 my $help = '';
 # bsc#1190040
-my @allowed_target_files = qw(/etc/rhn/rhn.conf /var/lib/rhn/rhn-satellite-prep/satellite-local-rules.conf );
+my @allowed_target_files = qw(/etc/rhn/rhn.conf /var/lib/rhn/rhn-satellite-prep/satellite-local-rules.conf /var/lib/rhn/rhn-satellite-prep/etc/rhn/rhn.conf);
 
 GetOptions("target=s" => \$target, "option=s" => \@options, "remove=s" => \@removals, "help" => \$help) or die $usage;
 

--- a/spacewalk/admin/spacewalk-admin.changes
+++ b/spacewalk/admin/spacewalk-admin.changes
@@ -1,3 +1,4 @@
+- Fix setup with rhn-config-satellite (bsc#1190300)
 - Allow admins to modify only spacewalk config files with
   rhn-config-satellite.pl (bsc#1190040) (CVE-2021-40348)
 


### PR DESCRIPTION
## What does this PR change?

Fix: allow admins to modify only spacewalk config files with rhn-config-satellite.pl (bsc#1190040)

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/15817
Tracks https://github.com/SUSE/spacewalk/pull/15813

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
