### PR TITLE
Add rights field to generated updateinfo.xml

### DIFF
--- a/backend/satellite_tools/reposync.py
+++ b/backend/satellite_tools/reposync.py
@@ -881,6 +881,7 @@ class RepoSync(object):
                return None
 
         log(0, "Add Patch %s" % patch_name)
+
         e = importLib.Erratum()
         e['errata_from']   = notice['from']
         e['advisory'] = e['advisory_name'] = patch_name
@@ -904,6 +905,7 @@ class RepoSync(object):
         e['update_date']   = updated_date
         e['org_id'] = self.org_id
         e['notes']         = ''
+        e['rights']        = notice['rights']
         e['refers_to']     = ''
         e['channels']      = [{'label':self.channel_label}]
         e['packages']      = []

--- a/backend/server/importlib/backendOracle.py
+++ b/backend/server/importlib/backendOracle.py
@@ -236,6 +236,7 @@ class OracleBackend(Backend):
                   'synopsis': DBstring(4000),
                   'topic': DBstring(4000),
                   'solution': DBstring(4000),
+                  'rights': DBstring(100),
                   'notes': DBstring(4000),
                   'refers_to': DBstring(4000),
                   'org_id': DBint(),

--- a/backend/spacewalk-backend.changes
+++ b/backend/spacewalk-backend.changes
@@ -1,3 +1,4 @@
+- Retrieve and store copyright information about patches
 - Unify decompression of metadata with uyuni.common.fileutils
 - Fix yum reposync plugin for Fedora 33-35 repos
 - require python macros for building

--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/Errata_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/Errata_queries.xml
@@ -436,7 +436,7 @@ SELECT DISTINCT E.id
 <query name="simple_errata_overview" class="com.redhat.rhn.frontend.dto.ErrataOverview">
 select e.id, e.advisory, e.advisory_name, e.advisory_type, e.advisory_rel,
        e.synopsis as advisory_synopsis, e.advisory_status,
-       e.description, e.issue_date, e.update_date, e.errata_from
+       e.description, e.issue_date, e.update_date, e.errata_from, e.rights
   from rhnErrata e
  where e.id in (%s)
 </query>

--- a/java/code/src/com/redhat/rhn/domain/errata/Errata.hbm.xml
+++ b/java/code/src/com/redhat/rhn/domain/errata/Errata.hbm.xml
@@ -32,6 +32,7 @@ PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
         <property name="issueDate" column="issue_date" type="timestamp" />
         <property name="updateDate" column="update_date" type="timestamp" />
         <property name="notes" column="notes" type="string" length="4000" />
+        <property name="rights" column="rights" type="string" length="100" />
         <property name="refersTo" column="refers_to" type="string"
             length="4000" />
         <property name="advisoryName" column="advisory_name" type="string"

--- a/java/code/src/com/redhat/rhn/domain/errata/Errata.java
+++ b/java/code/src/com/redhat/rhn/domain/errata/Errata.java
@@ -56,6 +56,7 @@ public class Errata extends BaseDomainHelper implements Selectable {
     private Date issueDate;
     private Date updateDate;
     private String notes;
+    private String rights;
     private String refersTo;
     private String advisoryName;
     private Long advisoryRel;
@@ -350,6 +351,27 @@ public class Errata extends BaseDomainHelper implements Selectable {
         }
         else {
             this.notes = notesIn;
+        }
+    }
+
+    /**
+     * Getter for rights
+     * @return the rights for this errata
+     */
+    public String getRights() {
+        return rights;
+    }
+
+    /**
+     * Setter for rights
+     * @param rightsIn value to set for this errata
+     */
+    public void setRights(String rightsIn) {
+        if (StringUtils.isEmpty(rightsIn)) {
+            this.rights = null;
+        }
+        else {
+            this.rights = rightsIn;
         }
     }
 

--- a/java/code/src/com/redhat/rhn/domain/errata/test/ErrataFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/errata/test/ErrataFactoryTest.java
@@ -261,6 +261,7 @@ public class ErrataFactoryTest extends BaseTestCaseWithUser {
         e.setSynopsis("Test synopsis");
         e.setSolution("Test solution");
         e.setNotes("Test notes for test errata");
+        e.setRights("Copyright for test errata");
         e.setTopic("test topic");
         e.setRefersTo("rhn unit tests");
         e.setUpdateDate(new Date());

--- a/java/code/src/com/redhat/rhn/domain/notification/test/NotificationFactoryTest.java
+++ b/java/code/src/com/redhat/rhn/domain/notification/test/NotificationFactoryTest.java
@@ -24,8 +24,10 @@ import com.redhat.rhn.domain.notification.UserNotificationFactory;
 import com.redhat.rhn.domain.notification.types.OnboardingFailed;
 import com.redhat.rhn.domain.role.RoleFactory;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
+import com.redhat.rhn.testing.TestUtils;
 
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -91,13 +93,17 @@ public class NotificationFactoryTest extends BaseTestCaseWithUser {
         UserNotificationFactory.storeNotificationMessageFor(
                 msg, Collections.singleton(RoleFactory.CHANNEL_ADMIN), empty());
 
-        // Should not be deleted
-        int result = UserNotificationFactory.deleteNotificationMessagesBefore(msg.getCreated());
+        msg = TestUtils.reload(msg);
+
+        // Should not be deleted at creation date
+        Date deleteBeforeDate = msg.getCreated();
+        int result = UserNotificationFactory.deleteNotificationMessagesBefore(deleteBeforeDate);
         assertEquals(0, result);
         assertEquals(1, UserNotificationFactory.listAllNotificationMessages().size());
 
-        // Should be deleted
-        result = UserNotificationFactory.deleteNotificationMessagesBefore(Date.from(Instant.now()));
+        // Should be deleted 1 second after creation date
+        deleteBeforeDate = Date.from(msg.getCreated().toInstant().plus(1, ChronoUnit.SECONDS));
+        result = UserNotificationFactory.deleteNotificationMessagesBefore(deleteBeforeDate);
         assertEquals(1, result);
         assertEquals(0, UserNotificationFactory.listAllNotificationMessages().size());
     }

--- a/java/code/src/com/redhat/rhn/frontend/dto/ErrataOverview.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/ErrataOverview.java
@@ -54,6 +54,7 @@ public class ErrataOverview extends BaseDto {
     private boolean restartSuggested;
     private Integer severityid;
     private String severityLabel;
+    private String rights;
 
     /**
      * This method is only used for csv export..
@@ -280,12 +281,18 @@ public class ErrataOverview extends BaseDto {
         issueDate = issueDateIn;
     }
     /**
-     * @param issueDateIn The issueDate to set.String 'yyyy-mm-dd"
+     * @param issueDateIn The issueDate to set. Supported formats: "yyyy-MM-dd HH:mm:ss" or "yyyy-MM-dd"
      * @throws ParseException when issueDateIn can't be parsed
      */
     public void setIssueDate(String issueDateIn) throws ParseException {
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
-        issueDate = sdf.parse(issueDateIn);
+        try {
+            SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+            issueDate = sdf.parse(issueDateIn);
+        }
+        catch (ParseException ex) {
+            SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd");
+            issueDate = sdf.parse(issueDateIn);
+        }
     }
     /**
      * @return Returns the advisoryName.
@@ -587,5 +594,19 @@ public class ErrataOverview extends BaseDto {
                     .toLowerCase();
         }
         return retval;
+    }
+
+    /**
+     * @return the copyright information for this errata
+     */
+    public String getRights() {
+        return rights;
+    }
+
+    /**
+     * @param rightsIn the copyright information for this errata
+     */
+    public void setRights(String rightsIn) {
+        this.rights = rightsIn;
     }
 }

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/UpdateInfoWriter.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/UpdateInfoWriter.java
@@ -52,8 +52,7 @@ public class UpdateInfoWriter extends RepomdWriter {
     public String getUpdateInfo(Channel channel) {
         begin(channel);
 
-        DataResult<ErrataOverview> errata = ChannelManager
-                .listErrataSimple(channel.getId());
+        final DataResult<ErrataOverview> errata = ChannelManager.listErrataSimple(channel.getId());
         final int batchSize = 500;
         for (int i = 0; i < errata.size(); i += batchSize) {
             DataResult<ErrataOverview> errataBatch = errata.subList(i, i + batchSize);
@@ -106,8 +105,7 @@ public class UpdateInfoWriter extends RepomdWriter {
      * @param channel channel info
      * @throws SAXException
      */
-    private void addErratum(ErrataOverview erratum, Channel channel)
-            throws SAXException {
+    private void addErratum(ErrataOverview erratum, Channel channel) throws SAXException {
         SimpleAttributesImpl attr = new SimpleAttributesImpl();
         attr.addAttribute("from", erratum.getErrataFrom());
         attr.addAttribute("status", erratum.getAdvisoryStatus().getMetadataValue());
@@ -127,12 +125,9 @@ public class UpdateInfoWriter extends RepomdWriter {
             }
         }
 
-        handler.addElementWithCharacters("id",
-                sanitize(0L, id));
-        handler.addElementWithCharacters("title", sanitize(0L, erratum
-                .getAdvisorySynopsis()));
-        handler.addElementWithCharacters("severity", sanitize(0L, erratum
-                .getSeverity()));
+        handler.addElementWithCharacters("id", sanitize(0L, id));
+        handler.addElementWithCharacters("title", sanitize(0L, erratum.getAdvisorySynopsis()));
+        handler.addElementWithCharacters("severity", sanitize(0L, erratum.getSeverity()));
 
         DateFormat df = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
 
@@ -146,9 +141,8 @@ public class UpdateInfoWriter extends RepomdWriter {
         handler.startElement("updated", attr);
         handler.endElement("updated");
 
-        handler.addElementWithCharacters("description",
-                sanitize(0L, erratum
-                .getDescription()));
+        handler.addElementWithCharacters("rights", sanitize(0L, erratum.getRights()));
+        handler.addElementWithCharacters("description", sanitize(0L, erratum.getDescription()));
 
         addErratumReferences(erratum);
         addErratumPkgList(erratum, channel);

--- a/java/code/src/com/redhat/rhn/taskomatic/task/repomd/test/UpdateInfoWriterTest.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/repomd/test/UpdateInfoWriterTest.java
@@ -29,10 +29,14 @@ import com.redhat.rhn.domain.channel.test.ChannelFactoryTest;
 import com.redhat.rhn.domain.errata.Errata;
 import com.redhat.rhn.domain.product.SUSEProduct;
 import com.redhat.rhn.frontend.action.channel.manage.ErrataHelper;
+import com.redhat.rhn.frontend.dto.ErrataOverview;
 import com.redhat.rhn.taskomatic.task.repomd.UpdateInfoWriter;
 import com.redhat.rhn.testing.BaseTestCaseWithUser;
+import com.redhat.rhn.testing.TestUtils;
 
 import java.io.StringWriter;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 
 /**
  * Tests for the {@link com.redhat.rhn.taskomatic.task.repomd.UpdateInfoWriter} generator.
@@ -71,6 +75,42 @@ public class UpdateInfoWriterTest extends BaseTestCaseWithUser {
         metadataWriter = new UpdateInfoWriter(buffer);
         metadataWriter.getUpdateInfo(clonedChannel);
         assertContains(buffer.toString(), "<id>CL-SUSE-SLE-SERVER-2016-1234</id>");
+    }
+
+    public void testErrataFieldsGeneratedCorrectly() throws Exception {
+
+        final ChannelFamily channelFamily = createTestChannelFamily();
+        final SUSEProduct product = createTestSUSEProduct(channelFamily);
+
+        // Create channels
+        final Channel baseChannel = createTestVendorBaseChannel(channelFamily, createTestChannelProduct());
+        baseChannel.setUpdateTag("SLE-SERVER");
+        createTestSUSEProductChannel(baseChannel, product, true);
+
+        Errata errata = createTestErrata(user.getId());
+        errata = TestUtils.reload(errata);
+
+        errata.setAdvisoryName("SUSE-2016-1234");
+        baseChannel.addErrata(errata);
+
+        StringWriter buffer = new StringWriter();
+        UpdateInfoWriter metadataWriter = new UpdateInfoWriter(buffer);
+        metadataWriter.getUpdateInfo(baseChannel);
+
+        DateFormat df = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+
+        final String xml = buffer.toString();
+
+        assertContains(xml, "<id>SUSE-SLE-SERVER-2016-1234</id>");
+        assertContains(xml, "<title>" + errata.getSynopsis() + "</title>");
+        assertContains(xml, "<severity>" + errata.getSeverity().getLocalizedLabel().toLowerCase() + "</severity>");
+        assertContains(xml, "<issued date=\"" + df.format(errata.getIssueDate()) + "\"/>");
+        assertContains(xml, "<updated date=\"" + df.format(errata.getUpdateDate()) + "\"/>");
+        assertContains(xml, "<rights>" + errata.getRights() + "</rights>");
+        assertContains(xml, "<description>" + errata.getDescription() + "</description>");
+
+        ErrataOverview o = new ErrataOverview();
+        o.setIssueDate("2021-11-22");
     }
 }
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Added rights field to generated updateinfo.xml to handle copyright
 - fix XML syntax in cobbler snippets (bsc#1193694)
 - Migrate the displaying of the date/time to rhn:formatDate
 - Suggest Product Migration when patch for CVE is in a successor Product (bsc#1191360)

--- a/schema/spacewalk/common/tables/rhnErrata.sql
+++ b/schema/spacewalk/common/tables/rhnErrata.sql
@@ -36,6 +36,7 @@ CREATE TABLE rhnErrata
     synopsis          VARCHAR(4000) NOT NULL,
     topic             VARCHAR(4000),
     solution          VARCHAR(4000) NOT NULL,
+    rights            VARCHAR(100),
     issue_date        TIMESTAMPTZ
                           DEFAULT (current_timestamp) NOT NULL,
     update_date       TIMESTAMPTZ

--- a/schema/spacewalk/susemanager-schema.changes
+++ b/schema/spacewalk/susemanager-schema.changes
@@ -1,3 +1,4 @@
+- Added rights column to rhnerrata to handle copyright information
 - Fix rhnChannelNewestPackageView in case there are duplicates (bsc#1193612)
 - Change rhnPackageCapability name data type to TEXT
 - Add support for custom SSH port for SSH minions

--- a/schema/spacewalk/upgrade/susemanager-schema-4.3.4-to-susemanager-schema-4.3.5/030-add-rights-to-errata.sql
+++ b/schema/spacewalk/upgrade/susemanager-schema-4.3.4-to-susemanager-schema-4.3.5/030-add-rights-to-errata.sql
@@ -1,0 +1,17 @@
+--
+-- Copyright (c) 2021 SUSE LLC
+--
+-- This software is licensed to you under the GNU General Public License,
+-- version 2 (GPLv2). There is NO WARRANTY for this software, express or
+-- implied, including the implied warranties of MERCHANTABILITY or FITNESS
+-- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+-- along with this software; if not, see
+-- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+--
+-- Red Hat trademarks are not licensed under GPLv2. No permission is
+-- granted to use or replicate Red Hat trademarks that are incorporated
+-- in this software or its documentation.
+--
+
+ALTER TABLE rhnErrata ADD COLUMN IF NOT EXISTS
+    rights VARCHAR(100);


### PR DESCRIPTION
## What does this PR change?

This PR retrieves and store the copyright information from the remote repository in order to add it to the updateinfo.xml of the generated repository. 

## GUI diff

No difference.

- [X] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [X] **DONE**

## Test coverage
- Unit tests were added

- [X] **DONE**

## Links

Fixes SUSE/spacewalk/issues/12198

- [X] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
