### PR TITLE
don't consider empty action chains done (bsc#1191377)

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/action/ActionChain.java
+++ b/java/code/src/com/redhat/rhn/domain/action/ActionChain.java
@@ -115,7 +115,8 @@ public class ActionChain extends BaseDomainHelper {
     public boolean isDone() {
         // check if all Actions has been executed (there must be an entry in ServerActions)
         // and all the ServerActions are Done
-        return getEntries().stream().allMatch(ace -> !ace.getAction().getServerActions().isEmpty()) &&
+        return !getEntries().isEmpty() &&
+                getEntries().stream().noneMatch(ace -> ace.getAction().getServerActions().isEmpty()) &&
                 getEntries().stream().flatMap(ace -> ace.getAction().getServerActions().stream())
                 .allMatch(sa -> sa.getStatus().isDone());
     }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- fix issue with empty action chains getting deleted too early (bsc#1191377)
 - Move pickedup actions to history as soon as they are pickedup (bsc#1191444)
 - Add additional matchers to package (nevra) filter
 - Add greater equals matcher to package (nevra) filter


### PR DESCRIPTION
## What does this PR change?

Before this patch empty action chains were considered done which lead to them being deleted every time a reboot event hit the server. This could lead to new action chains being deleted in between creating them and filling them with actions leading to an error. The patch now takes empty action chains into account so that they are not considered done. 

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed

- [x] **DONE**

## Test coverage
- No tests

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/16086

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
