### PR TITLE
Remove os_ltss_repo from CI minions

### DIFF
--- a/testsuite/features/secondary/min_ansible_control_node.feature
+++ b/testsuite/features/secondary/min_ansible_control_node.feature
@@ -14,7 +14,7 @@ Feature: Operate an Ansible control node in a normal minion
   Scenario: Pre-requisite: Enable client tools repositories
     Given I am on the Systems overview page of this "sle_minion"
     When I enable client tools repositories on "sle_minion"
-    And I enable repository "os_pool_repo os_update_repo os_ltss_repo" on this "sle_minion"
+    And I enable repository "os_pool_repo os_update_repo" on this "sle_minion"
     And I refresh the metadata for "sle_minion"
 
   Scenario: Enable "Ansible control node" system type
@@ -88,5 +88,5 @@ Feature: Operate an Ansible control node in a normal minion
   Scenario: Cleanup: Disable client tools channel
     Given I am on the Systems overview page of this "sle_minion"
     When I disable client tools repositories on "sle_minion"
-    And I disable repository "os_pool_repo os_update_repo os_ltss_repo" on this "sle_minion"
+    And I disable repository "os_pool_repo os_update_repo" on this "sle_minion"
     And I refresh the metadata for "sle_minion"

--- a/testsuite/features/secondary/min_salt_openscap_audit.feature
+++ b/testsuite/features/secondary/min_salt_openscap_audit.feature
@@ -12,7 +12,7 @@ Feature: OpenSCAP audit of Salt minion
 
   Scenario: Install the OpenSCAP packages on the SLE minion
     Given I am on the Systems overview page of this "sle_minion"
-    When I enable repository "os_pool_repo os_update_repo os_ltss_repo" on this "sle_minion"
+    When I enable repository "os_pool_repo os_update_repo" on this "sle_minion"
     And I enable client tools repositories on "sle_minion"
     And I refresh the metadata for "sle_minion"
     And I install OpenSCAP dependencies on "sle_minion"
@@ -88,5 +88,5 @@ Feature: OpenSCAP audit of Salt minion
 
   Scenario: Cleanup: remove the OpenSCAP packages from the SLE minion
     When I remove OpenSCAP dependencies from "sle_minion"
-    And I disable repository "os_pool_repo os_update_repo os_ltss_repo" on this "sle_minion"
+    And I disable repository "os_pool_repo os_update_repo" on this "sle_minion"
     And I disable client tools repositories on "sle_minion"

--- a/testsuite/features/secondary/minssh_ansible_control_node.feature
+++ b/testsuite/features/secondary/minssh_ansible_control_node.feature
@@ -16,7 +16,7 @@ Feature: Operate an Ansible control node in SSH minion
   Scenario: Pre-requisite: Enable client tools repositories
     Given I am on the Systems overview page of this "ssh_minion"
     When I enable client tools repositories on "ssh_minion"
-    And I enable repository "os_pool_repo os_update_repo os_ltss_repo" on this "ssh_minion"
+    And I enable repository "os_pool_repo os_update_repo" on this "ssh_minion"
     And I refresh the metadata for "ssh_minion"
 
   Scenario: Enable "Ansible control node" system type
@@ -90,5 +90,5 @@ Feature: Operate an Ansible control node in SSH minion
   Scenario: Cleanup: Disable client tools channel
     Given I am on the Systems overview page of this "ssh_minion"
     When I disable client tools repositories on "ssh_minion"
-    And I disable repository "os_pool_repo os_update_repo os_ltss_repo" on this "ssh_minion"
+    And I disable repository "os_pool_repo os_update_repo" on this "ssh_minion"
     And I refresh the metadata for "ssh_minion"

--- a/testsuite/features/secondary/trad_openscap_audit.feature
+++ b/testsuite/features/secondary/trad_openscap_audit.feature
@@ -9,7 +9,7 @@ Feature: OpenSCAP audit of traditional client
   I want to run an OpenSCAP scan on it
 
   Scenario: Install the OpenSCAP packages on the traditional client
-    When I enable repository "os_pool_repo os_update_repo os_ltss_repo" on this "sle_client"
+    When I enable repository "os_pool_repo os_update_repo" on this "sle_client"
     And I enable client tools repositories on "sle_client"
     And I refresh the metadata for "sle_client"
     And I install OpenSCAP dependencies on "sle_client"
@@ -66,4 +66,4 @@ Feature: OpenSCAP audit of traditional client
   Scenario: Cleanup: remove the OpenSCAP packages from the traditional client
     When I remove OpenSCAP dependencies from "sle_client"
     And I disable client tools repositories on "sle_client"
-    And I disable repository "os_pool_repo os_update_repo os_ltss_repo" on this "sle_client"
+    And I disable repository "os_pool_repo os_update_repo" on this "sle_client"


### PR DESCRIPTION
## What does this PR change?

Remove os_ltss_repo from CI minions to match the current status. We removed them from sumaform in the current 15sp2 and 15sp3 minions and this current PR is making the testsuite match. Supersedes https://github.com/uyuni-project/sumaform/pull/985

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes #
Tracks 4.2: https://github.com/SUSE/spacewalk/pull/16307
4.1: I think it's not needed on 4.1, because it's using 15sp1 minion and it's LTSS already

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
