### PR TITLE
Wait product migration

### DIFF
--- a/testsuite/features/init_clients/sle_minion.feature
+++ b/testsuite/features/init_clients/sle_minion.feature
@@ -59,7 +59,7 @@ Feature: Bootstrap a Salt minion via the GUI
     And I wait at most 600 seconds until event "Product Migration" is completed
     And I wait until event "Package List Refresh" is completed
     And I follow "Details" in the content area
-    Then I should see a "SUSE Linux Enterprise Server 15 SP3" text
+    Then I wait until I see "SUSE Linux Enterprise Server 15 SP3" text, refreshing the page
     And vendor change should be enabled for product migration on "sle_minion"
 
   Scenario: Install the latest Salt on this minion


### PR DESCRIPTION
## What does this PR change?

Wait after a Product Migration for the Products to be displayed correctly. There are background jobs running between the Package List Refresh is finished and the Product is showed correctly.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Partial port of https://github.com/SUSE/spacewalk/pull/16285

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
