### PR TITLE
Add missing changelog

### DIFF
--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Remove NullPointerException in rhn_web_ui.log when building an image (bsc#1185951)
 - Set product name and version in the User-Agent header when connecting to SCC
 - On salt-ssh minions, enforce package list refresh after state apply
 - Improve the API to query system events and history

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,5 +1,6 @@
 - Remove NullPointerException in rhn_web_ui.log when building an image (bsc#1185951)
-- Bugfix: Prevent "no session" hibernate error on deleting server- Set product name and version in the User-Agent header when connecting to SCC
+- Bugfix: Prevent "no session" hibernate error on deleting server
+- Set product name and version in the User-Agent header when connecting to SCC
 - On salt-ssh minions, enforce package list refresh after state apply
 - Improve the API to query system events and history
 - Fix internal server error on DuplicateSystemsCompare (bsc#1191643)


### PR DESCRIPTION
## What does this PR change?

add missing changelog in spacewalk-java

## GUI diff

- [x] **DONE**

## Documentation
- No documentation needed
- [x] **DONE**

## Test coverage
- [x] **DONE**

## Links
- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
