### PR TITLE
The postgresql pillar data are required to compute the formula pillar data

### DIFF
--- a/spacewalk/setup/salt/susemanager.conf
+++ b/spacewalk/setup/salt/susemanager.conf
@@ -57,10 +57,10 @@ master_tops:
 
 # Configure external pillar
 ext_pillar:
-  - suma_minion: True
   - postgres:
       - query: "SELECT minion_pillars(%s)"
         as_json: True
+  - suma_minion: True
 
 # Scalability configuration parameters
 

--- a/susemanager-utils/susemanager-sls/modules/pillar/suma_minion.py
+++ b/susemanager-utils/susemanager-sls/modules/pillar/suma_minion.py
@@ -70,7 +70,7 @@ def __virtual__():
     '''
     return True
 
-def ext_pillar(minion_id, *args):
+def ext_pillar(minion_id, pillar, *args):
     '''
     Find SUMA-related pillars for the registered minions and return the data.
     '''
@@ -109,13 +109,13 @@ def ext_pillar(minion_id, *args):
 
     # Including formulas into pillar data
     try:
-        ret.update(formula_pillars(minion_id, ret.get("group_ids", [])))
+        ret.update(formula_pillars(minion_id, pillar.get("group_ids", [])))
     except Exception as error:
         log.error('Error accessing formula pillar data: {message}'.format(message=str(error)))
 
     # Including images pillar
     try:
-        ret.update(image_pillars(minion_id, ret.get("group_ids", []), ret.get("org_id", 1)))
+        ret.update(image_pillars(minion_id, pillar.get("group_ids", []), pillar.get("org_id", 1)))
     except Exception as error:
         log.error('Error accessing image pillar data: {}'.format(str(error)))
 


### PR DESCRIPTION
## What does this PR change?

The `suma_minion.py` external pillar relies on the presence of `group_ids` and `org_id` in the data it parses. However since those are now in the DB, we need the postgresql external pillar processed first and then passed to the python external pillar.

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- No tests: already covered

- [X] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
