### PR TITLE
Force proxyid int

### DIFF
--- a/testsuite/features/support/xmlrpc_system.rb
+++ b/testsuite/features/support/xmlrpc_system.rb
@@ -46,7 +46,9 @@ class XMLRPCSystemTest < XMLRPCBaseTest
       @connection.call('system.bootstrap', @sid, host, 22, 'root', 'linux', activation_key, salt_ssh)
     else
       proxy = @connection.call('system.search_by_name', @sid, $proxy.ip)
-      proxy_id = proxy.map { |s| s['id'] }.first
+      # rubocop:disable Lint/NumberConversion
+      proxy_id = proxy.map { |s| s['id'] }.first.to_i
+      # rubocop:enable Lint/NumberConversion
       @connection.call('system.bootstrap', @sid, host, 22, 'root', 'linux', activation_key, proxy_id, salt_ssh)
     end
   end

--- a/testsuite/features/support/xmlrpc_system.rb
+++ b/testsuite/features/support/xmlrpc_system.rb
@@ -46,7 +46,7 @@ class XMLRPCSystemTest < XMLRPCBaseTest
       @connection.call('system.bootstrap', @sid, host, 22, 'root', 'linux', activation_key, salt_ssh)
     else
       proxy = @connection.call('system.search_by_name', @sid, $proxy.ip)
-      proxy_id = Integer(proxy.map { |s| s['id'] }.first, 10)
+      proxy_id = proxy.map { |s| s['id'] }.first
       @connection.call('system.bootstrap', @sid, host, 22, 'root', 'linux', activation_key, proxy_id, salt_ssh)
     end
   end


### PR DESCRIPTION
## What does this PR change?

Take care that we call the correct API function by forcing proxyid to be an int.

Port of https://github.com/SUSE/spacewalk/pull/16373

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
