### PR TITLE
Fix timepicker not reacting to to typing input

### DIFF
--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
@@ -2203,7 +2203,7 @@ select count(action_id) as count
   <query params="sid">
 select SA.action_id as ID,
                COALESCE(A.name, AType.name) || ' scheduled by ' || NVL(U.login, '(none)') as summary,
-               to_char(A.earliest_action, 'YYYY-MM-DD HH24:MI:SS') as scheduled_for,
+               A.earliest_action as scheduled_for,
                AType.label as history_type,
                AType.name as history_type_name,
                A.prerequisite as prereq_aid,
@@ -2232,7 +2232,7 @@ order by scheduled_for desc, prereq_aid nulls first
    and ST.label = :set_label-->
 select SA.action_id as ID,
                COALESCE(A.name, AType.name) || ' scheduled by ' || NVL(U.login, '(none)') as summary,
-               to_char(A.earliest_action, 'YYYY-MM-DD HH24:MI:SS') as scheduled_for,
+               A.earliest_action as scheduled_for,
                AType.label as history_type,
                AType.name as history_type_name,
                A.prerequisite as prereq_aid,

--- a/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
+++ b/java/code/src/com/redhat/rhn/common/db/datasource/xml/System_queries.xml
@@ -2091,9 +2091,9 @@ select s.id as id,
   class="com.redhat.rhn.frontend.dto.SystemEventDto">
   <query params="sid, oid, date, limit, offset">
 select event_id as id,
-       to_char(all_events.created, 'YYYY-MM-DD HH24:MI:SS') created,
-       to_char(all_events.picked_up, 'YYYY-MM-DD HH24:MI:SS') picked_up,
-       to_char(all_events.completed, 'YYYY-MM-DD HH24:MI:SS') completed,
+       all_events.created created,
+       all_events.picked_up picked_up,
+       all_events.completed completed,
        all_events.summary,
        all_events.history_type,
        all_events.history_type_name,
@@ -2144,9 +2144,9 @@ order by completed desc, picked_up desc, all_events.created desc, event_id desc
   class="com.suse.manager.xmlrpc.dto.SystemEventDetailsDto">
   <query params="sid, oid, eid">
   select event_id as id,
-         to_char(all_events.created, 'YYYY-MM-DD HH24:MI:SS') created,
-         to_char(all_events.picked_up, 'YYYY-MM-DD HH24:MI:SS') picked_up,
-         to_char(all_events.completed, 'YYYY-MM-DD HH24:MI:SS') completed,
+         all_events.created created,
+         all_events.picked_up picked_up,
+         all_events.completed completed,
          all_events.summary,
          all_events.history_type,
          all_events.history_type_name,

--- a/java/code/src/com/redhat/rhn/frontend/dto/SystemEventDto.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/SystemEventDto.java
@@ -21,8 +21,6 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.io.Serializable;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -91,21 +89,8 @@ public class SystemEventDto extends BaseDto implements Serializable {
     /**
      * @param createdIn Date of creation to set
      */
-    public void setCreated(String createdIn) {
-        if (createdIn == null) {
-            this.created = null;
-        }
-        else {
-            try {
-                this.created = new SimpleDateFormat(
-                        LocalizationService.RHN_DB_DATEFORMAT).parse(createdIn);
-            }
-            catch (ParseException e) {
-                throw new IllegalArgumentException("lastCheckin must be of the: [" +
-                        LocalizationService.RHN_DB_DATEFORMAT + "] it was: " +
-                        createdIn);
-            }
-        }
+    public void setCreated(Date createdIn) {
+        this.created = createdIn;
     }
 
     /**
@@ -118,21 +103,8 @@ public class SystemEventDto extends BaseDto implements Serializable {
     /**
      * @param pickedUpIn Date of pick up of event to set
      */
-    public void setPickedUp(String pickedUpIn) {
-        if (pickedUpIn == null) {
-            this.pickedUp = null;
-        }
-        else {
-            try {
-                this.pickedUp = new SimpleDateFormat(
-                        LocalizationService.RHN_DB_DATEFORMAT).parse(pickedUpIn);
-            }
-            catch (ParseException e) {
-                throw new IllegalArgumentException("lastCheckin must be of the: [" +
-                        LocalizationService.RHN_DB_DATEFORMAT + "] it was: " +
-                        pickedUpIn);
-            }
-        }
+    public void setPickedUp(Date pickedUpIn) {
+        this.pickedUp = pickedUpIn;
     }
 
     /**
@@ -158,21 +130,8 @@ public class SystemEventDto extends BaseDto implements Serializable {
     /**
      * @param completedIn Date of completion to set
      */
-    public void setCompleted(String completedIn) {
-        if (completedIn == null) {
-            this.completed = null;
-        }
-        else {
-            try {
-                this.completed = new SimpleDateFormat(
-                        LocalizationService.RHN_DB_DATEFORMAT).parse(completedIn);
-            }
-            catch (ParseException e) {
-                throw new IllegalArgumentException("lastCheckin must be of the: [" +
-                        LocalizationService.RHN_DB_DATEFORMAT + "] it was: " +
-                        completedIn);
-            }
-        }
+    public void setCompleted(Date completedIn) {
+        this.completed = completedIn;
     }
 
     /**

--- a/java/code/src/com/redhat/rhn/frontend/dto/SystemPendingEventDto.java
+++ b/java/code/src/com/redhat/rhn/frontend/dto/SystemPendingEventDto.java
@@ -14,11 +14,7 @@
  */
 package com.redhat.rhn.frontend.dto;
 
-import com.redhat.rhn.common.localization.LocalizationService;
-
 import java.io.Serializable;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.Date;
 
 /**
@@ -42,21 +38,8 @@ public class SystemPendingEventDto extends SystemEventDto implements Serializabl
     /**
      * @param scheduledForIn Date of creation to set
      */
-    public void setScheduledFor(String scheduledForIn) {
-        if (scheduledForIn == null) {
-            this.scheduledFor = null;
-        }
-        else {
-            try {
-                this.scheduledFor = new SimpleDateFormat(
-                        LocalizationService.RHN_DB_DATEFORMAT).parse(scheduledForIn);
-            }
-            catch (ParseException e) {
-                throw new IllegalArgumentException("lastCheckin must be of the: [" +
-                        LocalizationService.RHN_DB_DATEFORMAT + "] it was: " +
-                        scheduledForIn);
-            }
-        }
+    public void setScheduledFor(Date scheduledForIn) {
+        this.scheduledFor = scheduledForIn;
     }
 
     /**

--- a/java/code/src/com/suse/manager/xmlrpc/serializer/test/SystemEventDetailsDtoSerializerTest.java
+++ b/java/code/src/com/suse/manager/xmlrpc/serializer/test/SystemEventDetailsDtoSerializerTest.java
@@ -14,7 +14,6 @@
  */
 package com.suse.manager.xmlrpc.serializer.test;
 
-import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.domain.action.ActionFactory;
 
 import com.suse.manager.xmlrpc.dto.SystemEventDetailsDto;
@@ -26,7 +25,6 @@ import java.io.Writer;
 import java.sql.Date;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
 
 import junit.framework.TestCase;
 import redstone.xmlrpc.XmlRpcSerializer;
@@ -47,16 +45,19 @@ public class SystemEventDetailsDtoSerializerTest extends TestCase {
         dto.setHistoryTypeName(ActionFactory.TYPE_HARDWARE_REFRESH_LIST.getName());
         dto.setHistoryStatus(ActionFactory.STATUS_COMPLETED.getName());
         dto.setSummary("Hardware List Refresh scheduled by (none)");
-        dto.setCreated(LocalDateTime.of(2021, 10, 5, 16, 55)
-                                      .format(DateTimeFormatter.ofPattern(LocalizationService.RHN_DB_DATEFORMAT)));
-        dto.setPickedUp(LocalDateTime.of(2021, 10, 5, 16, 58)
-                                    .format(DateTimeFormatter.ofPattern(LocalizationService.RHN_DB_DATEFORMAT)));
-        dto.setCompleted(LocalDateTime.of(2021, 10, 5, 17, 0)
-                                      .format(DateTimeFormatter.ofPattern(LocalizationService.RHN_DB_DATEFORMAT)));
-
+        dto.setCreated(Date.from(LocalDateTime.of(2021, 10, 5, 16, 55)
+                .atZone(ZoneOffset.systemDefault())
+                .toInstant()));
+        dto.setPickedUp(Date.from(LocalDateTime.of(2021, 10, 5, 16, 58)
+                .atZone(ZoneOffset.systemDefault())
+                .toInstant()));
+        dto.setCompleted(Date.from(LocalDateTime.of(2021, 10, 5, 17, 0)
+                .atZone(ZoneOffset.systemDefault())
+                .toInstant()));
         dto.setEarliestAction(Date.from(LocalDateTime.of(2021, 10, 5, 16, 56)
-                                                     .atZone(ZoneOffset.systemDefault())
-                                                     .toInstant()));
+                .atZone(ZoneOffset.systemDefault())
+                .toInstant()));
+
         dto.setResultMsg("done");
         dto.setResultCode(0L);
 
@@ -83,15 +84,6 @@ public class SystemEventDetailsDtoSerializerTest extends TestCase {
 
         assertTrue(xml.contains("<name>picked_up</name>"));
         assertTrue(xml.contains("<dateTime.iso8601>20211005T16:58:00</dateTime.iso8601>"));
-
-        assertTrue(xml.contains("<name>completed</name>"));
-        assertTrue(xml.contains("<dateTime.iso8601>20211005T17:00:00</dateTime.iso8601>"));
-
-        assertTrue(xml.contains("<name>completed</name>"));
-        assertTrue(xml.contains("<dateTime.iso8601>20211005T17:00:00</dateTime.iso8601>"));
-
-        assertTrue(xml.contains("<name>completed</name>"));
-        assertTrue(xml.contains("<dateTime.iso8601>20211005T17:00:00</dateTime.iso8601>"));
 
         assertTrue(xml.contains("<name>completed</name>"));
         assertTrue(xml.contains("<dateTime.iso8601>20211005T17:00:00</dateTime.iso8601>"));

--- a/java/code/src/com/suse/manager/xmlrpc/serializer/test/SystemEventDtoSerializerTest.java
+++ b/java/code/src/com/suse/manager/xmlrpc/serializer/test/SystemEventDtoSerializerTest.java
@@ -14,7 +14,6 @@
  */
 package com.suse.manager.xmlrpc.serializer.test;
 
-import com.redhat.rhn.common.localization.LocalizationService;
 import com.redhat.rhn.domain.action.ActionFactory;
 import com.redhat.rhn.frontend.dto.SystemEventDto;
 
@@ -23,8 +22,9 @@ import com.suse.manager.xmlrpc.serializer.SystemEventDtoSerializer;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.sql.Date;
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
+import java.time.ZoneOffset;
 
 import junit.framework.TestCase;
 import redstone.xmlrpc.XmlRpcSerializer;
@@ -42,8 +42,9 @@ public class SystemEventDtoSerializerTest extends TestCase {
         dto.setHistoryTypeName(ActionFactory.TYPE_HARDWARE_REFRESH_LIST.getName());
         dto.setHistoryStatus(ActionFactory.STATUS_COMPLETED.getName());
         dto.setSummary("Hardware List Refresh scheduled by (none)");
-        dto.setCompleted(LocalDateTime.of(2021, 10, 5, 17, 0)
-                                      .format(DateTimeFormatter.ofPattern(LocalizationService.RHN_DB_DATEFORMAT)));
+        dto.setCompleted(Date.from(LocalDateTime.of(2021, 10, 5, 17, 0)
+                .atZone(ZoneOffset.systemDefault())
+                .toInstant()));
 
         final Writer output = new StringWriter();
 

--- a/java/code/webapp/WEB-INF/pages/systems/sdc/history.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/sdc/history.jsp
@@ -82,7 +82,7 @@
                     </c:choose>
                 </rl:column>
                 <rl:column headerkey="system.event.history.time">
-                    ${current.completedString}
+                    <rhn:formatDate value="${current.completed}"/>
                 </rl:column>
             </rl:list>
         </rl:listset>

--- a/java/code/webapp/WEB-INF/pages/systems/sdc/pending_events.jsp
+++ b/java/code/webapp/WEB-INF/pages/systems/sdc/pending_events.jsp
@@ -64,7 +64,7 @@
       <a href="/rhn/systems/details/history/Event.do?sid=${param.sid}&amp;aid=${current.id}">${current.summary}</a>
     </rl:column>
     <rl:column headerkey="system.event.pending.earliest">
-      ${current.scheduledFor}
+      <rhn:formatDate value="${current.scheduledFor}"/>
     </rl:column>
   </rl:list>
 </rl:listset>

--- a/web/html/src/components/datetime/DateTimePicker.tsx
+++ b/web/html/src/components/datetime/DateTimePicker.tsx
@@ -155,14 +155,11 @@ class TimePicker extends React.PureComponent<TimePickerProps> {
     this._input?.timepicker({
       roundingFunction: (seconds, options) => seconds,
     });
-    this._input?.on("change", () => {
-      // Do nothing
-    });
     this._input?.on("timeFormatError", () => {
       // Do nothing
     });
     this._input?.timepicker("setTime", this.toFauxBrowserDate(this.props));
-    this._input?.on("changeTime", () => {
+    this._input?.on("change", () => {
       const unsafeDate: Date | undefined = this._input?.timepicker("getTime");
 
       // Only if value has actually changed


### PR DESCRIPTION
## What does this PR change?

Fix an issue where the timepicker would not react to manually typed input (not using the dropdown)

This is a followup fix for https://github.com/uyuni-project/uyuni/pull/4483 and thus requires no additional changelog

Also fix issues where the wrong time would be displayed in system pending actions and action history if server timezone and user preferred timezone are differnt

## GUI diff

No difference.

- [x] **DONE**

## Documentation

- No documentation needed: **Bugfix**

- [x] **DONE**

## Test coverage

- No tests: **Bugfix**

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/16384

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [x] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
