### PR TITLE
Use EL8 client tools for all EL8 clones

### DIFF
--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,6 @@
+- Use EL8 Client Tools for EL8 clones, as CentOS8 will be end of
+  life by the end of the year
+
 -------------------------------------------------------------------
 Fri Nov 05 14:06:37 CET 2021 - jgonzalez@suse.com
 

--- a/schema/spacewalk/upgrade/susemanager-schema-4.3.3-to-susemanager-schema-4.3.4/001-centos8-eol.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.3.3-to-susemanager-schema-4.3.4/001-centos8-eol.sql
@@ -1,0 +1,7 @@
+--- After CentOS8 EoL, we need to use the EL8 client tools for all EL8 clones
+UPDATE rhnContentSource
+SET source_url = 'https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/EL8-Uyuni-Client-Tools/EL_8/'
+WHERE source_url = 'https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/CentOS8-Uyuni-Client-Tools/CentOS_8/' AND org_id IS NOT NULL;
+UPDATE rhnContentSource
+SET source_url = 'https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/EL8-Uyuni-Client-Tools/EL_8/'
+WHERE source_url = 'https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS8-Uyuni-Client-Tools/CentOS_8/' AND org_id IS NOT NULL;

--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -205,19 +205,19 @@ repo_url = http://mirrorlist.centos.org/?release=8&arch=%(arch)s&repo=PowerTools
 name     = Uyuni Client Tools for %(base_channel_name)s
 archs    = %(_x86_archs)s, ppc64le, aarch64
 base_channels = centos8-%(arch)s
-gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS8-Uyuni-Client-Tools/CentOS_8/repodata/repomd.xml.key
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/EL8-Uyuni-Client-Tools/EL_8/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS8-Uyuni-Client-Tools/CentOS_8/
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/EL8-Uyuni-Client-Tools/EL_8/
 
 [centos8-uyuni-client-devel]
 name     = Uyuni Client Tools for %(base_channel_name)s (Development)
 archs    = %(_x86_archs)s, ppc64le, aarch64
 base_channels = centos8-%(arch)s
-gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/CentOS8-Uyuni-Client-Tools/CentOS_8/repodata/repomd.xml.key
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/EL8-Uyuni-Client-Tools/EL_8/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/CentOS8-Uyuni-Client-Tools/CentOS_8/
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/EL8-Uyuni-Client-Tools/EL_8/
 
 [epel8]
 label    = epel8-%(base_channel)s
@@ -284,19 +284,19 @@ repo_url = http://springdale.princeton.edu/data/puias/buildsys/8/os/%(arch)s/
 name     = Uyuni Client Tools for %(base_channel_name)s
 archs    = %(_x86_archs)s
 base_channels = sdl8-%(arch)s
-gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS8-Uyuni-Client-Tools/CentOS_8/repodata/repomd.xml.key
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/EL8-Uyuni-Client-Tools/EL_8/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS8-Uyuni-Client-Tools/CentOS_8/
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/EL8-Uyuni-Client-Tools/EL_8/
 
 [sdl8-uyuni-client-devel]
 name     = Uyuni Client Tools for %(base_channel_name)s (Development)
 archs    = %(_x86_archs)s
 base_channels = sdl8-%(arch)s
-gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/CentOS8-Uyuni-Client-Tools/CentOS_8/repodata/repomd.xml.key
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/EL8-Uyuni-Client-Tools/EL_8/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/CentOS8-Uyuni-Client-Tools/CentOS_8/
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/EL8-Uyuni-Client-Tools/EL_8/
 
 [centos7]
 archs    = x86_64, ppc64le, aarch64
@@ -1417,19 +1417,19 @@ repo_url = https://yum.oracle.com/repo/OracleLinux/OL8/UEKR6/RDMA/%(arch)s/
 name     = Uyuni Client Tools for %(base_channel_name)s
 archs    = %(_x86_archs)s, aarch64
 base_channels = oraclelinux8-%(arch)s
-gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS8-Uyuni-Client-Tools/CentOS_8/repodata/repomd.xml.key
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/EL8-Uyuni-Client-Tools/EL_8/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/CentOS8-Uyuni-Client-Tools/CentOS_8/
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/EL8-Uyuni-Client-Tools/EL_8/
 
 [oraclelinux8-uyuni-client-devel]
 name     = Uyuni Client Tools for %(base_channel_name)s (Development)
 archs    = %(_x86_archs)s, aarch64
 base_channels = oraclelinux8-%(arch)s
-gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/CentOS8-Uyuni-Client-Tools/CentOS_8/repodata/repomd.xml.key
+gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/EL8-Uyuni-Client-Tools/EL_8/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
 gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
-repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/CentOS8-Uyuni-Client-Tools/CentOS_8/
+repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/EL8-Uyuni-Client-Tools/EL_8/
 
 [oraclelinux7]
 archs    = x86_64, aarch64

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,6 @@
+- Use EL8 Client Tools for EL8 clones, as CentOS8 will be end of
+  life by the end of the year
+
 -------------------------------------------------------------------
 Fri Sep 17 12:12:12 CEST 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Use EL8 client tools for all EL8 clones (instead of the CentOS8 client tools, that will be EoL by the end of the year)

NOTE: We  still need to ensure that the EL8 client tools have packages that are newer or same version as CentOS8. See the [comment below](https://github.com/uyuni-project/uyuni/pull/4471#issuecomment-969036503).

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Transparent for the user

- [x] **DONE**

## Test coverage
- No tests: We still don't cover CentOS8 or clones with the testsuite

- [x] **DONE**

## Links

Tracks: https://github.com/SUSE/spacewalk/issues/14445

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests" (Test skipped, there are no changes to test)
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
