### PR TITLE
[DCM Workshop] Publishing Kafka events for every request processed in RhnRequestProcessor

### DIFF
--- a/backend/rhn-conf/rhn_server.conf
+++ b/backend/rhn-conf/rhn_server.conf
@@ -140,3 +140,9 @@ checksum_priority_list = sha512, sha384, sha256, sha1, md5
 sync_to_temp = 0
 
 sync_source_packages = 0
+
+# Kafka properties
+kafka.producer.enabled = 0
+kafka.application.id = susemanager
+kafka.bootstrap.servers = localhost:9092
+kafka.topic = suma-events

--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -131,5 +131,8 @@
         <dependency org="org.jacoco" name="org.jacoco.ant" rev="0.8.7" transitive="false">
            <artifact name="nodeps" type="jar" url="https://repo1.maven.org/maven2/org/jacoco/org.jacoco.ant/0.8.7/org.jacoco.ant-0.8.7-nodeps.jar"/>
         </dependency>
+        <dependency org="org.apache.kafka" name="kafka-streams" rev="3.0.0" transitive="true">
+            <artifact name="" type="jar" url="https://repo1.maven.org/maven2/org/apache/kafka/kafka-streams/3.0.0/kafka-streams-3.0.0.jar"/>
+        </dependency>
     </dependencies>
 </ivy-module>

--- a/java/buildconf/ivy/ivy-suse.xml
+++ b/java/buildconf/ivy/ivy-suse.xml
@@ -132,7 +132,11 @@
            <artifact name="nodeps" type="jar" url="https://repo1.maven.org/maven2/org/jacoco/org.jacoco.ant/0.8.7/org.jacoco.ant-0.8.7-nodeps.jar"/>
         </dependency>
         <dependency org="org.apache.kafka" name="kafka-streams" rev="3.0.0" transitive="true">
-            <artifact name="" type="jar" url="https://repo1.maven.org/maven2/org/apache/kafka/kafka-streams/3.0.0/kafka-streams-3.0.0.jar"/>
+            <artifact name="kafka-streams" type="jar" url="https://repo1.maven.org/maven2/org/apache/kafka/kafka-streams/3.0.0/kafka-streams-3.0.0.jar"/>
+        </dependency>
+        <dependency org="org.apache.kafka" name="connect-json" rev="3.0.0" transitive="true">
+            <artifact name="connect-json" type="jar" url="https://repo1.maven.org/maven2/org/apache/kafka/connect-json/3.0.0/connect-json-3.0.0.jar"/>
+            <exclude org="javax.ws.rs"/>
         </dependency>
     </dependencies>
 </ivy-module>

--- a/java/buildconf/manager-developer-build.properties
+++ b/java/buildconf/manager-developer-build.properties
@@ -7,7 +7,3 @@ deploy.host = dev-server.tf.local
 # Uncomment to get javascript sourcemaps in Reactjs pages
 #javascript.devel = true
 
-# TODO: See how to add these properties using the property file
-# Kafka properties
-# application.id = suma
-# bootstrap.servers = obarrios.tf.local:9092

--- a/java/buildconf/manager-developer-build.properties
+++ b/java/buildconf/manager-developer-build.properties
@@ -1,5 +1,5 @@
 # Host that Manager will be deployed to ("deploy" task)
-deploy.host = d52.suse.de
+deploy.host = dev-server.tf.local
 
 # Uncomment to use .class files from the build/classes directory directly to avoid calling javac
 #precompiled = true
@@ -7,3 +7,7 @@ deploy.host = d52.suse.de
 # Uncomment to get javascript sourcemaps in Reactjs pages
 #javascript.devel = true
 
+# TODO: See how to add these properties using the property file
+# Kafka properties
+# application.id = suma
+# bootstrap.servers = obarrios.tf.local:9092

--- a/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
+++ b/java/code/src/com/redhat/rhn/common/conf/ConfigDefaults.java
@@ -345,6 +345,14 @@ public class ConfigDefaults {
      */
     public static final String DEFAULT_DOCS_LOCALE = "web.docs_locale";
 
+    /**
+     * Kafka properties
+     */
+    public static final String KAFKA_PRODUCER_ENABLED = "kafka.producer.enabled";
+    public static final String KAFKA_APPLICATION_ID = "kafka.application.id";
+    public static final String KAFKA_BOOTSTRAP_SERVERS = "kafka.bootstrap.servers";
+    public static final String KAFKA_TOPIC = "kafka.topic";
+
     private ConfigDefaults() {
     }
 
@@ -1058,5 +1066,37 @@ public class ConfigDefaults {
      */
     public boolean isForwardRegistrationEnabled() {
         return Config.get().getBoolean(FORWARD_REGISTRATION);
+    }
+
+    /**
+     * Get Kafka publishing
+     * @return true if the Kafka Producer is enabled
+     */
+    public boolean isKafkaProducerEnabled() {
+        return Config.get().getBoolean(KAFKA_PRODUCER_ENABLED);
+    }
+
+    /**
+     * Get Kafka Application Id
+     * @return the Kafka application Id
+     */
+    public String getKafkaApplicationId() {
+        return Config.get().getString(KAFKA_APPLICATION_ID, "susemanager");
+    }
+
+    /**
+     * Get Kafka boostrap servers
+     * @return the Kafka boostrap servers
+     */
+    public String getKafkaBootstrapServers() {
+        return Config.get().getString(KAFKA_BOOTSTRAP_SERVERS, "localhost");
+    }
+
+    /**
+     * Get Kafka default topic
+     * @return the Kafka default topic
+     */
+    public String getKafkaTopic() {
+        return Config.get().getString(KAFKA_TOPIC, "suma-events");
     }
 }

--- a/java/code/src/com/redhat/rhn/frontend/struts/GsonSerializer.java
+++ b/java/code/src/com/redhat/rhn/frontend/struts/GsonSerializer.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.frontend.struts;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import org.apache.kafka.common.serialization.Serializer;
+
+public class GsonSerializer<T> implements Serializer<T> {
+
+    private Gson gson = new GsonBuilder().create();
+
+    @Override
+    public byte[] serialize(String s, T t) {
+        return gson.toJson(t).getBytes();
+    }
+
+}

--- a/spacewalk/config/var/lib/rhn/rhn-satellite-prep/etc/rhn/rhn.conf
+++ b/spacewalk/config/var/lib/rhn/rhn-satellite-prep/etc/rhn/rhn.conf
@@ -70,3 +70,8 @@ cobbler.host = @@cobblerDOThost@@
 # Maximum Java Heap Size (in MB)
 # taskomatic.java.maxmemory=4096
 
+# Kafka properties
+kafka.producer.enabled = 0
+kafka.application.id = susemanager
+kafka.bootstrap.servers = localhost:9092
+kafka.topic = suma-events


### PR DESCRIPTION
## What does this PR change?

This is just my DCM workshop.
I'm including Kafka in our Java Server, so we produce events for every request we do from the WebUI.
That can be useful to be consumed by third-party apps.

### Kafka Quickstart

https://kafka.apache.org/quickstart
#### Download and uncompress the latest version of Kafka
```
wget https://dlcdn.apache.org/kafka/3.0.0/kafka_2.13-3.0.0.tgz
tar xvfz kafka_2.13-3.0.0.tgz
sudo mv kafka_2.13-3.0.0/ /opt/kafka
```
#### Start Zookeeper
```
cd /opt/kafka/
bin/zookeeper-server-start.sh config/zookeeper.properties
```
#### Start Kafka
```
cd /opt/kafka/
bin/kafka-server-start.sh config/server.properties
```
#### Create a topic
```
bin/kafka-topics.sh --create --topic suma-events --partitions 1 --replication-factor 1 --bootstrap-server localhost:9092
```
#### Check status of your topic
```
bin/kafka-topics.sh --describe --topic suma-events --bootstrap-server localhost:9092
Topic: suma-events  TopicId: qQJfnnLcQDSvhzEEd-g4Vg PartitionCount: 1   ReplicationFactor: 1    Configs: segment.bytes=1073741824
    Topic: suma-events  Partition: 0    Leader: 0   Replicas: 0 Isr: 0
```
#### Publish an event into the topic
```
$ bin/kafka-console-producer.sh --topic suma-events --bootstrap-server localhost:9092
```
#### Consum events from the topic
```
bin/kafka-console-consumer.sh --topic suma-events --from-beginning --bootstrap-server localhost:9092
```

### Output example

After navigating through our Uyuni WebUI, the events published to the Kafka topic has that JSON format:
```
{"uuid":"9603b878-9bbd-4d94-876b-1381c7a526ff","uri":"/rhn/systems/details/packages/Packages.do","parameters":{"sid":["1000010000"]}}
{"uuid":"7cec6c3d-34c3-4daf-a005-70b941241805","uri":"/rhn/systems/details/SystemRemoteCommand.do","parameters":{"sid":["1000010000"]}}
{"uuid":"c398dee0-aeef-4a3b-9be5-c3e6de82acdd","uri":"/rhn/systems/details/SystemRemoteCommand.do","parameters":{"sid":["1000010000","1000010000"],"csrf_token":["6904986792858075967"],"uid":["root"],"gid":["root"],"timeout":["600"],"lbl":[""],"script_body":["#!/bin/sh\r\n# Add your shell script below\r\necho test1"],"schedule_type":["date"],"date_day":["10"],"date_month":["10"],"date_year":["2021"],"date_hour":["2"],"date_minute":["1"],"date_am_pm":["1"],"action_chain":["new action chain"],"schedule":["Schedule"],"submitted":["true"]}}
{"uuid":"07038d02-1f52-48ee-b109-191fdbb04601","uri":"/rhn/systems/details/SystemRemoteCommand.do","parameters":{"sid":["1000010000","1000010000"],"csrf_token":["6904986792858075967"],"uid":["root"],"gid":["root"],"timeout":["600"],"lbl":[""],"script_body":["#!/bin/sh\r\n# Add your shell script below\r\n"],"schedule_type":["date"],"date_day":["10"],"date_month":["10"],"date_year":["2021"],"date_hour":["2"],"date_minute":["1"],"date_am_pm":["1"],"action_chain":["new action chain"],"schedule":["Schedule"],"submitted":["true"]}}
{"uuid":"f4a63d19-0b6d-4f7c-94ab-d455b71f9fd3","uri":"/rhn/systems/details/history/Pending.do","parameters":{"sid":["1000010000"]}}
{"uuid":"cc1cf0e2-f07e-4909-9987-4c07b410caba","uri":"/rhn/systems/details/history/History.do","parameters":{"sid":["1000010000"]}}
{"uuid":"2b744048-772d-483d-95ee-4c8e6abb3a67","uri":"/rhn/systems/details/packages/Packages.do","parameters":{"sid":["1000010000"]}}
{"uuid":"a0fd0e1e-3d80-4afd-add8-a6c7bb69f722","uri":"/rhn/systems/SystemList.do","parameters":{}}
{"uuid":"0f83b975-695b-4ed0-9f10-b282bd73b8bf","uri":"/rhn/systems/VirtualList.do","parameters":{}}
{"uuid":"42b6ffa8-5711-4c49-985c-afe0c74d511d","uri":"/rhn/systems/RequiringReboot.do","parameters":{}}
{"uuid":"bdee51ad-6626-4ba9-a64a-40d68d257f78","uri":"/rhn/systems/Unentitled.do","parameters":{}}
{"uuid":"57ea0f99-c84e-475d-b876-cd8dea15acb1","uri":"/rhn/systems/OutOfDate.do","parameters":{}}
```

We connected the tool "akhq" to consume this data (https://akhq.io/docs/installation.html#stand-alone):
![image](https://user-images.githubusercontent.com/2827771/141271614-0de4906b-f98f-4e1e-81a2-030464584adf.png)

`java -Dmicronaut.config.files=/path/to/application.yml -jar akhq.jar`

application.yml
```
akhq:
  connections:
    local:
      properties:
        bootstrap.servers: "localhost:9092"
```

From that point we could use this data to use it in other apps, for whatever purpose like monitoring, telemetry, trigger some actions in a webservice...

- [x] No changelog needed

