### PR TITLE
Fix disabling self monitoring

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/srvmonitoring/disable.sls
+++ b/susemanager-utils/susemanager-sls/salt/srvmonitoring/disable.sls
@@ -8,11 +8,17 @@ postgres_exporter_service:
     - name: prometheus-postgres_exporter
     - enable: False
 
+{% set remove_jmx_props = {'service': 'tomcat', 'file': '/etc/sysconfig/tomcat'} %}
+{% include 'srvmonitoring/removejmxprops.sls' %}
+
 jmx_tomcat_config:
   file.absent:
     - name: /usr/lib/systemd/system/tomcat.service.d/jmx.conf
   mgrcompat.module_run:
     - name: service.systemctl_reload
+
+{% set remove_jmx_props = {'service': 'taskomatic', 'file': '/etc/rhn/taskomatic.conf'} %}
+{%- include 'srvmonitoring/removejmxprops.sls' %}
 
 jmx_taskomatic_config:
   file.absent:


### PR DESCRIPTION
## What does this PR change?

Remove old configuration options when disabling monitoring.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
