### PR TITLE
Remove spacewalk-abrt

### DIFF
--- a/scripts/translation/update-all-translation-strings.sh
+++ b/scripts/translation/update-all-translation-strings.sh
@@ -54,7 +54,7 @@ function update_xliff() {
     return 0
 }
 
-PO_DIRS=(backend client/rhel/yum-rhn-plugin client/rhel/mgr-daemon client/rhel/spacewalk-client-tools client/tools/spacewalk-abrt web susemanager spacecmd)
+PO_DIRS=(backend client/rhel/yum-rhn-plugin client/rhel/mgr-daemon client/rhel/spacewalk-client-tools web susemanager spacecmd)
 commits=0
 safe=0
 


### PR DESCRIPTION


## What does this PR change?

spacewalk-abrt was removed from client tools[0]. We need to remove the
reference in the translation update script.

[0] https://github.com/uyuni-project/uyuni/commit/f7f21baddf87b3c84bbbb32f0a4ecc5d84f50d8e

## GUI diff

No difference.



- [X] **DONE**

## Documentation
- No documentation needed

- [X] **DONE**

## Test coverage
- No tests

- [X] **DONE**

## Links

No issue. I found this while doing another thing.

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
