### PR TITLE
Change copyright according to offical docs

### DIFF
--- a/spacewalk/setup/doc/conf.py
+++ b/spacewalk/setup/doc/conf.py
@@ -1,7 +1,7 @@
 # -- Project information -----------------------------------------------------
 
 project = 'spacewalk-cobbler-setup'
-copyright = '2021, SUSE Linux LLC'
+copyright = '2021, The Uyuni Project'
 author = 'Uyuni Project'
 
 # -- General configuration ---------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

Correct the copyright incorrectly introduced in #4030

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: Docs only PR

- [x] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [x] **DONE**

## Changelogs

These are just small changes to the manpage.

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
