### PR TITLE
Small or cosmetical changes for test suite

### DIFF
--- a/testsuite/features/secondary/min_bootstrap_reactivation.feature
+++ b/testsuite/features/secondary/min_bootstrap_reactivation.feature
@@ -11,57 +11,57 @@ Feature: bootstrapping with reactivation key
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
-  Scenario: generate a re-activation key
-     Given I am on the Systems overview page of this "sle_minion"
-     When I follow "Reactivation"
-     And I click on "Generate New Key"
-     Then I should see a "Key:" text
+  Scenario: Generate a re-activation key
+    Given I am on the Systems overview page of this "sle_minion"
+    When I follow "Reactivation"
+    And I click on "Generate New Key"
+    Then I should see a "Key:" text
 
   Scenario: Bootstrap should fail when minion already exists
-     And I follow the left menu "Systems > Bootstrapping"
-     Then I should see a "Bootstrap Minions" text
-     When I enter the hostname of "sle_minion" as "hostname"
-     And I enter "22" as "port"
-     And I enter "root" as "user"
-     And I enter "linux" as "password"
-     And I click on "Bootstrap"
-     And I wait until I see "A salt key for this host" text
-     Then I should not see a "GenericSaltError" text
-     And I should see a "seems to already exist, please check!" text
+    When I follow the left menu "Systems > Bootstrapping"
+    Then I should see a "Bootstrap Minions" text
+    When I enter the hostname of "sle_minion" as "hostname"
+    And I enter "22" as "port"
+    And I enter "root" as "user"
+    And I enter "linux" as "password"
+    And I click on "Bootstrap"
+    And I wait until I see "A salt key for this host" text
+    Then I should not see a "GenericSaltError" text
+    And I should see a "seems to already exist, please check!" text
 
   Scenario: Bootstrap should fail when system already exists in the server
-     Given I delete "sle_minion" key in the Salt master
-     And I follow the left menu "Systems > Bootstrapping"
-     Then I should see a "Bootstrap Minions" text
-     When I enter the hostname of "sle_minion" as "hostname"
-     And I enter "22" as "port"
-     And I enter "root" as "user"
-     And I enter "linux" as "password"
-     And I click on "Bootstrap"
-     And I wait until I see "seems to already exist, please check!" text
-     Then I should not see a "GenericSaltError" text
-     And I should see a "with minion id" text
+    Given I delete "sle_minion" key in the Salt master
+    When I follow the left menu "Systems > Bootstrapping"
+    Then I should see a "Bootstrap Minions" text
+    When I enter the hostname of "sle_minion" as "hostname"
+    And I enter "22" as "port"
+    And I enter "root" as "user"
+    And I enter "linux" as "password"
+    And I click on "Bootstrap"
+    And I wait until I see "seems to already exist, please check!" text
+    Then I should not see a "GenericSaltError" text
+    And I should see a "with minion id" text
 
   Scenario: Bootstrap a SLES minion with reactivation key
-     And I follow the left menu "Systems > Bootstrapping"
-     Then I should see a "Bootstrap Minions" text
-     When I enter the hostname of "sle_minion" as "hostname"
-     And I enter "22" as "port"
-     And I enter "root" as "user"
-     And I enter "linux" as "password"
-     And I enter the reactivation key of "sle_minion"
-     And I click on "Bootstrap"
-     And I wait until I see "Successfully bootstrapped host!" text
-     And I follow the left menu "Systems > Overview"
-     And I wait until I see the name of "sle_minion", refreshing the page
-      
-  Scenario: Check that events history for the reactivation
-     Given I am on the Systems overview page of this "sle_minion"
-     When I follow "Events" in the content area
-     And I follow "History" in the content area
-     Then I wait until I see "Server reactivated as Salt minion" text, refreshing the page
+    When I follow the left menu "Systems > Bootstrapping"
+    Then I should see a "Bootstrap Minions" text
+    When I enter the hostname of "sle_minion" as "hostname"
+    And I enter "22" as "port"
+    And I enter "root" as "user"
+    And I enter "linux" as "password"
+    And I enter the reactivation key of "sle_minion"
+    And I click on "Bootstrap"
+    And I wait until I see "Successfully bootstrapped host!" text
+    And I follow the left menu "Systems > Overview"
+    And I wait until I see the name of "sle_minion", refreshing the page
 
-  Scenario: Cleanup: delete SLES minion system profile
+  Scenario: Check the events history for the reactivation
+    Given I am on the Systems overview page of this "sle_minion"
+    When I follow "Events" in the content area
+    And I follow "History" in the content area
+    And I wait until I see "Server reactivated as Salt minion" text, refreshing the page
+
+  Scenario: Cleanup: delete SLES minion after reactivation tests
     Given I am on the Systems overview page of this "sle_minion"
     When I follow "Delete System"
     Then I should see a "Confirm System Profile Deletion" text
@@ -70,17 +70,17 @@ Feature: bootstrapping with reactivation key
     Then "sle_minion" should not be registered
 
   Scenario: Cleanup: bootstrap a SLES minion after reactivation tests
-     When I follow the left menu "Systems > Bootstrapping"
-     Then I should see a "Bootstrap Minions" text
-     When I enter the hostname of "sle_minion" as "hostname"
-     And I enter "22" as "port"
-     And I enter "root" as "user"
-     And I enter "linux" as "password"
-     And I select the hostname of "proxy" from "proxies"
-     And I click on "Bootstrap"
-     And I wait until I see "Successfully bootstrapped host!" text
-     And I follow the left menu "Systems > Overview"
-     And I wait until I see the name of "sle_minion", refreshing the page
+    When I follow the left menu "Systems > Bootstrapping"
+    Then I should see a "Bootstrap Minions" text
+    When I enter the hostname of "sle_minion" as "hostname"
+    And I enter "22" as "port"
+    And I enter "root" as "user"
+    And I enter "linux" as "password"
+    And I select the hostname of "proxy" from "proxies"
+    And I click on "Bootstrap"
+    And I wait until I see "Successfully bootstrapped host!" text
+    And I follow the left menu "Systems > Overview"
+    And I wait until I see the name of "sle_minion", refreshing the page
 
   Scenario: Cleanup: subscribe again to base channel after reactivation tests
     Given I am on the Systems overview page of this "sle_minion"
@@ -93,4 +93,4 @@ Feature: bootstrapping with reactivation key
     Then I should see a "Confirm Software Channel Change" text
     When I click on "Confirm"
     Then I should see a "Changing the channels has been scheduled." text
-    And I wait until event "Subscribe channels scheduled by admin" is completed
+    When I wait until event "Subscribe channels scheduled by admin" is completed

--- a/testsuite/features/secondary/minssh_bootstrap_xmlrpc.feature
+++ b/testsuite/features/secondary/minssh_bootstrap_xmlrpc.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017-2021 SUSE LLC.
+# Copyright (c) 2017-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @scope_salt_ssh
@@ -9,7 +9,7 @@ Feature: Register a salt-ssh system via XML-RPC
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
 
-  Scenario: Setup XML-RPC bootstrap: delete SSH minion system profile
+  Scenario: Delete SSH minion system profile before XML-RPC bootstrap test
     Given I am on the Systems overview page of this "ssh_minion"
     When I follow "Delete System"
     Then I should see a "Confirm System Profile Deletion" text
@@ -23,9 +23,9 @@ Feature: Register a salt-ssh system via XML-RPC
     And I logout from XML-RPC system namespace
 
   Scenario: Check new XML-RPC bootstrapped salt-ssh system in System Overview page
-     And I follow the left menu "Systems > Overview"
-     And I wait until I see the name of "ssh_minion", refreshing the page
-     And I wait until onboarding is completed for "ssh_minion"
+    When I follow the left menu "Systems > Overview"
+    And I wait until I see the name of "ssh_minion", refreshing the page
+    And I wait until onboarding is completed for "ssh_minion"
 
   Scenario: Check contact method of this Salt SSH system
     Given I am on the Systems overview page of this "ssh_minion"
@@ -46,10 +46,10 @@ Feature: Register a salt-ssh system via XML-RPC
     Given I am on the Systems overview page of this "ssh_minion"
     Then I check for failed events on history event page
 
-  Scenario: Cleanup: subscribe SSH minion to base channel
+  Scenario: XML-RPC bootstrap: subscribe SSH minion to base channel
     Given I am on the Systems overview page of this "ssh_minion"
     When I follow "Software" in the content area
-    Then I follow "Software Channels" in the content area
+    And I follow "Software Channels" in the content area
     And I wait until I do not see "Loading..." text
     And I check radio button "Test-Channel-x86_64"
     And I wait until I do not see "Loading..." text

--- a/testsuite/features/secondary/srv_datepicker.feature
+++ b/testsuite/features/secondary/srv_datepicker.feature
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 SUSE LLC
+# Copyright (c) 2017-2021 SUSE LLC
 # Licensed under the terms of the MIT license.
 
 @scope_visualization
@@ -9,19 +9,19 @@ Feature: Pick dates
 
   Scenario: Log in as admin user
     Given I am authorized for the "Admin" section
+    And I am on the Systems overview page of this "sle_client"
 
   Scenario: Date picker is by default set to today
-    Given I am on the Systems overview page of this "sle_client"
-    And I follow "Remote Command" in the content area
+    When I follow "Remote Command" in the content area
     And I open the date picker
     Then the date picker title should be the current month and year
 
-  Scenario: Picking a time should set the hidden fields
-    Given I follow "Details" in the content area
+  Scenario: Picking a time sets the hidden fields
+    When I follow "Details" in the content area
     And I follow "Remote Command" in the content area
     And I enter "ls" as "Script"
-    And I pick "2016-08-27" as date
+    And I pick "2022-08-27" as date
     And I pick "17:30" as time
-    Then the date field is set to "2016-08-27"
-    And the time field is set to "17:30"
-    And the date picker is closed
+    Then the date field should be set to "2022-08-27"
+    And the time field should be set to "17:30"
+    And the date picker should be closed

--- a/testsuite/features/step_definitions/datepicker_steps.rb
+++ b/testsuite/features/step_definitions/datepicker_steps.rb
@@ -48,8 +48,8 @@ Given(/^I pick "([^"]*)" as date$/) do |desired_date|
   days_find(picker_days, value.day)
 end
 
-Then(/^the date field is set to "([^"]*)"$/) do |arg1|
-  value = Date.parse(arg1)
+Then(/^the date field should be set to "([^"]*)"$/) do |expected_date|
+  value = Date.parse(expected_date)
   # the fields that give backwards compatibility
   day_compat = find('input#date_day', visible: false)
   month_compat = find('input#date_month', visible: false)
@@ -65,7 +65,7 @@ Given(/^I open the date picker$/) do
   find('input[data-testid="date-picker"]').click
 end
 
-Then(/^the date picker is closed$/) do
+Then(/^the date picker should be closed$/) do
   raise unless has_no_css?('.datepicker')
 end
 
@@ -107,14 +107,14 @@ When(/^I schedule action to (\d+) minutes from now$/) do |minutes|
   execute_script("window.schedulePage.setScheduleTime('#{action_time}')")
 end
 
-Then(/^the time field is set to "([^"]*)"$/) do |arg1|
-  h, m = arg1.chomp.split(':').map(&:to_i)
+Then(/^the time field should be set to "([^"]*)"$/) do |expected_time|
+  h, m = expected_time.chomp.split(':').map(&:to_i)
   # the fields that give backwards compatibility
   h_compat = find('input#date_hour', visible: false)
   m_compat = find('input#date_minute', visible: false)
   ampm_compat = find('input#date_am_pm', visible: false)
 
-  raise if h_compat.value.to_i != h % 12
-  raise if m_compat.value.to_i != m
-  raise if ampm_compat.value.to_i != (h >= 12 ? 1 : 0)
+  raise 'invalid hidden hour' if h_compat.value.to_i != h % 12
+  raise 'invalid hidden minute' if m_compat.value.to_i != m
+  raise 'invalid hidden AM/PM' if ampm_compat.value.to_i != (h >= 12 ? 1 : 0)
 end

--- a/testsuite/features/support/xmlrpc_system.rb
+++ b/testsuite/features/support/xmlrpc_system.rb
@@ -46,9 +46,7 @@ class XMLRPCSystemTest < XMLRPCBaseTest
       @connection.call('system.bootstrap', @sid, host, 22, 'root', 'linux', activation_key, salt_ssh)
     else
       proxy = @connection.call('system.search_by_name', @sid, $proxy.ip)
-      # rubocop:disable Lint/NumberConversion
-      proxy_id = proxy.map { |s| s['id'] }.first.to_i
-      # rubocop:enable Lint/NumberConversion
+      proxy_id = proxy.map { |s| s['id'] }.first
       @connection.call('system.bootstrap', @sid, host, 22, 'root', 'linux', activation_key, proxy_id, salt_ssh)
     end
   end


### PR DESCRIPTION
## What does this PR change?

Many small or cosmetical changes, including:
* better error reporting for date picker tests
* remove unneeded `to_i` for XML-RPC tests


## Links

Ports:
* 4.1: SUSE/spacewalk#16398
* 4.2: SUSE/spacewalk#16397


## Changelogs

- [x] No changelog needed
