### PR TITLE
Grandfather old date constructor uses

### DIFF
--- a/web/html/src/components/datetime/DateTimePicker.tsx
+++ b/web/html/src/components/datetime/DateTimePicker.tsx
@@ -99,8 +99,8 @@ class DatePicker extends React.PureComponent<DatePickerProps> {
     this.setVisible(props.open);
   }
 
-  // The jQuery date picker always uses browser time (not user or server time), so we can only use it to get specific numeric values, not a coherent object
   toFauxBrowserDate(props: DatePickerProps) {
+    // The jQuery date picker always uses browser time (not user or server time), so we can only use it to get specific numeric values, not a coherent object
     // eslint-disable-next-line local-rules/no-raw-date
     const date = new Date();
     date.setFullYear(props.year);
@@ -201,8 +201,9 @@ class TimePicker extends React.PureComponent<TimePickerProps> {
     this.setVisible(props.open);
   }
 
-  // The jQuery date picker always uses browser time (not user or server time), so we can only use it to get specific numeric values, not a coherent object
   toFauxBrowserDate(props: TimePickerProps) {
+    // The jQuery date picker always uses browser time (not user or server time), so we can only use it to get specific numeric values, not a coherent object
+    // eslint-disable-next-line local-rules/no-raw-date
     const date = new Date();
     date.setHours(props.hours);
     date.setMinutes(props.minutes);

--- a/web/html/src/components/input/DateTime.stories.tsx
+++ b/web/html/src/components/input/DateTime.stories.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { Form } from "./Form";
 import { DateTime } from "./DateTime";
 import { SubmitButton } from "components/buttons";
+import { localizedMoment } from "utils";
 
 export default {
   component: DateTime,
@@ -9,7 +10,7 @@ export default {
 };
 
 let model = {
-  time: new Date(),
+  time: localizedMoment(),
 };
 
 export const Example = () => (

--- a/web/html/src/core/spa/spa-engine.tsx
+++ b/web/html/src/core/spa/spa-engine.tsx
@@ -103,6 +103,8 @@ window.pageRenderers.spaengine.init = function init(timeout = 30) {
         }
       }
 
+      // This doesn't affect user-facing date time values, however if you touch this code, please use `localizedMoment()` here instead
+      // eslint-disable-next-line local-rules/no-raw-date
       Loggerhead.info("[" + new Date().toUTCString() + "] - Loading `" + window.location + "`");
       SpaRenderer.onSpaEndNavigation();
       onDocumentReadyInitOldJS();

--- a/web/html/src/manager/audit/cveaudit/cveaudit.tsx
+++ b/web/html/src/manager/audit/cveaudit/cveaudit.tsx
@@ -37,6 +37,8 @@ const PATCH_STATUS_LABEL = {
 const TARGET_IMAGE = "IMAGE";
 const TARGET_SERVER = "SERVER";
 const CVE_REGEX = /(\d{4})-(\d{4,7})/i;
+// TODO: If you touch this code, please use `localizedMoment()` here instead
+// eslint-disable-next-line local-rules/no-raw-date
 const CURRENT_YEAR = new Date().getFullYear();
 const YEARS = (function () {
   const arr: number[] = [];
@@ -100,6 +102,7 @@ class CVEAudit extends React.Component<Props, State> {
     this.setState({ selectedItems: items }, () => {
       DWRItemSelector.select("system_list", list, isAdd, (res) => {
         // TODO: If you touch this code, please get rid of this `eval()` call, see https://github.com/SUSE/spacewalk/issues/15069
+        // eslint-disable-next-line no-eval
         dwr.util.setValue("header_selcount", eval(res).header, { escapeHtml: false });
       });
     });

--- a/web/html/src/manager/virtualization/guests/console/guests-console.tsx
+++ b/web/html/src/manager/virtualization/guests/console/guests-console.tsx
@@ -36,6 +36,8 @@ type State = {
 function getTokenLifetime(token: String): number {
   const jwsParts = token.split(".");
   const claims = JSON.parse(atob(jwsParts[1]));
+  // TODO: If you touch this code, please use `localizedMoment()` here instead
+  // eslint-disable-next-line local-rules/no-raw-date
   return new Date(claims["exp"] * 1000).valueOf() - new Date(claims["iat"] * 1000).valueOf();
 }
 

--- a/web/html/src/manager/visualization/ui/components.ts
+++ b/web/html/src/manager/visualization/ui/components.ts
@@ -47,14 +47,20 @@ function addCheckinTimePartitioningSelect(anchorId, applyCallback, clearCallback
     autoclose: true,
     format: "yyyy-mm-dd",
   });
+  // TODO: If you touch this code, please use `localizedMoment()` here instead
+  // eslint-disable-next-line local-rules/no-raw-date
   jQuery(anchorId + " .partitioning-datepicker").datepicker("setDate", new Date());
   jQuery(anchorId + " .partitioning-timepicker").timepicker({ timeFormat: "H:i:s", maxTime: "23:30:00" });
+  // TODO: If you touch this code, please use `localizedMoment()` here instead
+  // eslint-disable-next-line local-rules/no-raw-date
   jQuery(anchorId + " .partitioning-timepicker").timepicker("setTime", new Date());
 
   const checkinPartitioningButtons = checkinTimePartitioning.append("div").attr("class", "btn-group");
   addButton(checkinPartitioningButtons, "Apply", () => {
     const date = jQuery(anchorId + " .partitioning-datepicker").datepicker("getDate");
     const time = jQuery(anchorId + " .partitioning-timepicker").timepicker("getTime");
+    // TODO: If you touch this code, please use `localizedMoment()` here instead
+    // eslint-disable-next-line local-rules/no-raw-date
     const datetime = new Date(
       date.getFullYear(),
       date.getMonth(),

--- a/web/html/src/utils/functions.ts
+++ b/web/html/src/utils/functions.ts
@@ -53,6 +53,7 @@ function sortByNumber(aRaw: any, bRaw: any, columnKey: string, sortDirection: nu
   return result * sortDirection;
 }
 
+// TODO: This function needs to be reworked, see https://github.com/SUSE/spacewalk/issues/15389 and the commentary below
 function sortByDate(aRaw: any, bRaw: any, columnKey: string, sortDirection: number): number {
   /**
    *  HACK
@@ -88,13 +89,15 @@ function sortByDate(aRaw: any, bRaw: any, columnKey: string, sortDirection: numb
       ? null
       : aRaw[columnKey] instanceof Date
       ? aRaw[columnKey]
-      : new Date(aRaw[columnKey].replace(unparsableDateRegex, "$1"));
+      : // eslint-disable-next-line local-rules/no-raw-date
+        new Date(aRaw[columnKey].replace(unparsableDateRegex, "$1"));
   const bDate =
     bRaw[columnKey] === null
       ? null
       : bRaw[columnKey] instanceof Date
       ? bRaw[columnKey]
-      : new Date(bRaw[columnKey].replace(unparsableDateRegex, "$1"));
+      : // eslint-disable-next-line local-rules/no-raw-date
+        new Date(bRaw[columnKey].replace(unparsableDateRegex, "$1"));
 
   const result = aDate > bDate ? 1 : aDate < bDate ? -1 : 0;
   return result * sortDirection;

--- a/web/html/src/utils/test-utils/timer.ts
+++ b/web/html/src/utils/test-utils/timer.ts
@@ -1,3 +1,5 @@
+import { localizedMoment } from "utils/datetime";
+
 let timerId = 0;
 
 /**
@@ -8,13 +10,13 @@ let timerId = 0;
 export class Timer {
   id: number;
   isEnabled: boolean;
-  start: Date;
-  prev: Date;
+  start: moment.Moment;
+  prev: moment.Moment;
 
   constructor(isEnabled = true) {
     this.id = timerId++;
     this.isEnabled = isEnabled;
-    this.start = new Date();
+    this.start = localizedMoment();
     this.prev = this.start;
   }
 
@@ -22,10 +24,10 @@ export class Timer {
     if (!this.isEnabled) {
       return;
     }
-    const now = new Date();
+    const now = localizedMoment();
     console.log(
-      `[timer ${this.id}] ${description}: +${now.getTime() - this.prev.getTime()}ms (total: ${
-        now.getTime() - this.start.getTime()
+      `[timer ${this.id}] ${description}: +${now.valueOf() - this.prev.valueOf()}ms (total: ${
+        now.valueOf() - this.start.valueOf()
       }ms)`
     );
     this.prev = now;


### PR DESCRIPTION
## What does this PR change?

We currently have lint warnings on old code which we don't plan to touch unless otherwise necessary. This PR adds commentary and ignores those raw date constructor uses so the lint output isn't littered.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
