### PR TITLE
Update snakeyaml from version 1.25 -> 1.28

### DIFF
--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -79,7 +79,7 @@
         <dependency org="suse" name="sitemesh" rev="2.1" />
         <dependency org="suse" name="slf4j-api" rev="1.7.30" />
         <dependency org="suse" name="slf4j-log4j12" rev="1.7.30" />
-        <dependency org="suse" name="snakeyaml" rev="1.25" />
+        <dependency org="suse" name="snakeyaml" rev="1.28" />
         <dependency org="suse" name="spark-core" rev="2.7.2" />
         <dependency org="suse" name="spark-template-jade" rev="2.3" />
         <dependency org="suse" name="spy" rev="0.8.3" />


### PR DESCRIPTION
## What does this PR change?

This patch is updating the `snakeyaml` dependency to version 1.28 as they apparently updated it in openSUSE Leap 15.3.

## GUI diff

No difference.

- [X] **DONE**

## Documentation

- No documentation needed: only internal and user invisible changes (dependencies)

- [X] **DONE**

## Test coverage

- No tests: already covered

- [X] **DONE**

## Links

There is currently no issue for this.

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [X] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below).

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
