### PR TITLE
Fix docker secondary test

### DIFF
--- a/testsuite/features/secondary/buildhost_docker_auth_registry.feature
+++ b/testsuite/features/secondary/buildhost_docker_auth_registry.feature
@@ -14,7 +14,7 @@ Feature: Build image with authenticated registry
     And I check "useCredentials"
     And I enter URI, username and password for registry
     And I click on "create-btn"
-    Then I wait until I see "registry" text
+    Then I wait until I see "auth_registry" text
 
   Scenario: Create a profile for the authenticated image store as Docker admin
     When I follow the left menu "Images > Profiles"
@@ -33,25 +33,24 @@ Feature: Build image with authenticated registry
     And I select the hostname of "build_host" from "buildHostId"
     And I click on "submit-btn"
     Then I wait until I see "auth_registry_profile" text
-    # Verify the status of images in the authenticated image store
-    When I wait at most 660 seconds until container "auth_registry_profile" is built successfully
-    And I refresh the page
-    Then table row for "auth_registry_profile" should contain "1"
+    And I wait until the image build "build auth_registry_profile" with version "latest" scheduled by "admin" is completed
+    And I wait at most 1000 seconds until all "1" container images are built correctly in the GUI
 
   Scenario: Cleanup: remove Docker profile for the authenticated image store
     When I follow the left menu "Images > Profiles"
     And I check the row with the "auth_registry_profile" text
     And I click on "Delete"
     And I click on the red confirmation button
-    And I should see a "Image profile has been deleted." text
+    Then I should see a "Image profile has been deleted." text
 
   Scenario: Cleanup: remove authenticated image store
     When I follow the left menu "Images > Stores"
     And I check the row with the "auth_registry" text
     And I click on "Delete"
     And I click on the red confirmation button
-    And I should see a "Image store has been deleted." text
+    Then I should see a "Image store has been deleted." text
 
   Scenario: Cleanup: delete registry image
     Given I am authorized as "admin" with password "admin"
     When I delete the image "auth_registry_profile" with version "latest" via XML-RPC calls
+    Then the image "auth_registry_profile" with version "latest" doesn't exist via XML-RPC calls

--- a/testsuite/features/secondary/buildhost_docker_build_image.feature
+++ b/testsuite/features/secondary/buildhost_docker_build_image.feature
@@ -22,14 +22,7 @@ Feature: Build container images
     And I select "galaxy-registry" from "imageStore"
     And I enter "Docker" relative to profiles as "path"
     And I click on "create-btn"
-
-  Scenario: Create a simple real image profile without activation key
-    When I follow the left menu "Images > Profiles"
-    And I follow "Create"
-    And I enter "suse_real_simple" as "label"
-    And I select "galaxy-registry" from "imageStore"
-    And I enter "Docker/serverhost" relative to profiles as "path"
-    And I click on "create-btn"
+    Then I wait until I see "suse_simple" text
 
   Scenario: Create an image profile with activation key
     When I follow the left menu "Images > Profiles"
@@ -39,6 +32,7 @@ Feature: Build container images
     And I select "1-DOCKER-TEST" from "activationKey"
     And I enter "Docker" relative to profiles as "path"
     And I click on "create-btn"
+    Then I wait until I see "suse_key" text
 
   Scenario: Create a simple real image profile with activation key
     When I follow the left menu "Images > Profiles"
@@ -48,19 +42,23 @@ Feature: Build container images
     And I select "1-DOCKER-TEST" from "activationKey"
     And I enter "Docker/serverhost" relative to profiles as "path"
     And I click on "create-btn"
+    Then I wait until I see "suse_real_key" text
 
   Scenario: Build the images with and without activation key
     Given I am on the Systems overview page of this "build_host"
     When I schedule the build of image "suse_key" via XML-RPC calls
-    And I wait at most 660 seconds until event "Image Build suse_key scheduled by admin" is completed
     And I schedule the build of image "suse_simple" via XML-RPC calls
-    And I wait at most 660 seconds until event "Image Build suse_simple scheduled by admin" is completed
     And I schedule the build of image "suse_real_key" via XML-RPC calls
-    And I wait at most 660 seconds until event "Image Build suse_real_key scheduled by admin" is completed
+    Then I wait until the image build "suse_key" with version "latest" scheduled by "admin" is completed
+    And I wait until the image build "suse_simple" with version "latest" scheduled by "admin" is completed
+    And I wait until the image build "suse_real_key" with version "latest" scheduled by "admin" is completed
+    And I wait at most 1000 seconds until all "3" container images are built correctly in the GUI
 
   Scenario: Build same images with different versions
     When I schedule the build of image "suse_key" with version "Latest_key-activation1" via XML-RPC calls
     And I schedule the build of image "suse_simple" with version "Latest_simple" via XML-RPC calls
+    Then I wait until the image build "suse_key" with version "Latest_key-activation1" scheduled by "admin" is completed
+    And I wait until the image build "suse_simple" with version "Latest_simple" scheduled by "admin" is completed
     And I wait at most 1000 seconds until all "5" container images are built correctly in the GUI
 
   Scenario: Delete image via XML-RPC calls
@@ -68,10 +66,14 @@ Feature: Build container images
     And I delete the image "suse_simple" with version "Latest_simple" via XML-RPC calls
     Then the image "suse_simple" with version "Latest_key-activation1" doesn't exist via XML-RPC calls
     And the image "suse_simple" with version "Latest_simple" doesn't exist via XML-RPC calls
+    And I wait at most 1000 seconds until all "3" container images are built correctly in the GUI
 
   Scenario: Rebuild the images
     When I schedule the build of image "suse_simple" with version "Latest_simple" via XML-RPC calls
     And I schedule the build of image "suse_key" with version "Latest_key-activation1" via XML-RPC calls
+    And I wait at most 1000 seconds until all "5" container images are built correctly in the GUI
+    Then I wait until the image build "suse_key" with version "Latest_key-activation1" scheduled by "admin" is completed
+    And I wait until the image build "suse_simple" with version "Latest_simple" scheduled by "admin" is completed
     And I wait at most 1000 seconds until all "5" container images are built correctly in the GUI
 
   Scenario: Build an image via the GUI
@@ -81,6 +83,8 @@ Feature: Build container images
     And I select the hostname of "build_host" from "buildHostId"
     And I click on "submit-btn"
     Then I wait until I see "GUI_BUILT_IMAGE" text
+    And I wait until the image build "suse_real_key" with version "GUI_BUILT_IMAGE" scheduled by "admin" is completed
+    And I wait at most 1000 seconds until all "6" container images are built correctly in the GUI
 
   Scenario: Login as Docker image administrator and build an image
     Given I am authorized as "docker" with password "docker"
@@ -90,22 +94,32 @@ Feature: Build container images
     And I select the hostname of "build_host" from "buildHostId"
     And I click on "submit-btn"
     Then I wait until I see "GUI_DOCKERADMIN" text
+    And I wait until the image build "suse_real_key" with version "GUI_DOCKERADMIN" scheduled by "admin" is completed
+    And I wait at most 1000 seconds until all "7" container images are built correctly in the GUI
 
   Scenario: Cleanup: delete all images
     Given I am authorized as "admin" with password "admin"
-    When I delete the image "suse_key" with version "Latest" via XML-RPC calls
-    And I delete the image "suse_simple" with version "Latest_simple" via XML-RPC calls
+    When I delete the image "suse_key" with version "latest" via XML-RPC calls
+    And I delete the image "suse_simple" with version "latest" via XML-RPC calls
+    And I delete the image "suse_real_key" with version "latest" via XML-RPC calls
     And I delete the image "suse_key" with version "Latest_key-activation1" via XML-RPC calls
+    And I delete the image "suse_simple" with version "Latest_simple" via XML-RPC calls
     And I delete the image "suse_real_key" with version "GUI_BUILT_IMAGE" via XML-RPC calls
     And I delete the image "suse_real_key" with version "GUI_DOCKERADMIN" via XML-RPC calls
+    Then the image "suse_key" with version "latest" doesn't exist via XML-RPC calls
+    And the image "suse_simple" with version "latest" doesn't exist via XML-RPC calls
+    And the image "suse_real_key" with version "latest" doesn't exist via XML-RPC calls
+    And the image "suse_key" with version "Latest_key-activation1" doesn't exist via XML-RPC calls
+    And the image "suse_simple" with version "Latest_simple" doesn't exist via XML-RPC calls
+    And the image "suse_real_key" with version "GUI_BUILT_IMAGE" doesn't exist via XML-RPC calls
+    And the image "suse_real_key" with version "GUI_DOCKERADMIN" doesn't exist via XML-RPC calls
 
   Scenario: Cleanup: delete all profiles
     When I follow the left menu "Images > Profiles"
     And I check "suse_simple" in the list
-    And I check "suse_real_simple" in the list
     And I check "suse_key" in the list
     And I check "suse_real_key" in the list
     And I click on "Delete"
     And I should see a "Are you sure you want to delete selected profiles?" text
     And I click on the red confirmation button
-    And I wait until I see "Image profiles have been deleted" text
+    Then I wait until I see "Image profiles have been deleted" text

--- a/testsuite/features/step_definitions/docker_steps.rb
+++ b/testsuite/features/step_definitions/docker_steps.rb
@@ -30,6 +30,13 @@ Then(/^I wait until the image build "([^"]*)" is completed$/) do |image_name|
   )
 end
 
+Then(/^I wait until the image build "([^"]*)" with version "([^"]*)" scheduled by "([^"]*)" is completed$/) do |image_name, image_tag, current_user|
+  steps %(
+    When I wait at most 3300 seconds until event "Image Build #{image_name} scheduled by #{current_user}" is completed
+    And I wait at most 300 seconds until event "Image Inspect 1//#{image_name}:#{image_tag} scheduled by #{current_user}" is completed
+  )
+end
+
 Then(/^I am on the image store of the kiwi image for organization "([^"]*)"$/) do |org|
   # It doesn't exist any navigation step to access this URL, so we must use a visit call (https://github.com/SUSE/spacewalk/issues/15256)
   visit("https://#{$server.full_hostname}/os-images/#{org}/")


### PR DESCRIPTION
## What does this PR change?

Fix docker secondary test:
- do not delete registry before building has been finished
- delete images correctly

## GUI diff

No difference.

- [x] **DONE**

## Documentation
N/A

- [x] **DONE**

## Test coverage
- Cucumber tests were added

- [x] **DONE**

## Links

Fixes https://github.com/SUSE/spacewalk/issues/16403

- [x] **DONE**

## Changelogs

- [x] No changelog needed

## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
