### PR TITLE
Fix legacy timepicker passing wrong time to the backend

### DIFF
--- a/java/code/src/com/redhat/rhn/frontend/taglibs/DateTimePickerTag.java
+++ b/java/code/src/com/redhat/rhn/frontend/taglibs/DateTimePickerTag.java
@@ -207,7 +207,7 @@ public class DateTimePickerTag extends TagSupport {
         out.append(createHiddenInput("minute", String.valueOf(data.getMinute())).render());
         if (data.isLatin()) {
             out.append(createHiddenInput("am_pm",
-                    String.valueOf((data.getHourOfDay() > 12) ? 1 : 0)).render());
+                    String.valueOf((data.getHourOfDay() >= 12) ? 1 : 0)).render());
         }
     }
 

--- a/web/html/src/manager/legacy/DateTimePicker.tsx
+++ b/web/html/src/manager/legacy/DateTimePicker.tsx
@@ -29,8 +29,6 @@ function mountDateTimePickerTo(mountingPoint: HTMLElement | null) {
 
   // Raw value is an ISO 8601 format date time string with timezone info intact, a-la `"2021-06-08T20:00+0100"`
   const rawValue = mountingPoint.getAttribute("data-value") || mountingPoint.innerText;
-  // We store the expected UTC offset separately so we can set it back before setting values for the legacy inputs
-  const utcOffset = localizedMoment.parseZone(rawValue).utcOffset();
   const initialValue = localizedMoment(rawValue);
   if (!rawValue || !initialValue.isValid()) {
     Loggerhead.error("Found no valid value for picker");
@@ -53,8 +51,10 @@ function mountDateTimePickerTo(mountingPoint: HTMLElement | null) {
     const [value, setValue] = useState(initialValue);
 
     const onChange = (value: moment.Moment) => {
-      // Create a copy of the value in the original UTC offset
-      const adjustedValue = localizedMoment(value).utcOffset(utcOffset);
+      // Per default the picker outputs the time in server timezone. Since in this case converting to
+      // server timezone is already done on the backend side we create a copy of the value in the user
+      // selected timezone to prevent applying the offset between server and user timezone twice.
+      const adjustedValue = localizedMoment(value).utc().tz(localizedMoment.userTimeZone);
       yearInput.value = adjustedValue.year().toString();
       monthInput.value = adjustedValue.month().toString();
       dateInput.value = adjustedValue.date().toString();
@@ -62,7 +62,7 @@ function mountDateTimePickerTo(mountingPoint: HTMLElement | null) {
       const hour = adjustedValue.hour();
       if (isAmPm) {
         hourInput.value = (hour > 12 ? hour % 12 : hour).toString();
-        amPmInput!.value = hour > 12 ? "1" : "0";
+        amPmInput!.value = hour >= 12 ? "1" : "0";
       } else {
         hourInput.value = hour.toString();
       }

--- a/web/spacewalk-web.changes
+++ b/web/spacewalk-web.changes
@@ -1,3 +1,8 @@
+- Fix legacy timepicker passing wrong time to the backend if server and
+  user time differ (bsc#1192699)
+- Fix legacy timepicker passing wrong time to the backend if selected
+  date is in summer time (bsc#1192776)
+
 -------------------------------------------------------------------
 Tue Nov 16 10:08:45 CET 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

Fix cases where the legacy `DateTimePicker` would pass the wrong time to the backend if selected date is in summer time or if server and user timezone differ.

As well as an issue where times between 12:00 and 12:59 would be parsed as 00:XX

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: **Bugfix**

- [x] **DONE**

## Test coverage

- No tests: **Bugfix**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/16384 
Tracks https://github.com/SUSE/spacewalk/issues/16406

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
