### PR TITLE
Detect correct xmlrpc function

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/BaseHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/BaseHandler.java
@@ -82,6 +82,7 @@ public class BaseHandler implements XmlRpcInvocationHandler {
      * @return the results of the method of the subclass
      * @exception XmlRpcFault if some error occurs
      */
+    @Override
     public Object invoke(String methodCalled, List params) throws XmlRpcFault {
         Class myClass = this.getClass();
         Method[] methods;
@@ -194,8 +195,13 @@ public class BaseHandler implements XmlRpcInvocationHandler {
     private Method findPerfectMethod(List params, List<Method> matchedMethods) {
         //now lets try to find one that matches parameters exactly
         for (Method currMethod : matchedMethods) {
+            log.debug("findPerfectMethod test:" + currMethod.toGenericString());
             Class[] types = currMethod.getParameterTypes();
             for (int i = 0; i < types.length; i++) {
+                if (log.isDebugEnabled()) {
+                    log.debug("  findPerfectMethod: compare: " + types[i].getCanonicalName() +
+                            " isAssignableFrom " + params.get(i).getClass().getCanonicalName());
+                }
                 //if we find a param that doesn't match, go to the next method
                 if (!types[i].isAssignableFrom(params.get(i).getClass())) {
                     break;
@@ -203,6 +209,7 @@ public class BaseHandler implements XmlRpcInvocationHandler {
                 //if we have gone through all of the params, and are here it is a
                 //      perfect match.
                 if (i == types.length - 1) {
+                    log.debug("  all parameter match");
                     return currMethod;
                 }
             }

--- a/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
+++ b/java/code/src/com/redhat/rhn/frontend/xmlrpc/system/SystemHandler.java
@@ -7742,7 +7742,7 @@ public class SystemHandler extends BaseHandler {
      * @xmlrpc.returntype #return_int_success()
      */
     public int bootstrap(User user, String host, Integer sshPort, String sshUser,
-            String sshPassword, String activationKey, boolean saltSSH) {
+            String sshPassword, String activationKey, Boolean saltSSH) {
         Optional<String> maybePassword = maybeString(sshPassword);
         List<String> activationKeys = maybeActivationKeys(activationKey);
         BootstrapParameters params = new BootstrapParameters(host, of(sshPort), sshUser, maybePassword, activationKeys,
@@ -7781,7 +7781,7 @@ public class SystemHandler extends BaseHandler {
      * @xmlrpc.returntype #return_int_success()
      */
     public int bootstrapWithPrivateSshKey(User user, String host, Integer sshPort, String sshUser,
-            String sshPrivKey, String sshPrivKeyPass, String activationKey, boolean saltSSH) {
+            String sshPrivKey, String sshPrivKeyPass, String activationKey, Boolean saltSSH) {
         List<String> activationKeys = maybeActivationKeys(activationKey);
         BootstrapParameters params = new BootstrapParameters(host, of(sshPort), sshUser, sshPrivKey,
                 maybeString(sshPrivKeyPass), activationKeys, empty(), true, empty());
@@ -7816,7 +7816,7 @@ public class SystemHandler extends BaseHandler {
      * @xmlrpc.returntype #return_int_success()
      */
     public int bootstrap(User user, String host, Integer sshPort, String sshUser,
-            String sshPassword, String activationKey, Integer proxyId, boolean saltSSH) {
+            String sshPassword, String activationKey, Integer proxyId, Boolean saltSSH) {
         Optional<String> maybePassword = maybeString(sshPassword);
         List<String> activationKeys = maybeActivationKeys(activationKey);
         BootstrapParameters params = new BootstrapParameters(host, of(sshPort), sshUser, maybePassword, activationKeys,
@@ -7857,7 +7857,7 @@ public class SystemHandler extends BaseHandler {
      * @xmlrpc.returntype #return_int_success()
      */
     public int bootstrapWithPrivateSshKey(User user, String host, Integer sshPort, String sshUser,
-            String sshPrivKey, String sshPrivKeyPass, String activationKey, Integer proxyId, boolean saltSSH) {
+            String sshPrivKey, String sshPrivKeyPass, String activationKey, Integer proxyId, Boolean saltSSH) {
         List<String> activationKeys = maybeActivationKeys(activationKey);
         BootstrapParameters params = new BootstrapParameters(host, of(sshPort), sshUser, sshPrivKey,
                 maybeString(sshPrivKeyPass), activationKeys, empty(), true, of(proxyId.longValue()));
@@ -7892,7 +7892,7 @@ public class SystemHandler extends BaseHandler {
      * @xmlrpc.returntype #return_int_success()
      */
     public int bootstrap(User user, String host, Integer sshPort, String sshUser,
-            String sshPassword, String activationKey, String reactivationKey, boolean saltSSH) {
+            String sshPassword, String activationKey, String reactivationKey, Boolean saltSSH) {
         Optional<String> maybePassword = maybeString(sshPassword);
         List<String> activationKeys = maybeActivationKeys(activationKey);
         BootstrapParameters params = new BootstrapParameters(host, of(sshPort), sshUser, maybePassword, activationKeys,
@@ -7934,7 +7934,7 @@ public class SystemHandler extends BaseHandler {
      */
     public int bootstrapWithPrivateSshKey(User user, String host, Integer sshPort, String sshUser,
             String sshPrivKey, String sshPrivKeyPass, String activationKey, String reactivationKey,
-            boolean saltSSH) {
+            Boolean saltSSH) {
         List<String> activationKeys = maybeActivationKeys(activationKey);
         BootstrapParameters params = new BootstrapParameters(host, of(sshPort), sshUser, sshPrivKey,
                 maybeString(sshPrivKeyPass), activationKeys, maybeString(reactivationKey), true, empty());
@@ -7972,7 +7972,7 @@ public class SystemHandler extends BaseHandler {
      */
     public int bootstrap(User user, String host, Integer sshPort, String sshUser,
             String sshPassword, String activationKey, String reactivationKey, Integer proxyId,
-            boolean saltSSH) {
+            Boolean saltSSH) {
         Optional<String> maybePassword = maybeString(sshPassword);
         List<String> activationKeys = maybeActivationKeys(activationKey);
         BootstrapParameters params = new BootstrapParameters(host, of(sshPort), sshUser, maybePassword, activationKeys,
@@ -8016,7 +8016,7 @@ public class SystemHandler extends BaseHandler {
      */
     public int bootstrapWithPrivateSshKey(User user, String host, Integer sshPort, String sshUser,
             String sshPrivKey, String sshPrivKeyPass, String activationKey, String reactivationKey,
-            Integer proxyId, boolean saltSSH) {
+            Integer proxyId, Boolean saltSSH) {
         List<String> activationKeys = maybeActivationKeys(activationKey);
         BootstrapParameters params = new BootstrapParameters(host, of(sshPort), sshUser, sshPrivKey,
                 maybeString(sshPrivKeyPass), activationKeys, maybeString(reactivationKey), true,

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- Fix calling wrong XMLRPC bootstrap method (bsc#1192736)
+
 -------------------------------------------------------------------
 Tue Nov 16 10:06:56 CET 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

For the XMLRPC function `bootstrap(...)` we used as last parameter the primitive type `boolean`.
This caused problems when detecting the right function. To find the function, the code look for the name and the same number of parameters like in the function call. In our case we fin 2:

```
int bootstrap(User, String, Integer, String, String, String, Integer, boolean)
int bootstrap(User, String, Integer, String, String, String, String, boolean)
```

The method `findPerfectMethod` compare now the XML converted type with the type in the signature.
As the XMLRPC library convert all types to Objects, we compare `boolean` with `Boolean`
which does not match.

In this case the first found method is used and a type convert is tried. But the first method is randomly changing and we could get sometimes the wrong one. As an Integer can be converted to a String and a Boolean into a boolean, the function can be called successfully.

Changing the function signature to use `Boolean` fix the problem.

Port of https://github.com/SUSE/spacewalk/pull/16391
## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
