### PR TITLE
Add missing repositories for aarch64 for AlmaLinux 8

### DIFF
--- a/susemanager/src/mgr_bootstrap_data.py
+++ b/susemanager/src/mgr_bootstrap_data.py
@@ -1389,11 +1389,15 @@ DATA = {
     'almalinux-8-aarch64' : {
         'PDID' : [-26, 2362], 'BETAPDID' : [2364], 'PKGLIST' : RES8,
         'DEST' : '/srv/www/htdocs/pub/repositories/almalinux/8/bootstrap/'
-    },    
+    },
     'almalinux-8-x86_64-uyuni' : {
         'BASECHANNEL' : 'almalinux8-x86_64', 'PKGLIST' : RES8 + RES8_X86,
         'DEST' : '/srv/www/htdocs/pub/repositories/almalinux/8/bootstrap/'
-    },    
+    },
+    'almalinux-8-aarch64-uyuni' : {
+        'BASECHANNEL' : 'almalinux8-aarch64', 'PKGLIST' : RES8,
+        'DEST' : '/srv/www/htdocs/pub/repositories/almalinux/8/bootstrap/'
+    },
     'rockylinux-8-x86_64' : {
         'PDID' : [-24, 2007], 'BETAPDID' : [2066], 'PKGLIST' : RES8 + RES8_X86,
         'DEST' : '/srv/www/htdocs/pub/repositories/rockylinux/8/bootstrap/'

--- a/susemanager/susemanager.changes
+++ b/susemanager/susemanager.changes
@@ -1,3 +1,5 @@
+- Add missing aarch64 bootstrap definition for AlmaLinux 8
+
 -------------------------------------------------------------------
 Fri Nov 05 14:04:35 CET 2021 - jgonzalez@suse.com
 

--- a/utils/spacewalk-common-channels.ini
+++ b/utils/spacewalk-common-channels.ini
@@ -2912,7 +2912,7 @@ gpgkey_fingerprint = %(_uyuni_gpgkey_fingerprint)s
 repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/CentOS7-Uyuni-Client-Tools/CentOS_7/
 
 [almalinux8]
-archs    = x86_64
+archs    = x86_64, aarch64
 name     = AlmaLinux 8 (%(arch)s)
 gpgkey_url = https://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux
 gpgkey_id = 3ABB34F8
@@ -2922,35 +2922,35 @@ dist_map_release = 8
 
 [almalinux8-appstream]
 label    = %(base_channel)s-appstream
-archs    = x86_64
+archs    = x86_64, aarch64
 name     = AlmaLinux 8 AppStream (%(arch)s)
 base_channels = almalinux8-%(arch)s
 repo_url = https://repo.almalinux.org/almalinux/8/AppStream/%(arch)s/os/
 
 [almalinux8-extras]
 label    = %(base_channel)s-extras
-archs    = x86_64
+archs    = x86_64, aarch64
 name     = AlmaLinux 8 Extras (%(arch)s)
 base_channels = almalinux8-%(arch)s
 repo_url = https://repo.almalinux.org/almalinux/8/extras/%(arch)s/os/
 
 [almalinux8-powertools]
 label    = %(base_channel)s-powertools
-archs    = x86_64
+archs    = x86_64, aarch64
 name     = AlmaLinux 8 PowerTools (%(arch)s)
 base_channels = almalinux8-%(arch)s
 repo_url = https://repo.almalinux.org/almalinux/8/PowerTools/%(arch)s/os/
 
 [almalinux8-ha]
 label    = %(base_channel)s-ha
-archs    = x86_64
+archs    = x86_64, aarch64
 name     = AlmaLinux 8 High Availability (%(arch)s)
 base_channels = almalinux8-%(arch)s
 repo_url = https://repo.almalinux.org/almalinux/8/HighAvailability/%(arch)s/os/
 
 [almalinux8-uyuni-client]
 name     = Uyuni Client Tools for %(base_channel_name)s
-archs    = %(_x86_archs)s
+archs    = %(_x86_archs)s, aarch64
 base_channels = almalinux8-%(arch)s
 gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Stable:/EL8-Uyuni-Client-Tools/EL_8/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s
@@ -2959,7 +2959,7 @@ repo_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/
 
 [almalinux8-uyuni-client-devel]
 name     = Uyuni Client Tools for %(base_channel_name)s (Development)
-archs    = %(_x86_archs)s
+archs    = %(_x86_archs)s, aarch64
 base_channels = almalinux8-%(arch)s
 gpgkey_url = https://download.opensuse.org/repositories/systemsmanagement:/Uyuni:/Master:/EL8-Uyuni-Client-Tools/EL_8/repodata/repomd.xml.key
 gpgkey_id = %(_uyuni_gpgkey_id)s

--- a/utils/spacewalk-utils.changes
+++ b/utils/spacewalk-utils.changes
@@ -1,3 +1,5 @@
+- Enable aarch64 for AlmaLinux 8
+
 -------------------------------------------------------------------
 Fri Sep 17 12:12:12 CEST 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Add missing repositories for aarch64 for AlmaLinux 8. We did it for SUSE Manager, but not for Uyuni.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: Was added already.

- [x] **DONE**

## Test coverage
- No tests: Not covered by the testsuite as of today

- [x] **DONE**

## Links

Detected while doing https://github.com/uyuni-project/uyuni/pull/4471 for https://github.com/SUSE/spacewalk/issues/14445

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
