### PR TITLE
Testsuite: Adjust some scenarios and steps definition to work with "venv-salt-minion"

### DIFF
--- a/testsuite/features/secondary/min_salt_software_states.feature
+++ b/testsuite/features/secondary/min_salt_software_states.feature
@@ -122,13 +122,8 @@ Feature: Salt package states
     And I click on "Show full highstate output"
     And I wait until I see "No reply from minion" text
 
-  @uyuni
   Scenario: Cleanup: restart the salt service on SLES minion
-    When I run "rcvenv-salt-minion restart" on "sle_minion"
-
-  @susemanager
-  Scenario: Cleanup: restart the salt service on SLES minion
-    When I run "rcsalt-minion restart" on "sle_minion"
+    When I restart salt-minion on "sle_minion"
 
   Scenario: Cleanup: remove old packages from SLES minion
     When I disable repository "test_repo_rpm_pool" on this "sle_minion"

--- a/testsuite/features/secondary/min_salt_software_states.feature
+++ b/testsuite/features/secondary/min_salt_software_states.feature
@@ -116,8 +116,8 @@ Feature: Salt package states
 
   Scenario: Use Salt presence mechanism on an unreachable minion
     Then I follow "States" in the content area
-    And I run "pkill salt-minion" on "sle_minion"  without error control
-    And I run "pkill venv-salt-minion" on "sle_minion"  without error control
+    And I run "pkill salt-minion" on "sle_minion" without error control
+    And I run "pkill venv-salt-minion" on "sle_minion" without error control
     And I follow "Highstate" in the content area
     And I click on "Show full highstate output"
     And I wait until I see "No reply from minion" text

--- a/testsuite/features/secondary/min_salt_software_states.feature
+++ b/testsuite/features/secondary/min_salt_software_states.feature
@@ -116,7 +116,8 @@ Feature: Salt package states
 
   Scenario: Use Salt presence mechanism on an unreachable minion
     Then I follow "States" in the content area
-    And I run "pkill salt-minion|venv-salt-minion" on "sle_minion"
+    And I run "pkill salt-minion" on "sle_minion"  without error control
+    And I run "pkill venv-salt-minion" on "sle_minion"  without error control
     And I follow "Highstate" in the content area
     And I click on "Show full highstate output"
     And I wait until I see "No reply from minion" text

--- a/testsuite/features/secondary/min_salt_software_states.feature
+++ b/testsuite/features/secondary/min_salt_software_states.feature
@@ -116,11 +116,16 @@ Feature: Salt package states
 
   Scenario: Use Salt presence mechanism on an unreachable minion
     Then I follow "States" in the content area
-    And I run "pkill salt-minion" on "sle_minion"
+    And I run "pkill salt-minion|venv-salt-minion" on "sle_minion"
     And I follow "Highstate" in the content area
     And I click on "Show full highstate output"
     And I wait until I see "No reply from minion" text
 
+  @uyuni
+  Scenario: Cleanup: restart the salt service on SLES minion
+    When I run "rcvenv-salt-minion restart" on "sle_minion"
+
+  @susemanager
   Scenario: Cleanup: restart the salt service on SLES minion
     When I run "rcsalt-minion restart" on "sle_minion"
 

--- a/testsuite/features/secondary/minkvm_guests.feature
+++ b/testsuite/features/secondary/minkvm_guests.feature
@@ -448,9 +448,14 @@ Feature: Be able to manage KVM virtual machines via the GUI
     When I run "zypper -n mr -e --all" on "kvm_server" without error control
     And I run "zypper -n rr SUSE-Manager-Bootstrap" on "kvm_server" without error control
     And I run "systemctl stop salt-minion" on "kvm_server" without error control
+    And I run "systemctl stop venv-salt-minion" on "kvm_server" without error control
     And I run "rm /etc/salt/minion.d/susemanager*" on "kvm_server" without error control
     And I run "rm /etc/salt/minion.d/libvirt-events.conf" on "kvm_server" without error control
     And I run "rm /etc/salt/pki/minion/minion_master.pub" on "kvm_server" without error control
+    # Now in case of venv-salt-minion
+    And I run "rm /etc/venv-salt-minion/minion.d/susemanager*" on "kvm_server" without error control
+    And I run "rm /etc/venv-salt-minion/minion.d/libvirt-events.conf" on "kvm_server" without error control
+    And I run "rm /etc/venv-salt-minion/pki/minion/minion_master.pub" on "kvm_server" without error control
     # In case the delete VM test failed we need to clean up ourselves.
     And I run "virsh undefine --remove-all-storage test-vm" on "kvm_server" without error control
     And I run "virsh destroy test-vm2" on "kvm_server" without error control

--- a/testsuite/features/secondary/minkvm_guests.feature
+++ b/testsuite/features/secondary/minkvm_guests.feature
@@ -447,7 +447,6 @@ Feature: Be able to manage KVM virtual machines via the GUI
   Scenario: Cleanup: Cleanup KVM virtualization host
     When I run "zypper -n mr -e --all" on "kvm_server" without error control
     And I run "zypper -n rr SUSE-Manager-Bootstrap" on "kvm_server" without error control
-    And I run "systemctl stop salt-minion" on "kvm_server" without error control
     And I stop salt-minion on "kvm_server"
     And I run "rm /etc/salt/minion.d/susemanager*" on "kvm_server" without error control
     And I run "rm /etc/salt/minion.d/libvirt-events.conf" on "kvm_server" without error control

--- a/testsuite/features/secondary/minkvm_guests.feature
+++ b/testsuite/features/secondary/minkvm_guests.feature
@@ -448,14 +448,10 @@ Feature: Be able to manage KVM virtual machines via the GUI
     When I run "zypper -n mr -e --all" on "kvm_server" without error control
     And I run "zypper -n rr SUSE-Manager-Bootstrap" on "kvm_server" without error control
     And I run "systemctl stop salt-minion" on "kvm_server" without error control
-    And I run "systemctl stop venv-salt-minion" on "kvm_server" without error control
+    And I stop salt-minion on "kvm_server"
     And I run "rm /etc/salt/minion.d/susemanager*" on "kvm_server" without error control
     And I run "rm /etc/salt/minion.d/libvirt-events.conf" on "kvm_server" without error control
     And I run "rm /etc/salt/pki/minion/minion_master.pub" on "kvm_server" without error control
-    # Now in case of venv-salt-minion
-    And I run "rm /etc/venv-salt-minion/minion.d/susemanager*" on "kvm_server" without error control
-    And I run "rm /etc/venv-salt-minion/minion.d/libvirt-events.conf" on "kvm_server" without error control
-    And I run "rm /etc/venv-salt-minion/pki/minion/minion_master.pub" on "kvm_server" without error control
     # In case the delete VM test failed we need to clean up ourselves.
     And I run "virsh undefine --remove-all-storage test-vm" on "kvm_server" without error control
     And I run "virsh destroy test-vm2" on "kvm_server" without error control
@@ -466,3 +462,9 @@ Feature: Be able to manage KVM virtual machines via the GUI
     And I delete test-pool0 virtual storage pool on "kvm_server" without error control
     And I delete test-pool1 virtual storage pool on "kvm_server" without error control
     And I delete all "test-vm.*" volumes from "test-pool0" pool on "kvm_server" without error control
+
+  @uyuni
+  Scenario: Cleanup: Cleanup venv-salt-minion files from KVM virtualization host
+    And I run "rm /etc/venv-salt-minion/minion.d/susemanager*" on "kvm_server" without error control
+    And I run "rm /etc/venv-salt-minion/minion.d/libvirt-events.conf" on "kvm_server" without error control
+    And I run "rm /etc/venv-salt-minion/pki/minion/minion_master.pub" on "kvm_server" without error control

--- a/testsuite/features/secondary/trad_migrate_to_minion.feature
+++ b/testsuite/features/secondary/trad_migrate_to_minion.feature
@@ -92,7 +92,7 @@ Feature: Migrate a traditional client into a Salt minion
     And I wait until I see "has been deleted" text
     Then "sle_client" should not be registered
 
-  @uyuni
+  @susemanager
   Scenario: Cleanup: register minion again as traditional client
     When I enable client tools repositories on "sle_client"
     And I install the traditional stack utils on "sle_client"
@@ -100,7 +100,7 @@ Feature: Migrate a traditional client into a Salt minion
     And I bootstrap traditional client "sle_client" using bootstrap script with activation key "1-SUSE-KEY-x86_64" from the proxy
     Then I should see "sle_client" via spacecmd
 
-  @susemanager
+  @uyuni
   Scenario: Cleanup: register minion again as traditional client
     When I enable client tools repositories on "sle_client"
     And I install the traditional stack utils on "sle_client"

--- a/testsuite/features/secondary/trad_migrate_to_minion.feature
+++ b/testsuite/features/secondary/trad_migrate_to_minion.feature
@@ -92,10 +92,19 @@ Feature: Migrate a traditional client into a Salt minion
     And I wait until I see "has been deleted" text
     Then "sle_client" should not be registered
 
+  @uyuni
   Scenario: Cleanup: register minion again as traditional client
     When I enable client tools repositories on "sle_client"
     And I install the traditional stack utils on "sle_client"
     And I remove package "salt-minion" from this "sle_client"
+    And I bootstrap traditional client "sle_client" using bootstrap script with activation key "1-SUSE-KEY-x86_64" from the proxy
+    Then I should see "sle_client" via spacecmd
+
+  @susemanager
+  Scenario: Cleanup: register minion again as traditional client
+    When I enable client tools repositories on "sle_client"
+    And I install the traditional stack utils on "sle_client"
+    And I remove package "venv-salt-minion" from this "sle_client"
     And I bootstrap traditional client "sle_client" using bootstrap script with activation key "1-SUSE-KEY-x86_64" from the proxy
     Then I should see "sle_client" via spacecmd
 


### PR DESCRIPTION
## What does this PR change?

Since we are introducing the Salt Bundle for the registered clients, this PR adjusts some scenarios and steps definition in order to deal with the case where `venv-salt-minion` and not `salt-minion` is installed in the instances where the testsuite is running.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/14325

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
