### PR TITLE
Improve image management

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/cve_audit_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/cve_audit_queries.xml
@@ -162,7 +162,7 @@
   <query params="cve_identifier, user_id">
     WITH affected_and_patched AS (
       SELECT suseImageInfoPackage.image_info_id as image_info_id,
-        suseImageInfo.name || ':' || suseImageInfo.version as image_name,
+        suseImageInfo.name || ':' || suseImageInfo.version || '-' || suseImageInfo.curr_revision_num as image_name,
         rhnChannelErrata.errata_id,
         rhnErrata.advisory as errata_advisory,
         rhnErrataPackage.package_id,
@@ -226,10 +226,11 @@
           AND rhnCVE.name = :cve_identifier
           AND web_contact.org_id = suseImageInfo.org_id
           AND web_contact.id = :user_id
+          AND suseImageInfo.built = 'Y'
     ),
     not_affected AS (
       SELECT suseImageInfo.id as image_info_id,
-        suseImageInfo.name || ':' || suseImageInfo.version as image_name,
+        suseImageInfo.name || ':' || suseImageInfo.version || '-' || suseImageInfo.curr_revision_num as image_name,
         CAST(NULL AS INTEGER) AS errata_id,
         CAST(NULL AS CHAR) AS errata_advisory,
         CAST(NULL AS INTEGER) AS package_id,
@@ -247,6 +248,7 @@
         FROM suseImageInfo
           JOIN web_contact ON suseImageInfo.org_id = web_contact.org_id
         WHERE web_contact.id = :user_id
+          AND suseImageInfo.built = 'Y'
           AND suseImageInfo.id NOT IN (
             SELECT image_info_id FROM affected_and_patched
         )

--- a/java/code/src/com/redhat/rhn/common/hibernate/AnnotationRegistry.java
+++ b/java/code/src/com/redhat/rhn/common/hibernate/AnnotationRegistry.java
@@ -29,7 +29,7 @@ import com.redhat.rhn.domain.contentmgmt.ProjectSource;
 import com.redhat.rhn.domain.contentmgmt.SoftwareEnvironmentTarget;
 import com.redhat.rhn.domain.contentmgmt.SoftwareProjectSource;
 import com.redhat.rhn.domain.image.DockerfileProfile;
-import com.redhat.rhn.domain.image.ImageBuildHistory;
+import com.redhat.rhn.domain.image.ImageFile;
 import com.redhat.rhn.domain.image.ImageInfo;
 import com.redhat.rhn.domain.image.ImageInfoCustomDataValue;
 import com.redhat.rhn.domain.image.ImageOverview;
@@ -98,11 +98,11 @@ public class AnnotationRegistry {
         KiwiProfile.class,
         ImageProfile.class,
         ProfileCustomDataValue.class,
+        ImageFile.class,
         ImageInfo.class,
         ImageInfoCustomDataValue.class,
         ImageOverview.class,
         ImagePackage.class,
-        ImageBuildHistory.class,
         ImageRepoDigest.class,
         VirtualHostManagerNodeInfo.class,
         NotificationMessage.class,

--- a/java/code/src/com/redhat/rhn/common/hibernate/AnnotationRegistry.java
+++ b/java/code/src/com/redhat/rhn/common/hibernate/AnnotationRegistry.java
@@ -28,6 +28,7 @@ import com.redhat.rhn.domain.contentmgmt.PackageFilter;
 import com.redhat.rhn.domain.contentmgmt.ProjectSource;
 import com.redhat.rhn.domain.contentmgmt.SoftwareEnvironmentTarget;
 import com.redhat.rhn.domain.contentmgmt.SoftwareProjectSource;
+import com.redhat.rhn.domain.image.DeltaImageInfo;
 import com.redhat.rhn.domain.image.DockerfileProfile;
 import com.redhat.rhn.domain.image.ImageFile;
 import com.redhat.rhn.domain.image.ImageInfo;
@@ -98,6 +99,7 @@ public class AnnotationRegistry {
         KiwiProfile.class,
         ImageProfile.class,
         ProfileCustomDataValue.class,
+        DeltaImageInfo.class,
         ImageFile.class,
         ImageInfo.class,
         ImageInfoCustomDataValue.class,

--- a/java/code/src/com/redhat/rhn/domain/image/DeltaImageInfo.java
+++ b/java/code/src/com/redhat/rhn/domain/image/DeltaImageInfo.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.domain.image;
+
+import com.redhat.rhn.domain.BaseDomainHelper;
+import com.redhat.rhn.domain.server.Pillar;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.IdClass;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+
+/**
+ * DeltaImageInfo
+ */
+@Entity
+@IdClass(DeltaImageInfoKey.class)
+@Table(name = "suseDeltaImageInfo")
+public class DeltaImageInfo extends BaseDomainHelper {
+
+    private ImageInfo sourceImageInfo;
+    private ImageInfo targetImageInfo;
+    private Pillar pillar;
+    private String file;
+
+    /**
+     * @return the source image info
+     */
+    @Id
+    @OneToOne
+    @JoinColumn(name = "source_image_id", nullable = false)
+    public ImageInfo getSourceImageInfo() {
+        return sourceImageInfo;
+    }
+
+    /**
+     * @param imageInfoIn the source image info
+     */
+    public void setSourceImageInfo(ImageInfo imageInfoIn) {
+        this.sourceImageInfo = imageInfoIn;
+    }
+
+    /**
+     * @return the target image info
+     */
+    @Id
+    @OneToOne
+    @JoinColumn(name = "target_image_id", nullable = false)
+    public ImageInfo getTargetImageInfo() {
+        return targetImageInfo;
+    }
+
+    /**
+     * @param imageInfoIn the target image info
+     */
+    public void setTargetImageInfo(ImageInfo imageInfoIn) {
+        this.targetImageInfo = imageInfoIn;
+    }
+
+
+    /**
+     * @return the file
+     */
+    @Column(name = "file")
+    public String getFile() {
+        return file;
+    }
+
+    /**
+     * @param fileIn file to set
+     */
+    public void setFile(String fileIn) {
+        this.file = fileIn;
+    }
+
+    /**
+     * @return the pillar
+     */
+    @OneToOne
+    @JoinColumn(name = "pillar_id")
+    public Pillar getPillar() {
+        return pillar;
+    }
+
+    /**
+     * @param pillarIn pillar to set
+     */
+    public void setPillar(Pillar pillarIn) {
+        this.pillar = pillarIn;
+    }
+
+
+
+}

--- a/java/code/src/com/redhat/rhn/domain/image/DeltaImageInfoKey.java
+++ b/java/code/src/com/redhat/rhn/domain/image/DeltaImageInfoKey.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.redhat.rhn.domain.image;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import java.io.Serializable;
+
+/**
+ * Primary key class for DeltaImageInfo.
+ */
+public class DeltaImageInfoKey implements Serializable {
+
+    private ImageInfo sourceImageInfo;
+    private ImageInfo targetImageInfo;
+
+    /**
+     * @return the source image info
+     */
+    public ImageInfo getSourceImageInfo() {
+        return sourceImageInfo;
+    }
+
+    /**
+     * @param imageInfoIn the source image info
+     */
+    public void setSourceImageInfo(ImageInfo imageInfoIn) {
+        this.sourceImageInfo = imageInfoIn;
+    }
+
+    /**
+     * @return the target image info
+     */
+    public ImageInfo getTargetImageInfo() {
+        return targetImageInfo;
+    }
+
+    /**
+     * @param imageInfoIn the target image info
+     */
+    public void setTargetImageInfo(ImageInfo imageInfoIn) {
+        this.targetImageInfo = imageInfoIn;
+    }
+
+    /**
+     *
+     * {@inheritDoc}
+     */
+    public int hashCode() {
+        HashCodeBuilder builder =  new HashCodeBuilder()
+                .append(sourceImageInfo.getId())
+                .append(targetImageInfo.getId());
+        return builder.toHashCode();
+
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public boolean equals(Object other) {
+
+        if (other instanceof DeltaImageInfoKey) {
+            DeltaImageInfoKey otherInfo = (DeltaImageInfoKey) other;
+            return new EqualsBuilder()
+                    .append(this.getSourceImageInfo(), otherInfo.getSourceImageInfo())
+                    .append(this.getTargetImageInfo(), otherInfo.getTargetImageInfo())
+                    .isEquals();
+        }
+        else {
+            return false;
+        }
+    }
+
+}

--- a/java/code/src/com/redhat/rhn/domain/image/ImageFile.java
+++ b/java/code/src/com/redhat/rhn/domain/image/ImageFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017 SUSE LLC
+ * Copyright (c) 2021 SUSE LLC
  *
  * This software is licensed to you under the GNU General Public License,
  * version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -19,43 +19,39 @@ import com.redhat.rhn.domain.BaseDomainHelper;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.hibernate.annotations.Type;
 
-import java.util.HashSet;
-import java.util.Set;
-
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 
 /**
- * ImageBuildHistory
+ * ImageFile
  */
 @Entity
-@Table(name = "suseImageBuildHistory")
-public class ImageBuildHistory extends BaseDomainHelper {
+@Table(name = "suseImageFile")
+public class ImageFile extends BaseDomainHelper {
 
     private Long id;
-    private int revisionNumber;
     private ImageInfo imageInfo;
-    private Set<ImageRepoDigest> repoDigests = new HashSet<>();
+    private String file;
+    private String type;
+    private boolean external;
 
     /**
      * @return the id
      */
     @Id
     @Column(name = "id")
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "imgbuildhistory_seq")
-    @SequenceGenerator(name = "imgbuildhistory_seq",
-            sequenceName = "suse_img_buildhistory_id_seq")
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "imgfile_seq")
+    @SequenceGenerator(name = "imgfile_seq",
+            sequenceName = "suse_image_file_id_seq")
     public Long getId() {
         return id;
     }
@@ -68,25 +64,10 @@ public class ImageBuildHistory extends BaseDomainHelper {
     }
 
     /**
-     * @return the revision number
-     */
-    @Column(name = "revision_num")
-    public int getRevisionNumber() {
-        return revisionNumber;
-    }
-
-    /**
-     * @param revisionNumberIn the revision number
-     */
-    public void setRevisionNumber(int revisionNumberIn) {
-        this.revisionNumber = revisionNumberIn;
-    }
-
-    /**
      * @return the image info
      */
     @ManyToOne
-    @JoinColumn(name = "image_info_id")
+    @JoinColumn(name = "image_info_id", nullable = false)
     public ImageInfo getImageInfo() {
         return imageInfo;
     }
@@ -98,32 +79,69 @@ public class ImageBuildHistory extends BaseDomainHelper {
         this.imageInfo = imageInfoIn;
     }
 
+
     /**
-     * @return the repo digests
+     * @return the file
      */
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "buildHistory", cascade = CascadeType.ALL)
-    public Set<ImageRepoDigest> getRepoDigests() {
-        return repoDigests;
+    @Column(name = "file")
+    public String getFile() {
+        return file;
     }
 
     /**
-     * @param repoDigestsIn the repo digests
+     * @param fileIn file to set
      */
-    public void setRepoDigests(Set<ImageRepoDigest> repoDigestsIn) {
-        this.repoDigests = repoDigestsIn;
+    public void setFile(String fileIn) {
+        this.file = fileIn;
     }
+
+    /**
+     * @return the type
+     */
+    @Column(name = "type")
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * @param typeIn file to set
+     */
+    public void setType(String typeIn) {
+        this.type = typeIn;
+    }
+
+
+    /**
+     * @return true if the file is not managed
+     */
+    @Column(name = "external")
+    @Type(type = "yes_no")
+    public boolean isExternal() {
+        return external;
+    }
+
+
+    /**
+     * @param externalIn the external file
+     */
+    public void setExternal(boolean externalIn) {
+        this.external = externalIn;
+    }
+
 
     /**
      * {@inheritDoc}
      */
     public boolean equals(final Object other) {
-        if (!(other instanceof ImageBuildHistory)) {
+        if (!(other instanceof ImageFile)) {
             return false;
         }
-        ImageBuildHistory castOther = (ImageBuildHistory) other;
+        ImageFile castOther = (ImageFile) other;
         return new EqualsBuilder()
                 .append(imageInfo, castOther.imageInfo)
-                .append(revisionNumber, castOther.revisionNumber)
+                .append(file, castOther.file)
+                .append(type, castOther.type)
+                .append(external, castOther.external)
                 .isEquals();
     }
 
@@ -133,7 +151,9 @@ public class ImageBuildHistory extends BaseDomainHelper {
     public int hashCode() {
         return new HashCodeBuilder()
                 .append(imageInfo)
-                .append(revisionNumber)
+                .append(file)
+                .append(type)
+                .append(external)
                 .toHashCode();
     }
 

--- a/java/code/src/com/redhat/rhn/domain/image/ImageInfo.java
+++ b/java/code/src/com/redhat/rhn/domain/image/ImageInfo.java
@@ -23,6 +23,7 @@ import com.redhat.rhn.domain.org.Org;
 import com.redhat.rhn.domain.rhnpackage.PackageType;
 import com.redhat.rhn.domain.server.InstalledProduct;
 import com.redhat.rhn.domain.server.MinionServer;
+import com.redhat.rhn.domain.server.Pillar;
 import com.redhat.rhn.domain.server.ServerArch;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
@@ -71,10 +72,14 @@ public class ImageInfo extends BaseDomainHelper {
     private Set<Channel> channels = new HashSet<>();
     private Set<ImagePackage> packages = new HashSet<>();
     private Set<InstalledProduct> installedProducts = new HashSet<>();
-    private Set<ImageBuildHistory> buildHistory = new HashSet<>();
+    private Set<ImageRepoDigest> repoDigests = new HashSet<>();
     private Org org;
     private ServerArch imageArch;
     private boolean externalImage;
+    private boolean obsolete;
+    private boolean built;
+    private Set<ImageFile> imageFiles = new HashSet<>();
+    private Pillar pillar;
 
     /**
      * @return the id
@@ -253,11 +258,46 @@ public class ImageInfo extends BaseDomainHelper {
     }
 
     /**
-     * @return the build history
+     * @return true if the image is obsolete (has been replaced in the store)
+     */
+    @Column(name = "obsolete")
+    @Type(type = "yes_no")
+    public boolean isObsolete() {
+        return obsolete;
+    }
+
+    /**
+     * @return true if the image has been successfully built
+     */
+    @Column(name = "built")
+    @Type(type = "yes_no")
+    public boolean isBuilt() {
+        return built;
+    }
+
+    /**
+     * @return the repo digests
      */
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "imageInfo", cascade = CascadeType.ALL)
-    public Set<ImageBuildHistory> getBuildHistory() {
-        return buildHistory;
+    public Set<ImageRepoDigest> getRepoDigests() {
+        return repoDigests;
+    }
+
+    /**
+     * @return the files
+     */
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "imageInfo", cascade = CascadeType.ALL)
+    public Set<ImageFile> getImageFiles() {
+        return imageFiles;
+    }
+
+    /**
+     * @return the pillar
+     */
+    @OneToOne
+    @JoinColumn(name = "pillar_id")
+    public Pillar getPillar() {
+        return pillar;
     }
 
     /**
@@ -352,10 +392,10 @@ public class ImageInfo extends BaseDomainHelper {
     }
 
     /**
-     * @param buildHistoryIn the build history
+     * @param repoDigestsIn the repo digests
      */
-    public void setBuildHistory(Set<ImageBuildHistory> buildHistoryIn) {
-        this.buildHistory = buildHistoryIn;
+    public void setRepoDigests(Set<ImageRepoDigest> repoDigestsIn) {
+        this.repoDigests = repoDigestsIn;
     }
 
     /**
@@ -379,10 +419,40 @@ public class ImageInfo extends BaseDomainHelper {
         this.externalImage = externalImageIn;
     }
 
+    /**
+     * @param obsoleteIn the obsolete flag
+     */
+    public void setObsolete(boolean obsoleteIn) {
+        this.obsolete = obsoleteIn;
+    }
+
+    /**
+     * @param builtIn the built flag
+     */
+    public void setBuilt(boolean builtIn) {
+        this.built = builtIn;
+    }
+
     @Transient
     public PackageType getPackageType() {
         return getImageArch().getArchType().getPackageType();
     }
+
+
+    /**
+     * @param imageFilesIn the image files
+     */
+    public void setImageFiles(Set<ImageFile> imageFilesIn) {
+        this.imageFiles = imageFilesIn;
+    }
+
+    /**
+     * @param pillarIn file to set
+     */
+    public void setPillar(Pillar pillarIn) {
+        this.pillar = pillarIn;
+    }
+
 
     /**
      * {@inheritDoc}
@@ -394,10 +464,7 @@ public class ImageInfo extends BaseDomainHelper {
         }
         ImageInfo castOther = (ImageInfo) other;
         return new EqualsBuilder()
-                .append(name, castOther.name)
-                .append(version, castOther.version)
-                .append(checksum, castOther.checksum)
-                .append(store, castOther.store)
+                .append(id, castOther.id)
                 .isEquals();
     }
 
@@ -407,10 +474,7 @@ public class ImageInfo extends BaseDomainHelper {
     @Override
     public int hashCode() {
         return new HashCodeBuilder()
-                .append(name)
-                .append(version)
-                .append(checksum)
-                .append(store)
+                .append(id)
                 .toHashCode();
     }
 

--- a/java/code/src/com/redhat/rhn/domain/image/ImageInfo.java
+++ b/java/code/src/com/redhat/rhn/domain/image/ImageInfo.java
@@ -80,6 +80,8 @@ public class ImageInfo extends BaseDomainHelper {
     private boolean built;
     private Set<ImageFile> imageFiles = new HashSet<>();
     private Pillar pillar;
+    private Set<DeltaImageInfo> deltaSourceFor = new HashSet<>();
+    private Set<DeltaImageInfo> deltaTargetFor = new HashSet<>();
 
     /**
      * @return the id
@@ -300,6 +302,18 @@ public class ImageInfo extends BaseDomainHelper {
         return pillar;
     }
 
+    @OneToMany
+    @JoinColumn(name = "source_image_id")
+    public Set<DeltaImageInfo> getDeltaSourceFor() {
+        return deltaSourceFor;
+    }
+
+    @OneToMany
+    @JoinColumn(name = "target_image_id")
+    public Set<DeltaImageInfo> getDeltaTargetFor() {
+        return deltaTargetFor;
+    }
+
     /**
      * @param idIn id to set
      */
@@ -453,6 +467,13 @@ public class ImageInfo extends BaseDomainHelper {
         this.pillar = pillarIn;
     }
 
+    public void setDeltaSourceFor(Set<DeltaImageInfo> deltaSourceForIn) {
+        deltaSourceFor = deltaSourceForIn;
+    }
+
+    public void setDeltaTargetFor(Set<DeltaImageInfo> deltaTargetForIn) {
+        deltaTargetFor = deltaTargetForIn;
+    }
 
     /**
      * {@inheritDoc}

--- a/java/code/src/com/redhat/rhn/domain/image/ImageOverview.java
+++ b/java/code/src/com/redhat/rhn/domain/image/ImageOverview.java
@@ -66,11 +66,14 @@ public class ImageOverview {
     private Action buildAction;
     private Action inspectAction;
     private boolean externalImage;
+    private boolean obsolete;
+    private boolean built;
     private Set<ImageInfoCustomDataValue> customDataValues;
     private Set<Channel> channels;
     private Set<InstalledProduct> installedProducts;
     private Set<ImagePackage> packages;
     private Set<Errata> patches;
+    private Set<ImageFile> imageFiles;
     private Org org;
     private Integer securityErrata;
     private Integer bugErrata;
@@ -196,6 +199,24 @@ public class ImageOverview {
     }
 
     /**
+     * @return true if the image is obsolete (has been replaced in the store)
+     */
+    @Column(name = "obsolete")
+    @Type(type = "yes_no")
+    public boolean isObsolete() {
+        return obsolete;
+    }
+
+    /**
+     * @return true if the image has been successfully built
+     */
+    @Column(name = "built")
+    @Type(type = "yes_no")
+    public boolean isBuilt() {
+        return built;
+    }
+
+    /**
      * @return the custom data values
      */
     @OneToMany(fetch = FetchType.LAZY, mappedBy = "imageInfo")
@@ -249,6 +270,14 @@ public class ImageOverview {
     )
     public Set<Errata> getPatches() {
         return patches;
+    }
+
+    /**
+     * @return the files
+     */
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "imageInfo")
+    public Set<ImageFile> getImageFiles() {
+        return imageFiles;
     }
 
     /**
@@ -428,6 +457,20 @@ public class ImageOverview {
     }
 
     /**
+     * @param obsoleteIn the obsolete flag
+     */
+    public void setObsolete(boolean obsoleteIn) {
+        this.obsolete = obsoleteIn;
+    }
+
+    /**
+     * @param builtIn the built flag
+     */
+    public void setBuilt(boolean builtIn) {
+        this.built = builtIn;
+    }
+
+    /**
      * @param customDataValuesIn the custom data values
      */
     public void setCustomDataValues(Set<ImageInfoCustomDataValue> customDataValuesIn) {
@@ -453,6 +496,13 @@ public class ImageOverview {
      */
     public void setPatches(Set<Errata> patchesIn) {
         this.patches = patchesIn;
+    }
+
+    /**
+     * @param imageFilesIn the image files
+     */
+    public void setImageFiles(Set<ImageFile> imageFilesIn) {
+        this.imageFiles = imageFilesIn;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/image/ImageOverview.java
+++ b/java/code/src/com/redhat/rhn/domain/image/ImageOverview.java
@@ -81,6 +81,8 @@ public class ImageOverview {
     private Integer outdatedPackages;
     private Integer installedPackages;
     private Date modified;
+    private Set<DeltaImageInfo> deltaSourceFor;
+    private Set<DeltaImageInfo> deltaTargetFor;
 
     /**
      * @return the id
@@ -365,6 +367,18 @@ public class ImageOverview {
                 .filter(sa -> sa.getServer().equals(getBuildServer())).findAny();
     }
 
+    @OneToMany
+    @JoinColumn(name = "source_image_id")
+    public Set<DeltaImageInfo> getDeltaSourceFor() {
+        return deltaSourceFor;
+    }
+
+    @OneToMany
+    @JoinColumn(name = "target_image_id")
+    public Set<DeltaImageInfo> getDeltaTargetFor() {
+        return deltaTargetFor;
+    }
+
     /**
      * @param idIn the id
      */
@@ -554,6 +568,14 @@ public class ImageOverview {
      */
     public void setModified(Date modifiedIn) {
         this.modified = modifiedIn;
+    }
+
+    public void setDeltaSourceFor(Set<DeltaImageInfo> deltaSourceForIn) {
+        deltaSourceFor = deltaSourceForIn;
+    }
+
+    public void setDeltaTargetFor(Set<DeltaImageInfo> deltaTargetForIn) {
+        deltaTargetFor = deltaTargetForIn;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/domain/image/ImageRepoDigest.java
+++ b/java/code/src/com/redhat/rhn/domain/image/ImageRepoDigest.java
@@ -39,7 +39,7 @@ public class ImageRepoDigest extends BaseDomainHelper {
 
     private Long id;
     private String repoDigest;
-    private ImageBuildHistory buildHistory;
+    private ImageInfo imageInfo;
 
     /**
      * @return the id
@@ -79,16 +79,16 @@ public class ImageRepoDigest extends BaseDomainHelper {
      * @return the build history
      */
     @ManyToOne
-    @JoinColumn(name = "image_history_id")
-    public ImageBuildHistory getBuildHistory() {
-        return buildHistory;
+    @JoinColumn(name = "image_info_id")
+    public ImageInfo getImageInfo() {
+        return imageInfo;
     }
 
     /**
-     * @param buildHistoryIn the build history
+     * @param imageInfoIn the image info
      */
-    public void setBuildHistory(ImageBuildHistory buildHistoryIn) {
-        this.buildHistory = buildHistoryIn;
+    public void setImageInfo(ImageInfo imageInfoIn) {
+        this.imageInfo = imageInfoIn;
     }
 
     /**
@@ -100,7 +100,7 @@ public class ImageRepoDigest extends BaseDomainHelper {
         }
         ImageRepoDigest castOther = (ImageRepoDigest) other;
         return new EqualsBuilder()
-                .append(buildHistory, castOther.buildHistory)
+                .append(imageInfo, castOther.imageInfo)
                 .append(repoDigest, castOther.repoDigest)
                 .isEquals();
     }
@@ -110,7 +110,7 @@ public class ImageRepoDigest extends BaseDomainHelper {
      */
     public int hashCode() {
         return new HashCodeBuilder()
-                .append(buildHistory)
+                .append(imageInfo)
                 .append(repoDigest)
                 .toHashCode();
     }

--- a/java/code/src/com/redhat/rhn/domain/image/OSImageStoreUtils.java
+++ b/java/code/src/com/redhat/rhn/domain/image/OSImageStoreUtils.java
@@ -39,6 +39,19 @@ public class OSImageStoreUtils {
     }
 
     /**
+     * Returns a OS Image Store Path for an Image
+     *
+     * @param image the OS image
+     * @return the full local path
+     */
+    public static String getOSImageStorePathForImage(ImageInfo image) {
+        if (!image.getStore().getStoreType().equals(ImageStoreFactory.TYPE_OS_IMAGE)) {
+            throw new IllegalArgumentException("Image store is not OS Image Store");
+        }
+        return getOSImageStorePathForOrg(image.getOrg());
+    }
+
+    /**
      * Returns the OS Image Store Path base local path
      *
      * @return the full local path
@@ -75,5 +88,31 @@ public class OSImageStoreUtils {
      */
     public static String getOSImageStoreRelativeURI(Org org) {
         return "/" + osImageWWWDirectory + "/" + org.getId() + "/";
+    }
+
+    /**
+     * Returns a OS Image File local path
+     *
+     * @param file the image file
+     * @return the local path
+     */
+    public static String getOSImageFilePath(ImageFile file) {
+        if (file.isExternal()) {
+            throw new IllegalArgumentException("External file has no local path");
+        }
+        return getOSImageStorePathForImage(file.getImageInfo()) + file.getFile();
+    }
+
+    /**
+     * Returns a OS Image File URI
+     *
+     * @param file the image file
+     * @return the URI
+     */
+    public static String getOSImageFileURI(ImageFile file) {
+        if (file.isExternal()) {
+            return file.getFile();
+        }
+        return getOSImageStoreURIForOrg(file.getImageInfo().getOrg()) + file.getFile();
     }
 }

--- a/java/code/src/com/redhat/rhn/domain/image/OSImageStoreUtils.java
+++ b/java/code/src/com/redhat/rhn/domain/image/OSImageStoreUtils.java
@@ -115,4 +115,15 @@ public class OSImageStoreUtils {
         }
         return getOSImageStoreURIForOrg(file.getImageInfo().getOrg()) + file.getFile();
     }
+
+    /**
+     * Returns a Delta Image local path
+     *
+     * @param delta the delta image info
+     * @return the local path
+     */
+    public static String getDeltaImageFilePath(DeltaImageInfo delta) {
+        return getOSImageStorePathForImage(delta.getSourceImageInfo()) + delta.getFile();
+    }
+
 }

--- a/java/code/src/com/redhat/rhn/domain/image/test/ImageInfoFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/image/test/ImageInfoFactoryTest.java
@@ -21,16 +21,20 @@ import static com.redhat.rhn.testing.ImageTestUtils.createImageProfile;
 import static com.redhat.rhn.testing.ImageTestUtils.createImageStore;
 import static com.redhat.rhn.testing.ImageTestUtils.createProfileCustomDataValue;
 
+import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.domain.action.Action;
 import com.redhat.rhn.domain.action.salt.inspect.ImageInspectActionDetails;
 import com.redhat.rhn.domain.channel.Channel;
 import com.redhat.rhn.domain.common.Checksum;
+import com.redhat.rhn.domain.image.DeltaImageInfo;
+import com.redhat.rhn.domain.image.ImageFile;
 import com.redhat.rhn.domain.image.ImageInfo;
 import com.redhat.rhn.domain.image.ImageInfoFactory;
 import com.redhat.rhn.domain.image.ImageOverview;
 import com.redhat.rhn.domain.image.ImagePackage;
 import com.redhat.rhn.domain.image.ImageProfile;
 import com.redhat.rhn.domain.image.ImageStore;
+import com.redhat.rhn.domain.image.ImageStoreFactory;
 import com.redhat.rhn.domain.image.ProfileCustomDataValue;
 import com.redhat.rhn.domain.org.CustomDataKey;
 import com.redhat.rhn.domain.org.Org;
@@ -40,6 +44,7 @@ import com.redhat.rhn.domain.rhnpackage.Package;
 import com.redhat.rhn.domain.rhnpackage.test.PackageTest;
 import com.redhat.rhn.domain.server.InstalledProduct;
 import com.redhat.rhn.domain.server.MinionServer;
+import com.redhat.rhn.domain.server.Pillar;
 import com.redhat.rhn.domain.server.test.MinionServerFactoryTest;
 import com.redhat.rhn.domain.token.ActivationKey;
 import com.redhat.rhn.domain.user.User;
@@ -72,6 +77,7 @@ import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.jmock.integration.junit3.JUnit3Mockery;
 import org.jmock.lib.concurrent.Synchroniser;
 
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -79,6 +85,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeMap;
 
 public class ImageInfoFactoryTest extends BaseTestCaseWithUser {
 
@@ -87,6 +94,7 @@ public class ImageInfoFactoryTest extends BaseTestCaseWithUser {
     }};
 
     private static TaskomaticApi taskomaticApi;
+    private static SaltApi saltApiMock;
     private final SystemQuery systemQuery = new TestSystemQuery();
     private final SaltApi saltApi = new TestSaltApi();
     private final ServerGroupManager serverGroupManager = new ServerGroupManager(saltApi);
@@ -101,6 +109,9 @@ public class ImageInfoFactoryTest extends BaseTestCaseWithUser {
     public void setUp() throws Exception {
         super.setUp();
         CONTEXT.setImposteriser(ByteBuddyClassImposteriser.INSTANCE);
+        if (saltApiMock == null) {
+            saltApiMock = CONTEXT.mock(TestSaltApi.class);
+        }
     }
 
     public final void testConvertChecksum() {
@@ -522,6 +533,104 @@ public class ImageInfoFactoryTest extends BaseTestCaseWithUser {
         assertEquals(2, img2.getRevisionNumber());
         ImageInfoFactory.updateRevision(img2);
         assertEquals(2, img2.getRevisionNumber());
+    }
+
+    public void testDelete() throws Exception {
+        CONTEXT.checking(new Expectations() {{
+            allowing(saltApiMock).removeFile(
+                    with(equal(Paths.get(String.format("/srv/www/os-images/%d/test-1.0.0.tgz",
+                                             user.getOrg().getId())))));
+            will(returnValue(Optional.of(true)));
+        }});
+
+        ImageStore store = ImageStoreFactory.lookupBylabelAndOrg("SUSE Manager OS Image Store", user.getOrg()).get();
+
+        ImageInfo image = createImageInfo("test", "1.0.0", store, user);
+        String category = "Image" + image.getId();
+        Pillar pillarEntry = new Pillar(category, new TreeMap<String, Object>(), image.getOrg());
+        HibernateFactory.getSession().save(pillarEntry);
+        image.setPillar(pillarEntry);
+
+        ImageFile bundleFile = new ImageFile();
+        bundleFile.setFile("test-1.0.0.tgz");
+        bundleFile.setType("bundle");
+        bundleFile.setImageInfo(image);
+        image.getImageFiles().add(bundleFile);
+
+
+        ImageInfoFactory.save(image);
+        HibernateFactory.getSession().flush();
+
+        ImageInfoFactory.delete(image, saltApiMock);
+
+        HibernateFactory.getSession().flush();
+
+        assertFalse(user.getOrg().getPillars().stream()
+              .filter(item -> (category.equals(item.getCategory())))
+              .findAny().isPresent());
+
+    }
+
+    public void testDeltaImage() throws Exception {
+        CONTEXT.checking(new Expectations() {{
+            allowing(saltApiMock).removeFile(
+                    with(equal(Paths.get(String.format("/srv/www/os-images/%d/delta1.tgz",
+                                             user.getOrg().getId())))));
+            will(returnValue(Optional.of(true)));
+            allowing(saltApiMock).removeFile(
+                    with(equal(Paths.get(String.format("/srv/www/os-images/%d/delta2.tgz",
+                                             user.getOrg().getId())))));
+            will(returnValue(Optional.of(true)));
+        }});
+
+        Org org = user.getOrg();
+        ImageStore store = ImageStoreFactory.lookupBylabelAndOrg("SUSE Manager OS Image Store", org).get();
+
+        ImageInfo img1 = createImageInfo("test", "1.0.0", store, user);
+        ImageInfo img2 = createImageInfo("test", "1.0.1", store, user);
+        ImageInfo img3 = createImageInfo("test", "1.0.2", store, user);
+
+        HibernateFactory.getSession().flush();
+
+        DeltaImageInfo delta1 = ImageInfoFactory.createDeltaImageInfo(img1, img2,
+                                                 "delta1.tgz", new TreeMap<String, Object>());
+        DeltaImageInfo delta2 = ImageInfoFactory.createDeltaImageInfo(img2, img3,
+                                                 "delta2.tgz", new TreeMap<String, Object>());
+
+        HibernateFactory.getSession().flush();
+        assertEquals(3, ImageInfoFactory.listImageInfos(org).size());
+        assertEquals(2, ImageInfoFactory.listDeltaImageInfos(org).size());
+        assertEquals(2, org.getPillars().size()); //each delta has a pillar
+
+        // deleting a target image should delete also the delta
+        ImageInfoFactory.delete(img3, saltApiMock);
+
+        HibernateFactory.getSession().flush();
+        org = TestUtils.reload(org);
+
+        assertEquals(2, ImageInfoFactory.listImageInfos(org).size());
+        assertEquals(1, ImageInfoFactory.listDeltaImageInfos(org).size());
+        assertEquals(1, org.getPillars().size());
+
+        // deleting a delta should not delte the images
+        ImageInfoFactory.deleteDeltaImage(delta1, saltApiMock);
+
+        HibernateFactory.getSession().flush();
+        org = TestUtils.reload(org);
+
+        assertEquals(2, ImageInfoFactory.listImageInfos(org).size());
+        assertEquals(0, ImageInfoFactory.listDeltaImageInfos(org).size());
+        assertEquals(0, org.getPillars().size());
+
+        // deleting a source image should delete also the delta
+        ImageInfoFactory.delete(img1, saltApiMock);
+
+        HibernateFactory.getSession().flush();
+        org = TestUtils.reload(org);
+
+        assertEquals(1, ImageInfoFactory.listImageInfos(org).size());
+        assertEquals(0, ImageInfoFactory.listDeltaImageInfos(org).size());
+        assertEquals(0, org.getPillars().size());
     }
 
     private TaskomaticApi getTaskomaticApi() throws TaskomaticApiException {

--- a/java/code/src/com/redhat/rhn/domain/image/test/ImageInfoFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/image/test/ImageInfoFactoryTest.java
@@ -365,8 +365,8 @@ public class ImageInfoFactoryTest extends BaseTestCaseWithUser {
         ImageInfoFactory.scheduleBuild(buildHost.getId(), "v1.0", profile, new Date(),
                 user);
 
-        // Image info should be reset
-        assertEquals(1, ImageInfoFactory.listImageInfos(user.getOrg()).size());
+        // Image info should be added
+        assertEquals(2, ImageInfoFactory.listImageInfos(user.getOrg()).size());
         ImageInfo info2 = ImageInfoFactory.lookupByName("suma-3.1-base", "v1.0", store.getId()).get();
 
         // ImageInfo instance is preserved on new builds if it exists already with the same name/version and store
@@ -380,12 +380,12 @@ public class ImageInfoFactoryTest extends BaseTestCaseWithUser {
         ImageInfoFactory.scheduleBuild(buildHost.getId(), "v2.0", profile, new Date(),
                 user);
 
-        // We should have two image infos with same labels but different versions
+        // We should have 3 image infos: suma-3.1-base-v1.0-1, suma-3.1-base-v1.0-2, suma-3.1-base-v2.0-1
         List<ImageInfo> infoList = ImageInfoFactory.listImageInfos(user.getOrg());
 
-        assertEquals(2, infoList.size());
+        assertEquals(3, infoList.size());
         infoList.forEach(i -> assertEquals("suma-3.1-base", i.getName()));
-        assertFalse(infoList.get(0).getVersion().equals(infoList.get(1).getVersion()));
+        //assertFalse(infoList.get(0).getVersion().equals(infoList.get(1).getVersion()));
 
         info = ImageInfoFactory.lookupByName("suma-3.1-base", "v2.0", store.getId()).get();
 
@@ -508,6 +508,20 @@ public class ImageInfoFactoryTest extends BaseTestCaseWithUser {
         lookup = ImageInfoFactory.lookupByIdsAndOrg(ids, user.getOrg());
         assertEquals(1, lookup.size());
         assertEquals(img1, lookup.get(0));
+    }
+
+    public void testUpdateRevision() throws Exception {
+        ImageStore store = createImageStore("mystore", user);
+        ImageInfo img1 = createImageInfo("test", "1.0.0", user);
+        ImageInfoFactory.updateRevision(img1);
+        assertEquals(1, img1.getRevisionNumber());
+        ImageInfoFactory.updateRevision(img1);
+        assertEquals(1, img1.getRevisionNumber());
+        ImageInfo img2 = createImageInfo("test", "1.0.0", user);
+        ImageInfoFactory.updateRevision(img2);
+        assertEquals(2, img2.getRevisionNumber());
+        ImageInfoFactory.updateRevision(img2);
+        assertEquals(2, img2.getRevisionNumber());
     }
 
     private TaskomaticApi getTaskomaticApi() throws TaskomaticApiException {

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/HandlerFactory.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/HandlerFactory.java
@@ -34,6 +34,7 @@ import com.redhat.rhn.frontend.xmlrpc.contentmgmt.ContentManagementHandler;
 import com.redhat.rhn.frontend.xmlrpc.distchannel.DistChannelHandler;
 import com.redhat.rhn.frontend.xmlrpc.errata.ErrataHandler;
 import com.redhat.rhn.frontend.xmlrpc.formula.FormulaHandler;
+import com.redhat.rhn.frontend.xmlrpc.image.DeltaImageInfoHandler;
 import com.redhat.rhn.frontend.xmlrpc.image.ImageInfoHandler;
 import com.redhat.rhn.frontend.xmlrpc.image.profile.ImageProfileHandler;
 import com.redhat.rhn.frontend.xmlrpc.image.store.ImageStoreHandler;
@@ -163,6 +164,7 @@ public class HandlerFactory {
         factory.addHandler("distchannel", new DistChannelHandler());
         factory.addHandler("errata", new ErrataHandler());
         factory.addHandler("formula", new FormulaHandler(formulaManager, saltApi));
+        factory.addHandler("image.delta", new DeltaImageInfoHandler());
         factory.addHandler("image.store", new ImageStoreHandler());
         factory.addHandler("image.profile", new ImageProfileHandler());
         factory.addHandler("image", new ImageInfoHandler());

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/DeltaImageInfoHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/DeltaImageInfoHandler.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2022 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.frontend.xmlrpc.image;
+
+import com.redhat.rhn.domain.image.DeltaImageInfo;
+import com.redhat.rhn.domain.image.ImageInfo;
+import com.redhat.rhn.domain.image.ImageInfoFactory;
+import com.redhat.rhn.domain.user.User;
+import com.redhat.rhn.frontend.xmlrpc.BaseHandler;
+import com.redhat.rhn.frontend.xmlrpc.EntityExistsFaultException;
+import com.redhat.rhn.frontend.xmlrpc.NoSuchImageException;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * ImageInfoHandler
+ * @xmlrpc.namespace image
+ * @xmlrpc.doc Provides methods to access and modify images.
+ */
+public class DeltaImageInfoHandler extends BaseHandler {
+
+    /**
+     * List all delta images visible for the logged in user
+     * @param loggedInUser The current User
+     * @return Array of DeltaImageInfo Objects
+     *
+     * @xmlrpc.doc List available DeltaImages
+     * @xmlrpc.param #param("string", "sessionKey")
+     * @xmlrpc.returntype #array_begin() $DeltaImageInfoSerializer #array_end()
+     */
+    public List<DeltaImageInfo> listDeltas(User loggedInUser) {
+        ensureImageAdmin(loggedInUser);
+        return ImageInfoFactory.listDeltaImageInfos(loggedInUser.getOrg());
+    }
+
+    /**
+     * Get Image Details
+     * @param loggedInUser The Current User
+     * @param sourceImageId the source Image id
+     * @param targetImageId the target Image id
+     * @return ImageOverview Object
+     *
+     * @xmlrpc.doc Get details of an Image
+     * @xmlrpc.param #param("string", "sessionKey")
+     * @xmlrpc.param #param("int", "sourceImageId")
+     * @xmlrpc.param #param("int", "targetImageId")
+     * @xmlrpc.returntype $DeltaImageSerializer
+     */
+    public DeltaImageInfo getDetails(User loggedInUser, Integer sourceImageId, Integer targetImageId) {
+        ensureImageAdmin(loggedInUser);
+        Optional<DeltaImageInfo> opt = ImageInfoFactory.lookupDeltaImageInfo(sourceImageId, targetImageId);
+        if (!opt.isPresent()) {
+            throw new NoSuchImageException();
+        }
+        return opt.get();
+    }
+
+    /**
+     * Create DeltaImage record
+     * @param loggedInUser The current user
+     * @param sourceImageId the source Image id
+     * @param targetImageId the target Image id
+     * @param file the file path
+     * @param pillar pillar data
+     * @return the image inspect action id
+     *
+     * @xmlrpc.doc Import an image and schedule an inspect afterwards
+     * @xmlrpc.param #param("string", "sessionKey")
+     * @xmlrpc.param #param("int", "sourceImageId")
+     * @xmlrpc.param #param("int", "targetImageId")
+     * @xmlrpc.param #param("string", "file")
+     * @xmlrpc.param #param("struct", "pillar")
+     * @xmlrpc.returntype #param_desc("int", "id", "ID of the inspect action created")
+     */
+    public Long createDeltaImage(User loggedInUser, Integer sourceImageId, Integer targetImageId,
+            String file, Map<String, Object> pillar) {
+        ensureImageAdmin(loggedInUser);
+
+        Optional<ImageInfo> sourceOpt = ImageInfoFactory.lookupByIdAndOrg(sourceImageId,
+                loggedInUser.getOrg());
+        Optional<ImageInfo> targetOpt = ImageInfoFactory.lookupByIdAndOrg(targetImageId,
+                loggedInUser.getOrg());
+
+        if (!sourceOpt.isPresent() || !targetOpt.isPresent()) {
+            throw new NoSuchImageException();
+        }
+
+        Optional<DeltaImageInfo> existing = ImageInfoFactory.lookupDeltaImageInfo(sourceImageId, targetImageId);
+        if (existing.isPresent()) {
+            throw new EntityExistsFaultException(existing.get());
+        }
+
+        ImageInfoFactory.createDeltaImageInfo(sourceOpt.get(), targetOpt.get(), file, pillar);
+
+        return 1L;
+    }
+
+}

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/ImageInfoHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/ImageInfoHandler.java
@@ -15,6 +15,7 @@
 package com.redhat.rhn.frontend.xmlrpc.image;
 
 import com.redhat.rhn.FaultException;
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.errata.Errata;
 import com.redhat.rhn.domain.errata.ErrataFactory;
 import com.redhat.rhn.domain.image.ImageInfo;
@@ -332,7 +333,7 @@ public class ImageInfoHandler extends BaseHandler {
         if (!opt.isPresent()) {
             throw new NoSuchImageException();
         }
-        ImageInfoFactory.deleteWithObsoletes(opt.get());
+        ImageInfoFactory.deleteWithObsoletes(opt.get(), GlobalInstanceHolder.SALT_API);
         return 1;
     }
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/ImageInfoHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/ImageInfoHandler.java
@@ -95,6 +95,27 @@ public class ImageInfoHandler extends BaseHandler {
     }
 
     /**
+     * Get Image Pillar
+     * @param loggedInUser The Current User
+     * @param imageId the Image id
+     * @return the pillar
+     *
+     * @xmlrpc.doc Get pillar of an Image
+     * @xmlrpc.param #param("string", "sessionKey")
+     * @xmlrpc.param #param("int", "imageId")
+     * @xmlrpc.returntype struct
+     */
+    public Map<String, Object> getPillar(User loggedInUser, Integer imageId) {
+        ensureImageAdmin(loggedInUser);
+        Optional<ImageInfo> opt = ImageInfoFactory.lookupByIdAndOrg(imageId,
+                loggedInUser.getOrg());
+        if (!opt.isPresent()) {
+            throw new NoSuchImageException();
+        }
+        return opt.get().getPillar().getPillar();
+    }
+
+    /**
      * Schedule an image import
      * @param loggedInUser The current user
      * @param name The name

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/ImageInfoHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/ImageInfoHandler.java
@@ -311,7 +311,7 @@ public class ImageInfoHandler extends BaseHandler {
         if (!opt.isPresent()) {
             throw new NoSuchImageException();
         }
-        ImageInfoFactory.delete(opt.get());
+        ImageInfoFactory.deleteWithObsoletes(opt.get());
         return 1;
     }
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/test/ImageInfoHandlerTest.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/image/test/ImageInfoHandlerTest.java
@@ -143,7 +143,7 @@ public class ImageInfoHandlerTest extends BaseHandlerTestCase {
             assertEquals("Image already exists.", e.getMessage());
         }
 
-        ImageInfoFactory.delete(info.get());
+        ImageInfoFactory.delete(info.get(), saltServiceMock);
         ret = handler.importImage(admin, "my-external-image", "1.0",
                 server.getId().intValue(), store.getLabel(), "", getNow());
         assertTrue(ret > 0);

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/DeltaImageSerializer.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/DeltaImageSerializer.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2022 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.frontend.xmlrpc.serializer;
+
+import com.redhat.rhn.domain.image.DeltaImageInfo;
+import com.redhat.rhn.frontend.xmlrpc.serializer.util.SerializerHelper;
+
+import java.io.IOException;
+import java.io.Writer;
+
+import redstone.xmlrpc.XmlRpcException;
+import redstone.xmlrpc.XmlRpcSerializer;
+
+/**
+ * DeltaImageSerializer
+ * @xmlrpc.doc
+ * #struct_begin("Delta Image information")
+ *   #prop("int", "source_id")
+ *   #prop("int", "target_id")
+ *   #prop_desc("string", "file", "file path")
+ *   #prop_desc("struct", "pillar", "pillar data")
+ * #struct_end()
+ */
+public class DeltaImageSerializer extends RhnXmlRpcCustomSerializer {
+
+    @Override
+    protected void doSerialize(Object value, Writer writer, XmlRpcSerializer serializer)
+            throws XmlRpcException, IOException {
+        SerializerHelper helper = new SerializerHelper(serializer);
+        DeltaImageInfo delta = (DeltaImageInfo) value;
+        helper.add("source_id", delta.getSourceImageInfo().getId());
+        helper.add("target_id", delta.getTargetImageInfo().getId());
+        helper.add("file", delta.getFile());
+        helper.add("pillar", delta.getPillar().getPillar());
+        helper.writeTo(writer);
+    }
+
+    @Override
+    public Class getSupportedClass() {
+        return DeltaImageInfo.class;
+    }
+}

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/ImageFileSerializer.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/ImageFileSerializer.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2022 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+package com.redhat.rhn.frontend.xmlrpc.serializer;
+
+import com.redhat.rhn.domain.image.ImageFile;
+import com.redhat.rhn.frontend.xmlrpc.serializer.util.SerializerHelper;
+
+import java.io.IOException;
+import java.io.Writer;
+
+import redstone.xmlrpc.XmlRpcException;
+import redstone.xmlrpc.XmlRpcSerializer;
+
+/**
+ * ImageFileSerializer
+ * @xmlrpc.doc
+ * #struct_begin("Image information")
+ *   #prop_desc("string", "file", "file name")
+ *   #prop_desc("string", "type", "file type")
+ *   #prop_desc("boolean", "external", "true if the file is external,
+ *          false otherwise")
+ * #struct_end()
+ */
+public class ImageFileSerializer extends RhnXmlRpcCustomSerializer {
+
+    @Override
+    protected void doSerialize(Object value, Writer writer, XmlRpcSerializer serializer)
+            throws XmlRpcException, IOException {
+        SerializerHelper helper = new SerializerHelper(serializer);
+        ImageFile file = (ImageFile) value;
+        helper.add("file", file.getFile());
+        helper.add("type", file.getType());
+        helper.add("external", file.isExternal());
+        helper.writeTo(writer);
+    }
+
+    @Override
+    public Class getSupportedClass() {
+        return ImageFile.class;
+    }
+}

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/ImageInfoSerializer.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/ImageInfoSerializer.java
@@ -57,6 +57,7 @@ public class ImageInfoSerializer extends RhnXmlRpcCustomSerializer {
         helper.add("external", image.isExternalImage());
         helper.add("storeLabel", store != null ? store.getLabel() : "");
         helper.add("checksum", chk != null ? chk.getChecksum() : "");
+        helper.add("obsolete", image.isObsolete());
         helper.writeTo(writer);
     }
 

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/ImageOverviewSerializer.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/ImageOverviewSerializer.java
@@ -93,6 +93,7 @@ public class ImageOverviewSerializer extends RhnXmlRpcCustomSerializer {
                 ba -> helper.add("buildStatus", ba.getStatus().getName().toLowerCase()));
         image.getInspectServerAction().ifPresent(
                 ia -> helper.add("inspectStatus", ia.getStatus().getName().toLowerCase()));
+        helper.add("files", image.getImageFiles());
 
         helper.writeTo(writer);
     }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/SerializerRegistry.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/serializer/SerializerRegistry.java
@@ -50,6 +50,7 @@ public class SerializerRegistry {
         SERIALIZER_CLASSES.add(ChannelInfoSerializer.class);
         SERIALIZER_CLASSES.add(ChannelSerializer.class);
         SERIALIZER_CLASSES.add(CpuSerializer.class);
+        SERIALIZER_CLASSES.add(DeltaImageSerializer.class);
         SERIALIZER_CLASSES.add(DeviceSerializer.class);
         SERIALIZER_CLASSES.add(DmiSerializer.class);
         SERIALIZER_CLASSES.add(EndpointInfoSerializer.class);
@@ -143,6 +144,7 @@ public class SerializerRegistry {
         SERIALIZER_CLASSES.add(ImageStoreSerializer.class);
         SERIALIZER_CLASSES.add(ImageProfileSerializer.class);
         SERIALIZER_CLASSES.add(ImageInfoSerializer.class);
+        SERIALIZER_CLASSES.add(ImageFileSerializer.class);
         SERIALIZER_CLASSES.add(ImageOverviewSerializer.class);
         SERIALIZER_CLASSES.add(ContentProjectSerializer.class);
         SERIALIZER_CLASSES.add(ContentEnvironmentSerializer.class);

--- a/java/code/src/com/redhat/rhn/manager/audit/test/CVEAuditManagerTest.java
+++ b/java/code/src/com/redhat/rhn/manager/audit/test/CVEAuditManagerTest.java
@@ -1681,7 +1681,7 @@ public class CVEAuditManagerTest extends RhnBaseTestCase {
         Set<Channel> channels = new HashSet<>();
         channels.add(channel);
         createTestPackage(user, errata, channel, "noarch");
-        ImageInfo image = createImageInfo(channels, user);
+        ImageInfo image = createImageInfo(channels, user, true);
         CVEAuditManager.populateCVEChannels();
 
         // No filtering
@@ -1723,7 +1723,7 @@ public class CVEAuditManagerTest extends RhnBaseTestCase {
         Package unpatched = createTestPackage(user, channel, "noarch");
         createLaterTestPackage(user, errata, channel, unpatched);
 
-        ImageInfo image = createImageInfo(channels, user);
+        ImageInfo image = createImageInfo(channels, user, true);
         createImagePackage(unpatched, image);
 
         CVEAuditManager.populateCVEChannels();
@@ -1763,7 +1763,7 @@ public class CVEAuditManagerTest extends RhnBaseTestCase {
         createLaterTestPackage(user, errata, channel, unpatched, null, unpatched.getPackageEvr().getVersion(),
                 unpatched.getPackageEvr().getRelease());
 
-        ImageInfo image = createImageInfo(channels, user);
+        ImageInfo image = createImageInfo(channels, user, true);
         createImagePackage(unpatched, image);
 
         CVEAuditManager.populateCVEChannels();
@@ -1812,7 +1812,7 @@ public class CVEAuditManagerTest extends RhnBaseTestCase {
         Set<Channel> channels = new HashSet<>();
         channels.add(baseChannel);
 
-        ImageInfo image = createImageInfo(channels, user);
+        ImageInfo image = createImageInfo(channels, user, true);
         createImagePackage(unpatched, image);
 
         CVEAuditManager.populateCVEChannels();

--- a/java/code/src/com/redhat/rhn/testing/ImageTestUtils.java
+++ b/java/code/src/com/redhat/rhn/testing/ImageTestUtils.java
@@ -113,11 +113,12 @@ public class ImageTestUtils {
      * Create an image info.
      * @param channels the channels used for building the image
      * @param user the user
+     * @param built mark the image as built
      * @return the image info
      */
-    public static ImageInfo createImageInfo(Set<Channel> channels, User user) {
+    public static ImageInfo createImageInfo(Set<Channel> channels, User user, boolean built) {
         return createImageInfo("image-" + TestUtils.randomString(), "latest", channels,
-                user);
+                user, built);
     }
 
     /**
@@ -126,10 +127,11 @@ public class ImageTestUtils {
      * @param version the version of the image
      * @param channels the channels used for building the image
      * @param user the user
+     * @param built mark the image as built
      * @return the image info
      */
     public static ImageInfo createImageInfo(String name, String version,
-            Set<Channel> channels, User user) {
+            Set<Channel> channels, User user, boolean built) {
         ImageInfo image = new ImageInfo();
         image.setName(name);
         image.setVersion(version);
@@ -137,6 +139,7 @@ public class ImageTestUtils {
         image.setImageArch(ServerFactory.lookupServerArchByLabel("x86_64-redhat-linux"));
         image.setOrg(user.getOrg());
         image.setChannels(channels);
+        image.setBuilt(built);
         TestUtils.saveAndFlush(image);
         return image;
     }
@@ -149,7 +152,7 @@ public class ImageTestUtils {
      * @return the image info
      */
     public static ImageInfo createImageInfo(String name, String version, User user) {
-        return createImageInfo(name, version, (Set<Channel>)null, user);
+        return createImageInfo(name, version, (Set<Channel>)null, user, false);
     }
 
     /**

--- a/java/code/src/com/suse/manager/webui/controllers/ImageBuildController.java
+++ b/java/code/src/com/suse/manager/webui/controllers/ImageBuildController.java
@@ -23,6 +23,7 @@ import static com.suse.manager.webui.utils.SparkApplicationHelper.withUserPrefer
 import static com.suse.utils.Json.GSON;
 import static spark.Spark.post;
 
+import com.redhat.rhn.GlobalInstanceHolder;
 import com.redhat.rhn.domain.action.ActionChain;
 import com.redhat.rhn.domain.action.ActionChainFactory;
 import com.redhat.rhn.domain.action.ActionFactory;
@@ -796,7 +797,7 @@ public class ImageBuildController {
             return json(res, ResultJson.error("not_found"));
         }
 
-        images.forEach(ImageInfoFactory::deleteWithObsoletes);
+        images.forEach(info -> ImageInfoFactory.deleteWithObsoletes(info, GlobalInstanceHolder.SALT_API));
         return json(res, ResultJson.success(images.size()));
     }
 

--- a/java/code/src/com/suse/manager/webui/utils/gson/ImageInfoJson.java
+++ b/java/code/src/com/suse/manager/webui/utils/gson/ImageInfoJson.java
@@ -17,7 +17,9 @@ package com.suse.manager.webui.utils.gson;
 
 import com.redhat.rhn.domain.action.server.ServerAction;
 import com.redhat.rhn.domain.common.Checksum;
+import com.redhat.rhn.domain.image.DeltaImageInfo;
 import com.redhat.rhn.domain.image.ImageFile;
+import com.redhat.rhn.domain.image.ImageInfo;
 import com.redhat.rhn.domain.image.ImageInfoCustomDataValue;
 import com.redhat.rhn.domain.image.ImageOverview;
 import com.redhat.rhn.domain.image.ImageProfile;
@@ -62,6 +64,8 @@ public class ImageInfoJson {
     private Integer packages;
     private Integer installedPackages;
     private List<JsonObject> imageFiles;
+    private List<JsonObject> deltaSourceFor;
+    private List<JsonObject> deltaTargetFor;
 
     /**
      * @return the id
@@ -390,6 +394,50 @@ public class ImageInfoJson {
     }
 
     /**
+     * @return the delta images that have this image as a source
+     */
+    public List<JsonObject> getDeltaSourceFor() {
+        return deltaSourceFor;
+    }
+
+    /**
+     * @param deltaSourceForIn set of delta images that have this image as a source
+     */
+    public void setDeltaSourceFor(Set<DeltaImageInfo> deltaSourceForIn) {
+        this.deltaSourceFor = deltaSourceForIn.stream().map(delta -> {
+            JsonObject json = new JsonObject();
+            ImageInfo target = delta.getTargetImageInfo();
+            json.addProperty("id", target.getId());
+            json.addProperty("name", target.getName() + "-" +
+                                     target.getVersion() + "-" +
+                                     target.getRevisionNumber());
+            return json;
+        }).collect(Collectors.toList());
+    }
+
+    /**
+     * @return the delta images that have this image as a target
+     */
+    public List<JsonObject> getDeltaTargetFor() {
+        return deltaTargetFor;
+    }
+
+    /**
+     * @param deltaTargetForIn  set of delta images that have this image as a target
+     */
+    public void setDeltaTargetFor(Set<DeltaImageInfo> deltaTargetForIn) {
+        this.deltaTargetFor = deltaTargetForIn.stream().map(delta -> {
+            JsonObject json = new JsonObject();
+            ImageInfo source = delta.getSourceImageInfo();
+            json.addProperty("id", source.getId());
+            json.addProperty("name", source.getName() + "-" +
+                                     source.getVersion() + "-" +
+                                     source.getRevisionNumber());
+            return json;
+        }).collect(Collectors.toList());
+    }
+
+    /**
      * Creates a JSON object from an image overview object
      *
      * @param imageOverview the image overview
@@ -425,6 +473,8 @@ public class ImageInfoJson {
         json.setInstalledProducts(installedProductsJson.orElse(null));
         json.setCustomData(imageOverview.getCustomDataValues());
         json.setImageFiles(imageOverview.getImageFiles());
+        json.setDeltaSourceFor(imageOverview.getDeltaSourceFor());
+        json.setDeltaTargetFor(imageOverview.getDeltaTargetFor());
 
         return json;
     }

--- a/java/code/src/com/suse/manager/webui/utils/gson/ImageInfoJson.java
+++ b/java/code/src/com/suse/manager/webui/utils/gson/ImageInfoJson.java
@@ -17,10 +17,12 @@ package com.suse.manager.webui.utils.gson;
 
 import com.redhat.rhn.domain.action.server.ServerAction;
 import com.redhat.rhn.domain.common.Checksum;
+import com.redhat.rhn.domain.image.ImageFile;
 import com.redhat.rhn.domain.image.ImageInfoCustomDataValue;
 import com.redhat.rhn.domain.image.ImageOverview;
 import com.redhat.rhn.domain.image.ImageProfile;
 import com.redhat.rhn.domain.image.ImageStore;
+import com.redhat.rhn.domain.image.OSImageStoreUtils;
 import com.redhat.rhn.domain.product.SUSEProduct;
 import com.redhat.rhn.domain.server.InstalledProduct;
 import com.redhat.rhn.domain.server.MinionServer;
@@ -47,6 +49,7 @@ public class ImageInfoJson {
     private Integer revision;
     private String checksum;
     private boolean external;
+    private boolean obsolete;
     private JsonObject profile;
     private JsonObject store;
     private JsonObject buildServer;
@@ -58,6 +61,7 @@ public class ImageInfoJson {
     private JsonObject patches;
     private Integer packages;
     private Integer installedPackages;
+    private List<JsonObject> imageFiles;
 
     /**
      * @return the id
@@ -151,10 +155,24 @@ public class ImageInfoJson {
     }
 
     /**
+     * @return true if the image is obsolete
+     */
+    public boolean isObsolete() {
+        return obsolete;
+    }
+
+    /**
      * @param externalIn the external boolean
      */
     public void setExternal(boolean externalIn) {
         this.external = externalIn;
+    }
+
+    /**
+     * @param obsoleteIn the obsolete boolean
+     */
+    public void setObsolete(boolean obsoleteIn) {
+        this.obsolete = obsoleteIn;
     }
 
     /**
@@ -353,6 +371,25 @@ public class ImageInfoJson {
     }
 
     /**
+     * @return the image files
+     */
+    public List<JsonObject> getImageFiles() {
+        return imageFiles;
+    }
+
+    /**
+     * @param imageFilesIn set of image files
+     */
+    public void setImageFiles(Set<ImageFile> imageFilesIn) {
+        this.imageFiles = imageFilesIn.stream().map(file -> {
+            JsonObject json = new JsonObject();
+            json.addProperty("name", file.getFile());
+            json.addProperty("url", OSImageStoreUtils.getOSImageFileURI(file));
+            return json;
+        }).collect(Collectors.toList());
+    }
+
+    /**
      * Creates a JSON object from an image overview object
      *
      * @param imageOverview the image overview
@@ -368,6 +405,7 @@ public class ImageInfoJson {
         json.setRevision(imageOverview.getCurrRevisionNum());
         json.setChecksum(c != null ? c.getChecksum() : "");
         json.setExternal(imageOverview.isExternalImage());
+        json.setObsolete(imageOverview.isObsolete());
         json.setProfile(imageOverview.getProfile());
         json.setStore(imageOverview.getStore());
         json.setBuildServer(imageOverview.getBuildServer());
@@ -386,6 +424,7 @@ public class ImageInfoJson {
                         collect.get(false).stream().map(ImageInfoJson::getProductName).collect(Collectors.toSet())));
         json.setInstalledProducts(installedProductsJson.orElse(null));
         json.setCustomData(imageOverview.getCustomDataValues());
+        json.setImageFiles(imageOverview.getImageFiles());
 
         return json;
     }

--- a/java/code/src/com/suse/manager/webui/utils/salt/custom/OSImageBuildImageInfoResult.java
+++ b/java/code/src/com/suse/manager/webui/utils/salt/custom/OSImageBuildImageInfoResult.java
@@ -33,4 +33,11 @@ public class OSImageBuildImageInfoResult {
     public List<OSImageInspectSlsResult.Bundle> getBundles() {
         return Optional.ofNullable(bundles).orElseGet(() -> Collections.singletonList(bundle));
     }
+
+    /**
+     * @return the image info
+     */
+    public OSImageInspectSlsResult.Image getImage() {
+        return image;
+    }
 }

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Improve image management
+- Store delta image info in the database
 - fix class cast exception during action chains (bsc#1195772)
 - Finding empty profiles by mac address must be case insensitive (bsc#1196407)
 - prepare to use new postgresql-jdbc driver with stringprep and saslprep

--- a/schema/spacewalk/common/tables/suseDeltaImageInfo.sql
+++ b/schema/spacewalk/common/tables/suseDeltaImageInfo.sql
@@ -1,0 +1,25 @@
+CREATE TABLE suseDeltaImageInfo
+(
+    source_image_id NUMERIC NOT NULL
+                     CONSTRAINT suse_deltaimg_source_fk
+                     REFERENCES suseImageInfo (id) ON DELETE CASCADE,
+
+    target_image_id NUMERIC NOT NULL
+                     CONSTRAINT suse_deltaimg_target_fk
+                     REFERENCES suseImageInfo (id) ON DELETE CASCADE,
+
+    pillar_id       NUMERIC
+                     CONSTRAINT suse_deltaimg_pillar_fk
+                       REFERENCES suseSaltPillar (id)
+                       ON DELETE SET NULL,
+
+    file           TEXT NOT NULL,
+
+    created        TIMESTAMPTZ
+                     DEFAULT (current_timestamp) NOT NULL,
+    modified       TIMESTAMPTZ
+                     DEFAULT (current_timestamp) NOT NULL,
+
+    CONSTRAINT suse_delta_image_info_pk PRIMARY KEY (source_image_id, target_image_id)
+);
+

--- a/schema/spacewalk/common/tables/suseImageFile.sql
+++ b/schema/spacewalk/common/tables/suseImageFile.sql
@@ -1,5 +1,5 @@
 --
--- Copyright (c) 2017 SUSE LLC
+-- Copyright (c) 2022 SUSE LLC
 --
 -- This software is licensed to you under the GNU General Public License,
 -- version 2 (GPLv2). There is NO WARRANTY for this software, express or
@@ -13,20 +13,22 @@
 -- in this software or its documentation.
 --
 
-CREATE TABLE suseImageRepoDigest
+
+CREATE TABLE suseImageFile
 (
     id             NUMERIC NOT NULL
-                     CONSTRAINT suse_rdigest_id_pk PRIMARY KEY,
-    image_info_id    NUMERIC NOT NULL,
-    repo_digest    VARCHAR(255) NOT NULL,
+                     CONSTRAINT suse_imgfile_fileid_pk PRIMARY KEY,
+    image_info_id  NUMERIC NOT NULL,
+    file           TEXT NOT NULL,
+    type           VARCHAR(16) NOT NULL,
+    external       CHAR(1) DEFAULT ('N') NOT NULL,
     created        TIMESTAMPTZ
                      DEFAULT (current_timestamp) NOT NULL,
     modified       TIMESTAMPTZ
                      DEFAULT (current_timestamp) NOT NULL,
-    CONSTRAINT suse_rdigest_imginfo_fk FOREIGN KEY (image_info_id)
+
+    CONSTRAINT suse_imgfile_imginfo_fk FOREIGN KEY (image_info_id)
         REFERENCES suseImageInfo (id) ON DELETE CASCADE
-)
+);
 
-;
-
-CREATE SEQUENCE suse_img_repodigest_id_seq;
+CREATE SEQUENCE suse_image_file_id_seq;

--- a/schema/spacewalk/common/tables/suseImageInfo.sql
+++ b/schema/spacewalk/common/tables/suseImageInfo.sql
@@ -46,6 +46,17 @@ CREATE TABLE suseImageInfo
                          REFERENCES suseMinionInfo (server_id)
                          ON DELETE SET NULL,
     external_image CHAR(1) DEFAULT ('N') NOT NULL,
+
+    obsolete       CHAR(1) DEFAULT ('N') NOT NULL,
+
+    built          CHAR(1) DEFAULT ('N') NOT NULL,
+
+    pillar_id      NUMERIC
+                     CONSTRAINT suse_imginfo_pillar_fk
+                       REFERENCES suseSaltPillar (id)
+                       ON DELETE SET NULL,
+    log            TEXT,
+
     created        TIMESTAMPTZ
                      DEFAULT (current_timestamp) NOT NULL,
     modified       TIMESTAMPTZ

--- a/schema/spacewalk/common/tables/tables.deps
+++ b/schema/spacewalk/common/tables/tables.deps
@@ -235,7 +235,7 @@ suseKiwiProfile                :: suseImageProfile
 suseProfileCustomDataValue     :: rhnCustomDataKey suseImageProfile web_contact
 suseImageCustomDataValue       :: rhnCustomDataKey suseImageInfo web_contact
 suseImageInfo                  :: rhnServerAction suseImageProfile suseImageStore suseMinionInfo \
-                                  rhnChecksum
+                                  rhnChecksum suseSaltPillar
 suseImageInfoPackage           :: suseImageInfo rhnPackageName rhnPackageEVR rhnPackageArch
 suseImageInfoChannel           :: suseImageInfo rhnChannel
 suseImageInfoInstalledProduct  :: suseInstalledProduct suseImageInfo
@@ -254,6 +254,7 @@ suseProducts                   :: rhnPackageArch rhnChannelFamily
 suseProductChannel             :: suseProducts rhnChannel
 suseProductExtension           :: suseProducts
 suseProductSCCRepository       :: suseProducts suseSCCRepository
+suseSaltPillar                 :: rhnServer rhnServerGroup web_customer
 suseSCCOrderItem               :: suseCredentials
 suseSCCRegCache                :: suseCredentials rhnServer
 suseSCCRepositoryAuth          :: suseCredentials rhnContentSource

--- a/schema/spacewalk/postgres/triggers/suseDeltaImageInfo.sql
+++ b/schema/spacewalk/postgres/triggers/suseDeltaImageInfo.sql
@@ -1,0 +1,31 @@
+--
+-- Copyright (c) 2022 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- triggers for suseImageInfo
+
+CREATE OR REPLACE FUNCTION suse_delta_image_info_mod_trig_fun() RETURNS TRIGGER AS
+$$
+BEGIN
+	new.modified := current_timestamp;
+	return new;
+END;
+$$ LANGUAGE PLPGSQL;
+
+CREATE TRIGGER suse_delta_image_info_mod_trig BEFORE INSERT OR UPDATE ON suseDeltaImageInfo
+  FOR EACH ROW EXECUTE PROCEDURE suse_delta_image_info_mod_trig_fun();
+
+CREATE OR REPLACE FUNCTION suse_delta_image_info_image_removed_trig_fun() RETURNS TRIGGER AS $$
+BEGIN
+  DELETE FROM suseSaltPillar WHERE id = OLD.pillar_id;
+  RETURN OLD;
+END $$ LANGUAGE PLPGSQL;
+
+CREATE TRIGGER suse_delta_image_info_image_removed_trig AFTER DELETE ON suseDeltaImageInfo
+  FOR EACH ROW EXECUTE PROCEDURE suse_delta_image_info_image_removed_trig_fun();

--- a/schema/spacewalk/postgres/triggers/suseImageInfo.sql
+++ b/schema/spacewalk/postgres/triggers/suseImageInfo.sql
@@ -23,3 +23,12 @@ suse_imginfo_mod_trig
 before insert or update on suseImageInfo
 for each row
 execute procedure suse_imginfo_mod_trig_fun();
+
+CREATE OR REPLACE FUNCTION suse_image_info_image_removed_trig_fun() RETURNS TRIGGER AS $$
+BEGIN
+  DELETE FROM suseSaltPillar WHERE id = OLD.pillar_id;
+  RETURN OLD;
+END $$ LANGUAGE PLPGSQL;
+
+CREATE TRIGGER suse_image_info_image_removed_trig AFTER DELETE ON suseImageInfo
+  FOR EACH ROW EXECUTE PROCEDURE suse_image_info_image_removed_trig_fun();

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,5 @@
+- Improve image management
+- Store delta image info in the database
 - fix advisory status migration (bsc#1195765)
 - Corrected source URLs in spec file.
 

--- a/schema/spacewalk/upgrade/susemanager-schema-4.3.7-to-susemanager-schema-4.3.8/310-suseImageInfo.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.3.7-to-susemanager-schema-4.3.8/310-suseImageInfo.sql
@@ -1,0 +1,23 @@
+ALTER TABLE suseImageInfo ADD COLUMN IF NOT EXISTS obsolete       CHAR(1) DEFAULT ('N') NOT NULL;
+
+ALTER TABLE suseImageInfo ADD COLUMN IF NOT EXISTS built          CHAR(1) DEFAULT ('N') NOT NULL;
+
+ALTER TABLE suseImageInfo ADD COLUMN IF NOT EXISTS pillar_id      NUMERIC
+                        CONSTRAINT suse_imginfo_pillar_fk
+                        REFERENCES suseSaltPillar (id)
+                        ON DELETE SET NULL;
+
+ALTER TABLE suseImageInfo ADD COLUMN IF NOT EXISTS log            TEXT;
+
+UPDATE suseImageInfo SET built='Y' WHERE id IN (SELECT DISTINCT image_info_id FROM suseImageInfoPackage);
+
+CREATE OR REPLACE FUNCTION suse_image_info_image_removed_trig_fun() RETURNS TRIGGER AS $$
+BEGIN
+  DELETE FROM suseSaltPillar WHERE id = OLD.pillar_id;
+  RETURN OLD;
+END $$ LANGUAGE PLPGSQL;
+
+DROP TRIGGER IF EXISTS suse_image_info_image_removed_trig ON suseImageInfo;
+CREATE TRIGGER suse_image_info_image_removed_trig AFTER DELETE ON suseImageInfo
+  FOR EACH ROW EXECUTE PROCEDURE suse_image_info_image_removed_trig_fun();
+

--- a/schema/spacewalk/upgrade/susemanager-schema-4.3.7-to-susemanager-schema-4.3.8/320-suseImageRepoDigest.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.3.7-to-susemanager-schema-4.3.8/320-suseImageRepoDigest.sql
@@ -1,0 +1,112 @@
+DO $$
+    BEGIN
+        IF EXISTS
+            (
+                SELECT 1
+                FROM information_schema.columns
+                WHERE table_name='suseimagerepodigest' AND column_name='image_history_id'
+            )
+        THEN
+            CREATE TEMP TABLE tmpImageDigest AS
+                 SELECT name,
+                   version,
+                   image_type,
+                   org_id,
+                   store_id,
+                   revision_num,
+                   suseImageBuildHistory.created,
+                   suseImageBuildHistory.modified,
+                   repo_digest
+                 FROM suseImageInfo
+                     LEFT JOIN suseImageBuildHistory ON suseImageInfo.id = suseImageBuildHistory.image_info_id
+                     LEFT JOIN suseImageRepoDigest ON suseImageBuildHistory.id = suseImageRepoDigest.image_history_id;
+
+            CREATE TEMP TABLE tmpImageHistory AS
+            SELECT name,
+                   version,
+                   image_type,
+                   checksum_id,
+                   image_arch_id,
+                   org_id,
+                   profile_id,
+                   store_id,
+                   build_server_id,
+                   external_image,
+                   revision_num,
+                   curr_revision_num,
+                   suseImageBuildHistory.created,
+                   suseImageBuildHistory.modified
+                 FROM suseImageInfo
+                     LEFT JOIN suseImageBuildHistory ON suseImageInfo.id = suseImageBuildHistory.image_info_id;
+
+            INSERT INTO suseImageInfo (
+                  id,
+                  name,
+                  version,
+                  image_type,
+                  image_arch_id,
+                  org_id,
+                  profile_id,
+                  store_id,
+                  build_server_id,
+                  external_image,
+                  curr_revision_num,
+                  created,
+                  modified,
+                  obsolete
+                )
+                SELECT sequence_nextval('suse_imginfo_imgid_seq'),
+                       name,
+                       version,
+                       image_type,
+                       image_arch_id,
+                       org_id,
+                       profile_id,
+                       store_id,
+                       build_server_id,
+                       external_image,
+                       revision_num,
+                       created,
+                       modified,
+                       'Y'
+                     FROM tmpImagehistory
+                         WHERE revision_num != curr_revision_num;
+
+
+            DROP TABLE suseImageRepoDigest;
+            DROP SEQUENCE suse_img_repodigest_id_seq;
+            DROP TABLE suseImageBuildHistory;
+
+            CREATE TABLE suseImageRepoDigest
+            (
+                id             NUMERIC NOT NULL
+                                 CONSTRAINT suse_rdigest_id_pk PRIMARY KEY,
+                image_info_id    NUMERIC NOT NULL,
+                repo_digest    VARCHAR(255) NOT NULL,
+                created        TIMESTAMPTZ
+                                 DEFAULT (current_timestamp) NOT NULL,
+                modified       TIMESTAMPTZ
+                                 DEFAULT (current_timestamp) NOT NULL,
+                CONSTRAINT suse_rdigest_imginfo_fk FOREIGN KEY (image_info_id)
+                    REFERENCES suseImageInfo (id) ON DELETE CASCADE
+            );
+
+
+            CREATE SEQUENCE suse_img_repodigest_id_seq;
+
+            INSERT INTO suseImageRepoDigest (id, image_info_id, repo_digest, created, modified)
+                   SELECT sequence_nextval('suse_img_repodigest_id_seq'), suseImageInfo.id, repo_digest, tmpImageDigest.created, tmpImageDigest.modified
+                       FROM suseImageInfo, tmpImageDigest
+                          WHERE suseImageInfo.name = tmpImageDigest.name
+                            AND suseImageInfo.version = tmpImageDigest.version
+                            AND suseImageInfo.image_type = tmpImageDigest.image_type
+                            AND suseImageInfo.org_id = tmpImageDigest.org_id
+                            AND suseImageInfo.store_id = tmpImageDigest.store_id
+                            AND suseImageInfo.curr_revision_num = tmpImageDigest.revision_num;
+
+            DROP TABLE tmpImageDigest;
+            DROP TABLE tmpImageHistory;
+
+        END IF;
+    END
+$$ LANGUAGE plpgsql;

--- a/schema/spacewalk/upgrade/susemanager-schema-4.3.7-to-susemanager-schema-4.3.8/330-suseImageFile.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.3.7-to-susemanager-schema-4.3.8/330-suseImageFile.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS suseImageFile
+(
+    id             NUMERIC NOT NULL
+                     CONSTRAINT suse_imgfile_fileid_pk PRIMARY KEY,
+    image_info_id  NUMERIC NOT NULL,
+    file           TEXT NOT NULL,
+    type           VARCHAR(16) NOT NULL,
+    external       CHAR(1) DEFAULT ('N') NOT NULL,
+    created        TIMESTAMPTZ
+                     DEFAULT (current_timestamp) NOT NULL,
+    modified       TIMESTAMPTZ
+                     DEFAULT (current_timestamp) NOT NULL,
+
+    CONSTRAINT suse_imgfile_imginfo_fk FOREIGN KEY (image_info_id)
+        REFERENCES suseImageInfo (id) ON DELETE CASCADE
+);
+
+CREATE SEQUENCE IF NOT EXISTS suse_image_file_id_seq;

--- a/schema/spacewalk/upgrade/susemanager-schema-4.3.7-to-susemanager-schema-4.3.8/340-suseImageOverview.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.3.7-to-susemanager-schema-4.3.8/340-suseImageOverview.sql
@@ -1,13 +1,4 @@
---
--- Copyright (c) 2017 SUSE LLC
---
--- This software is licensed to you under the GNU General Public License,
--- version 2 (GPLv2). There is NO WARRANTY for this software, express or
--- implied, including the implied warranties of MERCHANTABILITY or FITNESS
--- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
--- along with this software; if not, see
--- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
---
+drop view suseImageOverview;
 
 create or replace view
 suseImageOverview

--- a/schema/spacewalk/upgrade/susemanager-schema-4.3.7-to-susemanager-schema-4.3.8/350-suseDeltaImageInfo.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.3.7-to-susemanager-schema-4.3.8/350-suseDeltaImageInfo.sql
@@ -1,0 +1,46 @@
+CREATE TABLE IF NOT EXISTS suseDeltaImageInfo
+(
+    source_image_id NUMERIC NOT NULL
+                     CONSTRAINT suse_deltaimg_source_fk
+                     REFERENCES suseImageInfo (id) ON DELETE CASCADE,
+
+    target_image_id NUMERIC NOT NULL
+                     CONSTRAINT suse_deltaimg_target_fk
+                     REFERENCES suseImageInfo (id) ON DELETE CASCADE,
+
+    pillar_id       NUMERIC
+                     CONSTRAINT suse_deltaimg_pillar_fk
+                       REFERENCES suseSaltPillar (id)
+                       ON DELETE SET NULL,
+
+    file           TEXT NOT NULL,
+
+    created        TIMESTAMPTZ
+                     DEFAULT (current_timestamp) NOT NULL,
+    modified       TIMESTAMPTZ
+                     DEFAULT (current_timestamp) NOT NULL,
+
+    CONSTRAINT suse_deltaimg_pk PRIMARY KEY (source_image_id, target_image_id)
+);
+
+CREATE OR REPLACE FUNCTION suse_delta_image_info_mod_trig_fun() RETURNS TRIGGER AS
+$$
+BEGIN
+        new.modified := current_timestamp;
+        return new;
+END;
+$$ LANGUAGE PLPGSQL;
+
+DROP TRIGGER IF EXISTS suse_delta_image_info_mod_trig ON suseDeltaImageInfo;
+CREATE TRIGGER suse_delta_image_info_mod_trig BEFORE INSERT OR UPDATE ON suseDeltaImageInfo
+  FOR EACH ROW EXECUTE PROCEDURE suse_delta_image_info_mod_trig_fun();
+
+CREATE OR REPLACE FUNCTION suse_delta_image_info_image_removed_trig_fun() RETURNS TRIGGER AS $$
+BEGIN
+  DELETE FROM suseSaltPillar WHERE id = OLD.pillar_id;
+  RETURN OLD;
+END $$ LANGUAGE PLPGSQL;
+
+DROP TRIGGER IF EXISTS suse_delta_image_info_image_removed_trig ON suseDeltaImageInfo;
+CREATE TRIGGER suse_delta_image_info_image_removed_trig AFTER DELETE ON suseDeltaImageInfo
+  FOR EACH ROW EXECUTE PROCEDURE suse_delta_image_info_image_removed_trig_fun();

--- a/susemanager-utils/susemanager-sls/salt/images/kiwi-image-build.sls
+++ b/susemanager-utils/susemanager-sls/salt/images/kiwi-image-build.sls
@@ -57,14 +57,18 @@ mgr_buildimage_prepare_activation_key_in_source:
 
 mgr_buildimage_kiwi_prepare:
   cmd.run:
-    - name: "{{ kiwi }} --logfile={{ root_dir }}/prepare.log --shared-cache-dir={{ cache_dir }} {{ kiwi_options }} system prepare --description {{ source_dir }} --root {{ chroot_dir }} {{ kiwi_params() }}"
+    - name: "{{ kiwi }} {{ kiwi_options }} $GLOBAL_PARAMS system prepare $PARAMS"
+    - hide_output: True
+    - env:
+      - GLOBAL_PARAMS: "--logfile={{ root_dir }}/build.log --shared-cache-dir={{ cache_dir }}"
+      - PARAMS:  "--description {{ source_dir }} --root {{ chroot_dir }} {{ kiwi_params() }}"
     - require:
       - mgrcompat: mgr_buildimage_prepare_source
       - file: mgr_buildimage_prepare_activation_key_in_source
 
 mgr_buildimage_kiwi_create:
   cmd.run:
-    - name: "{{ kiwi }} --logfile={{ root_dir }}/create.log --shared-cache-dir={{ cache_dir }} {{ kiwi_options }} system create --root {{ chroot_dir }} --target-dir  {{ dest_dir }}"
+    - name: "{{ kiwi }} --logfile={{ root_dir }}/build.log --shared-cache-dir={{ cache_dir }} {{ kiwi_options }} system create --root {{ chroot_dir }} --target-dir  {{ dest_dir }}"
     - require:
       - cmd: mgr_buildimage_kiwi_prepare
 
@@ -168,3 +172,9 @@ mgr_buildimage_info:
 {%- else %}
       - mgr_buildimage_kiwi_bundle
 {%- endif %}
+
+mgr_buildimage_kiwi_collect_logs:
+  mgrcompat.module_run:
+    - name: cp.push
+    - path: {{ root_dir }}/build.log
+    - order: last

--- a/testsuite/features/secondary/buildhost_osimage_build_image.feature
+++ b/testsuite/features/secondary/buildhost_osimage_build_image.feature
@@ -8,6 +8,10 @@
 # For the scope of these tests, we configure it as follows:
 #   java.kiwi_os_image_building_enabled = true
 # which means "Enable Kiwi OS Image building"
+#
+# Idempotency note:
+# This feature leaves an JeOS image built
+# The image is used in proxy_retail_pxeboot_and_mass_import.feature
 
 @buildhost
 @scope_retail
@@ -54,15 +58,6 @@ Feature: Build OS images
     And I synchronize all Salt dynamic modules on "proxy"
     And I apply state "image-sync" to "proxy"
     Then the image should exist on "proxy"
-
-  Scenario: Cleanup: remove the image from Uyuni server
-    Given I am authorized for the "Images" section
-    When I follow the left menu "Images > Image List"
-    And I wait until I do not see "There are no entries to show." text
-    And I check the first image
-    And I click on "Delete"
-    And I click on "Delete" in "Delete Selected Image(s)" modal
-    And I wait until I see "Deleted successfully." text
 
 @proxy
 @private_net

--- a/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
+++ b/testsuite/features/secondary/proxy_retail_pxeboot_and_mass_import.feature
@@ -1,6 +1,7 @@
 # Copyright (c) 2018-2022 SUSE LLC
 # Licensed under the terms of the MIT license.
 #
+# Idempotency note:
 # This feature depends on a JeOS image present on the proxy
 # Please make sure that the feature
 #     features/buildhost_osimage_build_image.feature

--- a/web/html/src/manager/images/image-view-overview.tsx
+++ b/web/html/src/manager/images/image-view-overview.tsx
@@ -430,6 +430,34 @@ class ImageInfo extends React.Component<ImageInfoProps, ImageInfoState> {
                 <td>-</td>
               )}
             </tr>
+            {data.deltaSourceFor.length ? (
+              <tr>
+                <td>This image is used as delta source for:</td>
+                <td>
+                  <ul>
+                    {data.deltaSourceFor.map((d) => (
+                      <li>{d.name}</li>
+                    ))}
+                  </ul>
+                </td>
+              </tr>
+            ) : (
+              ""
+            )}
+            {data.deltaTargetFor.length ? (
+              <tr>
+                <td>This image is used as delta target for:</td>
+                <td>
+                  <ul>
+                    {data.deltaTargetFor.map((d) => (
+                      <li>{d.name}</li>
+                    ))}
+                  </ul>
+                </td>
+              </tr>
+            ) : (
+              ""
+            )}
           </tbody>
         </table>
         <PopUp

--- a/web/html/src/manager/images/image-view-overview.tsx
+++ b/web/html/src/manager/images/image-view-overview.tsx
@@ -355,6 +355,24 @@ class ImageInfo extends React.Component<ImageInfoProps, ImageInfoState> {
                 <td>-</td>
               )}
             </tr>
+            {data.imageFiles.length ? (
+              <tr>
+                <td>Files:</td>
+                <td>
+                  <ul>
+                    {data.imageFiles.map((f) => (
+                      <li>
+                        <a href={f.url} target="_blank" rel="noopener noreferrer">
+                          {f.name}
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                </td>
+              </tr>
+            ) : (
+              ""
+            )}
             <tr>
               <td>Build Host:</td>
               {data.buildServer ? (

--- a/web/html/src/manager/images/image-view.tsx
+++ b/web/html/src/manager/images/image-view.tsx
@@ -424,6 +424,7 @@ type ImageViewListState = {
   selectedItems: any;
   instancePopupContent: any;
   selected?: any;
+  showObsolete: boolean;
 };
 
 class ImageViewList extends React.Component<ImageViewListProps, ImageViewListState> {
@@ -432,6 +433,7 @@ class ImageViewList extends React.Component<ImageViewListProps, ImageViewListSta
     this.state = {
       selectedItems: [],
       instancePopupContent: {},
+      showObsolete: false,
     };
     this.props.onSelectCount(0);
   }
@@ -461,6 +463,12 @@ class ImageViewList extends React.Component<ImageViewListProps, ImageViewListSta
       selectedItems: items,
     });
     this.props.onSelectCount(items.length);
+  };
+
+  showObsoleteChanged = (event) => {
+    this.setState({
+      showObsolete: event.target.checked,
+    });
   };
 
   renderUpdatesIcon(row) {
@@ -602,10 +610,22 @@ class ImageViewList extends React.Component<ImageViewListProps, ImageViewListSta
       );
     }
 
+    const obsoleteFilter = (
+      <label>
+        <input
+          name="obsoleteFilter"
+          type="checkbox"
+          checked={this.state.showObsolete}
+          onChange={this.showObsoleteChanged}
+        />
+        <span>{t("Show obsolete")}</span>
+      </label>
+    );
+
     return (
       <div>
         <Table
-          data={this.props.data}
+          data={this.state.showObsolete ? this.props.data : this.props.data.filter((img) => !img.obsolete)}
           identifier={(img) => img.id}
           initialSortColumnKey="modified"
           initialSortDirection={-1}
@@ -613,6 +633,7 @@ class ImageViewList extends React.Component<ImageViewListProps, ImageViewListSta
           selectable
           selectedItems={this.state.selectedItems}
           onSelect={this.handleSelectItems}
+          additionalFilters={[obsoleteFilter]}
         >
           <Column columnKey="type" comparator={Utils.sortByText} header={t("Type")} cell={(row) => typeMap[row.type]} />
           <Column columnKey="name" comparator={Utils.sortByText} header={t("Name")} cell={(row) => row.name} />
@@ -621,7 +642,7 @@ class ImageViewList extends React.Component<ImageViewListProps, ImageViewListSta
             columnKey="revision"
             header={t("Revision")}
             comparator={Utils.sortByNumber}
-            cell={(row) => (row.revision > 0 ? row.revision : "-")}
+            cell={(row) => (row.revision > 0 ? row.revision : "-") + (row.obsolete ? " " + t("(obsolete)") : "")}
           />
           <Column columnKey="updates" header={t("Updates")} cell={(row) => this.renderUpdatesIcon(row)} />
           <Column

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,4 @@
+- Show image history, files and deltas in Image Overview
 - Provide a search box on section name for Formulas content
 - Add expand/collapse all button for formula sections
 - Add ssh_salt_pre_flight_script and ssh_use_salt_thin parameters


### PR DESCRIPTION
## What does this PR change?

This is an implementation of Image Management RFC https://github.com/uyuni-project/uyuni-rfc/pull/61
It includes database changes, image versioning and minimal API for registration of delta images.

Missing parts:
- build logs in DB
- complete API
- upload of images to SUMA store

This will be handled in separate PRs.

## GUI diff

WIP

Before:

After:

It is possible to list obsolete images (rewritten in docker store)
Image details shows additional fields - files, deltas

- [ ] **DONE**

## Documentation
WIP
- [ ] **DONE**

## Test coverage
- Unit tests were adjusted
- Cucumber tests WIP

- [ ] **DONE**

## Links

Fixes #
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [x] Re-run test "java_pgsql_tests" 
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
