### PR TITLE
increase timeout for docker build to 660

### DIFF
--- a/testsuite/features/secondary/buildhost_docker_auth_registry.feature
+++ b/testsuite/features/secondary/buildhost_docker_auth_registry.feature
@@ -34,7 +34,7 @@ Feature: Build image with authenticated registry
     And I click on "submit-btn"
     Then I wait until I see "auth_registry_profile" text
     # Verify the status of images in the authenticated image store
-    When I wait at most 600 seconds until container "auth_registry_profile" is built successfully
+    When I wait at most 660 seconds until container "auth_registry_profile" is built successfully
     And I refresh the page
     Then table row for "auth_registry_profile" should contain "1"
 

--- a/testsuite/features/secondary/buildhost_docker_build_image.feature
+++ b/testsuite/features/secondary/buildhost_docker_build_image.feature
@@ -52,11 +52,11 @@ Feature: Build container images
   Scenario: Build the images with and without activation key
     Given I am on the Systems overview page of this "build_host"
     When I schedule the build of image "suse_key" via XML-RPC calls
-    And I wait at most 600 seconds until event "Image Build suse_key scheduled by admin" is completed
+    And I wait at most 660 seconds until event "Image Build suse_key scheduled by admin" is completed
     And I schedule the build of image "suse_simple" via XML-RPC calls
-    And I wait at most 600 seconds until event "Image Build suse_simple scheduled by admin" is completed
+    And I wait at most 660 seconds until event "Image Build suse_simple scheduled by admin" is completed
     And I schedule the build of image "suse_real_key" via XML-RPC calls
-    And I wait at most 600 seconds until event "Image Build suse_real_key scheduled by admin" is completed
+    And I wait at most 660 seconds until event "Image Build suse_real_key scheduled by admin" is completed
 
   Scenario: Build same images with different versions
     When I schedule the build of image "suse_key" with version "Latest_key-activation1" via XML-RPC calls


### PR DESCRIPTION
## What does this PR change?

Increase timeout for docker build tests to succeed also on slower test server

Port of https://github.com/SUSE/spacewalk/pull/16278

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Cucumber tests changed

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
