### PR TITLE
Bootstrap with broken repos

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/channels/gpg-keys.sls
+++ b/susemanager-utils/susemanager-sls/salt/channels/gpg-keys.sls
@@ -47,6 +47,7 @@ install_gnupg_debian:
   pkg.latest:
     - pkgs:
       - gnupg
+    - refresh: False
 
 trust_suse_manager_tools_deb_gpg_key:
   mgrcompat.module_run:

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,4 @@
+- fix bootstrapping with unavailable repositories (bsc#1191925)
 - Use global import for which_bin in sumautil module
 - Get the formula pillar data from the database
 - Use flat repositories format for Debian based systems


### PR DESCRIPTION
## What does this PR change?

Make it possible to bootstrap a system which has unavailable repositories configured.
The idea:
- force a refresh of all repos and ignore errors if a repository is not available
- any package installation which happens during the bootstrap phase, happens without refreshing the repositories and use just the available data
- as last step all repositories not provided by Uyuni are disabled, which disable also the broken once

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: **add explanation**
- No tests: already covered
- Unit tests were added
- Cucumber tests were added

- [ ] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/16216
Tracks # **add downstream PR, if any**

- [ ] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

https://ci.nue.suse.com/view/Manager/view/Uyuni-PRs/job/uyuni-prs-ci-tests/1011/