### PR TITLE
Testsuite: Adapt execution of "salt-call" to use "venv-salt-call" in Uyuni

### DIFF
--- a/testsuite/features/secondary/min_salt_mgrcompat_state.feature
+++ b/testsuite/features/secondary/min_salt_mgrcompat_state.feature
@@ -21,7 +21,7 @@ Feature: Verify that Salt mgrcompat state works when the new module.run syntax i
     Given I remove "/var/cache/salt/minion/extmods/states/mgrcompat.py" from "sle_minion"
     And I remove "/var/cache/salt/minion/extmods/states/__pycache__/mgrcompat*" from "sle_minion"
     And I store "grains: {__suse_reserved_saltutil_states_support: False}" into file "/etc/salt/minion.d/custom_grains.conf" on "sle_minion"
-    And I run "salt-call saltutil.refresh_grains" on "sle_minion"
+    And I refresh salt-minion grains on "sle_minion"
     And I am on the Systems overview page of this "sle_minion"
     When I follow "Hardware"
     And I click on "Schedule Hardware Refresh"

--- a/testsuite/features/step_definitions/command_steps.rb
+++ b/testsuite/features/step_definitions/command_steps.rb
@@ -841,8 +841,9 @@ end
 # Repositories and packages management
 When(/^I migrate the non-SUMA repositories on "([^"]*)"$/) do |host|
   node = get_target(host)
+  salt_call = $product == 'Uyuni' ? "venv-salt-call" : "salt-call"
   # use sumaform states to migrate to latest SP the system repositories:
-  node.run('salt-call --local --file-root /root/salt/ state.apply repos')
+  node.run("#{salt_call} --local --file-root /root/salt/ state.apply repos")
   # disable again the non-SUMA repositories:
   node.run("for repo in $(zypper lr | awk 'NR>7 && !/susemanager:/ {print $3}'); do zypper mr -d $repo; done")
   # node.run('salt-call state.apply channels.disablelocalrepos') does not work
@@ -1672,11 +1673,12 @@ end
 
 When(/^I apply "([^"]*)" local salt state on "([^"]*)"$/) do |state, host|
   node = get_target(host)
+  salt_call = $product == 'Uyuni' ? "venv-salt-call" : "salt-call"
   source = File.dirname(__FILE__) + '/../upload_files/salt/' + state + '.sls'
   remote_file = '/usr/share/susemanager/salt/' + state + '.sls'
   return_code = file_inject(node, source, remote_file)
   raise 'File injection failed' unless return_code.zero?
-  node.run('salt-call --local --file-root=/usr/share/susemanager/salt --module-dirs=/usr/share/susemanager/salt/ --log-level=info --retcode-passthrough state.apply ' + state)
+  node.run("#{salt_call} --local --file-root=/usr/share/susemanager/salt --module-dirs=/usr/share/susemanager/salt/ --log-level=info --retcode-passthrough state.apply " + state)
 end
 
 When(/^I copy autoinstall mocked files on server$/) do

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -70,8 +70,9 @@ end
 
 When(/^I wait until no Salt job is running on "([^"]*)"$/) do |minion|
   target = get_target(minion)
+  salt_call = $product == 'Uyuni' ? "venv-salt-call" : "salt-call"
   repeat_until_timeout(message: "A Salt job is still running on #{minion}") do
-    output, _code = target.run('salt-call -lquiet saltutil.running')
+    output, _code = target.run("#{salt_call} -lquiet saltutil.running")
     break if output == "local:\n"
     sleep 3
   end
@@ -589,7 +590,8 @@ end
 
 When(/^I see "([^"]*)" fingerprint$/) do |host|
   node = get_target(host)
-  output, _code = node.run('salt-call --local key.finger')
+  salt_call = $product == 'Uyuni' ? "venv-salt-call" : "salt-call"
+  output, _code = node.run("#{salt_call} --local key.finger")
   fing = output.split("\n")[1].strip!
   raise "Text: #{fing} not found" unless has_content?(fing)
 end

--- a/testsuite/features/step_definitions/salt_steps.rb
+++ b/testsuite/features/step_definitions/salt_steps.rb
@@ -50,6 +50,12 @@ When(/^I restart salt-minion on "(.*?)"$/) do |minion|
   node.run("systemctl restart #{pkgname}", check_errors: false) if %w[ceos_minion ubuntu_minion kvm_server xen_server].include?(minion)
 end
 
+When(/^I refresh salt-minion grains on "(.*?)"$/) do |minion|
+  node = get_target(minion)
+  salt_call = $product == 'Uyuni' ? "venv-salt-call" : "salt-call"
+  node.run("#{salt_call} saltutil.refresh_grains")
+end
+
 When(/^I wait at most (\d+) seconds until Salt master sees "([^"]*)" as "([^"]*)"$/) do |key_timeout, minion, key_type|
   cmd = "salt-key --list #{key_type}"
   repeat_until_timeout(timeout: key_timeout.to_i, message: "Minion '#{minion}' is not listed among #{key_type} keys on Salt master") do


### PR DESCRIPTION
## What does this PR change?

This PR fixes the manual execution of `salt-call` done by the testsuite to use `venv-salt-call` instead when running for Uyuni, as we are pushing the Salt bundle and this would be right way on the clients.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

https://github.com/SUSE/spacewalk/issues/14325

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
