### PR TITLE
Fix scap tailoring option

### DIFF
--- a/java/code/src/com/redhat/rhn/manager/audit/scap/xml/Profile.java
+++ b/java/code/src/com/redhat/rhn/manager/audit/scap/xml/Profile.java
@@ -27,7 +27,7 @@ public class Profile {
     @Attribute
     private String id;
 
-    @Attribute
+    @Attribute(required = false)
     private String description;
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/audit/scap/xml/Profile.java
+++ b/java/code/src/com/redhat/rhn/manager/audit/scap/xml/Profile.java
@@ -16,6 +16,8 @@ package com.redhat.rhn.manager.audit.scap.xml;
 
 import org.simpleframework.xml.Attribute;
 
+import java.util.Optional;
+
 /**
  * Bean used to unmarshall an intermediary SCAP report.
  */
@@ -78,8 +80,8 @@ public class Profile {
     /**
      * @return description to get
      */
-    public String getDescription() {
-        return description;
+    public Optional<String> getDescription() {
+        return Optional.ofNullable(description);
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/manager/audit/test/ScapManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/audit/test/ScapManagerTest.java
@@ -82,6 +82,44 @@ public class ScapManagerTest extends JMockBaseTestCaseWithUser {
         assertEquals("Default vanilla kernel hardening", result.getProfile().getTitle());
     }
 
+    public void testXccdfEvalTransformXccdfWithTailoring() throws Exception {
+        MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
+        SystemManager.giveCapability(minion.getId(), SystemManager.CAP_SCAP, 1L);
+
+        TaskomaticApi taskomaticMock = mock(TaskomaticApi.class);
+        ActionManager.setTaskomaticApi(taskomaticMock);
+
+        context().checking(new Expectations() { {
+            allowing(taskomaticMock).scheduleActionExecution(with(any(Action.class)));
+        } });
+
+        ScapAction action = ActionManager.scheduleXccdfEval(user,
+                minion, "/usr/share/xml/scap/ssg/content/ssg-sle15-ds-1.2.xml",
+                "--profile suse_test --tailoring-file /root/tailoring.xml", new Date());
+
+        File resumeXsl = new File(TestUtils.findTestData(
+                "/com/redhat/rhn/manager/audit/test/openscap/suma-ref42-min-sles15/xccdf-resume.xslt.in").getPath());
+        InputStream resultsIn = TestUtils.findTestData(
+                "/com/redhat/rhn/manager/audit/test/openscap/suma-ref42-min-sles15/results.xml")
+                .openStream();
+        XccdfTestResult result = ScapManager.xccdfEval(minion, action, 2, "", resultsIn, resumeXsl);
+
+        HibernateFactory.getSession().flush();
+        HibernateFactory.getSession().clear();
+
+        result = HibernateFactory.getSession().get(XccdfTestResult.class, result.getId());
+        assertNotNull(result);
+
+        assertEquals("xccdf_org.ssgproject.content_profile_cis_suse_test", result.getProfile().getIdentifier());
+        assertEquals("Tailored profile", result.getProfile().getTitle());
+        assertRuleResults(result, "pass",
+                Arrays.asList(
+                    "xccdf_org.ssgproject.content_rule_rpm_verify_ownership",
+                    "xccdf_org.ssgproject.content_rule_ensure_suse_gpgkey_installed",
+                    "CCE-85796-1"
+                ));
+    }
+
     public void testXccdfEvalResume() throws Exception {
         MinionServer minion = MinionServerFactoryTest.createTestMinionServer(user);
         SystemManager.giveCapability(minion.getId(), SystemManager.CAP_SCAP, 1L);
@@ -297,7 +335,9 @@ public class ScapManagerTest extends JMockBaseTestCaseWithUser {
                 .map(ident -> ident.getIdentifier())
                 .collect(Collectors.toSet());
         assertEquals(ruleIds.size(), resultIds.size());
-        assertTrue(resultIds.containsAll(ruleIds));
+        assertTrue("Expected but missing rules: " + resultIds.stream()
+                     .filter(r -> !ruleIds.contains(r)).collect(Collectors.toList()),
+            resultIds.containsAll(ruleIds));
     }
 
     private void assertRuleResultsCount(XccdfTestResult result, String ruleType, int count) {

--- a/java/code/src/com/redhat/rhn/manager/audit/test/openscap/suma-ref42-min-sles15/xccdf-resume.xslt.in
+++ b/java/code/src/com/redhat/rhn/manager/audit/test/openscap/suma-ref42-min-sles15/xccdf-resume.xslt.in
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2012 Red Hat Inc., Durham, North Carolina. All Rights Reserved.
+
+This library is free software; you can redistribute it and/or modify it under
+the terms of the GNU Lesser General Public License as published by the Free
+Software Foundation; either version 2.1 of the License.
+
+This library is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this library; if not, write to the Free Software Foundation, Inc., 59
+Temple Place, Suite 330, Boston, MA  02111-1307 USA
+
+Authors:
+     Simon Lukasik <slukasik@redhat.com>
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0"
+    xmlns:cdf1="http://checklists.nist.gov/xccdf/1.1"
+    xmlns:cdf2="http://checklists.nist.gov/xccdf/1.2">
+    <xsl:output method="xml" encoding="UTF-8"/>
+
+    <xsl:template match="/">
+        <benchmark-resume>
+            <xsl:apply-templates select="*[local-name()='Benchmark']"/>
+        </benchmark-resume>
+    </xsl:template>
+
+    <xsl:template match="cdf1:Benchmark | cdf2:Benchmark">
+        <xsl:copy-of select="@id"/>
+        <xsl:attribute name="version">
+            <xsl:value-of select="normalize-space(cdf1:version/text()|cdf2:version/text())"/>
+        </xsl:attribute>
+
+        <xsl:variable name="profileId" select="cdf1:TestResult[1]/cdf1:profile/@idref | cdf2:TestResult[1]/cdf2:profile/@idref"/>
+        <xsl:choose>
+            <xsl:when test="not($profileId)"/> <!-- Do not send profile element when scanning with 'default' profile. -->
+            <xsl:when test="cdf1:Profile[@id = $profileId] | cdf2:Profile[@id = $profileId]">
+                <xsl:apply-templates select="cdf1:Profile[@id = $profileId] | cdf2:Profile[@id = $profileId]"/>
+            </xsl:when>
+            <xsl:otherwise>
+                <profile title="Tailored profile">
+                    <xsl:attribute name="id">
+                         <xsl:value-of select="$profileId"/>
+                    </xsl:attribute>
+                </profile>
+            </xsl:otherwise>
+        </xsl:choose>
+        <xsl:apply-templates select="cdf1:TestResult[1] | cdf2:TestResult[1]"/>
+    </xsl:template>
+
+    <xsl:template match="cdf1:Profile | cdf2:Profile">
+        <profile>
+            <xsl:attribute name="title">
+                <xsl:value-of select="normalize-space(cdf1:title/text() | cdf2:title/text())"/>
+            </xsl:attribute>
+            <xsl:copy-of select="@id"/>
+            <xsl:attribute name="description">
+                <xsl:value-of select="normalize-space(cdf1:description[@xml:lang='en-US']/text() | cdf2:description[@xml:lang='en-US']/text())"/>
+            </xsl:attribute>
+        </profile>
+    </xsl:template>
+
+    <xsl:template match="cdf1:TestResult | cdf2:TestResult">
+        <TestResult>
+            <xsl:copy-of select="@id"/>
+            <xsl:copy-of select="@start-time"/>
+            <xsl:copy-of select="@end-time"/>
+            <pass>
+                    <xsl:apply-templates select="cdf1:rule-result[cdf1:result = 'pass'] | cdf2:rule-result[cdf2:result = 'pass']"/>
+            </pass>
+            <fail>
+                    <xsl:apply-templates select="cdf1:rule-result[cdf1:result = 'fail'] | cdf2:rule-result[cdf2:result = 'fail']"/>
+            </fail>
+            <error>
+                    <xsl:apply-templates select="cdf1:rule-result[cdf1:result = 'error'] | cdf2:rule-result[cdf2:result = 'error']"/>
+            </error>
+            <unknown>
+                    <xsl:apply-templates select="cdf1:rule-result[cdf1:result = 'unknown'] | cdf2:rule-result[cdf2:result = 'unknown']"/>
+            </unknown>
+            <notapplicable>
+                    <xsl:apply-templates select="cdf1:rule-result[cdf1:result = 'notapplicable'] | cdf2:rule-result[cdf2:result = 'notapplicable']"/>
+            </notapplicable>
+            <notchecked>
+                    <xsl:apply-templates select="cdf1:rule-result[cdf1:result = 'notchecked'] | cdf2:rule-result[cdf2:result = 'notchecked']"/>
+            </notchecked>
+            <notselected>
+                    <xsl:apply-templates select="cdf1:rule-result[cdf1:result = 'notselected'] | cdf2:rule-result[cdf2:result = 'notselected']"/>
+            </notselected>
+            <informational>
+                   <xsl:apply-templates select="cdf1:rule-result[cdf1:result = 'informational'] | cdf2:rule-result[cdf2:result = 'informational']"/>
+            </informational>
+            <fixed>
+                    <xsl:apply-templates select="cdf1:rule-result[cdf1:result = 'fixed'] | cdf2:rule-result[cdf2:result = 'fixed']"/>
+            </fixed>
+        </TestResult>
+    </xsl:template>
+
+    <xsl:template match="cdf1:rule-result | cdf2:rule-result">
+        <rr>
+            <xsl:attribute name="id">
+                <xsl:value-of select="normalize-space(@idref)"/>
+            </xsl:attribute>
+            <xsl:apply-templates select="cdf1:ident | cdf2:ident"/>
+        </rr>
+    </xsl:template>
+
+    <xsl:template match="cdf1:ident | cdf2:ident">
+        <ident>
+            <xsl:copy-of select="@system"/>
+            <xsl:value-of select="normalize-space(text())"/>
+        </ident>
+    </xsl:template>
+</xsl:stylesheet>

--- a/java/code/src/com/redhat/rhn/testing/JMockBaseTestCaseWithUser.java
+++ b/java/code/src/com/redhat/rhn/testing/JMockBaseTestCaseWithUser.java
@@ -49,6 +49,7 @@ public abstract class JMockBaseTestCaseWithUser extends RhnJmockBaseTestCase {
         tmpPillarRoot = Files.createTempDirectory("pillar");
         tmpSaltRoot = Files.createTempDirectory("salt");
         MinionPillarManager.INSTANCE.setPillarDataPath(tmpPillarRoot.toAbsolutePath());
+        SaltStateGeneratorService.INSTANCE.setSkipSetOwner(true);
         SaltStateGeneratorService.INSTANCE.setSuseManagerStatesFilesRoot(tmpSaltRoot
                 .toAbsolutePath());
         Files.createDirectory(tmpSaltRoot.resolve(SALT_CONFIG_STATES_DIR));

--- a/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
+++ b/java/code/src/com/suse/manager/webui/services/SaltServerActionService.java
@@ -1630,7 +1630,7 @@ public class SaltServerActionService {
                 .matcher(scapActionDetails.getParametersContents());
         Matcher ruleMatcher = Pattern.compile("--rule ((\\w|\\.|_|-)+)")
                 .matcher(scapActionDetails.getParametersContents());
-        Matcher tailoringFileMatcher = Pattern.compile("--tailoring-file ((\\w|\\.|_|-)+)")
+        Matcher tailoringFileMatcher = Pattern.compile("--tailoring-file ((\\w|\\.|_|-|\\/)+)")
                 .matcher(scapActionDetails.getParametersContents());
         Matcher tailoringIdMatcher = Pattern.compile("--tailoring-id ((\\w|\\.|_|-)+)")
                 .matcher(scapActionDetails.getParametersContents());

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- fix parsing error by making SCAP Profile description attribute optional
+  (bsc#1192321)
 - fix openscap scan with tailoring-file option (bsc#1192321)
 - Pass the "allow_vendor_change" flag using the right name when installing patches
 - Fix legacy timepicker passing wrong time to the backend if server and

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- fix openscap scan with tailoring-file option (bsc#1192321)
 - Pass the "allow_vendor_change" flag using the right name when installing patches
 - Fix legacy timepicker passing wrong time to the backend if server and
   user time differ (bsc#1192699)

--- a/susemanager-utils/susemanager-sls/salt/scap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/scap/init.sls
@@ -28,4 +28,10 @@ mgr_scap:
         {%- if "fetch_remote_resources" in pillar.get('mgr_scap_params') %}
         fetch_remote_resources: {{ pillar['mgr_scap_params']['fetch_remote_resources'] }}
         {%- endif %}
+        {%- if "tailoring_file" in pillar.get('mgr_scap_params') %}
+        tailoring_file: {{ pillar['mgr_scap_params']['tailoring_file'] }}
+        {%- endif %}
+        {%- if "tailoring_id" in pillar.get('mgr_scap_params') %}
+        tailoring_id: {{ pillar['mgr_scap_params']['tailoring_id'] }}
+        {%- endif %}
 {% endif %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- fix openscap scan with tailoring options (bsc#1192321)
 - Align allow_vendor_change pillar name across SLS files
 - Use venv-salt-minion instead of salt for docker states
 - Fix libvirt engine config destination for Salt Bundle


### PR DESCRIPTION
## What does this PR change?

When parsing tailoring-file from the parameters we need to allow `/` for the file component.
In addition we need to check for the taloring options in the state to set the correct parameters for the call

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- Unit tests added

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/16358 and https://github.com/SUSE/spacewalk/pull/16467

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
