### PR TITLE
exchange zypp-plugin dependency to use the python3 version

### DIFF
--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,5 @@
+- exchange zypp-plugin dependency to use the python3 version
+
 -------------------------------------------------------------------
 Tue Nov 16 10:03:10 CET 2021 - jgonzalez@suse.com
 

--- a/backend/spacewalk-backend.spec
+++ b/backend/spacewalk-backend.spec
@@ -241,7 +241,7 @@ Requires:       (python3-dateutil or python3-python-dateutil)
 %if 0%{?suse_version}
 Requires(pre):  libzypp(plugin:system) >= 0
 Requires:       apache2-prefork
-Requires:       zypp-plugin-python
+Requires:       python3-zypp-plugin
 %endif
 %if 0%{?fedora} || 0%{?rhel}
 Requires:       mod_ssl


### PR DESCRIPTION
## What does this PR change?

We still have a python2 dependency in a package which is already ported to python3.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/pull/16395 https://github.com/SUSE/spacewalk/pull/16396

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
