### PR TITLE
use a permanent config key for SSHMinionActionExecutor parallel threads

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/TaskoJob.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/TaskoJob.java
@@ -14,14 +14,11 @@
  */
 package com.redhat.rhn.taskomatic;
 
-import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.common.hibernate.HibernateFactory;
 import com.redhat.rhn.taskomatic.domain.TaskoRun;
 import com.redhat.rhn.taskomatic.domain.TaskoSchedule;
 import com.redhat.rhn.taskomatic.domain.TaskoTask;
 import com.redhat.rhn.taskomatic.domain.TaskoTemplate;
-import com.redhat.rhn.taskomatic.task.MinionActionExecutor;
-import com.redhat.rhn.taskomatic.task.RepoSyncTask;
 import com.redhat.rhn.taskomatic.task.RhnJob;
 import com.redhat.rhn.taskomatic.task.RhnQueueJob;
 import com.redhat.rhn.taskomatic.task.TaskHelper;
@@ -35,7 +32,6 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -53,7 +49,6 @@ public class TaskoJob implements Job {
     private static final DateTimeFormatter TIMESTAMP_FORMAT = DateTimeFormatter.ofPattern("HH:mm:ss")
             .withZone(ZoneId.systemDefault());
 
-    private static final Map<String, Integer> DEFAULT_RESCHEDULE_TIMES = new HashMap<>();
 
     private Long scheduleId;
 
@@ -63,9 +58,6 @@ public class TaskoJob implements Job {
             lastStatus.put(task.getName(), TaskoRun.STATUS_FINISHED);
         }
         TaskoFactory.closeSession();
-
-        DEFAULT_RESCHEDULE_TIMES.put("taskomatic." + MinionActionExecutor.class.getName() + ".reschedule_time", 10);
-        DEFAULT_RESCHEDULE_TIMES.put("taskomatic." + RepoSyncTask.class.getName() + ".reschedule_time", 30);
     }
 
     /**
@@ -105,9 +97,8 @@ public class TaskoJob implements Job {
         return tasks.get(task.getName()) > 0;
     }
 
-    private boolean isTaskThreadAvailable(TaskoTask task) {
-        return tasks.get(task.getName()) < Config.get().getInt("taskomatic." +
-                task.getTaskClass() + ".parallel_threads", 1);
+    private boolean isTaskThreadAvailable(RhnJob job, TaskoTask task) {
+        return tasks.get(task.getName()) < job.getParallelThreads();
     }
 
     private static synchronized void markTaskRunning(TaskoTask task) {
@@ -152,92 +143,82 @@ public class TaskoJob implements Job {
                         log.debug(schedule.getJobLabel() + ":" + " task " + task.getName() +
                                 " already running ... LEAVING");
                         previousRun = null;
-                        continue;
                     }
                 }
                 else {
-                    if (!isTaskThreadAvailable(task)) {
-                        String rescheduleTimeKey = "taskomatic." + task.getTaskClass() + ".reschedule_time";
-                        int rescheduleSeconds = Config.get().getInt(rescheduleTimeKey,
-                                DEFAULT_RESCHEDULE_TIMES.getOrDefault(rescheduleTimeKey, 10));
-                        log.info(schedule.getJobLabel() + " RESCHEDULED in " + rescheduleSeconds + " seconds");
-                        TaskoQuartzHelper.rescheduleJob(schedule,
-                                ZonedDateTime.now().plusSeconds(rescheduleSeconds).toInstant());
-                        continue;
-                    }
-                }
-                markTaskRunning(task);
-
-                try {
-                    log.debug(schedule.getJobLabel() + ":" + " task " + task.getName() +
-                            " started");
-                    TaskoRun taskRun = new TaskoRun(schedule.getOrgId(), template, scheduleId);
-                    TaskoFactory.save(taskRun);
-                    HibernateFactory.commitTransaction();
-                    HibernateFactory.closeSession();
-
-                    Class jobClass = null;
-                    RhnJob job = null;
-                    try {
-                        jobClass = Class.forName(template.getTask().getTaskClass());
-                        job = (RhnJob) jobClass.newInstance();
-                    }
-                    catch (Exception e) {
-                        String errorLog = e.getClass().toString() + ": " +
-                                e.getMessage() + '\n' + e.getCause() + '\n';
-                        taskRun.appendToErrorLog(errorLog);
-                        taskRun.saveStatus(TaskoRun.STATUS_FAILED);
-                        HibernateFactory.commitTransaction();
-                        HibernateFactory.closeSession();
-                        // log the exception properly to the rhn_taskomatic_daemon.log log
-                        e.printStackTrace();
-                        return;
-                    }
 
                     try {
-                        job.execute(context, taskRun);
-                    }
-                    catch (Exception e) {
-                        if (HibernateFactory.getSession().getTransaction().isActive()) {
-                            HibernateFactory.rollbackTransaction();
-                            HibernateFactory.closeSession();
-                        }
-                        job.appendExceptionToLogError(e);
-                        taskRun.failed();
-                        HibernateFactory.commitTransaction();
-                        HibernateFactory.closeSession();
-                    }
-
-                    // rollback everything, what the application changed and didn't committed
-                    if (TaskoFactory.getSession().getTransaction().isActive()) {
-                        TaskoFactory.rollbackTransaction();
-                        HibernateFactory.closeSession();
-                    }
-
-                    log.debug(task.getName() + " (" + schedule.getJobLabel() + ") ... " +
-                            taskRun.getStatus().toLowerCase());
-                    if (((taskRun.getStatus() == TaskoRun.STATUS_FINISHED) ||
-                            (taskRun.getStatus() == TaskoRun.STATUS_FAILED)) &&
-                            (taskRun.getStatus() != lastStatus.get(task.getName()))) {
-                        String email = "Taskomatic bunch " + schedule.getBunch().getName() +
-                                " was scheduled to run within the " + schedule.getJobLabel() +
-                                " schedule.\n\n" + "Subtask " + task.getName();
-                        if (taskRun.getStatus() == TaskoRun.STATUS_FAILED) {
-                            email += " failed.\n\n" + "For more information check ";
-                            email += taskRun.getStdErrorPath() + ".";
+                        Class<RhnJob> jobClass = (Class<RhnJob>) Class.forName(template.getTask().getTaskClass());
+                        RhnJob job = jobClass.getDeclaredConstructor().newInstance();
+                        int rescheduleSeconds = job.getRescheduleTime();
+                        if (!isTaskThreadAvailable(job, task)) {
+                            log.info(schedule.getJobLabel() + " RESCHEDULED in " + rescheduleSeconds + " seconds");
+                            TaskoQuartzHelper.rescheduleJob(schedule,
+                                    ZonedDateTime.now().plusSeconds(rescheduleSeconds).toInstant());
                         }
                         else {
-                            email += " finished successfully and is back to normal.";
+
+                            markTaskRunning(task);
+
+                            try {
+                                log.debug(schedule.getJobLabel() + ":" + " task " + task.getName() +
+                                        " started");
+                                TaskoRun taskRun = new TaskoRun(schedule.getOrgId(), template, scheduleId);
+                                TaskoFactory.save(taskRun);
+                                HibernateFactory.commitTransaction();
+                                HibernateFactory.closeSession();
+
+                                try {
+                                    job.execute(context, taskRun);
+                                }
+                                catch (Exception e) {
+                                    if (HibernateFactory.getSession().getTransaction().isActive()) {
+                                        HibernateFactory.rollbackTransaction();
+                                        HibernateFactory.closeSession();
+                                    }
+                                    job.appendExceptionToLogError(e);
+                                    taskRun.failed();
+                                    HibernateFactory.commitTransaction();
+                                    HibernateFactory.closeSession();
+                                }
+
+                                // rollback everything, what the application changed and didn't committed
+                                if (TaskoFactory.getSession().getTransaction().isActive()) {
+                                    TaskoFactory.rollbackTransaction();
+                                    HibernateFactory.closeSession();
+                                }
+
+                                log.debug(task.getName() + " (" + schedule.getJobLabel() + ") ... " +
+                                        taskRun.getStatus().toLowerCase());
+                                if (((taskRun.getStatus() == TaskoRun.STATUS_FINISHED) ||
+                                        (taskRun.getStatus() == TaskoRun.STATUS_FAILED)) &&
+                                        (taskRun.getStatus() != lastStatus.get(task.getName()))) {
+                                    String email = "Taskomatic bunch " + schedule.getBunch().getName() +
+                                            " was scheduled to run within the " + schedule.getJobLabel() +
+                                            " schedule.\n\n" + "Subtask " + task.getName();
+                                    if (taskRun.getStatus() == TaskoRun.STATUS_FAILED) {
+                                        email += " failed.\n\n" + "For more information check ";
+                                        email += taskRun.getStdErrorPath() + ".";
+                                    }
+                                    else {
+                                        email += " finished successfully and is back to normal.";
+                                    }
+                                    log.info("Sending e-mail ... " + task.getName());
+                                    TaskHelper.sendTaskoEmail(taskRun.getOrgId(), email);
+                                    lastStatus.put(task.getName(), taskRun.getStatus());
+                                }
+                                previousRun = taskRun;
+                            }
+                            finally {
+                                unmarkTaskRunning(task);
+                            }
                         }
-                        log.info("Sending e-mail ... " + task.getName());
-                        TaskHelper.sendTaskoEmail(taskRun.getOrgId(), email);
-                        lastStatus.put(task.getName(), taskRun.getStatus());
                     }
-                    previousRun = taskRun;
+                    catch (Exception e) {
+                        log.error(e);
+                    }
                 }
-                finally {
-                    unmarkTaskRunning(task);
-                }
+
             }
             else {
                 log.info("Interrupting " + schedule.getBunch().getName() +

--- a/java/code/src/com/redhat/rhn/taskomatic/TaskoJob.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/TaskoJob.java
@@ -138,12 +138,10 @@ public class TaskoJob implements Job {
                     (previousRun.getStatus().equals(template.getStartIf()))) {
                 TaskoTask task = template.getTask();
 
-                if (isTaskSingleThreaded(task)) {
-                    if (isTaskRunning(task)) {
-                        log.debug(schedule.getJobLabel() + ":" + " task " + task.getName() +
-                                " already running ... LEAVING");
-                        previousRun = null;
-                    }
+                if (isTaskSingleThreaded(task) && isTaskRunning(task)) {
+                    log.debug(schedule.getJobLabel() + ":" + " task " + task.getName() +
+                            " already running ... LEAVING");
+                    previousRun = null;
                 }
                 else {
 

--- a/java/code/src/com/redhat/rhn/taskomatic/task/AutoErrataTask.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/AutoErrataTask.java
@@ -57,6 +57,11 @@ public class AutoErrataTask extends RhnJavaJob {
 
     private Queue<Action> actionsToSchedule = new LinkedList<>();
 
+    @Override
+    public String getConfigNamespace() {
+        return "auto_errata";
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/java/code/src/com/redhat/rhn/taskomatic/task/CVEServerChannels.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/CVEServerChannels.java
@@ -27,6 +27,11 @@ import java.util.Date;
  */
 public class CVEServerChannels extends RhnJavaJob {
 
+    @Override
+    public String getConfigNamespace() {
+        return "cve_server_channels";
+    }
+
     /**
      * @param context the job execution context
      * @see org.quartz.Job#execute(org.quartz.JobExecutionContext)

--- a/java/code/src/com/redhat/rhn/taskomatic/task/ChangeLogCleanUp.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/ChangeLogCleanUp.java
@@ -28,6 +28,11 @@ import java.util.HashMap;
  */
 public class ChangeLogCleanUp extends RhnJavaJob {
 
+    @Override
+    public String getConfigNamespace() {
+        return "changelog_cleanup";
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/java/code/src/com/redhat/rhn/taskomatic/task/ChannelRepodata.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/ChannelRepodata.java
@@ -36,6 +36,11 @@ public class ChannelRepodata extends RhnQueueJob {
     }
 
     @Override
+    public String getConfigNamespace() {
+        return "channel_repodata";
+    }
+
+    @Override
     protected Class getDriverClass() {
         return ChannelRepodataDriver.class;
     }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/ClearLogHistory.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/ClearLogHistory.java
@@ -34,6 +34,12 @@ import java.util.List;
 public class ClearLogHistory extends RhnJavaJob {
 
     private static final Integer DEFAULT_DAYS_VALUE = 7;
+
+    @Override
+    public String getConfigNamespace() {
+        return "clear_log_history";
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/java/code/src/com/redhat/rhn/taskomatic/task/CobblerSyncTask.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/CobblerSyncTask.java
@@ -55,6 +55,11 @@ public class CobblerSyncTask extends RhnJavaJob {
         distroWarnCount = 0;
     }
 
+    @Override
+    public String getConfigNamespace() {
+        return "cobbler_sync";
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/java/code/src/com/redhat/rhn/taskomatic/task/CompareConfigFilesTask.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/CompareConfigFilesTask.java
@@ -47,6 +47,11 @@ public class CompareConfigFilesTask extends RhnJavaJob {
     public CompareConfigFilesTask() {
     }
 
+    @Override
+    public String getConfigNamespace() {
+        return "compare_config_files";
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/java/code/src/com/redhat/rhn/taskomatic/task/DailySummary.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/DailySummary.java
@@ -56,6 +56,11 @@ public class DailySummary extends RhnJavaJob {
     private static final String ERRATA_UPDATE = "Errata Update";
     private static final String ERRATA_INDENTION = StringUtils.repeat(" ", ERRATA_SPACER);
 
+    @Override
+    public String getConfigNamespace() {
+        return "daily_summary";
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/java/code/src/com/redhat/rhn/taskomatic/task/ErrataCacheTask.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/ErrataCacheTask.java
@@ -28,6 +28,11 @@ public class ErrataCacheTask extends RhnQueueJob {
     private static Logger log = null;
 
     @Override
+    public String getConfigNamespace() {
+        return "errata_cache";
+    }
+
+    @Override
     protected Logger getLogger() {
         if (log == null) {
             log = Logger.getLogger(ErrataCacheTask.class);

--- a/java/code/src/com/redhat/rhn/taskomatic/task/ErrataMailer.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/ErrataMailer.java
@@ -44,6 +44,11 @@ import java.util.Map;
  */
 public class ErrataMailer extends RhnJavaJob {
 
+    @Override
+    public String getConfigNamespace() {
+        return "errata_mailer";
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/java/code/src/com/redhat/rhn/taskomatic/task/ErrataQueue.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/ErrataQueue.java
@@ -29,6 +29,11 @@ public class ErrataQueue extends RhnQueueJob {
     private static Logger log = null;
 
     @Override
+    public String getConfigNamespace() {
+        return "errata_queue";
+    }
+
+    @Override
     protected Logger getLogger() {
         if (log == null) {
             log = Logger.getLogger(ErrataQueue.class);

--- a/java/code/src/com/redhat/rhn/taskomatic/task/ForwardRegistrationTask.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/ForwardRegistrationTask.java
@@ -39,6 +39,11 @@ import java.util.concurrent.ThreadLocalRandom;
 public class ForwardRegistrationTask extends RhnJavaJob {
 
     @Override
+    public String getConfigNamespace() {
+        return "forward_registration";
+    }
+
+    @Override
     public void execute(JobExecutionContext arg0) throws JobExecutionException {
         if (!ConfigDefaults.get().isForwardRegistrationEnabled()) {
             log.debug("Forwarding registrations disabled");

--- a/java/code/src/com/redhat/rhn/taskomatic/task/KickstartCleanup.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/KickstartCleanup.java
@@ -39,6 +39,11 @@ import java.util.Map;
 
 public class KickstartCleanup extends RhnJavaJob {
 
+    @Override
+    public String getConfigNamespace() {
+        return "kickstart_cleanup";
+    }
+
     /**
      * Primarily a convenience method to make testing easier
      * @param ctx Quartz job runtime environment

--- a/java/code/src/com/redhat/rhn/taskomatic/task/KickstartFileSyncTask.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/KickstartFileSyncTask.java
@@ -37,6 +37,11 @@ import java.util.List;
  */
 public class KickstartFileSyncTask extends RhnJavaJob {
 
+    @Override
+    public String getConfigNamespace() {
+        return "kickstart_filesync";
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/java/code/src/com/redhat/rhn/taskomatic/task/MgrSyncRefresh.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/MgrSyncRefresh.java
@@ -41,6 +41,11 @@ public class MgrSyncRefresh extends RhnJavaJob {
 
     private static final String NO_REPO_SYNC_KEY = "noRepoSync";
 
+    @Override
+    public String getConfigNamespace() {
+        return "mgrsyncrefresh";
+    }
+
     /**
      * {@inheritDoc}
      * @throws JobExecutionException in case of errors during mgr-inter-sync execution

--- a/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionChainCleanup.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionChainCleanup.java
@@ -28,6 +28,11 @@ public class MinionActionChainCleanup extends RhnJavaJob {
 
     private final MinionActionUtils minionActionUtils = GlobalInstanceHolder.MINION_ACTION_UTILS;
 
+    @Override
+    public String getConfigNamespace() {
+        return "minion_actionchain_cleanup";
+    }
+
     /**
      * @param context the job execution context
      * @see org.quartz.Job#execute(JobExecutionContext)

--- a/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionChainExecutor.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionChainExecutor.java
@@ -41,6 +41,11 @@ public class MinionActionChainExecutor extends RhnJavaJob {
 
     private final SaltServerActionService saltServerActionService = GlobalInstanceHolder.SALT_SERVER_ACTION_SERVICE;
 
+    @Override
+    public String getConfigNamespace() {
+        return "minion_actionchain_executor";
+    }
+
     /**
      * @param context the job execution context
      * @see org.quartz.Job#execute(JobExecutionContext)

--- a/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionCleanup.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionCleanup.java
@@ -30,6 +30,11 @@ public class MinionActionCleanup extends RhnJavaJob {
 
     private final MinionActionUtils minionActionUtils = GlobalInstanceHolder.MINION_ACTION_UTILS;
 
+    @Override
+    public String getConfigNamespace() {
+        return "minion_action_cleanup";
+    }
+
     /**
      * @param context the job execution context
      * @see org.quartz.Job#execute(JobExecutionContext)

--- a/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionExecutor.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/MinionActionExecutor.java
@@ -46,6 +46,16 @@ public class MinionActionExecutor extends RhnJavaJob {
 
     private SaltServerActionService saltServerActionService = GlobalInstanceHolder.SALT_SERVER_ACTION_SERVICE;
 
+    @Override
+    public int getDefaultRescheduleTime() {
+        return 10;
+    }
+
+    @Override
+    public String getConfigNamespace() {
+        return "minion_action_executor";
+    }
+
     /**
      * @param context the job execution context
      * @see org.quartz.Job#execute(JobExecutionContext)

--- a/java/code/src/com/redhat/rhn/taskomatic/task/MinionCheckin.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/MinionCheckin.java
@@ -35,6 +35,11 @@ public class MinionCheckin extends RhnJavaJob {
 
     private SaltApi saltApi = GlobalInstanceHolder.SALT_API;
 
+    @Override
+    public String getConfigNamespace() {
+        return "minion_checkin";
+    }
+
     /**
      * @param context the job execution context
      * @see org.quartz.Job#execute(JobExecutionContext)

--- a/java/code/src/com/redhat/rhn/taskomatic/task/ModularDataCleanup.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/ModularDataCleanup.java
@@ -41,6 +41,11 @@ public class ModularDataCleanup extends RhnJavaJob {
     private static final String MODULES_REL_PATH = "rhn/modules";
 
     @Override
+    public String getConfigNamespace() {
+        return "modular_data_cleanup";
+    }
+
+    @Override
     public void execute(JobExecutionContext jobExecutionContext) throws JobExecutionException {
         Set<String> usedModularDataPaths = HibernateFactory.getSession()
                 .createQuery("SELECT DISTINCT(m.relativeFilename) FROM Modules m", String.class)

--- a/java/code/src/com/redhat/rhn/taskomatic/task/NotificationsCleanup.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/NotificationsCleanup.java
@@ -30,6 +30,11 @@ import java.util.Date;
 public class NotificationsCleanup extends RhnJavaJob {
 
     @Override
+    public String getConfigNamespace() {
+        return "notification_cleanup";
+    }
+
+    @Override
     public void execute(JobExecutionContext arg0In) throws JobExecutionException {
         if (log.isDebugEnabled()) {
             log.debug("start notifications cleanup");

--- a/java/code/src/com/redhat/rhn/taskomatic/task/PackageCleanup.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/PackageCleanup.java
@@ -37,6 +37,11 @@ import java.util.Map;
 
 public class PackageCleanup extends RhnJavaJob {
 
+    @Override
+    public String getConfigNamespace() {
+        return "package_cleanup";
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/java/code/src/com/redhat/rhn/taskomatic/task/RebootActionCleanup.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/RebootActionCleanup.java
@@ -44,6 +44,11 @@ import java.util.Map;
  */
 public class RebootActionCleanup extends RhnJavaJob {
 
+    @Override
+    public String getConfigNamespace() {
+        return "reboot_action_cleanup";
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/java/code/src/com/redhat/rhn/taskomatic/task/RecurringStateApplyJob.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/RecurringStateApplyJob.java
@@ -35,6 +35,11 @@ public class RecurringStateApplyJob extends RhnJavaJob {
 
     private static MaintenanceManager maintenanceManager = new MaintenanceManager();
 
+    @Override
+    public String getConfigNamespace() {
+        return "recurring_state_apply";
+    }
+
     /**
      * Schedule highstate application.
      *

--- a/java/code/src/com/redhat/rhn/taskomatic/task/RepoSyncTask.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/RepoSyncTask.java
@@ -42,6 +42,11 @@ import java.util.Optional;
  */
 public class RepoSyncTask extends RhnJavaJob {
 
+    @Override
+    public String getConfigNamespace() {
+        return "reposync";
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/java/code/src/com/redhat/rhn/taskomatic/task/RepoSyncTask.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/RepoSyncTask.java
@@ -43,6 +43,11 @@ import java.util.Optional;
 public class RepoSyncTask extends RhnJavaJob {
 
     @Override
+    public int getDefaultRescheduleTime() {
+        return 30;
+    }
+
+    @Override
     public String getConfigNamespace() {
         return "reposync";
     }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/RhnJob.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/RhnJob.java
@@ -34,20 +34,34 @@ public interface RhnJob extends Job {
      */
     String getConfigNamespace();
 
+    /**
+     * @return default fallback value for number of parallel threads used
+     */
     default int getDefaultParallelThreads() {
         return 1;
     }
 
+    /**
+     * Gets the number of parallel threads for this job either from config or a fallback value
+     * @return number of parallel
+     */
     default int getParallelThreads() {
         return Config.get().getInt("taskomatic." + getConfigNamespace() + "." + "parallel_threads",
                 Config.get().getInt("taskomatic." + this.getClass().getCanonicalName() + ".parallel_threads",
                  getDefaultParallelThreads()));
     }
 
+    /**
+     * @return default fallback reschedule time for jobs
+     */
     default int getDefaultRescheduleTime() {
        return 10;
     }
 
+    /**
+     * Gets the reschedule time for this job either from config or a fallback value
+     * @return reschedule time
+     */
     default int getRescheduleTime() {
         return Config.get().getInt("taskomatic." + getConfigNamespace() + "." + "reschedule_time",
                 Config.get().getInt("taskomatic." + this.getClass().getCanonicalName() + ".reschedule_time",

--- a/java/code/src/com/redhat/rhn/taskomatic/task/RhnJob.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/RhnJob.java
@@ -14,6 +14,7 @@
  */
 package com.redhat.rhn.taskomatic.task;
 
+import com.redhat.rhn.common.conf.Config;
 import com.redhat.rhn.taskomatic.domain.TaskoRun;
 
 import org.quartz.Job;
@@ -26,6 +27,32 @@ import org.quartz.JobExecutionException;
 public interface RhnJob extends Job {
 
     String DEFAULT_LOGGING_LAYOUT = "%d [%t] %-5p %c %x - %m%n";
+
+    /**
+     * @return a string representing the namespace from which job specific
+     * configuration parameters are read
+     */
+    String getConfigNamespace();
+
+    default int getDefaultParallelThreads() {
+        return 1;
+    }
+
+    default int getParallelThreads() {
+        return Config.get().getInt("taskomatic." + getConfigNamespace() + "." + "parallel_threads",
+                Config.get().getInt("taskomatic." + this.getClass().getCanonicalName() + ".parallel_threads",
+                 getDefaultParallelThreads()));
+    }
+
+    default int getDefaultRescheduleTime() {
+       return 10;
+    }
+
+    default int getRescheduleTime() {
+        return Config.get().getInt("taskomatic." + getConfigNamespace() + "." + "reschedule_time",
+                Config.get().getInt("taskomatic." + this.getClass().getCanonicalName() + ".reschedule_time",
+                 getDefaultRescheduleTime()));
+    }
 
     /**
      * execute method to be called

--- a/java/code/src/com/redhat/rhn/taskomatic/task/SSHMinionActionExecutor.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/SSHMinionActionExecutor.java
@@ -33,6 +33,11 @@ import java.util.Optional;
  */
 public class SSHMinionActionExecutor extends RhnJavaJob {
 
+    @Override
+    public String getConfigNamespace() {
+        return "sshminion_action_executor";
+    }
+
     /**
      * @param context the job execution context
      * @see org.quartz.Job#execute(JobExecutionContext)

--- a/java/code/src/com/redhat/rhn/taskomatic/task/SSHMinionActionExecutor.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/SSHMinionActionExecutor.java
@@ -34,6 +34,11 @@ import java.util.Optional;
 public class SSHMinionActionExecutor extends RhnJavaJob {
 
     @Override
+    public int getDefaultParallelThreads() {
+        return 20;
+    }
+
+    @Override
     public String getConfigNamespace() {
         return "sshminion_action_executor";
     }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/SSHPush.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/SSHPush.java
@@ -26,6 +26,11 @@ public class SSHPush extends RhnQueueJob {
     public static final String QUEUE_NAME = "ssh_push";
     private static Logger log = null;
 
+    @Override
+    public String getConfigNamespace() {
+        return "sshpush";
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/java/code/src/com/redhat/rhn/taskomatic/task/SandboxCleanup.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/SandboxCleanup.java
@@ -32,6 +32,11 @@ import java.util.Map;
  */
 public class SandboxCleanup extends RhnJavaJob {
 
+    @Override
+    public String getConfigNamespace() {
+        return "sandbox_cleanup";
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/java/code/src/com/redhat/rhn/taskomatic/task/SatSyncTask.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/SatSyncTask.java
@@ -26,6 +26,11 @@ import java.util.List;
  */
 public class SatSyncTask extends RhnJavaJob {
 
+    @Override
+    public String getConfigNamespace() {
+        return "satsync";
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/java/code/src/com/redhat/rhn/taskomatic/task/SessionCleanup.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/SessionCleanup.java
@@ -31,6 +31,11 @@ import java.util.Map;
  */
 public class SessionCleanup extends RhnJavaJob {
 
+    @Override
+    public String getConfigNamespace() {
+        return "session_cleanup";
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/java/code/src/com/redhat/rhn/taskomatic/task/SummaryPopulation.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/SummaryPopulation.java
@@ -38,6 +38,11 @@ import java.util.Set;
  */
 public class SummaryPopulation extends RhnJavaJob {
 
+    @Override
+    public String getConfigNamespace() {
+        return "summary_population";
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/java/code/src/com/redhat/rhn/taskomatic/task/SynchProbeState.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/SynchProbeState.java
@@ -21,6 +21,11 @@ import org.quartz.JobExecutionContext;
  */
 public class SynchProbeState extends RhnJavaJob {
 
+    @Override
+    public String getConfigNamespace() {
+        return "sync_probe_state";
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/java/code/src/com/redhat/rhn/taskomatic/task/TokenCleanup.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/TokenCleanup.java
@@ -40,6 +40,11 @@ public class TokenCleanup extends RhnJavaJob {
 
     private final SaltApi saltApi = GlobalInstanceHolder.SALT_API;
 
+    @Override
+    public String getConfigNamespace() {
+        return "token_cleanup";
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/java/code/src/com/redhat/rhn/taskomatic/task/UuidCleanup.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/UuidCleanup.java
@@ -29,6 +29,11 @@ import java.util.HashMap;
  */
 public class UuidCleanup extends RhnJavaJob {
 
+    @Override
+    public String getConfigNamespace() {
+        return "uuid_cleanup";
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/java/code/src/com/redhat/rhn/taskomatic/task/gatherer/GathererJob.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/gatherer/GathererJob.java
@@ -39,6 +39,11 @@ public class GathererJob extends RhnJavaJob {
 
     public static final String VHM_LABEL = "vhmLabel";
 
+    @Override
+    public String getConfigNamespace() {
+        return "gatherer";
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/java/code/src/com/redhat/rhn/taskomatic/task/matcher/MatcherJob.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/matcher/MatcherJob.java
@@ -32,6 +32,11 @@ public class MatcherJob extends RhnJavaJob {
 
     public static final String CSV_SEPARATOR = "server.susemanager.matchercsvseparator";
 
+    @Override
+    public String getConfigNamespace() {
+        return "matcher";
+    }
+
     /**
      * {@inheritDoc}
      */

--- a/java/conf/rhn_java.conf
+++ b/java/conf/rhn_java.conf
@@ -228,7 +228,7 @@ java.http_socket_timeout = 300
 #java.allow_adding_patches_via_api = centos6-x86_64,centos7-x86_64,centos8-x86_64
 
 # Maximum number of actions targetting Salt SSH minions executing at the same time
-taskomatic.com.redhat.rhn.taskomatic.task.SSHMinionActionExecutor.parallel_threads = 20
+taskomatic.sshminion_action_executor.parallel_threads = 20
 
 # minimal required DB schema version
 java.min_schema_version = 4.3.1

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,5 @@
+- provide static configuration key name for SSHMinionActionExecutor
+  parallel threads
 - Add link to the original vendor advisory in the patch details page
 - fix issue with empty action chains getting deleted too early (bsc#1191377)
 - Move pickedup actions to history as soon as they are pickedup (bsc#1191444)

--- a/spacewalk/config/spacewalk-config.changes
+++ b/spacewalk/config/spacewalk-config.changes
@@ -1,3 +1,5 @@
+- add migration for changed rhn.conf values
+
 -------------------------------------------------------------------
 Fri Nov 05 13:37:55 CET 2021 - jgonzalez@suse.com
 

--- a/spacewalk/config/spacewalk-config.spec
+++ b/spacewalk/config/spacewalk-config.spec
@@ -190,4 +190,16 @@ if [ -e /etc/sudoers.d/spacewalk.rpmsave ]; then
 fi
 rm -f /etc/sudoers.d/spacewalk.{rpmnew,rpmorig,rpmsave}
 
+### TO-REMOVE AFTER: 2023-12-01
+if egrep -m1 "^taskomatic.com.redhat.rhn.taskomatic.task.SSHMinionActionExecutor.parallel_threads[[:space:]]*=" /etc/rhn/rhn.conf >/dev/null; then
+    sed -i "s/taskomatic.com.redhat.rhn.taskomatic.task.SSHMinionActionExecutor.parallel_threads[[:space:]]*=\(.\+\)/taskomatic.sshminion_action_executor.parallel_threads =\1/" /etc/rhn/rhn.conf
+fi
+if egrep -m1 "^taskomatic.com.redhat.rhn.taskomatic.task.MinionActionExecutor.parallel_threads[[:space:]]*=" /etc/rhn/rhn.conf >/dev/null; then
+    sed -i "s/taskomatic.com.redhat.rhn.taskomatic.task.MinionActionExecutor.parallel_threads[[:space:]]*=\(.\+\)/taskomatic.minion_action_executor.parallel_threads =\1/" /etc/rhn/rhn.conf
+fi
+if egrep -m1 "^taskomatic.com.redhat.rhn.taskomatic.task" /etc/rhn/rhn.conf >/dev/null; then
+    echo "WARNING: Found deprecated configuration items in /etc/rhn/rhn.conf"
+fi
+### END
+
 %changelog


### PR DESCRIPTION
## What does this PR change?

The number of parallel threads can be configured only by using the class name as config variable name.
When moving the Class to a new package or rename the class, the config variable become invalid.

To solve this, this PR introduce an annotation to specify the config key. The class name is still used as fallback to stay compatible with existing configurations. In future the class can be renamed or moved without changing the main config name.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- https://github.com/uyuni-project/uyuni-docs/pull/1331

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/13612
Tracks https://github.com/SUSE/spacewalk/pull/16541

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"

https://ci.nue.suse.com/view/Manager/view/Uyuni-PRs/job/uyuni-prs-ci-tests/981/