### PR TITLE
Fix ContentSource links when auth items switch

### DIFF
--- a/java/code/src/com/redhat/rhn/domain/credentials/Credentials.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/credentials/Credentials.hbm.xml
@@ -19,8 +19,4 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
     <property name="modified" column="modified" type="timestamp"/>
 
   </class>
-  <query name="Credentials.findByUserAndTypeLabel">
-    <![CDATA[from com.redhat.rhn.domain.credentials.Credentials as c
-             where c.user = :user and c.type.label = :label]]>
-  </query>
 </hibernate-mapping>

--- a/java/code/src/com/redhat/rhn/domain/credentials/CredentialsFactory.java
+++ b/java/code/src/com/redhat/rhn/domain/credentials/CredentialsFactory.java
@@ -16,7 +16,6 @@
 package com.redhat.rhn.domain.credentials;
 
 import com.redhat.rhn.common.hibernate.HibernateFactory;
-import com.redhat.rhn.domain.user.User;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
@@ -65,23 +64,6 @@ public class CredentialsFactory extends HibernateFactory {
      */
     public static void removeCredentials(Credentials creds) {
         singleton.removeObject(creds);
-    }
-
-    /**
-     * Load {@link Credentials} for a given {@link User} and type label.
-     * @param user user
-     * @param typeLabel type label
-     * @return credentials or null
-     */
-    public static Credentials lookupByUserAndType(User user, String typeLabel) {
-        if (user == null || typeLabel == null) {
-            return null;
-        }
-        Map<String, Object> params = new HashMap<String, Object>();
-        params.put("user", user);
-        params.put("label", typeLabel);
-        return (Credentials) singleton.lookupObjectByNamedQuery(
-                "Credentials.findByUserAndTypeLabel", params);
     }
 
     /**
@@ -143,7 +125,7 @@ public class CredentialsFactory extends HibernateFactory {
      */
     public static Credentials lookupCredentialsById(long id) {
         Session session = getSession();
-        Credentials creds = (Credentials) session.get(Credentials.class, id);
+        Credentials creds = session.get(Credentials.class, id);
         return creds;
     }
 

--- a/java/code/src/com/redhat/rhn/domain/product/test/SUSEProductTestUtils.java
+++ b/java/code/src/com/redhat/rhn/domain/product/test/SUSEProductTestUtils.java
@@ -569,9 +569,15 @@ public class SUSEProductTestUtils extends HibernateFactory {
     }
 
     public static Credentials createSCCCredentials(String name, User user) {
+        Credentials credentials = createSecondarySCCCredentials(name, user);
+        credentials.setUrl("dummy");
+        CredentialsFactory.storeCredentials(credentials);
+        return credentials;
+    }
+
+    public static Credentials createSecondarySCCCredentials(String name, User user) {
         Credentials credentials = CredentialsFactory.createSCCCredentials();
         credentials.setPassword(TestUtils.randomString());
-        credentials.setUrl("dummy");
         credentials.setUsername(name);
         credentials.setUser(user);
         CredentialsFactory.storeCredentials(credentials);

--- a/java/code/src/com/redhat/rhn/domain/scc/SCCRepository.java
+++ b/java/code/src/com/redhat/rhn/domain/scc/SCCRepository.java
@@ -275,7 +275,10 @@ public class SCCRepository extends BaseDomainHelper {
                     return Optional.of(a);
                 }
             }
-            result = Optional.of(a);
+            if (result.isEmpty() || a.getId().longValue() < result.get().getId().longValue()) {
+                // get always the same result and use the oldest alternative if there are multiple
+                result = Optional.of(a);
+            }
         }
         return result;
     }

--- a/java/code/src/com/redhat/rhn/domain/scc/SCCRepository.java
+++ b/java/code/src/com/redhat/rhn/domain/scc/SCCRepository.java
@@ -275,7 +275,7 @@ public class SCCRepository extends BaseDomainHelper {
                     return Optional.of(a);
                 }
             }
-            if (result.isEmpty() || a.getId().longValue() < result.get().getId().longValue()) {
+            if (result.isEmpty() || a.getId() < result.get().getId()) {
                 // get always the same result and use the oldest alternative if there are multiple
                 result = Optional.of(a);
             }

--- a/java/code/src/com/redhat/rhn/domain/scc/SCCRepositoryAuth.java
+++ b/java/code/src/com/redhat/rhn/domain/scc/SCCRepositoryAuth.java
@@ -195,6 +195,7 @@ public abstract class SCCRepositoryAuth extends BaseDomainHelper {
         return new EqualsBuilder()
             .append(getCredentials(), otherSCCRepository.getCredentials())
             .append(getRepo(), otherSCCRepository.getRepo())
+            .append(getUrl(), otherSCCRepository.getUrl())
             .isEquals();
     }
 

--- a/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -607,6 +607,7 @@ public class ContentSyncManager {
                         }, auth -> {
                             log.debug("Has new auth: " + cs.getLabel());
                             auth.setContentSource(cs);
+                            SCCCachingFactory.saveRepositoryAuth(auth);
                         })
                     )
                 )
@@ -620,22 +621,55 @@ public class ContentSyncManager {
             orphanChannels.forEach(c -> {
                 Opt.consume(ChannelFactory.findVendorRepositoryByChannel(c),
                     () -> log.error("No repository found for channel: '" + c.getLabel() + "'"),
-                    repo -> repo.getBestAuth().ifPresent(a -> createOrUpdateContentSource(a, c, mirrorUrl))
+                    repo -> {
+                        log.debug("configure orphan repo " + repo.toString());
+                        repo.getBestAuth().ifPresentOrElse(
+                                a -> createOrUpdateContentSource(a, c, mirrorUrl),
+                                () -> log.info("No Auth available for " + repo.toString())
+                                );
+                    }
                 );
             });
         }
         // update URL if needed
-        SCCCachingFactory.lookupRepositoryAuthWithContentSource().stream()
-            .forEach(a -> {
-                ContentSource cs = a.getContentSource();
-                String overwriteUrl = contentSourceUrlOverwrite(a.getRepo(), a.getUrl(), mirrorUrl);
-                if (!cs.getSourceUrl().equals(overwriteUrl)) {
-                    cs.setSourceUrl(overwriteUrl);
-                }
-                if (cs.getMetadataSigned() != a.getRepo().isSigned()) {
-                    cs.setMetadataSigned(a.getRepo().isSigned());
-                }
-            });
+        for (SCCRepositoryAuth auth : SCCCachingFactory.lookupRepositoryAuthWithContentSource()) {
+            boolean save = false;
+            ContentSource cs = auth.getContentSource();
+
+            // check if this auth item is the "best" available auth for this repo
+            // if not, switch it over to the best
+            if (!auth.getRepo().getBestAuth().isPresent()) {
+                log.warn("no best auth available for repo " + auth.getRepo());
+                continue;
+            }
+            SCCRepositoryAuth bestAuth = auth.getRepo().getBestAuth().get();
+            if (!bestAuth.equals(auth)) {
+                // we are not the "best" available repository auth item.
+                // remove the content source link and set it to the "best"
+                log.info("Auth '" + bestAuth.getId() + "' became the best auth. Remove CS link from " + auth.getId());
+                auth.setContentSource(null);
+                bestAuth.setContentSource(cs);
+                SCCCachingFactory.saveRepositoryAuth(auth);
+                SCCCachingFactory.saveRepositoryAuth(bestAuth);
+                // and continue with the best
+                auth = bestAuth;
+            }
+            String overwriteUrl = contentSourceUrlOverwrite(auth.getRepo(), auth.getUrl(), mirrorUrl);
+            log.debug(String.format("Linked ContentSource: '%s' OverwriteURL: '%s' AuthUrl: '%s' Mirror: '%s'",
+                    cs.getSourceUrl(), overwriteUrl, auth.getUrl(), mirrorUrl));
+            if (!cs.getSourceUrl().equals(overwriteUrl)) {
+                log.debug("Change URL to : " + overwriteUrl);
+                cs.setSourceUrl(overwriteUrl);
+                save = true;
+            }
+            if (cs.getMetadataSigned() != auth.getRepo().isSigned()) {
+                cs.setMetadataSigned(auth.getRepo().isSigned());
+                save = true;
+            }
+            if (save) {
+                ChannelFactory.save(cs);
+            }
+        }
     }
 
     /**
@@ -648,6 +682,8 @@ public class ContentSyncManager {
         for (SCCRepositoryAuth a : SCCCachingFactory.lookupRepositoryAuthWithContentSource()) {
             ContentSource cs = a.getContentSource();
             String overwriteUrl = contentSourceUrlOverwrite(a.getRepo(), a.getUrl(), mirrorUrl);
+            log.debug(String.format("Linked ContentSource: '%s' OverwriteURL: '%s' AuthUrl: '%s' Mirror: %s",
+                    cs.getSourceUrl(), overwriteUrl, a.getUrl(), mirrorUrl));
             if (!cs.getSourceUrl().equals(overwriteUrl)) {
                 log.debug("Source and overwrite urls differ: " + cs.getSourceUrl() + " != " + overwriteUrl);
                 return true;

--- a/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
+++ b/java/code/src/com/redhat/rhn/manager/content/ContentSyncManager.java
@@ -638,7 +638,7 @@ public class ContentSyncManager {
 
             // check if this auth item is the "best" available auth for this repo
             // if not, switch it over to the best
-            if (!auth.getRepo().getBestAuth().isPresent()) {
+            if (auth.getRepo().getBestAuth().isEmpty()) {
                 log.warn("no best auth available for repo " + auth.getRepo());
                 continue;
             }

--- a/java/code/src/com/redhat/rhn/manager/content/test/ContentSyncManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/content/test/ContentSyncManagerTest.java
@@ -672,7 +672,7 @@ public class ContentSyncManagerTest extends BaseTestCaseWithUser {
         List<SCCRepositoryJson> repositoriesChanged = gson.fromJson(
                 inReaderRepos, new TypeToken<List<SCCRepositoryJson>>() { }.getType());
 
-        Credentials sccCreds = CredentialsFactory.lookupByUserAndType(user, Credentials.TYPE_SCC);
+        Credentials sccCreds = CredentialsFactory.lookupSCCCredentials().get(0);
 
         ContentSyncManager csm = new ContentSyncManager();
         csm.updateSUSEProducts(productsChanged, upgradePaths, staticTreeChanged, Collections.emptyList());

--- a/java/code/src/com/redhat/rhn/manager/content/test/ContentSyncManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/content/test/ContentSyncManagerTest.java
@@ -711,7 +711,8 @@ public class ContentSyncManagerTest extends BaseTestCaseWithUser {
      * @throws Exception if anything goes wrong
      */
     public void testSwitchingBestAuthItem() throws Exception {
-        SUSEProductTestUtils.createVendorSUSEProductEnvironment(user, "/com/redhat/rhn/manager/content/test/smallBase", true);
+        SUSEProductTestUtils.createVendorSUSEProductEnvironment(user,
+                "/com/redhat/rhn/manager/content/test/smallBase", true);
         HibernateFactory.getSession().flush();
         HibernateFactory.getSession().clear();
 
@@ -745,14 +746,22 @@ public class ContentSyncManagerTest extends BaseTestCaseWithUser {
         Gson gson = new GsonBuilder()
                 .setDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSX")
                 .create();
-        InputStreamReader inReaderProducts = new InputStreamReader(ContentSyncManager.class.getResourceAsStream("/com/redhat/rhn/manager/content/test/data1/productsUnscoped.json"));
-        List<SCCProductJson> productsChanged = gson.fromJson(inReaderProducts, new TypeToken<List<SCCProductJson>>() {}.getType());
-        InputStreamReader inReaderUpgrade = new InputStreamReader(ContentSyncManager.class.getResourceAsStream("/com/redhat/rhn/manager/content/test/upgrade_paths.json"));
-        List<UpgradePathJson> upgradePaths = gson.fromJson(inReaderUpgrade, new TypeToken<List<UpgradePathJson>>() {}.getType());
-        InputStreamReader inReaderTree = new InputStreamReader(ContentSyncManager.class.getResourceAsStream("/com/redhat/rhn/manager/content/test/data1/product_tree.json"));
-        List<ProductTreeEntry> staticTreeChanged = JsonParser.GSON.fromJson(inReaderTree, new TypeToken<List<ProductTreeEntry>>() {}.getType());
-        InputStreamReader inReaderRepos = new InputStreamReader(ContentSyncManager.class.getResourceAsStream("/com/redhat/rhn/manager/content/test/data1/repositories.json"));
-        List<SCCRepositoryJson> repositoriesChanged = gson.fromJson(inReaderRepos, new TypeToken<List<SCCRepositoryJson>>() {}.getType());
+        InputStreamReader inReaderProducts = new InputStreamReader(ContentSyncManager.class
+                .getResourceAsStream("/com/redhat/rhn/manager/content/test/data1/productsUnscoped.json"));
+        List<SCCProductJson> productsChanged = gson.fromJson(
+                inReaderProducts, new TypeToken<List<SCCProductJson>>() { }.getType());
+        InputStreamReader inReaderUpgrade = new InputStreamReader(ContentSyncManager.class
+                .getResourceAsStream("/com/redhat/rhn/manager/content/test/upgrade_paths.json"));
+        List<UpgradePathJson> upgradePaths = gson.fromJson(
+                inReaderUpgrade, new TypeToken<List<UpgradePathJson>>() { }.getType());
+        InputStreamReader inReaderTree = new InputStreamReader(ContentSyncManager.class
+                .getResourceAsStream("/com/redhat/rhn/manager/content/test/data1/product_tree.json"));
+        List<ProductTreeEntry> staticTreeChanged = JsonParser.GSON.fromJson(
+                inReaderTree, new TypeToken<List<ProductTreeEntry>>() { }.getType());
+        InputStreamReader inReaderRepos = new InputStreamReader(ContentSyncManager.class
+                .getResourceAsStream("/com/redhat/rhn/manager/content/test/data1/repositories.json"));
+        List<SCCRepositoryJson> repositoriesChanged = gson.fromJson(
+                inReaderRepos, new TypeToken<List<SCCRepositoryJson>>() { }.getType());
 
         ContentSyncManager csm = new ContentSyncManager();
         //csm.updateSUSEProducts(productsChanged, upgradePaths, staticTreeChanged, Collections.emptyList());

--- a/java/code/src/com/redhat/rhn/manager/content/test/data1/productsUnscoped.json
+++ b/java/code/src/com/redhat/rhn/manager/content/test/data1/productsUnscoped.json
@@ -1192,5 +1192,1252 @@
         "installer_updates": false
       }
     ]
+  },
+  {
+    "arch": "x86_64",
+    "cpe": "cpe:/o:suse:sles:15",
+    "description": "SUSE Linux Enterprise offers a comprehensive suite of products built on a single code base. The platform addresses business needs from the smallest thin-client devices to the world's most powerful high-performance computing and mainframe servers. SUSE Linux Enterprise offers common management tools and technology certifications across the platform, and each product is enterprise-class.",
+    "eula_url": "https://updates.suse.com/SUSE/Products/SLE-Product-SLES/15/x86_64/product.license/",
+    "extensions": [
+      {
+        "arch": "x86_64",
+        "cpe": "cpe:/o:suse:sle-module-basesystem:15",
+        "description": "<p> The SUSE Linux Enterprise Basesystem Module delivers the base system of the product. </p>",
+        "eula_url": "",
+        "extensions": [
+          {
+            "arch": "x86_64",
+            "cpe": "cpe:/o:suse:sle-module-desktop-applications:15",
+            "description": "<p> The SUSE Linux Enterprise Desktop Applications Module delivers a basic set of Desktop functionality. </p> <p> Access to the Desktop Applications Module is included in your SUSE Linux Enterprise product subscription. </p>",
+            "eula_url": "",
+            "extensions": [
+              {
+                "arch": "x86_64",
+                "cpe": "cpe:/o:suse:sle-module-development-tools:15",
+                "description": "<p> The Development Tools Module helps you developing applications for SUSE Linux Enterprise 15. </p> <p> Access to the Development Tools Module is included in your SUSE Linux Enterprise product subscription. The module has a different lifecycle than SUSE Linux Enterprise itself. </p>",
+                "eula_url": "",
+                "extensions": [],
+                "former_identifier": "sle-sdk",
+                "free": true,
+                "friendly_name": "Development Tools Module 15 x86_64",
+                "friendly_version": "15",
+                "id": 1579,
+                "identifier": "sle-module-development-tools",
+                "migration_extra": true,
+                "name": "Development Tools Module",
+                "offline_predecessor_ids": [
+                  1223,
+                  1323,
+                  1341,
+                  1366,
+                  1427,
+                  1630,
+                  1892
+                ],
+                "online_predecessor_ids": [],
+                "predecessor_ids": [],
+                "product_class": "MODULE",
+                "product_type": "module",
+                "recommended": false,
+                "release_stage": "released",
+                "release_type": null,
+                "repositories": [
+                  {
+                    "autorefresh": true,
+                    "description": "SLE-Module-DevTools15-Updates for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": true,
+                    "id": 2539,
+                    "installer_updates": false,
+                    "name": "SLE-Module-DevTools15-Updates",
+                    "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Development-Tools/15/x86_64/update/"
+                  },
+                  {
+                    "autorefresh": true,
+                    "description": "SLE-Module-DevTools15-Debuginfo-Updates for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": false,
+                    "id": 2540,
+                    "installer_updates": false,
+                    "name": "SLE-Module-DevTools15-Debuginfo-Updates",
+                    "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Development-Tools/15/x86_64/update_debug/"
+                  },
+                  {
+                    "autorefresh": false,
+                    "description": "SLE-Module-DevTools15-Pool for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": true,
+                    "id": 2541,
+                    "installer_updates": false,
+                    "name": "SLE-Module-DevTools15-Pool",
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Development-Tools/15/x86_64/product/"
+                  },
+                  {
+                    "autorefresh": false,
+                    "description": "SLE-Module-DevTools15-Debuginfo-Pool for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": false,
+                    "id": 2542,
+                    "installer_updates": false,
+                    "name": "SLE-Module-DevTools15-Debuginfo-Pool",
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Development-Tools/15/x86_64/product_debug/"
+                  },
+                  {
+                    "autorefresh": false,
+                    "description": "SLE-Module-DevTools15-Source-Pool for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": false,
+                    "id": 2543,
+                    "installer_updates": false,
+                    "name": "SLE-Module-DevTools15-Source-Pool",
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Development-Tools/15/x86_64/product_source/"
+                  }
+                ],
+                "shortname": "Development-Tools-Module",
+                "version": "15"
+              },
+              {
+                "arch": "x86_64",
+                "cpe": "cpe:/o:suse:sle-we:15",
+                "description": "SUSE Linux Enterprise Workstation Extension adds additional functionality to a base SUSE Linux Enterprise installation. The Workstation Extension offers additional desktop applications (office suite, email client, graphical editor, multimedia tools) and libraries. Workstation Extension is enabled and installed by default on SUSE Linux Enterprise Desktop installation. Adding the Workstation Extension to a SUSE Linux Enterprise Server installation allows to seamlessly combine both products to create a full featured server workstation.",
+                "eula_url": "https://updates.suse.com/SUSE/Products/SLE-Product-WE/15/x86_64/product.license/",
+                "extensions": [],
+                "former_identifier": "sle-we",
+                "free": false,
+                "friendly_name": "SUSE Linux Enterprise Workstation Extension 15 x86_64",
+                "friendly_version": "15",
+                "id": 1583,
+                "identifier": "sle-we",
+                "migration_extra": false,
+                "name": "SUSE Linux Enterprise Workstation Extension",
+                "offline_predecessor_ids": [
+                  1222,
+                  1338,
+                  1359,
+                  1431,
+                  1639,
+                  1893
+                ],
+                "online_predecessor_ids": [],
+                "predecessor_ids": [],
+                "product_class": "SLE-WE",
+                "product_type": "extension",
+                "recommended": false,
+                "release_stage": "released",
+                "release_type": null,
+                "repositories": [
+                  {
+                    "autorefresh": true,
+                    "description": "SLE-Product-WE15-Updates for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": true,
+                    "id": 2742,
+                    "installer_updates": false,
+                    "name": "SLE-Product-WE15-Updates",
+                    "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-WE/15/x86_64/update/"
+                  },
+                  {
+                    "autorefresh": true,
+                    "description": "SLE-Product-WE15-Debuginfo-Updates for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": false,
+                    "id": 2743,
+                    "installer_updates": false,
+                    "name": "SLE-Product-WE15-Debuginfo-Updates",
+                    "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-WE/15/x86_64/update_debug/"
+                  },
+                  {
+                    "autorefresh": false,
+                    "description": "SLE-Product-WE15-Pool for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": true,
+                    "id": 2744,
+                    "installer_updates": false,
+                    "name": "SLE-Product-WE15-Pool",
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Product-WE/15/x86_64/product/"
+                  },
+                  {
+                    "autorefresh": false,
+                    "description": "SLE-Product-WE15-Debuginfo-Pool for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": false,
+                    "id": 2745,
+                    "installer_updates": false,
+                    "name": "SLE-Product-WE15-Debuginfo-Pool",
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Product-WE/15/x86_64/product_debug/"
+                  },
+                  {
+                    "autorefresh": false,
+                    "description": "SLE-Product-WE15-Source-Pool for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": false,
+                    "id": 2746,
+                    "installer_updates": false,
+                    "name": "SLE-Product-WE15-Source-Pool",
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Product-WE/15/x86_64/product_source/"
+                  },
+                  {
+                    "autorefresh": true,
+                    "description": "SLE-15-GA-Desktop-NVIDIA-Driver for ",
+                    "distro_target": null,
+                    "enabled": true,
+                    "id": 2747,
+                    "installer_updates": false,
+                    "name": "SLE-15-GA-Desktop-NVIDIA-Driver",
+                    "url": "https://download.nvidia.com/suse/sle15/"
+                  }
+                ],
+                "shortname": "SLEWE15",
+                "version": "15"
+              }
+            ],
+            "former_identifier": "sle-module-desktop-applications",
+            "free": true,
+            "friendly_name": "Desktop Applications Module 15 x86_64",
+            "friendly_version": "15",
+            "id": 1578,
+            "identifier": "sle-module-desktop-applications",
+            "migration_extra": true,
+            "name": "Desktop Applications Module",
+            "offline_predecessor_ids": [],
+            "online_predecessor_ids": [],
+            "predecessor_ids": [],
+            "product_class": "MODULE",
+            "product_type": "module",
+            "recommended": false,
+            "release_stage": "released",
+            "release_type": null,
+            "repositories": [
+              {
+                "autorefresh": true,
+                "description": "SLE-Module-Desktop-Applications15-Updates for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": true,
+                "id": 2534,
+                "installer_updates": false,
+                "name": "SLE-Module-Desktop-Applications15-Updates",
+                "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Desktop-Applications/15/x86_64/update/"
+              },
+              {
+                "autorefresh": true,
+                "description": "SLE-Module-Desktop-Applications15-Debuginfo-Updates for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": false,
+                "id": 2535,
+                "installer_updates": false,
+                "name": "SLE-Module-Desktop-Applications15-Debuginfo-Updates",
+                "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Desktop-Applications/15/x86_64/update_debug/"
+              },
+              {
+                "autorefresh": false,
+                "description": "SLE-Module-Desktop-Applications15-Pool for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": true,
+                "id": 2536,
+                "installer_updates": false,
+                "name": "SLE-Module-Desktop-Applications15-Pool",
+                "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Desktop-Applications/15/x86_64/product/"
+              },
+              {
+                "autorefresh": false,
+                "description": "SLE-Module-Desktop-Applications15-Debuginfo-Pool for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": false,
+                "id": 2537,
+                "installer_updates": false,
+                "name": "SLE-Module-Desktop-Applications15-Debuginfo-Pool",
+                "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Desktop-Applications/15/x86_64/product_debug/"
+              },
+              {
+                "autorefresh": false,
+                "description": "SLE-Module-Desktop-Applications15-Source-Pool for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": false,
+                "id": 2538,
+                "installer_updates": false,
+                "name": "SLE-Module-Desktop-Applications15-Source-Pool",
+                "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Desktop-Applications/15/x86_64/product_source/"
+              }
+            ],
+            "shortname": "Desktop-Applications-Module",
+            "version": "15"
+          },
+          {
+            "arch": "x86_64",
+            "cpe": "cpe:/o:suse:sle-module-server-applications:15",
+            "description": "<p> The SUSE Linux Enterprise Server Applications Module delivers a basic set of Server functionality. </p> <p> Access to the Server Applications Module is included in your SUSE Linux Enterprise Server subscription. </p>",
+            "eula_url": "",
+            "extensions": [
+              {
+                "arch": "x86_64",
+                "cpe": "cpe:/o:suse:sle-module-legacy:15",
+                "description": "<p> The Legacy Module helps you migrating applications from SUSE Linux Enterprise 12 and other systems to SUSE Linux Enterprise 15, by providing packages which are discontinued on SUSE Linux Enterprise Server, such as: ntp, IBM Java 8, and a number of libraries. </p> <p> Access to the Legacy Module is included in your SUSE Linux Enterprise Server subscription. The module has a different lifecycle than SUSE Linux Enterprise Server itself. Packages in the this module are usually supported for at most three years. </p>",
+                "eula_url": "",
+                "extensions": [],
+                "former_identifier": "sle-module-legacy",
+                "free": true,
+                "friendly_name": "Legacy Module 15 x86_64",
+                "friendly_version": "15",
+                "id": 1581,
+                "identifier": "sle-module-legacy",
+                "migration_extra": true,
+                "name": "Legacy Module",
+                "offline_predecessor_ids": [
+                  1150
+                ],
+                "online_predecessor_ids": [],
+                "predecessor_ids": [],
+                "product_class": "MODULE",
+                "product_type": "module",
+                "recommended": false,
+                "release_stage": "released",
+                "release_type": null,
+                "repositories": [
+                  {
+                    "autorefresh": true,
+                    "description": "SLE-Module-Legacy15-Updates for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": true,
+                    "id": 2549,
+                    "installer_updates": false,
+                    "name": "SLE-Module-Legacy15-Updates",
+                    "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Legacy/15/x86_64/update/"
+                  },
+                  {
+                    "autorefresh": true,
+                    "description": "SLE-Module-Legacy15-Debuginfo-Updates for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": false,
+                    "id": 2550,
+                    "installer_updates": false,
+                    "name": "SLE-Module-Legacy15-Debuginfo-Updates",
+                    "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Legacy/15/x86_64/update_debug/"
+                  },
+                  {
+                    "autorefresh": false,
+                    "description": "SLE-Module-Legacy15-Pool for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": true,
+                    "id": 2551,
+                    "installer_updates": false,
+                    "name": "SLE-Module-Legacy15-Pool",
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Legacy/15/x86_64/product/"
+                  },
+                  {
+                    "autorefresh": false,
+                    "description": "SLE-Module-Legacy15-Debuginfo-Pool for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": false,
+                    "id": 2552,
+                    "installer_updates": false,
+                    "name": "SLE-Module-Legacy15-Debuginfo-Pool",
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Legacy/15/x86_64/product_debug/"
+                  },
+                  {
+                    "autorefresh": false,
+                    "description": "SLE-Module-Legacy15-Source-Pool for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": false,
+                    "id": 2553,
+                    "installer_updates": false,
+                    "name": "SLE-Module-Legacy15-Source-Pool",
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Legacy/15/x86_64/product_source/"
+                  }
+                ],
+                "shortname": "Legacy-Module",
+                "version": "15"
+              },
+              {
+                "arch": "x86_64",
+                "cpe": "cpe:/o:suse:sle-ha:15",
+                "description": "SUSE Linux High Availability Extension provides mature, industry-leading open-source high-availability clustering technologies that are easy to set up and use. It can be deployed in physical and/or virtual environments, and can cluster physical servers, virtual servers, or any combination of the two to suit your business\u2019 needs.",
+                "eula_url": "https://updates.suse.com/SUSE/Products/SLE-Product-HA/15/x86_64/product.license/",
+                "extensions": [],
+                "former_identifier": "sle-ha",
+                "free": false,
+                "friendly_name": "SUSE Linux Enterprise High Availability Extension 15 x86_64",
+                "friendly_version": "15",
+                "id": 1582,
+                "identifier": "sle-ha",
+                "migration_extra": false,
+                "name": "SUSE Linux Enterprise High Availability Extension",
+                "offline_predecessor_ids": [
+                  958,
+                  961,
+                  967,
+                  971,
+                  1101,
+                  1107,
+                  1157,
+                  1245,
+                  1256,
+                  1286,
+                  1324,
+                  1337,
+                  1361,
+                  1363,
+                  1432,
+                  1435,
+                  1634,
+                  1637,
+                  1884,
+                  1886
+                ],
+                "online_predecessor_ids": [],
+                "predecessor_ids": [],
+                "product_class": "SLE-HAE-X86",
+                "product_type": "extension",
+                "recommended": false,
+                "release_stage": "released",
+                "release_type": null,
+                "repositories": [
+                  {
+                    "autorefresh": true,
+                    "description": "SLE-Product-HA15-Updates for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": true,
+                    "id": 2754,
+                    "installer_updates": false,
+                    "name": "SLE-Product-HA15-Updates",
+                    "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-HA/15/x86_64/update/"
+                  },
+                  {
+                    "autorefresh": true,
+                    "description": "SLE-Product-HA15-Debuginfo-Updates for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": false,
+                    "id": 2755,
+                    "installer_updates": false,
+                    "name": "SLE-Product-HA15-Debuginfo-Updates",
+                    "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-HA/15/x86_64/update_debug/"
+                  },
+                  {
+                    "autorefresh": false,
+                    "description": "SLE-Product-HA15-Pool for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": true,
+                    "id": 2756,
+                    "installer_updates": false,
+                    "name": "SLE-Product-HA15-Pool",
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Product-HA/15/x86_64/product/"
+                  },
+                  {
+                    "autorefresh": false,
+                    "description": "SLE-Product-HA15-Debuginfo-Pool for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": false,
+                    "id": 2757,
+                    "installer_updates": false,
+                    "name": "SLE-Product-HA15-Debuginfo-Pool",
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Product-HA/15/x86_64/product_debug/"
+                  },
+                  {
+                    "autorefresh": false,
+                    "description": "SLE-Product-HA15-Source-Pool for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": false,
+                    "id": 2758,
+                    "installer_updates": false,
+                    "name": "SLE-Product-HA15-Source-Pool",
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Product-HA/15/x86_64/product_source/"
+                  }
+                ],
+                "shortname": "SLEHA15",
+                "version": "15"
+              },
+              {
+                "arch": "x86_64",
+                "cpe": "cpe:/o:suse:sle-module-public-cloud:15",
+                "description": "<p> The Public Cloud Module is a collection of tools that enables you to create and manage cloud images from the commandline on SUSE Linux Enterprise Server. When building your own images with KIWI or SUSE Studio, initialization code specific to the target cloud is included in that image. </p> <p> Access to the Public Cloud Module is included in your SUSE Linux Enterprise Server subscription. The module has a different lifecycle than SUSE Linux Enterprise Server itself; please check the Release Notes for further details. </p>",
+                "eula_url": "",
+                "extensions": [],
+                "former_identifier": "sle-module-public-cloud",
+                "free": true,
+                "friendly_name": "Public Cloud Module 15 x86_64",
+                "friendly_version": "15",
+                "id": 1611,
+                "identifier": "sle-module-public-cloud",
+                "migration_extra": true,
+                "name": "Public Cloud Module",
+                "offline_predecessor_ids": [
+                  1220
+                ],
+                "online_predecessor_ids": [],
+                "predecessor_ids": [],
+                "product_class": "MODULE",
+                "product_type": "module",
+                "recommended": false,
+                "release_stage": "released",
+                "release_type": null,
+                "repositories": [
+                  {
+                    "autorefresh": true,
+                    "description": "SLE-Module-Public-Cloud15-Updates for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": true,
+                    "id": 2673,
+                    "installer_updates": false,
+                    "name": "SLE-Module-Public-Cloud15-Updates",
+                    "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Public-Cloud/15/x86_64/update/"
+                  },
+                  {
+                    "autorefresh": true,
+                    "description": "SLE-Module-Public-Cloud15-Debuginfo-Updates for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": false,
+                    "id": 2674,
+                    "installer_updates": false,
+                    "name": "SLE-Module-Public-Cloud15-Debuginfo-Updates",
+                    "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Public-Cloud/15/x86_64/update_debug/"
+                  },
+                  {
+                    "autorefresh": false,
+                    "description": "SLE-Module-Public-Cloud15-Pool for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": true,
+                    "id": 2675,
+                    "installer_updates": false,
+                    "name": "SLE-Module-Public-Cloud15-Pool",
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Public-Cloud/15/x86_64/product/"
+                  },
+                  {
+                    "autorefresh": false,
+                    "description": "SLE-Module-Public-Cloud15-Debuginfo-Pool for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": false,
+                    "id": 2676,
+                    "installer_updates": false,
+                    "name": "SLE-Module-Public-Cloud15-Debuginfo-Pool",
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Public-Cloud/15/x86_64/product_debug/"
+                  },
+                  {
+                    "autorefresh": false,
+                    "description": "SLE-Module-Public-Cloud15-Source-Pool for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": false,
+                    "id": 3129,
+                    "installer_updates": false,
+                    "name": "SLE-Module-Public-Cloud15-Source-Pool",
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Public-Cloud/15/x86_64/product_source/"
+                  }
+                ],
+                "shortname": "Public-Cloud-Module",
+                "version": "15"
+              },
+              {
+                "arch": "x86_64",
+                "cpe": "cpe:/o:suse:sle-module-web-scripting:15",
+                "description": "<p> The SUSE Linux Enterprise Web and Scripting Module should contains additional packages that are helpful when running a webserver. </p> <p> Access to the Web and Scripting Module is included in your SUSE Linux Enterprise Server subscription. The module has a different lifecycle than SUSE Linux Enterprise Server itself: Package versions in this module are usually supported for at most three years. We are planning to release more recent versions on a schedule of approximately 18 month; the exact dates may differ per package. </p>",
+                "eula_url": "",
+                "extensions": [],
+                "former_identifier": "sle-module-web-scripting",
+                "free": true,
+                "friendly_name": "Web and Scripting Module 15 x86_64",
+                "friendly_version": "15",
+                "id": 1721,
+                "identifier": "sle-module-web-scripting",
+                "migration_extra": true,
+                "name": "Web and Scripting Module",
+                "offline_predecessor_ids": [
+                  1153
+                ],
+                "online_predecessor_ids": [],
+                "predecessor_ids": [],
+                "product_class": "MODULE",
+                "product_type": "module",
+                "recommended": false,
+                "release_stage": "released",
+                "release_type": null,
+                "repositories": [
+                  {
+                    "autorefresh": true,
+                    "description": "SLE-Module-Web-Scripting15-Updates for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": true,
+                    "id": 2972,
+                    "installer_updates": false,
+                    "name": "SLE-Module-Web-Scripting15-Updates",
+                    "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Web-Scripting/15/x86_64/update/"
+                  },
+                  {
+                    "autorefresh": true,
+                    "description": "SLE-Module-Web-Scripting15-Debuginfo-Updates for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": false,
+                    "id": 2973,
+                    "installer_updates": false,
+                    "name": "SLE-Module-Web-Scripting15-Debuginfo-Updates",
+                    "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Web-Scripting/15/x86_64/update_debug/"
+                  },
+                  {
+                    "autorefresh": false,
+                    "description": "SLE-Module-Web-Scripting15-Pool for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": true,
+                    "id": 2974,
+                    "installer_updates": false,
+                    "name": "SLE-Module-Web-Scripting15-Pool",
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Web-Scripting/15/x86_64/product/"
+                  },
+                  {
+                    "autorefresh": false,
+                    "description": "SLE-Module-Web-Scripting15-Debuginfo-Pool for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": false,
+                    "id": 2975,
+                    "installer_updates": false,
+                    "name": "SLE-Module-Web-Scripting15-Debuginfo-Pool",
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Web-Scripting/15/x86_64/product_debug/"
+                  },
+                  {
+                    "autorefresh": false,
+                    "description": "SLE-Module-Web-Scripting15-Source-Pool for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": false,
+                    "id": 2976,
+                    "installer_updates": false,
+                    "name": "SLE-Module-Web-Scripting15-Source-Pool",
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Web-Scripting/15/x86_64/product_source/"
+                  }
+                ],
+                "shortname": "Web-Scripting-Module",
+                "version": "15"
+              }
+            ],
+            "former_identifier": "sle-module-server-applications",
+            "free": true,
+            "friendly_name": "Server Applications Module 15 x86_64",
+            "friendly_version": "15",
+            "id": 1580,
+            "identifier": "sle-module-server-applications",
+            "migration_extra": false,
+            "name": "Server Applications Module",
+            "offline_predecessor_ids": [],
+            "online_predecessor_ids": [],
+            "predecessor_ids": [],
+            "product_class": "MODULE",
+            "product_type": "module",
+            "recommended": true,
+            "release_stage": "released",
+            "release_type": null,
+            "repositories": [
+              {
+                "autorefresh": true,
+                "description": "SLE-Module-Server-Applications15-Updates for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": true,
+                "id": 2544,
+                "installer_updates": false,
+                "name": "SLE-Module-Server-Applications15-Updates",
+                "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Server-Applications/15/x86_64/update/"
+              },
+              {
+                "autorefresh": true,
+                "description": "SLE-Module-Server-Applications15-Debuginfo-Updates for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": false,
+                "id": 2545,
+                "installer_updates": false,
+                "name": "SLE-Module-Server-Applications15-Debuginfo-Updates",
+                "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Server-Applications/15/x86_64/update_debug/"
+              },
+              {
+                "autorefresh": false,
+                "description": "SLE-Module-Server-Applications15-Pool for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": true,
+                "id": 2546,
+                "installer_updates": false,
+                "name": "SLE-Module-Server-Applications15-Pool",
+                "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Server-Applications/15/x86_64/product/"
+              },
+              {
+                "autorefresh": false,
+                "description": "SLE-Module-Server-Applications15-Debuginfo-Pool for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": false,
+                "id": 2547,
+                "installer_updates": false,
+                "name": "SLE-Module-Server-Applications15-Debuginfo-Pool",
+                "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Server-Applications/15/x86_64/product_debug/"
+              },
+              {
+                "autorefresh": false,
+                "description": "SLE-Module-Server-Applications15-Source-Pool for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": false,
+                "id": 2548,
+                "installer_updates": false,
+                "name": "SLE-Module-Server-Applications15-Source-Pool",
+                "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Server-Applications/15/x86_64/product_source/"
+              }
+            ],
+            "shortname": "Server-Applications-Module",
+            "version": "15"
+          },
+          {
+            "arch": "x86_64",
+            "cpe": "cpe:/o:suse:sle-module-containers:15",
+            "description": "<p>This Module contains several packages revolving around containers and related tools. </p>",
+            "eula_url": "",
+            "extensions": [],
+            "former_identifier": "sle-module-containers",
+            "free": true,
+            "friendly_name": "Containers Module 15 x86_64",
+            "friendly_version": "15",
+            "id": 1642,
+            "identifier": "sle-module-containers",
+            "migration_extra": true,
+            "name": "Containers Module",
+            "offline_predecessor_ids": [
+              1332
+            ],
+            "online_predecessor_ids": [],
+            "predecessor_ids": [],
+            "product_class": "MODULE",
+            "product_type": "module",
+            "recommended": false,
+            "release_stage": "released",
+            "release_type": null,
+            "repositories": [
+              {
+                "autorefresh": true,
+                "description": "SLE-Module-Containers15-Updates for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": true,
+                "id": 2864,
+                "installer_updates": false,
+                "name": "SLE-Module-Containers15-Updates",
+                "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Containers/15/x86_64/update/"
+              },
+              {
+                "autorefresh": true,
+                "description": "SLE-Module-Containers15-Debuginfo-Updates for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": false,
+                "id": 2865,
+                "installer_updates": false,
+                "name": "SLE-Module-Containers15-Debuginfo-Updates",
+                "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Containers/15/x86_64/update_debug/"
+              },
+              {
+                "autorefresh": false,
+                "description": "SLE-Module-Containers15-Pool for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": true,
+                "id": 2866,
+                "installer_updates": false,
+                "name": "SLE-Module-Containers15-Pool",
+                "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Containers/15/x86_64/product/"
+              },
+              {
+                "autorefresh": false,
+                "description": "SLE-Module-Containers15-Debuginfo-Pool for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": false,
+                "id": 2867,
+                "installer_updates": false,
+                "name": "SLE-Module-Containers15-Debuginfo-Pool",
+                "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Containers/15/x86_64/product_debug/"
+              },
+              {
+                "autorefresh": false,
+                "description": "SLE-Module-Containers15-Source-Pool for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": false,
+                "id": 2868,
+                "installer_updates": false,
+                "name": "SLE-Module-Containers15-Source-Pool",
+                "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Containers/15/x86_64/product_source/"
+              }
+            ],
+            "shortname": "Containers-Module",
+            "version": "15"
+          },
+          {
+            "arch": "x86_64",
+            "cpe": "cpe:/o:suse:sle-module-cap-tools:15",
+            "description": "<p> The SUSE Cloud Application Platform Tools Module is a collection of tools that enables you to interact with the SUSE Cloud Application Platform product itself, providing the commandline client for instance. </p> <p> Access to the SUSE Cloud Application Platform Tools Module is included in your SUSE Linux Enterprise Server subscription. The module has a different lifecycle than SUSE Linux Enterprise Server itself; please check the Release Notes for further details. </p>",
+            "eula_url": "",
+            "extensions": [],
+            "former_identifier": "sle-module-cap-tools",
+            "free": true,
+            "friendly_name": "SUSE Cloud Application Platform Tools Module 15 x86_64",
+            "friendly_version": "15",
+            "id": 1728,
+            "identifier": "sle-module-cap-tools",
+            "migration_extra": true,
+            "name": "SUSE Cloud Application Platform Tools Module",
+            "offline_predecessor_ids": [
+              1678
+            ],
+            "online_predecessor_ids": [],
+            "predecessor_ids": [],
+            "product_class": "MODULE",
+            "product_type": "module",
+            "recommended": false,
+            "release_stage": "released",
+            "release_type": null,
+            "repositories": [
+              {
+                "autorefresh": true,
+                "description": "SLE-Module-CAP-Tools15-Updates for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": true,
+                "id": 3000,
+                "installer_updates": false,
+                "name": "SLE-Module-CAP-Tools15-Updates",
+                "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-CAP-Tools/15/x86_64/update/"
+              },
+              {
+                "autorefresh": true,
+                "description": "SLE-Module-CAP-Tools15-Debuginfo-Updates for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": false,
+                "id": 3001,
+                "installer_updates": false,
+                "name": "SLE-Module-CAP-Tools15-Debuginfo-Updates",
+                "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-CAP-Tools/15/x86_64/update_debug/"
+              },
+              {
+                "autorefresh": false,
+                "description": "SLE-Module-CAP-Tools15-Pool for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": true,
+                "id": 3002,
+                "installer_updates": false,
+                "name": "SLE-Module-CAP-Tools15-Pool",
+                "url": "https://updates.suse.com/SUSE/Products/SLE-Module-CAP-Tools/15/x86_64/product/"
+              },
+              {
+                "autorefresh": false,
+                "description": "SLE-Module-CAP-Tools15-Debuginfo-Pool for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": false,
+                "id": 3003,
+                "installer_updates": false,
+                "name": "SLE-Module-CAP-Tools15-Debuginfo-Pool",
+                "url": "https://updates.suse.com/SUSE/Products/SLE-Module-CAP-Tools/15/x86_64/product_debug/"
+              },
+              {
+                "autorefresh": false,
+                "description": "SLE-Module-CAP-Tools15-Source-Pool for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": false,
+                "id": 3123,
+                "installer_updates": false,
+                "name": "SLE-Module-CAP-Tools15-Source-Pool",
+                "url": "https://updates.suse.com/SUSE/Products/SLE-Module-CAP-Tools/15/x86_64/product_source/"
+              }
+            ],
+            "shortname": "SUSE-CAP-Tools-Module",
+            "version": "15"
+          },
+          {
+            "arch": "x86_64",
+            "cpe": "cpe:/o:suse:sle-module-live-patching:15",
+            "description": "<p> SUSE Linux Enterprise Live Patching provides packages to update critical components in SUSE Linux Enterprise. With SUSE Linux Enterprise Live Patching, you can perform critical patching without shutting down your system, reducing the need for planned downtime and increasing service availability. <p>",
+            "eula_url": "",
+            "extensions": [],
+            "former_identifier": "sle-module-live-patching",
+            "free": false,
+            "friendly_name": "SUSE Linux Enterprise Live Patching 15 x86_64",
+            "friendly_version": "15",
+            "id": 1736,
+            "identifier": "sle-module-live-patching",
+            "migration_extra": false,
+            "name": "SUSE Linux Enterprise Live Patching",
+            "offline_predecessor_ids": [
+              1536,
+              1757,
+              1888
+            ],
+            "online_predecessor_ids": [],
+            "predecessor_ids": [],
+            "product_class": "SLE-LP",
+            "product_type": "module",
+            "recommended": false,
+            "release_stage": "released",
+            "release_type": null,
+            "repositories": [
+              {
+                "autorefresh": true,
+                "description": "SLE-Module-Live-Patching15-Updates for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": true,
+                "id": 3033,
+                "installer_updates": false,
+                "name": "SLE-Module-Live-Patching15-Updates",
+                "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Live-Patching/15/x86_64/update/"
+              },
+              {
+                "autorefresh": true,
+                "description": "SLE-Module-Live-Patching15-Debuginfo-Updates for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": false,
+                "id": 3034,
+                "installer_updates": false,
+                "name": "SLE-Module-Live-Patching15-Debuginfo-Updates",
+                "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Live-Patching/15/x86_64/update_debug/"
+              },
+              {
+                "autorefresh": false,
+                "description": "SLE-Module-Live-Patching15-Pool for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": true,
+                "id": 3035,
+                "installer_updates": false,
+                "name": "SLE-Module-Live-Patching15-Pool",
+                "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Live-Patching/15/x86_64/product/"
+              },
+              {
+                "autorefresh": false,
+                "description": "SLE-Module-Live-Patching15-Debuginfo-Pool for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": false,
+                "id": 3036,
+                "installer_updates": false,
+                "name": "SLE-Module-Live-Patching15-Debuginfo-Pool",
+                "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Live-Patching/15/x86_64/product_debug/"
+              },
+              {
+                "autorefresh": false,
+                "description": "SLE-Module-Live-Patching15-Source-Pool for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": false,
+                "id": 3125,
+                "installer_updates": false,
+                "name": "SLE-Module-Live-Patching15-Source-Pool",
+                "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Live-Patching/15/x86_64/product_source/"
+              }
+            ],
+            "shortname": "Live-Patching",
+            "version": "15"
+          },
+          {
+            "arch": "x86_64",
+            "cpe": "cpe:/o:suse:packagehub:15",
+            "description": "SUSE Package Hub is a free of charge extension providing access to community maintained packages built to run on SUSE Linux Enterprise Server. Built from the same sources used in the openSUSE distributions, these quality packages provide additional software to what is found in the SUSE Linux Enterprise Server product. Packages from the Package Hub are delivered without L3 support from SUSE. General updates and fixes to the packages in SUSE Package Hub are provided by the openSUSE community based on their discretion though SUSE will monitor and ensure that any known critical security issues will be addressed. Packages in the Package Hub are approved by SUSE for use with SUSE Linux Enterprise Server 15 and to not interfere with the supportability of SUSE Linux Enterprise Server it's modules and extensions. For more information about SUSE Package Hub please visit https://packagehub.suse.com.",
+            "eula_url": "",
+            "extensions": [],
+            "former_identifier": "PackageHub",
+            "free": true,
+            "friendly_name": "SUSE Package Hub 15 x86_64",
+            "friendly_version": "15",
+            "id": 1743,
+            "identifier": "PackageHub",
+            "migration_extra": false,
+            "name": "SUSE Package Hub",
+            "offline_predecessor_ids": [
+              1529,
+              1813,
+              1915
+            ],
+            "online_predecessor_ids": [],
+            "predecessor_ids": [],
+            "product_class": "MODULE",
+            "product_type": "extension",
+            "recommended": false,
+            "release_stage": "released",
+            "release_type": null,
+            "repositories": [
+              {
+                "autorefresh": false,
+                "description": "SUSE-PackageHub-15-Standard-Pool for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": true,
+                "id": 3059,
+                "installer_updates": false,
+                "name": "SUSE-PackageHub-15-Standard-Pool",
+                "url": "https://updates.suse.com/SUSE/Backports/SLE-15_x86_64/standard/"
+              },
+              {
+                "autorefresh": true,
+                "description": "SUSE-PackageHub-15-Debuginfo for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": false,
+                "id": 3060,
+                "installer_updates": false,
+                "name": "SUSE-PackageHub-15-Debuginfo",
+                "url": "https://updates.suse.com/SUSE/Backports/SLE-15_x86_64/standard_debug/"
+              },
+              {
+                "autorefresh": false,
+                "description": "SUSE-PackageHub-15-Pool for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": true,
+                "id": 3061,
+                "installer_updates": false,
+                "name": "SUSE-PackageHub-15-Pool",
+                "url": "https://updates.suse.com/SUSE/Backports/SLE-15_x86_64/product/"
+              },
+              {
+                "autorefresh": true,
+                "description": "SLE-Module-Packagehub-Subpackages15-Updates for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": true,
+                "id": 3182,
+                "installer_updates": false,
+                "name": "SLE-Module-Packagehub-Subpackages15-Updates",
+                "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Packagehub-Subpackages/15/x86_64/update/"
+              },
+              {
+                "autorefresh": true,
+                "description": "SLE-Module-Packagehub-Subpackages15-Debuginfo-Updates for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": false,
+                "id": 3183,
+                "installer_updates": false,
+                "name": "SLE-Module-Packagehub-Subpackages15-Debuginfo-Updates",
+                "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Packagehub-Subpackages/15/x86_64/update_debug/"
+              },
+              {
+                "autorefresh": false,
+                "description": "SLE-Module-Packagehub-Subpackages15-Pool for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": true,
+                "id": 3184,
+                "installer_updates": false,
+                "name": "SLE-Module-Packagehub-Subpackages15-Pool",
+                "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Packagehub-Subpackages/15/x86_64/product/"
+              },
+              {
+                "autorefresh": false,
+                "description": "SLE-Module-Packagehub-Subpackages15-Debuginfo-Pool for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": false,
+                "id": 3185,
+                "installer_updates": false,
+                "name": "SLE-Module-Packagehub-Subpackages15-Debuginfo-Pool",
+                "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Packagehub-Subpackages/15/x86_64/product_debug/"
+              },
+              {
+                "autorefresh": false,
+                "description": "SLE-Module-Packagehub-Subpackages15-Source-Pool for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": false,
+                "id": 3186,
+                "installer_updates": false,
+                "name": "SLE-Module-Packagehub-Subpackages15-Source-Pool",
+                "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Packagehub-Subpackages/15/x86_64/product_source/"
+              }
+            ],
+            "shortname": "SUSE-PackageHub-15",
+            "version": "15"
+          }
+        ],
+        "former_identifier": "sle-module-basesystem",
+        "free": true,
+        "friendly_name": "Basesystem Module 15 x86_64",
+        "friendly_version": "15",
+        "id": 1576,
+        "identifier": "sle-module-basesystem",
+        "migration_extra": false,
+        "name": "Basesystem Module",
+        "offline_predecessor_ids": [
+          1212,
+          1368,
+          1440,
+          1618
+        ],
+        "online_predecessor_ids": [],
+        "predecessor_ids": [],
+        "product_class": "MODULE",
+        "product_type": "module",
+        "recommended": true,
+        "release_stage": "released",
+        "release_type": null,
+        "repositories": [
+          {
+            "autorefresh": true,
+            "description": "SLE-Module-Basesystem15-Updates for sle-15-x86_64",
+            "distro_target": "sle-15-x86_64",
+            "enabled": true,
+            "id": 2524,
+            "installer_updates": false,
+            "name": "SLE-Module-Basesystem15-Updates",
+            "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Basesystem/15/x86_64/update/"
+          },
+          {
+            "autorefresh": true,
+            "description": "SLE-Module-Basesystem15-Debuginfo-Updates for sle-15-x86_64",
+            "distro_target": "sle-15-x86_64",
+            "enabled": false,
+            "id": 2525,
+            "installer_updates": false,
+            "name": "SLE-Module-Basesystem15-Debuginfo-Updates",
+            "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Basesystem/15/x86_64/update_debug/"
+          },
+          {
+            "autorefresh": false,
+            "description": "SLE-Module-Basesystem15-Pool for sle-15-x86_64",
+            "distro_target": "sle-15-x86_64",
+            "enabled": true,
+            "id": 2526,
+            "installer_updates": false,
+            "name": "SLE-Module-Basesystem15-Pool",
+            "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Basesystem/15/x86_64/product/"
+          },
+          {
+            "autorefresh": false,
+            "description": "SLE-Module-Basesystem15-Debuginfo-Pool for sle-15-x86_64",
+            "distro_target": "sle-15-x86_64",
+            "enabled": false,
+            "id": 2527,
+            "installer_updates": false,
+            "name": "SLE-Module-Basesystem15-Debuginfo-Pool",
+            "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Basesystem/15/x86_64/product_debug/"
+          },
+          {
+            "autorefresh": false,
+            "description": "SLE-Module-Basesystem15-Source-Pool for sle-15-x86_64",
+            "distro_target": "sle-15-x86_64",
+            "enabled": false,
+            "id": 2528,
+            "installer_updates": false,
+            "name": "SLE-Module-Basesystem15-Source-Pool",
+            "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Basesystem/15/x86_64/product_source/"
+          }
+        ],
+        "shortname": "Basesystem-Module",
+        "version": "15"
+      },
+      {
+        "arch": "x86_64",
+        "cpe": "cpe:/o:suse:sles-ltss:15",
+        "description": "SUSE Linux Enterprise offers a comprehensive suite of products built on a single code base. The platform addresses business needs from the smallest thin-client devices to the world's most powerful high-performance computing and mainframe servers. SUSE Linux Enterprise offers common management tools and technology certifications across the platform, and each product is enterprise-class.",
+        "eula_url": "",
+        "extensions": [],
+        "former_identifier": "SLES-LTSS",
+        "free": false,
+        "friendly_name": "SUSE Linux Enterprise Server LTSS 15 x86_64",
+        "friendly_version": "15",
+        "id": 2056,
+        "identifier": "SLES-LTSS",
+        "migration_extra": false,
+        "name": "SUSE Linux Enterprise Server LTSS",
+        "offline_predecessor_ids": [],
+        "online_predecessor_ids": [],
+        "predecessor_ids": [],
+        "product_class": "SLES15-GA-LTSS-X86",
+        "product_type": "extension",
+        "recommended": false,
+        "release_stage": "released",
+        "release_type": null,
+        "repositories": [
+          {
+            "autorefresh": true,
+            "description": "SLE-Product-SLES15-LTSS-Updates for sle-15-x86_64",
+            "distro_target": "sle-15-x86_64",
+            "enabled": true,
+            "id": 4390,
+            "installer_updates": false,
+            "name": "SLE-Product-SLES15-LTSS-Updates",
+            "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-SLES/15-LTSS/x86_64/update/"
+          },
+          {
+            "autorefresh": true,
+            "description": "SLE-Product-SLES15-Debuginfo-LTSS-Updates for sle-15-x86_64",
+            "distro_target": "sle-15-x86_64",
+            "enabled": false,
+            "id": 4391,
+            "installer_updates": false,
+            "name": "SLE-Product-SLES15-Debuginfo-LTSS-Updates",
+            "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-SLES/15-LTSS/x86_64/update_debug/"
+          }
+        ],
+        "shortname": "SLES15-LTSS",
+        "version": "15"
+      }
+    ],
+    "former_identifier": "SLES",
+    "free": false,
+    "friendly_name": "SUSE Linux Enterprise Server 15 x86_64",
+    "friendly_version": "15",
+    "id": 1575,
+    "identifier": "SLES",
+    "migration_extra": false,
+    "name": "SUSE Linux Enterprise Server",
+    "offline_predecessor_ids": [
+      690,
+      769,
+      814,
+      824,
+      1300,
+      1421,
+      1625,
+      1878
+    ],
+    "online_predecessor_ids": [],
+    "predecessor_ids": [],
+    "product_class": "7261",
+    "product_type": "base",
+    "recommended": false,
+    "release_stage": "released",
+    "release_type": null,
+    "repositories": [
+      {
+        "autorefresh": true,
+        "description": "SLE-Product-SLES15-Updates for sle-15-x86_64",
+        "distro_target": "sle-15-x86_64",
+        "enabled": true,
+        "id": 2705,
+        "installer_updates": false,
+        "name": "SLE-Product-SLES15-Updates",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-SLES/15/x86_64/update/"
+      },
+      {
+        "autorefresh": true,
+        "description": "SLE15-Installer-Updates for sle-15-x86_64",
+        "distro_target": "sle-15-x86_64",
+        "enabled": false,
+        "id": 2706,
+        "installer_updates": true,
+        "name": "SLE15-Installer-Updates",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-INSTALLER/15/x86_64/update/"
+      },
+      {
+        "autorefresh": false,
+        "description": "SLE-Product-SLES15-Pool for sle-15-x86_64",
+        "distro_target": "sle-15-x86_64",
+        "enabled": true,
+        "id": 2707,
+        "installer_updates": false,
+        "name": "SLE-Product-SLES15-Pool",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-SLES/15/x86_64/product/"
+      },
+      {
+        "autorefresh": true,
+        "description": "SLE-Product-SLES15-Debuginfo-Updates for sle-15-x86_64",
+        "distro_target": "sle-15-x86_64",
+        "enabled": false,
+        "id": 3114,
+        "installer_updates": false,
+        "name": "SLE-Product-SLES15-Debuginfo-Updates",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-SLES/15/x86_64/update_debug/"
+      },
+      {
+        "autorefresh": false,
+        "description": "SLE-Product-SLES15-Debuginfo-Pool for sle-15-x86_64",
+        "distro_target": "sle-15-x86_64",
+        "enabled": false,
+        "id": 3115,
+        "installer_updates": false,
+        "name": "SLE-Product-SLES15-Debuginfo-Pool",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-SLES/15/x86_64/product_debug/"
+      },
+      {
+        "autorefresh": false,
+        "description": "SLE-Product-SLES15-Source-Pool for sle-15-x86_64",
+        "distro_target": "sle-15-x86_64",
+        "enabled": false,
+        "id": 3116,
+        "installer_updates": false,
+        "name": "SLE-Product-SLES15-Source-Pool",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-SLES/15/x86_64/product_source/"
+      }
+    ],
+    "shortname": "SLES15",
+    "version": "15"
   }
 ]

--- a/java/code/src/com/redhat/rhn/manager/content/test/data1/repositories.json
+++ b/java/code/src/com/redhat/rhn/manager/content/test/data1/repositories.json
@@ -7727,7 +7727,7 @@
     "id": 1724,
     "installer_updates": false,
     "name": "SLE-Manager-Tools12-Updates",
-    "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/12/ppc64le/update/?my-fake-token"
+    "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/12/ppc64le/update/?my-fake-token2"
   },
   {
     "autorefresh": true,
@@ -7737,7 +7737,7 @@
     "id": 1725,
     "installer_updates": false,
     "name": "SLE-Manager-Tools12-Debuginfo-Updates",
-    "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/12/ppc64le/update_debug/?my-fake-token"
+    "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/12/ppc64le/update_debug/?my-fake-token2"
   },
   {
     "autorefresh": false,
@@ -7747,7 +7747,7 @@
     "id": 1726,
     "installer_updates": false,
     "name": "SLE-Manager-Tools12-Pool",
-    "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/12/ppc64le/product/?my-fake-token"
+    "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/12/ppc64le/product/?my-fake-token2"
   },
   {
     "autorefresh": false,
@@ -7757,7 +7757,7 @@
     "id": 1727,
     "installer_updates": false,
     "name": "SLE-Manager-Tools12-Debuginfo-Pool",
-    "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/12/ppc64le/product_debug/?my-fake-token"
+    "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/12/ppc64le/product_debug/?my-fake-token2"
   },
   {
     "autorefresh": true,
@@ -7767,7 +7767,7 @@
     "id": 1728,
     "installer_updates": false,
     "name": "SLE-Manager-Tools12-Updates",
-    "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/12/s390x/update/?my-fake-token"
+    "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/12/s390x/update/?my-fake-token2"
   },
   {
     "autorefresh": true,
@@ -7777,7 +7777,7 @@
     "id": 1729,
     "installer_updates": false,
     "name": "SLE-Manager-Tools12-Debuginfo-Updates",
-    "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/12/s390x/update_debug/?my-fake-token"
+    "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/12/s390x/update_debug/?my-fake-token2"
   },
   {
     "autorefresh": false,
@@ -7787,7 +7787,7 @@
     "id": 1730,
     "installer_updates": false,
     "name": "SLE-Manager-Tools12-Pool",
-    "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/12/s390x/product/?my-fake-token"
+    "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/12/s390x/product/?my-fake-token2"
   },
   {
     "autorefresh": false,
@@ -7797,7 +7797,7 @@
     "id": 1731,
     "installer_updates": false,
     "name": "SLE-Manager-Tools12-Debuginfo-Pool",
-    "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/12/s390x/product_debug/?my-fake-token"
+    "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/12/s390x/product_debug/?my-fake-token2"
   },
   {
     "autorefresh": true,
@@ -7807,7 +7807,7 @@
     "id": 1732,
     "installer_updates": false,
     "name": "SLE-Manager-Tools12-Updates",
-    "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/12/x86_64/update/?my-fake-token"
+    "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/12/x86_64/update/?my-fake-token2"
   },
   {
     "autorefresh": true,
@@ -7817,7 +7817,7 @@
     "id": 1733,
     "installer_updates": false,
     "name": "SLE-Manager-Tools12-Debuginfo-Updates",
-    "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/12/x86_64/update_debug/?my-fake-token"
+    "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/12/x86_64/update_debug/?my-fake-token2"
   },
   {
     "autorefresh": false,
@@ -7827,7 +7827,7 @@
     "id": 1734,
     "installer_updates": false,
     "name": "SLE-Manager-Tools12-Pool",
-    "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/12/x86_64/product/?my-fake-token"
+    "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/12/x86_64/product/?my-fake-token2"
   },
   {
     "autorefresh": false,
@@ -7837,7 +7837,7 @@
     "id": 1735,
     "installer_updates": false,
     "name": "SLE-Manager-Tools12-Debuginfo-Pool",
-    "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/12/x86_64/product_debug/?my-fake-token"
+    "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/12/x86_64/product_debug/?my-fake-token2"
   },
   {
     "autorefresh": true,
@@ -11547,7 +11547,7 @@
     "id": 2179,
     "installer_updates": false,
     "name": "SLE-Manager-Tools12-Updates",
-    "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/12/aarch64/update/?my-fake-token"
+    "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/12/aarch64/update/?my-fake-token2"
   },
   {
     "autorefresh": true,
@@ -11557,7 +11557,7 @@
     "id": 2180,
     "installer_updates": false,
     "name": "SLE-Manager-Tools12-Debuginfo-Updates",
-    "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/12/aarch64/update_debug/?my-fake-token"
+    "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/12/aarch64/update_debug/?my-fake-token2"
   },
   {
     "autorefresh": false,
@@ -11567,7 +11567,7 @@
     "id": 2181,
     "installer_updates": false,
     "name": "SLE-Manager-Tools12-Pool",
-    "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/12/aarch64/product/?my-fake-token"
+    "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/12/aarch64/product/?my-fake-token2"
   },
   {
     "autorefresh": false,
@@ -11577,7 +11577,7 @@
     "id": 2182,
     "installer_updates": false,
     "name": "SLE-Manager-Tools12-Debuginfo-Pool",
-    "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/12/aarch64/product_debug/?my-fake-token"
+    "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/12/aarch64/product_debug/?my-fake-token2"
   },
   {
     "autorefresh": true,
@@ -15187,7 +15187,7 @@
     "id": 2705,
     "installer_updates": false,
     "name": "SLE-Product-SLES15-Updates",
-    "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-SLES/15/x86_64/update/?my-fake-token"
+    "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-SLES/15/x86_64/update/?my-fake-token2"
   },
   {
     "autorefresh": true,
@@ -15197,7 +15197,7 @@
     "id": 2706,
     "installer_updates": true,
     "name": "SLE15-Installer-Updates",
-    "url": "https://updates.suse.com/SUSE/Updates/SLE-INSTALLER/15/x86_64/update/?my-fake-token"
+    "url": "https://updates.suse.com/SUSE/Updates/SLE-INSTALLER/15/x86_64/update/?my-fake-token2"
   },
   {
     "autorefresh": false,
@@ -15207,7 +15207,7 @@
     "id": 2707,
     "installer_updates": false,
     "name": "SLE-Product-SLES15-Pool",
-    "url": "https://updates.suse.com/SUSE/Products/SLE-Product-SLES/15/x86_64/product/?my-fake-token"
+    "url": "https://updates.suse.com/SUSE/Products/SLE-Product-SLES/15/x86_64/product/?my-fake-token2"
   },
   {
     "autorefresh": true,
@@ -16537,7 +16537,7 @@
     "id": 2917,
     "installer_updates": false,
     "name": "SLE-Manager-Tools15-Updates",
-    "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/15/aarch64/update/?my-fake-token"
+    "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/15/aarch64/update/?my-fake-token2"
   },
   {
     "autorefresh": true,
@@ -16547,7 +16547,7 @@
     "id": 2918,
     "installer_updates": false,
     "name": "SLE-Manager-Tools15-Debuginfo-Updates",
-    "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/15/aarch64/update_debug/?my-fake-token"
+    "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/15/aarch64/update_debug/?my-fake-token2"
   },
   {
     "autorefresh": false,
@@ -16557,7 +16557,7 @@
     "id": 2919,
     "installer_updates": false,
     "name": "SLE-Manager-Tools15-Pool",
-    "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/15/aarch64/product/?my-fake-token"
+    "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/15/aarch64/product/?my-fake-token2"
   },
   {
     "autorefresh": false,
@@ -16567,7 +16567,7 @@
     "id": 2920,
     "installer_updates": false,
     "name": "SLE-Manager-Tools15-Debuginfo-Pool",
-    "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/15/aarch64/product_debug/?my-fake-token"
+    "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/15/aarch64/product_debug/?my-fake-token2"
   },
   {
     "autorefresh": false,
@@ -16577,7 +16577,7 @@
     "id": 2921,
     "installer_updates": false,
     "name": "SLE-Manager-Tools15-Source-Pool",
-    "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/15/aarch64/product_source/?my-fake-token"
+    "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/15/aarch64/product_source/?my-fake-token2"
   },
   {
     "autorefresh": true,
@@ -16587,7 +16587,7 @@
     "id": 2922,
     "installer_updates": false,
     "name": "SLE-Manager-Tools15-Updates",
-    "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/15/ppc64le/update/?my-fake-token"
+    "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/15/ppc64le/update/?my-fake-token2"
   },
   {
     "autorefresh": true,
@@ -16597,7 +16597,7 @@
     "id": 2923,
     "installer_updates": false,
     "name": "SLE-Manager-Tools15-Debuginfo-Updates",
-    "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/15/ppc64le/update_debug/?my-fake-token"
+    "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/15/ppc64le/update_debug/?my-fake-token2"
   },
   {
     "autorefresh": false,
@@ -16607,7 +16607,7 @@
     "id": 2924,
     "installer_updates": false,
     "name": "SLE-Manager-Tools15-Pool",
-    "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/15/ppc64le/product/?my-fake-token"
+    "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/15/ppc64le/product/?my-fake-token2"
   },
   {
     "autorefresh": false,
@@ -16617,7 +16617,7 @@
     "id": 2925,
     "installer_updates": false,
     "name": "SLE-Manager-Tools15-Debuginfo-Pool",
-    "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/15/ppc64le/product_debug/?my-fake-token"
+    "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/15/ppc64le/product_debug/?my-fake-token2"
   },
   {
     "autorefresh": false,
@@ -16627,7 +16627,7 @@
     "id": 2926,
     "installer_updates": false,
     "name": "SLE-Manager-Tools15-Source-Pool",
-    "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/15/ppc64le/product_source/?my-fake-token"
+    "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/15/ppc64le/product_source/?my-fake-token2"
   },
   {
     "autorefresh": true,
@@ -16637,7 +16637,7 @@
     "id": 2927,
     "installer_updates": false,
     "name": "SLE-Manager-Tools15-Updates",
-    "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/15/s390x/update/?my-fake-token"
+    "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/15/s390x/update/?my-fake-token2"
   },
   {
     "autorefresh": true,
@@ -16647,7 +16647,7 @@
     "id": 2928,
     "installer_updates": false,
     "name": "SLE-Manager-Tools15-Debuginfo-Updates",
-    "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/15/s390x/update_debug/?my-fake-token"
+    "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/15/s390x/update_debug/?my-fake-token2"
   },
   {
     "autorefresh": false,
@@ -16657,7 +16657,7 @@
     "id": 2929,
     "installer_updates": false,
     "name": "SLE-Manager-Tools15-Pool",
-    "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/15/s390x/product/?my-fake-token"
+    "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/15/s390x/product/?my-fake-token2"
   },
   {
     "autorefresh": false,
@@ -16667,7 +16667,7 @@
     "id": 2930,
     "installer_updates": false,
     "name": "SLE-Manager-Tools15-Debuginfo-Pool",
-    "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/15/s390x/product_debug/?my-fake-token"
+    "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/15/s390x/product_debug/?my-fake-token2"
   },
   {
     "autorefresh": false,
@@ -16677,7 +16677,7 @@
     "id": 2931,
     "installer_updates": false,
     "name": "SLE-Manager-Tools15-Source-Pool",
-    "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/15/s390x/product_source/?my-fake-token"
+    "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/15/s390x/product_source/?my-fake-token2"
   },
   {
     "autorefresh": true,
@@ -16687,7 +16687,7 @@
     "id": 2932,
     "installer_updates": false,
     "name": "SLE-Manager-Tools15-Updates",
-    "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/15/x86_64/update/?my-fake-token"
+    "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/15/x86_64/update/?my-fake-token2"
   },
   {
     "autorefresh": true,
@@ -16697,7 +16697,7 @@
     "id": 2933,
     "installer_updates": false,
     "name": "SLE-Manager-Tools15-Debuginfo-Updates",
-    "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/15/x86_64/update_debug/?my-fake-token"
+    "url": "https://updates.suse.com/SUSE/Updates/SLE-Manager-Tools/15/x86_64/update_debug/?my-fake-token2"
   },
   {
     "autorefresh": false,
@@ -16707,7 +16707,7 @@
     "id": 2934,
     "installer_updates": false,
     "name": "SLE-Manager-Tools15-Pool",
-    "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/15/x86_64/product/?my-fake-token"
+    "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/15/x86_64/product/?my-fake-token2"
   },
   {
     "autorefresh": false,
@@ -16717,7 +16717,7 @@
     "id": 2935,
     "installer_updates": false,
     "name": "SLE-Manager-Tools15-Debuginfo-Pool",
-    "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/15/x86_64/product_debug/?my-fake-token"
+    "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/15/x86_64/product_debug/?my-fake-token2"
   },
   {
     "autorefresh": false,
@@ -16727,7 +16727,7 @@
     "id": 2936,
     "installer_updates": false,
     "name": "SLE-Manager-Tools15-Source-Pool",
-    "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/15/x86_64/product_source/?my-fake-token"
+    "url": "https://updates.suse.com/SUSE/Products/SLE-Manager-Tools/15/x86_64/product_source/?my-fake-token2"
   },
   {
     "autorefresh": true,

--- a/java/code/src/com/redhat/rhn/manager/content/test/smallBase/productsUnscoped.json
+++ b/java/code/src/com/redhat/rhn/manager/content/test/smallBase/productsUnscoped.json
@@ -1248,5 +1248,1252 @@
     ],
     "shortname": null,
     "version": "7"
+  },
+  {
+    "arch": "x86_64",
+    "cpe": "cpe:/o:suse:sles:15",
+    "description": "SUSE Linux Enterprise offers a comprehensive suite of products built on a single code base. The platform addresses business needs from the smallest thin-client devices to the world's most powerful high-performance computing and mainframe servers. SUSE Linux Enterprise offers common management tools and technology certifications across the platform, and each product is enterprise-class.",
+    "eula_url": "https://updates.suse.com/SUSE/Products/SLE-Product-SLES/15/x86_64/product.license/",
+    "extensions": [
+      {
+        "arch": "x86_64",
+        "cpe": "cpe:/o:suse:sle-module-basesystem:15",
+        "description": "<p> The SUSE Linux Enterprise Basesystem Module delivers the base system of the product. </p>",
+        "eula_url": "",
+        "extensions": [
+          {
+            "arch": "x86_64",
+            "cpe": "cpe:/o:suse:sle-module-desktop-applications:15",
+            "description": "<p> The SUSE Linux Enterprise Desktop Applications Module delivers a basic set of Desktop functionality. </p> <p> Access to the Desktop Applications Module is included in your SUSE Linux Enterprise product subscription. </p>",
+            "eula_url": "",
+            "extensions": [
+              {
+                "arch": "x86_64",
+                "cpe": "cpe:/o:suse:sle-module-development-tools:15",
+                "description": "<p> The Development Tools Module helps you developing applications for SUSE Linux Enterprise 15. </p> <p> Access to the Development Tools Module is included in your SUSE Linux Enterprise product subscription. The module has a different lifecycle than SUSE Linux Enterprise itself. </p>",
+                "eula_url": "",
+                "extensions": [],
+                "former_identifier": "sle-sdk",
+                "free": true,
+                "friendly_name": "Development Tools Module 15 x86_64",
+                "friendly_version": "15",
+                "id": 1579,
+                "identifier": "sle-module-development-tools",
+                "migration_extra": true,
+                "name": "Development Tools Module",
+                "offline_predecessor_ids": [
+                  1223,
+                  1323,
+                  1341,
+                  1366,
+                  1427,
+                  1630,
+                  1892
+                ],
+                "online_predecessor_ids": [],
+                "predecessor_ids": [],
+                "product_class": "MODULE",
+                "product_type": "module",
+                "recommended": false,
+                "release_stage": "released",
+                "release_type": null,
+                "repositories": [
+                  {
+                    "autorefresh": true,
+                    "description": "SLE-Module-DevTools15-Updates for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": true,
+                    "id": 2539,
+                    "installer_updates": false,
+                    "name": "SLE-Module-DevTools15-Updates",
+                    "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Development-Tools/15/x86_64/update/"
+                  },
+                  {
+                    "autorefresh": true,
+                    "description": "SLE-Module-DevTools15-Debuginfo-Updates for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": false,
+                    "id": 2540,
+                    "installer_updates": false,
+                    "name": "SLE-Module-DevTools15-Debuginfo-Updates",
+                    "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Development-Tools/15/x86_64/update_debug/"
+                  },
+                  {
+                    "autorefresh": false,
+                    "description": "SLE-Module-DevTools15-Pool for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": true,
+                    "id": 2541,
+                    "installer_updates": false,
+                    "name": "SLE-Module-DevTools15-Pool",
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Development-Tools/15/x86_64/product/"
+                  },
+                  {
+                    "autorefresh": false,
+                    "description": "SLE-Module-DevTools15-Debuginfo-Pool for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": false,
+                    "id": 2542,
+                    "installer_updates": false,
+                    "name": "SLE-Module-DevTools15-Debuginfo-Pool",
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Development-Tools/15/x86_64/product_debug/"
+                  },
+                  {
+                    "autorefresh": false,
+                    "description": "SLE-Module-DevTools15-Source-Pool for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": false,
+                    "id": 2543,
+                    "installer_updates": false,
+                    "name": "SLE-Module-DevTools15-Source-Pool",
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Development-Tools/15/x86_64/product_source/"
+                  }
+                ],
+                "shortname": "Development-Tools-Module",
+                "version": "15"
+              },
+              {
+                "arch": "x86_64",
+                "cpe": "cpe:/o:suse:sle-we:15",
+                "description": "SUSE Linux Enterprise Workstation Extension adds additional functionality to a base SUSE Linux Enterprise installation. The Workstation Extension offers additional desktop applications (office suite, email client, graphical editor, multimedia tools) and libraries. Workstation Extension is enabled and installed by default on SUSE Linux Enterprise Desktop installation. Adding the Workstation Extension to a SUSE Linux Enterprise Server installation allows to seamlessly combine both products to create a full featured server workstation.",
+                "eula_url": "https://updates.suse.com/SUSE/Products/SLE-Product-WE/15/x86_64/product.license/",
+                "extensions": [],
+                "former_identifier": "sle-we",
+                "free": false,
+                "friendly_name": "SUSE Linux Enterprise Workstation Extension 15 x86_64",
+                "friendly_version": "15",
+                "id": 1583,
+                "identifier": "sle-we",
+                "migration_extra": false,
+                "name": "SUSE Linux Enterprise Workstation Extension",
+                "offline_predecessor_ids": [
+                  1222,
+                  1338,
+                  1359,
+                  1431,
+                  1639,
+                  1893
+                ],
+                "online_predecessor_ids": [],
+                "predecessor_ids": [],
+                "product_class": "SLE-WE",
+                "product_type": "extension",
+                "recommended": false,
+                "release_stage": "released",
+                "release_type": null,
+                "repositories": [
+                  {
+                    "autorefresh": true,
+                    "description": "SLE-Product-WE15-Updates for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": true,
+                    "id": 2742,
+                    "installer_updates": false,
+                    "name": "SLE-Product-WE15-Updates",
+                    "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-WE/15/x86_64/update/"
+                  },
+                  {
+                    "autorefresh": true,
+                    "description": "SLE-Product-WE15-Debuginfo-Updates for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": false,
+                    "id": 2743,
+                    "installer_updates": false,
+                    "name": "SLE-Product-WE15-Debuginfo-Updates",
+                    "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-WE/15/x86_64/update_debug/"
+                  },
+                  {
+                    "autorefresh": false,
+                    "description": "SLE-Product-WE15-Pool for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": true,
+                    "id": 2744,
+                    "installer_updates": false,
+                    "name": "SLE-Product-WE15-Pool",
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Product-WE/15/x86_64/product/"
+                  },
+                  {
+                    "autorefresh": false,
+                    "description": "SLE-Product-WE15-Debuginfo-Pool for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": false,
+                    "id": 2745,
+                    "installer_updates": false,
+                    "name": "SLE-Product-WE15-Debuginfo-Pool",
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Product-WE/15/x86_64/product_debug/"
+                  },
+                  {
+                    "autorefresh": false,
+                    "description": "SLE-Product-WE15-Source-Pool for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": false,
+                    "id": 2746,
+                    "installer_updates": false,
+                    "name": "SLE-Product-WE15-Source-Pool",
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Product-WE/15/x86_64/product_source/"
+                  },
+                  {
+                    "autorefresh": true,
+                    "description": "SLE-15-GA-Desktop-NVIDIA-Driver for ",
+                    "distro_target": null,
+                    "enabled": true,
+                    "id": 2747,
+                    "installer_updates": false,
+                    "name": "SLE-15-GA-Desktop-NVIDIA-Driver",
+                    "url": "https://download.nvidia.com/suse/sle15/"
+                  }
+                ],
+                "shortname": "SLEWE15",
+                "version": "15"
+              }
+            ],
+            "former_identifier": "sle-module-desktop-applications",
+            "free": true,
+            "friendly_name": "Desktop Applications Module 15 x86_64",
+            "friendly_version": "15",
+            "id": 1578,
+            "identifier": "sle-module-desktop-applications",
+            "migration_extra": true,
+            "name": "Desktop Applications Module",
+            "offline_predecessor_ids": [],
+            "online_predecessor_ids": [],
+            "predecessor_ids": [],
+            "product_class": "MODULE",
+            "product_type": "module",
+            "recommended": false,
+            "release_stage": "released",
+            "release_type": null,
+            "repositories": [
+              {
+                "autorefresh": true,
+                "description": "SLE-Module-Desktop-Applications15-Updates for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": true,
+                "id": 2534,
+                "installer_updates": false,
+                "name": "SLE-Module-Desktop-Applications15-Updates",
+                "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Desktop-Applications/15/x86_64/update/"
+              },
+              {
+                "autorefresh": true,
+                "description": "SLE-Module-Desktop-Applications15-Debuginfo-Updates for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": false,
+                "id": 2535,
+                "installer_updates": false,
+                "name": "SLE-Module-Desktop-Applications15-Debuginfo-Updates",
+                "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Desktop-Applications/15/x86_64/update_debug/"
+              },
+              {
+                "autorefresh": false,
+                "description": "SLE-Module-Desktop-Applications15-Pool for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": true,
+                "id": 2536,
+                "installer_updates": false,
+                "name": "SLE-Module-Desktop-Applications15-Pool",
+                "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Desktop-Applications/15/x86_64/product/"
+              },
+              {
+                "autorefresh": false,
+                "description": "SLE-Module-Desktop-Applications15-Debuginfo-Pool for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": false,
+                "id": 2537,
+                "installer_updates": false,
+                "name": "SLE-Module-Desktop-Applications15-Debuginfo-Pool",
+                "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Desktop-Applications/15/x86_64/product_debug/"
+              },
+              {
+                "autorefresh": false,
+                "description": "SLE-Module-Desktop-Applications15-Source-Pool for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": false,
+                "id": 2538,
+                "installer_updates": false,
+                "name": "SLE-Module-Desktop-Applications15-Source-Pool",
+                "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Desktop-Applications/15/x86_64/product_source/"
+              }
+            ],
+            "shortname": "Desktop-Applications-Module",
+            "version": "15"
+          },
+          {
+            "arch": "x86_64",
+            "cpe": "cpe:/o:suse:sle-module-server-applications:15",
+            "description": "<p> The SUSE Linux Enterprise Server Applications Module delivers a basic set of Server functionality. </p> <p> Access to the Server Applications Module is included in your SUSE Linux Enterprise Server subscription. </p>",
+            "eula_url": "",
+            "extensions": [
+              {
+                "arch": "x86_64",
+                "cpe": "cpe:/o:suse:sle-module-legacy:15",
+                "description": "<p> The Legacy Module helps you migrating applications from SUSE Linux Enterprise 12 and other systems to SUSE Linux Enterprise 15, by providing packages which are discontinued on SUSE Linux Enterprise Server, such as: ntp, IBM Java 8, and a number of libraries. </p> <p> Access to the Legacy Module is included in your SUSE Linux Enterprise Server subscription. The module has a different lifecycle than SUSE Linux Enterprise Server itself. Packages in the this module are usually supported for at most three years. </p>",
+                "eula_url": "",
+                "extensions": [],
+                "former_identifier": "sle-module-legacy",
+                "free": true,
+                "friendly_name": "Legacy Module 15 x86_64",
+                "friendly_version": "15",
+                "id": 1581,
+                "identifier": "sle-module-legacy",
+                "migration_extra": true,
+                "name": "Legacy Module",
+                "offline_predecessor_ids": [
+                  1150
+                ],
+                "online_predecessor_ids": [],
+                "predecessor_ids": [],
+                "product_class": "MODULE",
+                "product_type": "module",
+                "recommended": false,
+                "release_stage": "released",
+                "release_type": null,
+                "repositories": [
+                  {
+                    "autorefresh": true,
+                    "description": "SLE-Module-Legacy15-Updates for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": true,
+                    "id": 2549,
+                    "installer_updates": false,
+                    "name": "SLE-Module-Legacy15-Updates",
+                    "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Legacy/15/x86_64/update/"
+                  },
+                  {
+                    "autorefresh": true,
+                    "description": "SLE-Module-Legacy15-Debuginfo-Updates for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": false,
+                    "id": 2550,
+                    "installer_updates": false,
+                    "name": "SLE-Module-Legacy15-Debuginfo-Updates",
+                    "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Legacy/15/x86_64/update_debug/"
+                  },
+                  {
+                    "autorefresh": false,
+                    "description": "SLE-Module-Legacy15-Pool for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": true,
+                    "id": 2551,
+                    "installer_updates": false,
+                    "name": "SLE-Module-Legacy15-Pool",
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Legacy/15/x86_64/product/"
+                  },
+                  {
+                    "autorefresh": false,
+                    "description": "SLE-Module-Legacy15-Debuginfo-Pool for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": false,
+                    "id": 2552,
+                    "installer_updates": false,
+                    "name": "SLE-Module-Legacy15-Debuginfo-Pool",
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Legacy/15/x86_64/product_debug/"
+                  },
+                  {
+                    "autorefresh": false,
+                    "description": "SLE-Module-Legacy15-Source-Pool for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": false,
+                    "id": 2553,
+                    "installer_updates": false,
+                    "name": "SLE-Module-Legacy15-Source-Pool",
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Legacy/15/x86_64/product_source/"
+                  }
+                ],
+                "shortname": "Legacy-Module",
+                "version": "15"
+              },
+              {
+                "arch": "x86_64",
+                "cpe": "cpe:/o:suse:sle-ha:15",
+                "description": "SUSE Linux High Availability Extension provides mature, industry-leading open-source high-availability clustering technologies that are easy to set up and use. It can be deployed in physical and/or virtual environments, and can cluster physical servers, virtual servers, or any combination of the two to suit your business\u2019 needs.",
+                "eula_url": "https://updates.suse.com/SUSE/Products/SLE-Product-HA/15/x86_64/product.license/",
+                "extensions": [],
+                "former_identifier": "sle-ha",
+                "free": false,
+                "friendly_name": "SUSE Linux Enterprise High Availability Extension 15 x86_64",
+                "friendly_version": "15",
+                "id": 1582,
+                "identifier": "sle-ha",
+                "migration_extra": false,
+                "name": "SUSE Linux Enterprise High Availability Extension",
+                "offline_predecessor_ids": [
+                  958,
+                  961,
+                  967,
+                  971,
+                  1101,
+                  1107,
+                  1157,
+                  1245,
+                  1256,
+                  1286,
+                  1324,
+                  1337,
+                  1361,
+                  1363,
+                  1432,
+                  1435,
+                  1634,
+                  1637,
+                  1884,
+                  1886
+                ],
+                "online_predecessor_ids": [],
+                "predecessor_ids": [],
+                "product_class": "SLE-HAE-X86",
+                "product_type": "extension",
+                "recommended": false,
+                "release_stage": "released",
+                "release_type": null,
+                "repositories": [
+                  {
+                    "autorefresh": true,
+                    "description": "SLE-Product-HA15-Updates for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": true,
+                    "id": 2754,
+                    "installer_updates": false,
+                    "name": "SLE-Product-HA15-Updates",
+                    "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-HA/15/x86_64/update/"
+                  },
+                  {
+                    "autorefresh": true,
+                    "description": "SLE-Product-HA15-Debuginfo-Updates for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": false,
+                    "id": 2755,
+                    "installer_updates": false,
+                    "name": "SLE-Product-HA15-Debuginfo-Updates",
+                    "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-HA/15/x86_64/update_debug/"
+                  },
+                  {
+                    "autorefresh": false,
+                    "description": "SLE-Product-HA15-Pool for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": true,
+                    "id": 2756,
+                    "installer_updates": false,
+                    "name": "SLE-Product-HA15-Pool",
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Product-HA/15/x86_64/product/"
+                  },
+                  {
+                    "autorefresh": false,
+                    "description": "SLE-Product-HA15-Debuginfo-Pool for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": false,
+                    "id": 2757,
+                    "installer_updates": false,
+                    "name": "SLE-Product-HA15-Debuginfo-Pool",
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Product-HA/15/x86_64/product_debug/"
+                  },
+                  {
+                    "autorefresh": false,
+                    "description": "SLE-Product-HA15-Source-Pool for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": false,
+                    "id": 2758,
+                    "installer_updates": false,
+                    "name": "SLE-Product-HA15-Source-Pool",
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Product-HA/15/x86_64/product_source/"
+                  }
+                ],
+                "shortname": "SLEHA15",
+                "version": "15"
+              },
+              {
+                "arch": "x86_64",
+                "cpe": "cpe:/o:suse:sle-module-public-cloud:15",
+                "description": "<p> The Public Cloud Module is a collection of tools that enables you to create and manage cloud images from the commandline on SUSE Linux Enterprise Server. When building your own images with KIWI or SUSE Studio, initialization code specific to the target cloud is included in that image. </p> <p> Access to the Public Cloud Module is included in your SUSE Linux Enterprise Server subscription. The module has a different lifecycle than SUSE Linux Enterprise Server itself; please check the Release Notes for further details. </p>",
+                "eula_url": "",
+                "extensions": [],
+                "former_identifier": "sle-module-public-cloud",
+                "free": true,
+                "friendly_name": "Public Cloud Module 15 x86_64",
+                "friendly_version": "15",
+                "id": 1611,
+                "identifier": "sle-module-public-cloud",
+                "migration_extra": true,
+                "name": "Public Cloud Module",
+                "offline_predecessor_ids": [
+                  1220
+                ],
+                "online_predecessor_ids": [],
+                "predecessor_ids": [],
+                "product_class": "MODULE",
+                "product_type": "module",
+                "recommended": false,
+                "release_stage": "released",
+                "release_type": null,
+                "repositories": [
+                  {
+                    "autorefresh": true,
+                    "description": "SLE-Module-Public-Cloud15-Updates for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": true,
+                    "id": 2673,
+                    "installer_updates": false,
+                    "name": "SLE-Module-Public-Cloud15-Updates",
+                    "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Public-Cloud/15/x86_64/update/"
+                  },
+                  {
+                    "autorefresh": true,
+                    "description": "SLE-Module-Public-Cloud15-Debuginfo-Updates for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": false,
+                    "id": 2674,
+                    "installer_updates": false,
+                    "name": "SLE-Module-Public-Cloud15-Debuginfo-Updates",
+                    "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Public-Cloud/15/x86_64/update_debug/"
+                  },
+                  {
+                    "autorefresh": false,
+                    "description": "SLE-Module-Public-Cloud15-Pool for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": true,
+                    "id": 2675,
+                    "installer_updates": false,
+                    "name": "SLE-Module-Public-Cloud15-Pool",
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Public-Cloud/15/x86_64/product/"
+                  },
+                  {
+                    "autorefresh": false,
+                    "description": "SLE-Module-Public-Cloud15-Debuginfo-Pool for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": false,
+                    "id": 2676,
+                    "installer_updates": false,
+                    "name": "SLE-Module-Public-Cloud15-Debuginfo-Pool",
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Public-Cloud/15/x86_64/product_debug/"
+                  },
+                  {
+                    "autorefresh": false,
+                    "description": "SLE-Module-Public-Cloud15-Source-Pool for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": false,
+                    "id": 3129,
+                    "installer_updates": false,
+                    "name": "SLE-Module-Public-Cloud15-Source-Pool",
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Public-Cloud/15/x86_64/product_source/"
+                  }
+                ],
+                "shortname": "Public-Cloud-Module",
+                "version": "15"
+              },
+              {
+                "arch": "x86_64",
+                "cpe": "cpe:/o:suse:sle-module-web-scripting:15",
+                "description": "<p> The SUSE Linux Enterprise Web and Scripting Module should contains additional packages that are helpful when running a webserver. </p> <p> Access to the Web and Scripting Module is included in your SUSE Linux Enterprise Server subscription. The module has a different lifecycle than SUSE Linux Enterprise Server itself: Package versions in this module are usually supported for at most three years. We are planning to release more recent versions on a schedule of approximately 18 month; the exact dates may differ per package. </p>",
+                "eula_url": "",
+                "extensions": [],
+                "former_identifier": "sle-module-web-scripting",
+                "free": true,
+                "friendly_name": "Web and Scripting Module 15 x86_64",
+                "friendly_version": "15",
+                "id": 1721,
+                "identifier": "sle-module-web-scripting",
+                "migration_extra": true,
+                "name": "Web and Scripting Module",
+                "offline_predecessor_ids": [
+                  1153
+                ],
+                "online_predecessor_ids": [],
+                "predecessor_ids": [],
+                "product_class": "MODULE",
+                "product_type": "module",
+                "recommended": false,
+                "release_stage": "released",
+                "release_type": null,
+                "repositories": [
+                  {
+                    "autorefresh": true,
+                    "description": "SLE-Module-Web-Scripting15-Updates for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": true,
+                    "id": 2972,
+                    "installer_updates": false,
+                    "name": "SLE-Module-Web-Scripting15-Updates",
+                    "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Web-Scripting/15/x86_64/update/"
+                  },
+                  {
+                    "autorefresh": true,
+                    "description": "SLE-Module-Web-Scripting15-Debuginfo-Updates for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": false,
+                    "id": 2973,
+                    "installer_updates": false,
+                    "name": "SLE-Module-Web-Scripting15-Debuginfo-Updates",
+                    "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Web-Scripting/15/x86_64/update_debug/"
+                  },
+                  {
+                    "autorefresh": false,
+                    "description": "SLE-Module-Web-Scripting15-Pool for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": true,
+                    "id": 2974,
+                    "installer_updates": false,
+                    "name": "SLE-Module-Web-Scripting15-Pool",
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Web-Scripting/15/x86_64/product/"
+                  },
+                  {
+                    "autorefresh": false,
+                    "description": "SLE-Module-Web-Scripting15-Debuginfo-Pool for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": false,
+                    "id": 2975,
+                    "installer_updates": false,
+                    "name": "SLE-Module-Web-Scripting15-Debuginfo-Pool",
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Web-Scripting/15/x86_64/product_debug/"
+                  },
+                  {
+                    "autorefresh": false,
+                    "description": "SLE-Module-Web-Scripting15-Source-Pool for sle-15-x86_64",
+                    "distro_target": "sle-15-x86_64",
+                    "enabled": false,
+                    "id": 2976,
+                    "installer_updates": false,
+                    "name": "SLE-Module-Web-Scripting15-Source-Pool",
+                    "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Web-Scripting/15/x86_64/product_source/"
+                  }
+                ],
+                "shortname": "Web-Scripting-Module",
+                "version": "15"
+              }
+            ],
+            "former_identifier": "sle-module-server-applications",
+            "free": true,
+            "friendly_name": "Server Applications Module 15 x86_64",
+            "friendly_version": "15",
+            "id": 1580,
+            "identifier": "sle-module-server-applications",
+            "migration_extra": false,
+            "name": "Server Applications Module",
+            "offline_predecessor_ids": [],
+            "online_predecessor_ids": [],
+            "predecessor_ids": [],
+            "product_class": "MODULE",
+            "product_type": "module",
+            "recommended": true,
+            "release_stage": "released",
+            "release_type": null,
+            "repositories": [
+              {
+                "autorefresh": true,
+                "description": "SLE-Module-Server-Applications15-Updates for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": true,
+                "id": 2544,
+                "installer_updates": false,
+                "name": "SLE-Module-Server-Applications15-Updates",
+                "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Server-Applications/15/x86_64/update/"
+              },
+              {
+                "autorefresh": true,
+                "description": "SLE-Module-Server-Applications15-Debuginfo-Updates for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": false,
+                "id": 2545,
+                "installer_updates": false,
+                "name": "SLE-Module-Server-Applications15-Debuginfo-Updates",
+                "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Server-Applications/15/x86_64/update_debug/"
+              },
+              {
+                "autorefresh": false,
+                "description": "SLE-Module-Server-Applications15-Pool for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": true,
+                "id": 2546,
+                "installer_updates": false,
+                "name": "SLE-Module-Server-Applications15-Pool",
+                "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Server-Applications/15/x86_64/product/"
+              },
+              {
+                "autorefresh": false,
+                "description": "SLE-Module-Server-Applications15-Debuginfo-Pool for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": false,
+                "id": 2547,
+                "installer_updates": false,
+                "name": "SLE-Module-Server-Applications15-Debuginfo-Pool",
+                "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Server-Applications/15/x86_64/product_debug/"
+              },
+              {
+                "autorefresh": false,
+                "description": "SLE-Module-Server-Applications15-Source-Pool for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": false,
+                "id": 2548,
+                "installer_updates": false,
+                "name": "SLE-Module-Server-Applications15-Source-Pool",
+                "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Server-Applications/15/x86_64/product_source/"
+              }
+            ],
+            "shortname": "Server-Applications-Module",
+            "version": "15"
+          },
+          {
+            "arch": "x86_64",
+            "cpe": "cpe:/o:suse:sle-module-containers:15",
+            "description": "<p>This Module contains several packages revolving around containers and related tools. </p>",
+            "eula_url": "",
+            "extensions": [],
+            "former_identifier": "sle-module-containers",
+            "free": true,
+            "friendly_name": "Containers Module 15 x86_64",
+            "friendly_version": "15",
+            "id": 1642,
+            "identifier": "sle-module-containers",
+            "migration_extra": true,
+            "name": "Containers Module",
+            "offline_predecessor_ids": [
+              1332
+            ],
+            "online_predecessor_ids": [],
+            "predecessor_ids": [],
+            "product_class": "MODULE",
+            "product_type": "module",
+            "recommended": false,
+            "release_stage": "released",
+            "release_type": null,
+            "repositories": [
+              {
+                "autorefresh": true,
+                "description": "SLE-Module-Containers15-Updates for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": true,
+                "id": 2864,
+                "installer_updates": false,
+                "name": "SLE-Module-Containers15-Updates",
+                "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Containers/15/x86_64/update/"
+              },
+              {
+                "autorefresh": true,
+                "description": "SLE-Module-Containers15-Debuginfo-Updates for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": false,
+                "id": 2865,
+                "installer_updates": false,
+                "name": "SLE-Module-Containers15-Debuginfo-Updates",
+                "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Containers/15/x86_64/update_debug/"
+              },
+              {
+                "autorefresh": false,
+                "description": "SLE-Module-Containers15-Pool for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": true,
+                "id": 2866,
+                "installer_updates": false,
+                "name": "SLE-Module-Containers15-Pool",
+                "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Containers/15/x86_64/product/"
+              },
+              {
+                "autorefresh": false,
+                "description": "SLE-Module-Containers15-Debuginfo-Pool for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": false,
+                "id": 2867,
+                "installer_updates": false,
+                "name": "SLE-Module-Containers15-Debuginfo-Pool",
+                "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Containers/15/x86_64/product_debug/"
+              },
+              {
+                "autorefresh": false,
+                "description": "SLE-Module-Containers15-Source-Pool for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": false,
+                "id": 2868,
+                "installer_updates": false,
+                "name": "SLE-Module-Containers15-Source-Pool",
+                "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Containers/15/x86_64/product_source/"
+              }
+            ],
+            "shortname": "Containers-Module",
+            "version": "15"
+          },
+          {
+            "arch": "x86_64",
+            "cpe": "cpe:/o:suse:sle-module-cap-tools:15",
+            "description": "<p> The SUSE Cloud Application Platform Tools Module is a collection of tools that enables you to interact with the SUSE Cloud Application Platform product itself, providing the commandline client for instance. </p> <p> Access to the SUSE Cloud Application Platform Tools Module is included in your SUSE Linux Enterprise Server subscription. The module has a different lifecycle than SUSE Linux Enterprise Server itself; please check the Release Notes for further details. </p>",
+            "eula_url": "",
+            "extensions": [],
+            "former_identifier": "sle-module-cap-tools",
+            "free": true,
+            "friendly_name": "SUSE Cloud Application Platform Tools Module 15 x86_64",
+            "friendly_version": "15",
+            "id": 1728,
+            "identifier": "sle-module-cap-tools",
+            "migration_extra": true,
+            "name": "SUSE Cloud Application Platform Tools Module",
+            "offline_predecessor_ids": [
+              1678
+            ],
+            "online_predecessor_ids": [],
+            "predecessor_ids": [],
+            "product_class": "MODULE",
+            "product_type": "module",
+            "recommended": false,
+            "release_stage": "released",
+            "release_type": null,
+            "repositories": [
+              {
+                "autorefresh": true,
+                "description": "SLE-Module-CAP-Tools15-Updates for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": true,
+                "id": 3000,
+                "installer_updates": false,
+                "name": "SLE-Module-CAP-Tools15-Updates",
+                "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-CAP-Tools/15/x86_64/update/"
+              },
+              {
+                "autorefresh": true,
+                "description": "SLE-Module-CAP-Tools15-Debuginfo-Updates for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": false,
+                "id": 3001,
+                "installer_updates": false,
+                "name": "SLE-Module-CAP-Tools15-Debuginfo-Updates",
+                "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-CAP-Tools/15/x86_64/update_debug/"
+              },
+              {
+                "autorefresh": false,
+                "description": "SLE-Module-CAP-Tools15-Pool for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": true,
+                "id": 3002,
+                "installer_updates": false,
+                "name": "SLE-Module-CAP-Tools15-Pool",
+                "url": "https://updates.suse.com/SUSE/Products/SLE-Module-CAP-Tools/15/x86_64/product/"
+              },
+              {
+                "autorefresh": false,
+                "description": "SLE-Module-CAP-Tools15-Debuginfo-Pool for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": false,
+                "id": 3003,
+                "installer_updates": false,
+                "name": "SLE-Module-CAP-Tools15-Debuginfo-Pool",
+                "url": "https://updates.suse.com/SUSE/Products/SLE-Module-CAP-Tools/15/x86_64/product_debug/"
+              },
+              {
+                "autorefresh": false,
+                "description": "SLE-Module-CAP-Tools15-Source-Pool for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": false,
+                "id": 3123,
+                "installer_updates": false,
+                "name": "SLE-Module-CAP-Tools15-Source-Pool",
+                "url": "https://updates.suse.com/SUSE/Products/SLE-Module-CAP-Tools/15/x86_64/product_source/"
+              }
+            ],
+            "shortname": "SUSE-CAP-Tools-Module",
+            "version": "15"
+          },
+          {
+            "arch": "x86_64",
+            "cpe": "cpe:/o:suse:sle-module-live-patching:15",
+            "description": "<p> SUSE Linux Enterprise Live Patching provides packages to update critical components in SUSE Linux Enterprise. With SUSE Linux Enterprise Live Patching, you can perform critical patching without shutting down your system, reducing the need for planned downtime and increasing service availability. <p>",
+            "eula_url": "",
+            "extensions": [],
+            "former_identifier": "sle-module-live-patching",
+            "free": false,
+            "friendly_name": "SUSE Linux Enterprise Live Patching 15 x86_64",
+            "friendly_version": "15",
+            "id": 1736,
+            "identifier": "sle-module-live-patching",
+            "migration_extra": false,
+            "name": "SUSE Linux Enterprise Live Patching",
+            "offline_predecessor_ids": [
+              1536,
+              1757,
+              1888
+            ],
+            "online_predecessor_ids": [],
+            "predecessor_ids": [],
+            "product_class": "SLE-LP",
+            "product_type": "module",
+            "recommended": false,
+            "release_stage": "released",
+            "release_type": null,
+            "repositories": [
+              {
+                "autorefresh": true,
+                "description": "SLE-Module-Live-Patching15-Updates for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": true,
+                "id": 3033,
+                "installer_updates": false,
+                "name": "SLE-Module-Live-Patching15-Updates",
+                "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Live-Patching/15/x86_64/update/"
+              },
+              {
+                "autorefresh": true,
+                "description": "SLE-Module-Live-Patching15-Debuginfo-Updates for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": false,
+                "id": 3034,
+                "installer_updates": false,
+                "name": "SLE-Module-Live-Patching15-Debuginfo-Updates",
+                "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Live-Patching/15/x86_64/update_debug/"
+              },
+              {
+                "autorefresh": false,
+                "description": "SLE-Module-Live-Patching15-Pool for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": true,
+                "id": 3035,
+                "installer_updates": false,
+                "name": "SLE-Module-Live-Patching15-Pool",
+                "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Live-Patching/15/x86_64/product/"
+              },
+              {
+                "autorefresh": false,
+                "description": "SLE-Module-Live-Patching15-Debuginfo-Pool for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": false,
+                "id": 3036,
+                "installer_updates": false,
+                "name": "SLE-Module-Live-Patching15-Debuginfo-Pool",
+                "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Live-Patching/15/x86_64/product_debug/"
+              },
+              {
+                "autorefresh": false,
+                "description": "SLE-Module-Live-Patching15-Source-Pool for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": false,
+                "id": 3125,
+                "installer_updates": false,
+                "name": "SLE-Module-Live-Patching15-Source-Pool",
+                "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Live-Patching/15/x86_64/product_source/"
+              }
+            ],
+            "shortname": "Live-Patching",
+            "version": "15"
+          },
+          {
+            "arch": "x86_64",
+            "cpe": "cpe:/o:suse:packagehub:15",
+            "description": "SUSE Package Hub is a free of charge extension providing access to community maintained packages built to run on SUSE Linux Enterprise Server. Built from the same sources used in the openSUSE distributions, these quality packages provide additional software to what is found in the SUSE Linux Enterprise Server product. Packages from the Package Hub are delivered without L3 support from SUSE. General updates and fixes to the packages in SUSE Package Hub are provided by the openSUSE community based on their discretion though SUSE will monitor and ensure that any known critical security issues will be addressed. Packages in the Package Hub are approved by SUSE for use with SUSE Linux Enterprise Server 15 and to not interfere with the supportability of SUSE Linux Enterprise Server it's modules and extensions. For more information about SUSE Package Hub please visit https://packagehub.suse.com.",
+            "eula_url": "",
+            "extensions": [],
+            "former_identifier": "PackageHub",
+            "free": true,
+            "friendly_name": "SUSE Package Hub 15 x86_64",
+            "friendly_version": "15",
+            "id": 1743,
+            "identifier": "PackageHub",
+            "migration_extra": false,
+            "name": "SUSE Package Hub",
+            "offline_predecessor_ids": [
+              1529,
+              1813,
+              1915
+            ],
+            "online_predecessor_ids": [],
+            "predecessor_ids": [],
+            "product_class": "MODULE",
+            "product_type": "extension",
+            "recommended": false,
+            "release_stage": "released",
+            "release_type": null,
+            "repositories": [
+              {
+                "autorefresh": false,
+                "description": "SUSE-PackageHub-15-Standard-Pool for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": true,
+                "id": 3059,
+                "installer_updates": false,
+                "name": "SUSE-PackageHub-15-Standard-Pool",
+                "url": "https://updates.suse.com/SUSE/Backports/SLE-15_x86_64/standard/"
+              },
+              {
+                "autorefresh": true,
+                "description": "SUSE-PackageHub-15-Debuginfo for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": false,
+                "id": 3060,
+                "installer_updates": false,
+                "name": "SUSE-PackageHub-15-Debuginfo",
+                "url": "https://updates.suse.com/SUSE/Backports/SLE-15_x86_64/standard_debug/"
+              },
+              {
+                "autorefresh": false,
+                "description": "SUSE-PackageHub-15-Pool for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": true,
+                "id": 3061,
+                "installer_updates": false,
+                "name": "SUSE-PackageHub-15-Pool",
+                "url": "https://updates.suse.com/SUSE/Backports/SLE-15_x86_64/product/"
+              },
+              {
+                "autorefresh": true,
+                "description": "SLE-Module-Packagehub-Subpackages15-Updates for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": true,
+                "id": 3182,
+                "installer_updates": false,
+                "name": "SLE-Module-Packagehub-Subpackages15-Updates",
+                "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Packagehub-Subpackages/15/x86_64/update/"
+              },
+              {
+                "autorefresh": true,
+                "description": "SLE-Module-Packagehub-Subpackages15-Debuginfo-Updates for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": false,
+                "id": 3183,
+                "installer_updates": false,
+                "name": "SLE-Module-Packagehub-Subpackages15-Debuginfo-Updates",
+                "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Packagehub-Subpackages/15/x86_64/update_debug/"
+              },
+              {
+                "autorefresh": false,
+                "description": "SLE-Module-Packagehub-Subpackages15-Pool for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": true,
+                "id": 3184,
+                "installer_updates": false,
+                "name": "SLE-Module-Packagehub-Subpackages15-Pool",
+                "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Packagehub-Subpackages/15/x86_64/product/"
+              },
+              {
+                "autorefresh": false,
+                "description": "SLE-Module-Packagehub-Subpackages15-Debuginfo-Pool for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": false,
+                "id": 3185,
+                "installer_updates": false,
+                "name": "SLE-Module-Packagehub-Subpackages15-Debuginfo-Pool",
+                "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Packagehub-Subpackages/15/x86_64/product_debug/"
+              },
+              {
+                "autorefresh": false,
+                "description": "SLE-Module-Packagehub-Subpackages15-Source-Pool for sle-15-x86_64",
+                "distro_target": "sle-15-x86_64",
+                "enabled": false,
+                "id": 3186,
+                "installer_updates": false,
+                "name": "SLE-Module-Packagehub-Subpackages15-Source-Pool",
+                "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Packagehub-Subpackages/15/x86_64/product_source/"
+              }
+            ],
+            "shortname": "SUSE-PackageHub-15",
+            "version": "15"
+          }
+        ],
+        "former_identifier": "sle-module-basesystem",
+        "free": true,
+        "friendly_name": "Basesystem Module 15 x86_64",
+        "friendly_version": "15",
+        "id": 1576,
+        "identifier": "sle-module-basesystem",
+        "migration_extra": false,
+        "name": "Basesystem Module",
+        "offline_predecessor_ids": [
+          1212,
+          1368,
+          1440,
+          1618
+        ],
+        "online_predecessor_ids": [],
+        "predecessor_ids": [],
+        "product_class": "MODULE",
+        "product_type": "module",
+        "recommended": true,
+        "release_stage": "released",
+        "release_type": null,
+        "repositories": [
+          {
+            "autorefresh": true,
+            "description": "SLE-Module-Basesystem15-Updates for sle-15-x86_64",
+            "distro_target": "sle-15-x86_64",
+            "enabled": true,
+            "id": 2524,
+            "installer_updates": false,
+            "name": "SLE-Module-Basesystem15-Updates",
+            "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Basesystem/15/x86_64/update/"
+          },
+          {
+            "autorefresh": true,
+            "description": "SLE-Module-Basesystem15-Debuginfo-Updates for sle-15-x86_64",
+            "distro_target": "sle-15-x86_64",
+            "enabled": false,
+            "id": 2525,
+            "installer_updates": false,
+            "name": "SLE-Module-Basesystem15-Debuginfo-Updates",
+            "url": "https://updates.suse.com/SUSE/Updates/SLE-Module-Basesystem/15/x86_64/update_debug/"
+          },
+          {
+            "autorefresh": false,
+            "description": "SLE-Module-Basesystem15-Pool for sle-15-x86_64",
+            "distro_target": "sle-15-x86_64",
+            "enabled": true,
+            "id": 2526,
+            "installer_updates": false,
+            "name": "SLE-Module-Basesystem15-Pool",
+            "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Basesystem/15/x86_64/product/"
+          },
+          {
+            "autorefresh": false,
+            "description": "SLE-Module-Basesystem15-Debuginfo-Pool for sle-15-x86_64",
+            "distro_target": "sle-15-x86_64",
+            "enabled": false,
+            "id": 2527,
+            "installer_updates": false,
+            "name": "SLE-Module-Basesystem15-Debuginfo-Pool",
+            "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Basesystem/15/x86_64/product_debug/"
+          },
+          {
+            "autorefresh": false,
+            "description": "SLE-Module-Basesystem15-Source-Pool for sle-15-x86_64",
+            "distro_target": "sle-15-x86_64",
+            "enabled": false,
+            "id": 2528,
+            "installer_updates": false,
+            "name": "SLE-Module-Basesystem15-Source-Pool",
+            "url": "https://updates.suse.com/SUSE/Products/SLE-Module-Basesystem/15/x86_64/product_source/"
+          }
+        ],
+        "shortname": "Basesystem-Module",
+        "version": "15"
+      },
+      {
+        "arch": "x86_64",
+        "cpe": "cpe:/o:suse:sles-ltss:15",
+        "description": "SUSE Linux Enterprise offers a comprehensive suite of products built on a single code base. The platform addresses business needs from the smallest thin-client devices to the world's most powerful high-performance computing and mainframe servers. SUSE Linux Enterprise offers common management tools and technology certifications across the platform, and each product is enterprise-class.",
+        "eula_url": "",
+        "extensions": [],
+        "former_identifier": "SLES-LTSS",
+        "free": false,
+        "friendly_name": "SUSE Linux Enterprise Server LTSS 15 x86_64",
+        "friendly_version": "15",
+        "id": 2056,
+        "identifier": "SLES-LTSS",
+        "migration_extra": false,
+        "name": "SUSE Linux Enterprise Server LTSS",
+        "offline_predecessor_ids": [],
+        "online_predecessor_ids": [],
+        "predecessor_ids": [],
+        "product_class": "SLES15-GA-LTSS-X86",
+        "product_type": "extension",
+        "recommended": false,
+        "release_stage": "released",
+        "release_type": null,
+        "repositories": [
+          {
+            "autorefresh": true,
+            "description": "SLE-Product-SLES15-LTSS-Updates for sle-15-x86_64",
+            "distro_target": "sle-15-x86_64",
+            "enabled": true,
+            "id": 4390,
+            "installer_updates": false,
+            "name": "SLE-Product-SLES15-LTSS-Updates",
+            "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-SLES/15-LTSS/x86_64/update/"
+          },
+          {
+            "autorefresh": true,
+            "description": "SLE-Product-SLES15-Debuginfo-LTSS-Updates for sle-15-x86_64",
+            "distro_target": "sle-15-x86_64",
+            "enabled": false,
+            "id": 4391,
+            "installer_updates": false,
+            "name": "SLE-Product-SLES15-Debuginfo-LTSS-Updates",
+            "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-SLES/15-LTSS/x86_64/update_debug/"
+          }
+        ],
+        "shortname": "SLES15-LTSS",
+        "version": "15"
+      }
+    ],
+    "former_identifier": "SLES",
+    "free": false,
+    "friendly_name": "SUSE Linux Enterprise Server 15 x86_64",
+    "friendly_version": "15",
+    "id": 1575,
+    "identifier": "SLES",
+    "migration_extra": false,
+    "name": "SUSE Linux Enterprise Server",
+    "offline_predecessor_ids": [
+      690,
+      769,
+      814,
+      824,
+      1300,
+      1421,
+      1625,
+      1878
+    ],
+    "online_predecessor_ids": [],
+    "predecessor_ids": [],
+    "product_class": "7261",
+    "product_type": "base",
+    "recommended": false,
+    "release_stage": "released",
+    "release_type": null,
+    "repositories": [
+      {
+        "autorefresh": true,
+        "description": "SLE-Product-SLES15-Updates for sle-15-x86_64",
+        "distro_target": "sle-15-x86_64",
+        "enabled": true,
+        "id": 2705,
+        "installer_updates": false,
+        "name": "SLE-Product-SLES15-Updates",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-SLES/15/x86_64/update/"
+      },
+      {
+        "autorefresh": true,
+        "description": "SLE15-Installer-Updates for sle-15-x86_64",
+        "distro_target": "sle-15-x86_64",
+        "enabled": false,
+        "id": 2706,
+        "installer_updates": true,
+        "name": "SLE15-Installer-Updates",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-INSTALLER/15/x86_64/update/"
+      },
+      {
+        "autorefresh": false,
+        "description": "SLE-Product-SLES15-Pool for sle-15-x86_64",
+        "distro_target": "sle-15-x86_64",
+        "enabled": true,
+        "id": 2707,
+        "installer_updates": false,
+        "name": "SLE-Product-SLES15-Pool",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-SLES/15/x86_64/product/"
+      },
+      {
+        "autorefresh": true,
+        "description": "SLE-Product-SLES15-Debuginfo-Updates for sle-15-x86_64",
+        "distro_target": "sle-15-x86_64",
+        "enabled": false,
+        "id": 3114,
+        "installer_updates": false,
+        "name": "SLE-Product-SLES15-Debuginfo-Updates",
+        "url": "https://updates.suse.com/SUSE/Updates/SLE-Product-SLES/15/x86_64/update_debug/"
+      },
+      {
+        "autorefresh": false,
+        "description": "SLE-Product-SLES15-Debuginfo-Pool for sle-15-x86_64",
+        "distro_target": "sle-15-x86_64",
+        "enabled": false,
+        "id": 3115,
+        "installer_updates": false,
+        "name": "SLE-Product-SLES15-Debuginfo-Pool",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-SLES/15/x86_64/product_debug/"
+      },
+      {
+        "autorefresh": false,
+        "description": "SLE-Product-SLES15-Source-Pool for sle-15-x86_64",
+        "distro_target": "sle-15-x86_64",
+        "enabled": false,
+        "id": 3116,
+        "installer_updates": false,
+        "name": "SLE-Product-SLES15-Source-Pool",
+        "url": "https://updates.suse.com/SUSE/Products/SLE-Product-SLES/15/x86_64/product_source/"
+      }
+    ],
+    "shortname": "SLES15",
+    "version": "15"
   }
 ]

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- switch to best repo auth item for contentsources (bsc#1191442)
 - Add compressed flag to image pillars when kiwi image is compressed (bsc#1191702)
 
 -------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR change?

If 2 credentials provide access to the same repositories, we choose the "best" following some criterias.
When a repo is already setup and the auth item from a different credential become "the best", we have to switch
the assignment of the content source (repo) which did not happen.

In the old code just assigned the content source also to the new best auth, but leave the old assigned as well.
This had the consequence that in the re-link function, we switch the URL back and forth and under bad conditions
the `isRefreshNeeded()` function tell us, we use the wrong one and need to refresh which does not help.

Port of https://github.com/SUSE/spacewalk/pull/16123

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests were added

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
