### PR TITLE
Allow "mgr_force_venv_salt_minion" as pillar to force Salt Bundle during bootstrapping

### DIFF
--- a/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
+++ b/susemanager-utils/susemanager-sls/salt/bootstrap/init.sls
@@ -119,7 +119,7 @@ bootstrap_repo:
 {%- set salt_config_dir = '/etc/salt' %}
 {% set venv_available_request = salt['http.query'](bootstrap_repo_url + 'venv-enabled-' + grains['osarch'] + '.txt', status=True, verify_ssl=False) %}
 {# Prefer venv-salt-minion if available and not disabled #}
-{%- set use_venv_salt = (0 < venv_available_request.get('status', 404) < 300) and not salt['pillar.get']('mgr_avoid_venv_salt_minion') %}
+{%- set use_venv_salt = salt['pillar.get']('mgr_force_venv_salt_minion') or (0 < venv_available_request.get('status', 404) < 300) and not salt['pillar.get']('mgr_avoid_venv_salt_minion') %}
 {%- if use_venv_salt %}
 {%- set salt_minion_name = 'venv-salt-minion' %}
 {%- set salt_config_dir = '/etc/venv-salt-minion' %}

--- a/susemanager-utils/susemanager-sls/susemanager-sls.changes
+++ b/susemanager-utils/susemanager-sls/susemanager-sls.changes
@@ -1,3 +1,6 @@
+- Allow "mgr_force_venv_salt_minion" as pillar when bootstrapping
+  in order to force venv-salt-minion installation
+
 -------------------------------------------------------------------
 Tue Nov 16 10:09:40 CET 2021 - jgonzalez@suse.com
 


### PR DESCRIPTION
## What does this PR change?

This PR makes bootstrap state to react to `mgr_force_venv_salt_minion` pillar when performing the boostrap.

In the same way that `mgr_avoid_venv_salt_minion` pillar is disabling the usage of the Salt Bundle, this other one forces its usage, even if the bootstrap repositories do not have the `venv-salt-minion` package available, i.a. when `venv-salt-minion` is already installed in the system.

## GUI diff

No difference.

- [x] **DONE**

## Documentation
- No documentation needed: only internal and user invisible changes

- [x] **DONE**

## Test coverage
- No tests: already covered

- [x] **DONE**

## Links

Tracks https://github.com/SUSE/spacewalk/issues/16421

- [x] **DONE**

## Changelogs

Make sure the changelogs entries you are adding are compliant with https://github.com/uyuni-project/uyuni/wiki/Contributing#changelogs and https://github.com/uyuni-project/uyuni/wiki/Contributing#uyuni-projectuyuni-repository

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"
