### PR TITLE
Don't run package scripts by default

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -52,6 +52,7 @@ susemanager-frontend/ @uyuni-project/frontend
 .github/workflows/javascript-lint.yml @uyuni-project/frontend
 .github/workflows/javascript-unit-tests.yml @uyuni-project/frontend
 .github/workflows/typescript-compilation.yml @uyuni-project/frontend
+.yarnrc @uyuni-project/frontend
 
 # Testsuite
 testsuite/ @uyuni-project/qe

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,7 +1,10 @@
 yarn-path "./susemanager-frontend/susemanager-nodejs-sdk-devel/build/yarn/yarn-1.22.4.js"
+# See https://classic.yarnpkg.com/lang/en/docs/yarnrc/#toc-cli-arguments
 --install.cwd susemanager-frontend
 --clean.cwd susemanager-frontend
 --audit.cwd susemanager-frontend
 --autoclean.cwd susemanager-frontend
 --add.cwd susemanager-frontend/susemanager-nodejs-sdk-devel
 --remove.cwd susemanager-frontend/susemanager-nodejs-sdk-devel
+# Don't run package post-install etc scripts by default to reduce our vulnerable surface
+ignore-scripts true


### PR DESCRIPTION
## What does this PR change?

Disable running package post-install scripts etc by default. This reduces our surface to misc attack vectors from packages.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: Dependency management.

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
