### PR TITLE
Increase "max_event_size" value for the Salt master (bsc#1191340)

### DIFF
--- a/spacewalk/setup/salt/susemanager.conf
+++ b/spacewalk/setup/salt/susemanager.conf
@@ -96,4 +96,4 @@ file_recv: True
 file_recv_max_size: 300
 
 # Maximum size of a message allowed onto the master event bus. The value is expressed in bytes.
-max_event_size: 2097152
+max_event_size: 4194304

--- a/spacewalk/setup/salt/susemanager.conf
+++ b/spacewalk/setup/salt/susemanager.conf
@@ -94,3 +94,6 @@ rosters:
 # Allow minions to upload files to master
 file_recv: True
 file_recv_max_size: 300
+
+# Maximum size of a message allowed onto the master event bus. The value is expressed in bytes.
+max_event_size: 2097152

--- a/spacewalk/setup/spacewalk-setup.changes
+++ b/spacewalk/setup/spacewalk-setup.changes
@@ -1,3 +1,5 @@
+- Increase "max_event_size" value for the Salt master (bsc#1191340)
+
 -------------------------------------------------------------------
 Fri Nov 05 13:53:01 CET 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

This PR increased the `max_event_size` value (x4) in the Salt master in order to allow events that are bigger than the default value.

There are cases, usually in cloud instances, where certain actions, particularly the HW refresh action, produces a Salt return event which is higher than the default value for the Salt master. This caused an error and therefore Java not properly parsing the HW data.
 
## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **bugfix**
- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/16056

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
